### PR TITLE
Do not set ILM on ordinal indexes

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/OrdinalIndex.java
@@ -13,7 +13,6 @@ import java.util.regex.Pattern;
 
 record OrdinalIndex(IndexFamily indexFamily, int ordinal, String name) implements TargetIndex {
   static final int DEFAULT_ORDINAL = 0;
-  static final String ORDINAL_SUFFIX_START = "ord";
   static final Pattern ORDINAL_INDEX_PATTERN =
       Pattern.compile("^(.*)" + Pattern.quote(ORDINAL_SUFFIX_START) + "(\\d{5,})$");
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
@@ -8,6 +8,8 @@
 package io.camunda.exporter.index;
 
 public sealed interface TargetIndex permits MainIndex, OrdinalIndex {
+  String ORDINAL_SUFFIX_START = "ord";
+
   String name();
 
   /*

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -104,10 +105,12 @@ public interface ArchiverRepository extends AutoCloseable {
   }
 
   default String buildHistoricalIndicesPattern(final IndexTemplateDescriptor indexTemplate) {
-    return "%s,-%s,-%s"
+    return "%s,-%s,-%s,-%s%s*"
         .formatted(
             indexTemplate.getIndexPattern(),
             indexTemplate.getFullQualifiedName(),
-            indexTemplate.getAlias());
+            indexTemplate.getAlias(),
+            indexTemplate.getFullQualifiedName(),
+            TargetIndex.ORDINAL_SUFFIX_START);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskIT.java
@@ -20,8 +20,12 @@ import io.camunda.exporter.DefaultExporterResourceProvider;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
+import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiverRepository;
+import io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository;
+import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
 import io.camunda.exporter.utils.CamundaExporterITTemplateExtension;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
@@ -51,6 +55,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,6 +186,37 @@ public abstract class BackgroundTaskIT<T extends BackgroundTask> {
   protected OpenSearchAsyncClient createOSAsyncClient(final ExporterConfiguration config) {
     final var connector = new OpensearchConnector(config.getConnect());
     return connector.createAsyncClient();
+  }
+
+  protected ArchiverRepository createArchiverRepository(
+      final ExporterConfiguration config, final ExporterResourceProvider resourceProvider) {
+    final var isElasticsearch = ConnectionTypes.isElasticSearch(config.getConnect().getType());
+    if (isElasticsearch) {
+      return closeLater(
+          new ElasticsearchArchiverRepository(
+              PARTITION_ID,
+              config.getHistory(),
+              resourceProvider,
+              createAsyncESClient(config),
+              executor,
+              exporterMetrics,
+              LOGGER));
+    } else {
+      final var asyncClient = createOSAsyncClient(config);
+      final var genericClient =
+          new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
+
+      return closeLater(
+          new OpenSearchArchiverRepository(
+              PARTITION_ID,
+              config.getHistory(),
+              resourceProvider,
+              asyncClient,
+              genericClient,
+              executor,
+              exporterMetrics,
+              LOGGER));
+    }
   }
 
   protected <R extends AutoCloseable> R closeLater(final R resource) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ApplyRolloverPeriodJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ApplyRolloverPeriodJobIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.tasks.BackgroundTaskIT;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.TestTemplate;
 public class ApplyRolloverPeriodJobIT extends BackgroundTaskIT<ApplyRolloverPeriodJob> {
 
   private static final String DATE_SUFFIX = "2024-01-15";
+  private static final String ORDINAL_SUFFIX = TargetIndex.ORDINAL_SUFFIX_START + "12345";
 
   @Override
   protected ApplyRolloverPeriodJob createBackgroundTask(
@@ -80,6 +82,29 @@ public class ApplyRolloverPeriodJobIT extends BackgroundTaskIT<ApplyRolloverPeri
           assertThat(result).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(0);
 
           final var policy = client.getLifecyclePolicyNameForIndex(mainIndexName);
+          assertThat(policy).isNull();
+        });
+  }
+
+  @TestTemplate
+  void shouldNotApplyLifecyclePolicyToOrdinalIndex(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var ordinalIndexName = listViewTemplate.getFullQualifiedName() + ORDINAL_SUFFIX;
+          client.createIndex(ordinalIndexName, 0);
+
+          // when
+          final var result = job.execute();
+
+          // then
+          assertThat(result).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(0);
+
+          final var policy = client.getLifecyclePolicyNameForIndex(ordinalIndexName);
           assertThat(policy).isNull();
         });
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ApplyRolloverPeriodJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ApplyRolloverPeriodJobIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.tasks.BackgroundTaskIT;
+import io.camunda.search.test.utils.SearchClientAdapter;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.TestTemplate;
+
+public class ApplyRolloverPeriodJobIT extends BackgroundTaskIT<ApplyRolloverPeriodJob> {
+
+  private static final String DATE_SUFFIX = "2024-01-15";
+
+  @Override
+  protected ApplyRolloverPeriodJob createBackgroundTask(
+      final ExporterConfiguration config, final ExporterResourceProvider resourceProvider) {
+    final var repository = createArchiverRepository(config, resourceProvider);
+    return new ApplyRolloverPeriodJob(repository, LOGGER);
+  }
+
+  @Override
+  protected void updateConfig(final ExporterConfiguration config) {
+    config.getHistory().getRetention().setEnabled(true);
+    config.getHistory().getRetention().setPolicyName(testPrefix + "-camunda-retention-policy");
+  }
+
+  @TestTemplate
+  void shouldApplyLifecyclePolicyToDatedIndexes(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var datedIndexName = listViewTemplate.getFullQualifiedName() + DATE_SUFFIX;
+          client.createIndex(datedIndexName, 0);
+
+          // when
+          final var result = job.execute();
+
+          // then
+          assertThat(result).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(0);
+
+          Awaitility.await()
+              .atMost(EXECUTE_TIMEOUT)
+              .untilAsserted(
+                  () -> {
+                    final var policy = client.getLifecyclePolicyNameForIndex(datedIndexName);
+                    assertThat(policy).isEqualTo(testPrefix + "-camunda-retention-policy");
+                  });
+        });
+  }
+
+  @TestTemplate
+  void shouldNotApplyLifecyclePolicyToMainIndex(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var mainIndexName = listViewTemplate.getFullQualifiedName();
+
+          // when
+          final var result = job.execute();
+
+          // then
+          assertThat(result).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(0);
+
+          final var policy = client.getLifecyclePolicyNameForIndex(mainIndexName);
+          assertThat(policy).isNull();
+        });
+  }
+
+  @TestTemplate
+  void shouldNotApplyLifecyclePolicyWhenRetentionDisabled(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var datedIndexName = listViewTemplate.getFullQualifiedName() + DATE_SUFFIX;
+          client.createIndex(datedIndexName, 0);
+          config.getHistory().getRetention().setEnabled(false);
+
+          // when
+          final var result = job.execute();
+
+          // then
+          assertThat(result).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(0);
+
+          final var policy = client.getLifecyclePolicyNameForIndex(datedIndexName);
+          assertThat(policy).isNull();
+        });
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -10,7 +10,6 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.ExporterResourceProvider;
-import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.tasks.BackgroundTaskIT;
 import io.camunda.search.test.utils.SearchClientAdapter;
@@ -22,7 +21,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
-import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 
 public abstract class ArchiverJobIT<T extends ArchiverJob<?>> extends BackgroundTaskIT<T> {
   private LifecyclePolicyNameVerifier lifecyclePolicyNameVerifier;
@@ -135,37 +133,6 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> extends Background
 
   protected String getExpectedLifecyclePolicyName() {
     return testPrefix + "-camunda-retention-policy";
-  }
-
-  private ArchiverRepository createArchiverRepository(
-      final ExporterConfiguration config, final ExporterResourceProvider resourceProvider) {
-    final var isElasticsearch = ConnectionTypes.isElasticSearch(config.getConnect().getType());
-    if (isElasticsearch) {
-      return closeLater(
-          new ElasticsearchArchiverRepository(
-              PARTITION_ID,
-              config.getHistory(),
-              resourceProvider,
-              createAsyncESClient(config),
-              executor,
-              exporterMetrics,
-              LOGGER));
-    } else {
-      final var asyncClient = createOSAsyncClient(config);
-      final var genericClient =
-          new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
-
-      return closeLater(
-          new OpenSearchArchiverRepository(
-              PARTITION_ID,
-              config.getHistory(),
-              resourceProvider,
-              asyncClient,
-              genericClient,
-              executor,
-              exporterMetrics,
-              LOGGER));
-    }
   }
 
   abstract T createArchiveJob(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -1084,11 +1084,14 @@ final class ElasticsearchArchiverRepositoryIT {
     retention.setEnabled(true);
     // ensure all templates are created
     startupSchema();
-    // create indices for all templates with a date in the index name
+    // create indices for all templates with a date and ordinal in the index name
     final var searchClientAdapter = new SearchClientAdapter(testClient, objectMapper);
     final String date = "2026-01-10";
+    final String ordinalSuffix = "ord000001";
     for (final var indexTemplate : resourceProvider.getIndexTemplateDescriptors()) {
       searchClientAdapter.createIndex(indexTemplate.getIndexPattern().replace("*", date), 0);
+      searchClientAdapter.createIndex(
+          indexTemplate.getIndexPattern().replace("*", ordinalSuffix), 0);
     }
     final var asyncClient = spy(new ElasticsearchAsyncClient(transport));
     final var indicesClientSpy = spy(asyncClient.indices());
@@ -1116,7 +1119,9 @@ final class ElasticsearchArchiverRepositoryIT {
               assertThat(request.index()).hasSize(1);
               final String[] split = request.index().getFirst().split(",");
               assertThat(split)
-                  .hasSize(3); // 3 patterns (wildcard + runtime exclusion + alias exclusion)
+                  .hasSize(
+                      4); // 4 patterns (wildcard + runtime exclusion + alias exclusion + ordinal
+              // exclusion)
               final var matchingTemplate =
                   resourceProvider.getIndexTemplateDescriptors().stream()
                       .filter(
@@ -1128,7 +1133,8 @@ final class ElasticsearchArchiverRepositoryIT {
                   .containsExactly(
                       matchingTemplate.get().getIndexPattern(),
                       "-" + matchingTemplate.get().getFullQualifiedName(),
-                      "-" + matchingTemplate.get().getAlias());
+                      "-" + matchingTemplate.get().getAlias(),
+                      "-" + matchingTemplate.get().getFullQualifiedName() + "ord*");
             });
     for (final var template : resourceProvider.getIndexTemplateDescriptors()) {
       Awaitility.await()
@@ -1144,6 +1150,14 @@ final class ElasticsearchArchiverRepositoryIT {
                 assertThat(
                         settings
                             .get(template.getFullQualifiedName())
+                            .settings()
+                            .index()
+                            .lifecycle())
+                    .isNull();
+                // Check ordinal index (should not have ILM policy)
+                assertThat(
+                        settings
+                            .get(template.getIndexPattern().replace("*", ordinalSuffix))
                             .settings()
                             .index()
                             .lifecycle())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1186,11 +1186,14 @@ final class OpenSearchArchiverRepositoryIT {
     retention.setEnabled(true);
     // ensure all templates are created
     startupSchema();
-    // create indices for all templates with a date in the index name
+    // create indices for all templates with a date and ordinal in the index name
     final var searchClientAdapter = new SearchClientAdapter(testClient, MAPPER);
     final String date = "2026-01-10";
+    final String ordinalSuffix = "ord000001";
     for (final var indexTemplate : resourceProvider.getIndexTemplateDescriptors()) {
       searchClientAdapter.createIndex(indexTemplate.getIndexPattern().replace("*", date), 0);
+      searchClientAdapter.createIndex(
+          indexTemplate.getIndexPattern().replace("*", ordinalSuffix), 0);
     }
     final var asyncClient = createOpenSearchAsyncClient();
     final var genericClientSpy =
@@ -1225,7 +1228,9 @@ final class OpenSearchArchiverRepositoryIT {
                   request.getEndpoint().substring("/_plugins/_ism/add/".length());
               final String[] split = indexPattern.split(",");
               assertThat(split)
-                  .hasSize(3); // 3 patterns (wildcard + runtime exclusion + alias exclusion)
+                  .hasSize(
+                      4); // 4 patterns (wildcard + runtime exclusion + alias exclusion + ordinal
+              // exclusion)
               final var matchingTemplate =
                   resourceProvider.getIndexTemplateDescriptors().stream()
                       .filter(
@@ -1237,7 +1242,8 @@ final class OpenSearchArchiverRepositoryIT {
                   .containsExactly(
                       matchingTemplate.get().getIndexPattern(),
                       "-" + matchingTemplate.get().getFullQualifiedName(),
-                      "-" + matchingTemplate.get().getAlias());
+                      "-" + matchingTemplate.get().getAlias(),
+                      "-" + matchingTemplate.get().getFullQualifiedName() + "ord*");
             });
     for (final var template : resourceProvider.getIndexTemplateDescriptors()) {
       Awaitility.await()
@@ -1257,6 +1263,12 @@ final class OpenSearchArchiverRepositoryIT {
                 // Check runtime index (should not have ISM policy)
                 assertThat(
                         json.get(template.getFullQualifiedName())
+                            .get("index.plugins.index_state_management.policy_id")
+                            .isNull())
+                    .isTrue();
+                // Check ordinal index (should not have ISM policy)
+                assertThat(
+                        json.get(template.getIndexPattern().replace("*", ordinalSuffix))
                             .get("index.plugins.index_state_management.policy_id")
                             .isNull())
                     .isTrue();


### PR DESCRIPTION
## Description

The `ApplyRolloverPeriodJob` runs every now and then to ensure that the dated indexes have the relevant ILM policy applied (in case there was a problem applying this on a previous occasion).

That job excludes the main index and needed to be updated to ensure that ordinal indexes did not have an ILM policy applied (as they will not have the same lifecycle as the dated indexes).

## Related issues

closes #56993
