### PR TITLE
fix: retry Docker image build and Buildx setup on Docker Hub 5xx errors

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -108,7 +108,11 @@ runs:
     # composite action. A later step that does not declare one of these inputs itself would read the
     # stale value instead of that action's own default; `version`, `name` and `platforms` are common
     # enough input names to collide. GITHUB_ENV cannot unset, so blank them out.
+    # Runs even when the step above exhausted its attempts: that is exactly when the variables have
+    # been exported and no later step will overwrite them, so any `always()` or post step in the job
+    # would otherwise inherit them.
     - name: Clear buildx inputs leaked into the job environment by wretry
+      if: always()
       shell: bash
       run: |
         env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
@@ -138,17 +142,26 @@ runs:
       shell: bash
       run: echo "result=$(echo '${{ steps.get-image.outputs.tags }}' | head -n 1)" >> $GITHUB_OUTPUT
 
-    # docker/metadata-action emits one tag per line, and callers that pass several versions (the
-    # snapshot deploy jobs in ci.yml do) therefore produce a multi-line value. wretry re-parses the
-    # build step's inputs as YAML, where the second line would land at column 0 and break the block,
-    # so the list is joined onto one line here. build-push-action accepts a comma-separated list
-    # just as well -- `platforms` is already passed to it that way.
-    - name: Join image tags onto a single line
-      id: get-tags
+    # The `version` input accepts a list, and the snapshot deploy jobs in ci.yml pass two versions.
+    # Both values derived from it reach the wrapped build step, whose inputs wretry re-parses as
+    # YAML: a second line would land at column 0 and break the block before build-push-action ever
+    # runs. Both are reduced to a single line here.
+    - name: Reduce the multi-valued build inputs to a single line
+      id: get-build-inputs
       shell: bash
       env:
         TAGS: ${{ steps.get-image.outputs.tags }}
-      run: echo "result=$(echo "$TAGS" | paste -sd, -)" >> "$GITHUB_OUTPUT"
+        VERSION_INPUT: ${{ inputs.version }}
+        MAVEN_VERSION: ${{ steps.get-version.outputs.result }}
+      run: |
+        # build-push-action parses `tags` with the same list helper as `platforms`, which this action
+        # already passes comma-separated, so joining is equivalent to the newline-separated form.
+        echo "tags=$(echo "$TAGS" | paste -sd, -)" >> "$GITHUB_OUTPUT"
+        # The VERSION build arg takes a single version. Keeping the first one matches both the image
+        # name output above and what build-push-action already resolved this to: it splits build args
+        # on newlines, so any further line was never a VERSION value to begin with.
+        version="${VERSION_INPUT:-$MAVEN_VERSION}"
+        echo "version=$(echo "$version" | head -n 1)" >> "$GITHUB_OUTPUT"
 
     - name: Set DISTBALL path relative to the build context
       id: get-distball
@@ -195,7 +208,7 @@ runs:
         with: |
           context: .
           file: ${{ inputs.dockerfile }}
-          tags: ${{ steps.get-tags.outputs.result }}
+          tags: ${{ steps.get-build-inputs.outputs.tags }}
           load: ${{ inputs.push != 'true' }}
           push: false
           platforms: ${{ inputs.platforms }}
@@ -205,11 +218,13 @@ runs:
             DISTBALL=${{ steps.get-distball.outputs.result }}
             DATE=${{ steps.get-date.outputs.result }}
             REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
-            VERSION=${{ inputs.version != '' && inputs.version || steps.get-version.outputs.result }}
+            VERSION=${{ steps.get-build-inputs.outputs.version }}
             ${{ steps.get-additional-build-args.outputs.result }}
           target: app
 
+    # As above: a build that fails every attempt is the case where this matters most.
     - name: Clear build-push inputs leaked into the job environment by wretry
