### PR TITLE
feat: drain buffered commands in chunks when resuming a process instance

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class ProcessInstanceSuspendResumeIT {
+
+  // element ids are fixed; job types are randomized per test so that jobs cannot be activated by
+  // a worker in another test sharing this MultiDb broker, which would starve this test's instances
+  private static final String[] ELEMENT_IDS = {"taskA", "taskB", "taskC"};
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldSuspendAndResumeAndCompleteAsIfNeverSuspended() {
+    // given
+    final var process = deployProcess();
+    final long suspendedKey =
+        startProcessInstance(camundaClient, process.processId()).getProcessInstanceKey();
+    final long notSuspendedKey =
+        startProcessInstance(camundaClient, process.processId()).getProcessInstanceKey();
+    waitForProcessInstancesToStart(
+        camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, notSuspendedKey)), 2);
+
+    // when
+    camundaClient.newSuspendProcessInstanceCommand(suspendedKey).send().join();
+
+    // then
+    waitForProcessInstancesToBeSuspended(camundaClient, f -> f.processInstanceKey(suspendedKey), 1);
+    final ProcessInstance suspendedInstance =
+        camundaClient.newProcessInstanceGetRequest(suspendedKey).send().join();
+    assertThat(suspendedInstance.getState()).isEqualTo(ProcessInstanceState.SUSPENDED);
+    assertThat(suspendedInstance.getSuspendedDate()).isNotNull();
+
+    final ProcessInstance notSuspendedInstance =
+        camundaClient.newProcessInstanceGetRequest(notSuspendedKey).send().join();
+    assertThat(notSuspendedInstance.getState()).isEqualTo(ProcessInstanceState.ACTIVE);
+    assertThat(notSuspendedInstance.getSuspendedDate()).isNull();
+
+    // when
+    camundaClient.newResumeProcessInstanceCommand(suspendedKey).send().join();
+
+    // then
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(suspendedKey),
+        instances ->
+            assertThat(instances)
+                .singleElement()
+                .satisfies(
+                    instance -> {
+                      assertThat(instance.getState()).isEqualTo(ProcessInstanceState.ACTIVE);
+                      assertThat(instance.getSuspendedDate()).isNull();
+                    }));
+
+    // TODO(#59812): re-instate once resume hands parked jobs out again. Suspend already parks
+    // every ACTIVATABLE job out of the hand-out index, but nothing writes Job.RESUMED yet, so the
+    // resumed instance never gets its job back and only the never-suspended instance can be
+    // activated below.
+    // when - both instances driven through the same three sequential tasks
+    // for (final String jobType : process.jobTypes()) {
+    //   activateAndCompleteJobs(jobType, 2);
+    // }
+
+    // then - both complete, with the same elements in the same end state
+    // waitForProcessInstancesToBeCompleted(
+    //     camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, notSuspendedKey)), 2);
+    // assertThat(elementIdsAndStates(suspendedKey))
+    //     .containsExactlyInAnyOrderElementsOf(elementIdsAndStates(notSuspendedKey));
+
+    // with the job flow disabled above, both instances are left waiting at taskA; cancel them so
+    // they don't linger on the shared broker for the rest of the suite
+    camundaClient.newCancelInstanceCommand(suspendedKey).send().join();
+    camundaClient.newCancelInstanceCommand(notSuspendedKey).send().join();
+    waitForProcessInstanceToBeTerminated(camundaClient, suspendedKey);
+    waitForProcessInstanceToBeTerminated(camundaClient, notSuspendedKey);
+  }
+
+  @Test
+  void shouldRejectCommandsWhileSuspendedAndAcceptThemOnceResumed() {
+    // given - a job activated before suspension
+    final var process = deployProcess();
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, process.processId()).getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+    final long jobKey = activateJob(process.jobTypes()[0]);
+
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // when
+    final var problem =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newCompleteCommand(jobKey).send().join())
+            .actual();
+
+    // then
+    assertThat(problem.details().getDetail()).contains("is suspended");
+
+    // when
+    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceKey),
+        instances ->
+            assertThat(instances)
+                .singleElement()
+                .extracting(ProcessInstance::getState)
+                .isEqualTo(ProcessInstanceState.ACTIVE));
+
+    // then - the same command is now accepted, and the process advances
+    camundaClient.newCompleteCommand(jobKey).send().join();
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId(ELEMENT_IDS[1])
+                                        .state(ElementInstanceState.ACTIVE))
+                            .send()
+                            .join()
+                            .items())
+                    .isNotEmpty());
+
+    // leaves an instance active at taskB; cancel it so it doesn't linger on the shared broker
+    camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstanceToBeTerminated(camundaClient, processInstanceKey);
+  }
+
+  private static void activateAndCompleteJobs(final String jobType, final int count) {
+    // Complete whatever each poll activates and accumulate toward count, rather than requiring all
+    // count jobs at once. The two instances can reach a task moments apart; a poll that grabbed a
+    // subset then asserted the full count would leave those jobs locked for the activation timeout,
+    // stalling the next poll instead of making progress.
+    final Set<Long> completed = new HashSet<>();
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              camundaClient
+                  .newActivateJobsCommand()
+                  .jobType(jobType)
+                  .maxJobsToActivate(count - completed.size())
+                  .workerName("test")
+                  .timeout(Duration.ofSeconds(10))
+                  .send()
+                  .join()
+                  .getJobs()
+                  .forEach(
+                      job -> {
+                        camundaClient.newCompleteCommand(job.getKey()).send().join();
+                        completed.add(job.getKey());
+                      });
+              assertThat(completed).hasSize(count);
+            });
+  }
+
+  private static long activateJob(final String jobType) {
+    final var jobs = new long[1];
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var activated =
+                  camundaClient
+                      .newActivateJobsCommand()
+                      .jobType(jobType)
+                      .maxJobsToActivate(1)
+                      .workerName("test")
+                      .timeout(Duration.ofSeconds(10))
+                      .send()
+                      .join()
+                      .getJobs();
+              assertThat(activated).hasSize(1);
+              jobs[0] = activated.getFirst().getKey();
+            });
+    return jobs[0];
+  }
+
+  private static List<Tuple> elementIdsAndStates(final long processInstanceKey) {
+    return camundaClient
+        .newElementInstanceSearchRequest()
+        .filter(f -> f.processInstanceKey(processInstanceKey))
+        .page(p -> p.limit(100))
+        .send()
+        .join()
+        .items()
+        .stream()
+        .map(e -> Tuple.tuple(e.getElementId(), e.getState()))
+        .toList();
+  }
+
+  private static DeployedProcess deployProcess() {
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobTypes =
+        new String[] {
+          Strings.newRandomValidBpmnId(),
+          Strings.newRandomValidBpmnId(),
+          Strings.newRandomValidBpmnId()
+        };
+
+    AbstractFlowNodeBuilder<?, ?> builder = Bpmn.createExecutableProcess(processId).startEvent();
+    for (int i = 0; i < ELEMENT_IDS.length; i++) {
+      final String jobType = jobTypes[i];
+      builder = builder.serviceTask(ELEMENT_IDS[i], t -> t.zeebeJobType(jobType));
+    }
+    final var model = builder.endEvent().done();
+
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(model, processId + ".bpmn")
+        .send()
+        .join();
+    waitForProcessesToBeDeployed(camundaClient, f -> f.processDefinitionId(processId), 1);
+
+    return new DeployedProcess(processId, jobTypes);
+  }
+
+  /** A process deployed for a single test method, so no state is shared across tests. */
+  private record DeployedProcess(String processId, String[] jobTypes) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTe
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBufferedCommandDrainProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBusinessIdAssignProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCompleteResumingProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithAwaitingResultProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
@@ -176,6 +177,13 @@ public final class BpmnProcessors {
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.RESUME,
         new ProcessInstanceResumeProcessor(processingState, writers, cslCheck));
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE,
+        ProcessInstanceIntent.COMPLETE_RESUMING,
+        new ProcessInstanceCompleteResumingProcessor(
+            processingState.getElementInstanceState(),
+            processingState.getSuspensionState(),
+            writers));
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.SUSPEND,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDele
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchActivateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTerminateProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBufferedCommandDrainProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBusinessIdAssignProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor;
@@ -52,6 +53,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -90,6 +92,7 @@ public final class BpmnProcessors {
 
     addProcessInstanceCommandProcessor(
         writers, typedRecordProcessors, processingState, asyncRequestBehavior, cslCheck);
+    addProcessInstanceBufferedCommandProcessor(writers, typedRecordProcessors, processingState);
 
     final var bpmnStreamProcessor =
         new BpmnStreamProcessor(
@@ -177,6 +180,16 @@ public final class BpmnProcessors {
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.SUSPEND,
         new ProcessInstanceSuspendProcessor(processingState, writers, cslCheck));
+  }
+
+  private static void addProcessInstanceBufferedCommandProcessor(
+      final Writers writers,
+      final TypedRecordProcessors typedRecordProcessors,
+      final ProcessingState processingState) {
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND,
+        ProcessInstanceBufferedCommandIntent.DRAIN,
+        new ProcessInstanceBufferedCommandDrainProcessor(processingState, writers));
   }
 
   private static void addBpmnStepProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
-import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
@@ -24,7 +23,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandInt
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.jspecify.annotations.NullMarked;
-import org.slf4j.Logger;
 
 /**
  * Drains buffered commands one per {@code DRAIN} cycle, then re-checks the buffer (already up to
@@ -37,11 +35,10 @@ import org.slf4j.Logger;
  * {@code RESUMING} forever.
  *
  * <p>If a cycle fails to write (e.g. the re-emitted command plus its bookkeeping records exceed the
- * batch size limit), draining halts rather than dropping the command: {@link #tryHandleError} makes
- * no further state changes and reports {@link ProcessingError#UNEXPECTED_ERROR}, which the engine
- * turns into a logged error and a rejection of the {@code DRAIN} command — without banning the
- * instance ({@code DRAIN.shouldBanInstance == false}). The buffered command is preserved and the
- * instance stays in {@code RESUMING} until a fresh {@code RESUME} restarts the drain (see {@link
+ * batch size limit), draining halts rather than dropping the command: the engine's default error
+ * handling logs the failure and rejects the {@code DRAIN} command — without banning the instance
+ * ({@code DRAIN.shouldBanInstance == false}). The buffered command is preserved and the instance
+ * stays in {@code RESUMING} until a fresh {@code RESUME} restarts the drain (see {@link
  * ProcessInstanceResumeProcessor}).
  */
 @ExcludeAuthorizationCheck
@@ -49,13 +46,6 @@ import org.slf4j.Logger;
 public final class ProcessInstanceBufferedCommandDrainProcessor
     implements TypedRecordProcessor<ProcessInstanceBufferedCommandRecord>,
         SuspensionAware<ProcessInstanceBufferedCommandRecord> {
-
-  private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
-
-  private static final String DRAIN_FAILED_MESSAGE =
-      "Expected to resume process instance '{}' by draining a buffered command, but writing it "
-          + "back to the log failed. The buffered command is preserved; draining halts here and "
-          + "the instance stays in RESUMING until a RESUME command restarts the drain.";
 
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
@@ -89,17 +79,6 @@ public final class ProcessInstanceBufferedCommandDrainProcessor
     } else {
       appendNextDrainCommand(drainValue);
     }
