### PR TITLE
docs: extract cluster wide endpoints into standalone spec file

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -12,10 +12,23 @@
 # the runtime `/v2` prefixing that every other path gets.
 #
 # Cluster endpoints that are scoped to a single physical tenant live in `cluster.yaml`.
+#
+# The identical `servers` block below is duplicated per path item on purpose, not YAML-anchored.
+# Two independent, concrete failures came out of trying to share it via a YAML anchor/alias:
+# a plain value-alias (`servers: *anchor`) broke IntelliJ's Swagger UI preview for the aliased
+# operation, and a later attempt produced a nested list (`servers: [*anchor]` where the anchor is
+# already a list), which broke swagger-parser's Jackson deserialization and silently made
+# openapi-generator-maven-plugin skip regenerating clients/java's model classes entirely. Don't
+# re-attempt an anchor/alias/merge-key variant here — duplicate the literal block instead.
+#
+# Every operation below requires the cluster-admin security chain (see
+# ClusterAdminBasicSecurityConfiguration / CLUSTER_ADMIN_API_PATTERN), a separate credential set
+# from the Orchestration Cluster API. The `bearerAuth` / `basicAuth` scheme names below are reused
+# from that API for convenience but resolve against different credentials — an Orchestration
+# Cluster user session cannot authenticate against these operations.
 
 paths:
   /cluster/v2/status:
-    # Bare root on purpose; the `/cluster/v2` base is in the path key. See the file header.
     servers:
       - url: "{schema}://{host}:{port}"
         variables:
@@ -60,7 +73,6 @@ paths:
       x-added-in-version: "8.10"
 
   /cluster/v2/mode:
-    # Bare root on purpose; the `/cluster/v2` base is in the path key. See the file header.
     servers:
       - url: "{schema}://{host}:{port}"
         variables:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -21,11 +21,12 @@
 # openapi-generator-maven-plugin skip regenerating clients/java's model classes entirely. Don't
 # re-attempt an anchor/alias/merge-key variant here — duplicate the literal block instead.
 #
-# Every operation below requires the cluster-admin security chain (see
+# Every authenticated operation below sits behind the cluster-admin security chain (see
 # ClusterAdminBasicSecurityConfiguration / CLUSTER_ADMIN_API_PATTERN), a separate credential set
-# from the Orchestration Cluster API. The `bearerAuth` / `basicAuth` scheme names below are reused
-# from that API for convenience but resolve against different credentials — an Orchestration
-# Cluster user session cannot authenticate against these operations.
+# from the Orchestration Cluster API. Where an operation reuses the `bearerAuth` / `basicAuth`
+# scheme names from that API, it still resolves against different credentials — an Orchestration
+# Cluster user session cannot authenticate against it. `getClusterStatus` below is the one
+# exception: it is intentionally public (`security: []`), not cluster-admin-gated.
 
 paths:
   /cluster/v2/status:
@@ -57,6 +58,10 @@ paths:
         `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process
         work, and `DEGRADED` in every other case. No per-tenant detail is reported; use
         `GET /cluster/v2/topology` for that.
+
+
+        This endpoint is public and requires no authentication, unlike `PATCH /cluster/v2/mode`
+        below, which needs cluster-admin credentials.
       responses:
         "200":
           description: The cluster can process work; the body reports whether it is fully healthy or degraded.
@@ -101,6 +106,12 @@ paths:
 
         If the `physicalTenantId` parameter is not provided, all available physical tenants are
         transitioned individually.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here.
       parameters:
         - $ref: 'cluster.yaml#/components/parameters/ModeParameter'
         - $ref: '#/components/parameters/PhysicalTenantIdParameter'

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-wide.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-wide.yaml
@@ -1,0 +1,154 @@
+# Endpoint definitions for cluster-wide operations.
+#
+# These endpoints answer for the cluster as a whole, aggregated over every physical tenant, and are
+# served on the bare root rather than under the document's `/v2` server base. The `/cluster/v2` base
+# therefore lives in the path key, and each path item overrides `servers` to drop the document's
+# `/v2` suffix.
+#
+# Do not "align" the override by moving the base into it: `{host}:{port}/cluster/v2` plus the path
+# key resolves to `/cluster/v2/cluster/v2/status`. Shortening the keys to `/status` and `/mode`
+# instead is not an option either — both are already taken by `cluster.yaml` in the `rest-api.yaml`
+# path map, and `OpenApiYamlLoader.KNOWN_ROOTS` matches on the literal `/cluster/v2/` prefix to skip
+# the runtime `/v2` prefixing that every other path gets.
+#
+# Cluster endpoints that are scoped to a single physical tenant live in `cluster.yaml`.
+
+paths:
+  /cluster/v2/status:
+    # Bare root on purpose; the `/cluster/v2` base is in the path key. See the file header.
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Cluster
+      operationId: getClusterStatus
+      x-required-permissions: [ ]
+      # Public health-check endpoint — declared unauthenticated at runtime
+      # via SecurityPathAdapter. `security: []` overrides the conditional
+      # enforcement on the global schemes for this operation.
+      security: [ ]
+      summary: Get the status of the whole cluster
+      description: >-
+        Checks the health status of the whole cluster, aggregated over all physical tenants. Returns
+        `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process
+        work, and `DEGRADED` in every other case. No per-tenant detail is reported; use
+        `GET /cluster/v2/topology` for that.
+      responses:
+        "200":
+          description: The cluster can process work; the body reports whether it is fully healthy or degraded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterStatusResponse'
+        "503":
+          description: The cluster is DOWN because no physical tenant can process work.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterStatusResponse'
+      x-added-in-version: "8.10"
+
+  /cluster/v2/mode:
+    # Bare root on purpose; the `/cluster/v2` base is in the path key. See the file header.
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    patch:
+      x-eventually-consistent: false
+      tags:
+        - Recovery
+      operationId: changeClusterModeAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Change the cluster mode of one or every physical tenant
+      description: >-
+        Transitions physical tenants between processing and recovery mode.
+
+
+        If the `physicalTenantId` parameter is not provided, all available physical tenants are
+        transitioned individually.
+      parameters:
+        - $ref: 'cluster.yaml#/components/parameters/ModeParameter'
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+        - $ref: 'cluster.yaml#/components/parameters/DryRunParameter'
+      responses:
+        "200":
+          description: >-
+            The mode change request was accepted; returns the planned cluster change covering every
+            requested physical tenant.
+          content:
+            application/json:
+              schema:
+                $ref: 'cluster.yaml#/components/schemas/ClusterModeChangeResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "409":
+          description: >-
+            The mode change conflicts with the cluster state, for example because another
+            configuration change is in progress.
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
+## Schema definitions
+
+components:
+  parameters:
+    PhysicalTenantIdParameter:
+      name: physicalTenantId
+      in: query
+      required: false
+      description: >-
+        The physical tenant to apply the change to. When omitted, the change is applied to every
+        physical tenant of the cluster.
+      schema:
+        type: string
+        example: default
+
+  schemas:
+    ClusterStatusResponse:
+      description: The aggregated status of the whole cluster.
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: >-
+            `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can
+            process work, `DEGRADED` in every other case.
+          type: string
+          example: HEALTHY
+          enum:
+            - HEALTHY
+            - DEGRADED
+            - DOWN

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -57,114 +57,6 @@ paths:
           description: The default physical tenant is DOWN and does not have any partition with a healthy leader.
       x-added-in-version: "8.8"
 
-  # Not served under the document's `/v2` server base,
-  # hence the path-item `servers` override below
-  /cluster/v2/status:
-    servers:
-      - url: "{schema}://{host}:{port}"
-        variables:
-          host:
-            default: localhost
-            description: The hostname of the Orchestration Cluster REST Gateway.
-          port:
-            default: "8080"
-            description: The port of the Orchestration Cluster REST API server.
-          schema:
-            default: http
-            description: The schema of the Orchestration Cluster REST API server.
-    get:
-      x-eventually-consistent: false
-      tags:
-        - Cluster
-      operationId: getClusterStatus
-      x-required-permissions: [ ]
-      # Public health-check endpoint — declared unauthenticated at runtime
-      # via SecurityPathAdapter. `security: []` overrides the conditional
-      # enforcement on the global schemes for this operation.
-      security: [ ]
-      summary: Get the status of the whole cluster
-      description: >-
-        Checks the health status of the whole cluster, aggregated over all physical tenants. Returns
-        `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process
-        work, and `DEGRADED` in every other case. No per-tenant detail is reported; use
-        `GET /cluster/v2/topology` for that.
-      responses:
-        "200":
-          description: The cluster can process work; the body reports whether it is fully healthy or degraded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClusterStatusResponse'
-        "503":
-          description: The cluster is DOWN because no physical tenant can process work.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClusterStatusResponse'
-      x-added-in-version: "8.10"
-
-  # Not served under the document's `/v2` server base,
-  # hence the path-item `servers` override below
-  /cluster/v2/mode:
-    servers:
-      - url: "{schema}://{host}:{port}"
-        variables:
-          host:
-            default: localhost
-            description: The hostname of the Orchestration Cluster REST Gateway.
-          port:
-            default: "8080"
-            description: The port of the Orchestration Cluster REST API server.
-          schema:
-            default: http
-            description: The schema of the Orchestration Cluster REST API server.
-    patch:
-      x-eventually-consistent: false
-      tags:
-        - Recovery
-      operationId: changeClusterModeAsClusterAdmin
-      x-required-permissions: [ ]
-      security:
-        - bearerAuth: [ ]
-        - basicAuth: [ ]
-      summary: Change the cluster mode of one or every physical tenant
-      description: >-
-        Transitions physical tenants between processing and recovery mode.
-
-
-        If the `physicalTenantId` parameter is not provided, all available physical tenants are
-        transitioned individually.
-      parameters:
-        - $ref: '#/components/parameters/ModeParameter'
-        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
-        - $ref: '#/components/parameters/DryRunParameter'
-      responses:
-        "200":
-          description: >-
-            The mode change request was accepted; returns the planned cluster change covering every
-            requested physical tenant.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClusterModeChangeResponse'
-        "400":
-          $ref: 'common-responses.yaml#/components/responses/InvalidData'
-        "401":
-          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
-        "404":
-          description: The requested `physicalTenantId` does not exist in this cluster.
-          content:
-            application/problem+json:
-              schema:
-                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
-        "409":
-          description: >-
-            The mode change conflicts with the cluster state, for example because another
-            configuration change is in progress.
-        "500":
-          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
-      x-added-in-version: "8.10"
-
   /mode:
     patch:
       x-eventually-consistent: false