+      if: always()
       shell: bash
       run: |
         env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -83,12 +83,31 @@ runs:
         fi
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      # Wrapped in Wandalen/wretry.action: setup-buildx-action has intermittently failed with
+      # registry/CDN 5xx errors, and it's a `uses:` step so nick-fields/retry (our usual retry
+      # action, shell-command only) can't wrap it.
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       with:
-        # to be able to push to local registry, which we use in our tests, we need to use host network
-        driver-opts: network=host
-        buildkitd-flags: ${{ inputs.debug == 'true' && '--debug' || '' }}
-        endpoint: zeebe-context
+        action: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        attempt_limit: 3
+        attempt_delay: 10000
+        # wretry clones the wrapped action at runtime; without a token that clone gets HTTP 403
+        github_token: ${{ github.token }}
+        with: |
+          # to be able to push to local registry, which we use in our tests, we need to use host network
+          driver-opts: network=host
+          buildkitd-flags: ${{ inputs.debug == 'true' && '--debug' || '' }}
+          endpoint: zeebe-context
+
+    # wretry passes the wrapped action's inputs by exporting them into GITHUB_ENV, so all of
+    # setup-buildx-action's INPUT_* variables stay set for the rest of the job -- well past this
+    # composite action. A later step that does not declare one of these inputs itself would read the
+    # stale value instead of that action's own default; `version`, `name` and `platforms` are common
+    # enough input names to collide. GITHUB_ENV cannot unset, so blank them out.
+    - name: Clear buildx inputs leaked into the job environment by wretry
+      shell: bash
+      run: |
+        env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
 
     - name: Set semantic version from Maven project
       id: get-version
@@ -137,23 +156,40 @@ runs:
         fi
 
     - name: Build Docker image
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      # Wrapped for the same reason as the buildx setup above: BuildKit resolves the Dockerfile
+      # frontend and the base images through Docker Hub, whose token endpoint intermittently answers
+      # 5xx (INC-7065, INC-6769, INC-6731), failing the build before a single layer is built.
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:
         DOCKER_BUILD_SUMMARY: false
         DOCKER_BUILD_RECORD_UPLOAD: false
       with:
-        context: .
-        file: ${{ inputs.dockerfile }}
-        tags: ${{ steps.get-image.outputs.tags }}
-        load: ${{ inputs.push != 'true' }}
-        push: false
-        platforms: ${{ inputs.platforms }}
-        provenance: false
-        outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false,push=true' || '' }}
-        build-args: |
-          DISTBALL=${{ steps.get-distball.outputs.result }}
-          DATE=${{ steps.get-date.outputs.result }}
-          REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
-          VERSION=${{ inputs.version != '' && inputs.version || steps.get-version.outputs.result }}
-          ${{ steps.get-additional-build-args.outputs.result }}
-        target: app
+        action: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        attempt_limit: 3
+        attempt_delay: 10000
+        # wretry clones the wrapped action at runtime; without a token that clone gets HTTP 403
+        github_token: ${{ github.token }}
+        # wretry re-parses this block as YAML, so the indentation below is significant: it has to
+        # stay valid after the expressions expand. Keep every interpolated value single-line -- a
+        # multi-line one would have its later lines land at column 0 and break the nested scalar.
+        with: |
+          context: .
+          file: ${{ inputs.dockerfile }}
+          tags: ${{ steps.get-image.outputs.tags }}
+          load: ${{ inputs.push != 'true' }}
+          push: false
+          platforms: ${{ inputs.platforms }}
+          provenance: false
+          outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false,push=true' || '' }}
+          build-args: |
+            DISTBALL=${{ steps.get-distball.outputs.result }}
+            DATE=${{ steps.get-date.outputs.result }}
+            REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
+            VERSION=${{ inputs.version != '' && inputs.version || steps.get-version.outputs.result }}
+            ${{ steps.get-additional-build-args.outputs.result }}
+          target: app
+
+    - name: Clear build-push inputs leaked into the job environment by wretry
+      shell: bash
+      run: |
+        env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -83,10 +83,10 @@ runs:
         fi
 
     - name: Set up Docker Buildx
-      # Wrapped in Wandalen/wretry.action because this step pulls moby/buildkit from Docker Hub and
-      # is exposed to the same 5xx outages as the build below, though no incident has been traced to
-      # it so far. It's a `uses:` step, so nick-fields/retry (our usual retry action, shell-command
-      # only) can't wrap it.
+      # Wrapped in Wandalen/wretry.action: booting the builder pulls moby/buildkit from Docker Hub,
+      # which has answered 502 often enough to be the most frequent form of this failure
+      # (INC-6773, INC-7055, INC-7056, INC-7057, INC-7089). It's a `uses:` step, so
+      # nick-fields/retry (our usual retry action, shell-command only) can't wrap it.
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       with:
         action: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -186,8 +186,9 @@ runs:
 
     - name: Build Docker image
       # Wrapped for the same reason as the buildx setup above: BuildKit resolves the Dockerfile
