### PR TITLE
feat: protocol for forwarding rebalance requests to the coordinator

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -173,6 +173,7 @@ mwnw*                       @camunda/engineering-operations
 /zeebe/dynamic-node-id-provider/ @camunda/zeebe-distributed-platform
 /zeebe/journal/             @camunda/zeebe-distributed-platform
 /zeebe/logstreams/          @camunda/zeebe-distributed-platform
+/zeebe/rebalance/           @camunda/zeebe-distributed-platform
 /zeebe/restore/             @camunda/zeebe-distributed-platform
 /zeebe/restore-standalone/  @camunda/zeebe-distributed-platform
 /zeebe/scheduler/           @camunda/zeebe-distributed-platform

--- a/buf.yaml
+++ b/buf.yaml
@@ -6,6 +6,12 @@ modules:
       # changes
       use:
         - WIRE
+  - path: zeebe/rebalance/src/main/resources/proto
+    breaking:
+      # as we use this only internally, only break on wire incompatibility; ignore source breaking
+      # changes
+      use:
+        - WIRE
   - path: zeebe/gateway-protocol/src/main/proto
     breaking:
       # as this is meant to be consumed by clients for code generation, we do care about source

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -667,6 +667,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>zeebe-rebalance</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-gateway-model</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -68,6 +68,7 @@
     <module>restore</module>
     <module>restore-standalone</module>
     <module>dynamic-config</module>
+    <module>rebalance</module>
     <module>dynamic-node-id-provider</module>
   </modules>
 