@@ -303,35 +195,8 @@ components:
       schema:
         type: boolean
         default: false
-    PhysicalTenantIdParameter:
-      name: physicalTenantId
-      in: query
-      required: false
-      description: >-
-        The physical tenant to apply the change to. When omitted, the change is applied to every
-        physical tenant of the cluster.
-      schema:
-        type: string
-        example: default
 
   schemas:
-    ClusterStatusResponse:
-      description: The aggregated status of the whole cluster.
-      type: object
-      required:
-        - status
-      properties:
-        status:
-          description: >-
-            `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can
-            process work, `DEGRADED` in every other case.
-          type: string
-          example: HEALTHY
-          enum:
-            - HEALTHY
-            - DEGRADED
-            - DOWN
-
     Mode:
       description: The operating mode of a cluster's partitions.
       type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -496,20 +496,14 @@ paths:
     $ref: 'cluster.yaml#/paths/~1topology'
   /mode:
     $ref: 'cluster.yaml#/paths/~1mode'
-  /cluster/v2/mode: # New /cluster/v2/mode endpoint that works for all physical tenants.
-    $ref: 'cluster.yaml#/paths/~1cluster~1v2~1mode'
   /restore:
     $ref: 'cluster.yaml#/paths/~1restore'
 
-  # Cluster-wide endpoints, served on the bare root rather than under the `/v2` server base: the
-  # `/cluster/v2` base is part of the path key, not the server URL, so these keys must stay
-  # absolute. They cannot be shortened to `/status` and `/mode` — both are already taken above by
-  # `cluster.yaml`, and `OpenApiYamlLoader.KNOWN_ROOTS` matches the literal `/cluster/v2/` prefix to
-  # skip the runtime `/v2` prefixing. See `cluster-wide.yaml`.
+  # Cluster-wide endpoints. Path keys must stay absolute — see `cluster-admin.yaml` for why.
   /cluster/v2/mode:
-    $ref: 'cluster-wide.yaml#/paths/~1cluster~1v2~1mode'
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1mode'
   /cluster/v2/status:
-    $ref: 'cluster-wide.yaml#/paths/~1cluster~1v2~1status'
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1status'
 
   # User endpoints
   /users:

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -456,8 +456,6 @@ paths:
   # Cluster status endpoints
   /status: # Legacy `/status` endpoint that is deprecated and only works for the default physical tenant
     $ref: 'cluster.yaml#/paths/~1status'
-  /cluster/v2/status: # New /cluster/v2/status endpoint that works for all physical tenants.
-    $ref: 'cluster.yaml#/paths/~1cluster~1v2~1status'
 
   # System endpoints
   /system/usage-metrics:
@@ -502,6 +500,16 @@ paths:
     $ref: 'cluster.yaml#/paths/~1cluster~1v2~1mode'
   /restore:
     $ref: 'cluster.yaml#/paths/~1restore'
+
+  # Cluster-wide endpoints, served on the bare root rather than under the `/v2` server base: the
+  # `/cluster/v2` base is part of the path key, not the server URL, so these keys must stay
+  # absolute. They cannot be shortened to `/status` and `/mode` — both are already taken above by
+  # `cluster.yaml`, and `OpenApiYamlLoader.KNOWN_ROOTS` matches the literal `/cluster/v2/` prefix to
+  # skip the runtime `/v2` prefixing. See `cluster-wide.yaml`.
+  /cluster/v2/mode:
+    $ref: 'cluster-wide.yaml#/paths/~1cluster~1v2~1mode'
+  /cluster/v2/status:
+    $ref: 'cluster-wide.yaml#/paths/~1cluster~1v2~1status'
 
   # User endpoints
   /users:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Extracts the cluster-wide operations into a standalone spec file for clarity. In the finalized REST API spec, they still appear under the same group tags.

Note: The cluster-wide ops are executed under a different servier URL `host:port/cluster/v2` whereas the REST API spec currently defines the `host:port/v2` server. This creates unusable API endpoints for the cluster-wide ops through Swagger UI since the basepath is wrong.

_We could remove the `/v2` basepath from the Server URL but I'll leave this to the @camunda/c8-api-team to decide upon_ 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