-      # frontend and the base images through Docker Hub, whose token endpoint intermittently answers
-      # 5xx (INC-7065, INC-6769, INC-6731), failing the build before a single layer is built.
+      # frontend and the base images through Docker Hub, whose token endpoint answers 5xx or drops
+      # the connection often enough to fail the build before a single layer is built
+      # (INC-6847, INC-7065, and the closed INC-6769 and INC-6731).
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:
         DOCKER_BUILD_SUMMARY: false

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -134,6 +134,18 @@ runs:
       shell: bash
       run: echo "result=$(echo '${{ steps.get-image.outputs.tags }}' | head -n 1)" >> $GITHUB_OUTPUT
 
+    # docker/metadata-action emits one tag per line, and callers that pass several versions (the
+    # snapshot deploy jobs in ci.yml do) therefore produce a multi-line value. wretry re-parses the
+    # build step's inputs as YAML, where the second line would land at column 0 and break the block,
+    # so the list is joined onto one line here. build-push-action accepts a comma-separated list
+    # just as well -- `platforms` is already passed to it that way.
+    - name: Join image tags onto a single line
+      id: get-tags
+      shell: bash
+      env:
+        TAGS: ${{ steps.get-image.outputs.tags }}
+      run: echo "result=$(echo "$TAGS" | paste -sd, -)" >> "$GITHUB_OUTPUT"
+
     - name: Set DISTBALL path relative to the build context
       id: get-distball
       shell: bash
@@ -175,7 +187,7 @@ runs:
         with: |
           context: .
           file: ${{ inputs.dockerfile }}
-          tags: ${{ steps.get-image.outputs.tags }}
+          tags: ${{ steps.get-tags.outputs.result }}
           load: ${{ inputs.push != 'true' }}
           push: false
           platforms: ${{ inputs.platforms }}

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -83,12 +83,16 @@ runs:
         fi
 
     - name: Set up Docker Buildx
-      # Wrapped in Wandalen/wretry.action: setup-buildx-action has intermittently failed with
-      # registry/CDN 5xx errors, and it's a `uses:` step so nick-fields/retry (our usual retry
-      # action, shell-command only) can't wrap it.
+      # Wrapped in Wandalen/wretry.action because this step pulls moby/buildkit from Docker Hub and
+      # is exposed to the same 5xx outages as the build below, though no incident has been traced to
+      # it so far. It's a `uses:` step, so nick-fields/retry (our usual retry action, shell-command
+      # only) can't wrap it.
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       with:
         action: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        # wretry cannot inspect the wrapped action's error -- `retry_condition` only sees contexts
+        # captured before the step ran -- so this retries any failure, not just a 5xx. A genuine
+        # error therefore costs up to 3 attempts before reporting red.
         attempt_limit: 3
         attempt_delay: 10000
         # wretry clones the wrapped action at runtime; without a token that clone gets HTTP 403
@@ -177,6 +181,10 @@ runs:
         DOCKER_BUILD_RECORD_UPLOAD: false
       with:
         action: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        # As above, wretry cannot classify the failure, so a broken Dockerfile or a 4xx from the
+        # registry is retried just like a 5xx. Layers already built are cached in the builder, which
+        # persists across attempts, so a replay is cheap up to the point that failed -- but a failing
+        # RUN re-executes on every attempt.
         attempt_limit: 3
         attempt_delay: 10000
         # wretry clones the wrapped action at runtime; without a token that clone gets HTTP 403

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -84,9 +84,9 @@ runs:
 
     - name: Set up Docker Buildx
       # Wrapped in Wandalen/wretry.action: booting the builder pulls moby/buildkit from Docker Hub,
-      # which has answered 502 often enough to be the most frequent form of this failure
-      # (INC-6773, INC-7055, INC-7056, INC-7057, INC-7089). It's a `uses:` step, so
-      # nick-fields/retry (our usual retry action, shell-command only) can't wrap it.
+      # which answers 502 often enough to be the most frequent way an image build fails on healthy
+      # code. It's a `uses:` step, so nick-fields/retry (our usual retry action, shell-command only)
+      # can't wrap it.
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       with:
         action: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -187,8 +187,7 @@ runs:
     - name: Build Docker image
       # Wrapped for the same reason as the buildx setup above: BuildKit resolves the Dockerfile
       # frontend and the base images through Docker Hub, whose token endpoint answers 5xx or drops