--- a/zeebe/rebalance/pom.xml
+++ b/zeebe/rebalance/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>zeebe-rebalance</artifactId>
+  <name>Zeebe Rebalance</name>
+
+  <properties>
+    <proto.dir>${maven.multiModuleProjectDirectory}/zeebe/rebalance/src/main/resources/proto</proto.dir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-config</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-utils</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <!--  Ensure non-jqwik junit5 tests can be run -->
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- generate Java protobuf code -->
+      <plugin>
+        <groupId>io.github.ascopes</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <configuration>
+          <sourceDirectories>
+            <sourceDirectory>${proto.dir}</sourceDirectory>
+          </sourceDirectories>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredNonTestScopedDependencies>
+            <!-- When not set, we get error "Non-test scoped test only dependencies found". If we set the scope to test only, the build fails. -->
+            <ignoredNonTestScopedDependency>io.camunda:zeebe-atomix-utils</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/zeebe/rebalance/spotbugs/spotbugs-exclude.xml
+++ b/zeebe/rebalance/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+  <!-- Generated classes -->
+  <Match>
+    <Or>
+      <Class name="io.camunda.zeebe.rebalance.protocol.Rebalance" />
+      <Class name="~io\.camunda\.zeebe\.rebalance\.protocol\.Rebalance\$.*" />
+    </Or>
+  </Match>
+
+</FindBugsFilter>

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/CancelRebalanceResponse.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/CancelRebalanceResponse.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+/**
+ * Response to a rebalance cancellation request.
+ *
+ * <p>Cancelling is always accepted, so {@code wasRunning} distinguishes a cancellation that stopped
+ * a running rebalance from a no-op.
+ */
+public record CancelRebalanceResponse(boolean wasRunning) {}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.camunda.zeebe.dynamic.config.serializer.DecodingFailed;
+import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
+import io.camunda.zeebe.rebalance.protocol.Rebalance;
+import io.camunda.zeebe.util.Either;
+import java.time.Duration;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSerializer {
+
+  @Override
+  public byte[] encodeTriggerRebalanceRequest(final TriggerRebalanceRequest request) {
+    return Rebalance.TriggerRebalanceRequest.newBuilder()
+        .setOverrides(encodeOverrides(request.overrides()))
+        .setDryRun(request.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
+  public TriggerRebalanceRequest decodeTriggerRebalanceRequest(final byte[] encodedRequest) {
+    try {
+      final var request = Rebalance.TriggerRebalanceRequest.parseFrom(encodedRequest);
+      return new TriggerRebalanceRequest(
+          decodeOverrides(request.getOverrides()), request.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public byte[] encodeResponse(final RebalanceStatus response) {
+    return Rebalance.Response.newBuilder().setStatus(encodeStatus(response)).build().toByteArray();
+  }
+
+  @Override
+  public byte[] encodeResponse(final CancelRebalanceResponse response) {
+    return Rebalance.Response.newBuilder()
+        .setCancelled(
+            Rebalance.CancelRebalanceResponse.newBuilder().setWasRunning(response.wasRunning()))
+        .build()
+        .toByteArray();
+  }
+
+  @Override
+  public byte[] encodeResponse(final RebalanceErrorResponse response) {
+    return Rebalance.Response.newBuilder()
+        .setError(
+            Rebalance.RebalanceErrorResponse.newBuilder()
+                .setErrorCode(encodeErrorCode(response.code()))
+                .setErrorMessage(response.message()))
+        .build()
+        .toByteArray();
+  }
+
+  @Override
+  public Either<RebalanceErrorResponse, RebalanceStatus> decodeRebalanceStatusResponse(
+      final byte[] encodedResponse) {
+    final var response = parseResponse(encodedResponse);
+    if (response.hasError()) {
+      return Either.left(decodeError(response.getError()));
+    }
+    if (response.hasStatus()) {
+      return Either.right(decodeStatus(response.getStatus()));
+    }
+    throw new DecodingFailed("Response has neither an error nor a rebalance status");
+  }
+
+  @Override
+  public Either<RebalanceErrorResponse, CancelRebalanceResponse> decodeCancelRebalanceResponse(
+      final byte[] encodedResponse) {
+    final var response = parseResponse(encodedResponse);
+    if (response.hasError()) {
+      return Either.left(decodeError(response.getError()));
+    }
+    if (response.hasCancelled()) {
+      return Either.right(new CancelRebalanceResponse(response.getCancelled().getWasRunning()));
+    }
+    throw new DecodingFailed("Response has neither an error nor a cancellation");
+  }
+
+  private Rebalance.Response parseResponse(final byte[] encodedResponse) {
+    try {
+      return Rebalance.Response.parseFrom(encodedResponse);
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  private Rebalance.RebalanceOverrides encodeOverrides(final RebalanceOverrides overrides) {
+    final var builder = Rebalance.RebalanceOverrides.newBuilder();
+    if (overrides.replicationLagThreshold() != null) {
+      builder.setReplicationLagThresholdBytes(overrides.replicationLagThreshold());
+    }
+    if (overrides.replicationTimeout() != null) {
+      builder.setReplicationTimeoutMillis(overrides.replicationTimeout().toMillis());
+    }
+    if (overrides.maxTransferAttempts() != null) {
+      builder.setMaxTransferAttempts(overrides.maxTransferAttempts());
+    }
+    return builder.build();
+  }
+
+  private RebalanceOverrides decodeOverrides(final Rebalance.RebalanceOverrides overrides) {
+    return new RebalanceOverrides(
+        overrides.hasReplicationLagThresholdBytes()
+            ? overrides.getReplicationLagThresholdBytes()
+            : null,
+        overrides.hasReplicationTimeoutMillis()
+            ? Duration.ofMillis(overrides.getReplicationTimeoutMillis())
+            : null,
+        overrides.hasMaxTransferAttempts() ? overrides.getMaxTransferAttempts() : null);
+  }
+
+  private Rebalance.RebalanceStatusResponse encodeStatus(final RebalanceStatus status) {
+    final var builder = Rebalance.RebalanceStatusResponse.newBuilder();
+    final var running = status.running();
+    if (running != null) {
+      builder.setRunning(
+          Rebalance.RunningRebalance.newBuilder()
+              .setRebalanceId(running.rebalanceId())
+              .setOverrides(encodeOverrides(running.overrides()))
+              .setDryRun(running.dryRun())
+              .setCancelRequested(running.cancelRequested()));
+    }
+    final var lastCompleted = status.lastCompleted();
+    if (lastCompleted != null) {
+      builder.setLastCompleted(
+          Rebalance.CompletedRebalance.newBuilder()
+              .setRebalanceId(lastCompleted.rebalanceId())
+              .setOutcome(encodeOutcome(lastCompleted.outcome())));
+    }
+    return builder.build();
+  }
+
+  private RebalanceStatus decodeStatus(final Rebalance.RebalanceStatusResponse status) {
+    return new RebalanceStatus(
+        status.hasRunning() ? decodeRunning(status.getRunning()) : null,
+        status.hasLastCompleted() ? decodeCompleted(status.getLastCompleted()) : null);
+  }
+
+  private RebalanceStatus.Running decodeRunning(final Rebalance.RunningRebalance running) {
+    return new RebalanceStatus.Running(
+        running.getRebalanceId(),
+        decodeOverrides(running.getOverrides()),
+        running.getDryRun(),
+        running.getCancelRequested());
+  }
+
+  private RebalanceStatus.Completed decodeCompleted(final Rebalance.CompletedRebalance completed) {
+    return new RebalanceStatus.Completed(
+        completed.getRebalanceId(), decodeOutcome(completed.getOutcome()));
+  }
+
+  private RebalanceErrorResponse decodeError(final Rebalance.RebalanceErrorResponse error) {
+    return new RebalanceErrorResponse(
+        decodeErrorCode(error.getErrorCode()), error.getErrorMessage());
+  }
+
+  private Rebalance.RebalanceOutcome encodeOutcome(final RebalanceOutcome outcome) {
+    return switch (outcome) {
+      case COMPLETED -> Rebalance.RebalanceOutcome.COMPLETED;
+      case CANCELLED -> Rebalance.RebalanceOutcome.CANCELLED;
+      case FAILED -> Rebalance.RebalanceOutcome.FAILED;
+    };
+  }
+
+  private RebalanceOutcome decodeOutcome(final Rebalance.RebalanceOutcome outcome) {
+    return switch (outcome) {
+      case COMPLETED -> RebalanceOutcome.COMPLETED;
+      case CANCELLED -> RebalanceOutcome.CANCELLED;
+      case FAILED -> RebalanceOutcome.FAILED;
+      case REBALANCE_OUTCOME_UNSPECIFIED, UNRECOGNIZED ->
+          throw new DecodingFailed("Rebalance outcome is missing or unrecognized: " + outcome);
+    };
+  }
+
+  private Rebalance.RebalanceErrorCode encodeErrorCode(final RebalanceErrorCode code) {
+    return switch (code) {
+      case REBALANCE_IN_PROGRESS -> Rebalance.RebalanceErrorCode.REBALANCE_IN_PROGRESS;
+      case NOT_COORDINATOR -> Rebalance.RebalanceErrorCode.NOT_COORDINATOR;
+      case INTERNAL_ERROR -> Rebalance.RebalanceErrorCode.INTERNAL_ERROR;
+    };
+  }
+
+  private RebalanceErrorCode decodeErrorCode(final Rebalance.RebalanceErrorCode code) {
+    return switch (code) {
+      case REBALANCE_IN_PROGRESS -> RebalanceErrorCode.REBALANCE_IN_PROGRESS;
+      case NOT_COORDINATOR -> RebalanceErrorCode.NOT_COORDINATOR;
+      case INTERNAL_ERROR, UNRECOGNIZED -> RebalanceErrorCode.INTERNAL_ERROR;
+    };
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -169,17 +169,17 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
 
   private Rebalance.RebalanceOutcome encodeOutcome(final RebalanceOutcome outcome) {
     return switch (outcome) {
-      case COMPLETED -> Rebalance.RebalanceOutcome.COMPLETED;
-      case CANCELLED -> Rebalance.RebalanceOutcome.CANCELLED;
-      case FAILED -> Rebalance.RebalanceOutcome.FAILED;
+      case COMPLETED -> Rebalance.RebalanceOutcome.REBALANCE_COMPLETED;
+      case CANCELLED -> Rebalance.RebalanceOutcome.REBALANCE_CANCELLED;
+      case FAILED -> Rebalance.RebalanceOutcome.REBALANCE_FAILED;
     };
   }
 
   private RebalanceOutcome decodeOutcome(final Rebalance.RebalanceOutcome outcome) {
     return switch (outcome) {
-      case COMPLETED -> RebalanceOutcome.COMPLETED;
-      case CANCELLED -> RebalanceOutcome.CANCELLED;
-      case FAILED -> RebalanceOutcome.FAILED;
+      case REBALANCE_COMPLETED -> RebalanceOutcome.COMPLETED;
+      case REBALANCE_CANCELLED -> RebalanceOutcome.CANCELLED;
+      case REBALANCE_FAILED -> RebalanceOutcome.FAILED;
       case REBALANCE_OUTCOME_UNSPECIFIED, UNRECOGNIZED ->
           throw new DecodingFailed("Rebalance outcome is missing or unrecognized: " + outcome);
     };
@@ -187,17 +187,17 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
 
   private Rebalance.RebalanceErrorCode encodeErrorCode(final RebalanceErrorCode code) {
     return switch (code) {
-      case REBALANCE_IN_PROGRESS -> Rebalance.RebalanceErrorCode.REBALANCE_IN_PROGRESS;
-      case NOT_COORDINATOR -> Rebalance.RebalanceErrorCode.NOT_COORDINATOR;
-      case INTERNAL_ERROR -> Rebalance.RebalanceErrorCode.INTERNAL_ERROR;
+      case REBALANCE_IN_PROGRESS -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_IN_PROGRESS;
+      case NOT_COORDINATOR -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_NOT_COORDINATOR;
+      case INTERNAL_ERROR -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_UNSPECIFIED;
     };
   }
 
   private RebalanceErrorCode decodeErrorCode(final Rebalance.RebalanceErrorCode code) {
     return switch (code) {
-      case REBALANCE_IN_PROGRESS -> RebalanceErrorCode.REBALANCE_IN_PROGRESS;
-      case NOT_COORDINATOR -> RebalanceErrorCode.NOT_COORDINATOR;
-      case INTERNAL_ERROR, UNRECOGNIZED -> RebalanceErrorCode.INTERNAL_ERROR;
+      case REBALANCE_ERROR_IN_PROGRESS -> RebalanceErrorCode.REBALANCE_IN_PROGRESS;
+      case REBALANCE_ERROR_NOT_COORDINATOR -> RebalanceErrorCode.NOT_COORDINATOR;
+      case REBALANCE_ERROR_UNSPECIFIED, UNRECOGNIZED -> RebalanceErrorCode.INTERNAL_ERROR;
     };
   }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceApi.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceApi.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
+import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.RebalanceInProgressException;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import org.jspecify.annotations.NullMarked;
+
+/** Interface for the rebalance coordinator. */
+@NullMarked
+public interface RebalanceApi {
+  /**
+   * Starts a cluster-wide rebalance and reports the status it starts from. Fails with {@link
+   * RebalanceInProgressException} if one is already running - rebalances neither queue nor merge,
+   * because each pins its own view of the desired leaders.
+   *
+   * @throws RebalanceInProgressException If a rebalance is already running.
+   * @throws NotCoordinatorException If the request is received by a broker that is not the current
+   *     coordinator.
+   */
+  ActorFuture<RebalanceStatus> triggerRebalance(TriggerRebalanceRequest request);
+
+  /**
+   * Reports the rebalance in flight, if any, and the last one this coordinator finished.
+   *
+   * @throws NotCoordinatorException If the request is received by a broker that is not the current
+   *     coordinator.
+   */
+  ActorFuture<RebalanceStatus> getRebalanceStatus();
+
+  /**
+   * Asks the running rebalance to stop once its in-flight transfer finishes, and reports whether
+   * there was one to stop. Partitions already transferred keep their new leaders.
+   *
+   * @throws NotCoordinatorException If the request is received by a broker that is not the current
+   *     coordinator.
+   */
+  ActorFuture<CancelRebalanceResponse> cancelRebalance();
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceErrorResponse.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceErrorResponse.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+/** Reasons for the rebalancing coordinator to refuse a request. */
+public record RebalanceErrorResponse(RebalanceErrorCode code, String message) {
+
+  public enum RebalanceErrorCode {
+    /** A rebalance is already running, and rebalances do not merge or queue. */
+    REBALANCE_IN_PROGRESS,
+    /** The member that received the request is not the current coordinator. */
+    NOT_COORDINATOR,
+    INTERNAL_ERROR
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceOutcome.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceOutcome.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+/** How a rebalance ended. */
+public enum RebalanceOutcome {
+  /**
+   * Every partition selected was processed (regardless of whether its leadership was transferred,
+   * or the transfer was skipped).
+   */
+  COMPLETED,
+  /** The rebalance was cancelled before all selected partitions were processed. */
+  CANCELLED,
+  /** The rebalance failed with an error before all selected partitions were processed. */
+  FAILED
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceOverrides.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceOverrides.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import java.time.Duration;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Per-rebalance overrides for the configured default rebalance settings.
+ *
+ * @param replicationLagThreshold The maximum replication lag a desired leader may have for the
+ *     current leader to attempt a transfer. Lag is the remaining Raft entries to replicate plus any
+ *     pending snapshot, in bytes.
+ * @param replicationTimeout How long the current leader waits (paused, declining writes) for the
+ *     desired leader to finish replicating.
+ * @param maxTransferAttempts The maximum number of TimeoutNow requests the current leader sends
+ *     (including the initial request).
+ */
+@NullMarked
+public record RebalanceOverrides(
+    @Nullable Long replicationLagThreshold,
+    @Nullable Duration replicationTimeout,
+    @Nullable Integer maxTransferAttempts) {
+
+  private static final RebalanceOverrides NONE = new RebalanceOverrides(null, null, null);
+
+  public RebalanceOverrides {
+    if (replicationLagThreshold != null && replicationLagThreshold < 0) {
+      throw new IllegalArgumentException(
+          "replicationLagThreshold must not be negative but was " + replicationLagThreshold);
+    }
+    if (replicationTimeout != null
+        && (replicationTimeout.isZero() || replicationTimeout.isNegative())) {
+      throw new IllegalArgumentException(
+          "replicationTimeout must be positive but was " + replicationTimeout);
+    }
+    if (maxTransferAttempts != null && maxTransferAttempts <= 0) {
+      throw new IllegalArgumentException(
+          "maxTransferAttempts must be positive but was " + maxTransferAttempts);
+    }
+  }
+
+  /** Overrides nothing, so all configured defaults are used. */
+  public static RebalanceOverrides none() {
+    return NONE;
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestFailedException.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestFailedException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
+
+/**
+ * Reasons for the rebalancing coordinator to refuse a request. Each maps to a {@link
+ * RebalanceErrorCode}.
+ */
+public abstract sealed class RebalanceRequestFailedException extends RuntimeException {
+  protected RebalanceRequestFailedException(final String message) {
+    super(message);
+  }
+
+  public abstract RebalanceErrorCode getErrorCode();
+
+  /** Signals that a rebalance is already running, so this one is refused rather than queued. */
+  public static final class RebalanceInProgressException extends RebalanceRequestFailedException {
+    public RebalanceInProgressException(final String message) {
+      super(message);
+    }
+
+    @Override
+    public RebalanceErrorCode getErrorCode() {
+      return RebalanceErrorCode.REBALANCE_IN_PROGRESS;
+    }
+  }
+
+  /** Signals that the request reached a member that is not the coordinator. */
+  public static final class NotCoordinatorException extends RebalanceRequestFailedException {
+    public NotCoordinatorException(final String message) {
+      super(message);
+    }
+
+    @Override
+    public RebalanceErrorCode getErrorCode() {
+      return RebalanceErrorCode.NOT_COORDINATOR;
+    }
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestSender.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestSender.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
+import io.camunda.zeebe.util.Either;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Forwards rebalance requests to the coordinator (the lowest-id member of the cluster).
+ *
+ * <p>Rebalances are run asynchronously, so these requests only ever start, check, or stop one (none
+ * of them waits for a rebalance to finish).
+ */
+@NullMarked
+public final class RebalanceRequestSender {
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  private final ClusterCommunicationService communicationService;
+  private final ClusterConfigurationCoordinatorSupplier coordinatorSupplier;
+  private final RebalanceRequestsSerializer serializer;
+
+  public RebalanceRequestSender(
+      final ClusterCommunicationService communicationService,
+      final ClusterConfigurationCoordinatorSupplier coordinatorSupplier,
+      final RebalanceRequestsSerializer serializer) {
+    this.communicationService = communicationService;
+    this.coordinatorSupplier = coordinatorSupplier;
+    this.serializer = serializer;
+  }
+
+  public CompletableFuture<Either<RebalanceErrorResponse, RebalanceStatus>> triggerRebalance(
+      final TriggerRebalanceRequest request) {
+    return communicationService.send(
+        RebalanceRequestTopics.TRIGGER_REBALANCE.topic(),
+        request,
+        serializer::encodeTriggerRebalanceRequest,
+        serializer::decodeRebalanceStatusResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<RebalanceErrorResponse, RebalanceStatus>> getRebalanceStatus() {
+    return communicationService.send(
+        RebalanceRequestTopics.REBALANCE_STATUS.topic(),
+        new byte[0],
+        Function.identity(),
+        serializer::decodeRebalanceStatusResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<RebalanceErrorResponse, CancelRebalanceResponse>>
+      cancelRebalance() {
+    return communicationService.send(
+        RebalanceRequestTopics.CANCEL_REBALANCE.topic(),
+        new byte[0],
+        Function.identity(),
+        serializer::decodeCancelRebalanceResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestServer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestServer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Receives the forwarded rebalance requests on every member and answers them from the local {@link
+ * RebalanceApi} implementation. On any node other than the current coordinator, the API refuses
+ * requests with {@link RebalanceErrorCode#NOT_COORDINATOR}.
+ */
+@NullMarked
+public final class RebalanceRequestServer implements AutoCloseable {
+  private final ClusterCommunicationService communicationService;
+  private final RebalanceRequestsSerializer serializer;
+  private final RebalanceApi rebalanceApi;
+
+  public RebalanceRequestServer(
+      final ClusterCommunicationService communicationService,
+      final RebalanceRequestsSerializer serializer,
+      final RebalanceApi rebalanceApi) {
+    this.communicationService = communicationService;
+    this.serializer = serializer;
+    this.rebalanceApi = rebalanceApi;
+  }
+
+  public void start() {
+    communicationService.replyTo(
+        RebalanceRequestTopics.TRIGGER_REBALANCE.topic(),
+        serializer::decodeTriggerRebalanceRequest,
+        request -> mapResponse(rebalanceApi.triggerRebalance(request)),
+        this::encodeStatusResponse);
+    communicationService.replyTo(
+        RebalanceRequestTopics.REBALANCE_STATUS.topic(),
+        Function.identity(),
+        request -> mapResponse(rebalanceApi.getRebalanceStatus()),
+        this::encodeStatusResponse);
+    communicationService.replyTo(
+        RebalanceRequestTopics.CANCEL_REBALANCE.topic(),
+        Function.identity(),
+        request -> mapResponse(rebalanceApi.cancelRebalance()),
+        this::encodeCancelResponse);
+  }
+
+  @Override
+  public void close() {
+    Stream.of(RebalanceRequestTopics.values())
+        .forEach(topic -> communicationService.unsubscribe(topic.topic()));
+  }
+
+  private byte[] encodeStatusResponse(
+      final Either<RebalanceErrorResponse, RebalanceStatus> response) {
+    return response.isLeft()
+        ? serializer.encodeResponse(response.getLeft())
+        : serializer.encodeResponse(response.get());
+  }
+
+  private byte[] encodeCancelResponse(
+      final Either<RebalanceErrorResponse, CancelRebalanceResponse> response) {
+    return response.isLeft()
+        ? serializer.encodeResponse(response.getLeft())
+        : serializer.encodeResponse(response.get());
+  }
+
+  private static <T> CompletableFuture<Either<RebalanceErrorResponse, T>> mapResponse(
+      final ActorFuture<T> result) {
+    return result
+        .toCompletableFuture()
+        .thenApply(Either::<RebalanceErrorResponse, T>right)
+        .exceptionally(RebalanceRequestServer::mapError);
+  }
+
+  private static <T> Either<RebalanceErrorResponse, T> mapError(final Throwable throwable) {
+    // throwable should be a CompletionException wrapping what the coordinator threw
+    final var wrapped = throwable.getCause();
+    final var failure = wrapped != null ? wrapped : throwable;
+    final var message = Objects.toString(failure.getMessage(), failure.toString());
+
+    final RebalanceErrorCode code;
+    if (failure instanceof final RebalanceRequestFailedException rebalanceException) {
+      code = rebalanceException.getErrorCode();
+    } else {
+      code = RebalanceErrorCode.INTERNAL_ERROR;
+    }
+
+    return Either.left(new RebalanceErrorResponse(code, message));
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestServer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestServer.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -84,9 +85,7 @@ public final class RebalanceRequestServer implements AutoCloseable {
   }
 
   private static <T> Either<RebalanceErrorResponse, T> mapError(final Throwable throwable) {
-    // throwable should be a CompletionException wrapping what the coordinator threw
-    final var wrapped = throwable.getCause();
-    final var failure = wrapped != null ? wrapped : throwable;
+    final var failure = FuturesUtil.unwrapCompletionException(throwable);
     final var message = Objects.toString(failure.getMessage(), failure.toString());
 
     final RebalanceErrorCode code;

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestTopics.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestTopics.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+public enum RebalanceRequestTopics {
+  TRIGGER_REBALANCE("cluster-rebalance-trigger"),
+  REBALANCE_STATUS("cluster-rebalance-status"),
+  CANCEL_REBALANCE("cluster-rebalance-cancel");
+
+  private final String topic;
+
+  RebalanceRequestTopics(final String topic) {
+    this.topic = topic;
+  }
+
+  public String topic() {
+    return topic;
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestsSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestsSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.zeebe.util.Either;
+import org.jspecify.annotations.NullMarked;
+
+/** Serializes rebalance requests to be forwarded to the coordinator. */
+@NullMarked
+public interface RebalanceRequestsSerializer {
+
+  byte[] encodeTriggerRebalanceRequest(TriggerRebalanceRequest request);
+
+  TriggerRebalanceRequest decodeTriggerRebalanceRequest(byte[] encodedRequest);
+
+  byte[] encodeResponse(RebalanceStatus response);
+
+  byte[] encodeResponse(CancelRebalanceResponse response);
+
+  byte[] encodeResponse(RebalanceErrorResponse response);
+
+  Either<RebalanceErrorResponse, RebalanceStatus> decodeRebalanceStatusResponse(
+      byte[] encodedResponse);
+
+  Either<RebalanceErrorResponse, CancelRebalanceResponse> decodeCancelRebalanceResponse(
+      byte[] encodedResponse);
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The current status of the rebalance coordinator (any running rebalance, and the last completed
+ * rebalance).
+ *
+ * @param running the currently running rebalance, or {@code null}
+ * @param lastCompleted the last rebalance this coordinator finished, or {@code null} if it has not
+ *     finished one since becoming coordinator (not preserved over restarts)
+ */
+@NullMarked
+public record RebalanceStatus(@Nullable Running running, @Nullable Completed lastCompleted) {
+  /** No running rebalance, no previously completed rebalance. */
+  public static RebalanceStatus idle() {
+    return new RebalanceStatus(null, null);
+  }
+
+  /**
+   * Status of the currently running rebalance.
+   *
+   * @param rebalanceId identifies this rebalance in the coordinator's logs
+   * @param overrides any overrides for rebalance settings applying to this run
+   * @param dryRun true if this rebalance is a dry-run (no pauses or transfers will be performed)
+   * @param cancelRequested the rebalance has been requested to stop (will take effect after any
+   *     in-flight transfer finishes)
+   */
+  public record Running(
+      long rebalanceId, RebalanceOverrides overrides, boolean dryRun, boolean cancelRequested) {}
+
+  /**
+   * Outcome of the last completed rebalance.
+   *
+   * @param rebalanceId identifies this rebalance in the coordinator's logs
+   * @param outcome the outcome of the rebalance
+   */
+  public record Completed(long rebalanceId, RebalanceOutcome outcome) {}
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/TriggerRebalanceRequest.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/TriggerRebalanceRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Asks the coordinator to start a cluster-wide rebalance.
+ *
+ * @param overrides any overrides for rebalance settings applying to this run
+ * @param dryRun run pre-checks and report the plan without pausing or transferring anything
+ */
+@NullMarked
+public record TriggerRebalanceRequest(RebalanceOverrides overrides, boolean dryRun) {
+  public static TriggerRebalanceRequest withConfiguredSettings() {
+    return new TriggerRebalanceRequest(RebalanceOverrides.none(), false);
+  }
+}

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -40,9 +40,9 @@ message CancelRebalanceResponse {
 
 enum RebalanceOutcome {
   REBALANCE_OUTCOME_UNSPECIFIED = 0;
-  COMPLETED = 1;
-  CANCELLED = 2;
-  FAILED = 3;
+  REBALANCE_COMPLETED = 1;
+  REBALANCE_CANCELLED = 2;
+  REBALANCE_FAILED = 3;
 }
 
 message Response {
@@ -59,7 +59,7 @@ message RebalanceErrorResponse {
 }
 
 enum RebalanceErrorCode {
-  INTERNAL_ERROR = 0;
-  REBALANCE_IN_PROGRESS = 1;
-  NOT_COORDINATOR = 2;
+  REBALANCE_ERROR_UNSPECIFIED = 0;
+  REBALANCE_ERROR_IN_PROGRESS = 1;
+  REBALANCE_ERROR_NOT_COORDINATOR = 2;
 }

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -10,9 +10,9 @@ message TriggerRebalanceRequest {
 
 // Each override is absent unless specified when triggering the rebalance.
 message RebalanceOverrides {
-  optional int64 replicationLagThresholdBytes = 1;
-  optional int64 replicationTimeoutMillis = 2;
-  optional int32 maxTransferAttempts = 3;
+  optional uint64 replicationLagThresholdBytes = 1;
+  optional uint64 replicationTimeoutMillis = 2;
+  optional uint32 maxTransferAttempts = 3;
 }
 
 message RebalanceStatusResponse {
@@ -23,14 +23,14 @@ message RebalanceStatusResponse {
 }
 
 message RunningRebalance {
-  int64 rebalanceId = 1;
+  uint64 rebalanceId = 1;
   RebalanceOverrides overrides = 2;
   bool dryRun = 3;
   bool cancelRequested = 4;
 }
 
 message CompletedRebalance {
-  int64 rebalanceId = 1;
+  uint64 rebalanceId = 1;
   RebalanceOutcome outcome = 2;
 }
 

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -1,0 +1,65 @@
+syntax = 'proto3';
+package rebalance_requests;
+
+option java_package = "io.camunda.zeebe.rebalance.protocol";
+
+message TriggerRebalanceRequest {
+  RebalanceOverrides overrides = 1;
+  bool dryRun = 2;
+}
+
+// Each override is absent unless specified when triggering the rebalance.
+message RebalanceOverrides {
+  optional int64 replicationLagThresholdBytes = 1;
+  optional int64 replicationTimeoutMillis = 2;
+  optional int32 maxTransferAttempts = 3;
+}
+
+message RebalanceStatusResponse {
+  // Absent while no rebalance is running.
+  RunningRebalance running = 1;
+  // Absent until a rebalance has run on this coordinator.
+  CompletedRebalance lastCompleted = 2;
+}
+
+message RunningRebalance {
+  int64 rebalanceId = 1;
+  RebalanceOverrides overrides = 2;
+  bool dryRun = 3;
+  bool cancelRequested = 4;
+}
+
+message CompletedRebalance {
+  int64 rebalanceId = 1;
+  RebalanceOutcome outcome = 2;
+}
+
+message CancelRebalanceResponse {
+  bool wasRunning = 1;
+}
+
+enum RebalanceOutcome {
+  REBALANCE_OUTCOME_UNSPECIFIED = 0;
+  COMPLETED = 1;
+  CANCELLED = 2;
+  FAILED = 3;
+}
+
+message Response {
+  oneof response {
+    RebalanceErrorResponse error = 1;
+    RebalanceStatusResponse status = 2;
+    CancelRebalanceResponse cancelled = 3;
+  }
+}
+
+message RebalanceErrorResponse {
+  RebalanceErrorCode errorCode = 1;
+  string errorMessage = 2;
+}
+
+enum RebalanceErrorCode {
+  INTERNAL_ERROR = 0;
+  REBALANCE_IN_PROGRESS = 1;
+  NOT_COORDINATOR = 2;
+}

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.dynamic.config.serializer.DecodingFailed;
+import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
+import io.camunda.zeebe.rebalance.protocol.Rebalance;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+final class ProtoBufRebalanceSerializerTest {
+
+  private final ProtoBufRebalanceSerializer serializer = new ProtoBufRebalanceSerializer();
+
+  @Test
+  void shouldRoundTripATriggerThatOverridesNothing() {
+    // given
+    final var request = TriggerRebalanceRequest.withConfiguredSettings();
+
+    // when
+    final var decoded =
+        serializer.decodeTriggerRebalanceRequest(serializer.encodeTriggerRebalanceRequest(request));
+
+    // then
+    assertThat(decoded).isEqualTo(request);
+    assertThat(decoded.overrides()).isEqualTo(RebalanceOverrides.none());
+  }
+
+  @Test
+  void shouldRoundTripATriggerThatOverridesEverything() {
+    // given
+    final var request =
+        new TriggerRebalanceRequest(new RebalanceOverrides(8192L, Duration.ofMinutes(2), 7), true);
+
+    // when
+    final var decoded =
+        serializer.decodeTriggerRebalanceRequest(serializer.encodeTriggerRebalanceRequest(request));
+
+    // then
+    assertThat(decoded).isEqualTo(request);
+  }
+
+  @Test
+  void shouldDistinguishAnOverriddenSettingFromAnAbsentOne() {
+    // given
+    final var request = new TriggerRebalanceRequest(new RebalanceOverrides(0L, null, null), false);
+
+    // when
+    final var decoded =
+        serializer.decodeTriggerRebalanceRequest(serializer.encodeTriggerRebalanceRequest(request));
+
+    // then
+    assertThat(decoded.overrides().replicationLagThreshold()).isZero();
+    assertThat(decoded.overrides().replicationTimeout()).isNull();
+    assertThat(decoded.overrides().maxTransferAttempts()).isNull();
+  }
+
+  @Test
+  void shouldRoundTripAnIdleStatus() {
+    // given
+    final var status = RebalanceStatus.idle();
+
+    // when
+    final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
+
+    // then
+    assertThat(decoded.get()).isEqualTo(status);
+  }
+
+  @Test
+  void shouldRoundTripAStatusWithARunningAndACompletedRebalance() {
+    // given
+    final var status =
+        new RebalanceStatus(
+            new RebalanceStatus.Running(
+                42, new RebalanceOverrides(null, Duration.ofSeconds(15), null), true, true),
+            new RebalanceStatus.Completed(41, RebalanceOutcome.CANCELLED));
+
+    // when
+    final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
+
+    // then
+    assertThat(decoded.get()).isEqualTo(status);
+  }
+
+  @ParameterizedTest
+  @EnumSource(RebalanceOutcome.class)
+  void shouldRoundTripEveryOutcome(final RebalanceOutcome outcome) {
+    // given
+    final var status = new RebalanceStatus(null, new RebalanceStatus.Completed(7, outcome));
+
+    // when
+    final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
+
+    // then
+    assertThat(decoded.get()).isEqualTo(status);
+  }
+
+  @Test
+  void shouldRejectAnUnspecifiedOutcome() {
+    // given
+    final var encoded =
+        Rebalance.Response.newBuilder()
+            .setStatus(
+                Rebalance.RebalanceStatusResponse.newBuilder()
+                    .setLastCompleted(Rebalance.CompletedRebalance.newBuilder().setRebalanceId(7)))
+            .build()
+            .toByteArray();
+
+    // when/then
+    assertThatThrownBy(() -> serializer.decodeRebalanceStatusResponse(encoded))
+        .isInstanceOf(DecodingFailed.class);
+  }
+
+  @Test
+  void shouldRoundTripACancellation() {
+    // given
+    final var response = new CancelRebalanceResponse(true);
+
+    // when
+    final var decoded =
+        serializer.decodeCancelRebalanceResponse(serializer.encodeResponse(response));
+
+    // then
+    assertThat(decoded.get()).isEqualTo(response);
+  }
+
+  @ParameterizedTest
+  @EnumSource(RebalanceErrorCode.class)
+  void shouldRoundTripAnErrorOnEitherResponse(final RebalanceErrorCode code) {
+    // given
+    final var error = new RebalanceErrorResponse(code, "refused");
+
+    // when
+    final var encoded = serializer.encodeResponse(error);
+
+    // then
+    assertThat(serializer.decodeRebalanceStatusResponse(encoded).getLeft()).isEqualTo(error);
+    assertThat(serializer.decodeCancelRebalanceResponse(encoded).getLeft()).isEqualTo(error);
+  }
+}

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
+import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
+import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
+import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.RebalanceInProgressException;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the hop an operator request makes from the member that received it to the coordinator.
+ *
+ * <p>The cluster is shared by every test because each node assigns a port, and the tests only
+ * differ in what the coordinator answers.
+ */
+final class RebalanceForwardingTest {
+
+  private static final MemberId GATEWAY_ID = MemberId.from("gateway");
+  private static final MemberId COORDINATOR_ID = MemberId.from("0");
+
+  private static final MeterRegistry REGISTRY = new SimpleMeterRegistry();
+  private static final RecordingRebalanceApi COORDINATOR = new RecordingRebalanceApi();
+
+  private static AtomixCluster gatewayNode;
+  private static AtomixCluster coordinatorNode;
+  private static RebalanceRequestServer requestServer;
+  private static RebalanceRequestSender sender;
+
+  @BeforeAll
+  static void startCluster() {
+    final var gateway =
+        Node.builder()
+            .withId(GATEWAY_ID.id())
+            .withPort(SocketUtil.getNextAddress().getPort())
+            .build();
+    final var coordinator =
+        Node.builder()
+            .withId(COORDINATOR_ID.id())
+            .withPort(SocketUtil.getNextAddress().getPort())
+            .build();
+    final var nodes = List.of(gateway, coordinator);
+
+    gatewayNode = createClusterNode(gateway, nodes);
+    coordinatorNode = createClusterNode(coordinator, nodes);
+    CompletableFuture.allOf(gatewayNode.start(), coordinatorNode.start()).join();
+
+    sender =
+        new RebalanceRequestSender(
+            gatewayNode.getCommunicationService(),
+            ClusterConfigurationCoordinatorSupplier.ofMembers(Set.of(COORDINATOR_ID)),
+            new ProtoBufRebalanceSerializer());
+    requestServer =
+        new RebalanceRequestServer(
+            coordinatorNode.getCommunicationService(),
+            new ProtoBufRebalanceSerializer(),
+            COORDINATOR);
+    requestServer.start();
+  }
+
+  @AfterAll
+  static void stopCluster() {
+    requestServer.close();
+    CompletableFuture.allOf(gatewayNode.stop(), coordinatorNode.stop()).join();
+    REGISTRY.close();
+  }
+
+  @BeforeEach
+  void resetCoordinator() {
+    COORDINATOR.reset();
+  }
+
+  @Test
+  void shouldForwardATriggerToTheCoordinator() {
+    // given
+    final var request =
+        new TriggerRebalanceRequest(new RebalanceOverrides(2048L, Duration.ofSeconds(20), 3), true);
+    COORDINATOR.status =
+        new RebalanceStatus(new RebalanceStatus.Running(9, request.overrides(), true, false), null);
+
+    // when
+    final var response = sender.triggerRebalance(request).join();
+
+    // then
+    assertThat(COORDINATOR.triggered).isEqualTo(request);
+    assertThat(response.get()).isEqualTo(COORDINATOR.status);
+  }
+
+  @Test
+  void shouldForwardAStatusQuery() {
+    // given
+    COORDINATOR.status =
+        new RebalanceStatus(null, new RebalanceStatus.Completed(8, RebalanceOutcome.COMPLETED));
+
+    // when
+    final var response = sender.getRebalanceStatus().join();
+
+    // then
+    assertThat(response.get()).isEqualTo(COORDINATOR.status);
+  }
+
+  @Test
+  void shouldForwardACancellation() {
+    // given
+    COORDINATOR.wasRunning = true;
+
+    // when
+    final var response = sender.cancelRebalance().join();
+
+    // then
+    assertThat(COORDINATOR.cancelled).isTrue();
+    assertThat(response.get()).isEqualTo(new CancelRebalanceResponse(true));
+  }
+
+  @Test
+  void shouldReportARefusedTrigger() {
+    // given
+    COORDINATOR.failure = new RebalanceInProgressException("Rebalance 7 is already running");
+
+    // when
+    final var response =
+        sender.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings()).join();
+
+    // then
+    assertThat(response.getLeft())
+        .isEqualTo(
+            new RebalanceErrorResponse(
+                RebalanceErrorCode.REBALANCE_IN_PROGRESS, "Rebalance 7 is already running"));
+  }
+
+  @Test
+  void shouldReportARequestThatReachedANonCoordinator() {
+    // given
+    COORDINATOR.failure =
+        new NotCoordinatorException("Member 0 is not the rebalancing coordinator");
+
+    // when
+    final var response = sender.getRebalanceStatus().join();
+
+    // then
+    assertThat(response.getLeft().code()).isEqualTo(RebalanceErrorCode.NOT_COORDINATOR);
+  }
+
+  @Test
+  void shouldReportAnUnexpectedFailureAsInternal() {
+    // given
+    COORDINATOR.failure = new IllegalStateException("actor is closed");
+
+    // when
+    final var response = sender.cancelRebalance().join();
+
+    // then
+    assertThat(response.getLeft())
+        .isEqualTo(
+            new RebalanceErrorResponse(RebalanceErrorCode.INTERNAL_ERROR, "actor is closed"));
+  }
+
+  private static AtomixCluster createClusterNode(final Node localNode, final List<Node> nodes) {
+    return AtomixCluster.builder(REGISTRY)
+        .withMemberId(localNode.id().id())
+        .withAddress(localNode.address())
+        .withMembershipProvider(new BootstrapDiscoveryProvider(nodes))
+        .withMembershipProtocol(new DiscoveryMembershipProtocol())
+        .build();
+  }
+
+  private static final class RecordingRebalanceApi implements RebalanceApi {
+
+    private RebalanceStatus status = RebalanceStatus.idle();
+    private boolean wasRunning;
+    private RuntimeException failure;
+
+    private TriggerRebalanceRequest triggered;
+    private boolean cancelled;
+
+    void reset() {
+      status = RebalanceStatus.idle();
+      wasRunning = false;
+      failure = null;
+      triggered = null;
+      cancelled = false;
+    }
+
+    @Override
+    public ActorFuture<RebalanceStatus> triggerRebalance(final TriggerRebalanceRequest request) {
+      triggered = request;
+      return answerWith(status);
+    }
+
+    @Override
+    public ActorFuture<RebalanceStatus> getRebalanceStatus() {
+      return answerWith(status);
+    }
+
+    @Override
+    public ActorFuture<CancelRebalanceResponse> cancelRebalance() {
+      cancelled = true;
+      return answerWith(new CancelRebalanceResponse(wasRunning));
+    }
+
+    private <T> ActorFuture<T> answerWith(final T answer) {
+      return failure != null
+          ? CompletableActorFuture.completedExceptionally(failure)
+          : CompletableActorFuture.completed(answer);
+    }
+  }
+}


### PR DESCRIPTION
When a rebalance request arrives, it may land on any node. Here, we define the protocol, serialization and response mapping to forward rebalance requests to the current coordinator.

The supported requests are:
- Trigger a rebalance: if accepted, results can be retrieved asynchronously by requesting rebalance status. Will fail if a rebalance is already in progress, or if the receiving broker is not the current coordinator.
- Get rebalance status: returns any running rebalance as well as the last completed rebalance (state not maintained across restarts or coordinator changes). Fails if the receiving broker is not the current coordinator.
- Cancel current rebalance: stops any running rebalance after the current partition transfer, and returns whether any such rebalance was running. Fails if the receiving broker is not the current coordinator.

Closes #59840.

BREAKING CHANGE: adding the new zeebe/rebalance proto module (net new, so no actual breakage - but the buf check asserts the number of modules to be the same and requires this comment in the PR)