### PR TITLE
test: cover resource search and binary content endpoints end-to-end

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-api.spec.ts
@@ -6,18 +6,27 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {expect, test} from '@playwright/test';
 import {
   assertStatusCode,
   buildUrl,
+  credentials,
   defaultHeaders,
   assertUnauthorizedRequest,
   jsonHeaders,
   assertNotFoundRequest,
   assertBadRequest,
+  assertPaginatedRequest,
+  authHeaders,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {deployResourceAndGetMetadata} from '@requestHelpers';
+import {
+  deployInlineResource,
+  deployResourceAndGetMetadata,
+  searchResources,
+  uniqueResourceName,
+} from '@requestHelpers';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Resource Delete API', () => {
@@ -47,6 +56,61 @@ test.describe.parallel('Resource Delete API', () => {
       },
       res,
     );
+  });
+
+  test('Delete Resource - deleted generic resource stops being served', async ({
+    request,
+  }) => {
+    const resource = await deployInlineResource(
+      request,
+      uniqueResourceName('system-prompt', 'md'),
+      '# System prompt',
+    );
+    const resourceKey = resource.resourceKey;
+    const contentBinaryUrl = buildUrl(
+      '/resources/{resourceKey}/content/binary',
+      {resourceKey},
+    );
+
+    await expect(async () => {
+      const searchRes = await searchResources(request, {filter: {resourceKey}});
+      await assertPaginatedRequest(searchRes, {itemsLengthEqualTo: 1});
+
+      const contentRes = await request.get(contentBinaryUrl, {
+        headers: authHeaders(credentials.accessToken),
+      });
+      await assertStatusCode(contentRes, 200);
+    }).toPass(defaultAssertionOptions);
+
+    const deleteRes = await request.post(
+      buildUrl('/resources/{resourceKey}/deletion', {resourceKey}),
+      {
+        headers: defaultHeaders(),
+      },
+    );
+    await assertStatusCode(deleteRes, 200);
+
+    await expect(async () => {
+      const searchRes = await searchResources(request, {filter: {resourceKey}});
+      await assertPaginatedRequest(searchRes, {itemsLengthEqualTo: 0});
+
+      const getRes = await request.get(
+        buildUrl('/resources/{resourceKey}', {resourceKey}),
+        {headers: defaultHeaders()},
+      );
+      await assertNotFoundRequest(
+        getRes,
+        `Resource with key '${resourceKey}' not found`,
+      );
+
+      const contentRes = await request.get(contentBinaryUrl, {
+        headers: authHeaders(credentials.accessToken),
+      });
+      await assertNotFoundRequest(
+        contentRes,
+        `Resource with key '${resourceKey}' not found`,
+      );
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Delete Resource - Not Found 404', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-api.spec.ts
@@ -12,10 +12,15 @@ import {
   buildUrl,
   defaultHeaders,
   assertUnauthorizedRequest,
+  assertNotAcceptableRequest,
   assertNotFoundRequest,
 } from '../../../../utils/http';
 import {getExpectedContent} from '../../../../utils/beans/requestBeans';
-import {deployResourceAndGetMetadata} from '@requestHelpers';
+import {
+  deployInlineResource,
+  deployResourceAndGetMetadata,
+  uniqueResourceName,
+} from '@requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 
 test.describe.parallel('Resource Get Content API', () => {
@@ -40,6 +45,34 @@ test.describe.parallel('Resource Get Content API', () => {
 
       await assertStatusCode(res, 200);
       expect(await res.text()).toBe(expectedContent);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Resource Content - Not Acceptable 406 for a non-RPA resource', async ({
+    request,
+  }) => {
+    const resource = await deployInlineResource(
+      request,
+      uniqueResourceName('system-prompt', 'md'),
+      '# System prompt',
+    );
+
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl('/resources/{resourceKey}/content', {
+          resourceKey: resource.resourceKey,
+        }),
+        {
+          headers: defaultHeaders(),
+        },
+      );
+
+      await assertNotAcceptableRequest(
+        res,
+        new RegExp(
+          `Resource with key '${resource.resourceKey}' is of type '.*', expected 'rpa'`,
+        ),
+      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-binary-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-binary-api.spec.ts
@@ -34,6 +34,7 @@ function contentBinaryUrl(resourceKey: string): string {
   return buildUrl('/resources/{resourceKey}/content/binary', {resourceKey});
 }
 
+// Workaround for bug #59831: https://github.com/camunda/camunda/issues/59831
 // The handler is mapped with the gateway's default JSON produces list, so an
 // explicit `Accept: application/octet-stream` — the media type the API spec
 // documents — is answered with 406. Send no Accept header until that is fixed.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-binary-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-binary-api.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertNotFoundRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  authHeaders,
+  buildUrl,
+  credentials,
+} from '../../../../utils/http';
+import {
+  deployInlineResource,
+  rpaResourceContent,
+  uniqueResourceName,
+} from '@requestHelpers';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+function contentBinaryUrl(resourceKey: string): string {
+  return buildUrl('/resources/{resourceKey}/content/binary', {resourceKey});
+}
+
+// The handler is mapped with the gateway's default JSON produces list, so an
+// explicit `Accept: application/octet-stream` — the media type the API spec
+// documents — is answered with 406. Send no Accept header until that is fixed.
+function binaryHeaders(): Record<string, string> {
+  return authHeaders(credentials.accessToken);
+}
+
+test.describe.parallel('Resource Get Content Binary API', () => {
+  test('Get Resource Content Binary - Generic Resource Success 200', async ({
+    request,
+  }) => {
+    const content = '# System prompt\n\nYou are a helpful agent.';
+    const resource = await deployInlineResource(
+      request,
+      uniqueResourceName('system-prompt', 'md'),
+      content,
+    );
+
+    await expect(async () => {
+      const res = await request.get(contentBinaryUrl(resource.resourceKey), {
+        headers: binaryHeaders(),
+      });
+
+      await assertStatusCode(res, 200);
+      expect(res.headers()['content-type']).toContain(
+        'application/octet-stream',
+      );
+      expect(await res.text()).toBe(content);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Resource Content Binary - RPA Resource Success 200', async ({
+    request,
+  }) => {
+    const content = rpaResourceContent(`rpa_${generateUniqueId()}`);
+    const resource = await deployInlineResource(
+      request,
+      uniqueResourceName('robot', 'rpa'),
+      content,
+    );
+
+    await expect(async () => {
+      const res = await request.get(contentBinaryUrl(resource.resourceKey), {
+        headers: binaryHeaders(),
+      });
+
+      await assertStatusCode(res, 200);
+      expect(await res.text()).toBe(content);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Resource Content Binary - returns byte-identical binary content', async ({
+    request,
+  }) => {
+    const resource = await deployInlineResource(
+      request,
+      uniqueResourceName('logo', 'png'),
+      PNG_BYTES,
+    );
+
+    await expect(async () => {
+      const res = await request.get(contentBinaryUrl(resource.resourceKey), {
+        headers: binaryHeaders(),
+      });
+
+      await assertStatusCode(res, 200);
+      expect(await res.body()).toEqual(PNG_BYTES);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Get Resource Content Binary - Not Found 404', async ({request}) => {
+    const nonExistentResourceKey = '2251799813733053';
+
+    const res = await request.get(contentBinaryUrl(nonExistentResourceKey), {
+      headers: binaryHeaders(),
+    });
+
+    await assertNotFoundRequest(
+      res,
+      `Resource with key '${nonExistentResourceKey}' not found`,
+    );
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Get Resource Content Binary - Unauthorized 401', async ({request}) => {
+    const res = await request.get(contentBinaryUrl('someKey'), {
+      headers: {},
+    });
+
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-search-api.spec.ts
@@ -1,0 +1,408 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertBadRequest,
+  assertPaginatedRequest,
+  assertUnauthorizedRequest,
+  assertStatusCode,
+  buildUrl,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  assertResourceInSearchResult,
+  DeployedResource,
+  deployInlineResource,
+  deployInlineResources,
+  deployResourceAndGetMetadata,
+  resourceKeysOf,
+  rpaResourceContent,
+  searchResources,
+  uniqueResourceName,
+  ResourceMetadata,
+} from '@requestHelpers';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+
+const SORT_FIELDS = [
+  'resourceKey',
+  'resourceName',
+  'resourceId',
+  'version',
+  'versionTag',
+  'deploymentKey',
+  'tenantId',
+] as const;
+
+async function searchAndValidate(
+  request: Parameters<typeof searchResources>[0],
+  body: Record<string, unknown>,
+) {
+  const res = await searchResources(request, body);
+  await validateResponse(
+    {path: '/resources/search', method: 'POST', status: '200'},
+    res,
+  );
+  return res;
+}
+
+test.describe('Resource Search API', () => {
+  let deploymentKey: string;
+  let genericResources: DeployedResource[];
+  let rpaResource: DeployedResource;
+  let versionTag: string;
+  let versionedV1: DeployedResource;
+  let versionedV2: DeployedResource;
+  let processDefinition: ResourceMetadata;
+
+  test.beforeAll(async ({request}) => {
+    const suffix = generateUniqueId();
+    const deployment = await deployInlineResources(request, [
+      {fileName: `prompt-${suffix}.md`, content: '# System prompt'},
+      {fileName: `config-${suffix}.yml`, content: 'server:\n  port: 8080'},
+      {fileName: `notes-${suffix}.txt`, content: 'plain text resource'},
+    ]);
+    deploymentKey = deployment.deploymentKey;
+    genericResources = deployment.resources;
+
+    versionTag = `vt-${suffix}`;
+    rpaResource = await deployInlineResource(
+      request,
+      `robot-${suffix}.rpa`,
+      rpaResourceContent(`rpa_${suffix}`, versionTag),
+    );
+
+    const versionedName = uniqueResourceName('versioned', 'md');
+    versionedV1 = await deployInlineResource(
+      request,
+      versionedName,
+      '# version one',
+    );
+    versionedV2 = await deployInlineResource(
+      request,
+      versionedName,
+      '# version two',
+    );
+
+    processDefinition = await deployResourceAndGetMetadata(
+      request,
+      'Zeebe_User_Task_Process.bpmn',
+      0,
+    );
+  });
+
+  test('Search Resources - returns deployed generic and RPA resources', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const unfiltered = await searchAndValidate(request, {});
+      await assertPaginatedRequest(unfiltered, {
+        itemLengthGreaterThan: 0,
+        totalItemGreaterThan: 0,
+      });
+
+      const res = await searchAndValidate(request, {
+        filter: {
+          resourceKey: {
+            $in: [
+              ...genericResources.map((resource) => resource.resourceKey),
+              rpaResource.resourceKey,
+            ],
+          },
+        },
+      });
+      const json = await res.json();
+      for (const resource of genericResources) {
+        assertResourceInSearchResult(json, resource);
+      }
+      assertResourceInSearchResult(json, rpaResource, versionTag);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - excludes process definitions', async ({request}) => {
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {resourceKey: processDefinition.resourceKey},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - by resourceKey', async ({request}) => {
+    const expected = genericResources[0];
+
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {resourceKey: expected.resourceKey},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      assertResourceInSearchResult(await res.json(), expected);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - by resourceId', async ({request}) => {
+    const expected = genericResources[1];
+
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {resourceId: expected.resourceId},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      assertResourceInSearchResult(await res.json(), expected);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - by resourceName', async ({request}) => {
+    const expected = genericResources[2];
+
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {resourceName: expected.resourceName},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      assertResourceInSearchResult(await res.json(), expected);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - by deploymentKey', async ({request}) => {
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {deploymentKey},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: genericResources.length,
+        totalItemsEqualTo: genericResources.length,
+      });
+      const json = await res.json();
+      for (const resource of genericResources) {
+        assertResourceInSearchResult(json, resource);
+      }
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - by tenantId', async ({request}) => {
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {tenantId: '<default>', deploymentKey},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: genericResources.length,
+        totalItemsEqualTo: genericResources.length,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - by versionTag', async ({request}) => {
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {versionTag},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      assertResourceInSearchResult(await res.json(), rpaResource, versionTag);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - by version', async ({request}) => {
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {resourceId: versionedV2.resourceId, version: {$gt: 1}},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      assertResourceInSearchResult(await res.json(), versionedV2);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Resources - advanced filter operators', async ({request}) => {
+    const [first, second, third] = genericResources;
+
+    await expect(async () => {
+      const inRes = await searchAndValidate(request, {
+        filter: {
+          resourceKey: {$in: [first.resourceKey, second.resourceKey]},
+        },
+      });
+      expect(resourceKeysOf(await inRes.json()).sort()).toEqual(
+        [first.resourceKey, second.resourceKey].sort(),
+      );
+
+      const notInRes = await searchAndValidate(request, {
+        filter: {
+          deploymentKey,
+          resourceKey: {$notIn: [first.resourceKey]},
+        },
+      });
+      expect(resourceKeysOf(await notInRes.json()).sort()).toEqual(
+        [second.resourceKey, third.resourceKey].sort(),
+      );
+
+      const neqRes = await searchAndValidate(request, {
+        filter: {deploymentKey, resourceId: {$neq: first.resourceId}},
+      });
+      expect(resourceKeysOf(await neqRes.json())).not.toContain(
+        first.resourceKey,
+      );
+
+      const eqRes = await searchAndValidate(request, {
+        filter: {resourceName: {$eq: first.resourceName}},
+      });
+      expect(resourceKeysOf(await eqRes.json())).toEqual([first.resourceKey]);
+
+      const existsRes = await searchAndValidate(request, {
+        filter: {deploymentKey, resourceId: {$exists: true}},
+      });
+      expect(resourceKeysOf(await existsRes.json()).sort()).toEqual(
+        genericResources.map((resource) => resource.resourceKey).sort(),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  for (const field of ['resourceKey', 'resourceName', 'resourceId'] as const) {
+    test(`Search Resources - sort by ${field} ascending and descending`, async ({
+      request,
+    }) => {
+      await expect(async () => {
+        const ascRes = await searchAndValidate(request, {
+          filter: {deploymentKey},
+          sort: [{field, order: 'ASC'}],
+        });
+        const ascending = (await ascRes.json()).items.map(
+          (item: Record<string, string>) => item[field],
+        );
+        expect(ascending).toHaveLength(genericResources.length);
+        expect(ascending).toEqual([...ascending].sort());
+
+        const descRes = await searchAndValidate(request, {
+          filter: {deploymentKey},
+          sort: [{field, order: 'DESC'}],
+        });
+        const descending = (await descRes.json()).items.map(
+          (item: Record<string, string>) => item[field],
+        );
+        expect(descending).toEqual([...ascending].reverse());
+      }).toPass(defaultAssertionOptions);
+    });
+  }
+
+  test('Search Resources - sort by version', async ({request}) => {
+    await expect(async () => {
+      const res = await searchAndValidate(request, {
+        filter: {resourceId: versionedV1.resourceId},
+        sort: [{field: 'version', order: 'DESC'}],
+      });
+
+      const versions = (await res.json()).items.map(
+        (item: Record<string, number>) => item.version,
+      );
+      expect(versions).toEqual([versionedV2.version, versionedV1.version]);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Search Resources - accepts every documented sort field', async ({
+    request,
+  }) => {
+    for (const field of SORT_FIELDS) {
+      const res = await searchResources(request, {
+        sort: [{field, order: 'ASC'}],
+        page: {limit: 1},
+      });
+      await assertStatusCode(res, 200);
+    }
+  });
+
+  test('Search Resources - paginates with a cursor', async ({request}) => {
+    await expect(async () => {
+      const firstRes = await searchAndValidate(request, {
+        filter: {deploymentKey},
+        sort: [{field: 'resourceKey', order: 'ASC'}],
+        page: {limit: 2},
+      });
+      const firstPage = await firstRes.json();
+      expect(firstPage.items).toHaveLength(2);
+      expect(firstPage.page.totalItems).toBe(genericResources.length);
+
+      const secondRes = await searchAndValidate(request, {
+        filter: {deploymentKey},
+        sort: [{field: 'resourceKey', order: 'ASC'}],
+        page: {limit: 2, after: firstPage.page.endCursor},
+      });
+      const secondPage = await secondRes.json();
+      expect(secondPage.items).toHaveLength(1);
+
+      const keys = [
+        ...resourceKeysOf(firstPage),
+        ...resourceKeysOf(secondPage),
+      ];
+      expect(new Set(keys).size).toBe(genericResources.length);
+      expect(keys.sort()).toEqual(
+        genericResources.map((resource) => resource.resourceKey).sort(),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Search Resources - Bad Request 400 - unknown sort field', async ({
+    request,
+  }) => {
+    const res = await searchResources(request, {
+      sort: [{field: 'unknownField', order: 'ASC'}],
+    });
+
+    await assertBadRequest(res, /unknownField/);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Search Resources - Bad Request 400 - unknown sort order', async ({
+    request,
+  }) => {
+    const res = await searchResources(request, {
+      sort: [{field: 'resourceKey', order: 'SIDEWAYS'}],
+    });
+
+    await assertBadRequest(res, /SIDEWAYS/);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Search Resources - Unauthorized 401', async ({request}) => {
+    const res = await request.post(buildUrl('/resources/search'), {
+      headers: {'Content-Type': 'application/json'},
+      data: {},
+    });
+
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -149,6 +149,17 @@ export async function assertInvalidState(
   assertRequiredFields(json, ['detail', 'title']);
   expect(json.title).toBe('INVALID_STATE');
 }
+export async function assertNotAcceptableRequest(
+  response: APIResponse,
+  detail: string | RegExp,
+) {
+  await assertStatusCode(response, 406);
+  const json = await response.json();
+  assertRequiredFields(json, ['detail', 'title']);
+  expect(json.title).toBe('NOT_ACCEPTABLE');
+  expect(json.detail).toMatch(detail);
+}
+
 export async function assertNotFoundRequest(
   response: APIResponse,
   detail: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
@@ -6,10 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {expect} from '@playwright/test';
+import {APIResponse, expect} from '@playwright/test';
 import {readFileSync} from 'node:fs';
 import {APIRequestContext} from 'playwright-core';
-import {assertStatusCode, buildUrl, defaultHeaders} from '../http';
+import {assertStatusCode, buildUrl, defaultHeaders, jsonHeaders} from '../http';
+import {generateUniqueId} from '../constants';
 
 type DeploymentItem = Record<string, Record<string, unknown> | undefined>;
 
@@ -232,4 +233,126 @@ export async function deployResourceAndGetMetadata(
   }
 
   throw new Error(`Unknown deployment type: ${JSON.stringify(deployment)}`);
+}
+
+export interface DeployedResource extends ResourceMetadata {
+  deploymentKey: string;
+}
+
+export interface InlineResource {
+  fileName: string;
+  content: string | Buffer;
+}
+
+// A minimal valid RPA document. `id` and `versionTag` are the only fields the
+// deployment transformer reads, and versionTag is the sole way any resource
+// type can carry one.
+export function rpaResourceContent(rpaId: string, versionTag?: string): string {
+  return JSON.stringify({
+    id: rpaId,
+    name: rpaId,
+    executionPlatform: 'Camunda Cloud',
+    executionPlatformVersion: '8.8.0',
+    ...(versionTag ? {versionTag} : {}),
+    script: '*** Tasks ***\nDo nothing\n    Log    hello',
+  });
+}
+
+export function uniqueResourceName(prefix: string, extension: string): string {
+  return `${prefix}-${generateUniqueId()}.${extension}`;
+}
+
+export async function deployInlineResources(
+  request: APIRequestContext,
+  resources: InlineResource[],
+): Promise<{deploymentKey: string; resources: DeployedResource[]}> {
+  const formData = new FormData();
+  for (const {fileName, content} of resources) {
+    const bytes = Uint8Array.from(
+      typeof content === 'string' ? Buffer.from(content, 'utf-8') : content,
+    );
+    formData.append(
+      'resources',
+      new Blob([bytes], {type: 'application/octet-stream'}),
+      fileName,
+    );
+  }
+
+  const res = await request.post(buildUrl('/deployments'), {
+    headers: defaultHeaders(),
+    multipart: formData,
+  });
+
+  await assertStatusCode(res, 200);
+  const body = await res.json();
+  const deployed = (body.deployments as DeploymentItem[])
+    .filter((deployment) => deployment.resource != null)
+    .map((deployment) => {
+      const resource = deployment.resource!;
+      return {
+        deploymentKey: body.deploymentKey as string,
+        resourceKey: resource.resourceKey as string,
+        resourceName: resource.resourceName as string,
+        resourceId: resource.resourceId as string,
+        version: resource.version as number,
+      };
+    });
+
+  expect(
+    deployed.length,
+    `Expected every deployed file to be a resource, got ${JSON.stringify(body.deployments)}`,
+  ).toBe(resources.length);
+
+  return {deploymentKey: body.deploymentKey, resources: deployed};
+}
+
+export async function deployInlineResource(
+  request: APIRequestContext,
+  fileName: string,
+  content: string | Buffer,
+): Promise<DeployedResource> {
+  const {resources} = await deployInlineResources(request, [
+    {fileName, content},
+  ]);
+  return resources[0];
+}
+
+export async function searchResources(
+  request: APIRequestContext,
+  body: Record<string, unknown> = {},
+): Promise<APIResponse> {
+  return request.post(buildUrl('/resources/search'), {
+    headers: jsonHeaders(),
+    data: body,
+  });
+}
+
+export function resourceKeysOf(json: {items: {resourceKey: string}[]}) {
+  return json.items.map((item) => item.resourceKey);
+}
+
+export function assertResourceInSearchResult(
+  json: {items: Record<string, unknown>[]},
+  expected: DeployedResource,
+  expectedVersionTag?: string,
+): void {
+  const match = json.items.find(
+    (item) => item.resourceKey === expected.resourceKey,
+  );
+  expect(
+    match,
+    `Resource ${expected.resourceName} (${expected.resourceKey}) missing from ${JSON.stringify(
+      json.items,
+    )}`,
+  ).toBeDefined();
+  expect(match).toMatchObject({
+    resourceKey: expected.resourceKey,
+    resourceName: expected.resourceName,
+    resourceId: expected.resourceId,
+    version: expected.version,
+    tenantId: '<default>',
+    ...(expectedVersionTag === undefined
+      ? {}
+      : {versionTag: expectedVersionTag}),
+  });
 }


### PR DESCRIPTION
## Description

Adds end-to-end coverage for the resource API changes made in #51042: `POST /v2/resources/search` and `GET /v2/resources/{resourceKey}/content/binary` are new in 8.10, `/content` is deprecated and now answers 406 for non-RPA resources, and resource reads moved to secondary storage.

Before this PR the resource specs exercised RPA metadata and RPA content only, so both new endpoints and the changed error contract were covered by unit and acceptance tests alone, with nothing verifying them over HTTP against a real cluster.

**New**

- `resource-search-api.spec.ts` — filters (`resourceKey`, `resourceId`, `resourceName`, `deploymentKey`, `tenantId`, `versionTag`, `version`), advanced operators (`$eq $neq $in $notIn $exists`), sorting ASC/DESC plus acceptance of every documented sort field, cursor pagination, 400 on unknown sort field/order, 401, and the guarantee that process definitions are excluded from results.
- `resource-get-content-binary-api.spec.ts` — generic and RPA content, byte-identical binary payload, 404, 401.

**Extended**

- `resource-get-content-api.spec.ts` — 406 for a non-RPA resource (#52739).
- `resource-delete-api.spec.ts` — after deletion the resource disappears from search and both read endpoints answer 404; regression guard for the service-layer resource cache (#51045).
- `resource-requestHelpers.ts` / `http.ts` — inline-content deployment helpers, search helpers, `assertNotAcceptableRequest`.

## Why this approach

Resources are deployed from inline content under a per-run unique file name instead of from fixtures in `resources/`. Deployed resources are immutable and accumulate across runs, so a shared fixture would make every count- and filter-based assertion depend on what earlier runs left behind. The alternative — adding fixed fixture files — was rejected for that reason, and it also avoids checking a binary fixture into the repo for the byte-exactness test.

Every read assertion polls with `toPass(defaultAssertionOptions)`, since all of these endpoints are `x-eventually-consistent: true`; this is what broke the suite before in #51373.

## Defects found while writing these tests

Both are worked around in the specs, with the reason stated at the point of the workaround:

- #59831 — the binary endpoint answers 406 to the `Accept: application/octet-stream` its own specification documents, so the tests send no `Accept` header.
- #59832 — search returns `versionTag` as an empty string rather than `null`, so `$exists: false` matches nothing; `$exists` is asserted against `resourceId` instead.

Both should be revisited in these specs once fixed.

## Verification

- Local run against an Elasticsearch cluster: 45/45 passing, twice.
- On-demand workflow: https://github.com/camunda/camunda/actions/runs/31482834474

## Links

- QA tracking issue (this is the regression automation it is being written for): https://github.com/camunda/product-hub/issues/3752
- Epic: https://github.com/camunda/camunda/issues/51160
- Feature: https://github.com/camunda/camunda/issues/51042
- TestRail suite: https://camunda.testrail.com/index.php?/suites/view/17050