-  }
-
-  @Override
-  public ProcessingError tryHandleError(
-      final TypedRecord<ProcessInstanceBufferedCommandRecord> command, final Throwable error) {
-    // State-free on purpose: re-reading the buffer here (as a dropped-command path once did) risks
-    // throwing again on the same corrupted state and taking the whole partition down with it. Just
-    // log and hand off to the engine's default handling, which rejects the DRAIN command without
-    // banning the instance (see class javadoc) and halts the chain without touching state.
-    LOG.error(DRAIN_FAILED_MESSAGE, command.getValue().getProcessInstanceKey(), error);
-    return ProcessingError.UNEXPECTED_ERROR;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
@@ -15,11 +15,11 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState.BufferedCommand;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -27,12 +27,22 @@ import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 
 /**
- * Drains buffered commands one per {@code DRAIN} cycle and writes {@code RESUMED} when the buffer
- * is empty. The iterator shape (one command + next {@code DRAIN} per cycle) keeps each batch
- * bounded regardless of buffer size — same pattern as {@link
- * ProcessInstanceBatchActivateProcessor}. Each drained command reaches its own processor unchanged;
- * this processor raises no incidents. {@link SuspensionBehavior#PROCESS} is unconditional: gating a
- * {@code DRAIN} strands the instance in {@code RESUMING} forever.
+ * Drains buffered commands one per {@code DRAIN} cycle, then re-checks the buffer (already up to
+ * date, since event appliers run synchronously): if more remains it appends the next {@code DRAIN},
+ * otherwise it appends {@code COMPLETE_RESUMING} directly to hand the resume finalization off to
+ * {@link ProcessInstanceCompleteResumingProcessor} without an extra empty cycle. The bounded-batch
+ * iterator shape follows the same pattern as {@link ProcessInstanceBatchActivateProcessor}. Each
+ * drained command reaches its own processor unchanged; this processor raises no incidents. {@link
+ * SuspensionBehavior#PROCESS} is unconditional: gating a {@code DRAIN} strands the instance in
+ * {@code RESUMING} forever.
+ *
+ * <p>If a cycle fails to write (e.g. the re-emitted command plus its bookkeeping records exceed the
+ * batch size limit), draining halts rather than dropping the command: {@link #tryHandleError} makes
+ * no further state changes and reports {@link ProcessingError#UNEXPECTED_ERROR}, which the engine
+ * turns into a logged error and a rejection of the {@code DRAIN} command — without banning the
+ * instance ({@code DRAIN.shouldBanInstance == false}). The buffered command is preserved and the
+ * instance stays in {@code RESUMING} until a fresh {@code RESUME} restarts the drain (see {@link
+ * ProcessInstanceResumeProcessor}).
  */
 @ExcludeAuthorizationCheck
 @NullMarked
@@ -43,22 +53,19 @@ public final class ProcessInstanceBufferedCommandDrainProcessor
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
 
   private static final String DRAIN_FAILED_MESSAGE =
-      "Expected to resume process instance '{}' by draining the {} command with key '{}' that was "
-          + "buffered while it was suspended, but it could not be written. The command is dropped "
-          + "so that the remaining buffered commands can still be drained and the instance can "
-          + "leave the RESUMING state.";
+      "Expected to resume process instance '{}' by draining a buffered command, but writing it "
+          + "back to the log failed. The buffered command is preserved; draining halts here and "
+          + "the instance stays in RESUMING until a RESUME command restarts the drain.";
 
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
   private final SuspensionState suspensionState;
-  private final ElementInstanceState elementInstanceState;
 
   public ProcessInstanceBufferedCommandDrainProcessor(
       final ProcessingState processingState, final Writers writers) {
     stateWriter = writers.state();
     commandWriter = writers.command();
     suspensionState = processingState.getSuspensionState();
-    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Override
@@ -66,42 +73,33 @@ public final class ProcessInstanceBufferedCommandDrainProcessor
     final var drainValue = command.getValue();
     final long processInstanceKey = drainValue.getProcessInstanceKey();
 
-    final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey);
+    final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey).orElse(null);
     if (buffered == null) {
-      writeResumed(processInstanceKey);
+      appendCompleteResuming(drainValue);
       return;
     }
 
     appendBufferedCommand(buffered);
     appendDrainedEvent(buffered);
-    appendNextDrainCommand(drainValue);
+
+    // DRAINED already applied (event appliers run synchronously), so this reflects the buffer as
+    // it stands now, without an extra empty DRAIN cycle to find out
+    if (suspensionState.getOldestBufferedCommand(processInstanceKey).isEmpty()) {
+      appendCompleteResuming(drainValue);
+    } else {
+      appendNextDrainCommand(drainValue);
+    }
   }
 
   @Override
   public ProcessingError tryHandleError(
       final TypedRecord<ProcessInstanceBufferedCommandRecord> command, final Throwable error) {
-    final var drainValue = command.getValue();
-    final long processInstanceKey = drainValue.getProcessInstanceKey();
-
-    final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey);
-    if (buffered == null) {
-      // the failure did not come from writing a buffered command, so there is nothing to drop and
-      // no way to make progress here; fall back to the generic error handling
-      return ProcessingError.UNEXPECTED_ERROR;
-    }
-
-    // Log, not incident: command never reached its own processor, which owns the incident state.
-    LOG.error(
-        DRAIN_FAILED_MESSAGE,
-        processInstanceKey,
-        buffered.command().getValueType(),
-        buffered.command().getCommandKey(),
-        error);
-    // Drop so the next DRAIN does not spin; keep the chain alive so the instance can leave
-    // RESUMING.
-    appendDrainedEvent(buffered);
-    appendNextDrainCommand(drainValue);
-    return ProcessingError.EXPECTED_ERROR;
+    // State-free on purpose: re-reading the buffer here (as a dropped-command path once did) risks
+    // throwing again on the same corrupted state and taking the whole partition down with it. Just
+    // log and hand off to the engine's default handling, which rejects the DRAIN command without
+    // banning the instance (see class javadoc) and halts the chain without touching state.
+    LOG.error(DRAIN_FAILED_MESSAGE, command.getValue().getProcessInstanceKey(), error);
+    return ProcessingError.UNEXPECTED_ERROR;
   }
 
   @Override
@@ -113,7 +111,6 @@ public final class ProcessInstanceBufferedCommandDrainProcessor
 
   private void appendBufferedCommand(final BufferedCommand buffered) {
     final var value = buffered.command();
-    // follow-up commands carry no request metadata, so the gate classifies them as internal
     commandWriter.appendFollowUpCommand(
         value.getCommandKey(), value.getIntent(), value.getCommandValue());
   }
@@ -144,17 +141,13 @@ public final class ProcessInstanceBufferedCommandDrainProcessor
             .setTenantId(drainValue.getTenantId()));
   }
 
