### PR TITLE
test: cover generic resource deployment and linked generic resources

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-linked-generic-resources.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-linked-generic-resources.spec.ts
@@ -157,6 +157,12 @@ test.describe.parallel('Job Linked Generic Resources', () => {
     const [link] = parseLinkedResourcesHeader(job.customHeaders);
 
     expect(link.resourceKey).toBe(pinnedResourceKey);
+    await expect(async () => {
+      expect(await fetchResourceContent(request, link.resourceKey)).toBe(
+        'timeout: 30',
+      );
+    }).toPass(defaultAssertionOptions);
+
     await completeJob(request, job.jobKey);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-linked-generic-resources.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-linked-generic-resources.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {
+  assertStatusCode,
+  authHeaders,
+  buildUrl,
+  credentials,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {
+  activateJobAndGetHeaders,
+  completeJob,
+  deployInlineFiles,
+  deployInlineResource,
+  parseLinkedResourcesHeader,
+  serviceTaskWithLinkedResourcesBpmn,
+} from '@requestHelpers';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+
+const RESOURCE_TYPE = 'GenericScript';
+const LINK_NAME = 'my_generic_link';
+
+async function startProcessInstance(
+  request: APIRequestContext,
+  processDefinitionId: string,
+): Promise<string> {
+  const res = await request.post(buildUrl('/process-instances'), {
+    headers: jsonHeaders(),
+    data: {processDefinitionId},
+  });
+  await assertStatusCode(res, 200);
+  return String((await res.json()).processInstanceKey);
+}
+
+async function fetchResourceContent(
+  request: APIRequestContext,
+  resourceKey: string,
+): Promise<string> {
+  const res = await request.get(
+    buildUrl('/resources/{resourceKey}/content/binary', {resourceKey}),
+    // No Accept header — see camunda/camunda#59831.
+    {headers: authHeaders(credentials.accessToken)},
+  );
+  await assertStatusCode(res, 200);
+  return res.text();
+}
+
+test.describe.parallel('Job Linked Generic Resources', () => {
+  test('Linked generic resource with latest binding resolves to the newest version', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const resourceName = `prompt-${suffix}.md`;
+    const processDefinitionId = `linked-generic-latest-${suffix}`;
+    const jobType = `linked-generic-latest-job-${suffix}`;
+
+    const firstVersion = await deployInlineResource(
+      request,
+      resourceName,
+      '# version one',
+    );
+    await deployInlineFiles(request, [
+      {
+        fileName: `${processDefinitionId}.bpmn`,
+        content: serviceTaskWithLinkedResourcesBpmn(
+          processDefinitionId,
+          jobType,
+          [
+            {
+              resourceId: resourceName,
+              resourceType: RESOURCE_TYPE,
+              bindingType: 'latest',
+              linkName: LINK_NAME,
+            },
+          ],
+        ),
+      },
+    ]);
+
+    await startProcessInstance(request, processDefinitionId);
+    const job = await activateJobAndGetHeaders(request, jobType);
+    const [link] = parseLinkedResourcesHeader(job.customHeaders);
+
+    expect(link).toMatchObject({
+      resourceType: RESOURCE_TYPE,
+      linkName: LINK_NAME,
+      resourceKey: firstVersion.resourceKey,
+    });
+    await completeJob(request, job.jobKey);
+
+    const secondVersion = await deployInlineResource(
+      request,
+      resourceName,
+      '# version two',
+    );
+    expect(secondVersion.version).toBe(2);
+
+    await startProcessInstance(request, processDefinitionId);
+    const jobAfterRedeploy = await activateJobAndGetHeaders(request, jobType);
+    const [linkAfterRedeploy] = parseLinkedResourcesHeader(
+      jobAfterRedeploy.customHeaders,
+    );
+
+    expect(linkAfterRedeploy.resourceKey).toBe(secondVersion.resourceKey);
+    await completeJob(request, jobAfterRedeploy.jobKey);
+  });
+
+  test('Linked generic resource with deployment binding stays pinned to its deployment', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const resourceName = `config-${suffix}.yml`;
+    const processDefinitionId = `linked-generic-deployment-${suffix}`;
+    const jobType = `linked-generic-deployment-job-${suffix}`;
+
+    const deployment = await deployInlineFiles(request, [
+      {fileName: resourceName, content: 'timeout: 30'},
+      {
+        fileName: `${processDefinitionId}.bpmn`,
+        content: serviceTaskWithLinkedResourcesBpmn(
+          processDefinitionId,
+          jobType,
+          [
+            {
+              resourceId: resourceName,
+              resourceType: RESOURCE_TYPE,
+              bindingType: 'deployment',
+              linkName: LINK_NAME,
+            },
+          ],
+        ),
+      },
+    ]);
+    const pinnedResourceKey = (
+      deployment.deployments as {resource?: {resourceKey: string}}[]
+    ).find((item) => item.resource != null)!.resource!.resourceKey;
+
+    const laterVersion = await deployInlineResource(
+      request,
+      resourceName,
+      'timeout: 60',
+    );
+    expect(laterVersion.resourceKey).not.toBe(pinnedResourceKey);
+
+    await startProcessInstance(request, processDefinitionId);
+    const job = await activateJobAndGetHeaders(request, jobType);
+    const [link] = parseLinkedResourcesHeader(job.customHeaders);
+
+    expect(link.resourceKey).toBe(pinnedResourceKey);
+    await completeJob(request, job.jobKey);
+  });
+
+  test('Worker can fetch the linked resource content using the key from the job header', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const resourceName = `system-prompt-${suffix}.md`;
+    const content = '# System prompt\n\nYou are a helpful agent.';
+    const processDefinitionId = `linked-generic-fetch-${suffix}`;
+    const jobType = `linked-generic-fetch-job-${suffix}`;
+
+    await deployInlineResource(request, resourceName, content);
+    await deployInlineFiles(request, [
+      {
+        fileName: `${processDefinitionId}.bpmn`,
+        content: serviceTaskWithLinkedResourcesBpmn(
+          processDefinitionId,
+          jobType,
+          [
+            {
+              resourceId: resourceName,
+              resourceType: RESOURCE_TYPE,
+              bindingType: 'latest',
+              linkName: LINK_NAME,
+            },
+          ],
+        ),
+      },
+    ]);
+
+    await startProcessInstance(request, processDefinitionId);
+    const job = await activateJobAndGetHeaders(request, jobType);
+    const [link] = parseLinkedResourcesHeader(job.customHeaders);
+
+    await expect(async () => {
+      expect(await fetchResourceContent(request, link.resourceKey)).toBe(
+        content,
+      );
+    }).toPass(defaultAssertionOptions);
+
+    await completeJob(request, job.jobKey);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-deploy-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-deploy-api.spec.ts
@@ -23,7 +23,16 @@ import {
   validateRpaDeployment,
   createMultiResourceFormData,
   createResourceFormData,
+  deployInlineFilesRaw,
+  deployInlineResource,
+  searchResources,
+  serviceTaskWithLinkedResourcesBpmn,
+  uniqueResourceName,
 } from '@requestHelpers';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Resource Deploy API', () => {
@@ -217,6 +226,148 @@ test.describe.parallel('Resource Deploy API', () => {
     expect(deploymentTypes).toContain('decisionDefinition');
     expect(deploymentTypes).toContain('decisionRequirements');
     expect(deploymentTypes).toContain('resource');
+  });
+
+  test('Deploy Resource - Generic File Success', async ({request}) => {
+    const genericResourceName = uniqueResourceName('system-prompt', 'md');
+
+    const res = await deployInlineFilesRaw(request, [
+      {fileName: genericResourceName, content: '# System prompt'},
+    ]);
+
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/deployments',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+
+    const body = await res.json();
+    validateDeploymentResponse(body, 1);
+    expect(body.deployments[0].resource).toMatchObject({
+      resourceName: genericResourceName,
+      resourceId: genericResourceName,
+      version: 1,
+      tenantId: '<default>',
+    });
+    expect(body.deployments[0].resource.resourceKey).toBeDefined();
+  });
+
+  test('Deploy Resource - File Types That Are Not Interpreted As A Model', async ({
+    request,
+  }) => {
+    const xmlResourceName = uniqueResourceName('sap-mapping', 'xml');
+    const extensionlessResourceName = `LICENSE-${generateUniqueId()}`;
+
+    const res = await deployInlineFilesRaw(request, [
+      {
+        fileName: xmlResourceName,
+        content: '<mapping><field name="amount" /></mapping>',
+      },
+      {fileName: extensionlessResourceName, content: 'Camunda License 1.0'},
+    ]);
+
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    validateDeploymentResponse(body, 2);
+    expect(
+      body.deployments.map(
+        (deployment: {resource?: {resourceName: string}}) =>
+          deployment.resource?.resourceName,
+      ),
+    ).toEqual(
+      expect.arrayContaining([xmlResourceName, extensionlessResourceName]),
+    );
+  });
+
+  test('Deploy Resource - Generic File Versioning', async ({request}) => {
+    const genericResourceName = uniqueResourceName('config', 'json');
+
+    const firstVersion = await deployInlineResource(
+      request,
+      genericResourceName,
+      '{"timeout": 30}',
+    );
+    const secondVersion = await deployInlineResource(
+      request,
+      genericResourceName,
+      '{"timeout": 60}',
+    );
+
+    expect(firstVersion.version).toBe(1);
+    expect(secondVersion.version).toBe(2);
+    expect(secondVersion.resourceKey).not.toBe(firstVersion.resourceKey);
+
+    await expect(async () => {
+      const res = await searchResources(request, {
+        filter: {resourceId: genericResourceName},
+      });
+      await assertStatusCode(res, 200);
+      const keys = (await res.json()).items.map(
+        (item: {resourceKey: string}) => item.resourceKey,
+      );
+      expect(keys.sort()).toEqual(
+        [firstVersion.resourceKey, secondVersion.resourceKey].sort(),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Deploy Resource - Rejected Deployment Leaves No Resource Behind', async ({
+    request,
+  }) => {
+    const genericResourceName = uniqueResourceName('runbook', 'md');
+
+    const rejected = await deployInlineFilesRaw(request, [
+      {fileName: genericResourceName, content: '# Runbook'},
+      {fileName: `broken-${generateUniqueId()}.bpmn`, content: 'not bpmn'},
+    ]);
+    await assertStatusCode(rejected, 400);
+
+    await expect(async () => {
+      const res = await searchResources(request, {
+        filter: {resourceId: genericResourceName},
+      });
+      await assertStatusCode(res, 200);
+      expect((await res.json()).items).toHaveLength(0);
+    }).toPass(defaultAssertionOptions);
+
+    const redeployed = await deployInlineResource(
+      request,
+      genericResourceName,
+      '# Runbook',
+    );
+    expect(redeployed.version).toBe(1);
+  });
+
+  test('Deploy Resource - Bad Request 400 - Linked Resource Missing From Deployment', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const processDefinitionId = `linked-generic-missing-${suffix}`;
+
+    const res = await deployInlineFilesRaw(request, [
+      {
+        fileName: `${processDefinitionId}.bpmn`,
+        content: serviceTaskWithLinkedResourcesBpmn(
+          processDefinitionId,
+          `linked-generic-missing-job-${suffix}`,
+          [
+            {
+              resourceId: `absent-${suffix}.md`,
+              resourceType: 'GenericScript',
+              bindingType: 'deployment',
+              linkName: 'my_generic_link',
+            },
+          ],
+        ),
+      },
+    ]);
+
+    await assertStatusCode(res, 400);
+    expect((await res.json()).detail).toContain(`absent-${suffix}.md`);
   });
 
   test('Deploy Resource - Unauthorized 401', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
@@ -113,7 +113,6 @@ test.describe.parallel('Resource Get API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  // eslint-disable-next-line playwright/expect-expect
   test('Get Resource - Not Found 404 For A Process Definition Key', async ({
     request,
   }) => {
@@ -122,6 +121,19 @@ test.describe.parallel('Resource Get API', () => {
       'Zeebe_User_Task_Process.bpmn',
       0,
     );
+
+    // Both endpoints read secondary storage. Waiting for the process definition
+    // to be projected is what makes the 404 below meaningful — asserted earlier
+    // it would pass simply because nothing has been indexed yet.
+    await expect(async () => {
+      const definitionRes = await request.get(
+        buildUrl('/process-definitions/{processDefinitionKey}', {
+          processDefinitionKey: processDefinition.resourceKey,
+        }),
+        {headers: jsonHeaders()},
+      );
+      await assertStatusCode(definitionRes, 200);
+    }).toPass(defaultAssertionOptions);
 
     const res = await request.get(
       buildUrl('/resources/{resourceKey}', {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
@@ -19,7 +19,12 @@ import {
   validateResponse,
   validateResponseShape,
 } from '../../../../json-body-assertions';
-import {deployResourceAndGetMetadata, ResourceMetadata} from '@requestHelpers';
+import {
+  deployInlineResource,
+  deployResourceAndGetMetadata,
+  ResourceMetadata,
+  uniqueResourceName,
+} from '@requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 
 function validateResourceResponse(
@@ -75,6 +80,62 @@ test.describe.parallel('Resource Get API', () => {
       );
       validateResourceResponse(await res.json(), metadata);
     }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Resource - Generic Resource Success 200', async ({request}) => {
+    const resourceName = uniqueResourceName('system-prompt', 'md');
+    const metadata = await deployInlineResource(
+      request,
+      resourceName,
+      '# System prompt',
+    );
+
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl('/resources/{resourceKey}', {
+          resourceKey: metadata.resourceKey,
+        }),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/resources/{resourceKey}',
+          method: 'GET',
+          status: '200',
+        },
+        res,
+      );
+      validateResourceResponse(await res.json(), metadata);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Get Resource - Not Found 404 For A Process Definition Key', async ({
+    request,
+  }) => {
+    const processDefinition = await deployResourceAndGetMetadata(
+      request,
+      'Zeebe_User_Task_Process.bpmn',
+      0,
+    );
+
+    const res = await request.get(
+      buildUrl('/resources/{resourceKey}', {
+        resourceKey: processDefinition.resourceKey,
+      }),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+
+    await assertNotFoundRequest(
+      res,
+      `Resource with key '${processDefinition.resourceKey}' not found`,
+    );
   });
 
   // eslint-disable-next-line playwright/expect-expect

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
@@ -262,12 +262,9 @@ export function uniqueResourceName(prefix: string, extension: string): string {
   return `${prefix}-${generateUniqueId()}.${extension}`;
 }
 
-export async function deployInlineResources(
-  request: APIRequestContext,
-  resources: InlineResource[],
-): Promise<{deploymentKey: string; resources: DeployedResource[]}> {
+export function createInlineFormData(files: InlineResource[]): FormData {
   const formData = new FormData();
-  for (const {fileName, content} of resources) {
+  for (const {fileName, content} of files) {
     const bytes = Uint8Array.from(
       typeof content === 'string' ? Buffer.from(content, 'utf-8') : content,
     );
@@ -277,14 +274,33 @@ export async function deployInlineResources(
       fileName,
     );
   }
+  return formData;
+}
 
-  const res = await request.post(buildUrl('/deployments'), {
+export function deployInlineFilesRaw(
+  request: APIRequestContext,
+  files: InlineResource[],
+): Promise<APIResponse> {
+  return request.post(buildUrl('/deployments'), {
     headers: defaultHeaders(),
-    multipart: formData,
+    multipart: createInlineFormData(files),
   });
+}
 
+export async function deployInlineFiles(
+  request: APIRequestContext,
+  files: InlineResource[],
+): Promise<Record<string, unknown>> {
+  const res = await deployInlineFilesRaw(request, files);
   await assertStatusCode(res, 200);
-  const body = await res.json();
+  return res.json();
+}
+
+export async function deployInlineResources(
+  request: APIRequestContext,
+  resources: InlineResource[],
+): Promise<{deploymentKey: string; resources: DeployedResource[]}> {
+  const body = await deployInlineFiles(request, resources);
   const deployed = (body.deployments as DeploymentItem[])
     .filter((deployment) => deployment.resource != null)
     .map((deployment) => {
@@ -303,7 +319,78 @@ export async function deployInlineResources(
     `Expected every deployed file to be a resource, got ${JSON.stringify(body.deployments)}`,
   ).toBe(resources.length);
 
-  return {deploymentKey: body.deploymentKey, resources: deployed};
+  return {deploymentKey: body.deploymentKey as string, resources: deployed};
+}
+
+export interface LinkedResourceBinding {
+  resourceId: string;
+  resourceType: string;
+  bindingType: 'latest' | 'deployment' | 'versionTag';
+  linkName: string;
+  versionTag?: string;
+}
+
+// Generated per test rather than kept as a fixture: the job type has to be
+// unique, because /jobs/activation has no process-instance filter and would
+// otherwise hand a parallel test's job to this one.
+export function serviceTaskWithLinkedResourcesBpmn(
+  processDefinitionId: string,
+  jobType: string,
+  linkedResources: LinkedResourceBinding[],
+): string {
+  const links = linkedResources
+    .map(
+      (link) =>
+        `<zeebe:linkedResource resourceId="${link.resourceId}" resourceType="${link.resourceType}" bindingType="${link.bindingType}" linkName="${link.linkName}"${
+          link.versionTag ? ` versionTag="${link.versionTag}"` : ''
+        } />`,
+    )
+    .join('\n            ');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_${processDefinitionId}"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="${processDefinitionId}" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>flow_to_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_task" sourceRef="start" targetRef="linked_task" />
+    <bpmn:serviceTask id="linked_task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="${jobType}" />
+        <zeebe:linkedResources>
+            ${links}
+        </zeebe:linkedResources>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_task</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="linked_task" targetRef="end" />
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>`;
+}
+
+export interface LinkedResourceHeader {
+  resourceType: string;
+  linkName: string;
+  resourceKey: string;
+}
+
+export function parseLinkedResourcesHeader(
+  customHeaders: unknown,
+): LinkedResourceHeader[] {
+  const linkedResources = (customHeaders as Record<string, string>)
+    ?.linkedResources;
+  expect(
+    linkedResources,
+    `Job has no linkedResources header: ${JSON.stringify(customHeaders)}`,
+  ).toBeDefined();
+  return JSON.parse(linkedResources);
 }
 
 export async function deployInlineResource(


### PR DESCRIPTION
> **Stacked on #59834** — targets `qa-resource-search-and-binary-content-api-tests` because it reuses the inline-deployment helpers added there. Review the base PR first; this one retargets to `main` automatically once it merges.

## Description

Adds end-to-end coverage for #20758, which opened `POST /v2/deployments` to any file type: anything not parsed as BPMN, DMN, form or RPA is stored as a generic resource, addressable by filename and consumable at runtime through `zeebe:linkedResources`.

The suite only ever deployed the four modelled types, so nothing verified that a plain file survives a deployment, gets versioned, or reaches a job worker.

**Deployment** (`resource-deploy-api.spec.ts`)

- a generic file comes back under `deployments[].resource` with the filename as both `resourceName` and `resourceId`
- files that are not interpreted as a model deploy as generic resources — an `.xml` file that is not BPMN, and a file with no extension
- redeploying the same filename produces version 2 while version 1 stays addressable
- a deployment rejected because of a broken BPMN leaves no generic resource behind, and the same file then deploys cleanly as version 1 — the regression guard for the cache-invalidation bug in #50908
- a `deployment`-bound linked resource missing from the deployment is rejected, naming the absent resource

**Retrieval** (`resource-get-api.spec.ts`)

- `GET /v2/resources/{key}` returns a generic resource
- 404 for a process definition key, which the endpoint deliberately does not serve

**Runtime** (new `job-linked-generic-resources.spec.ts`)

- a service task with a linked generic resource receives `linkedResources` in its job headers
- `latest` binding follows a redeployment; `deployment` binding stays pinned to the version deployed alongside the process
- the key from the job header fetches the original content back through the binary content endpoint

That last test is the point of the feature — a worker resolving a deployment-bound file — and no test exercised it end to end.

## Why this approach

The BPMN is generated per test instead of being added as a fixture. `/jobs/activation` has no process-instance filter, so a shared job type would let a parallel test steal the job, and the linked `resourceId` has to match a per-run unique filename anyway — a fixture would need substitution on both values.

Note on the job header shape: it carries `resourceType`, `linkName` and `resourceKey`, but no `resourceId`. That matches the engine tests, so the tests assert the shape as built.

## Verification

- Local run against Elasticsearch: 55/55 passing (45 from the base PR plus the 10 added here).
- On-demand workflow: see comment below.

## Links

- QA tracking issue (this is the regression automation it is being written for): https://github.com/camunda/product-hub/issues/3752
- Epic: https://github.com/camunda/camunda/issues/51160
- Feature: https://github.com/camunda/camunda/issues/20758
- Cache-invalidation sub-issue covered by the rejected-deployment test: https://github.com/camunda/camunda/issues/50908
- TestRail suite: https://camunda.testrail.com/index.php?/suites/view/17050
