### PR TITLE
fix: reclaim jobs when JobBatch activation response is lost (DRAFT)

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -205,6 +205,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setCandidateGroupNameResolution(caches.isCandidateGroupNameResolution())
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
         .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
+        .setJobsDeliveryAckTimeout(jobs.getDeliveryAckTimeout())
         .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize())
         .setMaxIdFieldLength(validators.getMaxIdFieldLength())
         .setMaxNameFieldLength(validators.getMaxNameFieldLength())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/JobsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/JobsCfg.java
@@ -16,6 +16,7 @@ public class JobsCfg implements ConfigurationEntry {
       EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
   private int timeoutCheckerBatchLimit =
       EngineConfiguration.DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
+  private Duration deliveryAckTimeout = EngineConfiguration.DEFAULT_JOBS_DELIVERY_ACK_TIMEOUT;
   private boolean includeVariablesInJobCompletedEvent =
       EngineConfiguration.DEFAULT_JOBS_INCLUDE_VARIABLES_IN_JOB_COMPLETED_EVENT;
 
@@ -35,6 +36,14 @@ public class JobsCfg implements ConfigurationEntry {
     this.timeoutCheckerBatchLimit = timeoutCheckerBatchLimit;
   }
 
+  public Duration getDeliveryAckTimeout() {
+    return deliveryAckTimeout;
+  }
+
+  public void setDeliveryAckTimeout(final Duration deliveryAckTimeout) {
+    this.deliveryAckTimeout = deliveryAckTimeout;
+  }
+
   public boolean isIncludeVariablesInJobCompletedEvent() {
     return includeVariablesInJobCompletedEvent;
   }
@@ -51,6 +60,8 @@ public class JobsCfg implements ConfigurationEntry {
         + timeoutCheckerPollingInterval
         + ", timeoutCheckerBatchLimit="
         + timeoutCheckerBatchLimit
+        + ", deliveryAckTimeout="
+        + deliveryAckTimeout
         + ", includeVariablesInJobCompletedEvent="
         + includeVariablesInJobCompletedEvent
         + '}';

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -35,6 +35,8 @@ final class EngineCfgTest {
     assertThat(configuration.getJobsTimeoutCheckerPollingInterval())
         .isEqualTo(Duration.ofSeconds(1));
     assertThat(configuration.getJobsTimeoutCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(configuration.getJobsDeliveryAckTimeout())
+        .isEqualTo(EngineConfiguration.DEFAULT_JOBS_DELIVERY_ACK_TIMEOUT);
     assertThat(configuration.getFormCacheCapacity())
         .isEqualTo(EngineConfiguration.DEFAULT_FORM_CACHE_CAPACITY);
     assertThat(configuration.getProcessCacheCapacity())
@@ -102,6 +104,7 @@ final class EngineCfgTest {
     assertThat(configuration.getJobsTimeoutCheckerPollingInterval())
         .isEqualTo(Duration.ofSeconds(15));
     assertThat(configuration.getJobsTimeoutCheckerBatchLimit()).isEqualTo(1000);
+    assertThat(configuration.getJobsDeliveryAckTimeout()).isEqualTo(Duration.ofSeconds(45));
     assertThat(configuration.getValidatorsResultsOutputMaxSize()).isEqualTo(2000);
     assertThat(configuration.getMaxProcessDepth()).isEqualTo(2000);
     assertThat(configuration.getCommandRedistributionInterval()).isEqualTo(Duration.ofSeconds(60));

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -14,6 +14,7 @@ zeebe:
         jobs:
           timeoutCheckerPollingInterval: 15s
           timeoutCheckerBatchLimit: 1000
+          deliveryAckTimeout: 45s
         jobMetrics:
           exportInterval: 10m
           enabled: false

--- a/zeebe/docs/adr/0009-810-job-batch-delivery-ack.md
+++ b/zeebe/docs/adr/0009-810-job-batch-delivery-ack.md
@@ -1,0 +1,98 @@
+# JobBatch delivery ACK: reclaim activations the gateway never received
+
+**DRI**: Ambrose Tan
+
+**Status**: Accepted (8.10)
+
+**Purpose**: Recover jobs that the broker activated but whose JobBatch response never
+reached the gateway, without waiting for the full worker job timeout.
+
+**Audience**: Zeebe engineers working on job activation, the gateway, or delivery
+guarantees between broker and gateway.
+
+## Context
+
+The gateway activates jobs with a `JobBatch ACTIVATE` command. The broker commits
+`ACTIVATED`, sets each job's worker deadline, and sends the batch back. If that
+response is lost (connection closed, request timeout, short leader disconnect), the
+gateway has no job keys. It cannot run the existing `reactivateJobs` / `FAIL` path,
+so the jobs stay `ACTIVATED` until the worker timeout (often hours). The client gets
+an empty activate response.
+
+The stream (push) path already recovers: `YieldingJobStreamErrorHandler` appends
+`JobIntent.YIELD` when a push fails. The poll path has no equivalent for a lost
+response. Retrying `ACTIVATE` is wrong: it would activate a second batch.
+
+Production evidence and full analysis: [camunda/camunda#59354](https://github.com/camunda/camunda/issues/59354).
+
+## Decision
+
+**D1. Broker-side delivery handshake for poll activation.**
+When the gateway includes a non-zero `deliveryAttemptKey` on `JobBatch ACTIVATE`, the
+broker registers a short-lived **pending delivery** for the activated job keys after
+`ACTIVATED`. The gateway must **ACK** that attempt when it receives the broker
+response. If it does not, the broker **YIELDs** the pending jobs.
+
+**D2. Gateway generates `deliveryAttemptKey`; transport request id is not enough.**
+The attempt key is set on the command before send. After connection loss the transport
+request id is gone; the attempt key remains known to the gateway so it can REJECT.
+
+**D3. ACK means "gateway received the broker response", not "client received jobs".**
+Client-send failure already uses `reactivateJobs` → `FAIL` with preserved retries.
+ACK runs on broker-response success, before the client send, so it does not race the
+delivery timer while the gateway is writing to the client.
+
+**D4. Fast path REJECT + safety-net delivery deadline.**
+On ambiguous response errors (`ConnectionClosed`, timeout, and similar — not
+`RESOURCE_EXHAUSTED` or command rejections), the gateway sends `JobBatch REJECT` for
+the attempt. Independently, a broker scheduler yields pending deliveries past
+`jobDeliveryAckTimeout` (default 30s). REJECT covers the confirmed production case;
+the timer covers gateway crash or lost REJECT.
+
+**D5. Do not overload the worker job deadline.**
+`JobRecord.deadline` stays the full worker timeout. Pending delivery uses separate
+state and a separate checker. Delivery expiry becomes `YIELD`, never `TIME_OUT`.
+
+**D6. Recovery primitive is `JobIntent.YIELD`.**
+Same as the stream path. Does not burn retries. Job lease fencing (ADR 0005) is
+unchanged: yield is engine-internal and unfenced; a worker that still holds a yielded
+job is an at-least-once case the lease already covers when enabled.
+
+**D7. Rolling upgrade: attempt key optional.**
+- Missing / zero `deliveryAttemptKey` → no pending delivery (legacy gateways).
+- New gateway + old broker: ACK/REJECT ignored until brokers upgrade; orphans remain
+until then.
+- Old gateway + new broker: no spurious yields.
+
+**D8. Handshake is gateway↔broker only.**
+No public client API change. gRPC and REST both use `ActivateJobsHandler`, so one
+gateway change covers both.
+
+## Alternatives considered
+
+- **Recoverable JobBatch response by attempt id.** Gateway re-fetches the committed
+  result. Better for same-poll recovery, but needs response cache, leader-change
+  handling, and secret re-injection (secrets live only on the response copy). Deferred
+  as a follow-up.
+- **Short provisional worker deadline, then UpdateTimeout on ACK.** Overloads worker
+  timeout semantics and races long-running workers if ACK is delayed.
+- **Gateway-only REJECT without broker timer.** Fixes the logged production path but
+  not gateway crash between commit and response.
+- **Logging job keys only on gateway error.** Impossible without keys on the lost
+  response path; broker-side logs on REJECT/timeout address operator visibility.
+
+## Consequences
+
+- One ACK command per successful partition activation; REJECT only on error paths.
+- Worst-case stall after an orphaned activation is bounded by
+  `jobDeliveryAckTimeout` (plus checker polling), not the worker job timeout.
+- Lost ACK after a successful client delivery can yield a job the worker already has
+  (at-least-once; lease when enabled).
+- Protocol and engine state change; support backports need explicit assessment.
+
+## Source
+
+- [Jobs stay activated until the job timeout when a JobBatch activation response does not reach the gateway (#59354)](https://github.com/camunda/camunda/issues/59354)
+- [Job lease ADR (0005)](0005-810-job-lease.md)
+- Original client-send reactivation (#3631)
+

--- a/zeebe/docs/adr/README.md
+++ b/zeebe/docs/adr/README.md
@@ -18,4 +18,5 @@ process-execution data path). These are module-scoped decisions; see the
 | [0006](0006-810-late-business-id-assignment.md)                     | Late Business ID assignment: one irreversible forward-only assignment on a running instance (uniqueness off)  |
 | [0007](0007-810-job-waiting-for-secret-resolution-state.md)         | Persisted `WAITING_FOR_SECRET_RESOLUTION` job state for jobs parked while their secret references resolve     |
 | [0008](0008-810-suspended-job-state.md)                             | Persisted `SUSPENDED` job state that withholds the jobs of a suspended process instance from hand-out         |
+| [0009](0009-810-job-batch-delivery-ack.md)                          | JobBatch delivery ACK: short pending delivery + yield when the gateway never receives the activation response |
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -34,6 +34,10 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   public static final boolean DEFAULT_JOBS_INCLUDE_VARIABLES_IN_JOB_COMPLETED_EVENT = false;
   public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
+
+  /** Bound for reclaiming activations whose response never reached the gateway. */
+  public static final Duration DEFAULT_JOBS_DELIVERY_ACK_TIMEOUT = Duration.ofSeconds(30);
+
   public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;
   public static final boolean DEFAULT_ENABLE_AUTHORIZATION_CHECKS = false;
 
@@ -127,6 +131,7 @@ public final class EngineConfiguration {
   private boolean candidateGroupNameResolution = DEFAULT_CANDIDATE_GROUP_NAME_RESOLUTION;
   private Duration jobsTimeoutCheckerPollingInterval = DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
   private int jobsTimeoutCheckerBatchLimit = DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
+  private Duration jobsDeliveryAckTimeout = DEFAULT_JOBS_DELIVERY_ACK_TIMEOUT;
   private int validatorsResultsOutputMaxSize = DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
   private boolean enableAuthorization = DEFAULT_ENABLE_AUTHORIZATION_CHECKS;
   private int maxProcessDepth = DEFAULT_MAX_PROCESS_DEPTH;
@@ -292,6 +297,15 @@ public final class EngineConfiguration {
   public EngineConfiguration setJobsTimeoutCheckerBatchLimit(
       final int jobsTimeoutCheckerBatchLimit) {
     this.jobsTimeoutCheckerBatchLimit = jobsTimeoutCheckerBatchLimit;
+    return this;
+  }
+
+  public Duration getJobsDeliveryAckTimeout() {
+    return jobsDeliveryAckTimeout;
+  }
+
+  public EngineConfiguration setJobsDeliveryAckTimeout(final Duration jobsDeliveryAckTimeout) {
+    this.jobsDeliveryAckTimeout = jobsDeliveryAckTimeout;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchAcknowledgeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchAcknowledgeProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+/**
+ * Confirms that the gateway received a JobBatch activation response. Idempotent: a missing pending
+ * delivery is treated as already settled.
+ */
+@ExcludeAuthorizationCheck
+public final class JobBatchAcknowledgeProcessor implements TypedRecordProcessor<JobBatchRecord> {
+
+  private final StateWriter stateWriter;
+
+  public JobBatchAcknowledgeProcessor(final Writers writers) {
+    stateWriter = writers.state();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<JobBatchRecord> record) {
+    // Always write ACKNOWLEDGED so retries are safe; the applier no-ops when already cleared.
+    stateWriter.appendFollowUpEvent(
+        record.getKey(), JobBatchIntent.ACKNOWLEDGED, record.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -72,6 +72,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final CslTenantCheck tenantCheck;
   private final IncidentMetrics incidentMetrics;
   private final JobSecretInjector jobSecretInjector;
+  private final InstantSource clock;
+  private final long deliveryAckTimeoutMillis;
 
   public JobBatchActivateProcessor(
       final Writers writers,
@@ -82,13 +84,16 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final CslTenantCheck tenantCheck,
       final InstantSource clock,
       final IncidentMetrics incidentMetrics,
-      final SecretStoreRegistry secretStoreRegistry) {
+      final SecretStoreRegistry secretStoreRegistry,
+      final long deliveryAckTimeoutMillis) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.cslCheck = cslCheck;
     this.tenantCheck = tenantCheck;
+    this.clock = clock;
+    this.deliveryAckTimeoutMillis = deliveryAckTimeoutMillis;
     jobSecretInjector = new JobSecretInjector(secretStoreRegistry);
     jobBatchCollector =
         new JobBatchCollector(
@@ -262,6 +267,11 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     // building the response can drop jobs from the batch (those whose injected secret values
     // would exceed the max message size), so it must happen before the ACTIVATED event
     final var response = responseValueFor(record, value);
+    if (value.getDeliveryAttemptKey() > 0
+        && !value.getJobKeys().isEmpty()
+        && deliveryAckTimeoutMillis > 0) {
+      value.setDeliveryDeadline(clock.millis() + deliveryAckTimeoutMillis);
+    }
     // append (and apply to state) the ACTIVATED event with the unresolved placeholders
     stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, value);
     responseWriter.writeAcceptedResponseOnCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchDeliveryAckCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchDeliveryAckCheckScheduler.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.state.immutable.JobBatchDeliveryState;
+import io.camunda.zeebe.engine.state.immutable.JobBatchDeliveryState.DeliveryDeadlineIndex;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.stream.api.scheduling.Task;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.Duration;
+import java.time.InstantSource;
+import org.agrona.collections.MutableInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Yields JobBatch activations whose delivery ACK never arrived, by appending {@link
+ * JobBatchIntent#REJECT} for each timed-out pending delivery.
+ */
+final class JobBatchDeliveryAckCheckScheduler implements Task, StreamProcessorLifecycleAware {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(JobBatchDeliveryAckCheckScheduler.class);
+
+  private boolean shouldReschedule = false;
+  private long executionTimestamp = -1;
+  private DeliveryDeadlineIndex startAtIndex = null;
+
+  private final JobBatchDeliveryState state;
+  private ReadonlyStreamProcessorContext processingContext;
+  private final Duration pollingInterval;
+  private final int batchLimit;
+  private final InstantSource clock;
+  private final JobBatchRecord rejectCommand = new JobBatchRecord();
+
+  JobBatchDeliveryAckCheckScheduler(
+      final JobBatchDeliveryState state,
+      final Duration pollingInterval,
+      final int batchLimit,
+      final InstantSource clock) {
+    this.state = state;
+    this.pollingInterval = pollingInterval;
+    this.batchLimit = batchLimit;
+    this.clock = clock;
+  }
+
+  public void schedule(final Duration idleInterval) {
+    if (shouldReschedule) {
+      processingContext.getScheduleService().runAt(clock.millis() + idleInterval.toMillis(), this);
+    }
+  }
+
+  @Override
+  public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    if (executionTimestamp == -1) {
+      executionTimestamp = clock.millis();
+    }
+
+    final var counter = new MutableInteger(0);
+    final DeliveryDeadlineIndex lastVisitedIndex =
+        state.forEachTimedOutDelivery(
+            executionTimestamp,
+            startAtIndex,
+            (attemptKey, pending) -> {
+              if (counter.getAndIncrement() >= batchLimit) {
+                return false;
+              }
+
+              rejectCommand.reset();
+              rejectCommand.setType(pending.getType());
+              rejectCommand.setDeliveryAttemptKey(attemptKey);
+              rejectCommand.setDeliveryDeadline(pending.getDeliveryDeadline());
+              for (final long jobKey : pending.getJobKeys()) {
+                rejectCommand.jobKeys().add().setValue(jobKey);
+              }
+              return taskResultBuilder.appendCommandRecord(
+                  attemptKey, JobBatchIntent.REJECT, rejectCommand);
+            });
+
+    if (lastVisitedIndex != null) {
+      LOG.trace(
+          "Job batch delivery-ack checker yielded early. Will reschedule immediately from {}",
+          lastVisitedIndex);
+      startAtIndex = lastVisitedIndex;
+      schedule(Duration.ZERO);
+    } else {
+      executionTimestamp = -1;
+      startAtIndex = null;
+      schedule(pollingInterval);
+    }
+
+    return taskResultBuilder.build();
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext processingContext) {
+    this.processingContext = processingContext;
+    shouldReschedule = true;
+    schedule(pollingInterval);
+  }
+
+  @Override
+  public void onClose() {
+    cancelTimer();
+  }
+
+  @Override
+  public void onFailed() {
+    cancelTimer();
+  }
+
+  @Override
+  public void onPaused() {
+    cancelTimer();
+  }
+
+  @Override
+  public void onResumed() {
+    shouldReschedule = true;
+    schedule(pollingInterval);
+  }
+
+  private void cancelTimer() {
+    shouldReschedule = false;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchRejectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchRejectProcessor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.JobBatchDeliveryState;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Rejects a pending JobBatch delivery: yields still-activated jobs so they become activatable
+ * again, then clears the pending delivery. Idempotent when no pending delivery remains.
+ */
+@ExcludeAuthorizationCheck
+public final class JobBatchRejectProcessor implements TypedRecordProcessor<JobBatchRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JobBatchRejectProcessor.class);
+
+  private final JobBatchDeliveryState jobBatchDeliveryState;
+  private final JobState jobState;
+  private final StateWriter stateWriter;
+  private final BpmnJobActivationBehavior jobActivationBehavior;
+
+  public JobBatchRejectProcessor(
+      final ProcessingState state,
+      final Writers writers,
+      final BpmnJobActivationBehavior jobActivationBehavior) {
+    jobBatchDeliveryState = state.getJobBatchDeliveryState();
+    jobState = state.getJobState();
+    stateWriter = writers.state();
+    this.jobActivationBehavior = jobActivationBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<JobBatchRecord> record) {
+    final var value = record.getValue();
+    final long attemptKey = value.getDeliveryAttemptKey();
+    if (attemptKey <= 0) {
+      // Nothing to reject; still emit REJECTED for a deterministic command completion.
+      stateWriter.appendFollowUpEvent(record.getKey(), JobBatchIntent.REJECTED, value);
+      return;
+    }
+
+    final var pending = jobBatchDeliveryState.getPendingDelivery(attemptKey);
+    if (pending.isEmpty()) {
+      stateWriter.appendFollowUpEvent(record.getKey(), JobBatchIntent.REJECTED, value);
+      return;
+    }
+
+    final var delivery = pending.get();
+    final var eventValue = new JobBatchRecord();
+    eventValue.setType(delivery.getType());
+    eventValue.setDeliveryAttemptKey(attemptKey);
+    eventValue.setDeliveryDeadline(delivery.getDeliveryDeadline());
+
+    for (final long jobKey : delivery.getJobKeys()) {
+      eventValue.jobKeys().add().setValue(jobKey);
+      if (jobState.getState(jobKey) != State.ACTIVATED) {
+        continue;
+      }
+      final JobRecord job = jobState.getJob(jobKey);
+      if (job == null) {
+        continue;
+      }
+      stateWriter.appendFollowUpEvent(jobKey, JobIntent.YIELDED, job);
+      jobActivationBehavior.notifyJobAvailableAsSideEffect(job);
+    }
+
+    LOG.warn(
+        "Rejected JobBatch delivery for type {} attempt {} with job keys {}; jobs yielded for re-activation",
+        delivery.getType(),
+        attemptKey,
+        delivery.getJobKeys());
+
+    stateWriter.appendFollowUpEvent(record.getKey(), JobBatchIntent.REJECTED, eventValue);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -136,10 +136,26 @@ public final class JobEventProcessors {
                 tenantCheck,
                 clock,
                 incidentMetrics,
-                secretStoreRegistry))
+                secretStoreRegistry,
+                config.getJobsDeliveryAckTimeout().toMillis()))
+        .onCommand(
+            ValueType.JOB_BATCH,
+            JobBatchIntent.ACKNOWLEDGE,
+            new JobBatchAcknowledgeProcessor(writers))
+        .onCommand(
+            ValueType.JOB_BATCH,
+            JobBatchIntent.REJECT,
+            new JobBatchRejectProcessor(
+                processingState, writers, bpmnBehaviors.jobActivationBehavior()))
         .withListener(
             new JobTimeoutCheckScheduler(
                 scheduledTaskStateFactory.get().getJobState(),
+                config.getJobsTimeoutCheckerPollingInterval(),
+                config.getJobsTimeoutCheckerBatchLimit(),
+                clock))
+        .withListener(
+            new JobBatchDeliveryAckCheckScheduler(
+                scheduledTaskStateFactory.get().getJobBatchDeliveryState(),
                 config.getJobsTimeoutCheckerPollingInterval(),
                 config.getJobsTimeoutCheckerBatchLimit(),
                 clock))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.engine.state.instance.DbIncidentState;
 import io.camunda.zeebe.engine.state.instance.DbJobState;
 import io.camunda.zeebe.engine.state.instance.DbTimerInstanceState;
 import io.camunda.zeebe.engine.state.instance.DbUserTaskState;
+import io.camunda.zeebe.engine.state.jobbatch.DbJobBatchDeliveryState;
 import io.camunda.zeebe.engine.state.jobmetrics.DbJobMetricsState;
 import io.camunda.zeebe.engine.state.jobmetrics.NoopJobMetricsState;
 import io.camunda.zeebe.engine.state.message.DbMessageCorrelationState;
@@ -78,6 +79,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableFormState;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobBatchDeliveryState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobMetricsState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingRuleState;
@@ -171,6 +173,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableGlobalListenersState globalListenersState;
   private final MutableJobMetricsState jobMetricsState;
   private final MutableSecretReferenceState secretReferenceState;
+  private final MutableJobBatchDeliveryState jobBatchDeliveryState;
   private final int partitionId;
 
   public ProcessingDbState(
@@ -249,6 +252,7 @@ public class ProcessingDbState implements MutableProcessingState {
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
     globalListenersState = new DbGlobalListenersState(zeebeDb, transactionContext);
     secretReferenceState = new DbSecretReferenceState(zeebeDb, transactionContext);
+    jobBatchDeliveryState = new DbJobBatchDeliveryState(zeebeDb, transactionContext);
     if (config.isJobMetricsExportEnabled()) {
       jobMetricsState = new DbJobMetricsState(zeebeDb, transactionContext, clock, config);
     } else {
@@ -494,6 +498,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableSecretReferenceState getSecretReferenceState() {
     return secretReferenceState;
+  }
+
+  @Override
+  public MutableJobBatchDeliveryState getJobBatchDeliveryState() {
+    return jobBatchDeliveryState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.DeploymentState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
+import io.camunda.zeebe.engine.state.immutable.JobBatchDeliveryState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceAskState;
 import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceDedupState;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.instance.DbJobState;
 import io.camunda.zeebe.engine.state.instance.DbTimerInstanceState;
 import io.camunda.zeebe.engine.state.instance.DbUserTaskState;
+import io.camunda.zeebe.engine.state.jobbatch.DbJobBatchDeliveryState;
 import io.camunda.zeebe.engine.state.message.DbMessageStartProcessInstanceAskState;
 import io.camunda.zeebe.engine.state.message.DbMessageStartProcessInstanceDedupState;
 import io.camunda.zeebe.engine.state.message.DbMessageState;
@@ -56,6 +58,7 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   private final BatchOperationState batchOperationState;
   private final DbRoutingState routingState;
   private final SecretReferenceState secretReferenceState;
+  private final JobBatchDeliveryState jobBatchDeliveryState;
 
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -84,6 +87,7 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
     batchOperationState = new DbBatchOperationState(zeebeDb, transactionContext);
     routingState = new DbRoutingState(zeebeDb, transactionContext);
     secretReferenceState = new DbSecretReferenceState(zeebeDb, transactionContext);
+    jobBatchDeliveryState = new DbJobBatchDeliveryState(zeebeDb, transactionContext);
   }
 
   @Override
@@ -149,5 +153,10 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   @Override
   public DbRoutingState getRoutingState() {
     return routingState;
+  }
+
+  @Override
+  public JobBatchDeliveryState getJobBatchDeliveryState() {
+    return jobBatchDeliveryState;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -125,7 +125,10 @@ public final class EventAppliers implements EventApplier {
 
     registerJobIntentEventAppliers(state);
     registerVariableEventAppliers(state);
-    register(JobBatchIntent.ACTIVATED, new JobBatchActivatedApplier(state));
+    register(JobBatchIntent.ACTIVATED, 1, new JobBatchActivatedApplier(state));
+    register(JobBatchIntent.ACTIVATED, 2, new JobBatchActivatedV2Applier(state));
+    register(JobBatchIntent.ACKNOWLEDGED, new JobBatchAcknowledgedApplier(state));
+    register(JobBatchIntent.REJECTED, new JobBatchRejectedApplier(state));
     registerIncidentEventAppliers(state);
     registerProcessMessageSubscriptionEventAppliers(state);
     registerTimeEventAppliers(state);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchAcknowledgedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchAcknowledgedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobBatchDeliveryState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+
+public final class JobBatchAcknowledgedApplier
+    implements TypedEventApplier<JobBatchIntent, JobBatchRecord> {
+
+  private final MutableJobBatchDeliveryState jobBatchDeliveryState;
+
+  public JobBatchAcknowledgedApplier(final MutableProcessingState state) {
+    jobBatchDeliveryState = state.getJobBatchDeliveryState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobBatchRecord value) {
+    jobBatchDeliveryState.removePendingDelivery(value.getDeliveryAttemptKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchActivatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchActivatedV2Applier.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobBatchDeliveryState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Activates jobs like {@link JobBatchActivatedApplier} and, when a delivery attempt key is present,
+ * registers a pending delivery so the gateway handshake can ACK or REJECT the batch.
+ */
+public final class JobBatchActivatedV2Applier
+    implements TypedEventApplier<JobBatchIntent, JobBatchRecord> {
+
+  private final MutableJobState jobState;
+  private final MutableJobBatchDeliveryState jobBatchDeliveryState;
+
+  public JobBatchActivatedV2Applier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+    jobBatchDeliveryState = state.getJobBatchDeliveryState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobBatchRecord value) {
+    final Iterator<JobRecord> iterator = value.jobs().iterator();
+    final Iterator<LongValue> keyIt = value.jobKeys().iterator();
+    final List<Long> activatedJobKeys = new ArrayList<>();
+    while (iterator.hasNext() && keyIt.hasNext()) {
+      final JobRecord jobRecord = iterator.next();
+      final long jobKey = keyIt.next().getValue();
+      jobState.activate(jobKey, jobRecord);
+      activatedJobKeys.add(jobKey);
+    }
+
+    final long deliveryAttemptKey = value.getDeliveryAttemptKey();
+    final long deliveryDeadline = value.getDeliveryDeadline();
+    if (deliveryAttemptKey > 0 && deliveryDeadline > 0 && !activatedJobKeys.isEmpty()) {
+      jobBatchDeliveryState.storePendingDelivery(
+          deliveryAttemptKey, value.getType(), deliveryDeadline, activatedJobKeys);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchRejectedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchRejectedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobBatchDeliveryState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+
+public final class JobBatchRejectedApplier
+    implements TypedEventApplier<JobBatchIntent, JobBatchRecord> {
+
+  private final MutableJobBatchDeliveryState jobBatchDeliveryState;
+
+  public JobBatchRejectedApplier(final MutableProcessingState state) {
+    jobBatchDeliveryState = state.getJobBatchDeliveryState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobBatchRecord value) {
+    jobBatchDeliveryState.removePendingDelivery(value.getDeliveryAttemptKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobBatchDeliveryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobBatchDeliveryState.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import io.camunda.zeebe.engine.state.jobbatch.PendingJobBatchDelivery;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+
+public interface JobBatchDeliveryState {
+
+  Optional<PendingJobBatchDelivery> getPendingDelivery(long deliveryAttemptKey);
+
+  /**
+   * Visits pending deliveries whose deadline is strictly before {@code executionTimestamp}.
+   *
+   * @return the last visited index when the callback stops iteration early, otherwise {@code null}
+   */
+  DeliveryDeadlineIndex forEachTimedOutDelivery(
+      long executionTimestamp,
+      DeliveryDeadlineIndex startAt,
+      BiPredicate<Long, PendingJobBatchDelivery> callback);
+
+  record DeliveryDeadlineIndex(long deadline, long deliveryAttemptKey) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -115,4 +115,6 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
   JobMetricsState getJobMetricsState();
 
   SecretReferenceState getSecretReferenceState();
+
+  JobBatchDeliveryState getJobBatchDeliveryState();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
@@ -36,4 +36,6 @@ public interface ScheduledTaskState {
   BatchOperationState getBatchOperationState();
 
   DbRoutingState getRoutingState();
+
+  JobBatchDeliveryState getJobBatchDeliveryState();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobbatch/DbJobBatchDeliveryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobbatch/DbJobBatchDeliveryState.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.jobbatch;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.engine.state.mutable.MutableJobBatchDeliveryState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
+
+public final class DbJobBatchDeliveryState implements MutableJobBatchDeliveryState {
+
+  private final DbLong deliveryAttemptKey;
+  private final PendingJobBatchDelivery pendingDeliveryToRead = new PendingJobBatchDelivery();
+  private final PendingJobBatchDelivery pendingDeliveryToWrite = new PendingJobBatchDelivery();
+  private final ColumnFamily<DbLong, PendingJobBatchDelivery> pendingDeliveryColumnFamily;
+
+  private final DbLong deadlineKey;
+  private final DbCompositeKey<DbLong, DbLong> deadlineAttemptKey;
+  private final ColumnFamily<DbCompositeKey<DbLong, DbLong>, DbNil> deadlinesColumnFamily;
+
+  public DbJobBatchDeliveryState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    deliveryAttemptKey = new DbLong();
+    pendingDeliveryColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.JOB_BATCH_PENDING_DELIVERY,
+            transactionContext,
+            deliveryAttemptKey,
+            pendingDeliveryToRead);
+
+    deadlineKey = new DbLong();
+    deadlineAttemptKey = new DbCompositeKey<>(deadlineKey, deliveryAttemptKey);
+    deadlinesColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.JOB_BATCH_PENDING_DELIVERY_DEADLINES,
+            transactionContext,
+            deadlineAttemptKey,
+            DbNil.INSTANCE);
+  }
+
+  @Override
+  public void storePendingDelivery(
+      final long attemptKey,
+      final String jobType,
+      final long deliveryDeadline,
+      final List<Long> jobKeys) {
+    if (attemptKey <= 0 || deliveryDeadline <= 0 || jobKeys.isEmpty()) {
+      return;
+    }
+
+    deliveryAttemptKey.wrapLong(attemptKey);
+    pendingDeliveryToWrite.wrap(jobType, deliveryDeadline, jobKeys);
+    pendingDeliveryColumnFamily.insert(deliveryAttemptKey, pendingDeliveryToWrite);
+
+    deadlineKey.wrapLong(deliveryDeadline);
+    deadlinesColumnFamily.insert(deadlineAttemptKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void removePendingDelivery(final long attemptKey) {
+    if (attemptKey <= 0) {
+      return;
+    }
+
+    deliveryAttemptKey.wrapLong(attemptKey);
+    final var pending = pendingDeliveryColumnFamily.get(deliveryAttemptKey);
+    if (pending == null) {
+      return;
+    }
+
+    final long deadline = pending.getDeliveryDeadline();
+    pendingDeliveryColumnFamily.deleteExisting(deliveryAttemptKey);
+
+    if (deadline > 0) {
+      deadlineKey.wrapLong(deadline);
+      deadlinesColumnFamily.deleteIfExists(deadlineAttemptKey);
+    }
+  }
+
+  @Override
+  public Optional<PendingJobBatchDelivery> getPendingDelivery(final long attemptKey) {
+    if (attemptKey <= 0) {
+      return Optional.empty();
+    }
+    deliveryAttemptKey.wrapLong(attemptKey);
+    final var pending = pendingDeliveryColumnFamily.get(deliveryAttemptKey);
+    if (pending == null) {
+      return Optional.empty();
+    }
+    // Copy out of the shared CF buffer before another read overwrites it.
+    final var copy = new PendingJobBatchDelivery();
+    copy.wrap(pending.getType(), pending.getDeliveryDeadline(), pending.getJobKeys());
+    return Optional.of(copy);
+  }
+
+  @Override
+  public DeliveryDeadlineIndex forEachTimedOutDelivery(
+      final long executionTimestamp,
+      final DeliveryDeadlineIndex startAt,
+      final BiPredicate<Long, PendingJobBatchDelivery> callback) {
+    final DbCompositeKey<DbLong, DbLong> startAtKey;
+    if (startAt != null) {
+      deadlineKey.wrapLong(startAt.deadline());
+      deliveryAttemptKey.wrapLong(startAt.deliveryAttemptKey());
+      startAtKey = deadlineAttemptKey;
+    } else {
+      startAtKey = null;
+    }
+
+    final var lastVisitedIndex = new AtomicReference<DeliveryDeadlineIndex>();
+    deadlinesColumnFamily.whileTrue(
+        startAtKey,
+        (key, value) -> {
+          final var deadline = key.first().getValue();
+          if (deadline >= executionTimestamp) {
+            return false;
+          }
+
+          final long attemptKey = key.second().getValue();
+          deliveryAttemptKey.wrapLong(attemptKey);
+          final var pending = pendingDeliveryColumnFamily.get(deliveryAttemptKey);
+          if (pending == null || pending.getDeliveryDeadline() != deadline) {
+            deadlinesColumnFamily.deleteExisting(key);
+            return true;
+          }
+
+          final var copy = new PendingJobBatchDelivery();
+          copy.wrap(pending.getType(), pending.getDeliveryDeadline(), pending.getJobKeys());
+          final boolean continueIteration = callback.test(attemptKey, copy);
+          if (!continueIteration) {
+            lastVisitedIndex.set(new DeliveryDeadlineIndex(deadline, attemptKey));
+          }
+          return continueIteration;
+        });
+
+    return lastVisitedIndex.get();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobbatch/PendingJobBatchDelivery.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobbatch/PendingJobBatchDelivery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.jobbatch;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.DirectBuffer;
+
+public final class PendingJobBatchDelivery extends UnpackedObject implements DbValue {
+
+  private static final StringValue TYPE_KEY = new StringValue("type");
+  private static final StringValue DELIVERY_DEADLINE_KEY = new StringValue("deliveryDeadline");
+  private static final StringValue JOB_KEYS_KEY = new StringValue("jobKeys");
+
+  private final StringProperty typeProp = new StringProperty(TYPE_KEY, "");
+  private final LongProperty deliveryDeadlineProp = new LongProperty(DELIVERY_DEADLINE_KEY, 0L);
+  private final ArrayProperty<LongValue> jobKeysProp =
+      new ArrayProperty<>(JOB_KEYS_KEY, LongValue::new);
+
+  public PendingJobBatchDelivery() {
+    super(3);
+    declareProperty(typeProp).declareProperty(deliveryDeadlineProp).declareProperty(jobKeysProp);
+  }
+
+  public PendingJobBatchDelivery wrap(
+      final String type, final long deliveryDeadline, final List<Long> jobKeys) {
+    typeProp.setValue(type);
+    deliveryDeadlineProp.setValue(deliveryDeadline);
+    jobKeysProp.reset();
+    for (final long jobKey : jobKeys) {
+      jobKeysProp.add().setValue(jobKey);
+    }
+    return this;
+  }
+
+  public String getType() {
+    return BufferUtil.bufferAsString(typeProp.getValue());
+  }
+
+  public DirectBuffer getTypeBuffer() {
+    return typeProp.getValue();
+  }
+
+  public long getDeliveryDeadline() {
+    return deliveryDeadlineProp.getValue();
+  }
+
+  public List<Long> getJobKeys() {
+    final var keys = new ArrayList<Long>();
+    for (final LongValue jobKey : jobKeysProp) {
+      keys.add(jobKey.getValue());
+    }
+    return keys;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobBatchDeliveryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobBatchDeliveryState.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.JobBatchDeliveryState;
+import java.util.List;
+
+public interface MutableJobBatchDeliveryState extends JobBatchDeliveryState {
+
+  void storePendingDelivery(
+      long deliveryAttemptKey, String jobType, long deliveryDeadline, List<Long> jobKeys);
+
+  void removePendingDelivery(long deliveryAttemptKey);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -151,5 +151,8 @@ public interface MutableProcessingState extends ProcessingState {
   @Override
   MutableSecretReferenceState getSecretReferenceState();
 
+  @Override
+  MutableJobBatchDeliveryState getJobBatchDeliveryState();
+
   KeyGenerator getKeyGenerator();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchDeliveryAckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchDeliveryAckTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobBatchRecords;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class JobBatchDeliveryAckTest {
+
+  private static final Duration DELIVERY_ACK_TIMEOUT = Duration.ofMillis(100);
+  private static final String PROCESS_ID = "process";
+  private static final int PARTITION_ID = 1;
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setJobsDeliveryAckTimeout(DELIVERY_ACK_TIMEOUT));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private String jobType;
+  private long deliveryAttemptKey;
+
+  @Before
+  public void setup() {
+    jobType = Strings.newRandomValidBpmnId();
+    deliveryAttemptKey = System.nanoTime();
+  }
+
+  @Test
+  public void shouldStampDeliveryDeadlineWhenAttemptKeyPresent() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final long before = ENGINE.getClock().getCurrentTimeInMillis();
+
+    // when
+    final Record<JobBatchRecordValue> activated =
+        ENGINE.jobs().withType(jobType).withDeliveryAttemptKey(deliveryAttemptKey).activate();
+
+    // then
+    assertThat(activated.getValue().getDeliveryAttemptKey()).isEqualTo(deliveryAttemptKey);
+    assertThat(activated.getValue().getDeliveryDeadline())
+        .isGreaterThanOrEqualTo(before + DELIVERY_ACK_TIMEOUT.toMillis());
+    assertThat(activated.getValue().getJobKeys()).isNotEmpty();
+  }
+
+  @Test
+  public void shouldNotStampDeliveryDeadlineWithoutAttemptKey() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+
+    // when
+    final Record<JobBatchRecordValue> activated = ENGINE.jobs().withType(jobType).activate();
+
+    // then
+    assertThat(activated.getValue().getDeliveryAttemptKey()).isZero();
+    assertThat(activated.getValue().getDeliveryDeadline()).isZero();
+  }
+
+  @Test
+  public void shouldAcknowledgePendingDelivery() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> activated =
+        ENGINE.jobs().withType(jobType).withDeliveryAttemptKey(deliveryAttemptKey).activate();
+    final long jobKey = activated.getValue().getJobKeys().getFirst();
+
+    // when
+    writeAcknowledge(deliveryAttemptKey, jobType);
+
+    // then
+    final Record<JobBatchRecordValue> acknowledged =
+        jobBatchRecords(JobBatchIntent.ACKNOWLEDGED)
+            .withType(jobType)
+            .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+            .getFirst();
+    assertThat(acknowledged.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(acknowledged.getValue().getDeliveryAttemptKey()).isEqualTo(deliveryAttemptKey);
+
+    // job stays activated (ACK does not yield)
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                ignored -> jobRecords(JobIntent.YIELDED).withRecordKey(jobKey).exists()))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldRejectPendingDeliveryAndYieldJobs() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> activated =
+        ENGINE.jobs().withType(jobType).withDeliveryAttemptKey(deliveryAttemptKey).activate();
+    final long jobKey = activated.getValue().getJobKeys().getFirst();
+
+    // when
+    writeReject(deliveryAttemptKey, jobType);
+
+    // then
+    final Record<JobBatchRecordValue> rejected =
+        jobBatchRecords(JobBatchIntent.REJECTED)
+            .withType(jobType)
+            .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+            .getFirst();
+    assertThat(rejected.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(rejected.getValue().getJobKeys()).containsExactly(jobKey);
+
+    final Record<JobRecordValue> yielded =
+        jobRecords(JobIntent.YIELDED).withRecordKey(jobKey).getFirst();
+    assertThat(yielded.getValue().getType()).isEqualTo(jobType);
+
+    // and the job can be activated again
+    final Record<JobBatchRecordValue> reactivated = ENGINE.jobs().withType(jobType).activate();
+    assertThat(reactivated.getValue().getJobKeys()).containsExactly(jobKey);
+  }
+
+  @Test
+  public void shouldBeIdempotentOnDoubleAcknowledge() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    ENGINE.jobs().withType(jobType).withDeliveryAttemptKey(deliveryAttemptKey).activate();
+    writeAcknowledge(deliveryAttemptKey, jobType);
+    jobBatchRecords(JobBatchIntent.ACKNOWLEDGED)
+        .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+        .await();
+
+    // when
+    writeAcknowledge(deliveryAttemptKey, jobType);
+    jobBatchRecords(JobBatchIntent.ACKNOWLEDGED)
+        .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+        .skip(1)
+        .await();
+
+    // then
+    assertThat(
+            jobBatchRecords(JobBatchIntent.ACKNOWLEDGED)
+                .withType(jobType)
+                .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+                .limit(2)
+                .count())
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldBeIdempotentOnDoubleReject() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> activated =
+        ENGINE.jobs().withType(jobType).withDeliveryAttemptKey(deliveryAttemptKey).activate();
+    final long jobKey = activated.getValue().getJobKeys().getFirst();
+    writeReject(deliveryAttemptKey, jobType);
+    jobRecords(JobIntent.YIELDED).withRecordKey(jobKey).await();
+    jobBatchRecords(JobBatchIntent.REJECTED)
+        .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+        .await();
+
+    // when
+    writeReject(deliveryAttemptKey, jobType);
+    jobBatchRecords(JobBatchIntent.REJECTED)
+        .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+        .skip(1)
+        .await();
+
+    // then — second reject does not yield again
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                ignored -> jobRecords(JobIntent.YIELDED).withRecordKey(jobKey).skip(1).exists()))
+        .isFalse();
+    assertThat(
+            jobBatchRecords(JobBatchIntent.REJECTED)
+                .withType(jobType)
+                .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+                .limit(2)
+                .count())
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldYieldOnDeliveryAckTimeout() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> activated =
+        ENGINE.jobs().withType(jobType).withDeliveryAttemptKey(deliveryAttemptKey).activate();
+    final long jobKey = activated.getValue().getJobKeys().getFirst();
+    final long deliveryDeadline = activated.getValue().getDeliveryDeadline();
+    assertThat(deliveryDeadline).isPositive();
+
+    // when — advance past delivery deadline + checker poll interval (same pattern as
+    // JobTimeOutTest)
+    ENGINE.increaseTime(
+        DELIVERY_ACK_TIMEOUT.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+
+    // then
+    final Record<JobRecordValue> yielded =
+        jobRecords(JobIntent.YIELDED).withRecordKey(jobKey).getFirst();
+    assertThat(yielded.getValue().getType()).isEqualTo(jobType);
+
+    final Record<JobBatchRecordValue> rejected =
+        jobBatchRecords(JobBatchIntent.REJECTED)
+            .withType(jobType)
+            .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+            .getFirst();
+    assertThat(rejected.getValue().getJobKeys()).containsExactly(jobKey);
+
+    final Record<JobBatchRecordValue> reactivated = ENGINE.jobs().withType(jobType).activate();
+    assertThat(reactivated.getValue().getJobKeys()).containsExactly(jobKey);
+  }
+
+  @Test
+  public void shouldNotTimeoutAfterAcknowledge() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> activated =
+        ENGINE.jobs().withType(jobType).withDeliveryAttemptKey(deliveryAttemptKey).activate();
+    final long jobKey = activated.getValue().getJobKeys().getFirst();
+    writeAcknowledge(deliveryAttemptKey, jobType);
+    jobBatchRecords(JobBatchIntent.ACKNOWLEDGED)
+        .filter(r -> r.getValue().getDeliveryAttemptKey() == deliveryAttemptKey)
+        .await();
+
+    // when
+    ENGINE.increaseTime(
+        DELIVERY_ACK_TIMEOUT.plus(
+            EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL.multipliedBy(2)));
+
+    // then — job remains activated (no yield from delivery checker)
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                ignored -> jobRecords(JobIntent.YIELDED).withRecordKey(jobKey).exists()))
+        .isFalse();
+  }
+
+  private void writeAcknowledge(final long attemptKey, final String type) {
+    final var command = new JobBatchRecord();
+    command.setType(type);
+    command.setDeliveryAttemptKey(attemptKey);
+    ENGINE.writeCommandOnPartition(PARTITION_ID, attemptKey, JobBatchIntent.ACKNOWLEDGE, command);
+  }
+
+  private void writeReject(final long attemptKey, final String type) {
+    final var command = new JobBatchRecord();
+    command.setType(type);
+    command.setDeliveryAttemptKey(attemptKey);
+    ENGINE.writeCommandOnPartition(PARTITION_ID, attemptKey, JobBatchIntent.REJECT, command);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
@@ -113,6 +113,11 @@ public final class JobActivationClient {
     return this;
   }
 
+  public JobActivationClient withDeliveryAttemptKey(final long deliveryAttemptKey) {
+    jobBatchRecord.setDeliveryAttemptKey(deliveryAttemptKey);
+    return this;
+  }
+
   public JobActivationClient withTenantFilter(final TenantFilter tenantFilter) {
     jobBatchRecord.setTenantFilter(tenantFilter);
     return this;

--- a/zeebe/engine/src/test/resources/state/appliers/golden/JobBatch_ACKNOWLEDGED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/JobBatch_ACKNOWLEDGED_v1.golden
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobBatchDeliveryState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+
+public final class JobBatchAcknowledgedApplier
+    implements TypedEventApplier<JobBatchIntent, JobBatchRecord> {
+
+  private final MutableJobBatchDeliveryState jobBatchDeliveryState;
+
+  public JobBatchAcknowledgedApplier(final MutableProcessingState state) {
+    jobBatchDeliveryState = state.getJobBatchDeliveryState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobBatchRecord value) {
+    jobBatchDeliveryState.removePendingDelivery(value.getDeliveryAttemptKey());
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/JobBatch_ACTIVATED_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/JobBatch_ACTIVATED_v2.golden
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobBatchDeliveryState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Activates jobs like {@link JobBatchActivatedApplier} and, when a delivery attempt key is present,
+ * registers a pending delivery so the gateway handshake can ACK or REJECT the batch.
+ */
+public final class JobBatchActivatedV2Applier
+    implements TypedEventApplier<JobBatchIntent, JobBatchRecord> {
+
+  private final MutableJobState jobState;
+  private final MutableJobBatchDeliveryState jobBatchDeliveryState;
+
+  public JobBatchActivatedV2Applier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+    jobBatchDeliveryState = state.getJobBatchDeliveryState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobBatchRecord value) {
+    final Iterator<JobRecord> iterator = value.jobs().iterator();
+    final Iterator<LongValue> keyIt = value.jobKeys().iterator();
+    final List<Long> activatedJobKeys = new ArrayList<>();
+    while (iterator.hasNext() && keyIt.hasNext()) {
+      final JobRecord jobRecord = iterator.next();
+      final long jobKey = keyIt.next().getValue();
+      jobState.activate(jobKey, jobRecord);
+      activatedJobKeys.add(jobKey);
+    }
+
+    final long deliveryAttemptKey = value.getDeliveryAttemptKey();
+    final long deliveryDeadline = value.getDeliveryDeadline();
+    if (deliveryAttemptKey > 0 && deliveryDeadline > 0 && !activatedJobKeys.isEmpty()) {
+      jobBatchDeliveryState.storePendingDelivery(
+          deliveryAttemptKey, value.getType(), deliveryDeadline, activatedJobKeys);
+    }
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/JobBatch_REJECTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/JobBatch_REJECTED_v1.golden
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobBatchDeliveryState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+
+public final class JobBatchRejectedApplier
+    implements TypedEventApplier<JobBatchIntent, JobBatchRecord> {
+
+  private final MutableJobBatchDeliveryState jobBatchDeliveryState;
+
+  public JobBatchRejectedApplier(final MutableProcessingState state) {
+    jobBatchDeliveryState = state.getJobBatchDeliveryState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobBatchRecord value) {
+    jobBatchDeliveryState.removePendingDelivery(value.getDeliveryAttemptKey());
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
@@ -202,6 +202,12 @@
             },
             "tenantFilter": {
               "type": "keyword"
+            },
+            "deliveryAttemptKey": {
+              "type": "long"
+            },
+            "deliveryDeadline": {
+              "type": "date"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
@@ -208,6 +208,12 @@
             },
             "tenantFilter": {
               "type": "keyword"
+            },
+            "deliveryAttemptKey": {
+              "type": "long"
+            },
+            "deliveryDeadline": {
+              "type": "date"
             }
           }
         }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateJobsRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateJobsRequest.java
@@ -66,6 +66,15 @@ public final class BrokerActivateJobsRequest extends BrokerExecuteCommand<JobBat
     return this;
   }
 
+  public BrokerActivateJobsRequest setDeliveryAttemptKey(final long deliveryAttemptKey) {
+    requestDto.setDeliveryAttemptKey(deliveryAttemptKey);
+    return this;
+  }
+
+  public long getDeliveryAttemptKey() {
+    return requestDto.getDeliveryAttemptKey();
+  }
+
   @Override
   public JobBatchRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerJobBatchAcknowledgeRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerJobBatchAcknowledgeRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import org.agrona.DirectBuffer;
+
+/** Confirms that the gateway received a JobBatch activation response for a delivery attempt. */
+public final class BrokerJobBatchAcknowledgeRequest extends BrokerExecuteCommand<JobBatchRecord> {
+
+  private final JobBatchRecord requestDto = new JobBatchRecord();
+
+  public BrokerJobBatchAcknowledgeRequest(
+      final int partitionId, final String jobType, final long deliveryAttemptKey) {
+    super(ValueType.JOB_BATCH, JobBatchIntent.ACKNOWLEDGE);
+    setPartitionId(partitionId);
+    requestDto.setType(jobType);
+    requestDto.setDeliveryAttemptKey(deliveryAttemptKey);
+  }
+
+  @Override
+  public JobBatchRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected JobBatchRecord toResponseDto(final DirectBuffer buffer) {
+    final JobBatchRecord responseDto = new JobBatchRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerJobBatchRejectRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerJobBatchRejectRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import org.agrona.DirectBuffer;
+
+/**
+ * Rejects a pending JobBatch delivery when the gateway did not receive a usable activation
+ * response. The broker yields still-activated jobs for that attempt.
+ */
+public final class BrokerJobBatchRejectRequest extends BrokerExecuteCommand<JobBatchRecord> {
+
+  private final JobBatchRecord requestDto = new JobBatchRecord();
+
+  public BrokerJobBatchRejectRequest(
+      final int partitionId, final String jobType, final long deliveryAttemptKey) {
+    super(ValueType.JOB_BATCH, JobBatchIntent.REJECT);
+    setPartitionId(partitionId);
+    requestDto.setType(jobType);
+    requestDto.setDeliveryAttemptKey(deliveryAttemptKey);
+  }
+
+  @Override
+  public JobBatchRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected JobBatchRecord toResponseDto(final DirectBuffer buffer) {
+    final JobBatchRecord responseDto = new JobBatchRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.broker.client.impl.RoundRobinDispatchStrategy;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerJobBatchAcknowledgeRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerJobBatchRejectRequest;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResult.ActivatedJob;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.ErrorCode;
@@ -125,14 +127,18 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
             final var brokerRequest = request.getRequest();
             final var partitionId = requestState.getNextPartition();
             final var remainingAmount = requestState.getRemainingAmount();
+            final var deliveryAttemptKey = ACTIVATE_JOBS_REQUEST_ID_GENERATOR.getAndIncrement();
 
             // partitions to check and jobs to activate left
             brokerRequest.setPartitionId(partitionId);
             brokerRequest.setMaxJobsToActivate(remainingAmount);
+            brokerRequest.setDeliveryAttemptKey(deliveryAttemptKey);
 
             brokerClient
                 .sendRequest(brokerRequest)
-                .whenCompleteAsync(handleBrokerResponse(request, requestState, delegate), actor);
+                .whenCompleteAsync(
+                    handleBrokerResponse(request, requestState, delegate, deliveryAttemptKey),
+                    actor);
 
           } else {
             // enough jobs activated or no more partitions left to check
@@ -146,14 +152,16 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
   private BiConsumer<BrokerResponse<JobBatchRecord>, Throwable> handleBrokerResponse(
       final InflightActivateJobsRequest<T> request,
       final InflightActivateJobsRequestState requestState,
-      final ResponseObserverDelegate delegate) {
+      final ResponseObserverDelegate delegate,
+      final long deliveryAttemptKey) {
     return (brokerResponse, error) -> {
       if (error == null && brokerResponse.isResponse()) {
-        handleResponseSuccess(request, requestState, delegate, brokerResponse);
+        handleResponseSuccess(request, requestState, delegate, brokerResponse, deliveryAttemptKey);
       } else if (error == null) {
-        handleBrokerErrorResponse(request, requestState, delegate, brokerResponse);
+        handleBrokerErrorResponse(
+            request, requestState, delegate, brokerResponse, deliveryAttemptKey);
       } else {
-        handleResponseError(request, requestState, delegate, error);
+        handleResponseError(request, requestState, delegate, error, deliveryAttemptKey);
       }
     };
   }
@@ -162,10 +170,16 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
       final InflightActivateJobsRequest<T> request,
       final InflightActivateJobsRequestState requestState,
       final ResponseObserverDelegate delegate,
-      final BrokerResponse<JobBatchRecord> brokerResponse) {
+      final BrokerResponse<JobBatchRecord> brokerResponse,
+      final long deliveryAttemptKey) {
     actor.run(
         () -> {
           final var response = brokerResponse.getResponse();
+          // ACK as soon as the broker response is received — before client delivery. Client-send
+          // failures still use reactivateJobs → FAIL.
+          acknowledgeDelivery(
+              brokerResponse.getPartitionId(), request.getType(), deliveryAttemptKey);
+
           final JobActivationResult<T> jobActivationResult =
               activationResultMapper.apply(
                   new JobActivationResponse(
@@ -263,7 +277,8 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
       final InflightActivateJobsRequest<T> request,
       final InflightActivateJobsRequestState state,
       final ResponseObserverDelegate delegate,
-      final Throwable error) {
+      final Throwable error,
+      final long deliveryAttemptKey) {
     actor.run(
         () -> {
           final var wasResourceExhausted = wasResourceExhausted(error);
@@ -272,6 +287,8 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
             return;
           } else if (!wasResourceExhausted) {
             logErrorResponse(state.getCurrentPartition(), request.getType(), error);
+            // Best-effort reclaim if the broker may have activated jobs but the response was lost.
+            rejectDelivery(state.getCurrentPartition(), request.getType(), deliveryAttemptKey);
           }
 
           state.setResourceExhaustedWasPresent(wasResourceExhausted);
@@ -284,8 +301,57 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
       final InflightActivateJobsRequest<T> request,
       final InflightActivateJobsRequestState state,
       final ResponseObserverDelegate delegate,
-      final BrokerResponse<JobBatchRecord> response) {
-    handleResponseError(request, state, delegate, response.toException());
+      final BrokerResponse<JobBatchRecord> response,
+      final long deliveryAttemptKey) {
+    handleResponseError(request, state, delegate, response.toException(), deliveryAttemptKey);
+  }
+
+  private void acknowledgeDelivery(
+      final int partitionId, final String jobType, final long deliveryAttemptKey) {
+    if (deliveryAttemptKey <= 0) {
+      return;
+    }
+    final var ackRequest =
+        new BrokerJobBatchAcknowledgeRequest(partitionId, jobType, deliveryAttemptKey);
+    ackRequest.setAuthorization(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
+    brokerClient
+        .sendRequestWithRetry(ackRequest)
+        .whenCompleteAsync(
+            (response, error) -> {
+              if (error != null) {
+                Loggers.GATEWAY_LOGGER.debug(
+                    "Failed to ACK JobBatch delivery attempt {} on partition {} for type {}: {}",
+                    deliveryAttemptKey,
+                    partitionId,
+                    jobType,
+                    error.getMessage());
+              }
+            },
+            actor);
+  }
+
+  private void rejectDelivery(
+      final int partitionId, final String jobType, final long deliveryAttemptKey) {
+    if (deliveryAttemptKey <= 0) {
+      return;
+    }
+    final var rejectRequest =
+        new BrokerJobBatchRejectRequest(partitionId, jobType, deliveryAttemptKey);
+    rejectRequest.setAuthorization(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
+    brokerClient
+        .sendRequestWithRetry(rejectRequest)
+        .whenCompleteAsync(
+            (response, error) -> {
+              if (error != null) {
+                Loggers.GATEWAY_LOGGER.debug(
+                    "Failed to REJECT JobBatch delivery attempt {} on partition {} for type {}: {}",
+                    deliveryAttemptKey,
+                    partitionId,
+                    jobType,
+                    error.getMessage());
+              }
+            },
+            actor);
   }
 
   private boolean isRejection(final Throwable error) {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsStub.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsStub.java
@@ -104,6 +104,7 @@ public class ActivateJobsStub
     response.setWorker(requestDto.getWorkerBuffer());
     response.setType(requestDto.getTypeBuffer());
     response.setTimeout(requestDto.getTimeout());
+    response.setDeliveryAttemptKey(requestDto.getDeliveryAttemptKey());
     addJobs(
         response,
         partitionId,

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsDeliveryAckTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsDeliveryAckTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
+import io.camunda.zeebe.broker.client.api.dto.BrokerErrorResponse;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerJobBatchAcknowledgeRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerJobBatchRejectRequest;
+import io.camunda.zeebe.gateway.impl.job.JobActivationResult.ActivatedJob;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.util.unit.DataSize;
+
+final class RoundRobinActivateJobsDeliveryAckTest {
+
+  private static final String TYPE = "delivery-ack-job";
+  private static final long MAX_MESSAGE_SIZE = DataSize.ofMegabytes(4).toBytes();
+
+  @RegisterExtension
+  final ControlledActorSchedulerExtension actorScheduler = new ControlledActorSchedulerExtension();
+
+  private final StubbedBrokerClient brokerClient = new StubbedBrokerClient();
+  private RoundRobinActivateJobsHandler<Object> handler;
+  private ActivateJobsStub activateJobsStub;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        new RoundRobinActivateJobsHandler<>(
+            brokerClient,
+            MAX_MESSAGE_SIZE,
+            response ->
+                new JobActivationResult<>() {
+                  @Override
+                  public int getJobsCount() {
+                    return response.brokerResponse().getJobKeys().size();
+                  }
+
+                  @Override
+                  public List<ActivatedJob> getJobs() {
+                    return response.brokerResponse().getJobKeys().stream()
+                        .map(key -> new ActivatedJob(key, 3))
+                        .toList();
+                  }
+
+                  @Override
+                  public Object getActivateJobsResponse() {
+                    return response;
+                  }
+
+                  @Override
+                  public List<ActivatedJob> getJobsToDefer() {
+                    return Collections.emptyList();
+                  }
+                },
+            RuntimeException::new);
+    final var ready = new CompletableFuture<Void>();
+    final var actor =
+        Actor.newActor()
+            .name("TestRoundRobinHandler")
+            .actorStartedHandler(handler.andThen(ignored -> ready.complete(null)))
+            .build();
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
+    ready.join();
+
+    activateJobsStub = new ActivateJobsStub();
+    activateJobsStub.registerWith(brokerClient);
+    brokerClient.registerHandler(
+        BrokerJobBatchAcknowledgeRequest.class,
+        request -> new BrokerResponse<>(request.getRequestWriter(), request.getPartitionId(), 1L));
+    brokerClient.registerHandler(
+        BrokerJobBatchRejectRequest.class,
+        request -> new BrokerResponse<>(request.getRequestWriter(), request.getPartitionId(), 1L));
+  }
+
+  @Test
+  void shouldSetDeliveryAttemptKeyAndSendAckOnSuccess() {
+    // given
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    final var completed = new AtomicBoolean(false);
+
+    // when
+    activate(completed);
+
+    // then
+    await().atMost(Duration.ofSeconds(2)).untilTrue(completed);
+
+    final var activateRequests =
+        brokerClient.getBrokerRequests().stream()
+            .filter(BrokerActivateJobsRequest.class::isInstance)
+            .map(BrokerActivateJobsRequest.class::cast)
+            .toList();
+    assertThat(activateRequests).isNotEmpty();
+    assertThat(activateRequests.getFirst().getDeliveryAttemptKey()).isPositive();
+
+    final var ackRequests =
+        brokerClient.getBrokerRequests().stream()
+            .filter(BrokerJobBatchAcknowledgeRequest.class::isInstance)
+            .map(BrokerJobBatchAcknowledgeRequest.class::cast)
+            .toList();
+    assertThat(ackRequests).isNotEmpty();
+    assertThat(ackRequests.getFirst().getRequestWriter().getDeliveryAttemptKey())
+        .isEqualTo(activateRequests.getFirst().getDeliveryAttemptKey());
+    assertThat(
+            brokerClient.getBrokerRequests().stream()
+                .anyMatch(BrokerJobBatchRejectRequest.class::isInstance))
+        .isFalse();
+  }
+
+  @Test
+  void shouldSendRejectOnTransportError() {
+    // given
+    brokerClient.registerHandler(
+        BrokerActivateJobsRequest.class,
+        request -> {
+          throw new TimeoutException("connection closed");
+        });
+    final var completed = new AtomicBoolean(false);
+
+    // when
+    activate(completed);
+
+    // then
+    await().atMost(Duration.ofSeconds(2)).untilTrue(completed);
+
+    final var rejectRequests =
+        brokerClient.getBrokerRequests().stream()
+            .filter(BrokerJobBatchRejectRequest.class::isInstance)
+            .map(BrokerJobBatchRejectRequest.class::cast)
+            .toList();
+    // round-robin continues across partitions — at least one REJECT
+    assertThat(rejectRequests).isNotEmpty();
+    assertThat(
+            brokerClient.getBrokerRequests().stream()
+                .anyMatch(BrokerJobBatchAcknowledgeRequest.class::isInstance))
+        .isFalse();
+  }
+
+  @Test
+  void shouldNotSendRejectOnResourceExhausted() {
+    // given
+    brokerClient.registerHandler(
+        BrokerActivateJobsRequest.class,
+        request ->
+            new BrokerErrorResponse<>(
+                new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")));
+    final var completed = new AtomicBoolean(false);
+
+    // when
+    activate(completed);
+
+    // then
+    await().atMost(Duration.ofSeconds(2)).untilTrue(completed);
+    assertThat(
+            brokerClient.getBrokerRequests().stream()
+                .anyMatch(BrokerJobBatchRejectRequest.class::isInstance))
+        .isFalse();
+    assertThat(
+            brokerClient.getBrokerRequests().stream()
+                .anyMatch(BrokerJobBatchAcknowledgeRequest.class::isInstance))
+        .isFalse();
+  }
+
+  private void activate(final AtomicBoolean completed) {
+    final var request =
+        new BrokerActivateJobsRequest(TYPE)
+            .setMaxJobsToActivate(1)
+            .setTimeout(10_000L)
+            .setWorker("worker")
+            .setVariables(Collections.emptyList())
+            .setTenantIds(Collections.emptyList());
+
+    handler.activateJobs(
+        request,
+        new ResponseObserver<>() {
+          @Override
+          public void onNext(final Object value) {}
+
+          @Override
+          public void onError(final Throwable t) {
+            completed.set(true);
+          }
+
+          @Override
+          public void onCompleted() {
+            completed.set(true);
+          }
+
+          @Override
+          public boolean isCancelled() {
+            return false;
+          }
+        },
+        cancel -> {},
+        5_000L);
+
+    // drain actor tasks including whenCompleteAsync callbacks
+    for (int i = 0; i < 50; i++) {
+      actorScheduler.workUntilDone();
+    }
+  }
+}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
@@ -25,6 +26,8 @@ public class WhiteListedCommands {
           JobIntent.FAIL,
           JobIntent.YIELD,
           JobIntent.TIME_OUT,
+          JobBatchIntent.ACKNOWLEDGE,
+          JobBatchIntent.REJECT,
           ProcessInstanceIntent.CANCEL,
           DeploymentIntent.CREATE,
           DeploymentIntent.DISTRIBUTE,

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -42,6 +42,8 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private static final StringValue TRUNCATED_KEY = new StringValue("truncated");
   private static final StringValue WITH_LEASE_KEY = new StringValue("withLease");
   private static final StringValue TENANT_FILTER_KEY = new StringValue("tenantFilter");
+  private static final StringValue DELIVERY_ATTEMPT_KEY = new StringValue("deliveryAttemptKey");
+  private static final StringValue DELIVERY_DEADLINE_KEY = new StringValue("deliveryDeadline");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, "");
@@ -59,9 +61,11 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final BooleanProperty withLeaseProp = new BooleanProperty(WITH_LEASE_KEY, false);
   private final EnumProperty<TenantFilter> tenantFilterProp =
       new EnumProperty<>(TENANT_FILTER_KEY, TenantFilter.class, TenantFilter.PROVIDED);
+  private final LongProperty deliveryAttemptKeyProp = new LongProperty(DELIVERY_ATTEMPT_KEY, 0L);
+  private final LongProperty deliveryDeadlineProp = new LongProperty(DELIVERY_DEADLINE_KEY, 0L);
 
   public JobBatchRecord() {
-    super(11);
+    super(13);
     declareProperty(typeProp)
         .declareProperty(workerProp)
         .declareProperty(timeoutProp)
@@ -72,7 +76,9 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
         .declareProperty(truncatedProp)
         .declareProperty(withLeaseProp)
         .declareProperty(tenantIdsProp)
-        .declareProperty(tenantFilterProp);
+        .declareProperty(tenantFilterProp)
+        .declareProperty(deliveryAttemptKeyProp)
+        .declareProperty(deliveryDeadlineProp);
   }
 
   public JobBatchRecord setType(final DirectBuffer buf, final int offset, final int length) {
@@ -168,8 +174,28 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
     return tenantFilterProp.getValue();
   }
 
+  @Override
+  public long getDeliveryAttemptKey() {
+    return deliveryAttemptKeyProp.getValue();
+  }
+
+  @Override
+  public long getDeliveryDeadline() {
+    return deliveryDeadlineProp.getValue();
+  }
+
   public JobBatchRecord setTenantFilter(final TenantFilter tenantFilter) {
     tenantFilterProp.setValue(tenantFilter);
+    return this;
+  }
+
+  public JobBatchRecord setDeliveryAttemptKey(final long deliveryAttemptKey) {
+    deliveryAttemptKeyProp.setValue(deliveryAttemptKey);
+    return this;
+  }
+
+  public JobBatchRecord setDeliveryDeadline(final long deliveryDeadline) {
+    deliveryDeadlineProp.setValue(deliveryDeadline);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -804,7 +804,9 @@ final class JsonSerializableToJsonTest {
                       .setType(type)
                       .setWorker(worker)
                       .setTruncated(true)
-                      .setWithLease(true);
+                      .setWithLease(true)
+                      .setDeliveryAttemptKey(42L)
+                      .setDeliveryDeadline(9000L);
 
               record.jobKeys().add().setValue(3L);
               final JobRecord jobRecord = record.jobs().add();
@@ -961,7 +963,9 @@ final class JsonSerializableToJsonTest {
                   ],
                   "timeout": 2,
                   "tenantIds": [],
-                  "tenantFilter": "PROVIDED"
+                  "tenantFilter": "PROVIDED",
+                  "deliveryAttemptKey": 42,
+                  "deliveryDeadline": 9000
                 }
                 """
       },
@@ -988,7 +992,9 @@ final class JsonSerializableToJsonTest {
                   "jobs": [],
                   "timeout": -1,
                   "tenantIds": [],
-                  "tenantFilter": "PROVIDED"
+                  "tenantFilter": "PROVIDED",
+                  "deliveryAttemptKey": 0,
+                  "deliveryDeadline": 0
                 }
                 """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -366,7 +366,12 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // (processDefinitionKey, elementId) -> agentDefinitionKey. Minted once per AI agent element at
   // deploy time and replicated identically to every partition (like process/decision/form
   // definitions), so this is GLOBAL rather than PARTITION_LOCAL.
-  AGENT_DEFINITION_KEY_BY_PROCESS_DEFINITION_KEY_AND_ELEMENT_ID(161, GLOBAL);
+  AGENT_DEFINITION_KEY_BY_PROCESS_DEFINITION_KEY_AND_ELEMENT_ID(161, GLOBAL),
+
+  // pending JobBatch delivery handshake: deliveryAttemptKey -> job keys + delivery deadline
+  JOB_BATCH_PENDING_DELIVERY(162, PARTITION_LOCAL),
+  // secondary index: (deliveryDeadline, deliveryAttemptKey) → ∅ for the delivery-ack checker
+  JOB_BATCH_PENDING_DELIVERY_DEADLINES(163, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobBatchIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobBatchIntent.java
@@ -17,7 +17,21 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public enum JobBatchIntent implements Intent {
   ACTIVATE((short) 0),
-  ACTIVATED((short) 1);
+  ACTIVATED((short) 1),
+
+  /**
+   * Gateway confirms it received the activation response for the delivery attempt key. Clears the
+   * pending delivery without changing job state.
+   */
+  ACKNOWLEDGE((short) 2),
+  ACKNOWLEDGED((short) 3),
+
+  /**
+   * Gateway or the delivery-ack timer rejects a pending delivery. Yields jobs that are still
+   * activated for that attempt so they become activatable again.
+   */
+  REJECT((short) 4),
+  REJECTED((short) 5);
 
   private final short value;
 
@@ -35,6 +49,14 @@ public enum JobBatchIntent implements Intent {
         return ACTIVATE;
       case 1:
         return ACTIVATED;
+      case 2:
+        return ACKNOWLEDGE;
+      case 3:
+        return ACKNOWLEDGED;
+      case 4:
+        return REJECT;
+      case 5:
+        return REJECTED;
       default:
         return Intent.UNKNOWN;
     }
@@ -49,6 +71,8 @@ public enum JobBatchIntent implements Intent {
   public boolean isEvent() {
     switch (this) {
       case ACTIVATED:
+      case ACKNOWLEDGED:
+      case REJECTED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
@@ -89,4 +89,20 @@ public interface JobBatchRecordValue extends RecordValue {
    * @return the tenant filtering strategy used for job activation
    */
   TenantFilter getTenantFilter();
+
+  /**
+   * Gateway-generated key that correlates a poll activation with its delivery ACK or REJECT. Zero
+   * means the caller does not use delivery acknowledgement (legacy behaviour).
+   *
+   * @return the delivery attempt key, or {@code 0} when unused
+   */
+  long getDeliveryAttemptKey();
+
+  /**
+   * Broker-computed deadline for the pending delivery handshake. Set on {@code ACTIVATED} when a
+   * delivery attempt key is present. Zero when unused.
+   *
+   * @return epoch millis when an unacked delivery may be rejected, or {@code 0}
+   */
+  long getDeliveryDeadline();
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -925,9 +925,18 @@ public class CompactRecordLogger {
     }
 
     if (jobKeys != null && !jobKeys.isEmpty()) {
+      final var jobs = value.getJobs();
       for (int i = 0; i < jobKeys.size(); i++) {
         final var jobKey = jobKeys.get(i);
-        final var job = value.getJobs().get(i);
+        // ACK/REJECT events may carry job keys without full job payloads
+        if (jobs == null || i >= jobs.size()) {
+          result
+              .append(StringUtils.rightPad("\n", 8 + valueTypeChars))
+              .append("- job key: ")
+              .append(jobKey);
+          continue;
+        }
+        final var job = jobs.get(i);
 
         result
             .append(StringUtils.rightPad("\n", 8 + valueTypeChars))


### PR DESCRIPTION
## Summary

Closes #59354 (SUPPORT-33773).

When the gateway loses the broker response for `JobBatch ACTIVATE`, it has no job keys and cannot FAIL/reactivate. Jobs stayed `ACTIVATED` until the full worker timeout (often hours).

This adds a gateway↔broker **delivery handshake**:

1. Gateway stamps `deliveryAttemptKey` on activate
2. Broker registers pending delivery with a short `deliveryDeadline` (default **30s**) on `ACTIVATED` v2
3. Gateway **ACK**s on successful broker response (before client send)
4. Gateway **REJECT**s on ambiguous transport/broker errors (not `RESOURCE_EXHAUSTED` / command rejections)
5. REJECT or delivery-ack timeout → `JobIntent.YIELDED` per still-activated job (same as stream push failure)
6. Rolling upgrade: attempt key `0` = legacy (no pending delivery)

Design: `zeebe/docs/adr/0009-810-job-batch-delivery-ack.md`

Config: `zeebe.broker.experimental.engine.jobs.deliveryAckTimeout`

## Test plan

- [x] `JobBatchDeliveryAckTest` (activate deadline, ACK, REJECT+yield, idempotent double ACK/REJECT, delivery timeout, no timeout after ACK) — green ×3
- [x] `YieldJobTest`
- [x] `RoundRobinActivateJobsDeliveryAckTest` (gateway)
- [x] Golden files for new appliers (`ACTIVATED` v2, `ACKNOWLEDGED`/`REJECTED` v1)
- [ ] CI full suite

## Backport

Protocol + engine state change. Please confirm whether this needs `backport stable/8.8` (or other) before merge — I have **not** added backport labels.