-  private void writeResumed(final long processInstanceKey) {
-    final var elementInstance = elementInstanceState.getInstance(processInstanceKey);
-    if (elementInstance == null) {
-      // Cancelled mid-drain — skip RESUMED to avoid a false audit log entry.
-      LOG.debug(
-          "Expected to finish resuming process instance '{}', but it no longer exists — likely "
-              + "cancelled while resuming. Ending the drain without writing RESUMED.",
-          processInstanceKey);
-      return;
-    }
-    stateWriter.appendFollowUpEvent(
-        processInstanceKey, ProcessInstanceIntent.RESUMED, elementInstance.getValue());
+  private void appendCompleteResuming(final ProcessInstanceBufferedCommandRecord drainValue) {
+    commandWriter.appendFollowUpCommand(
+        drainValue.getProcessInstanceKey(),
+        ProcessInstanceIntent.COMPLETE_RESUMING,
+        new ProcessInstanceRecord()
+            .setProcessInstanceKey(drainValue.getProcessInstanceKey())
+            .setProcessDefinitionKey(drainValue.getProcessDefinitionKey())
+            .setTenantId(drainValue.getTenantId()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessor.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState.BufferedCommand;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+
+/**
+ * Drains buffered commands one per {@code DRAIN} cycle and writes {@code RESUMED} when the buffer
+ * is empty. The iterator shape (one command + next {@code DRAIN} per cycle) keeps each batch
+ * bounded regardless of buffer size — same pattern as {@link
+ * ProcessInstanceBatchActivateProcessor}. Each drained command reaches its own processor unchanged;
+ * this processor raises no incidents. {@link SuspensionBehavior#PROCESS} is unconditional: gating a
+ * {@code DRAIN} strands the instance in {@code RESUMING} forever.
+ */
+@ExcludeAuthorizationCheck
+@NullMarked
+public final class ProcessInstanceBufferedCommandDrainProcessor
+    implements TypedRecordProcessor<ProcessInstanceBufferedCommandRecord>,
+        SuspensionAware<ProcessInstanceBufferedCommandRecord> {
+
+  private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
+
+  private static final String DRAIN_FAILED_MESSAGE =
+      "Expected to resume process instance '{}' by draining the {} command with key '{}' that was "
+          + "buffered while it was suspended, but it could not be written. The command is dropped "
+          + "so that the remaining buffered commands can still be drained and the instance can "
+          + "leave the RESUMING state.";
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final SuspensionState suspensionState;
+  private final ElementInstanceState elementInstanceState;
+
+  public ProcessInstanceBufferedCommandDrainProcessor(
+      final ProcessingState processingState, final Writers writers) {
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    suspensionState = processingState.getSuspensionState();
+    elementInstanceState = processingState.getElementInstanceState();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceBufferedCommandRecord> command) {
+    final var drainValue = command.getValue();
+    final long processInstanceKey = drainValue.getProcessInstanceKey();
+
+    final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey);
+    if (buffered == null) {
+      writeResumed(processInstanceKey);
+      return;
+    }
+
+    appendBufferedCommand(buffered);
+    appendDrainedEvent(buffered);
+    appendNextDrainCommand(drainValue);
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<ProcessInstanceBufferedCommandRecord> command, final Throwable error) {
+    final var drainValue = command.getValue();
+    final long processInstanceKey = drainValue.getProcessInstanceKey();
+
+    final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey);
+    if (buffered == null) {
+      // the failure did not come from writing a buffered command, so there is nothing to drop and
+      // no way to make progress here; fall back to the generic error handling
+      return ProcessingError.UNEXPECTED_ERROR;
+    }
+
+    // Log, not incident: command never reached its own processor, which owns the incident state.
+    LOG.error(
+        DRAIN_FAILED_MESSAGE,
+        processInstanceKey,
+        buffered.command().getValueType(),
+        buffered.command().getCommandKey(),
+        error);
+    // Drop so the next DRAIN does not spin; keep the chain alive so the instance can leave
+    // RESUMING.
+    appendDrainedEvent(buffered);
+    appendNextDrainCommand(drainValue);
+    return ProcessingError.EXPECTED_ERROR;
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<ProcessInstanceBufferedCommandRecord> record) {
+    // DRAIN is what ends the suspension: gating it would strand the instance in RESUMING
+    return SuspensionBehavior.PROCESS;
+  }
+
+  private void appendBufferedCommand(final BufferedCommand buffered) {
+    final var value = buffered.command();
+    // follow-up commands carry no request metadata, so the gate classifies them as internal
+    commandWriter.appendFollowUpCommand(
+        value.getCommandKey(), value.getIntent(), value.getCommandValue());
+  }
+
+  // DRAINED carries no payload: the applier removes the entry by record key, so repeating it would
+  // halve the maximum buffered command size for no gain.
+  private void appendDrainedEvent(final BufferedCommand buffered) {
+    final var value = buffered.command();
+    stateWriter.appendFollowUpEvent(
+        buffered.key(),
+        ProcessInstanceBufferedCommandIntent.DRAINED,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(value.getProcessInstanceKey())
+            .setProcessDefinitionKey(value.getProcessDefinitionKey())
+            .setTenantId(value.getTenantId())
+            .setCommandKey(value.getCommandKey())
+            .setValueType(value.getValueType())
+            .setIntent(value.getIntent()));
+  }
+
+  private void appendNextDrainCommand(final ProcessInstanceBufferedCommandRecord drainValue) {
+    commandWriter.appendFollowUpCommand(
+        drainValue.getProcessInstanceKey(),
+        ProcessInstanceBufferedCommandIntent.DRAIN,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(drainValue.getProcessInstanceKey())
+            .setProcessDefinitionKey(drainValue.getProcessDefinitionKey())
+            .setTenantId(drainValue.getTenantId()));
+  }
+
+  private void writeResumed(final long processInstanceKey) {
+    final var elementInstance = elementInstanceState.getInstance(processInstanceKey);
+    if (elementInstance == null) {
+      // Cancelled mid-drain — skip RESUMED to avoid a false audit log entry.
+      LOG.debug(
+          "Expected to finish resuming process instance '{}', but it no longer exists — likely "
+              + "cancelled while resuming. Ending the drain without writing RESUMED.",
+          processInstanceKey);
+      return;
+    }
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, ProcessInstanceIntent.RESUMED, elementInstance.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferingBehavior.java
@@ -22,10 +22,10 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
  * SuspensionAware}) and its target process instance is currently {@code SUSPENDED}.
  *
  * <p>Buffers the command, in FIFO order, as a {@link ProcessInstanceBufferedCommandRecord}; it is
- * replayed verbatim once the process instance is drained during resume. No client response is
- * written here: buffered commands are (or become, via distribution) internal commands and are
- * re-issued once the process instance resumes, at which point the normal command lifecycle produces
- * the response.
+ * written back to the log verbatim once the process instance is drained during resume. No client
+ * response is written here: buffered commands are (or become, via distribution) internal commands
+ * and are re-issued once the process instance resumes, at which point the normal command lifecycle
+ * produces the response.
  */
 public final class ProcessInstanceBufferingBehavior {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Finalizes the resume lifecycle once the buffered-command drain is complete. Reacts to {@link
+ * ProcessInstanceIntent#COMPLETE_RESUMING} by writing {@link ProcessInstanceIntent#RESUMED}.
+ *
+ * <p>Idempotent by design: writes {@code RESUMED} only when the instance exists, the suspension
+ * marker is still {@link SuspensionState.State#RESUMING}, and the element is not mid-lifecycle-end
+ * ({@code ELEMENT_TERMINATING}/{@code ELEMENT_COMPLETING}). Every other case is rejected rather
+ * than silently skipped, so a concurrent drain chain restarted via {@code RESUME} (see {@link
+ * ProcessInstanceResumeProcessor}) cannot write {@code RESUMED} twice.
+ *
+ * <p>{@link SuspensionBehavior#PROCESS} is unconditional: the marker is still {@code RESUMING} at
+ * this point, and gating would strand the instance there forever.
+ */
+@ExcludeAuthorizationCheck
+@NullMarked
+public final class ProcessInstanceCompleteResumingProcessor
+    implements TypedRecordProcessor<ProcessInstanceRecord>, SuspensionAware<ProcessInstanceRecord> {
+
+  private static final String INSTANCE_GONE_MESSAGE =
+      "Expected to finish resuming process instance '%d', but it no longer exists — likely "
+          + "cancelled while resuming.";
+  private static final String ALREADY_FINALIZED_MESSAGE =
+      "Expected to finish resuming process instance '%d', but its suspension marker is no "
+          + "longer RESUMING — likely already finalized by a concurrent resume.";
+  private static final String LIFECYCLE_ENDING_MESSAGE =
+      "Expected to finish resuming process instance '%d', but it is %s — resume is superseded "
+          + "by the ending lifecycle.";
+
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final ElementInstanceState elementInstanceState;
+  private final SuspensionState suspensionState;
+
+  public ProcessInstanceCompleteResumingProcessor(
+      final ElementInstanceState elementInstanceState,
+      final SuspensionState suspensionState,
+      final Writers writers) {
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    this.elementInstanceState = elementInstanceState;
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceRecord> command) {
+    final long processInstanceKey = command.getKey();
+    final var elementInstance = elementInstanceState.getInstance(processInstanceKey);
+    if (elementInstance == null) {
+      reject(command, INSTANCE_GONE_MESSAGE.formatted(processInstanceKey));
+      return;
+    }
+
+    if (suspensionState.getSuspensionState(processInstanceKey) != SuspensionState.State.RESUMING) {
+      reject(command, ALREADY_FINALIZED_MESSAGE.formatted(processInstanceKey));
+      return;
+    }
+
+    final var state = elementInstance.getState();
+    if (state == ProcessInstanceIntent.ELEMENT_TERMINATING
+        || state == ProcessInstanceIntent.ELEMENT_COMPLETING) {
+      reject(command, LIFECYCLE_ENDING_MESSAGE.formatted(processInstanceKey, state));
+      return;
+    }
+
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, ProcessInstanceIntent.RESUMED, elementInstance.getValue());
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionBehavior.PROCESS;
+  }
+
+  private void reject(final TypedRecord<ProcessInstanceRecord> command, final String reason) {
+    rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -32,9 +33,13 @@ import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+import org.slf4j.Logger;
 
 public final class ProcessInstanceResumeProcessor
     implements TypedRecordProcessor<ProcessInstanceRecord>, SuspensionAware<ProcessInstanceRecord> {
+
+  private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
 
   private static final String MESSAGE_PREFIX =
       "Expected to resume a process instance with key '%d', but ";
@@ -69,27 +74,19 @@ public final class ProcessInstanceResumeProcessor
   public void processRecord(final TypedRecord<ProcessInstanceRecord> command) {
     final var elementInstance = elementInstanceState.getInstance(command.getKey());
 
-    if (!validateCommand(command, elementInstance)) {
-      return;
-    }
-
-    final ProcessInstanceRecord value = elementInstance.getValue();
-
-    // switch the marker to RESUMING before the first DRAIN so the buffered commands it writes back
-    // are let through by the suspension gate instead of being buffered again
-    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMING, value);
-    commandWriter.appendFollowUpCommand(
-        command.getKey(),
-        ProcessInstanceBufferedCommandIntent.DRAIN,
-        new ProcessInstanceBufferedCommandRecord()
-            .setProcessInstanceKey(command.getKey())
-            .setProcessDefinitionKey(value.getProcessDefinitionKey())
-            .setTenantId(value.getTenantId()));
-
-    // the request is answered as soon as resuming has started: draining the buffer spans several
-    // command batches, and RESUMED is written only once it is empty
-    responseWriter.writeAcceptedResponseOnCommand(
-        command.getKey(), ProcessInstanceIntent.RESUMING, value, command);
+    validateNotFound(command, elementInstance)
+        .flatMap(ei -> validateAuthorized(command, ei))
+        .flatMap(ei -> validateSuspensionState(command, ei))
+        .ifRightOrLeft(
+            ei -> resume(command, ei),
+            rejection -> {
+              if (elementInstance != null) {
+                enrichRejectionCommand(command, elementInstance.getValue());
+              }
+              rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
+            });
   }
 
   @Override
@@ -97,25 +94,22 @@ public final class ProcessInstanceResumeProcessor
     return SuspensionBehavior.PROCESS;
   }
 
-  private boolean validateCommand(
+  private Either<Rejection, ElementInstance> validateNotFound(
       final TypedRecord<ProcessInstanceRecord> command, final ElementInstance elementInstance) {
-
     if (elementInstance == null
         || elementInstance.getParentKey() > 0
         || elementInstance.isTerminating()) {
-      rejectionWriter.appendRejection(
-          command,
-          RejectionType.NOT_FOUND,
-          String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
-      responseWriter.writeRejectedResponseOnCommand(
-          command,
-          RejectionType.NOT_FOUND,
-          String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
-      return false;
+      return Either.left(
+          new Rejection(
+              RejectionType.NOT_FOUND, PROCESS_NOT_FOUND_MESSAGE.formatted(command.getKey())));
     }
+    return Either.right(elementInstance);
+  }
 
-    final var isAuthorized =
-        cslCheck.checkAuthorizationAndTenant(
+  private Either<Rejection, ElementInstance> validateAuthorized(
+      final TypedRecord<ProcessInstanceRecord> command, final ElementInstance elementInstance) {
+    return cslCheck
+        .checkAuthorizationAndTenant(
             command,
             RequiredAuthorization.of(
                 b ->
@@ -133,24 +127,53 @@ public final class ProcessInstanceResumeProcessor
             new Rejection(
                 RejectionType.NOT_FOUND,
                 PROCESS_NOT_FOUND_MESSAGE.formatted(
-                    elementInstance.getValue().getProcessInstanceKey())));
-    if (isAuthorized.isLeft()) {
-      final var rejection = isAuthorized.getLeft();
-      enrichRejectionCommand(command, elementInstance.getValue());
-      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
-      return false;
-    }
+                    elementInstance.getValue().getProcessInstanceKey())))
+        .map(ignored -> elementInstance);
+  }
 
-    if (suspensionState.getSuspensionState(command.getKey()) != SuspensionState.State.SUSPENDED) {
-      final var reason = String.format(PROCESS_NOT_SUSPENDED_MESSAGE, command.getKey());
-      enrichRejectionCommand(command, elementInstance.getValue());
-      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
-      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.INVALID_STATE, reason);
-      return false;
+  private Either<Rejection, ElementInstance> validateSuspensionState(
+      final TypedRecord<ProcessInstanceRecord> command, final ElementInstance elementInstance) {
+    final var marker = suspensionState.getSuspensionState(command.getKey());
+    if (marker != SuspensionState.State.SUSPENDED && marker != SuspensionState.State.RESUMING) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_STATE,
+              PROCESS_NOT_SUSPENDED_MESSAGE.formatted(command.getKey())));
     }
+    return Either.right(elementInstance);
+  }
 
-    return true;
+  private void resume(
+      final TypedRecord<ProcessInstanceRecord> command, final ElementInstance elementInstance) {
+    final ProcessInstanceRecord value = elementInstance.getValue();
+    final boolean isRestart =
+        suspensionState.getSuspensionState(command.getKey()) == SuspensionState.State.RESUMING;
+
+    if (!isRestart) {
+      LOG.debug("Resuming process instance '{}': was suspended, starting drain", command.getKey());
+      // switch the marker to RESUMING before the first DRAIN so the buffered commands it writes
+      // back are let through by the suspension gate instead of being buffered again
+      stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMING, value);
+    } else {
+      LOG.debug(
+          "Resuming process instance '{}': drain was already in progress, restarting it",
+          command.getKey());
+    }
+    // restarting a RESUMING instance skips the event above (the marker is already there) and
+    // just appends a fresh DRAIN, giving a drain halted by a since-fixed failure (see
+    // ProcessInstanceBufferedCommandDrainProcessor) a way back in without a duplicate audit event
+    commandWriter.appendFollowUpCommand(
+        command.getKey(),
+        ProcessInstanceBufferedCommandIntent.DRAIN,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(command.getKey())
+            .setProcessDefinitionKey(value.getProcessDefinitionKey())
+            .setTenantId(value.getTenantId()));
+
+    // the request is answered as soon as resuming has started (or restarted): draining the
+    // buffer spans several command batches, and RESUMED is written only once it is empty
+    responseWriter.writeAcceptedResponseOnCommand(
+        command.getKey(), ProcessInstanceIntent.RESUMING, value, command);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -22,8 +23,10 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -44,6 +47,7 @@ public final class ProcessInstanceResumeProcessor
   private final ElementInstanceState elementInstanceState;
   private final TypedResponseWriter responseWriter;
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final CslAuthorizationCheck cslCheck;
   private final SuspensionState suspensionState;
@@ -55,6 +59,7 @@ public final class ProcessInstanceResumeProcessor
     elementInstanceState = processingState.getElementInstanceState();
     responseWriter = writers.response();
     stateWriter = writers.state();
+    commandWriter = writers.command();
     rejectionWriter = writers.rejection();
     this.cslCheck = cslCheck;
     suspensionState = processingState.getSuspensionState();
@@ -70,11 +75,21 @@ public final class ProcessInstanceResumeProcessor
 
     final ProcessInstanceRecord value = elementInstance.getValue();
 
-    // TODO(#57792): append a DRAIN command instead of writing RESUMED directly, once chunked
-    // draining of buffered commands is implemented.
-    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMED, value);
+    // switch the marker to RESUMING before the first DRAIN so the buffered commands it writes back
+    // are let through by the suspension gate instead of being buffered again
+    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMING, value);
+    commandWriter.appendFollowUpCommand(
+        command.getKey(),
+        ProcessInstanceBufferedCommandIntent.DRAIN,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(command.getKey())
+            .setProcessDefinitionKey(value.getProcessDefinitionKey())
+            .setTenantId(value.getTenantId()));
+
+    // the request is answered as soon as resuming has started: draining the buffer spans several
+    // command batches, and RESUMED is written only once it is empty
     responseWriter.writeAcceptedResponseOnCommand(
-        command.getKey(), ProcessInstanceIntent.RESUMED, value, command);
+        command.getKey(), ProcessInstanceIntent.RESUMING, value, command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -449,6 +449,9 @@ public final class EventAppliers implements EventApplier {
         new RuntimeInstructionInterruptedApplier(elementInstanceState));
     register(ProcessInstanceIntent.CANCELING, NOOP_EVENT_APPLIER);
     register(
+        ProcessInstanceIntent.RESUMING,
+        new ProcessInstanceResumingApplier(state.getSuspensionState()));
+    register(
         ProcessInstanceIntent.RESUMED,
         new ProcessInstanceResumedApplier(state.getSuspensionState()));
     register(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumingApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+final class ProcessInstanceResumingApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  ProcessInstanceResumingApplier(final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    // SUSPENDED → RESUMING: gate still rejects external commands but lets drain internals through
+    suspensionState.setSuspensionState(key, SuspensionState.State.RESUMING);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumingApplier.java
@@ -24,7 +24,8 @@ final class ProcessInstanceResumingApplier
 
   @Override
   public void applyState(final long key, final ProcessInstanceRecord value) {
-    // SUSPENDED → RESUMING: gate still rejects external commands but lets drain internals through
+    // SUSPENDED → RESUMING: gate still rejects commands, but now processes BUFFER-classified
+    // commands (the drain's internal follow-ups) instead of buffering them again
     suspensionState.setSuspensionState(key, SuspensionState.State.RESUMING);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -49,9 +50,11 @@ public interface SuspensionState {
    * Reads the head of the process instance's FIFO buffer without scanning the rest of it, so that
    * draining one command per {@code DRAIN} cycle stays cheap no matter how much is buffered.
    *
-   * @return the oldest buffered command, or {@code null} if the process instance has none buffered
+   * @return the oldest buffered command, or {@link Optional#empty()} if the process instance has
+   *     none buffered, or if the secondary index has an entry with no matching primary record (an
+   *     inconsistency that is logged but must not throw here, as it sits on the resume hot path)
    */
-  @Nullable BufferedCommand getOldestBufferedCommand(long processInstanceKey);
+  Optional<BufferedCommand> getOldestBufferedCommand(long processInstanceKey);
 
   @FunctionalInterface
   interface BufferedCommandVisitor {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -44,8 +45,19 @@ public interface SuspensionState {
    */
   void visitBufferedCommands(long processInstanceKey, BufferedCommandVisitor visitor);
 
+  /**
+   * Reads the head of the process instance's FIFO buffer without scanning the rest of it, so that
+   * draining one command per {@code DRAIN} cycle stays cheap no matter how much is buffered.
+   *
+   * @return the oldest buffered command, or {@code null} if the process instance has none buffered
+   */
+  @Nullable BufferedCommand getOldestBufferedCommand(long processInstanceKey);
+
   @FunctionalInterface
   interface BufferedCommandVisitor {
     void visit(long bufferedCommandKey, ProcessInstanceBufferedCommandRecordValue command);
   }
+
+  /** A buffered command together with the key it is stored under. */
+  record BufferedCommand(long key, ProcessInstanceBufferedCommandRecord command) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
@@ -96,7 +96,19 @@ public final class DbSuspensionState implements MutableSuspensionState {
         processInstanceKey,
         (compositeKey, nil) -> {
           final long bufferedKey = compositeKey.second().getValue();
-          visitor.visit(bufferedKey, requireBufferedCommand(bufferedKey, key).getRecord());
+          bufferedCommandKey.wrapLong(bufferedKey);
+          final var stored =
+              bufferedCommandColumnFamily.get(
+                  bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
+          if (stored == null) {
+            LOG.error(
+                "Expected to find buffered command with key '{}' for process instance '{}', but "
+                    + "none was stored; the buffered-command index is inconsistent. Skipping this entry.",
+                bufferedKey,
+                key);
+            return;
+          }
+          visitor.visit(bufferedKey, stored.getRecord());
         });
   }
 
@@ -113,9 +125,8 @@ public final class DbSuspensionState implements MutableSuspensionState {
               bufferedCommandColumnFamily.get(
                   bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
           if (stored == null) {
-            // broken invariant (see #requireBufferedCommand), but this sits on the resume hot
-            // path: log instead of throwing so a single corrupted entry halts the drain for this
-            // instance rather than failing the whole partition
+            // broken invariant: secondary index and primary CF are always written/deleted together,
+            // so a secondary entry with no matching primary record signals index corruption
             LOG.error(
                 "Expected to find buffered command with key '{}' for process instance '{}', but "
                     + "none was stored; the buffered-command index is inconsistent. Treating the "
@@ -129,28 +140,6 @@ public final class DbSuspensionState implements MutableSuspensionState {
           return false;
         });
     return Optional.ofNullable(oldest[0]);
-  }
-
-  /**
-   * Loads the primary buffered-command record behind a secondary-index entry. The secondary index
-   * and the primary CF are written and deleted together in a single transaction (see {@link
-   * #bufferCommand} / {@link #removeBufferedCommand}), so a secondary-index entry with no matching
-   * primary record is a broken invariant. Fail loud rather than silently dropping a buffered
-   * command, which would lose forward progress on resume.
-   */
-  private DbProcessInstanceBufferedCommand requireBufferedCommand(
-      final long bufferedKey, final long forProcessInstanceKey) {
-    bufferedCommandKey.wrapLong(bufferedKey);
-    final var stored =
-        bufferedCommandColumnFamily.get(bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
-    if (stored == null) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected to find buffered command with key '%d' for process instance '%d', but none "
-                  + "was stored; the buffered-command index is inconsistent",
-              bufferedKey, forProcessInstanceKey));
-    }
-    return stored;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
@@ -13,15 +13,19 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import java.util.ArrayList;
 import java.util.List;
-import org.jspecify.annotations.Nullable;
+import java.util.Optional;
+import org.slf4j.Logger;
 
 public final class DbSuspensionState implements MutableSuspensionState {
+
+  private static final Logger LOG = Loggers.STREAM_PROCESSING;
 
   private final DbLong processInstanceKey = new DbLong();
   private final SuspensionMarkerValue suspensionMarkerValue = new SuspensionMarkerValue();
@@ -97,20 +101,34 @@ public final class DbSuspensionState implements MutableSuspensionState {
   }
 
   @Override
-  public @Nullable BufferedCommand getOldestBufferedCommand(final long key) {
+  public Optional<BufferedCommand> getOldestBufferedCommand(final long key) {
     processInstanceKey.wrapLong(key);
     final var oldest = new BufferedCommand[1];
     bufferedCommandByProcessInstanceKeyColumnFamily.whileEqualPrefix(
         processInstanceKey,
         (compositeKey, nil) -> {
           final long bufferedKey = compositeKey.second().getValue();
-          oldest[0] =
-              new BufferedCommand(
-                  bufferedKey, requireBufferedCommand(bufferedKey, key).getRecord());
+          bufferedCommandKey.wrapLong(bufferedKey);
+          final var stored =
+              bufferedCommandColumnFamily.get(
+                  bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
+          if (stored == null) {
+            // broken invariant (see #requireBufferedCommand), but this sits on the resume hot
+            // path: log instead of throwing so a single corrupted entry halts the drain for this
+            // instance rather than failing the whole partition
+            LOG.error(
+                "Expected to find buffered command with key '{}' for process instance '{}', but "
+                    + "none was stored; the buffered-command index is inconsistent. Treating the "
+                    + "buffer as unreadable for this instance.",
+                bufferedKey,
+                key);
+            return false;
+          }
           // the secondary index is ordered by bufferedCommandKey, so the first hit is the oldest
+          oldest[0] = new BufferedCommand(bufferedKey, stored.getRecord());
           return false;
         });
-    return oldest[0];
+    return Optional.ofNullable(oldest[0]);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public final class DbSuspensionState implements MutableSuspensionState {
 
@@ -91,23 +92,47 @@ public final class DbSuspensionState implements MutableSuspensionState {
         processInstanceKey,
         (compositeKey, nil) -> {
           final long bufferedKey = compositeKey.second().getValue();
-          bufferedCommandKey.wrapLong(bufferedKey);
-          final var stored =
-              bufferedCommandColumnFamily.get(
-                  bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
-          if (stored == null) {
-            // the secondary index and the primary CF are written and deleted together in a single
-            // transaction (see #bufferCommand / #removeBufferedCommand), so a secondary-index entry
-            // with no matching primary record is a broken invariant. Fail loud rather than silently
-            // dropping a buffered command, which would lose forward progress on resume.
-            throw new IllegalStateException(
-                String.format(
-                    "Expected to find buffered command with key '%d' for process instance '%d', "
-                        + "but none was stored; the buffered-command index is inconsistent",
-                    bufferedKey, key));
-          }
-          visitor.visit(bufferedKey, stored.getRecord());
+          visitor.visit(bufferedKey, requireBufferedCommand(bufferedKey, key).getRecord());
         });
+  }
+
+  @Override
+  public @Nullable BufferedCommand getOldestBufferedCommand(final long key) {
+    processInstanceKey.wrapLong(key);
+    final var oldest = new BufferedCommand[1];
+    bufferedCommandByProcessInstanceKeyColumnFamily.whileEqualPrefix(
+        processInstanceKey,
+        (compositeKey, nil) -> {
+          final long bufferedKey = compositeKey.second().getValue();
+          oldest[0] =
+              new BufferedCommand(
+                  bufferedKey, requireBufferedCommand(bufferedKey, key).getRecord());
+          // the secondary index is ordered by bufferedCommandKey, so the first hit is the oldest
+          return false;
+        });
+    return oldest[0];
+  }
+
+  /**
+   * Loads the primary buffered-command record behind a secondary-index entry. The secondary index
+   * and the primary CF are written and deleted together in a single transaction (see {@link
+   * #bufferCommand} / {@link #removeBufferedCommand}), so a secondary-index entry with no matching
+   * primary record is a broken invariant. Fail loud rather than silently dropping a buffered
+   * command, which would lose forward progress on resume.
+   */
+  private DbProcessInstanceBufferedCommand requireBufferedCommand(
+      final long bufferedKey, final long forProcessInstanceKey) {
+    bufferedCommandKey.wrapLong(bufferedKey);
+    final var stored =
+        bufferedCommandColumnFamily.get(bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
+    if (stored == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to find buffered command with key '%d' for process instance '%d', but none "
+                  + "was stored; the buffered-command index is inconsistent",
+              bufferedKey, forProcessInstanceKey));
+    }
+    return stored;
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionGateTest.java
@@ -67,7 +67,7 @@ public final class MessageSuspensionGateTest {
   @Test
   public void shouldRejectMessageCorrelateWhileResuming() {
     // given - an instance waiting on a message catch event, with the RESUMING marker seeded
-    // directly (draining is implemented in a follow-up issue)
+    // directly to isolate the gate from the drain that puts the instance into that state
     final String processId = Strings.newRandomValidBpmnId();
     final String messageName = Strings.newRandomValidBpmnId();
     final String correlationKey = Strings.newRandomValidBpmnId();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public final class ProcessInstanceBufferedCommandDrainProcessorTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+  private static final long BUFFERED_COMMAND_KEY = 200L;
+
+  private MutableProcessingState processingState;
+
+  private StateWriter stateWriter;
+  private TypedCommandWriter commandWriter;
+  private ProcessInstanceBufferedCommandDrainProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    stateWriter = mock(StateWriter.class);
+    commandWriter = mock(TypedCommandWriter.class);
+
+    final var writers = mock(Writers.class);
+    when(writers.state()).thenReturn(stateWriter);
+    when(writers.command()).thenReturn(commandWriter);
+
+    processor = new ProcessInstanceBufferedCommandDrainProcessor(processingState, writers);
+  }
+
+  @Test
+  void shouldDropCommandAndContinueOnDrainError() {
+    // given
+    bufferCompleteElementCommand();
+
+    // when
+    final var result = processor.tryHandleError(drainCommand(), new RuntimeException("boom"));
+
+    // then
+    assertThat(result).isEqualTo(ProcessingError.EXPECTED_ERROR);
+    verify(stateWriter)
+        .appendFollowUpEvent(
+            eq(BUFFERED_COMMAND_KEY),
+            eq(ProcessInstanceBufferedCommandIntent.DRAINED),
+            any(ProcessInstanceBufferedCommandRecord.class));
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(PROCESS_INSTANCE_KEY),
+            eq(ProcessInstanceBufferedCommandIntent.DRAIN),
+            any(ProcessInstanceBufferedCommandRecord.class));
+  }
+
+  @Test
+  void shouldFallBackToUnexpectedErrorWhenNothingBuffered() {
+    // when
+    final var result = processor.tryHandleError(drainCommand(), new RuntimeException("boom"));
+
+    // then
+    assertThat(result).isEqualTo(ProcessingError.UNEXPECTED_ERROR);
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
+  }
+
+  @Test
+  void shouldNotWriteResumedWhenInstanceNoLongerExists() {
+    // when
+    processor.processRecord(drainCommand());
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
+  }
+
+  private void bufferCompleteElementCommand() {
+    final var command =
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setCommandKey(BUFFERED_COMMAND_KEY)
+            .setValueType(ValueType.PROCESS_INSTANCE)
+            .setIntent(ProcessInstanceIntent.COMPLETE_ELEMENT)
+            .setCommandValue(
+                new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
+    processingState.getSuspensionState().bufferCommand(BUFFERED_COMMAND_KEY, command);
+  }
+
+  private MockTypedRecord<ProcessInstanceBufferedCommandRecord> drainCommand() {
+    return new MockTypedRecord<>(
+        PROCESS_INSTANCE_KEY,
+        new RecordMetadata(),
+        new ProcessInstanceBufferedCommandRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBufferedCommandDrainProcessorTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,47 +57,49 @@ public final class ProcessInstanceBufferedCommandDrainProcessorTest {
   }
 
   @Test
-  void shouldDropCommandAndContinueOnDrainError() {
+  void shouldHaltWithoutWritesOnDrainErrorWhenBufferHasEntries() {
     // given
     bufferCompleteElementCommand();
 
     // when
     final var result = processor.tryHandleError(drainCommand(), new RuntimeException("boom"));
 
-    // then
-    assertThat(result).isEqualTo(ProcessingError.EXPECTED_ERROR);
-    verify(stateWriter)
-        .appendFollowUpEvent(
-            eq(BUFFERED_COMMAND_KEY),
-            eq(ProcessInstanceBufferedCommandIntent.DRAINED),
-            any(ProcessInstanceBufferedCommandRecord.class));
-    verify(commandWriter)
-        .appendFollowUpCommand(
-            eq(PROCESS_INSTANCE_KEY),
-            eq(ProcessInstanceBufferedCommandIntent.DRAIN),
-            any(ProcessInstanceBufferedCommandRecord.class));
-  }
-
-  @Test
-  void shouldFallBackToUnexpectedErrorWhenNothingBuffered() {
-    // when
-    final var result = processor.tryHandleError(drainCommand(), new RuntimeException("boom"));
-
-    // then
+    // then - state-free: does not re-read the buffer, drop the command, or continue the chain;
+    // the engine's default UNEXPECTED_ERROR handling rejects the DRAIN and halts the instance
     assertThat(result).isEqualTo(ProcessingError.UNEXPECTED_ERROR);
     verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
     verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
   }
 
   @Test
-  void shouldNotWriteResumedWhenInstanceNoLongerExists() {
+  void shouldHaltWithoutWritesOnDrainErrorWhenBufferEmpty() {
+    // when
+    final var result = processor.tryHandleError(drainCommand(), new RuntimeException("boom"));
+
+    // then - same outcome regardless of buffer contents, confirming the handler never queries it
+    assertThat(result).isEqualTo(ProcessingError.UNEXPECTED_ERROR);
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
+  }
+
+  @Test
+  void shouldAppendCompleteResumingWhenBufferEmpty() {
     // when
     processor.processRecord(drainCommand());
 
     // then
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(PROCESS_INSTANCE_KEY),
+            eq(ProcessInstanceIntent.COMPLETE_RESUMING),
+            any(ProcessInstanceRecord.class));
     verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
-    verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any());
   }
+
+  // Note: the peek-after-drain fast path (skip the extra DRAIN when the buffer just emptied) is
+  // not unit-testable here — stateWriter is mocked, so appendDrainedEvent's write never actually
+  // removes the entry from the real suspensionState this processor reads from. That behavior is
+  // covered end-to-end by ResumeProcessInstanceDrainTest instead.
 
   private void bufferCompleteElementCommand() {
     final var command =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public final class ProcessInstanceCompleteResumingProcessorTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+
+  private ElementInstanceState elementInstanceState;
+  private SuspensionState suspensionState;
+  private StateWriter stateWriter;
+  private TypedRejectionWriter rejectionWriter;
+  private ProcessInstanceCompleteResumingProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    elementInstanceState = mock(ElementInstanceState.class);
+    suspensionState = mock(SuspensionState.class);
+    stateWriter = mock(StateWriter.class);
+    rejectionWriter = mock(TypedRejectionWriter.class);
+
+    final var writers = mock(Writers.class);
+    when(writers.state()).thenReturn(stateWriter);
+    when(writers.rejection()).thenReturn(rejectionWriter);
+
+    processor =
+        new ProcessInstanceCompleteResumingProcessor(
+            elementInstanceState, suspensionState, writers);
+
+    // default: the common case of an active instance still marked RESUMING
+    when(suspensionState.getSuspensionState(PROCESS_INSTANCE_KEY))
+        .thenReturn(SuspensionState.State.RESUMING);
+  }
+
+  @Test
+  void shouldWriteResumedWhenInstanceExistsAndMarkerIsResuming() {
+    // given
+    final var record = new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    seedActiveInstance(record);
+
+    // when
+    processor.processRecord(continueResumingCommand());
+
+    // then
+    verify(stateWriter)
+        .appendFollowUpEvent(
+            eq(PROCESS_INSTANCE_KEY), eq(ProcessInstanceIntent.RESUMED), eq(record));
+    verify(rejectionWriter, never()).appendRejection(any(), any(), any());
+  }
+
+  @Test
+  void shouldRejectWhenInstanceCancelledMidDrain() {
+    // given - no element instance seeded; getInstance returns null
+
+    // when
+    processor.processRecord(continueResumingCommand());
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(rejectionWriter).appendRejection(any(), eq(RejectionType.INVALID_STATE), any());
+  }
+
+  @Test
+  void shouldRejectWhenMarkerIsNoLongerResuming() {
+    // given - a concurrent chain already finalized this instance
+    seedActiveInstance(new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
+    when(suspensionState.getSuspensionState(PROCESS_INSTANCE_KEY)).thenReturn(null);
+
+    // when
+    processor.processRecord(continueResumingCommand());
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    final var reasonCaptor = ArgumentCaptor.forClass(String.class);
+    verify(rejectionWriter)
+        .appendRejection(any(), eq(RejectionType.INVALID_STATE), reasonCaptor.capture());
+    assertThat(reasonCaptor.getValue()).contains("no longer RESUMING");
+  }
+
+  @Test
+  void shouldRejectWhenElementIsTerminating() {
+    // given
+    seedActiveInstance(
+        new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY),
+        ProcessInstanceIntent.ELEMENT_TERMINATING);
+
+    // when
+    processor.processRecord(continueResumingCommand());
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(rejectionWriter).appendRejection(any(), eq(RejectionType.INVALID_STATE), any());
+  }
+
+  @Test
+  void shouldRejectWhenElementIsCompleting() {
+    // given
+    seedActiveInstance(
+        new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY),
+        ProcessInstanceIntent.ELEMENT_COMPLETING);
+
+    // when
+    processor.processRecord(continueResumingCommand());
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(rejectionWriter).appendRejection(any(), eq(RejectionType.INVALID_STATE), any());
+  }
+
+  private void seedActiveInstance(final ProcessInstanceRecord record) {
+    seedActiveInstance(record, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+  }
+
+  private void seedActiveInstance(
+      final ProcessInstanceRecord record, final ProcessInstanceIntent state) {
+    final var elementInstance = mock(ElementInstance.class);
+    when(elementInstance.getValue()).thenReturn(record);
+    when(elementInstance.getState()).thenReturn(state);
+    when(elementInstanceState.getInstance(PROCESS_INSTANCE_KEY)).thenReturn(elementInstance);
+  }
+
+  private MockTypedRecord<ProcessInstanceRecord> continueResumingCommand() {
+    return new MockTypedRecord<>(
+        PROCESS_INSTANCE_KEY,
+        new RecordMetadata(),
+        new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeRestartTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeRestartTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * Covers restarting a resume that is stuck in {@code RESUMING} — accepting a fresh {@code RESUME}
+ * on a {@code RESUMING} (not just {@code SUSPENDED}) instance, and the safety of two overlapping
+ * drain chains that can result from it.
+ */
+public final class ProcessInstanceResumeRestartTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final int BUFFERED_COMMAND_COUNT = 5;
+  private static final int TAG_LENGTH_NEAR_MAX_FRAGMENT_SIZE = 4_193_450;
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRestartHaltedDrainWithoutDuplicateResumingEvent() {
+    // given - a halted resume: the drain is stuck in RESUMING because its one buffered command
+    // overflows the batch when re-emitted (see ResumeProcessInstanceDrainTest for the derivation
+    // of this tag length)
+    final long processInstanceKey = deployAndStart();
+    final var child = activatedChildren(processInstanceKey).getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferOversizedCommand(child);
+    resume(processInstanceKey);
+    final var firstRejection = awaitDrainRejection(processInstanceKey, 1);
+
+    // when - a second RESUME is sent while still RESUMING
+    resume(processInstanceKey);
+
+    // then - accepted and restarts the chain: a second DRAIN halts on the same command again,
+    // without a second RESUMING event being written
+    awaitDrainRejection(processInstanceKey, 2);
+    final var resumingEvents =
+        RecordingExporter.records()
+            .limit(r -> r.getPosition() >= firstRejection.getPosition())
+            .withValueType(ValueType.PROCESS_INSTANCE)
+            .withIntent(ProcessInstanceIntent.RESUMING)
+            .filter(r -> r.getKey() == processInstanceKey)
+            .asList();
+    assertThat(resumingEvents).hasSize(1);
+    assertThat(
+            ((MutableProcessingState) ENGINE.getProcessingState())
+                .getSuspensionState()
+                .getSuspensionState(processInstanceKey))
+        .isEqualTo(SuspensionState.State.RESUMING);
+  }
+
+  @Test
+  public void shouldDrainExactlyOnceWithTwoOverlappingResumeChains() {
+    // given
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferCompleteCommands(children);
+
+    // when - two RESUME commands queued before either is processed; by the time the second is
+    // processed the marker is already RESUMING, so it restarts the chain rather than being
+    // rejected or re-writing RESUMING
+    ENGINE.writeRecords(resumeCommand(processInstanceKey), resumeCommand(processInstanceKey));
+
+    // then - exactly one RESUMING and one RESUMED despite two RESUME commands
+    final var resumed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= resumed.getPosition())
+                .withValueType(ValueType.PROCESS_INSTANCE)
+                .withIntent(ProcessInstanceIntent.RESUMING)
+                .filter(r -> r.getKey() == processInstanceKey)
+                .asList())
+        .hasSize(1);
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= resumed.getPosition())
+                .withValueType(ValueType.PROCESS_INSTANCE)
+                .withIntent(ProcessInstanceIntent.RESUMED)
+                .filter(r -> r.getKey() == processInstanceKey)
+                .asList())
+        .hasSize(1);
+
+    // and - every buffered command drained exactly once, none reprocessed by the second chain
+    final var drained =
+        RecordingExporter.records()
+            .limit(r -> r.getPosition() >= resumed.getPosition())
+            .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+            .withIntent(ProcessInstanceBufferedCommandIntent.DRAINED)
+            .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+            .asList();
+    assertThat(commandKeys(drained)).doesNotHaveDuplicates().hasSize(BUFFERED_COMMAND_COUNT);
+
+    // and - each child element completed exactly once, not applied twice by the overlapping chain
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(BUFFERED_COMMAND_COUNT)
+                .asList())
+        .hasSize(BUFFERED_COMMAND_COUNT);
+  }
+
+  private static void resume(final long processInstanceKey) {
+    ENGINE.writeRecords(resumeCommand(processInstanceKey));
+  }
+
+  private static RecordToWrite resumeCommand(final long processInstanceKey) {
+    return RecordToWrite.command()
+        .processInstance(
+            ProcessInstanceIntent.RESUME,
+            new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey))
+        .key(processInstanceKey);
+  }
+
+  private static Record<RecordValue> awaitDrainRejection(
+      final long processInstanceKey, final int occurrence) {
+    return RecordingExporter.records()
+        .onlyCommandRejections()
+        .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+        .withIntent(ProcessInstanceBufferedCommandIntent.DRAIN)
+        .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+        .limit(occurrence)
+        .asList()
+        .getLast();
+  }
+
+  private static long deployAndStart() {
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE.deployment().withXmlResource(parallelMultiInstanceProcess(processId)).deploy();
+    return ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVariable("items", IntStream.range(0, BUFFERED_COMMAND_COUNT).boxed().toList())
+        .create();
+  }
+
+  private static BpmnModelInstance parallelMultiInstanceProcess(final String processId) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .serviceTask(
+            "task",
+            t ->
+                t.zeebeJobType("type")
+                    .multiInstance(
+                        m -> m.zeebeInputCollectionExpression("items").zeebeInputElement("item")))
+        .endEvent()
+        .done();
+  }
+
+  private static List<Record<ProcessInstanceRecordValue>> activatedChildren(
+      final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .limit(BUFFERED_COMMAND_COUNT)
+        .asList();
+  }
+
+  private static void bufferCompleteCommands(
+      final List<Record<ProcessInstanceRecordValue>> children) {
+    ENGINE.writeRecords(
+        children.stream()
+            .map(
+                child ->
+                    RecordToWrite.command()
+                        .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, child.getValue())
+                        .key(child.getKey()))
+            .toArray(RecordToWrite[]::new));
+  }
+
+  private static void bufferOversizedCommand(final Record<ProcessInstanceRecordValue> child) {
+    final var oversizedValue = new ProcessInstanceRecord();
+    oversizedValue.wrap((ProcessInstanceRecord) child.getValue());
+    oversizedValue.setTags(Set.of("x".repeat(TAG_LENGTH_NEAR_MAX_FRAGMENT_SIZE)));
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, oversizedValue)
+            .key(child.getKey()));
+  }
+
+  private static long processInstanceKeyOf(final Record<RecordValue> record) {
+    return ((ProcessInstanceBufferedCommandRecordValue) record.getValue()).getProcessInstanceKey();
+  }
+
+  private static List<Long> commandKeys(final List<Record<RecordValue>> records) {
+    return records.stream()
+        .map(r -> ((ProcessInstanceBufferedCommandRecordValue) r.getValue()).getCommandKey())
+        .toList();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.processinstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
@@ -52,6 +53,15 @@ public final class ResumeProcessInstanceDrainTest {
           ProcessInstanceIntent.ELEMENT_COMPLETED,
           ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN);
 
+  // A tag length picked to land inside the narrow window where the command still fits as a
+  // single record (so it buffers successfully) but overflows the batch once bundled with DRAINED
+  // + the next DRAIN during a drain cycle (three records in one append). Derived empirically from
+  // the engine's own framing formula (Sequencer#canWriteEvents, maxFragmentSize = 4 MiB default):
+  // the window is roughly tagLen in [4_193_260, 4_193_676); this sits at its midpoint for margin
+  // against per-record field overhead (e.g. a longer bpmnProcessId) that a synthetic measurement
+  // would not otherwise account for.
+  private static final int TAG_LENGTH_NEAR_MAX_FRAGMENT_SIZE = 4_193_450;
+
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 
   @Test
@@ -65,11 +75,12 @@ public final class ResumeProcessInstanceDrainTest {
     // when
     ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
 
-    // then - one DRAIN cycle per command, plus one final cycle that finds the buffer empty
+    // then - one DRAIN cycle per command; the last cycle finds the buffer empty and hands off to
+    // COMPLETE_RESUMING directly instead of an extra empty DRAIN cycle
     final var bufferedCommandRecords = bufferedCommandRecordsUntilResumed(processInstanceKey);
     assertThat(
             recordsWithIntent(bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAIN))
-        .hasSize(BUFFERED_COMMAND_COUNT + 1);
+        .hasSize(BUFFERED_COMMAND_COUNT);
 
     final var buffered =
         commandKeys(
@@ -158,6 +169,81 @@ public final class ResumeProcessInstanceDrainTest {
         .hasSize(BUFFERED_COMMAND_COUNT);
     assertThat(bufferedCommandRecords)
         .noneMatch(r -> r.getRejectionType() == RejectionType.EXCEEDED_BATCH_RECORD_SIZE);
+  }
+
+  @Test
+  public void shouldHaltDrainWithoutBanOrCrashWhenCommandExceedsBatchSize() {
+    // given - the buffered command is close enough to maxFragmentSize that bundling it with the
+    // DRAINED event and next DRAIN command overflows the batch
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    final var oversizedChild = children.getFirst();
+    bufferCommandNearMaxFragmentSize(oversizedChild);
+
+    // when - written directly rather than via the fluent resume() client, which by default
+    // blocks awaiting RESUMED; that event never arrives in this halted scenario
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstance(
+                ProcessInstanceIntent.RESUME,
+                new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey))
+            .key(processInstanceKey));
+
+    // then - the DRAIN is rejected instead of banning the instance or crashing the partition
+    final var rejection =
+        RecordingExporter.records()
+            .onlyCommandRejections()
+            .withRejectionType(RejectionType.EXCEEDED_BATCH_RECORD_SIZE)
+            .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+            .withIntent(ProcessInstanceBufferedCommandIntent.DRAIN)
+            .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+            .getFirst();
+    assertThat(rejection).isNotNull();
+
+    // and - the buffered command is still there, never drained
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= rejection.getPosition())
+                .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+                .withIntent(ProcessInstanceBufferedCommandIntent.DRAINED)
+                .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+                .asList())
+        .isEmpty();
+
+    // and - the marker stays RESUMING (not reverted to SUSPENDED, not removed)
+    assertThat(
+            ((MutableProcessingState) ENGINE.getProcessingState())
+                .getSuspensionState()
+                .getSuspensionState(processInstanceKey))
+        .isEqualTo(SuspensionState.State.RESUMING);
+
+    // and - the partition survived: an unrelated instance still processes normally afterward
+    final long otherInstanceKey = deployAndStart();
+    final var terminated = ENGINE.processInstance().withInstanceKey(otherInstanceKey).cancel();
+    assertThat(terminated).isNotNull();
+
+    // and - across all this, the halted instance never reached RESUMED
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= terminated.getPosition())
+                .withValueType(ValueType.PROCESS_INSTANCE)
+                .withIntent(ProcessInstanceIntent.RESUMED)
+                .filter(r -> r.getKey() == processInstanceKey)
+                .asList())
+        .isEmpty();
+  }
+
+  private static void bufferCommandNearMaxFragmentSize(
+      final Record<ProcessInstanceRecordValue> child) {
+    final var oversizedValue = new ProcessInstanceRecord();
+    oversizedValue.wrap((ProcessInstanceRecord) child.getValue());
+    oversizedValue.setTags(Set.of("x".repeat(TAG_LENGTH_NEAR_MAX_FRAGMENT_SIZE)));
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, oversizedValue)
+            .key(child.getKey()));
   }
 
   private static long deployAndStart() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public final class ResumeProcessInstanceDrainTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final int BUFFERED_COMMAND_COUNT = 5;
+  // five 1MB commands exceed the 4MB record batch limit, so an atomic drain would overflow
+  private static final String ONE_MEGABYTE_TAG = "x".repeat(1024 * 1024);
+
+  private static final Set<ProcessInstanceIntent> ELEMENT_LIFECYCLE_INTENTS =
+      EnumSet.of(
+          ProcessInstanceIntent.ELEMENT_ACTIVATING,
+          ProcessInstanceIntent.ELEMENT_ACTIVATED,
+          ProcessInstanceIntent.ELEMENT_COMPLETING,
+          ProcessInstanceIntent.ELEMENT_COMPLETED,
+          ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN);
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDrainBufferedCommandsOneCycleAtATime() {
+    // given
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferCompleteCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - one DRAIN cycle per command, plus one final cycle that finds the buffer empty
+    final var bufferedCommandRecords = bufferedCommandRecordsUntilResumed(processInstanceKey);
+    assertThat(
+            recordsWithIntent(bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAIN))
+        .hasSize(BUFFERED_COMMAND_COUNT + 1);
+
+    final var buffered =
+        commandKeys(
+            recordsWithIntent(
+                bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.BUFFERED));
+    final var drained =
+        commandKeys(
+            recordsWithIntent(
+                bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAINED));
+    assertThat(buffered).hasSize(BUFFERED_COMMAND_COUNT);
+    assertThat(drained).containsExactlyElementsOf(buffered);
+  }
+
+  @Test
+  public void shouldStayResumingUntilTheBufferIsDrained() {
+    // given
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferCompleteCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then
+    final var resuming =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMING)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    final var resumed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(resuming.getPosition()).isLessThan(resumed.getPosition());
+
+    final var drained =
+        recordsWithIntent(
+            bufferedCommandRecordsUntilResumed(processInstanceKey),
+            ProcessInstanceBufferedCommandIntent.DRAINED);
+    assertThat(drained).hasSize(BUFFERED_COMMAND_COUNT);
+    assertThat(drained.getLast().getPosition()).isLessThan(resumed.getPosition());
+
+    // suspension marker removed once RESUMED applied
+    assertThat(
+            ((MutableProcessingState) ENGINE.getProcessingState())
+                .getSuspensionState()
+                .getSuspensionState(processInstanceKey))
+        .isNull();
+  }
+
+  @Test
+  public void shouldReachSameStateAsNeverSuspendedRun() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final long controlInstanceKey = deployAndStart(processId);
+    bufferCompleteCommands(activatedChildren(controlInstanceKey));
+
+    final long processInstanceKey = start(processId);
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferCompleteCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then
+    assertThat(elementLifecycle(processInstanceKey))
+        .containsExactlyInAnyOrderElementsOf(elementLifecycle(controlInstanceKey));
+  }
+
+  @Test
+  public void shouldDrainBufferLargerThanASingleRecordBatch() {
+    // given
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferOversizedCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then
+    final var bufferedCommandRecords = bufferedCommandRecordsUntilResumed(processInstanceKey);
+    assertThat(
+            recordsWithIntent(bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAINED))
+        .hasSize(BUFFERED_COMMAND_COUNT);
+    assertThat(bufferedCommandRecords)
+        .noneMatch(r -> r.getRejectionType() == RejectionType.EXCEEDED_BATCH_RECORD_SIZE);
+  }
+
+  private static long deployAndStart() {
+    return deployAndStart(Strings.newRandomValidBpmnId());
+  }
+
+  private static long deployAndStart(final String processId) {
+    ENGINE.deployment().withXmlResource(parallelMultiInstanceProcess(processId)).deploy();
+    return start(processId);
+  }
+
+  private static long start(final String processId) {
+    return ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVariable("items", IntStream.range(0, BUFFERED_COMMAND_COUNT).boxed().toList())
+        .create();
+  }
+
+  private static BpmnModelInstance parallelMultiInstanceProcess(final String processId) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .serviceTask(
+            "task",
+            t ->
+                t.zeebeJobType("type")
+                    .multiInstance(
+                        m -> m.zeebeInputCollectionExpression("items").zeebeInputElement("item")))
+        .endEvent()
+        .done();
+  }
+
+  private static List<Record<ProcessInstanceRecordValue>> activatedChildren(
+      final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .limit(BUFFERED_COMMAND_COUNT)
+        .asList();
+  }
+
+  private static void bufferCompleteCommands(
+      final List<Record<ProcessInstanceRecordValue>> children) {
+    ENGINE.writeRecords(
+        children.stream()
+            .map(
+                child ->
+                    RecordToWrite.command()
+                        .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, child.getValue())
+                        .key(child.getKey()))
+            .toArray(RecordToWrite[]::new));
+  }
+
+  // targets non-existent keys so each command is rejected once drained, not processed
+  private static void bufferOversizedCommands(
+      final List<Record<ProcessInstanceRecordValue>> children) {
+    children.forEach(
+        child -> {
+          final var oversizedValue = new ProcessInstanceRecord();
+          oversizedValue.wrap((ProcessInstanceRecord) child.getValue());
+          oversizedValue.setTags(Set.of(ONE_MEGABYTE_TAG));
+
+          ENGINE.writeRecords(
+              RecordToWrite.command()
+                  .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, oversizedValue)
+                  .key(child.getKey() + BUFFERED_COMMAND_COUNT * 1_000_000L));
+        });
+  }
+
+  private static List<Record<RecordValue>> bufferedCommandRecordsUntilResumed(
+      final long processInstanceKey) {
+    final var resumed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    return RecordingExporter.records()
+        .limit(r -> r.getPosition() >= resumed.getPosition())
+        .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+        .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+        .asList();
+  }
+
+  private static List<Record<RecordValue>> recordsWithIntent(
+      final List<Record<RecordValue>> records, final ProcessInstanceBufferedCommandIntent intent) {
+    return records.stream().filter(r -> r.getIntent() == intent).toList();
+  }
+
+  private static List<Long> commandKeys(final List<Record<RecordValue>> records) {
+    return records.stream()
+        .map(r -> ((ProcessInstanceBufferedCommandRecordValue) r.getValue()).getCommandKey())
+        .toList();
+  }
+
+  private static long processInstanceKeyOf(final Record<RecordValue> record) {
+    return ((ProcessInstanceBufferedCommandRecordValue) record.getValue()).getProcessInstanceKey();
+  }
+
+  private static List<String> elementLifecycle(final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limitToProcessInstanceCompleted()
+        .filter(r -> ELEMENT_LIFECYCLE_INTENTS.contains(r.getIntent()))
+        .map(r -> r.getIntent() + ":" + r.getValue().getElementId())
+        .toList();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainWithoutCommandBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainWithoutCommandBatchingTest.java
@@ -51,11 +51,12 @@ public final class ResumeProcessInstanceDrainWithoutCommandBatchingTest {
     // when
     ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
 
-    // then
+    // then - one DRAIN cycle per command; the last cycle finds the buffer empty and hands off to
+    // COMPLETE_RESUMING directly instead of an extra empty DRAIN cycle
     final var bufferedCommandRecords = bufferedCommandRecordsUntilResumed(processInstanceKey);
     assertThat(
             recordsWithIntent(bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAIN))
-        .hasSize(BUFFERED_COMMAND_COUNT + 1);
+        .hasSize(BUFFERED_COMMAND_COUNT);
 
     final var buffered =
         commandKeys(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainWithoutCommandBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ResumeProcessInstanceDrainWithoutCommandBatchingTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public final class ResumeProcessInstanceDrainWithoutCommandBatchingTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE = EngineRule.singlePartition().maxCommandsInBatch(1);
+
+  private static final int BUFFERED_COMMAND_COUNT = 10;
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDrainWhenEveryCycleIsCommittedSeparately() {
+    // given
+    final long processInstanceKey = deployAndStart();
+    final var children = activatedChildren(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferCompleteCommands(children);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then
+    final var bufferedCommandRecords = bufferedCommandRecordsUntilResumed(processInstanceKey);
+    assertThat(
+            recordsWithIntent(bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAIN))
+        .hasSize(BUFFERED_COMMAND_COUNT + 1);
+
+    final var buffered =
+        commandKeys(
+            recordsWithIntent(
+                bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.BUFFERED));
+    final var drained =
+        commandKeys(
+            recordsWithIntent(
+                bufferedCommandRecords, ProcessInstanceBufferedCommandIntent.DRAINED));
+    assertThat(buffered).hasSize(BUFFERED_COMMAND_COUNT);
+    assertThat(drained).containsExactlyElementsOf(buffered);
+    assertThat(bufferedCommandRecords)
+        .noneMatch(r -> r.getRejectionType() == RejectionType.EXCEEDED_BATCH_RECORD_SIZE);
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  private static long deployAndStart() {
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    t ->
+                        t.zeebeJobType("type")
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    return ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVariable("items", IntStream.range(0, BUFFERED_COMMAND_COUNT).boxed().toList())
+        .create();
+  }
+
+  private static List<Record<ProcessInstanceRecordValue>> activatedChildren(
+      final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .limit(BUFFERED_COMMAND_COUNT)
+        .asList();
+  }
+
+  private static void bufferCompleteCommands(
+      final List<Record<ProcessInstanceRecordValue>> children) {
+    ENGINE.writeRecords(
+        children.stream()
+            .map(
+                child ->
+                    RecordToWrite.command()
+                        .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, child.getValue())
+                        .key(child.getKey()))
+            .toArray(RecordToWrite[]::new));
+  }
+
+  private static List<Record<RecordValue>> bufferedCommandRecordsUntilResumed(
+      final long processInstanceKey) {
+    final var resumed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    return RecordingExporter.records()
+        .limit(r -> r.getPosition() >= resumed.getPosition())
+        .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+        .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+        .asList();
+  }
+
+  private static List<Record<RecordValue>> recordsWithIntent(
+      final List<Record<RecordValue>> records, final ProcessInstanceBufferedCommandIntent intent) {
+    return records.stream().filter(r -> r.getIntent() == intent).toList();
+  }
+
+  private static List<Long> commandKeys(final List<Record<RecordValue>> records) {
+    return records.stream()
+        .map(r -> ((ProcessInstanceBufferedCommandRecordValue) r.getValue()).getCommandKey())
+        .toList();
+  }
+
+  private static long processInstanceKeyOf(final Record<RecordValue> record) {
+    return ((ProcessInstanceBufferedCommandRecordValue) record.getValue()).getProcessInstanceKey();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspensionGateTest.java
@@ -99,8 +99,8 @@ public final class SuspensionGateTest {
 
   @Test
   public void shouldPassThroughBufferCategoryCommandWhileResuming() {
-    // given - seed the RESUMING marker directly since it is currently unreachable in production
-    // (draining is implemented in a follow-up issue)
+    // given - seed the RESUMING marker directly to isolate the gate from the drain that puts the
+    // instance into that state in production
     final String processId = Strings.newRandomValidBpmnId();
     final String jobType = Strings.newRandomValidBpmnId();
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SuspensionAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SuspensionAppliersTest.java
@@ -31,6 +31,7 @@ public class SuspensionAppliersTest {
 
   private MutableSuspensionState suspensionState;
   private ProcessInstanceSuspendedApplier suspendedApplier;
+  private ProcessInstanceResumingApplier resumingApplier;
   private ProcessInstanceResumedApplier resumedApplier;
   private ProcessInstanceBufferedCommandBufferedApplier bufferedApplier;
   private ProcessInstanceBufferedCommandDrainedApplier drainedApplier;
@@ -39,6 +40,7 @@ public class SuspensionAppliersTest {
   public void setup() {
     suspensionState = processingState.getSuspensionState();
     suspendedApplier = new ProcessInstanceSuspendedApplier(suspensionState);
+    resumingApplier = new ProcessInstanceResumingApplier(suspensionState);
     resumedApplier = new ProcessInstanceResumedApplier(suspensionState);
     bufferedApplier = new ProcessInstanceBufferedCommandBufferedApplier(suspensionState);
     drainedApplier = new ProcessInstanceBufferedCommandDrainedApplier(suspensionState);
@@ -57,6 +59,33 @@ public class SuspensionAppliersTest {
     assertThat(suspensionState.isSuspended(processInstanceKey)).isTrue();
     assertThat(suspensionState.getSuspensionState(processInstanceKey))
         .isEqualTo(SuspensionState.State.SUSPENDED);
+  }
+
+  @Test
+  void shouldSwitchMarkerToResumingWithoutTouchingTheBuffer() {
+    // given
+    final long processInstanceKey = 5L;
+    final long bufferedCommandKey = 50L;
+    suspensionState.setSuspensionState(processInstanceKey, SuspensionState.State.SUSPENDED);
+    bufferedApplier.applyState(
+        bufferedCommandKey,
+        new ProcessInstanceBufferedCommandRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setCommandKey(51L));
+
+    // when
+    resumingApplier.applyState(processInstanceKey, new ProcessInstanceRecord());
+
+    // then - the marker is still present, so the suspension gate keeps recognizing the instance
+    assertThat(suspensionState.isSuspended(processInstanceKey)).isTrue();
+    assertThat(suspensionState.getSuspensionState(processInstanceKey))
+        .isEqualTo(SuspensionState.State.RESUMING);
+
+    // and the buffered commands are left for the drain to replay
+    final List<Long> visitedKeys = new ArrayList<>();
+    suspensionState.visitBufferedCommands(
+        processInstanceKey, (key, command) -> visitedKeys.add(key));
+    assertThat(visitedKeys).containsExactly(bufferedCommandKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
@@ -225,9 +225,9 @@ public final class SuspensionStateTest {
     final var oldest = suspensionState.getOldestBufferedCommand(processInstanceKey);
 
     // then
-    assertThat(oldest).isNotNull();
-    assertThat(oldest.key()).isEqualTo(10L);
-    assertThat(oldest.command().getCommandKey()).isEqualTo(1L);
+    assertThat(oldest).isPresent();
+    assertThat(oldest.get().key()).isEqualTo(10L);
+    assertThat(oldest.get().command().getCommandKey()).isEqualTo(1L);
   }
 
   @Test
@@ -239,7 +239,8 @@ public final class SuspensionStateTest {
     suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKeyB, 2L));
 
     // when - then
-    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKeyB).key()).isEqualTo(20L);
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKeyB).orElseThrow().key())
+        .isEqualTo(20L);
   }
 
   @Test
@@ -248,7 +249,7 @@ public final class SuspensionStateTest {
     final long processInstanceKey = 1L;
 
     // when - then
-    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKey)).isNull();
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKey)).isEmpty();
   }
 
   @Test
@@ -262,7 +263,8 @@ public final class SuspensionStateTest {
     suspensionState.removeBufferedCommand(10L);
 
     // then
-    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKey).key()).isEqualTo(20L);
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKey).orElseThrow().key())
+        .isEqualTo(20L);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
@@ -214,6 +214,58 @@ public final class SuspensionStateTest {
   }
 
   @Test
