### PR TITLE
ci: keep shared build artifacts available for re-runs later than 24h after the original run

### DIFF
--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           name: distball-${{ github.run_id }}
           path: ${{ steps.build-zeebe.outputs.distball }}
-          retention-days: 1
+          retention-days: 2
           compression-level: 0  # tarball is already gzipped
           if-no-files-found: error
       - name: Upload local Maven SNAPSHOT artifacts (artifact)
@@ -88,7 +88,7 @@ jobs:
         with:
           name: m2-installed-${{ github.run_id }}
           path: m2-installed.tar
-          retention-days: 1
+          retention-days: 2
           compression-level: 6
           if-no-files-found: error
       # integration-tests' gcp-perf shards consume these from GCS (ingress is free).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,30 +515,30 @@ jobs:
         with:
           directory: ./optimize/client
       # Share the built frontend bundles so the snapshot deploy jobs download them
-      # instead of rebuilding (see issue #52693). Short retention: consumed within the same run.
+      # instead of rebuilding (see issue #52693).
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fe-operate-${{ github.run_id }}
           path: operate/client/build
-          retention-days: 1
+          retention-days: 2
           if-no-files-found: error
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fe-tasklist-${{ github.run_id }}
           path: tasklist/client/build
-          retention-days: 1
+          retention-days: 2
           if-no-files-found: error
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fe-identity-${{ github.run_id }}
           path: identity/client/dist
-          retention-days: 1
+          retention-days: 2
           if-no-files-found: error
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fe-optimize-${{ github.run_id }}
           path: optimize/client/dist
-          retention-days: 1
+          retention-days: 2
           if-no-files-found: error
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

Raises `retention-days` from 1 to 2 on the six run-scoped artifacts that CI jobs share with each other: the four frontend bundles in [ci.yml](https://github.com/camunda/camunda/blob/228de732f163fefcc46c87a0900e42576090800a/.github/workflows/ci.yml#L516-L541) and the distball plus SNAPSHOT tarball in [ci-build-distball-reusable.yml](https://github.com/camunda/camunda/blob/228de732f163fefcc46c87a0900e42576090800a/.github/workflows/ci-build-distball-reusable.yml#L75-L94).

## Why

Relates to INC-7026. A *Re-run failed jobs* on a run older than 24h fails the snapshot deploy jobs. The incident run was created `2026-08-05T09:55Z`; the re-run of `deploy-snapshots` started `2026-08-06T10:01Z`, 24h and 6 minutes later, and died immediately:

```
##[error]Unable to download artifact(s): Artifact not found for name: fe-operate-30995254058
Please ensure that your artifact is not expired [...]
```

The producers of these artifacts — `build-platform-frontend` and the distball build — do not re-run when only the failed jobs are re-run, so nothing re-uploads them and every consumer fails. A re-run started the next morning is exactly the common case, which made the 1-day window the wrong trade.

GitHub Actions artifact storage is free for public repositories, so the longer window costs nothing here.

## Notes

- **This does not touch GCS.** The run-scoped copies in `camunda-monorepo-ci-artifacts` were never the missing input — the bucket lifecycle rule already retains them for 7 days (verified against the live bucket config).
- The stale `Short retention: consumed within the same run` comment is removed — a re-run is precisely the case where that isn't true.

## Validation

- `actionlint` — no new findings on either file (both carry the same 7 and 1 pre-existing `runner-label` warnings as `main`)
- `conftest --policy .github` — 57 tests, 56 passed, 0 failures; the single warning (`print-metadata`) is pre-existing
- `spotless` — no-op; the repo's Spotless config formats markdown only, and this change is YAML-only
- `act` — not applicable (Tier 3): the diff changes only a `retention-days` value consumed by GitHub's artifact service, with no internal control flow, expression, or shell logic to exercise; a harness would mock 100% of the behavior under test

🤖 Generated with [Claude Code](https://claude.com/claude-code)