### PR TITLE
feat: persist Optimize CSL web sessions in OpenSearch

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/security/OptimizeSessionStoreAdapterIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/security/OptimizeSessionStoreAdapterIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.optimize.service.security;
 
-import static io.camunda.optimize.AbstractIT.OPENSEARCH_SINGLE_TEST_FAIL_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,7 +18,6 @@ import io.camunda.security.api.model.session.PersistentSession;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,10 +29,10 @@ import org.junit.jupiter.api.Test;
  * with {@code optimize.security.csl.enabled=true}, which would swap the whole security chain and
  * break this rig's authentication. The store path exercised here is the same either way.
  *
- * <p>Elasticsearch-only until the OpenSearch store lands (#58472), hence the tag that keeps it out
- * of the OpenSearch pipeline.
+ * <p>Runs against both Elasticsearch and OpenSearch: the rig injects the {@link
+ * PersistentWebSessionRepository} implementation for the database under test, so the same
+ * assertions pin the behaviour of both stores.
  */
-@Tag(OPENSEARCH_SINGLE_TEST_FAIL_OK)
 public class OptimizeSessionStoreAdapterIT extends AbstractBrokerlessZeebeCCSMIT {
 
   private static final String ATTRIBUTE_NAME = "SPRING_SECURITY_CONTEXT";

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.optimize.rest.security.csl;
 
-import io.camunda.optimize.service.util.configuration.ConfigurationService;
-import io.camunda.optimize.service.util.configuration.DatabaseType;
 import io.camunda.security.api.model.config.SessionConfiguration;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -71,7 +69,6 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
 
     final Map<String, Object> derived = new HashMap<>();
     applyAlwaysOnDefaults(derived);
-    applySessionPersistence(env, derived);
     bridgeIdentityOidc(env, derived);
     bridgeAuth0Cloud(env, derived);
     bridgePublicApiJwt(env, derived);
@@ -99,25 +96,11 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     // (ADR-0038). CCSM reuses Optimize's existing /api/authentication/callback (no Identity-client
     // change); bridgeAuth0Cloud overrides it for Auth0. putIfAbsent so an explicit value wins.
     derived.putIfAbsent(OIDC_PREFIX + "redirect-uri", "{baseUrl}/api/authentication/callback");
-  }
-
-  /**
-   * Turns on CSL's server-side sessions, which {@code OptimizeSessionStoreAdapter} persists in the
-   * {@code web-session} index. Only for the Elasticsearch edition: the store has no OpenSearch
-   * implementation yet, and CSL's session repository requires a {@code SessionStorePort} bean once
-   * the property is set, so enabling it on OpenSearch would fail startup. OpenSearch therefore
-   * keeps CSL's in-memory sessions (single-node only) until the OpenSearch store lands.
-   */
-  private void applySessionPersistence(
-      final ConfigurableEnvironment env, final Map<String, Object> derived) {
-    if (ConfigurationService.getDatabaseType(env) == DatabaseType.ELASTICSEARCH) {
-      derived.putIfAbsent(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY, "true");
-    } else {
-      LOG.warn(
-          "Persistent web sessions are not enabled: the CSL session store is currently"
-              + " Elasticsearch-only. Sessions are kept in memory, so they are lost on restart and"
-              + " are not shared across Optimize instances.");
-    }
+    // Turns on CSL's server-side sessions, which OptimizeSessionStoreAdapter persists in the
+    // web-session index. Applies to both editions: the store has an Elasticsearch and an OpenSearch
+    // implementation, so CSL's session repository always finds the SessionStorePort bean it
+    // requires. putIfAbsent so an operator can still opt out.
+    derived.putIfAbsent(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY, "true");
   }
 
   // OIDC / Identity (CCSM), from the CAMUNDA_OPTIMIZE_IDENTITY_* env vars. Skipped when Auth0 is

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
@@ -9,7 +9,6 @@ package io.camunda.optimize.rest.security.csl;
 
 import io.camunda.optimize.dto.optimize.query.WebSessionDto;
 import io.camunda.optimize.service.db.repository.PersistentWebSessionRepository;
-import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import io.camunda.security.api.model.session.PersistentSession;
 import io.camunda.security.core.port.out.SessionStorePort;
 import java.util.List;
@@ -17,7 +16,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 /**
@@ -30,18 +28,18 @@ import org.springframework.stereotype.Component;
  * <p>OC's adapter cannot be reused: it lives in a module Optimize does not depend on and is bound
  * to that host's search clients.
  *
- * <p>Active only under Elasticsearch and when {@code optimize.security.csl.enabled=true}. CSL
- * routes sessions here only while {@code camunda.security.session.persistent.enabled=true}, which
- * {@link OptimizeSecurityConfigCompatibilityPostProcessor} sets for the Elasticsearch edition;
- * OpenSearch keeps CSL's in-memory sessions until the OpenSearch store lands.
+ * <p>Database-agnostic: it talks only to {@link PersistentWebSessionRepository}, whose
+ * Elasticsearch and OpenSearch implementations are selected by the configured database. Active when
+ * {@code optimize.security.csl.enabled=true}. CSL routes sessions here only while {@code
+ * camunda.security.session.persistent.enabled=true}, which {@link
+ * OptimizeSecurityConfigCompatibilityPostProcessor} sets for both editions.
  *
  * <p>A failed {@link #upsert(PersistentSession)} is logged and swallowed. Spring Session saves the
- * session while the response is being committed, so letting a storage failure through would turn an
- * Elasticsearch blip into failed requests. The reads stay strict: a session that cannot be loaded
- * must not be mistaken for one that does not exist.
+ * session while the response is being committed, so letting a storage failure through would turn a
+ * database blip into failed requests. The reads stay strict: a session that cannot be loaded must
+ * not be mistaken for one that does not exist.
  */
 @Component
-@Conditional(ElasticSearchCondition.class)
 @ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
 public class OptimizeSessionStoreAdapter implements SessionStorePort {
 
@@ -68,7 +66,7 @@ public class OptimizeSessionStoreAdapter implements SessionStorePort {
     } catch (final RuntimeException e) {
       // The session stays valid on the instance that handled the request, but it is not shared and
       // it does not survive a restart, so the user may have to log in again.
-      LOG.warn("Could not save web session {} to Elasticsearch.", session.id(), e);
+      LOG.warn("Could not save web session {} to the database.", session.id(), e);
     }
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/PersistentWebSessionRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/PersistentWebSessionRepositoryOS.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.os;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+import static io.camunda.optimize.service.db.DatabaseConstants.WEB_SESSION_INDEX_NAME;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.matchAll;
+import static java.lang.String.format;
+
+import io.camunda.optimize.dto.optimize.query.WebSessionDto;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.repository.PersistentWebSessionRepository;
+import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.List;
+import java.util.Optional;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class PersistentWebSessionRepositoryOS implements PersistentWebSessionRepository {
+
+  private final OptimizeOpenSearchClient osClient;
+  private final OptimizeIndexNameService indexNameService;
+
+  public PersistentWebSessionRepositoryOS(
+      final OptimizeOpenSearchClient osClient, final OptimizeIndexNameService indexNameService) {
+    this.osClient = osClient;
+    this.indexNameService = indexNameService;
+  }
+
+  @Override
+  public Optional<WebSessionDto> get(final String sessionId) {
+    // A get by id reads through the translog, so a session is visible without a prior refresh.
+    final GetRequest.Builder requestBuilder =
+        new GetRequest.Builder().index(webSessionIndexAlias()).id(sessionId);
+    final GetResponse<WebSessionDto> response =
+        osClient.get(
+            requestBuilder,
+            WebSessionDto.class,
+            format("Could not read web session %s", sessionId));
+    return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+  }
+
+  @Override
+  public void upsert(final WebSessionDto session) {
+    final IndexRequest.Builder<WebSessionDto> requestBuilder =
+        new IndexRequest.Builder<WebSessionDto>()
+            .index(webSessionIndexAlias())
+            .id(session.getId())
+            .document(session);
+    osClient.index(requestBuilder);
+  }
+
+  @Override
+  public void delete(final String sessionId) {
+    osClient.delete(webSessionIndexAlias(), sessionId);
+  }
+
+  @Override
+  public List<WebSessionDto> getAll() {
+    // Scrolled rather than a plain search: the sweep must see every session, not the first page.
+    final SearchRequest.Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(webSessionIndexAlias())
+            .query(matchAll())
+            .size(LIST_FETCH_LIMIT);
+    return osClient.scrollValues(requestBuilder, WebSessionDto.class);
+  }
+
+  private String webSessionIndexAlias() {
+    return indexNameService.getOptimizeIndexAliasForIndex(WEB_SESSION_INDEX_NAME);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslWebSessionWiringTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslWebSessionWiringTest.java
@@ -24,8 +24,8 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
  * Pins the contract between CSL's session lifecycle and Optimize's store: {@link
  * WebSessionConfiguration} activates on {@code camunda.security.session.persistent.enabled} and
  * then <em>requires</em> a {@code SessionStorePort}. That coupling is why {@link
- * OptimizeSecurityConfigCompatibilityPostProcessor} only sets the property for the database
- * Optimize has a store for.
+ * OptimizeSecurityConfigCompatibilityPostProcessor} may only set the property while every database
+ * Optimize supports has a store implementation.
  */
 class CslWebSessionWiringTest {
 
@@ -65,7 +65,7 @@ class CslWebSessionWiringTest {
 
   @Test
   void shouldFailToStartWhenPersistenceIsEnabledWithoutAStore() {
-    // given the wiring of a database Optimize has no session store for, such as OpenSearch
+    // given a context where no store implementation contributed a SessionStorePort bean
     new ApplicationContextRunner()
         .withPropertyValues(
             "optimize.security.csl.enabled=true",
@@ -74,8 +74,8 @@ class CslWebSessionWiringTest {
         .withUserConfiguration(WebSessionConfiguration.class)
         .run(
             context ->
-                // then the context cannot be built, which is why the post processor only sets the
-                // property for a database that has a store
+                // then the context cannot be built, which is why every supported database needs a
+                // store before the post processor may enable persistence
                 assertThat(context)
                     .getFailure()
                     .hasRootCauseInstanceOf(NoSuchBeanDefinitionException.class));

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.rest.security.csl;
 
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.CAMUNDA_OPTIMIZE_DATABASE;
+import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.ELASTICSEARCH_DATABASE_PROPERTY;
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.OPENSEARCH_DATABASE_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,6 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.event.Level;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
@@ -380,38 +383,24 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     assertThat(env.getProperty("contextPath")).isEqualTo("/explicit");
   }
 
-  @Test
-  void shouldEnablePersistentSessionsOnElasticsearch() {
-    // given the default database, which is Elasticsearch
-    final StandardEnvironment env = environmentWith(cslEnabledConfig());
-
-    // when
-    processor.postProcessEnvironment(env, null);
-
-    // then the CSL session store is active, so sessions survive a restart and are shared
-    assertThat(env.getProperty(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY)).isEqualTo("true");
-  }
-
-  @Test
-  void shouldNotEnablePersistentSessionsOnOpenSearch() {
+  @ParameterizedTest
+  @ValueSource(strings = {ELASTICSEARCH_DATABASE_PROPERTY, OPENSEARCH_DATABASE_PROPERTY})
+  void shouldEnablePersistentSessionsOnEveryDatabase(final String database) {
     // given
     final Map<String, Object> legacy = cslEnabledConfig();
-    legacy.put(CAMUNDA_OPTIMIZE_DATABASE, OPENSEARCH_DATABASE_PROPERTY);
+    legacy.put(CAMUNDA_OPTIMIZE_DATABASE, database);
     final StandardEnvironment env = environmentWith(legacy);
 
     // when
     processor.postProcessEnvironment(env, null);
 
-    // then CSL keeps its in-memory sessions: enabling persistence without an OpenSearch store
-    // would leave CSL's session repository without a SessionStorePort and fail startup
-    assertThat(env.getProperty(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY)).isNull();
-    logs.assertContains(
-        entry -> entry.getMessage().contains("Persistent web sessions are not enabled"),
-        "expected a warning that sessions are kept in memory on OpenSearch");
+    // then the CSL session store is active on both editions, so sessions survive a restart and are
+    // shared across instances rather than being kept in memory on one of them
+    assertThat(env.getProperty(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY)).isEqualTo("true");
   }
 
   @Test
-  void shouldLetOperatorTurnOffPersistentSessionsOnElasticsearch() {
+  void shouldLetOperatorTurnOffPersistentSessions() {
     // given an operator who explicitly opted out
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY, "false");


### PR DESCRIPTION
Closes #58472

## Why

With CSL enabled, server-side sessions only worked on Elasticsearch.
OpenSearch fell back to CSL's in-memory sessions: lost on restart, not
shared between replicas (so a sticky load balancer was required), and
logout could not invalidate a session cluster-wide. This kept CSL mode
Elasticsearch-only and blocked making it the default for OpenSearch
deployments.

## What

- Adds `PersistentWebSessionRepositoryOS`, implementing the existing
  `PersistentWebSessionRepository` port over `OptimizeOpenSearchClient`.
- Removes the two Elasticsearch gates: `ElasticSearchCondition` on
  `OptimizeSessionStoreAdapter`, and the `DatabaseType.ELASTICSEARCH`
  branch in `OptimizeSecurityConfigCompatibilityPostProcessor` that
  enabled persistent sessions for one edition only.

`WebSessionIndexOS` and its OpenSearch schema-manager registration
already landed with #58471, as did the port the adapter talks to, so the
adapter itself required no logic change.

The gate removal and the new repository must land together: CSL's
session repository requires a `SessionStorePort` bean once
`camunda.security.session.persistent.enabled` is set, so enabling the
property without a store fails startup.

## Testing

- `OptimizeSessionStoreAdapterIT` now runs in both pipelines. Verified
  locally: 6/6 against OpenSearch 2.19.5 and 6/6 against Elasticsearch.
- Confirmed the OpenSearch schema manager creates
  `optimize-web-session_v1` with `dynamic: strict` and `attributes` as a
  disabled object, i.e. the ES-authored mapping converts correctly.
- Full `optimize-backend` unit suite green (854 tests).

Not covered automatically: a real login/logout through CSL's chain with
`optimize.security.csl.enabled=true` on OpenSearch. The IT constructs
the adapter directly, because enabling the flag swaps the security chain
and breaks the IT rig's own authentication. Elasticsearch has the same
coverage profile since #58471; worth a manual smoke test before the
default flip, and #58474 covers the logout half.