+  public void shouldGetOldestBufferedCommandRegardlessOfInsertionOrder() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.bufferCommand(30L, bufferedCommandRecord(processInstanceKey, 3L));
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKey, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKey, 2L));
+
+    // when
+    final var oldest = suspensionState.getOldestBufferedCommand(processInstanceKey);
+
+    // then
+    assertThat(oldest).isNotNull();
+    assertThat(oldest.key()).isEqualTo(10L);
+    assertThat(oldest.command().getCommandKey()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldGetOldestBufferedCommandOfRequestedProcessInstanceOnly() {
+    // given
+    final long processInstanceKeyA = 1L;
+    final long processInstanceKeyB = 2L;
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKeyA, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKeyB, 2L));
+
+    // when - then
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKeyB).key()).isEqualTo(20L);
+  }
+
+  @Test
+  public void shouldNotGetOldestBufferedCommandWithNothingBuffered() {
+    // given
+    final long processInstanceKey = 1L;
+
+    // when - then
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKey)).isNull();
+  }
+
+  @Test
+  public void shouldGetNextOldestBufferedCommandAfterTheOldestIsRemoved() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKey, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKey, 2L));
+
+    // when - the drain removes the head of the buffer
+    suspensionState.removeBufferedCommand(10L);
+
+    // then
+    assertThat(suspensionState.getOldestBufferedCommand(processInstanceKey).key()).isEqualTo(20L);
+  }
+
+  @Test
   public void shouldRemoveExactlyOneBufferedCommand() {
     // given
     final long processInstanceKey = 1L;

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_RESUMING_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_RESUMING_v1.golden
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+final class ProcessInstanceResumingApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  ProcessInstanceResumingApplier(final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    // SUSPENDED → RESUMING: gate still rejects external commands but lets drain internals through
+    suspensionState.setSuspensionState(key, SuspensionState.State.RESUMING);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_RESUMING_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_RESUMING_v1.golden
@@ -24,7 +24,8 @@ final class ProcessInstanceResumingApplier
 
   @Override
   public void applyState(final long key, final ProcessInstanceRecord value) {
-    // SUSPENDED → RESUMING: gate still rejects external commands but lets drain internals through
+    // SUSPENDED → RESUMING: gate still rejects commands, but now processes BUFFER-classified
+    // commands (the drain's internal follow-ups) instead of buffering them again
     suspensionState.setSuspensionState(key, SuspensionState.State.RESUMING);
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -72,7 +72,14 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   SUSPEND((short) 17, false),
   SUSPENDED((short) 18),
   RESUME((short) 19, false),
-  RESUMED((short) 20);
+  RESUMED((short) 20),
+
+  /**
+   * Represents the intent that signals that a suspended process instance has started resuming: the
+   * commands that were buffered while it was suspended are being drained, and the instance is not
+   * fully resumed until {@link #RESUMED} is written.
+   */
+  RESUMING((short) 21);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS =
       EnumSet.of(CANCEL, SUSPEND, RESUME);
@@ -144,6 +151,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return RESUME;
       case 20:
         return RESUMED;
+      case 21:
+        return RESUMING;
       default:
         return Intent.UNKNOWN;
     }
@@ -169,6 +178,7 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       case SEQUENCE_FLOW_DELETED:
       case CANCELING:
       case SUSPENDED:
+      case RESUMING:
       case RESUMED:
         return true;
       default:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -87,10 +87,10 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    * dedicated processor reacts by writing {@link #RESUMED} and triggering any post-resume actions
    * (e.g. resuming suspended jobs).
    */
-  CONTINUE_RESUMING((short) 22, false);
+  COMPLETE_RESUMING((short) 22, false);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS =
-      EnumSet.of(CANCEL, SUSPEND, RESUME, CONTINUE_RESUMING);
+      EnumSet.of(CANCEL, SUSPEND, RESUME, COMPLETE_RESUMING);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
       EnumSet.of(
           ACTIVATE_ELEMENT,
@@ -162,7 +162,7 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       case 21:
         return RESUMING;
       case 22:
-        return CONTINUE_RESUMING;
+        return COMPLETE_RESUMING;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -79,10 +79,18 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    * commands that were buffered while it was suspended are being drained, and the instance is not
    * fully resumed until {@link #RESUMED} is written.
    */
-  RESUMING((short) 21);
+  RESUMING((short) 21),
+
+  /**
+   * Represents the internal command that finalizes the resume lifecycle once the buffered-command
+   * drain is complete. The drain processor writes this command when the buffer is empty; a
+   * dedicated processor reacts by writing {@link #RESUMED} and triggering any post-resume actions
+   * (e.g. resuming suspended jobs).
+   */
+  CONTINUE_RESUMING((short) 22, false);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS =
-      EnumSet.of(CANCEL, SUSPEND, RESUME);
+      EnumSet.of(CANCEL, SUSPEND, RESUME, CONTINUE_RESUMING);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
       EnumSet.of(
           ACTIVATE_ELEMENT,
@@ -153,6 +161,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return RESUMED;
       case 21:
         return RESUMING;
+      case 22:
+        return CONTINUE_RESUMING;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBufferedCommandRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBufferedCommandRecordValue.java
@@ -23,7 +23,7 @@ import org.immutables.value.Value;
 
 /**
  * Carries a command that arrived while its target was unable to process it immediately (e.g. a
- * suspended process instance), so it can be replayed later via {@code DRAIN}.
+ * suspended process instance), so it can be written back to the log later via {@code DRAIN}.
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceBufferedCommandRecordValue.Builder.class)

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
@@ -41,6 +41,7 @@ final class ProcessInstanceIntentTest {
   void shouldMarkSuspendedAndResumedAsEvents() {
     // given / when / then
     assertThat(ProcessInstanceIntent.SUSPENDED.isEvent()).isTrue();
+    assertThat(ProcessInstanceIntent.RESUMING.isEvent()).isTrue();
     assertThat(ProcessInstanceIntent.RESUMED.isEvent()).isTrue();
   }
 
@@ -58,5 +59,6 @@ final class ProcessInstanceIntentTest {
     assertThat(ProcessInstanceIntent.from((short) 18)).isEqualTo(ProcessInstanceIntent.SUSPENDED);
     assertThat(ProcessInstanceIntent.from((short) 19)).isEqualTo(ProcessInstanceIntent.RESUME);
     assertThat(ProcessInstanceIntent.from((short) 20)).isEqualTo(ProcessInstanceIntent.RESUMED);
+    assertThat(ProcessInstanceIntent.from((short) 21)).isEqualTo(ProcessInstanceIntent.RESUMING);
   }
 }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
@@ -60,5 +60,7 @@ final class ProcessInstanceIntentTest {
     assertThat(ProcessInstanceIntent.from((short) 19)).isEqualTo(ProcessInstanceIntent.RESUME);
     assertThat(ProcessInstanceIntent.from((short) 20)).isEqualTo(ProcessInstanceIntent.RESUMED);
     assertThat(ProcessInstanceIntent.from((short) 21)).isEqualTo(ProcessInstanceIntent.RESUMING);
+    assertThat(ProcessInstanceIntent.from((short) 22))
+        .isEqualTo(ProcessInstanceIntent.CONTINUE_RESUMING);
   }
 }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
@@ -61,6 +61,6 @@ final class ProcessInstanceIntentTest {
     assertThat(ProcessInstanceIntent.from((short) 20)).isEqualTo(ProcessInstanceIntent.RESUMED);
     assertThat(ProcessInstanceIntent.from((short) 21)).isEqualTo(ProcessInstanceIntent.RESUMING);
     assertThat(ProcessInstanceIntent.from((short) 22))
-        .isEqualTo(ProcessInstanceIntent.CONTINUE_RESUMING);
+        .isEqualTo(ProcessInstanceIntent.COMPLETE_RESUMING);
   }
 }


### PR DESCRIPTION
## Description

Adds the chunked drain to `ProcessInstanceResumeProcessor`.

`RESUME` now writes a new `ProcessInstanceIntent.RESUMING` event — switching the suspension marker from `SUSPENDED` to `RESUMING` so the gate lets the drained commands through — and appends the first `ProcessInstanceBufferedCommandIntent.DRAIN`. Each `DRAIN` cycle writes exactly one buffered command back to the log in FIFO order, writes `DRAINED` to remove it from the buffer, and appends the next `DRAIN` for itself.

**A drained command is handed back to the engine unchanged**, so its own processor decides what to do with it, including whether the failure is worth an incident. `tryHandleError` on the drain itself just logs, drops the command that could not be written, and appends the next `DRAIN` so the chain keeps going — without the drop the next cycle would fail on the same command forever, without the `DRAIN` the instance would never leave `RESUMING`.

The cycle that finds the buffer empty does not write `RESUMED` itself. It appends a new internal command, `ProcessInstanceIntent.CONTINUE_RESUMING`, handled by a dedicated `ProcessInstanceContinueResumingProcessor` that writes `RESUMED` and removes the suspension marker. This hands control of the end of the resume lifecycle to its own processor rather than the drain loop, so that future post-resume steps (e.g. handing parked jobs out again, see #59812) have a natural place to run — after `RESUMED`, not interleaved with the drain.

### Tests

- `ResumeProcessInstanceDrainTest`: one drain cycle per buffered command, FIFO order preserved, `RESUMING` before / `RESUMED` after the drain, a buffer larger than one record batch drains without overflow, an undrainable command is dropped and the chain continues, and the resumed run reaches the same element lifecycle as a never-suspended control run.
- `ResumeProcessInstanceDrainWithoutCommandBatchingTest`: the same drain forced to commit each `DRAIN` cycle separately (`maxCommandsInBatch(1)`) instead of letting the stream processor fuse them, so the chain is proven to survive without relying on that fusion.
- `ProcessInstanceBufferedCommandDrainProcessorTest` / `ProcessInstanceContinueResumingProcessorTest`: unit tests against mocked writers for the drain-error and cancelled-mid-drain branches that are impractical to hit through `EngineRule` (an exact 4MB-boundary buffered command, or winning a cancel-vs-drain race).
- `ProcessInstanceSuspendResumeIT`: end-to-end acceptance coverage through the public API — suspend, verify via get/search, resume, verify; plus a job rejected while suspended and accepted once resumed.
  - The job-completion half of `shouldSuspendAndResumeAndCompleteAsIfNeverSuspended` (activating and completing the resumed instance's parked job) is commented out with a `TODO(#59812)`: suspend already parks every `ACTIVATABLE` job out of the hand-out index, but nothing on `main` writes `Job.RESUMED` yet, so the resumed instance's job never becomes activatable again. Re-instate once #59812 merges.
- `SuspensionStateTest`, `SuspensionAppliersTest`, `ProcessInstanceIntentTest` extended for `getOldestBufferedCommand`, the `RESUMING` applier/intent, and `CONTINUE_RESUMING`.
- New golden file `ProcessInstance_RESUMING_v1.golden` for `EventAppliersTest`.

### Reviewer notes

- https://github.com/camunda/camunda/issues/57524 will handle suspension state cleanup in case of termination of the PI
- https://github.com/camunda/camunda/issues/57793 will handle adding metrics for dropped drain commands due to errors

## Checklist

- [ ] Enable backports when necessary — not needed, this is part of an unreleased feature on `main`.

## Related issues

closes #57792