-      # the connection often enough to fail the build before a single layer is built
-      # (INC-6847, INC-7065, and the closed INC-6769 and INC-6731).
+      # the connection often enough to fail the build before a single layer is built.
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:
         DOCKER_BUILD_SUMMARY: false

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -917,5 +917,16 @@
       depNameTemplate: "camunda/connectors-bundle",
       datasourceTemplate: "docker",
     },
+    {
+      description: "Track actions wrapped by Wandalen/wretry.action. The github-actions manager only extracts refs from `uses:` keys, so an action passed through wretry's `action:` input is invisible to it and its pinned digest would never be updated.",
+      customType: "regex",
+      managerFilePatterns: [
+        "/^\\.github/.+\\.ya?ml$/",
+      ],
+      matchStrings: [
+        "action:\\s+(?<depName>[\\w.-]+/[\\w.-]+)@(?<currentDigest>[a-f0-9]{40})\\s+#\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+      ],
+      datasourceTemplate: "github-tags",
+    },
   ],
 }

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -590,6 +590,7 @@ teleport-actions/setup@*,
 test-summary/action@*,
 tibdex/github-app-token@*,
 wagoid/commitlint-github-action@*,
+Wandalen/wretry.action@*,
 </details>
 
 ## Preview Environments


### PR DESCRIPTION
## Problem

Image builds fail on healthy code when Docker Hub misbehaves. Two steps of this action talk to it,
and both have failed in production:

- **`Set up Docker Buildx`** pulls `moby/buildkit` to boot the builder, and has repeatedly hit
  `502 Bad Gateway` from `registry-1.docker.io`:

  ```
  ERROR: unknown: failed to copy: httpReadSeeker: failed open: unexpected status from GET request
  to https://registry-1.docker.io/v2/moby/buildkit/blobs/sha256:79330c0d…: 502 Bad Gateway
  ```

- **`Build Docker image`** resolves the Dockerfile frontend and the base images, and fails before a
  single layer is built when the token endpoint answers badly or drops the connection:

  ```
  #2 resolve image config for docker-image://docker.io/docker/dockerfile:1.4
  #2 ERROR: failed to authorize: failed to fetch oauth token: unexpected status from POST request
  to https://auth.docker.io/token: 500
  ```

Reviewing every currently active CI incident, seven have their failure inside this action:

| Incident | Job | Branch | Step | Error |
| --- | --- | --- | --- | --- |
| INC-6773 | `integration-tests/root` | stable/8.7 | Set up Docker Buildx | 502 pulling `moby/buildkit` |
| INC-6847 | `integration-tests/root` | stable/8.9 | Build Docker image | `auth.docker.io` connection reset |
| INC-7055 | `integration-tests/zeebe-engine-modules` | stable/8.8 | Set up Docker Buildx | 502 pulling `moby/buildkit` |
| INC-7056 | `integration-tests/qa-update` | stable/8.8 | Set up Docker Buildx | 502 pulling `moby/buildkit` |
| INC-7057 | `integration-tests/schema-manager` | stable/8.8 | Set up Docker Buildx | 502 pulling `moby/buildkit` |
| INC-7065 | `integration-tests/zeebe-ds-modules` | main | Build Docker image | 500 from `auth.docker.io/token` |
| INC-7089 | `smoke-tests/linux-amd64` | main | Set up Docker Buildx | 502 pulling `moby/buildkit` |

The already-closed INC-6769 (520 fetching an OAuth token) and INC-6731 (502 during an image fetch)
are the same failure. INC-7055, INC-7056 and INC-7057 all come from run `31219773699`: one Docker Hub
blip failed three jobs and opened three incidents, which is the shape this costs us.

`build-platform-docker` backs every image build in the repository, so each occurrence costs a manual
re-run across 18 call sites.

Two incidents fail inside this action but for a different reason — INC-7066 and INC-6721, where the
`jattach` `curl` in a Dockerfile `RUN` layer could not reach github.com. The retry will re-attempt
them, but they are not expected to close as a result.

## Approach

Wrap both steps in `Wandalen/wretry.action` with 3 attempts and a 10s delay:

https://github.com/camunda/camunda/blob/890ce27b247e265ea2dab5d512c900add9382329/.github/actions/build-platform-docker/action.yml#L85-L104

https://github.com/camunda/camunda/blob/890ce27b247e265ea2dab5d512c900add9382329/.github/actions/build-platform-docker/action.yml#L187-L223

Both are `uses:` steps, which rules out `nick-fields/retry` — the retry action already used across
this repo, which only wraps a shell `command:`. `Wandalen/wretry.action` retries a `uses:` step
directly, so both upstream actions stay upstream and SHA-pinned instead of being reimplemented as
`docker buildx create` and `docker build` shell calls that we would then maintain against Docker's
own logic.

The alternative needing no new dependency — duplicating each step three times with
`continue-on-error` and `if: <prev>.outcome == 'failure'` — triples the YAML for every input and has
to be repeated at each step.

### Handling two properties of wretry

**`github_token` is passed explicitly.** wretry does not reuse the runner's action download; it
clones the wrapped action's repository at runtime. The credential persisted by `actions/checkout` is
scoped to the workspace repository through an `includeIf.gitdir` entry, so that clone does not
inherit it, and wretry otherwise builds the clone URL with an empty token, which GitHub rejects with
`HTTP 403`.

**`INPUT_*` variables are cleared after each wrapped step.** wretry passes the wrapped action its
inputs by exporting them into `GITHUB_ENV` rather than scoping them to the nested step, so they would
stay set for the rest of the job, well outside this composite action. The runner only sets
`INPUT_<NAME>` for the inputs a step declares itself and never clears the others, so a later step
would read a stale value in place of its own default — `version`, `name` and `platforms` are common
enough input names to collide. `GITHUB_ENV` cannot unset a variable, but an empty value is what
`core.getInput()` already returns for an unset input.

https://github.com/camunda/camunda/blob/890ce27b247e265ea2dab5d512c900add9382329/.github/actions/build-platform-docker/action.yml#L114-L118

The cleanup runs on `always()`. Skipping it is only tempting until you notice that a wrapped step
exhausting its attempts is exactly the case where the variables have been exported and nothing later
overwrites them, leaving every `always()` and post step in the job to inherit them.

**Multi-valued inputs are reduced to one line.** wretry re-parses the wrapped `with:` block as YAML,
so it has to stay valid *after* the expressions expand. The `version` input accepts a list, and the
snapshot deploy jobs in `ci.yml` pass two versions. That value reaches the wrapped build step twice —
as the tag list from `docker/metadata-action`, and as the `VERSION` build arg — and in both cases the
second line landed at column 0 and the block stopped parsing, failing the step before
`build-push-action` ran. Both jobs are gated to `main` and `stable/*`, so no pull request builds them
and the breakage would only have surfaced after merge, on the jobs that publish the snapshot images.

https://github.com/camunda/camunda/blob/890ce27b247e265ea2dab5d512c900add9382329/.github/actions/build-platform-docker/action.yml#L149-L164

Neither normalisation changes what the build receives. `build-push-action` parses `tags` with the
same list helper as `platforms`, which this action already passes comma-separated. And it splits
build args on newlines, so a second version line was never part of the `VERSION` value — it was
parsed as a separate, malformed build arg and discarded. Keeping the first version also matches the
image name output, which takes the first tag for the same reason.

Doing both in one step keeps the constraint stated in one place: anything interpolated into a wrapped
block has to be single-line, or reduced first.

### Retries are not conditional on the error

Retrying only on a 5xx is not expressible with wretry. `retry_condition` is an expression evaluated
against the `github`, `env`, `job` and `matrix` contexts captured *before* the step ran, plus the
wrapped step's outputs — none of which carry the action's error text, and `build-push-action`
publishes outputs only on success. `pre_retry_command` is the one dynamic hook, and a non-zero exit
from it stops further retries only after the attempt it precedes has already run.

Probing the registry between attempts would be worse than nothing: if Docker Hub recovers between the
failure and the probe, the probe reports healthy and retries stop — abandoning exactly the build the
retry was about to rescue.

So a broken Dockerfile or a 404 for a missing base image is retried like a transient outage. The cost
is bounded: the builder persists across attempts, so cached layers replay quickly and only the failing
layer re-executes. Both call sites carry a comment recording this.

