### PR TITLE
test: cover form retrieval by key and linked form resolution

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/form/form-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/form/form-get-api.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertBadRequest,
+  assertNotFoundRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  deployInlineForm,
+  formResourceContent,
+  getFormByKey,
+  uniqueResourceName,
+} from '@requestHelpers';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+
+test.describe.parallel('Form Get API', () => {
+  test('Get Form - Success 200', async ({request}) => {
+    const formId = `approval-form-${generateUniqueId()}`;
+    const schema = formResourceContent(formId, 'Applicant name');
+    const form = await deployInlineForm(
+      request,
+      uniqueResourceName('approval', 'form'),
+      schema,
+    );
+
+    await expect(async () => {
+      const res = await getFormByKey(request, form.formKey);
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/forms/{formKey}', method: 'GET', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body).toMatchObject({
+        formKey: form.formKey,
+        formId,
+        version: 1,
+        tenantId: '<default>',
+      });
+      expect(JSON.parse(body.schema)).toEqual(JSON.parse(schema));
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Form - Each Version Returns Its Own Schema', async ({request}) => {
+    const formId = `versioned-form-${generateUniqueId()}`;
+    const fileName = uniqueResourceName('versioned', 'form');
+    const firstSchema = formResourceContent(formId, 'Applicant name');
+    const secondSchema = formResourceContent(formId, 'Full legal name');
+
+    const firstVersion = await deployInlineForm(request, fileName, firstSchema);
+    const secondVersion = await deployInlineForm(
+      request,
+      fileName,
+      secondSchema,
+    );
+    expect(secondVersion.version).toBe(2);
+
+    await expect(async () => {
+      const firstRes = await getFormByKey(request, firstVersion.formKey);
+      await assertStatusCode(firstRes, 200);
+      const firstBody = await firstRes.json();
+      expect(firstBody.version).toBe(1);
+      expect(JSON.parse(firstBody.schema)).toEqual(JSON.parse(firstSchema));
+
+      const secondRes = await getFormByKey(request, secondVersion.formKey);
+      await assertStatusCode(secondRes, 200);
+      const secondBody = await secondRes.json();
+      expect(secondBody.version).toBe(2);
+      expect(JSON.parse(secondBody.schema)).toEqual(JSON.parse(secondSchema));
+    }).toPass(defaultAssertionOptions);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Get Form - Not Found 404', async ({request}) => {
+    const nonExistentFormKey = '2251799813733053';
+
+    const res = await getFormByKey(request, nonExistentFormKey);
+
+    await assertNotFoundRequest(
+      res,
+      `Form with key '${nonExistentFormKey}' not found`,
+    );
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Get Form - Bad Request 400 - Invalid formKey Format', async ({
+    request,
+  }) => {
+    const res = await getFormByKey(request, 'invalid-string-key');
+
+    await assertBadRequest(
+      res,
+      "Failed to convert 'formKey' with value: 'invalid-string-key'",
+    );
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Get Form - Unauthorized 401', async ({request}) => {
+    const res = await request.get(
+      buildUrl('/forms/{formKey}', {formKey: 'someKey'}),
+      {headers: {}},
+    );
+
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-linked-forms.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-linked-forms.spec.ts
@@ -1,0 +1,329 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {
+  activateJobAndGetHeaders,
+  completeJob,
+  deployInlineFiles,
+  deployInlineForm,
+  deployInlineForms,
+  deployInlineResource,
+  formResourceContent,
+  getFormByKey,
+  parseLinkedResourcesHeader,
+  serviceTaskWithLinkedResourcesBpmn,
+  uniqueResourceName,
+  LinkedResourceBinding,
+} from '@requestHelpers';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+
+const FORM_RESOURCE_TYPE = 'form';
+const LINK_NAME = 'my_form';
+
+async function startProcessInstance(
+  request: APIRequestContext,
+  processDefinitionId: string,
+): Promise<string> {
+  const res = await request.post(buildUrl('/process-instances'), {
+    headers: jsonHeaders(),
+    data: {processDefinitionId},
+  });
+  await assertStatusCode(res, 200);
+  return String((await res.json()).processInstanceKey);
+}
+
+function linkedFormProcess(
+  processDefinitionId: string,
+  jobType: string,
+  links: LinkedResourceBinding[],
+) {
+  return {
+    fileName: `${processDefinitionId}.bpmn`,
+    content: serviceTaskWithLinkedResourcesBpmn(
+      processDefinitionId,
+      jobType,
+      links,
+    ),
+  };
+}
+
+test.describe.parallel('Job Linked Forms', () => {
+  test('Linked form with latest binding resolves to the newest form version', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const formId = `approval-form-${suffix}`;
+    const fileName = uniqueResourceName('approval', 'form');
+    const processDefinitionId = `linked-form-latest-${suffix}`;
+    const jobType = `linked-form-latest-job-${suffix}`;
+
+    const firstVersion = await deployInlineForm(
+      request,
+      fileName,
+      formResourceContent(formId, 'Applicant name'),
+    );
+    await deployInlineFiles(request, [
+      linkedFormProcess(processDefinitionId, jobType, [
+        {
+          resourceId: formId,
+          resourceType: FORM_RESOURCE_TYPE,
+          bindingType: 'latest',
+          linkName: LINK_NAME,
+        },
+      ]),
+    ]);
+
+    await startProcessInstance(request, processDefinitionId);
+    const job = await activateJobAndGetHeaders(request, jobType);
+    const [link] = parseLinkedResourcesHeader(job.customHeaders);
+
+    expect(link).toMatchObject({
+      resourceType: FORM_RESOURCE_TYPE,
+      linkName: LINK_NAME,
+      resourceKey: firstVersion.formKey,
+    });
+    await completeJob(request, job.jobKey);
+
+    const secondVersion = await deployInlineForm(
+      request,
+      fileName,
+      formResourceContent(formId, 'Full legal name'),
+    );
+    expect(secondVersion.version).toBe(2);
+
+    await startProcessInstance(request, processDefinitionId);
+    const jobAfterRedeploy = await activateJobAndGetHeaders(request, jobType);
+    const [linkAfterRedeploy] = parseLinkedResourcesHeader(
+      jobAfterRedeploy.customHeaders,
+    );
+
+    expect(linkAfterRedeploy.resourceKey).toBe(secondVersion.formKey);
+    await completeJob(request, jobAfterRedeploy.jobKey);
+  });
+
+  test('Linked form with deployment binding stays pinned to its deployment', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const formId = `pinned-form-${suffix}`;
+    const fileName = uniqueResourceName('pinned', 'form');
+    const processDefinitionId = `linked-form-deployment-${suffix}`;
+    const jobType = `linked-form-deployment-job-${suffix}`;
+
+    const [pinnedForm] = await deployInlineForms(
+      request,
+      [{fileName, content: formResourceContent(formId, 'Applicant name')}],
+      [
+        linkedFormProcess(processDefinitionId, jobType, [
+          {
+            resourceId: formId,
+            resourceType: FORM_RESOURCE_TYPE,
+            bindingType: 'deployment',
+            linkName: LINK_NAME,
+          },
+        ]),
+      ],
+    );
+
+    const laterVersion = await deployInlineForm(
+      request,
+      fileName,
+      formResourceContent(formId, 'Full legal name'),
+    );
+    expect(laterVersion.formKey).not.toBe(pinnedForm.formKey);
+
+    await startProcessInstance(request, processDefinitionId);
+    const job = await activateJobAndGetHeaders(request, jobType);
+    const [link] = parseLinkedResourcesHeader(job.customHeaders);
+
+    expect(link.resourceKey).toBe(pinnedForm.formKey);
+    await completeJob(request, job.jobKey);
+  });
+
+  test('Linked form with versionTag binding resolves to the tagged version', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const formId = `tagged-form-${suffix}`;
+    const fileName = uniqueResourceName('tagged', 'form');
+    const versionTag = `v-${suffix}`;
+    const processDefinitionId = `linked-form-tag-${suffix}`;
+    const jobType = `linked-form-tag-job-${suffix}`;
+
+    const taggedVersion = await deployInlineForm(
+      request,
+      fileName,
+      formResourceContent(formId, 'Applicant name', versionTag),
+    );
+    await deployInlineForm(
+      request,
+      fileName,
+      formResourceContent(formId, 'Full legal name'),
+    );
+    await deployInlineFiles(request, [
+      linkedFormProcess(processDefinitionId, jobType, [
+        {
+          resourceId: formId,
+          resourceType: FORM_RESOURCE_TYPE,
+          bindingType: 'versionTag',
+          versionTag,
+          linkName: LINK_NAME,
+        },
+      ]),
+    ]);
+
+    await startProcessInstance(request, processDefinitionId);
+    const job = await activateJobAndGetHeaders(request, jobType);
+    const [link] = parseLinkedResourcesHeader(job.customHeaders);
+
+    expect(link.resourceKey).toBe(taggedVersion.formKey);
+    await completeJob(request, job.jobKey);
+  });
+
+  test('Worker can fetch the linked form schema using the key from the job header', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const formId = `render-form-${suffix}`;
+    const schema = formResourceContent(formId, 'Applicant name');
+    const processDefinitionId = `linked-form-fetch-${suffix}`;
+    const jobType = `linked-form-fetch-job-${suffix}`;
+
+    await deployInlineForm(
+      request,
+      uniqueResourceName('render', 'form'),
+      schema,
+    );
+    await deployInlineFiles(request, [
+      linkedFormProcess(processDefinitionId, jobType, [
+        {
+          resourceId: formId,
+          resourceType: FORM_RESOURCE_TYPE,
+          bindingType: 'latest',
+          linkName: LINK_NAME,
+        },
+      ]),
+    ]);
+
+    await startProcessInstance(request, processDefinitionId);
+    const job = await activateJobAndGetHeaders(request, jobType);
+    const [link] = parseLinkedResourcesHeader(job.customHeaders);
+
+    await expect(async () => {
+      const res = await getFormByKey(request, link.resourceKey);
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      expect(body.formId).toBe(formId);
+      expect(JSON.parse(body.schema)).toEqual(JSON.parse(schema));
+    }).toPass(defaultAssertionOptions);
+
+    await completeJob(request, job.jobKey);
+  });
+
+  test('A service task can link a form and a generic resource at the same time', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const formId = `mixed-form-${suffix}`;
+    const genericResourceName = `prompt-${suffix}.md`;
+    const processDefinitionId = `linked-form-mixed-${suffix}`;
+    const jobType = `linked-form-mixed-job-${suffix}`;
+
+    const form = await deployInlineForm(
+      request,
+      uniqueResourceName('mixed', 'form'),
+      formResourceContent(formId, 'Applicant name'),
+    );
+    const genericResource = await deployInlineResource(
+      request,
+      genericResourceName,
+      '# System prompt',
+    );
+    await deployInlineFiles(request, [
+      linkedFormProcess(processDefinitionId, jobType, [
+        {
+          resourceId: formId,
+          resourceType: FORM_RESOURCE_TYPE,
+          bindingType: 'latest',
+          linkName: LINK_NAME,
+        },
+        {
+          resourceId: genericResourceName,
+          resourceType: 'GenericScript',
+          bindingType: 'latest',
+          linkName: 'my_prompt',
+        },
+      ]),
+    ]);
+
+    await startProcessInstance(request, processDefinitionId);
+    const job = await activateJobAndGetHeaders(request, jobType);
+    const links = parseLinkedResourcesHeader(job.customHeaders);
+
+    expect(links).toHaveLength(2);
+    expect(links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceType: FORM_RESOURCE_TYPE,
+          linkName: LINK_NAME,
+          resourceKey: form.formKey,
+        }),
+        expect.objectContaining({
+          resourceType: 'GenericScript',
+          linkName: 'my_prompt',
+          resourceKey: genericResource.resourceKey,
+        }),
+      ]),
+    );
+    await completeJob(request, job.jobKey);
+  });
+
+  test('A linked form that does not exist raises a FORM_NOT_FOUND incident', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const missingFormId = `absent-form-${suffix}`;
+    const processDefinitionId = `linked-form-missing-${suffix}`;
+    const jobType = `linked-form-missing-job-${suffix}`;
+
+    await deployInlineFiles(request, [
+      linkedFormProcess(processDefinitionId, jobType, [
+        {
+          resourceId: missingFormId,
+          resourceType: FORM_RESOURCE_TYPE,
+          bindingType: 'latest',
+          linkName: LINK_NAME,
+        },
+      ]),
+    ]);
+
+    const processInstanceKey = await startProcessInstance(
+      request,
+      processDefinitionId,
+    );
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/process-instances/{processInstanceKey}/incidents/search', {
+          processInstanceKey,
+        }),
+        {headers: jsonHeaders(), data: {filter: {state: 'ACTIVE'}}},
+      );
+      await assertStatusCode(res, 200);
+      const {items} = await res.json();
+      expect(items).toHaveLength(1);
+      expect(items[0].errorType).toBe('FORM_NOT_FOUND');
+      expect(items[0].errorMessage).toContain(missingFormId);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -19,6 +19,7 @@ import {
 import {validateResponseShape} from '../../../../json-body-assertions';
 import {createInstances, deploy} from '../../../../utils/zeebeClient';
 import {
+  DEFAULT_PAGE_LIMIT,
   defaultAssertionOptions,
   extendedAssertionOptions,
 } from '../../../../utils/constants';
@@ -62,7 +63,11 @@ test.describe.parallel('Process Definition Search API', () => {
       );
       expect(body.page.totalItems).toBeGreaterThan(1);
       expect(body.items.length).toBeGreaterThan(1);
-      expect(body.page.totalItems).toBe(body.items.length);
+      // totalItems counts the whole result set while items holds one page, so
+      // the two only match while the cluster has fewer definitions than the
+      // default page size.
+      expect(body.items.length).toBeLessThanOrEqual(DEFAULT_PAGE_LIMIT);
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(body.items.length);
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -33,6 +33,10 @@ export const createUniqueUser = (customId?: string) => {
   };
 };
 
+// Default `page.limit` applied by the v2 search endpoints when a request does
+// not set one.
+export const DEFAULT_PAGE_LIMIT = 100;
+
 export const defaultAssertionOptions = {
   intervals: [5_000, 10_000, 15_000],
   timeout: 30_000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/form-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/form-requestHelpers.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIResponse, expect} from '@playwright/test';
+import {APIRequestContext} from 'playwright-core';
+import {buildUrl, jsonHeaders} from '../http';
+import {deployInlineFiles, InlineResource} from './resource-requestHelpers';
+
+export interface DeployedForm {
+  formKey: string;
+  formId: string;
+  version: number;
+  resourceName: string;
+  schema: string;
+}
+
+export function formResourceContent(
+  formId: string,
+  label: string,
+  versionTag?: string,
+): string {
+  return JSON.stringify({
+    type: 'default',
+    id: formId,
+    ...(versionTag ? {versionTag} : {}),
+    components: [{key: 'applicant', label, type: 'textfield'}],
+  });
+}
+
+export async function deployInlineForms(
+  request: APIRequestContext,
+  forms: InlineResource[],
+  extraFiles: InlineResource[] = [],
+): Promise<DeployedForm[]> {
+  const body = await deployInlineFiles(request, [...forms, ...extraFiles]);
+  const deployed = (
+    body.deployments as {
+      form?: {
+        formKey: string;
+        formId: string;
+        version: number;
+        resourceName: string;
+      };
+    }[]
+  )
+    .filter((deployment) => deployment.form != null)
+    .map((deployment) => {
+      const form = deployment.form!;
+      const source = forms.find((file) => file.fileName === form.resourceName);
+      expect(
+        source,
+        `Deployed form ${form.resourceName} is not among the requested files`,
+      ).toBeDefined();
+      return {
+        formKey: form.formKey,
+        formId: form.formId,
+        version: form.version,
+        resourceName: form.resourceName,
+        schema: String(source!.content),
+      };
+    });
+
+  expect(deployed).toHaveLength(forms.length);
+  return deployed;
+}
+
+export async function deployInlineForm(
+  request: APIRequestContext,
+  fileName: string,
+  content: string,
+): Promise<DeployedForm> {
+  const [form] = await deployInlineForms(request, [{fileName, content}]);
+  return form;
+}
+
+export function getFormByKey(
+  request: APIRequestContext,
+  formKey: string,
+): Promise<APIResponse> {
+  return request.get(buildUrl('/forms/{formKey}', {formKey}), {
+    headers: jsonHeaders(),
+  });
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -9,6 +9,7 @@
 export * from './element-instance-requestHelpers';
 export * from './decision-version-tag-requestHelpers';
 export * from './resource-requestHelpers';
+export * from './form-requestHelpers';
 export * from './user-task-requestHelpers';
 export * from './process-instance-requestHelpers';
 export * from './get-value-from-state-requestHelpers';


### PR DESCRIPTION
> **Stacked on #59835** (which is itself stacked on #59834) — it reuses the linked-resource BPMN generator and job-header parser added there. Review the base PRs first; this one retargets automatically as they merge.

## Description

Adds end-to-end coverage for #51057, which made forms usable outside a user task: `GET /v2/forms/{formKey}` retrieves a form by key, and a service task can bind one through `zeebe:linkedResources` with `resourceType="form"`, resolved by the engine from form state rather than resource state.

The App Integrations connector that motivated the issue consumes exactly this pair — it takes the `resourceKey` the engine puts in the job header and fetches the schema to render it as an Adaptive Card.

Neither half had e2e coverage. The endpoint was reachable only through the generated request-validation test, which checks a malformed path parameter and nothing else, and no test activated a job carrying a linked form.

**`form-get-api.spec.ts`** — a deployed form is returned with its schema, id, version and tenant; each version of the same form id returns its own schema; 404, 400 and 401.

**`job-linked-forms.spec.ts`**

- `latest` binding follows a redeployment
- `deployment` binding stays pinned to the form deployed alongside the process
- `versionTag` binding selects the tagged version rather than the newest
- a service task can carry a form and a generic resource at the same time, each with its own `resourceType` and `linkName`
- a link to a form that does not exist raises a `FORM_NOT_FOUND` incident naming the form id, rather than failing silently
- **the connector path**: take the `resourceKey` from the job header, call `GET /v2/forms/{key}` with it, assert the schema comes back unchanged

## Why this approach

Form helpers live in their own `form-requestHelpers` module rather than in the resource helpers, because forms are deployed and addressed as their own type — the deployment response reports them under `form`, not `resource`, and they are excluded from the resource endpoints by design.

Forms and BPMN are generated per test with unique ids, for the same reason as in #59835: `/jobs/activation` has no process-instance filter, so a shared job type lets a parallel test steal the job.

## Verification

- Local run against Elasticsearch: 11/11 for the new specs, 66/66 for the full resource + form + linked-resource set.
- On-demand workflow: see comment below.

## Links

- QA tracking issue (this is the regression automation it is being written for): https://github.com/camunda/product-hub/issues/3752
- Epic: https://github.com/camunda/camunda/issues/51160
- Feature: https://github.com/camunda/camunda/issues/51057
- Sub-issues covered: https://github.com/camunda/camunda/issues/51483 (get form by key), https://github.com/camunda/camunda/issues/51484 (resolve linked forms into job headers)
- TestRail suite: https://camunda.testrail.com/index.php?/suites/view/17050
