### PR TITLE
Add tests to check whether secret resolution is prevented from resuming a suspended job

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -267,8 +267,7 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void makeActivatableAfterSecretResolution(final long key) {
     if (!isInState(key, State.WAITING_FOR_SECRET_RESOLUTION)) {
-      // the job is gone, or was already reactivated by another resolved reference of the same
-      // activation; re-inserting it in either case corrupts the activatable index
+      // no-op unless waiting; re-inserting otherwise corrupts the activatable index
       return;
     }
     final JobRecord record = getJob(key);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -70,7 +70,11 @@ public interface MutableJobState extends JobState {
 
   /**
    * Makes a job activatable after its pending secret references have been resolved. Does nothing
-   * unless the job is in {@link State#WAITING_FOR_SECRET_RESOLUTION}.
+   * unless the job is in {@link State#WAITING_FOR_SECRET_RESOLUTION}, because a job can be
+   * reactivated by more than one resolved reference of the same activation, or may have left that
+   * state for another reason (for example suspension) by then. A job that carries a secret
+   * resolution incident is still waiting, so keeping it parked until the incident is resolved is up
+   * to the caller.
    */
   void makeActivatableAfterSecretResolution(long key);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -70,10 +70,7 @@ public interface MutableJobState extends JobState {
 
   /**
    * Makes a job activatable after its pending secret references have been resolved. Does nothing
-   * unless the job is in {@link State#WAITING_FOR_SECRET_RESOLUTION}, because a job can be
-   * reactivated by more than one resolved reference of the same activation and may be gone by then.
-   * A job that carries a secret resolution incident is still waiting, so keeping it parked until
-   * the incident is resolved is up to the caller.
+   * unless the job is in {@link State#WAITING_FOR_SECRET_RESOLUTION}.
    */
   void makeActivatableAfterSecretResolution(long key);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
@@ -104,7 +104,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
     // when
     applier.applyState(100L, value);
 
-    // then - the (storeId, secretReference) prefix no longer visits this job key
+    // then
     final var stillWaiting = new java.util.concurrent.atomic.AtomicBoolean(false);
     secretReferenceState.visitJobsBySecretReference(
         STORE_ID,
@@ -120,8 +120,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
 
   @Test
   void shouldNotMakeJobActivatableWhenOtherRefsArePending() {
-    // given - job is parked and waiting on two references; one is being resolved (secret1),
-    //         but the other (secret2) is still pending
+    // given
     final long jobKey = 4L;
     createParkedJob(jobKey);
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
@@ -137,7 +136,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
     // when
     applier.applyState(100L, value);
 
-    // then - the secret1 waiting entry is removed
+    // then
     final var stillWaiting = new java.util.concurrent.atomic.AtomicBoolean(false);
     secretReferenceState.visitJobsBySecretReference(
         STORE_ID,
@@ -149,15 +148,12 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
           return true;
         });
     assertThat(stillWaiting.get()).isFalse();
-
-    // but job is NOT made activatable, it still waits on secret2
     assertThat(jobState.getState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
   }
 
   @Test
   void shouldNotDisturbJobThatWasAlreadyReactivated() {
-    // given - a job waiting on two references that both resolved, so the batch event of the first
-    //         one already reactivated it and a worker activated it since
+    // given
     final long jobKey = 6L;
     final var job = createParkedJob(jobKey);
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
@@ -170,10 +166,10 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
             .setSecretReference(SECRET_REF)
             .addJobKey(jobKey);
 
-    // when - the batch event of the second reference reactivates the same job again
+    // when
     applier.applyState(100L, value);
 
-    // then - the activated job is left alone, it is not handed out a second time
+    // then
     assertThat(jobState.getState(jobKey)).isEqualTo(State.ACTIVATED);
     final var activatableJobs = new ArrayList<Long>();
     jobState.forEachActivatableJobs(
@@ -187,9 +183,49 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
   }
 
   @Test
+  void shouldNotMakeSuspendedJobActivatable() {
+    // given
+    final long jobKey = 7L;
+    final var job = createParkedJob(jobKey);
+    jobState.updateJobState(jobKey, State.SUSPENDED);
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(jobKey);
+
+    // when
+    applier.applyState(100L, value);
+
+    // then
+    final var stillWaiting = new java.util.concurrent.atomic.AtomicBoolean(false);
+    secretReferenceState.visitJobsBySecretReference(
+        STORE_ID,
+        SECRET_REF,
+        visitedJobKey -> {
+          if (visitedJobKey == jobKey) {
+            stillWaiting.set(true);
+          }
+          return true;
+        });
+    assertThat(stillWaiting.get()).isFalse();
+    assertThat(jobState.getState(jobKey)).isEqualTo(State.SUSPENDED);
+    final var activatableJobs = new ArrayList<Long>();
+    jobState.forEachActivatableJobs(
+        job.getTypeBuffer(),
+        List.of(job.getTenantId()),
+        (key, record) -> {
+          activatableJobs.add(key);
+          return true;
+        });
+    assertThat(activatableJobs).isEmpty();
+  }
+
+  @Test
   void shouldNotMakeJobActivatableWhenJobHasOpenIncident() {
-    // given - a parked job waiting on the secret reference, with an open incident raised for an
-    //         earlier failed secret reference of the same job
+    // given
     final long jobKey = 5L;
     final var jobRecord = createParkedJob(jobKey);
     processingState
@@ -212,8 +248,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
     // when
     applier.applyState(100L, value);
 
-    // then - the waiting entry is removed, but the job stays parked; resolving the incident is
-    //        the only path that reactivates it
+    // then
     assertThat(jobState.getState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
     final var activatableJobs = new ArrayList<Long>();
     jobState.forEachActivatableJobs(
@@ -228,7 +263,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
 
   @Test
   void shouldSkipActivationIfJobNoLongerExistsInState() {
-    // given - a waiting-job entry exists but the job itself was already removed
+    // given
     final long jobKey = 3L;
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
     secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
@@ -238,7 +273,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
             .setSecretReference(SECRET_REF)
             .addJobKey(jobKey);
 
-    // when / then - no exception is thrown and the waiting entry is still removed
+    // when / then
     applier.applyState(100L, value);
 
     final var stillWaiting = new java.util.concurrent.atomic.AtomicBoolean(false);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -383,7 +383,7 @@ public final class JobStateTest {
 
   @Test
   public void shouldNotParkJobForSecretResolutionWhenItIsNotUpForActivation() {
-    // given - a job a worker already holds
+    // given
     final long jobKey = 1L;
     final JobRecord jobRecord = newJobRecord();
     createAndActivateJobRecord(jobKey, jobRecord);
@@ -391,13 +391,13 @@ public final class JobStateTest {
     // when
     jobState.parkForSecretResolution(jobKey, jobRecord);
 
-    // then - the activation keeps the job, parking it would take its state away from the worker
+    // then
     assertJobState(jobKey, State.ACTIVATED);
   }
 
   @Test
   public void shouldMakeWaitingJobActivatableAfterSecretResolution() {
-    // given - a job parked while its secret references are resolved
+    // given
     final long jobKey = 1L;
     final JobRecord jobRecord = newJobRecord();
     parkJobForSecretResolution(jobKey, jobRecord);
@@ -412,19 +412,35 @@ public final class JobStateTest {
 
   @Test
   public void shouldNotMakeJobActivatableAfterSecretResolutionWhenItNoLongerWaits() {
-    // given - a job that was already reactivated by another resolved reference of the same
-    // activation, and has been activated by a worker since
+    // given
     final long jobKey = 1L;
     final JobRecord jobRecord = newJobRecord();
     parkJobForSecretResolution(jobKey, jobRecord);
     jobState.makeActivatableAfterSecretResolution(jobKey);
     jobState.activate(jobKey, jobRecord);
 
-    // when - the resolution of the second reference reactivates it again
+    // when
     jobState.makeActivatableAfterSecretResolution(jobKey);
 
-    // then - the activated job is left alone; re-inserting it would hand it out twice
+    // then
     assertJobState(jobKey, State.ACTIVATED);
+    refuteListedAsActivatable(jobKey, jobRecord.getTypeBuffer());
+  }
+
+  @Test
+  public void shouldNotMakeSuspendedJobActivatableAfterSecretResolution() {
+    // given
+    final long jobKey = 1L;
+    final JobRecord jobRecord = newJobRecord();
+    parkJobForSecretResolution(jobKey, jobRecord);
+    jobState.updateJobState(jobKey, State.SUSPENDED);
+    refuteListedAsActivatable(jobKey, jobRecord.getTypeBuffer());
+
+    // when
+    jobState.makeActivatableAfterSecretResolution(jobKey);
+
+    // then
+    assertJobState(jobKey, State.SUSPENDED);
     refuteListedAsActivatable(jobKey, jobRecord.getTypeBuffer());
   }
 
@@ -433,14 +449,14 @@ public final class JobStateTest {
     // given
     final long jobKey = 999L;
 
-    // when / then - no exception, no state change
+    // when / then
     jobState.makeActivatableAfterSecretResolution(jobKey);
     assertThat(jobState.exists(jobKey)).isFalse();
   }
 
   @Test
   public void shouldKeepJobParkedWhenUpdatingPriorityOfJobWaitingForSecretResolution() {
-    // given - a job parked while its secret references are resolved
+    // given
     final long jobKey = 1L;
     final JobRecord jobRecord = newJobRecord();
     parkJobForSecretResolution(jobKey, jobRecord);
@@ -448,7 +464,7 @@ public final class JobStateTest {
     // when
     jobState.updateJobPriority(jobKey, 99);
 
-    // then - the new priority is stored, but the job is not put back into the activatable index
+    // then
     assertThat(jobState.getJob(jobKey).getPriority()).isEqualTo(99);
     assertJobState(jobKey, State.WAITING_FOR_SECRET_RESOLUTION);
     refuteListedAsActivatable(jobKey, jobRecord.getTypeBuffer());


### PR DESCRIPTION
## Summary

Close the hand-out path where secret resolution could put a suspended job back into the activatable index.

After `WAITING_FOR_SECRET_RESOLUTION` (see #59338 / ADR 0007), `makeActivatableAfterSecretResolution` already acts only on that state. Suspension overrides secret-waiting to `SUSPENDED`. A later `BATCH_JOBS_REACTIVATED` therefore hits a silent no-op. The secret-reference batch carries no process-instance key, so this state guard is the only line that keeps the job out of the hand-out index.

This PR does not change production control flow. It documents suspension on the existing guard and adds unit tests that prove a suspended job stays out of the activatable index when secret resolution completes.

## Changes

- Document that `makeActivatableAfterSecretResolution` no-ops unless the job is still in `WAITING_FOR_SECRET_RESOLUTION`, including when it left that state for suspension, and keep the caller note for open secret-resolution incidents
- Shorten the matching no-op comment in `DbJobState`
- Add `JobStateTest.shouldNotMakeSuspendedJobActivatableAfterSecretResolution`
- Add `SecretReferenceBatchJobsReactivatedApplierTest.shouldNotMakeSuspendedJobActivatable`

End-to-end coverage for suspend while waiting on secrets lives in `JobSuspensionSecretWaitingTest` (landed with the suspend/resume stack).

## Testing

- `JobStateTest#shouldNotMakeSuspendedJobActivatableAfterSecretResolution`
- `SecretReferenceBatchJobsReactivatedApplierTest#shouldNotMakeSuspendedJobActivatable`
- Related suite: `JobStateTest`, `SecretReferenceBatchJobsReactivatedApplierTest`

## Links

- Parent: #58088
- Epic: #57507
- Related: #59617, #59812, #59562

Closes #59561