## Keeping the wrapped pins updatable

Renovate's `github-actions` manager extracts a dependency only from a step's `uses:` key. Everything
under `with:` is opaque input data to it, so moving both actions into wretry's `action:` input takes
them out of the manager's view — their digests would sit where they were pinned indefinitely while
every other action in the repo keeps being updated.

The manager cannot be taught additional keys (the behaviour is compiled in) and neither action is in
its `communityActions` registry, so a regex `customManager` is the documented extension point:

https://github.com/camunda/camunda/blob/890ce27b247e265ea2dab5d512c900add9382329/.github/renovate.json5#L920-L930

Capturing `depName`, `currentDigest` and `currentValue` gives Renovate what it needs for full
digest-pinning updates. The version comment is load-bearing: a wrapped action pinned without one is
skipped silently rather than reported.

## Security notes

`Wandalen/wretry.action` is pinned to the full commit SHA for v3.8.0 and added to the allowed
third-party action list, per the [CI security policy](https://github.com/camunda/camunda/blob/890ce27b247e265ea2dab5d512c900add9382329/docs/monorepo-docs/ci.md#usage-of-third-party-github-actions):

https://github.com/camunda/camunda/blob/890ce27b247e265ea2dab5d512c900add9382329/docs/monorepo-docs/ci.md#L593

Assessment of the new dependency: MIT licensed, no open GitHub security advisories, 8 contributors,
last release v3.8.0 (Jan 2025). It is low-velocity, which is the main reason to keep an eye on it.

Two points worth a reviewer's attention:

- Because wretry clones the wrapped action instead of resolving it as a `uses:` step, the wrapped
  action bypasses GitHub's action-allowlist enforcement. No policy violation here — both wrapped
  actions are already allowlisted and wretry checks out the pinned SHA, so integrity holds — but the
  allowlist is not a binding gate for anything wrapped this way.
- wretry forwards the `github`, `env`, `job` and `matrix` contexts into its nested JS action in order
  to reconstruct the wrapped action's inputs. It is not given the `secrets` context.

## Verification

- `Zeebe / Build / Docker Checks` is green with both steps wrapped. Both wretry steps report
  `outcome=success`; the wrapped build produced `containerimage.digest` and
  `image.name=localhost:5000/camunda/camunda:8.10.0-SNAPSHOT` in 54s, and `Verify Docker image`
  passes. `Build summary disabled` in the log confirms the step-level `env:` still reaches the
  nested action.
- The `INPUT_*` cleanup was checked in that job's log rather than only reasoned about.
  `INPUT_ENDPOINT: zeebe-context` appears exactly once — inside the cleanup step that reads it — and
  every later occurrence, including in `Verify Docker image` and the post-build steps, is empty. The
  variables remain present but blank, which is the most `GITHUB_ENV` allows and is equivalent to
  unset for anything reading inputs normally.
- Both multi-line regressions were reproduced first, then re-checked across five scenarios —
  docker-checks (1 tag, no version input), snapshot deploy (2 versions, push), release (1 version,
  push), fork PR (extra build arg) and 3 versions — by running the normalisation step under the
  runner's `bash -eo pipefail`, feeding its real output into `action.yml` parsed as the runner parses
  it, expanding the expressions, and re-parsing the result as wretry does. All five produce inputs
  identical to the unwrapped step, with `VERSION` resolving to the same value it did before.
- The Renovate pattern was run against every file its `managerFilePatterns` selects: it matches both
  wrapped actions with `depName`, `currentDigest` and `currentValue` captured correctly, and no false
  positives across 204 files.
- The retry path itself is **not** exercised yet. Every attempt so far succeeded on attempt 1, so
  this proves the happy path, not that a 5xx triggers a retry. A real 5xx cannot be forced on demand,
  so confirmation is observational: the next Docker Hub blip should now be absorbed instead of
  failing the build.
- Two behaviours are known and accepted rather than fixed: retries are not conditional on the error
  (see above), and wretry never registers a wrapped action's `post:` hook, so `setup-buildx-action`'s
  builder teardown does not run. The latter is harmless on the `ubuntu-latest` call sites, which are
  ephemeral; worth a look if the `gcp-*` self-hosted runners used by the SaaS deploy, preview-env and
  nightly jobs turn out to be reused rather than recycled per job.




