### PR TITLE
Implement get and list endpoints for /actuator/cluster/changes

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
@@ -58,8 +59,12 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
@@ -67,11 +72,13 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPar
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.BrokerStateCode;
+import io.camunda.zeebe.management.cluster.ConfigurationChange;
 import io.camunda.zeebe.management.cluster.Error;
 import io.camunda.zeebe.management.cluster.ExporterConfig;
 import io.camunda.zeebe.management.cluster.ExporterStateCode;
 import io.camunda.zeebe.management.cluster.ExporterStatus;
 import io.camunda.zeebe.management.cluster.ExportingConfig;
+import io.camunda.zeebe.management.cluster.GetConfigurationChangesResponse;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
 import io.camunda.zeebe.management.cluster.Operation;
@@ -97,6 +104,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
@@ -176,6 +184,154 @@ final class ClusterApiUtils {
     }
   }
 
+  static ResponseEntity<?> mapConfigurationChangeResponse(
+      final CurrentClusterConfiguration configuration, final long changeId) {
+    return findConfigurationChange(configuration, changeId)
+        .<ResponseEntity<?>>map(change -> ResponseEntity.status(200).body(change))
+        .orElseGet(
+            () -> {
+              final var error = new Error();
+              error.setMessage("No configuration change found with id " + changeId);
+              return ResponseEntity.status(404).body(error);
+            });
+  }
+
+  static ResponseEntity<?> mapConfigurationChangesResponse(
+      final CurrentClusterConfiguration configuration) {
+    final var phasedChangeState = configuration.phasedChangeState();
+    final List<ConfigurationChange> changes = new ArrayList<>();
+    phasedChangeState
+        .pending()
+        .map(plan -> mapConfigurationChange(configuration, plan))
+        .ifPresent(changes::add);
+    phasedChangeState
+        .lastChange()
+        .map(ClusterApiUtils::mapConfigurationChange)
+        .ifPresent(changes::add);
+    return ResponseEntity.status(200).body(new GetConfigurationChangesResponse().changes(changes));
+  }
+
+  /**
+   * Resolves {@code changeId} against the two changes {@link PhasedChangeState} currently retains
+   * (the pending plan and the last completed change) — there is no persisted change history beyond
+   * those two, so any other id is reported as not found.
+   */
+  private static Optional<ConfigurationChange> findConfigurationChange(
+      final CurrentClusterConfiguration configuration, final long changeId) {
+    final var phasedChangeState = configuration.phasedChangeState();
+    final var pendingMatch = phasedChangeState.pending().filter(plan -> plan.id() == changeId);
+    if (pendingMatch.isPresent()) {
+      return pendingMatch.map(plan -> mapConfigurationChange(configuration, plan));
+    }
+    return phasedChangeState
+        .lastChange()
+        .filter(change -> change.id() == changeId)
+        .map(ClusterApiUtils::mapConfigurationChange);
+  }
+
+  /**
+   * Maps a pending plan's operations to completed/pending, using the actual progress of whichever
+   * sub-config (global or physical tenant) the currently active phase targets: phases before {@code
+   * currentPhaseIndex} are fully done, phases after it are entirely untouched, but the active
+   * phase's own operations may be partially done already — activating a phase copies its operations
+   * into the target sub-config's {@link ClusterChangePlan}, which independently tracks which of
+   * those operations have completed so far.
+   */
+  private static ConfigurationChange mapConfigurationChange(
+      final CurrentClusterConfiguration configuration, final PhasedChangePlan plan) {
+    final var phases = plan.phases();
+    final var completedPhases = phases.subList(0, plan.currentPhaseIndex());
+    final var remainingPhases = phases.subList(plan.currentPhaseIndex(), phases.size());
+
+    final List<Operation> completed = new ArrayList<>(mapPhaseOperations(completedPhases));
+    final List<Operation> pending = new ArrayList<>();
+    if (!remainingPhases.isEmpty()) {
+      splitActivePhase(configuration, remainingPhases.get(0), completed, pending);
+      pending.addAll(mapPhaseOperations(remainingPhases.subList(1, remainingPhases.size())));
+    }
+
+    return new ConfigurationChange()
+        .id(plan.id())
+        .status(ConfigurationChange.StatusEnum.IN_PROGRESS)
+        .startedAt(mapInstantToDateTime(plan.startedAt()))
+        .completed(completed)
+        .pending(pending);
+  }
+
+  private static void splitActivePhase(
+      final CurrentClusterConfiguration configuration,
+      final Phase activePhase,
+      final List<Operation> completed,
+      final List<Operation> pending) {
+    switch (activePhase) {
+      case final GlobalPhase globalPhase ->
+          splitSubConfigOperations(
+              null,
+              globalPhase.operations(),
+              configuration.globalConfiguration().pendingChanges(),
+              completed,
+              pending);
+      case final PartitionGroupParallelPhase parallelPhase ->
+          parallelPhase
+              .groupOperations()
+              .forEach(
+                  (groupId, operations) ->
+                      splitSubConfigOperations(
+                          groupId,
+                          operations,
+                          Optional.ofNullable(configuration.partitionGroups().get(groupId))
+                              .flatMap(PartitionGroupConfiguration::pendingChanges),
+                          completed,
+                          pending));
+    }
+  }
+
+  /**
+   * Splits one sub-config's share of the active phase's operations between {@code completed} and
+   * {@code pending}. {@code subConfigPlan} is absent when the phase hasn't actually been activated
+   * into the sub-config yet (e.g. a plan reconstructed via {@link
+   * CurrentClusterConfiguration#fromLegacy}, which builds the pending plan at phase 0 without
+   * activating it) — in that case nothing has completed yet, so the whole phase is still pending.
+   */
+  private static void splitSubConfigOperations(
+      final String physicalTenantId,
+      final List<? extends ClusterConfigurationChangeOperation> phaseOperations,
+      final Optional<ClusterChangePlan> subConfigPlan,
+      final List<Operation> completed,
+      final List<Operation> pending) {
+    if (subConfigPlan.isEmpty()) {
+      pending.addAll(mapOperations(physicalTenantId, phaseOperations));
+      return;
+    }
+    final var plan = subConfigPlan.get();
+    plan.completedOperations()
+        .forEach(
+            completedOperation ->
+                completed.add(mapOperation(physicalTenantId, completedOperation.operation())));
+    pending.addAll(mapOperations(physicalTenantId, plan.pendingOperations()));
+  }
+
+  private static ConfigurationChange mapConfigurationChange(final CompletedPhasedChange change) {
+    // CompletedPhasedChange retains only id/status/timestamps, not the operations that made up the
+    // change, so completed/pending are necessarily empty here.
+    return new ConfigurationChange()
+        .id(change.id())
+        .status(mapPhasedChangeStatus(change.status()))
+        .startedAt(mapInstantToDateTime(change.startedAt()))
+        .completedAt(mapInstantToDateTime(change.completedAt()))
+        .completed(List.of())
+        .pending(List.of());
+  }
+
+  private static ConfigurationChange.StatusEnum mapPhasedChangeStatus(
+      final PhasedChangePlanStatus status) {
+    return switch (status) {
+      case COMPLETED -> ConfigurationChange.StatusEnum.COMPLETED;
+      case FAILED -> ConfigurationChange.StatusEnum.FAILED;
+      case CANCELLED -> ConfigurationChange.StatusEnum.CANCELLED;
+    };
+  }
+
   private static PlannedOperationsResponse mapResponseType(
       final ClusterConfigurationChangeResponse response) {
     // response.response() is absent when the responding peer hasn't populated the new
@@ -185,19 +341,7 @@ final class ClusterApiUtils {
     final List<Operation> operations =
         multiConfigResponse == null
             ? mapOperations(response.legacyResponse().plannedChanges())
-            : multiConfigResponse.phases().stream()
-                .flatMap(
-                    phase ->
-                        switch (phase) {
-                          case final GlobalPhase globalPhase ->
-                              mapOperations(null, globalPhase.operations()).stream();
-                          case final PartitionGroupParallelPhase partitionGroupPhase ->
-                              partitionGroupPhase.groupOperations().entrySet().stream()
-                                  .flatMap(
-                                      entry ->
-                                          mapOperations(entry.getKey(), entry.getValue()).stream());
-                        })
-                .toList();
+            : mapPhaseOperations(multiConfigResponse.phases());
     final List<BrokerState> currentTopology =
         multiConfigResponse == null
             ? mapBrokerStates(response.legacyResponse().currentConfiguration())
@@ -222,6 +366,21 @@ final class ClusterApiUtils {
       final String physicalTenantId,
       final List<? extends ClusterConfigurationChangeOperation> operations) {
     return operations.stream().map(op -> mapOperation(physicalTenantId, op)).toList();
+  }
+
+  private static List<Operation> mapPhaseOperations(final List<Phase> phases) {
+    return phases.stream()
+        .flatMap(
+            phase ->
+                switch (phase) {
+                  case final GlobalPhase globalPhase ->
+                      mapOperations(null, globalPhase.operations()).stream();
+                  case final PartitionGroupParallelPhase partitionGroupPhase ->
+                      partitionGroupPhase.groupOperations().entrySet().stream()
+                          .flatMap(
+                              entry -> mapOperations(entry.getKey(), entry.getValue()).stream());
+                })
+        .toList();
   }
 
   static Operation mapOperation(

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -101,6 +101,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -208,7 +209,11 @@ final class ClusterApiUtils {
         .lastChange()
         .map(ClusterApiUtils::mapConfigurationChange)
         .ifPresent(changes::add);
-    return ResponseEntity.status(200).body(new GetConfigurationChangesResponse().changes(changes));
+
+    final var sortedChanges =
+        changes.stream().sorted(Comparator.comparingLong(ConfigurationChange::getId)).toList();
+    return ResponseEntity.status(200)
+        .body(new GetConfigurationChangesResponse().changes(sortedChanges));
   }
 
   /**

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -26,6 +26,8 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
@@ -88,6 +90,45 @@ public class ClusterEndpoint {
     } catch (final Exception error) {
       return ClusterApiUtils.mapError(error);
     }
+  }
+
+  @GetMapping(path = "/changes/{changeId}", produces = "application/json")
+  public ResponseEntity<?> getConfigurationChange(@PathVariable final String changeId) {
+    final long id;
+    try {
+      id = Long.parseLong(changeId);
+    } catch (final NumberFormatException ignore) {
+      return invalidRequest("Change id must be a number");
+    }
+    try {
+      return withCurrentConfiguration(
+          configuration -> ClusterApiUtils.mapConfigurationChangeResponse(configuration, id));
+    } catch (final Exception error) {
+      return ClusterApiUtils.mapError(error);
+    }
+  }
+
+  @GetMapping(path = "/changes", produces = "application/json")
+  public ResponseEntity<?> listConfigurationChanges() {
+    try {
+      return withCurrentConfiguration(ClusterApiUtils::mapConfigurationChangesResponse);
+    } catch (final Exception error) {
+      return ClusterApiUtils.mapError(error);
+    }
+  }
+
+  /**
+   * Fetches the current topology and, until the coordinator's query response itself carries the new
+   * multi-partition-group model, converts it from the legacy {@link ClusterConfiguration} on every
+   * call before handing it to {@code action}.
+   */
+  private ResponseEntity<?> withCurrentConfiguration(
+      final Function<CurrentClusterConfiguration, ResponseEntity<?>> action) {
+    final var topology = requestSender.getTopology().join();
+    if (topology.isLeft()) {
+      return ClusterApiUtils.mapErrorResponse(topology.getLeft());
+    }
+    return action.apply(CurrentClusterConfiguration.fromLegacy(topology.get()));
   }
 
   private ResponseEntity<Error> invalidRequest(final String message) {

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -127,6 +127,38 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
+  /changes/{changeId}:
+    get:
+      summary: Get a configuration change
+      description: Returns the status and operations of one configuration change.
+      parameters:
+        - $ref: '#/components/parameters/ChangeId'
+      responses:
+        '200':
+          $ref: "#/components/responses/GetConfigurationChangeResponse"
+        '404':
+          $ref: 'components.yaml#/responses/NotFound'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
+  /changes:
+    get:
+      summary: List configuration changes
+      description: Returns every configuration change currently known to this broker.
+      responses:
+        '200':
+          $ref: "#/components/responses/GetConfigurationChangesResponse"
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
     patch:
       summary: Reconfigure cluster
       description: Reconfigure cluster by adding or removing brokers, adding more partitions, or
@@ -337,6 +369,13 @@ components:
       description: Name of the zone
       schema:
         type: string
+    ChangeId:
+      name: changeId
+      required: true
+      in: path
+      description: Id of the configuration change
+      schema:
+        $ref: 'components.yaml#/schemas/ChangeId'
     DryRunParameter:
       name: dryRun
       description: If true, requested changes are only simulated and not actually applied.
@@ -406,3 +445,17 @@ components:
         application/json:
           schema:
             $ref: "components.yaml#/schemas/GetTopologyResponse"
+
+    GetConfigurationChangeResponse:
+      description: response body for getting one configuration change
+      content:
+        application/json:
+          schema:
+            $ref: "components.yaml#/schemas/ConfigurationChange"
+
+    GetConfigurationChangesResponse:
+      description: response body for listing configuration changes
+      content:
+        application/json:
+          schema:
+            $ref: "components.yaml#/schemas/GetConfigurationChangesResponse"

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -34,6 +34,13 @@ responses:
         schema:
           "$ref": "components.yaml#/schemas/Error"
 
+  NotFound:
+    description: The requested resource was not found.
+    content:
+      application/json:
+        schema:
+          "$ref": "components.yaml#/schemas/Error"
+
 schemas:
   Error:
     title: Error response
@@ -421,6 +428,63 @@ schemas:
         type: array
         items:
           $ref: "components.yaml#/schemas/Operation"
+
+  ConfigurationChange:
+    title: ConfigurationChange
+    description: >
+      One configuration change plan, identified by its changeId, together with its status and the
+      operations it consists of. A change may target the global broker configuration, a single
+      physical tenant, or several physical tenants in parallel; each operation carries its own
+      `physicalTenant` (absent for a global operation) so operations belonging to different tenants
+      can still be told apart.
+
+
+      `completed`/`pending` reflect only what is currently available from the underlying
+      configuration state, not a persisted history: for the in-progress change, `completed` lists
+      operations from phases already advanced past, and `pending` lists the rest; for a change that
+      has already finished, the individual operations are no longer retained, so both lists are
+      empty and only `id`/`status`/`startedAt`/`completedAt` are meaningful.
+    type: object
+    properties:
+      id:
+        $ref: "components.yaml#/schemas/ChangeId"
+      status:
+        type: string
+        enum:
+          - IN_PROGRESS
+          - COMPLETED
+          - FAILED
+          - CANCELLED
+      startedAt:
+        type: string
+        format: date-time
+        description: The time when the configuration change was started
+        example: "2020-01-01T00:00:00Z"
+      completedAt:
+        type: string
+        format: date-time
+        description: The time when the configuration change was completed, if it has completed
+        example: "2020-01-01T00:00:00Z"
+      completed:
+        description: The list of operations that have been completed so far.
+        type: array
+        items:
+          $ref: "components.yaml#/schemas/Operation"
+      pending:
+        description: The list of operations that are pending.
+        type: array
+        items:
+          $ref: "components.yaml#/schemas/Operation"
+
+  GetConfigurationChangesResponse:
+    title: GetConfigurationChangesResponse
+    description: All configuration changes currently known to this broker.
+    type: object
+    properties:
+      changes:
+        type: array
+        items:
+          $ref: "components.yaml#/schemas/ConfigurationChange"
 
   Operation:
     type: object

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import static io.camunda.zeebe.management.cluster.Operation.OperationEnum.BROKER_REMOVE;
+import static io.camunda.zeebe.management.cluster.Operation.OperationEnum.PARTITION_JOIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -15,9 +17,12 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
@@ -59,15 +64,21 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.management.cluster.BrokerState;
+import io.camunda.zeebe.management.cluster.ConfigurationChange;
+import io.camunda.zeebe.management.cluster.Error;
 import io.camunda.zeebe.management.cluster.ExporterStatus;
 import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
+import io.camunda.zeebe.management.cluster.GetConfigurationChangesResponse;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
+import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.PhysicalTenantState;
@@ -200,7 +211,7 @@ final class ClusterApiUtilsTest {
     assertThat(body).isNotNull();
     assertThat(body.getPlannedChanges())
         .extracting(op -> op.getOperation(), op -> op.getPhysicalTenant())
-        .containsExactly(tuple(OperationEnum.BROKER_REMOVE, null));
+        .containsExactly(tuple(BROKER_REMOVE, null));
   }
 
   @Test
@@ -639,6 +650,15 @@ final class ClusterApiUtilsTest {
     return MemberId.from(String.valueOf(id));
   }
 
+  private static CurrentClusterConfiguration configWithPhasedChangeState(
+      final PhasedChangeState phasedChangeState) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        Map.of(),
+        phasedChangeState);
+  }
+
   /**
    * Generates all implementations of ClusterConfigurationChangeOperation interface. This method
    * creates instances of all concrete record implementations with sample data.
@@ -703,6 +723,169 @@ final class ClusterApiUtilsTest {
   /** Provides all ClusterConfigurationChangeOperation implementations as test arguments. */
   public static Stream<Arguments> generateAllClusterConfigurationChangeOperationsAsArguments() {
     return generateAllClusterConfigurationChangeOperations().stream().map(Arguments::of);
+  }
+
+  @Test
+  void shouldReturnEmptyChangeListWhenNoChanges() {
+    // given
+    final var config = CurrentClusterConfiguration.init();
+
+    // when
+    final var response = ClusterApiUtils.mapConfigurationChangesResponse(config);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    final var body = (GetConfigurationChangesResponse) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getChanges()).isEmpty();
+  }
+
+  @Test
+  void shouldListPendingAndLastCompletedChange() {
+    // given
+    final var startedAt = Instant.ofEpochSecond(1000);
+    final var lastCompletedAt = Instant.ofEpochSecond(500);
+    final var pendingPlan =
+        new PhasedChangePlan(
+            2, 0, List.of(new GlobalPhase(List.of(new MemberJoinOperation(member(1))))), startedAt);
+    final var lastChange =
+        new CompletedPhasedChange(1, PhasedChangePlanStatus.COMPLETED, startedAt, lastCompletedAt);
+    final var config =
+        configWithPhasedChangeState(
+            new PhasedChangeState(Optional.of(pendingPlan), Optional.of(lastChange)));
+
+    // when
+    final var response = ClusterApiUtils.mapConfigurationChangesResponse(config);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    final var body = (GetConfigurationChangesResponse) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getChanges())
+        .extracting(ConfigurationChange::getId, ConfigurationChange::getStatus)
+        .containsExactlyInAnyOrder(
+            tuple(2L, ConfigurationChange.StatusEnum.IN_PROGRESS),
+            tuple(1L, ConfigurationChange.StatusEnum.COMPLETED));
+  }
+
+  @Test
+  void shouldMapPendingOperationsOfInProgressChange() {
+    // given
+    final var memberId1 = member(1);
+    final List<Phase> phases =
+        List.of(
+            new PartitionGroupParallelPhase(
+                Map.of("default", List.of(new PartitionJoinOperation(memberId1, 1, 3)))),
+            new GlobalPhase(List.of(new MemberLeaveOperation(memberId1))));
+    final var config =
+        configWithPhasedChangeState(
+            new PhasedChangeState(
+                Optional.of(new PhasedChangePlan(2, 0, phases, Instant.now())), Optional.empty()));
+
+    // when
+    final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 2);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    final var body = (ConfigurationChange) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getId()).isEqualTo(2L);
+    assertThat(body.getStatus()).isEqualTo(ConfigurationChange.StatusEnum.IN_PROGRESS);
+    assertThat(body.getCompleted()).isEmpty();
+    assertThat(body.getPending())
+        .extracting(Operation::getOperation)
+        .containsExactly(PARTITION_JOIN, BROKER_REMOVE);
+  }
+
+  @Test
+  void shouldSplitActivePhaseOperationsUsingSubConfigProgress() {
+    // given: the active phase targets physical tenant "tenant-a" with two operations, but the
+    // tenant's own ClusterChangePlan shows the join already completed and only the leave pending
+    final var memberId1 = member(1);
+    final var joinOperation = new PartitionJoinOperation(memberId1, 3, 1);
+    final var leaveOperation = new PartitionLeaveOperation(memberId1, 3, 0);
+    final var tenantPlan =
+        new ClusterChangePlan(
+            1,
+            1,
+            Status.IN_PROGRESS,
+            Instant.now(),
+            List.of(new CompletedOperation(joinOperation, Instant.now())),
+            List.of(leaveOperation));
+    final var tenantGroup =
+        new PartitionGroupConfiguration(
+            1, 0, Map.of(), Optional.empty(), Optional.of(tenantPlan), Optional.empty());
+    final List<Phase> phases =
+        List.of(
+            new PartitionGroupParallelPhase(
+                Map.of("tenant-a", List.of(joinOperation, leaveOperation))),
+            new GlobalPhase(List.of(new MemberLeaveOperation(memberId1))));
+    final var config =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", tenantGroup),
+            new PhasedChangeState(
+                Optional.of(new PhasedChangePlan(7, 0, phases, Instant.now())), Optional.empty()));
+
+    // when
+    final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 7);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    final var body = (ConfigurationChange) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getCompleted())
+        .extracting(Operation::getOperation, Operation::getPhysicalTenant)
+        .containsExactly(tuple(PARTITION_JOIN, "tenant-a"));
+    assertThat(body.getPending())
+        .extracting(Operation::getOperation, Operation::getPhysicalTenant)
+        .containsExactly(
+            tuple(Operation.OperationEnum.PARTITION_LEAVE, "tenant-a"), tuple(BROKER_REMOVE, null));
+  }
+
+  @Test
+  void shouldReturnCompletedChangeWithoutOperations() {
+    // given
+    final var startedAt = Instant.ofEpochSecond(1000);
+    final var completedAt = Instant.ofEpochSecond(2000);
+    final var lastChange =
+        new CompletedPhasedChange(5, PhasedChangePlanStatus.FAILED, startedAt, completedAt);
+    final var config =
+        configWithPhasedChangeState(
+            new PhasedChangeState(Optional.empty(), Optional.of(lastChange)));
+
+    // when
+    final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 5);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    final var body = (ConfigurationChange) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getId()).isEqualTo(5L);
+    assertThat(body.getStatus()).isEqualTo(ConfigurationChange.StatusEnum.FAILED);
+    assertThat(body.getCompleted()).isEmpty();
+    assertThat(body.getPending()).isEmpty();
+  }
+
+  @Test
+  void shouldReturn404WhenChangeIdIsUnknown() {
+    // given
+    final List<Phase> phases =
+        List.of(new GlobalPhase(List.of(new MemberJoinOperation(member(1)))));
+    final var config =
+        configWithPhasedChangeState(
+            new PhasedChangeState(
+                Optional.of(new PhasedChangePlan(2, 0, phases, Instant.now())), Optional.empty()));
+
+    // when
+    final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 999);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(404);
+    final var body = (Error) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getMessage()).contains("999");
   }
 
   private record ExporterConfigParam(

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -15,10 +15,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.management.cluster.ConfigurationChange;
+import io.camunda.zeebe.management.cluster.GetConfigurationChangesResponse;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.UpdatePartitionDistributionRequest;
@@ -176,6 +181,85 @@ final class ClusterEndpointTest {
       // then
       assertThat(response.getStatusCode().value()).isEqualTo(400);
       verifyNoInteractions(sender);
+    }
+  }
+
+  @Nested
+  class ConfigurationChangesEndpoint {
+
+    // ClusterConfiguration.init() starts at version 1, so a change started from it always gets
+    // changeId 2 (version + 1); tests below query that fixed id.
+    private static ClusterConfiguration configWithPendingChange() {
+      return ClusterConfiguration.init()
+          .startConfigurationChange(List.of(new MemberJoinOperation(MemberId.from("1"))));
+    }
+
+    @Test
+    void shouldGetConfigurationChangeById() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      when(sender.getTopology())
+          .thenReturn(CompletableFuture.completedFuture(Either.right(configWithPendingChange())));
+
+      // when
+      final var response = endpoint.getConfigurationChange("2");
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(200);
+      final var body = (ConfigurationChange) response.getBody();
+      assertThat(body).isNotNull();
+      assertThat(body.getId()).isEqualTo(2L);
+      assertThat(body.getStatus()).isEqualTo(ConfigurationChange.StatusEnum.IN_PROGRESS);
+      verify(sender).getTopology();
+    }
+
+    @Test
+    void shouldReturn404WhenChangeIdIsUnknown() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      when(sender.getTopology())
+          .thenReturn(CompletableFuture.completedFuture(Either.right(configWithPendingChange())));
+
+      // when
+      final var response = endpoint.getConfigurationChange("999");
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldRejectNonNumericChangeId() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      final var response = endpoint.getConfigurationChange("not-a-number");
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(400);
+      verifyNoInteractions(sender);
+    }
+
+    @Test
+    void shouldListConfigurationChanges() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      when(sender.getTopology())
+          .thenReturn(CompletableFuture.completedFuture(Either.right(configWithPendingChange())));
+
+      // when
+      final var response = endpoint.listConfigurationChanges();
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(200);
+      final var body = (GetConfigurationChangesResponse) response.getBody();
+      assertThat(body).isNotNull();
+      assertThat(body.getChanges()).extracting(ConfigurationChange::getId).containsExactly(2L);
+      verify(sender).getTopology();
     }
   }
 }


### PR DESCRIPTION
## Summary
- Define the `ConfigurationChange`/`GetConfigurationChangesResponse` OpenAPI schema for the new changes API.
- Add `GET /actuator/cluster/changes/{changeId}` to look up one configuration change by id.
- Add `GET /actuator/cluster/changes` to list every configuration change currently known to a broker.

Both endpoints are resolved from `PhasedChangeState`, which currently retains only the pending plan and the last completed change — not a persisted history. `completed`/`pending` operation lists reflect only what that data model retains today: for the in-progress change they're derived from the plan's phases, for a completed change they're empty since `CompletedPhasedChange` only keeps id/status/timestamps.

PS: Topology query from the coordinator still contains only the legacy config. Hence the endpoint is not fully multi-PT aware. This should be done in a follow up.

related #59826
