### PR TITLE
feat: allow concurrent, independently-cancellable phased change plans

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -201,14 +201,12 @@ final class ClusterApiUtils {
       final CurrentClusterConfiguration configuration) {
     final var phasedChangeState = configuration.phasedChangeState();
     final List<ConfigurationChange> changes = new ArrayList<>();
-    phasedChangeState
-        .pending()
-        .map(plan -> mapConfigurationChange(configuration, plan))
-        .ifPresent(changes::add);
-    phasedChangeState
-        .lastChange()
+    phasedChangeState.pending().values().stream()
+        .map(phasedChangePlan -> mapConfigurationChange(configuration, phasedChangePlan))
+        .forEach(changes::add);
+    phasedChangeState.history().stream()
         .map(ClusterApiUtils::mapConfigurationChange)
-        .ifPresent(changes::add);
+        .forEach(changes::add);
 
     final var sortedChanges =
         changes.stream().sorted(Comparator.comparingLong(ConfigurationChange::getId)).toList();
@@ -224,13 +222,16 @@ final class ClusterApiUtils {
   private static Optional<ConfigurationChange> findConfigurationChange(
       final CurrentClusterConfiguration configuration, final long changeId) {
     final var phasedChangeState = configuration.phasedChangeState();
-    final var pendingMatch = phasedChangeState.pending().filter(plan -> plan.id() == changeId);
+    final var pendingMatch =
+        phasedChangeState.pending().values().stream()
+            .filter(plan -> plan.id() == changeId)
+            .findFirst();
     if (pendingMatch.isPresent()) {
       return pendingMatch.map(plan -> mapConfigurationChange(configuration, plan));
     }
-    return phasedChangeState
-        .lastChange()
+    return phasedChangeState.history().stream()
         .filter(change -> change.id() == changeId)
+        .findFirst()
         .map(ClusterApiUtils::mapConfigurationChange);
   }
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -741,18 +741,27 @@ final class ClusterApiUtilsTest {
   }
 
   @Test
-  void shouldListPendingAndLastCompletedChange() {
+  void shouldListAllPendingAndCompletedChanges() {
     // given
     final var startedAt = Instant.ofEpochSecond(1000);
     final var lastCompletedAt = Instant.ofEpochSecond(500);
-    final var pendingPlan =
+    final var pendingPlan1 =
         new PhasedChangePlan(
             2, 0, List.of(new GlobalPhase(List.of(new MemberJoinOperation(member(1))))), startedAt);
-    final var lastChange =
+    final var pendingPlan2 =
+        new PhasedChangePlan(
+            3,
+            0,
+            List.of(new GlobalPhase(List.of(new MemberLeaveOperation(member(2))))),
+            startedAt);
+    final var lastChange1 =
         new CompletedPhasedChange(1, PhasedChangePlanStatus.COMPLETED, startedAt, lastCompletedAt);
+    final var lastChange2 =
+        new CompletedPhasedChange(4, PhasedChangePlanStatus.CANCELLED, startedAt, lastCompletedAt);
     final var config =
         configWithPhasedChangeState(
-            new PhasedChangeState(Optional.of(pendingPlan), Optional.of(lastChange)));
+            new PhasedChangeState(
+                5, Map.of(2L, pendingPlan1, 3L, pendingPlan2), List.of(lastChange1, lastChange2)));
 
     // when
     final var response = ClusterApiUtils.mapConfigurationChangesResponse(config);
@@ -765,7 +774,9 @@ final class ClusterApiUtilsTest {
         .extracting(ConfigurationChange::getId, ConfigurationChange::getStatus)
         .containsExactlyInAnyOrder(
             tuple(2L, ConfigurationChange.StatusEnum.IN_PROGRESS),
-            tuple(1L, ConfigurationChange.StatusEnum.COMPLETED));
+            tuple(3L, ConfigurationChange.StatusEnum.IN_PROGRESS),
+            tuple(1L, ConfigurationChange.StatusEnum.COMPLETED),
+            tuple(4L, ConfigurationChange.StatusEnum.CANCELLED));
   }
 
   @Test
@@ -780,7 +791,7 @@ final class ClusterApiUtilsTest {
     final var config =
         configWithPhasedChangeState(
             new PhasedChangeState(
-                Optional.of(new PhasedChangePlan(2, 0, phases, Instant.now())), Optional.empty()));
+                5, Map.of(2L, new PhasedChangePlan(2, 0, phases, Instant.now())), List.of()));
 
     // when
     final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 2);
@@ -826,7 +837,7 @@ final class ClusterApiUtilsTest {
             GlobalConfiguration.init(),
             Map.of("tenant-a", tenantGroup),
             new PhasedChangeState(
-                Optional.of(new PhasedChangePlan(7, 0, phases, Instant.now())), Optional.empty()));
+                8, Map.of(7L, new PhasedChangePlan(7, 0, phases, Instant.now())), List.of()));
 
     // when
     final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 7);
@@ -852,8 +863,7 @@ final class ClusterApiUtilsTest {
     final var lastChange =
         new CompletedPhasedChange(5, PhasedChangePlanStatus.FAILED, startedAt, completedAt);
     final var config =
-        configWithPhasedChangeState(
-            new PhasedChangeState(Optional.empty(), Optional.of(lastChange)));
+        configWithPhasedChangeState(new PhasedChangeState(10, Map.of(), List.of(lastChange)));
 
     // when
     final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 5);
@@ -876,7 +886,7 @@ final class ClusterApiUtilsTest {
     final var config =
         configWithPhasedChangeState(
             new PhasedChangeState(
-                Optional.of(new PhasedChangePlan(2, 0, phases, Instant.now())), Optional.empty()));
+                3, Map.of(2L, new PhasedChangePlan(2, 0, phases, Instant.now())), List.of()));
 
     // when
     final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 999);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -100,7 +101,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private final Map<String, ExponentialBackoffRetryDelay> groupBackoffRetry = new HashMap<>();
   private final Duration minRetryDelay;
   private final Duration maxRetryDelay;
-  private ScheduledTimer advancePhaseRetryTimer;
+  // Keyed by plan id, since multiple plans can be advancing (and independently retrying) at once.
+  private final Map<Long, ScheduledTimer> advancePhaseRetryTimers = new HashMap<>();
+  private final int completedChangeHistoryLimit;
 
   ClusterConfigurationManagerImpl(
       final ConcurrencyControl executor,
@@ -135,6 +138,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     useNewConfig = false;
     persistedCurrentConfiguration = null;
     coordinatorSupplier = null;
+    completedChangeHistoryLimit = PhasedChangeState.DEFAULT_HISTORY_LIMIT;
   }
 
   /**
@@ -164,6 +168,29 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
       final TopologyManagerMetrics topologyMetrics,
       final Duration minRetryDelay,
       final Duration maxRetryDelay) {
+    this(
+        executor,
+        localMemberId,
+        persistedCurrentConfiguration,
+        topologyMetrics,
+        minRetryDelay,
+        maxRetryDelay,
+        PhasedChangeState.DEFAULT_HISTORY_LIMIT);
+  }
+
+  /**
+   * @param completedChangeHistoryLimit maximum number of completed changes retained in {@link
+   *     PhasedChangeState#history()}, oldest evicted first
+   */
+  @VisibleForTesting
+  ClusterConfigurationManagerImpl(
+      final ConcurrencyControl executor,
+      final MemberId localMemberId,
+      final PersistedCurrentClusterConfiguration persistedCurrentConfiguration,
+      final TopologyManagerMetrics topologyMetrics,
+      final Duration minRetryDelay,
+      final Duration maxRetryDelay,
+      final int completedChangeHistoryLimit) {
     this.executor = executor;
     persistedClusterConfiguration = null;
     this.persistedCurrentConfiguration = persistedCurrentConfiguration;
@@ -172,6 +199,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     this.topologyMetrics = topologyMetrics;
     this.minRetryDelay = minRetryDelay;
     this.maxRetryDelay = maxRetryDelay;
+    this.completedChangeHistoryLimit = completedChangeHistoryLimit;
     backoffRetry = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
     useNewConfig = true;
     coordinatorSupplier =
@@ -451,7 +479,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
    */
   private boolean wasTargetedByCurrentPlan(
       final CurrentClusterConfiguration configuration, final String groupId) {
-    return configuration.phasedChangeState().pending().stream()
+    return configuration.phasedChangeState().pending().values().stream()
         .flatMap(plan -> plan.phases().stream())
         .filter(PartitionGroupParallelPhase.class::isInstance)
         .map(PartitionGroupParallelPhase.class::cast)
@@ -695,19 +723,31 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   }
 
   /**
-   * Drives phased-plan advancement. Invoked after every successful local configuration update. Only
-   * the coordinator (the member with the lowest id, per {@link
-   * ClusterConfigurationCoordinatorSupplier}) advances the plan, so that a single member is
-   * responsible for the transition. When the current phase's sub-configuration(s) have drained
-   * their pending changes, the plan is advanced to the next phase, or completed if it was the last
-   * phase. The action is idempotent — re-firing on an already-advanced phase is a no-op.
+   * Drives phased-plan advancement for every currently pending plan (multiple may be pending
+   * concurrently, targeting disjoint sub-configurations). Invoked after every successful local
+   * configuration update. Only the coordinator (the member with the lowest id, per {@link
+   * ClusterConfigurationCoordinatorSupplier}) advances plans, so that a single member is
+   * responsible for the transition. When a plan's current phase's sub-configuration(s) have drained
+   * their pending changes, that plan is advanced to the next phase, or completed if it was the last
+   * phase. The action is idempotent — re-firing on an already-advanced phase is a no-op. Plans are
+   * advanced one at a time (each id re-reads the latest configuration before mutating it), so
+   * advancing one plan never clobbers a concurrent update to another.
    */
   private void maybeAdvancePhase(final CurrentClusterConfiguration config) {
-    final var pending = config.phasedChangeState().pending();
-    if (pending.isEmpty() || !isLocalMemberCoordinator()) {
+    if (config.phasedChangeState().pending().isEmpty() || !isLocalMemberCoordinator()) {
       return;
     }
-    final var plan = pending.get();
+    for (final var planId : List.copyOf(config.phasedChangeState().pending().keySet())) {
+      maybeAdvancePhase(config, planId);
+    }
+  }
+
+  private void maybeAdvancePhase(final CurrentClusterConfiguration config, final long planId) {
+    final var plan = config.phasedChangeState().pending().get(planId);
+    if (plan == null) {
+      // Already advanced/completed by a previous call in this same batch, or by another trigger.
+      return;
+    }
     final boolean currentPhaseComplete =
         switch (plan.currentPhase()) {
           case final GlobalPhase ignored -> !config.globalConfiguration().hasPendingChanges();
@@ -721,37 +761,47 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     }
 
     if (plan.hasNextPhase()) {
-      updateMultiConfiguration(CurrentClusterConfiguration::activateNextPhase)
+      updateMultiConfiguration(c -> c.activateNextPhase(planId))
           .onComplete(
               (ignore, error) -> {
                 if (error != null) {
-                  LOG.warn("Failed to advance phased change plan to next phase", error);
-                  scheduleAdvancePhase();
+                  LOG.warn(
+                      "Failed to advance phased change plan '{}' to next phase", planId, error);
+                  scheduleAdvancePhase(planId);
                 } else {
-                  advancePhaseRetryTimer = null;
+                  advancePhaseRetryTimers.remove(planId);
                 }
               });
     } else {
-      updateMultiConfiguration(c -> c.completePlan(PhasedChangePlanStatus.COMPLETED))
+      updateMultiConfiguration(
+              c ->
+                  c.completePlan(
+                      planId, PhasedChangePlanStatus.COMPLETED, completedChangeHistoryLimit))
           .onComplete(
               (ignore, error) -> {
                 if (error != null) {
-                  LOG.warn("Failed to complete phased change plan", error);
-                  scheduleAdvancePhase();
+                  LOG.warn("Failed to complete phased change plan '{}'", planId, error);
+                  scheduleAdvancePhase(planId);
                 } else {
-                  advancePhaseRetryTimer = null;
+                  advancePhaseRetryTimers.remove(planId);
                 }
               });
     }
   }
 
-  private void scheduleAdvancePhase() {
-    if (advancePhaseRetryTimer == null) {
-      advancePhaseRetryTimer =
-          executor.schedule(
-              backoffRetry.nextDelay(),
-              () -> maybeAdvancePhase(persistedCurrentConfiguration.getConfiguration()));
-    }
+  private void scheduleAdvancePhase(final long planId) {
+    advancePhaseRetryTimers.computeIfAbsent(
+        planId,
+        ignored ->
+            executor.schedule(
+                backoffRetry.nextDelay(),
+                () -> {
+                  // Cleared before firing (not in the success/failure branches of the retry
+                  // itself), so a repeat failure can schedule a new timer instead of finding a
+                  // stale, already-fired one still occupying this key.
+                  advancePhaseRetryTimers.remove(planId);
+                  maybeAdvancePhase(persistedCurrentConfiguration.getConfiguration(), planId);
+                }));
   }
 
   private boolean isLocalMemberCoordinator() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -200,6 +200,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     this.minRetryDelay = minRetryDelay;
     this.maxRetryDelay = maxRetryDelay;
     this.completedChangeHistoryLimit = completedChangeHistoryLimit;
+    PhasedChangeState.setHistoryLimit(completedChangeHistoryLimit);
     backoffRetry = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
     useNewConfig = true;
     coordinatorSupplier =

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
@@ -88,36 +88,24 @@ public interface ClusterConfigurationCoordinatorSupplier {
   private static Set<MemberId> getActiveMembers(
       final CurrentClusterConfiguration currentClusterConfiguration) {
     final var toBeRemovedMembers =
-        currentClusterConfiguration
-            .phasedChangeState()
-            .pending()
-            .map(
-                plan ->
-                    plan.phases().stream()
-                        .filter(phase -> phase instanceof GlobalPhase)
-                        .flatMap(
-                            phase ->
-                                ((GlobalPhase) phase)
-                                    .operations().stream()
-                                        .filter(
-                                            op ->
-                                                op
-                                                    instanceof
-                                                    GlobalChangeOperation.MemberRemoveOperation)
-                                        .map(
-                                            op ->
-                                                ((GlobalChangeOperation.MemberRemoveOperation) op)
-                                                    .memberToRemove()))
-                        .toList());
+        currentClusterConfiguration.phasedChangeState().pending().values().stream()
+            .flatMap(plan -> plan.phases().stream())
+            .filter(phase -> phase instanceof GlobalPhase)
+            .flatMap(
+                phase ->
+                    ((GlobalPhase) phase)
+                        .operations().stream()
+                            .filter(op -> op instanceof GlobalChangeOperation.MemberRemoveOperation)
+                            .map(
+                                op ->
+                                    ((GlobalChangeOperation.MemberRemoveOperation) op)
+                                        .memberToRemove()))
+            .collect(Collectors.toSet());
 
     final var result =
-        toBeRemovedMembers
-            .map(
-                memberIds ->
-                    currentClusterConfiguration.getMembers().stream()
-                        .filter(member -> !memberIds.contains(member))
-                        .collect(Collectors.toSet()))
-            .orElseGet(currentClusterConfiguration::getMembers);
+        currentClusterConfiguration.getMembers().stream()
+            .filter(member -> !toBeRemovedMembers.contains(member))
+            .collect(Collectors.toSet());
     return result;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -27,12 +27,14 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import org.agrona.collections.MutableLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,14 +44,28 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
   private final ClusterConfigurationManager clusterTopologyManager;
   private final ConcurrencyControl executor;
   private final MemberId localMemberId;
+  private final int completedChangeHistoryLimit;
 
   public ConfigurationChangeCoordinatorImpl(
       final ClusterConfigurationManager clusterTopologyManager,
       final MemberId localMemberId,
       final ConcurrencyControl executor) {
+    this(clusterTopologyManager, localMemberId, executor, PhasedChangeState.DEFAULT_HISTORY_LIMIT);
+  }
+
+  /**
+   * @param completedChangeHistoryLimit maximum number of completed changes retained in {@link
+   *     io.camunda.zeebe.dynamic.config.state.PhasedChangeState#history()}, oldest evicted first
+   */
+  public ConfigurationChangeCoordinatorImpl(
+      final ClusterConfigurationManager clusterTopologyManager,
+      final MemberId localMemberId,
+      final ConcurrencyControl executor,
+      final int completedChangeHistoryLimit) {
     this.clusterTopologyManager = clusterTopologyManager;
     this.executor = executor;
     this.localMemberId = localMemberId;
+    this.completedChangeHistoryLimit = completedChangeHistoryLimit;
   }
 
   @Override
@@ -100,7 +116,8 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                         return currentConfiguration;
                       }
                       LOG.warn("Cancelling configuration change '{}'.", changeId);
-                      return currentConfiguration.cancelPendingChanges();
+                      return currentConfiguration.cancelPendingChanges(
+                          changeId, completedChangeHistoryLimit);
                     })
                 .onComplete(
                     (updatedConfiguration, error) -> {
@@ -127,21 +144,19 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
               "Cannot cancel change " + changeId + " because the topology is not initialized"));
       return false;
     }
-    final var pendingPlan = currentConfiguration.phasedChangeState().pending();
-    if (pendingPlan.isEmpty()) {
+    final var state = currentConfiguration.phasedChangeState();
+    if (!state.wasIssued(changeId)) {
       failFuture(
           future,
           new InvalidRequest(
-              "Cannot cancel change " + changeId + " because no change is in progress"));
+              "Cannot cancel change " + changeId + " because it is not a known change"));
       return false;
     }
-    if (pendingPlan.orElseThrow().id() != changeId) {
-      failFuture(
-          future,
-          new InvalidRequest(
-              "Cannot cancel change " + changeId + " because it is not the current change"));
-      return false;
-    }
+    // changeId < nextId: either still pending (cancel proceeds below) or already resolved
+    // (completed/failed/cancelled, whether still in the retained history window or aged out of
+    // it) — cancelling an already-resolved change is treated as an idempotent no-op success,
+    // since a resolved id can never be re-distinguished from "no longer tracked" once history ages
+    // it out, and both cases mean "there is nothing left to cancel".
     return true;
   }
 
@@ -208,8 +223,12 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
       return;
     }
 
+    // Captured before any mutation: the id the coordinator's single-threaded executor is about to
+    // hand out for this request, whether or not it is ever actually applied (dry-run) or the
+    // request races with a concurrent one (checked in checkConcurrentModification below).
+    final long changeId = currentConfiguration.phasedChangeState().nextId();
     final ActorFuture<CurrentClusterConfiguration> validation =
-        validateNewModelChangeRequest(currentConfiguration, phases);
+        validateNewModelChangeRequest(currentConfiguration, changeId, phases);
 
     validation.onComplete(
         (simulatedFinalConfiguration, validationError) -> {
@@ -220,12 +239,6 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
 
           final var operations = flattenPhases(phases);
           if (dryRun) {
-            final long changeId =
-                currentConfiguration
-                    .phasedChangeState()
-                    .lastChange()
-                    .map(c -> c.id() + 1)
-                    .orElse(1L);
             future.complete(
                 new ConfigurationChangeResult(
                     currentConfiguration.toLegacyDefault(),
@@ -238,10 +251,17 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
             return;
           }
 
+          // The id actually assigned may differ from `changeId` (captured from the snapshot used
+          // to validate/simulate) if another, non-conflicting request was admitted in between —
+          // checkConcurrentModification only rejects overlapping scopes, not unrelated admissions
+          // that bump the counter. The applied id is therefore read fresh, inside the same
+          // single-threaded transaction that calls initPlan, so it is exact.
+          final MutableLong appliedChangeId = new MutableLong();
           clusterTopologyManager
               .updateMultiConfiguration(
                   config -> {
                     checkConcurrentModification(config, currentConfiguration, phases);
+                    appliedChangeId.set(config.phasedChangeState().nextId());
                     return config.initPlan(phases);
                   })
               .onComplete(
@@ -250,15 +270,13 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                       failFuture(future, error);
                       return;
                     }
-                    final long changeId =
-                        updated.phasedChangeState().pending().map(PhasedChangePlan::id).orElse(0L);
                     future.complete(
                         new ConfigurationChangeResult(
                             currentConfiguration.toLegacyDefault(),
                             simulatedFinalConfiguration.toLegacyDefault(),
                             currentConfiguration,
                             simulatedFinalConfiguration,
-                            changeId,
+                            appliedChangeId.get(),
                             operations,
                             phases));
                   },
@@ -271,9 +289,15 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
       final CurrentClusterConfiguration configUsedForGeneratingOperations,
       final List<Phase> phases) {
 
-    if (latestConfig.phasedChangeState().pending().isPresent()) {
-      throw new ConcurrentModificationException(
-          "Cannot apply configuration change. Another configuration change is in progress.");
+    final var scope = PhasedChangePlan.scopeOf(phases);
+    for (final var existing : latestConfig.phasedChangeState().pending().values()) {
+      if (PhasedChangePlan.conflicts(scope, existing.scope())) {
+        throw new ConcurrentModificationException(
+            String.format(
+                "Cannot apply configuration change. Another configuration change [%d] targeting an"
+                    + " overlapping group is in progress.",
+                existing.id()));
+      }
     }
 
     // simple equality check on the whole configuration is not enough, because we allow concurrent
@@ -317,7 +341,9 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
    * changes, the plan moved into {@code lastChange}), used as the expected final configuration.
    */
   private ActorFuture<CurrentClusterConfiguration> validateNewModelChangeRequest(
-      final CurrentClusterConfiguration currentConfiguration, final List<Phase> phases) {
+      final CurrentClusterConfiguration currentConfiguration,
+      final long newPlanId,
+      final List<Phase> phases) {
     final ActorFuture<CurrentClusterConfiguration> validationFuture = executor.createFuture();
 
     if (currentConfiguration.globalConfiguration().members().isEmpty()) {
@@ -325,53 +351,61 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
           validationFuture,
           new OperationNotAllowed(
               "Cannot apply configuration change. The configuration is not initialized."));
-    } else if (currentConfiguration.phasedChangeState().pending().isPresent()) {
-      failFuture(
-          validationFuture,
-          new ConcurrentModificationException(
-              String.format(
-                  "Cannot apply configuration change. Another configuration change [%d] is in progress.",
-                  currentConfiguration
-                      .phasedChangeState()
-                      .pending()
-                      .map(PhasedChangePlan::id)
-                      .orElseThrow())));
-    } else {
-      final var globalSimulator =
-          new GlobalConfigurationChangeAppliersImpl(
-              new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor());
-      final var groupSimulator =
-          new PartitionGroupConfigurationChangeAppliersImpl(
-              new NoopPartitionChangeExecutor(),
-              new NoopPartitionScalingChangeExecutor(),
-              new NoopModeChangeExecutor(),
-              new NoopRestoreChangeExecutor());
-      try {
-        final var withPlan = currentConfiguration.initPlan(phases);
-        simulateNewModelChange(withPlan, globalSimulator, groupSimulator, validationFuture);
-      } catch (final Exception e) {
-        failFuture(validationFuture, e);
+      return validationFuture;
+    }
+
+    final var scope = PhasedChangePlan.scopeOf(phases);
+    for (final var existing : currentConfiguration.phasedChangeState().pending().values()) {
+      if (PhasedChangePlan.conflicts(scope, existing.scope())) {
+        failFuture(
+            validationFuture,
+            new ConcurrentModificationException(
+                String.format(
+                    "Cannot apply configuration change. Another configuration change [%d]"
+                        + " targeting an overlapping scope is in progress.",
+                    existing.id())));
+        return validationFuture;
       }
+    }
+
+    final var globalSimulator =
+        new GlobalConfigurationChangeAppliersImpl(
+            new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor());
+    final var groupSimulator =
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor());
+    try {
+      final var withPlan = currentConfiguration.initPlan(phases);
+      simulateNewModelChange(
+          withPlan, newPlanId, globalSimulator, groupSimulator, validationFuture);
+    } catch (final Exception e) {
+      failFuture(validationFuture, e);
     }
     return validationFuture;
   }
 
   private void simulateNewModelChange(
       final CurrentClusterConfiguration config,
+      final long planId,
       final GlobalConfigurationChangeAppliers globalSimulator,
       final PartitionGroupConfigurationChangeAppliers groupSimulator,
       final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
-    final var pending = config.phasedChangeState().pending();
-    if (pending.isEmpty()) {
+    final var plan = config.phasedChangeState().pending().get(planId);
+    if (plan == null) {
+      // The plan has been fully drained and moved into history — simulation is done.
       simulationCompleted.complete(config);
       return;
     }
-    switch (pending.get().currentPhase()) {
+    switch (plan.currentPhase()) {
       case final GlobalPhase ignored ->
-          simulateGlobalPhase(config, globalSimulator, groupSimulator, simulationCompleted);
+          simulateGlobalPhase(config, planId, globalSimulator, groupSimulator, simulationCompleted);
       case final PartitionGroupParallelPhase parallelPhase ->
           simulatePartitionGroupPhase(
               config,
+              planId,
               new ArrayList<>(parallelPhase.groupOperations().keySet()),
               0,
               globalSimulator,
@@ -382,12 +416,13 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
 
   private void simulateGlobalPhase(
       final CurrentClusterConfiguration config,
+      final long planId,
       final GlobalConfigurationChangeAppliers globalSimulator,
       final PartitionGroupConfigurationChangeAppliers groupSimulator,
       final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
     if (!config.globalConfiguration().hasPendingChanges()) {
       advancePhaseAndContinueSimulation(
-          config, globalSimulator, groupSimulator, simulationCompleted);
+          config, planId, globalSimulator, groupSimulator, simulationCompleted);
       return;
     }
     final var operation =
@@ -410,12 +445,14 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
               final var advanced =
                   configWithInit.updateGlobalConfiguration(
                       g -> g.advanceConfigurationChange(transformer));
-              simulateGlobalPhase(advanced, globalSimulator, groupSimulator, simulationCompleted);
+              simulateGlobalPhase(
+                  advanced, planId, globalSimulator, groupSimulator, simulationCompleted);
             });
   }
 
   private void simulatePartitionGroupPhase(
       final CurrentClusterConfiguration config,
+      final long planId,
       final List<String> groupIds,
       final int index,
       final GlobalConfigurationChangeAppliers globalSimulator,
@@ -423,7 +460,7 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
       final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
     if (index >= groupIds.size()) {
       advancePhaseAndContinueSimulation(
-          config, globalSimulator, groupSimulator, simulationCompleted);
+          config, planId, globalSimulator, groupSimulator, simulationCompleted);
       return;
     }
     simulatePartitionGroupOperations(
@@ -432,7 +469,13 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
         groupSimulator,
         drained ->
             simulatePartitionGroupPhase(
-                drained, groupIds, index + 1, globalSimulator, groupSimulator, simulationCompleted),
+                drained,
+                planId,
+                groupIds,
+                index + 1,
+                globalSimulator,
+                groupSimulator,
+                simulationCompleted),
         simulationCompleted);
   }
 
@@ -474,15 +517,16 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
 
   private void advancePhaseAndContinueSimulation(
       final CurrentClusterConfiguration config,
+      final long planId,
       final GlobalConfigurationChangeAppliers globalSimulator,
       final PartitionGroupConfigurationChangeAppliers groupSimulator,
       final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
-    final var plan = config.phasedChangeState().pending().orElseThrow();
+    final var plan = config.phasedChangeState().pending().get(planId);
     final var next =
         plan.hasNextPhase()
-            ? config.activateNextPhase()
-            : config.completePlan(PhasedChangePlanStatus.COMPLETED);
-    simulateNewModelChange(next, globalSimulator, groupSimulator, simulationCompleted);
+            ? config.activateNextPhase(planId)
+            : config.completePlan(planId, PhasedChangePlanStatus.COMPLETED);
+    simulateNewModelChange(next, planId, globalSimulator, groupSimulator, simulationCompleted);
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1977,24 +1977,23 @@ public class ProtoBufSerializer
   }
 
   private Topology.PhasedChangeState encodePhasedChangeState(final PhasedChangeState state) {
-    final var builder = Topology.PhasedChangeState.newBuilder();
-    state.pending().ifPresent(plan -> builder.setPendingPlan(encodePhasedChangePlan(plan)));
+    final var builder = Topology.PhasedChangeState.newBuilder().setNextId(state.nextId());
+    state.pending().values().forEach(plan -> builder.addPending(encodePhasedChangePlan(plan)));
     state
-        .lastChange()
-        .ifPresent(lastChange -> builder.setLastChange(encodeCompletedPhasedChange(lastChange)));
+        .history()
+        .forEach(
+            completedChange -> builder.addHistory(encodeCompletedPhasedChange(completedChange)));
     return builder.build();
   }
 
   private PhasedChangeState decodePhasedChangeState(final Topology.PhasedChangeState proto) {
-    final Optional<PhasedChangePlan> pending =
-        proto.hasPendingPlan()
-            ? Optional.of(decodePhasedChangePlan(proto.getPendingPlan()))
-            : Optional.empty();
-    final Optional<CompletedPhasedChange> lastChange =
-        proto.hasLastChange()
-            ? Optional.of(decodeCompletedPhasedChange(proto.getLastChange()))
-            : Optional.empty();
-    return new PhasedChangeState(pending, lastChange);
+    final Map<Long, PhasedChangePlan> pending =
+        proto.getPendingList().stream()
+            .map(this::decodePhasedChangePlan)
+            .collect(Collectors.toMap(PhasedChangePlan::id, plan -> plan));
+    final List<CompletedPhasedChange> history =
+        proto.getHistoryList().stream().map(this::decodeCompletedPhasedChange).toList();
+    return new PhasedChangeState(proto.getNextId(), pending, history);
   }
 
   private Topology.PhasedChangePlan encodePhasedChangePlan(final PhasedChangePlan plan) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -190,7 +190,11 @@ public record CurrentClusterConfiguration(
    *     a change in progress
    */
   public CurrentClusterConfiguration activatePendingPhase() {
-    return phasedChangeState.pending().map(this::applyPhase).orElse(this);
+    var result = this;
+    for (final var plan : phasedChangeState.pending().values()) {
+      result = result.applyPhase(plan);
+    }
+    return result;
   }
 
   /**
@@ -379,70 +383,95 @@ public record CurrentClusterConfiguration(
           "Expected to init a plan with at least one phase, but the phase list is empty");
     }
 
+    final long newId = phasedChangeState.nextId();
     final var newState = phasedChangeState.initPlan(phases);
-    final var plan = newState.pending().orElseThrow();
+    final var plan = Objects.requireNonNull(newState.pending().get(newId));
     return withPhasedChangeState(newState).applyPhase(plan);
   }
 
   /**
-   * Advances the pending plan to the next phase and activates that phase into the
+   * Advances the pending plan {@code planId} to the next phase and activates that phase into the
    * sub-configurations.
    *
    * <p>The next phase must not target a sub-configuration that still has the previous phase's
    * change in progress (see {@link #initPlan(List)}); if it does, this throws because a
    * configuration change is already in progress on that sub-config.
    *
-   * @throws IllegalStateException if no plan is pending, or the plan is already on its last phase
+   * @throws IllegalStateException if no plan {@code planId} is pending, or it is already on its
+   *     last phase
    */
-  public CurrentClusterConfiguration activateNextPhase() {
-    final var plan =
-        phasedChangeState
-            .pending()
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Cannot activate the next phase when no plan is pending"));
+  public CurrentClusterConfiguration activateNextPhase(final long planId) {
+    final var plan = phasedChangeState.pending().get(planId);
+    if (plan == null) {
+      throw new IllegalStateException(
+          "Cannot activate the next phase: no plan '%d' is pending".formatted(planId));
+    }
     if (!plan.hasNextPhase()) {
       throw new IllegalStateException(
           "Cannot activate the next phase: the plan is already on its last phase");
     }
     final var advanced = plan.withNextPhase();
-    final var newState =
-        new PhasedChangeState(Optional.of(advanced), phasedChangeState.lastChange());
+    final var newState = phasedChangeState.withAdvancedPlan(advanced);
     return withPhasedChangeState(newState).applyPhase(advanced);
   }
 
   /**
-   * Completes the pending plan with the given terminal status, moving it into the last-completed
-   * change. Sub-configuration changes activated by the plan are left untouched.
+   * Completes the pending plan {@code planId} with the given terminal status, moving it into {@code
+   * history}. Sub-configuration changes activated by the plan are left untouched.
    *
-   * @throws IllegalStateException if no plan is pending
+   * @throws IllegalStateException if plan {@code planId} is not pending
    */
-  public CurrentClusterConfiguration completePlan(final PhasedChangePlanStatus status) {
-    return withPhasedChangeState(phasedChangeState.completePlan(status));
+  public CurrentClusterConfiguration completePlan(
+      final long planId, final PhasedChangePlanStatus status) {
+    return completePlan(planId, status, PhasedChangeState.DEFAULT_HISTORY_LIMIT);
+  }
+
+  /** Same as {@link #completePlan(long, PhasedChangePlanStatus)}, with an explicit history cap. */
+  public CurrentClusterConfiguration completePlan(
+      final long planId, final PhasedChangePlanStatus status, final int historyLimit) {
+    return withPhasedChangeState(phasedChangeState.completePlan(planId, status, historyLimit));
   }
 
   /**
-   * Cancels the pending plan: clears the pending change on every sub-configuration that has one
-   * (the global configuration and/or any partition group targeted by the plan's phases so far), and
-   * moves the plan into {@code lastChange} with {@link PhasedChangePlanStatus#CANCELLED}. This is
-   * an unsafe operation and should be used only as a last resort when a plan is stuck — already
-   * applied operations are not reverted, so sub-configurations affected by earlier phases may be
-   * left in an intermediate state.
+   * Cancels the pending plan {@code planId}: clears the pending change on the sub-configuration(s)
+   * targeted by its <em>current</em> phase (the only ones that can have a change in progress
+   * belonging to this plan — earlier phases have already drained), and moves the plan into {@code
+   * history} with {@link PhasedChangePlanStatus#CANCELLED}. This is an unsafe operation and should
+   * be used only as a last resort when a plan is stuck — already applied operations are not
+   * reverted, so sub-configurations affected by earlier phases may be left in an intermediate
+   * state.
    *
-   * @return {@code this} if no plan is pending
+   * <p>Only the named plan's own sub-configurations are touched; other concurrently pending plans
+   * (which, by admission, target disjoint sub-configurations) are unaffected.
+   *
+   * @return {@code this} if plan {@code planId} is not pending
    */
-  public CurrentClusterConfiguration cancelPendingChanges() {
-    if (phasedChangeState.pending().isEmpty()) {
+  public CurrentClusterConfiguration cancelPendingChanges(final long planId) {
+    return cancelPendingChanges(planId, PhasedChangeState.DEFAULT_HISTORY_LIMIT);
+  }
+
+  /** Same as {@link #cancelPendingChanges(long)}, with an explicit history cap. */
+  public CurrentClusterConfiguration cancelPendingChanges(
+      final long planId, final int historyLimit) {
+    final var plan = phasedChangeState.pending().get(planId);
+    if (plan == null) {
       return this;
     }
-    var result = updateGlobalConfiguration(GlobalConfiguration::cancelPendingChanges);
-    for (final var groupId : partitionGroups.keySet()) {
-      result =
-          result.updatePartitionGroupConfig(
-              groupId, PartitionGroupConfiguration::cancelPendingChanges);
-    }
-    return result.completePlan(PhasedChangePlanStatus.CANCELLED);
+    final var result =
+        switch (plan.currentPhase()) {
+          case final GlobalPhase ignored ->
+              updateGlobalConfiguration(GlobalConfiguration::cancelPendingChanges);
+          case final PartitionGroupParallelPhase parallelPhase -> {
+            var r = this;
+            for (final var groupId : parallelPhase.groupOperations().keySet()) {
+              r =
+                  r.updatePartitionGroupConfig(
+                      groupId, PartitionGroupConfiguration::cancelPendingChanges);
+            }
+            yield r;
+          }
+        };
+    return result.completePlan(planId, PhasedChangePlanStatus.CANCELLED, historyLimit);
   }
 
   /**
@@ -515,21 +544,18 @@ public record CurrentClusterConfiguration(
    * ClusterConfiguration#isAfterRestore()}.
    */
   public boolean isAfterRestore() {
-    return phasedChangeState
-        .pending()
-        .filter(PhasedChangePlan::hasRestorePlanId)
-        .filter(plan -> plan.phases().size() == 1)
-        .map(plan -> plan.phases().get(0))
-        .filter(
-            phase ->
-                phase instanceof final PartitionGroupParallelPhase parallelPhase
-                    && parallelPhase.groupOperations().size() == 1
-                    && parallelPhase.groupOperations().values().stream()
-                        .allMatch(
-                            operations ->
-                                operations.size() == 1
-                                    && operations.get(0) instanceof UpdateRoutingState))
-        .isPresent();
+    return phasedChangeState.pending().values().stream().anyMatch(this::isRestorePlan);
+  }
+
+  private boolean isRestorePlan(final PhasedChangePlan plan) {
+    return plan.hasRestorePlanId()
+        && plan.phases().size() == 1
+        && plan.phases().get(0) instanceof final PartitionGroupParallelPhase parallelPhase
+        && parallelPhase.groupOperations().size() == 1
+        && parallelPhase.groupOperations().values().stream()
+            .allMatch(
+                operations ->
+                    operations.size() == 1 && operations.get(0) instanceof UpdateRoutingState);
   }
 
   public @Nullable PartitionGroupConfiguration partitionGroup(final String groupId) {
@@ -555,7 +581,14 @@ public record CurrentClusterConfiguration(
     final long lastChangeId = lastChange.map(CompletedPhasedChange::id).orElse(0L);
     final Optional<PhasedChangePlan> pending =
         legacy.pendingChanges().flatMap(plan -> toPhasedChangePlan(plan, lastChangeId));
-    return new PhasedChangeState(pending, lastChange);
+    final List<CompletedPhasedChange> history = lastChange.map(List::of).orElse(List.of());
+    final long nextId =
+        pending
+            .map(plan -> plan.id() + 1)
+            .orElse(Math.max(lastChangeId + 1, PhasedChangePlan.INITIAL_PLAN_ID));
+    final Map<Long, PhasedChangePlan> pendingMap =
+        pending.map(plan -> Map.of(plan.id(), plan)).orElse(Map.of());
+    return new PhasedChangeState(nextId, pendingMap, history);
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.dynamic.config.state;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 
@@ -25,6 +27,12 @@ import org.jspecify.annotations.NullMarked;
  * <p>Merge rule (gossip convergence): if plan IDs are equal, the higher {@code currentPhaseIndex}
  * wins. If plan IDs differ, the higher plan ID always wins — plan IDs are monotonically increasing,
  * so the higher ID is always the newer plan.
+ *
+ * <p>{@link #scope()} identifies which sub-configuration(s) this plan touches, derived from its
+ * phases: a plan with any {@link GlobalPhase} has {@link Global} scope (cluster-wide, conflicts
+ * with everything); otherwise it has {@link Groups} scope, the union of every partition group named
+ * across its {@link PartitionGroupParallelPhase}s. Multiple plans with disjoint {@link Groups}
+ * scopes may be pending concurrently; see {@link PhasedChangeState}.
  */
 @NullMarked
 public record PhasedChangePlan(
@@ -103,6 +111,57 @@ public record PhasedChangePlan(
    */
   public boolean hasRestorePlanId() {
     return id == RESTORED_PLAN_ID;
+  }
+
+  /**
+   * Returns the scope of this plan: {@link Global} if any phase is a {@link GlobalPhase} (the plan
+   * touches cluster-wide broker lifecycle, and therefore conflicts with every other plan);
+   * otherwise {@link Groups}, the union of every partition group id named across the plan's {@link
+   * PartitionGroupParallelPhase}s.
+   */
+  public Scope scope() {
+    return scopeOf(phases);
+  }
+
+  /** Same as {@link #scope()}, computable before a plan (and its id) exists. */
+  public static Scope scopeOf(final List<Phase> phases) {
+    if (phases.stream().anyMatch(GlobalPhase.class::isInstance)) {
+      return new Global();
+    }
+    final Set<String> groupIds =
+        phases.stream()
+            .filter(PartitionGroupParallelPhase.class::isInstance)
+            .map(PartitionGroupParallelPhase.class::cast)
+            .flatMap(phase -> phase.groupOperations().keySet().stream())
+            .collect(Collectors.toUnmodifiableSet());
+    return new Groups(groupIds);
+  }
+
+  /**
+   * Returns {@code true} if {@code a} and {@code b} target overlapping sub-configurations and
+   * therefore cannot be pending concurrently: either one of them is {@link Global} (cluster-wide,
+   * conflicts with anything), or both are {@link Groups} and share at least one group id.
+   */
+  public static boolean conflicts(final Scope a, final Scope b) {
+    if (a instanceof Global || b instanceof Global) {
+      return true;
+    }
+    final var groupsA = ((Groups) a).groupIds();
+    final var groupsB = ((Groups) b).groupIds();
+    return !Collections.disjoint(groupsA, groupsB);
+  }
+
+  /** The sub-configuration(s) a {@link PhasedChangePlan} touches. See {@link #scope()}. */
+  public sealed interface Scope permits Global, Groups {}
+
+  /** Cluster-wide scope: touches {@link GlobalConfiguration}, conflicts with every other plan. */
+  public record Global() implements Scope {}
+
+  /** Scope limited to the named partition groups. */
+  public record Groups(Set<String> groupIds) implements Scope {
+    public Groups {
+      groupIds = Set.copyOf(groupIds);
+    }
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeState.java
@@ -65,6 +65,8 @@ public record PhasedChangeState(
   /** Default number of completed changes retained in {@link #history}. See {@link #wasIssued}. */
   public static final int DEFAULT_HISTORY_LIMIT = 10;
 
+  public static int historyLimit = DEFAULT_HISTORY_LIMIT;
+
   /**
    * Total order over {@link CompletedPhasedChange}, most-recently-completed last. Ties on {@code
    * completedAt} (possible with coarse clock resolution, or across two different nodes' clocks) are
@@ -102,6 +104,13 @@ public record PhasedChangeState(
         });
     pending = Map.copyOf(pending);
     history = List.copyOf(history);
+  }
+
+  public static void setHistoryLimit(final int limit) {
+    if (limit < 0) {
+      throw new IllegalArgumentException("historyLimit must be non-negative, got " + limit);
+    }
+    historyLimit = limit;
   }
 
   public static PhasedChangeState empty() {
@@ -257,8 +266,7 @@ public record PhasedChangeState(
     other.history.forEach(c -> mergedHistoryById.merge(c.id(), c, (a, b) -> a));
     // Fixed limit, not derived from either side's size: top-k of a union only converges regardless
     // of merge order when k is constant. See the class javadoc.
-    final var mergedHistory =
-        trimHistory(List.copyOf(mergedHistoryById.values()), DEFAULT_HISTORY_LIMIT);
+    final var mergedHistory = trimHistory(List.copyOf(mergedHistoryById.values()), historyLimit);
 
     final Map<Long, PhasedChangePlan> mergedPending = new HashMap<>();
     pending.forEach(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeState.java
@@ -41,11 +41,21 @@ import org.jspecify.annotations.NullMarked;
  * <ul>
  *   <li>{@code nextId}: the higher value wins (it only ever increases).
  *   <li>{@code pending}: union of both sides' entries by id; an id present on both sides is
- *       resolved via {@link PhasedChangePlan#merge}; an id resolved (present in the merged {@link
- *       #history}) on either side is dropped from the merged pending map.
+ *       resolved via {@link PhasedChangePlan#merge}. An id present on only one side is dropped
+ *       (treated as already resolved on the <em>other</em> side) if either: (a) the other side's
+ *       own {@code nextId}/{@code pending} shows it as resolved (see {@link
+ *       #isResolvedAccordingToItself}) — this is the primary, effectively permanent signal, since a
+ *       single writer (the coordinator) never re-admits an id, so its absence, once witnessed, is
+ *       never "forgotten" the way a bounded window would be; or (b) it is present in the merged
+ *       {@link #history} — a weaker, bounded fallback that only matters for the one id the counter
+ *       doesn't cover, {@link PhasedChangePlan#RESTORED_PLAN_ID}.
  *   <li>{@code history}: union of both sides' entries by id (a given id completes at most once, so
- *       this is a simple union, not a per-id merge), trimmed back to (at most) the larger side's
- *       size, oldest {@code completedAt} first, so a plain union does not grow unboundedly.
+ *       this is a simple union, not a per-id merge), trimmed to a <em>fixed</em> {@link
+ *       #DEFAULT_HISTORY_LIMIT} — not a value derived from either side's current size. Top-k
+ *       selection over a union is commutative/associative/idempotent only when k is fixed; deriving
+ *       it from input sizes (as this used to) makes the result depend on which nodes happen to
+ *       merge in which order, so two brokers that have each seen every completion can permanently
+ *       disagree about which ones they remember.
  * </ul>
  */
 @NullMarked
@@ -54,6 +64,16 @@ public record PhasedChangeState(
 
   /** Default number of completed changes retained in {@link #history}. See {@link #wasIssued}. */
   public static final int DEFAULT_HISTORY_LIMIT = 10;
+
+  /**
+   * Total order over {@link CompletedPhasedChange}, most-recently-completed last. Ties on {@code
+   * completedAt} (possible with coarse clock resolution, or across two different nodes' clocks) are
+   * broken by id, so ordering/trimming is fully deterministic regardless of which node computes it
+   * — required for {@link #merge} to converge.
+   */
+  private static final Comparator<CompletedPhasedChange> COMPLETION_ORDER =
+      Comparator.comparing(CompletedPhasedChange::completedAt)
+          .thenComparingLong(CompletedPhasedChange::id);
 
   public PhasedChangeState {
     requireNonNull(pending, "pending must not be null");
@@ -99,6 +119,27 @@ public record PhasedChangeState(
   }
 
   /**
+   * Returns {@code true} if this state's own bookkeeping shows {@code id} as resolved: it was
+   * issued by the counter ({@code id < nextId}) and is not currently in {@link #pending}.
+   *
+   * <p>Deliberately excludes {@link PhasedChangePlan#RESTORED_PLAN_ID}: that sentinel bypasses the
+   * counter entirely (it is assigned directly during legacy migration, not via {@link #initPlan}),
+   * so {@code nextId} advancing past it proves nothing about its history — every state's {@code
+   * nextId} is at least {@link PhasedChangePlan#INITIAL_PLAN_ID}, so this signal would otherwise
+   * unconditionally (and wrongly) call it resolved even for a state that has never witnessed it.
+   * {@link #merge} falls back to the (bounded, but adequate for a once-per-cluster-lifetime event)
+   * {@link #history}-based check for that one id.
+   *
+   * <p>For every other id, this is a permanent signal, unlike {@link #history}: a single writer
+   * (the coordinator) only ever removes a counter-issued id from {@link #pending} by explicitly
+   * resolving it, so once some state has witnessed {@code id < nextId} without it being pending,
+   * that fact never becomes false again, no matter how many unrelated ids are later issued.
+   */
+  private boolean isResolvedAccordingToItself(final long id) {
+    return id >= PhasedChangePlan.INITIAL_PLAN_ID && id < nextId && !pending.containsKey(id);
+  }
+
+  /**
    * Returns the single pending plan, assuming exactly one is pending. Convenience for call sites
    * (tests, and legacy single-plan flows such as {@link CurrentClusterConfiguration#fromLegacy})
    * that know only one plan can be in flight.
@@ -126,7 +167,7 @@ public record PhasedChangeState(
    * longer tracks completion order.
    */
   public Optional<CompletedPhasedChange> lastChange() {
-    return history.stream().max(Comparator.comparing(CompletedPhasedChange::completedAt));
+    return history.stream().max(COMPLETION_ORDER);
   }
 
   /**
@@ -193,7 +234,7 @@ public record PhasedChangeState(
   private static List<CompletedPhasedChange> trimHistory(
       final List<CompletedPhasedChange> entries, final int limit) {
     final var sorted = new ArrayList<>(entries);
-    sorted.sort(Comparator.comparing(CompletedPhasedChange::completedAt));
+    sorted.sort(COMPLETION_ORDER);
     final int from = Math.max(0, sorted.size() - Math.max(limit, 0));
     return List.copyOf(sorted.subList(from, sorted.size()));
   }
@@ -214,18 +255,24 @@ public record PhasedChangeState(
     final Map<Long, CompletedPhasedChange> mergedHistoryById = new HashMap<>();
     history.forEach(c -> mergedHistoryById.put(c.id(), c));
     other.history.forEach(c -> mergedHistoryById.merge(c.id(), c, (a, b) -> a));
-    // Bounded to the larger side's current size (not an explicit limit, which merge has no access
-    // to): each side was already trimmed to its own configured limit by completePlan, so this keeps
-    // a plain gossip union from growing history without bound across repeated merges.
+    // Fixed limit, not derived from either side's size: top-k of a union only converges regardless
+    // of merge order when k is constant. See the class javadoc.
     final var mergedHistory =
-        trimHistory(
-            List.copyOf(mergedHistoryById.values()),
-            Math.max(history.size(), other.history.size()));
+        trimHistory(List.copyOf(mergedHistoryById.values()), DEFAULT_HISTORY_LIMIT);
 
     final Map<Long, PhasedChangePlan> mergedPending = new HashMap<>();
-    pending.forEach((id, plan) -> mergedPending.merge(id, plan, (a, b) -> a.merge(b)));
-    other.pending.forEach((id, plan) -> mergedPending.merge(id, plan, (a, b) -> a.merge(b)));
-    mergedHistoryById.keySet().forEach(mergedPending::remove);
+    pending.forEach(
+        (id, plan) -> {
+          if (!other.isResolvedAccordingToItself(id) && !mergedHistoryById.containsKey(id)) {
+            mergedPending.merge(id, plan, (a, b) -> a.merge(b));
+          }
+        });
+    other.pending.forEach(
+        (id, plan) -> {
+          if (!isResolvedAccordingToItself(id) && !mergedHistoryById.containsKey(id)) {
+            mergedPending.merge(id, plan, (a, b) -> a.merge(b));
+          }
+        });
 
     return new PhasedChangeState(mergedNextId, mergedPending, mergedHistory);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeState.java
@@ -10,97 +10,223 @@ package io.camunda.zeebe.dynamic.config.state;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Holds at most one pending {@link PhasedChangePlan} together with the last completed change.
+ * Holds every currently pending {@link PhasedChangePlan}, keyed by id, plus a bounded window of
+ * recently completed changes.
  *
- * <p>The next plan ID is always derived as {@code lastChange.id() + 1} (or {@code 1} when no
- * previous change exists), so callers cannot accidentally supply a non-monotonic ID.
+ * <p>Plan ids are issued from a single monotonically increasing counter ({@link #nextId}), never
+ * derived from the completed-change history. This lets multiple plans be pending at once (with
+ * distinct ids) while still giving every id an unambiguous, cluster-wide-agreed meaning: an id is
+ * either currently {@link #pending}, or resolved (present in {@link #history}, or aged out of the
+ * bounded window — in which case it is <em>known</em> to have resolved, since {@code nextId} only
+ * ever advances past ids that were tracked in {@code pending} at some point), or, if {@code id >=
+ * nextId}, never issued at all. See {@link #wasIssued(long)}.
+ *
+ * <p>At most one pending plan may target a given partition group at a time: a new plan is only
+ * admitted (see {@link #initPlan}) if its {@link PhasedChangePlan.Scope} does not {@link
+ * PhasedChangePlan#conflicts} with any already-pending plan's scope. A {@link
+ * PhasedChangePlan.Global}-scoped plan conflicts with every other plan and vice versa, so at most
+ * one plan is ever pending while any global-scoped plan is pending.
  *
  * <p>Merge semantics (gossip convergence):
  *
  * <ul>
- *   <li>{@code pending}: delegates to {@link PhasedChangePlan#merge(PhasedChangePlan)}.
- *   <li>{@code lastChange}: the side with the higher ID wins.
+ *   <li>{@code nextId}: the higher value wins (it only ever increases).
+ *   <li>{@code pending}: union of both sides' entries by id; an id present on both sides is
+ *       resolved via {@link PhasedChangePlan#merge}; an id resolved (present in the merged {@link
+ *       #history}) on either side is dropped from the merged pending map.
+ *   <li>{@code history}: union of both sides' entries by id (a given id completes at most once, so
+ *       this is a simple union, not a per-id merge), trimmed back to (at most) the larger side's
+ *       size, oldest {@code completedAt} first, so a plain union does not grow unboundedly.
  * </ul>
  */
 @NullMarked
 public record PhasedChangeState(
-    Optional<PhasedChangePlan> pending, Optional<CompletedPhasedChange> lastChange) {
+    long nextId, Map<Long, PhasedChangePlan> pending, List<CompletedPhasedChange> history) {
+
+  /** Default number of completed changes retained in {@link #history}. See {@link #wasIssued}. */
+  public static final int DEFAULT_HISTORY_LIMIT = 10;
 
   public PhasedChangeState {
     requireNonNull(pending, "pending must not be null");
-    requireNonNull(lastChange, "lastChange must not be null");
-    pending.ifPresent(
-        p ->
-            lastChange.ifPresent(
-                lc -> {
-                  if (p.id() <= lc.id()) {
-                    throw new IllegalArgumentException(
-                        "pending plan ID %d must be greater than last completed change ID %d"
-                            .formatted(p.id(), lc.id()));
-                  }
-                }));
+    requireNonNull(history, "history must not be null");
+    if (nextId < PhasedChangePlan.INITIAL_PLAN_ID) {
+      throw new IllegalArgumentException(
+          "nextId must be at least %d, got %d".formatted(PhasedChangePlan.INITIAL_PLAN_ID, nextId));
+    }
+    pending.forEach(
+        (id, plan) -> {
+          if (!id.equals(plan.id())) {
+            throw new IllegalArgumentException(
+                "pending map key %d does not match plan id %d".formatted(id, plan.id()));
+          }
+          if (id >= nextId) {
+            throw new IllegalArgumentException(
+                "pending plan id %d must be less than nextId %d".formatted(id, nextId));
+          }
+        });
+    history.forEach(
+        c -> {
+          if (c.id() >= nextId) {
+            throw new IllegalArgumentException(
+                "history entry id %d must be less than nextId %d".formatted(c.id(), nextId));
+          }
+        });
+    pending = Map.copyOf(pending);
+    history = List.copyOf(history);
   }
 
   public static PhasedChangeState empty() {
-    return new PhasedChangeState(Optional.empty(), Optional.empty());
+    return new PhasedChangeState(PhasedChangePlan.INITIAL_PLAN_ID, Map.of(), List.of());
   }
 
   /**
-   * Creates a new pending plan from {@code phases}, deriving its ID from {@code lastChange} to
-   * guarantee monotonicity.
+   * Returns {@code true} if {@code id} was ever issued by this (or a merged-in) counter — i.e. it
+   * is either currently pending, resolved and still within the retained {@link #history} window, or
+   * resolved and aged out of that window. The only ids for which this returns {@code false} are
+   * ones the counter never handed out, including any id at or beyond {@link #nextId}.
+   */
+  public boolean wasIssued(final long id) {
+    return id < nextId;
+  }
+
+  /**
+   * Returns the single pending plan, assuming exactly one is pending. Convenience for call sites
+   * (tests, and legacy single-plan flows such as {@link CurrentClusterConfiguration#fromLegacy})
+   * that know only one plan can be in flight.
    *
-   * @throws IllegalStateException if a plan is already pending
+   * @throws IllegalStateException if zero or more than one plan is pending
+   */
+  public PhasedChangePlan onlyPending() {
+    if (pending.size() != 1) {
+      throw new IllegalStateException(
+          "Expected exactly one pending plan, found %d".formatted(pending.size()));
+    }
+    return pending.values().iterator().next();
+  }
+
+  /** Returns the completed change for {@code id}, if it is still within the retained window. */
+  public Optional<CompletedPhasedChange> historyFor(final long id) {
+    return history.stream().filter(c -> c.id() == id).findFirst();
+  }
+
+  /**
+   * Convenience accessor returning the most recently completed change, if any is retained. Used by
+   * consumers that only care about the latest completion (e.g. observability), not the full
+   * history. Ordered by {@code completedAt}, not by id — once plans can run concurrently, a lower
+   * id (admitted earlier) can finish after a higher id (admitted later but faster), so id order no
+   * longer tracks completion order.
+   */
+  public Optional<CompletedPhasedChange> lastChange() {
+    return history.stream().max(Comparator.comparing(CompletedPhasedChange::completedAt));
+  }
+
+  /**
+   * Creates a new pending plan from {@code phases}, assigning it the next id from the monotonic
+   * counter.
+   *
+   * @throws IllegalStateException if {@code phases}' scope conflicts with an already-pending plan
    */
   public PhasedChangeState initPlan(final List<PhasedChangePlan.Phase> phases) {
-    if (pending.isPresent()) {
-      throw new IllegalStateException(
-          "Cannot init a new plan while one is already pending: " + pending.get());
-    }
-    final long nextId = lastChange.map(c -> c.id() + 1).orElse(PhasedChangePlan.INITIAL_PLAN_ID);
     final var plan = PhasedChangePlan.init(nextId, phases, Instant.now());
-    return new PhasedChangeState(Optional.of(plan), lastChange);
-  }
-
-  /**
-   * Moves the pending plan to {@code lastChange} with the given terminal {@code status}.
-   *
-   * @throws IllegalStateException if no plan is currently pending
-   */
-  public PhasedChangeState completePlan(final PhasedChangePlanStatus status) {
-    if (pending.isEmpty()) {
-      throw new IllegalStateException("Cannot complete a plan when none is pending");
+    final var scope = plan.scope();
+    for (final var existing : pending.values()) {
+      if (PhasedChangePlan.conflicts(scope, existing.scope())) {
+        throw new IllegalStateException(
+            "Cannot init a new plan: its scope conflicts with pending plan '%d': %s"
+                .formatted(existing.id(), existing));
+      }
     }
-    final var plan = pending.get();
-    final var completed =
-        new CompletedPhasedChange(plan.id(), status, plan.startedAt(), Instant.now());
-    return new PhasedChangeState(Optional.empty(), Optional.of(completed));
+    final var newPending = new HashMap<>(pending);
+    newPending.put(plan.id(), plan);
+    return new PhasedChangeState(nextId + 1, newPending, history);
   }
 
   /**
-   * Merges this state with {@code other} using gossip-convergence semantics.
+   * Replaces the pending plan for {@code advanced.id()} with {@code advanced} (e.g. after moving to
+   * the next phase).
    *
-   * <p>The last completed change is resolved by taking the higher ID. The pending plan is resolved
-   * by {@link PhasedChangePlan#merge(PhasedChangePlan)} and then dropped if its ID is no greater
-   * than the merged last-change ID (the plan was already completed on one side).
+   * @throws IllegalStateException if no plan with that id is currently pending
+   */
+  public PhasedChangeState withAdvancedPlan(final PhasedChangePlan advanced) {
+    if (!pending.containsKey(advanced.id())) {
+      throw new IllegalStateException(
+          "Cannot advance plan '%d': no such plan is pending".formatted(advanced.id()));
+    }
+    final var newPending = new HashMap<>(pending);
+    newPending.put(advanced.id(), advanced);
+    return new PhasedChangeState(nextId, newPending, history);
+  }
+
+  /**
+   * Moves the pending plan {@code id} into {@link #history} with the given terminal {@code status},
+   * trimming the history to at most {@code historyLimit} entries, oldest {@code completedAt} first.
+   *
+   * @throws IllegalStateException if no plan with that id is currently pending
+   */
+  public PhasedChangeState completePlan(
+      final long id, final PhasedChangePlanStatus status, final int historyLimit) {
+    final var plan = pending.get(id);
+    if (plan == null) {
+      throw new IllegalStateException(
+          "Cannot complete plan '%d': no such plan is pending".formatted(id));
+    }
+    final var completed = new CompletedPhasedChange(id, status, plan.startedAt(), Instant.now());
+    final var newPending = new HashMap<>(pending);
+    newPending.remove(id);
+    final var newHistory = trimHistory(concat(history, completed), historyLimit);
+    return new PhasedChangeState(nextId, newPending, newHistory);
+  }
+
+  /**
+   * Returns {@code entries} sorted by {@code completedAt} ascending and trimmed to at most {@code
+   * limit} entries, dropping the oldest (lowest {@code completedAt}) first.
+   */
+  private static List<CompletedPhasedChange> trimHistory(
+      final List<CompletedPhasedChange> entries, final int limit) {
+    final var sorted = new ArrayList<>(entries);
+    sorted.sort(Comparator.comparing(CompletedPhasedChange::completedAt));
+    final int from = Math.max(0, sorted.size() - Math.max(limit, 0));
+    return List.copyOf(sorted.subList(from, sorted.size()));
+  }
+
+  private static List<CompletedPhasedChange> concat(
+      final List<CompletedPhasedChange> entries, final CompletedPhasedChange extra) {
+    final var result = new ArrayList<>(entries);
+    result.add(extra);
+    return result;
+  }
+
+  /**
+   * Merges this state with {@code other} using gossip-convergence semantics; see the class javadoc.
    */
   public PhasedChangeState merge(final PhasedChangeState other) {
-    final Optional<CompletedPhasedChange> mergedLastChange =
-        Stream.of(lastChange, other.lastChange)
-            .flatMap(Optional::stream)
-            .reduce((a, b) -> a.id() >= b.id() ? a : b);
+    final long mergedNextId = Math.max(nextId, other.nextId);
 
-    final Optional<PhasedChangePlan> mergedPending =
-        Stream.of(pending, other.pending)
-            .flatMap(Optional::stream)
-            .reduce(PhasedChangePlan::merge)
-            .filter(p -> mergedLastChange.map(lc -> p.id() > lc.id()).orElse(true));
+    final Map<Long, CompletedPhasedChange> mergedHistoryById = new HashMap<>();
+    history.forEach(c -> mergedHistoryById.put(c.id(), c));
+    other.history.forEach(c -> mergedHistoryById.merge(c.id(), c, (a, b) -> a));
+    // Bounded to the larger side's current size (not an explicit limit, which merge has no access
+    // to): each side was already trimmed to its own configured limit by completePlan, so this keeps
+    // a plain gossip union from growing history without bound across repeated merges.
+    final var mergedHistory =
+        trimHistory(
+            List.copyOf(mergedHistoryById.values()),
+            Math.max(history.size(), other.history.size()));
 
-    return new PhasedChangeState(mergedPending, mergedLastChange);
+    final Map<Long, PhasedChangePlan> mergedPending = new HashMap<>();
+    pending.forEach((id, plan) -> mergedPending.merge(id, plan, (a, b) -> a.merge(b)));
+    other.pending.forEach((id, plan) -> mergedPending.merge(id, plan, (a, b) -> a.merge(b)));
+    mergedHistoryById.keySet().forEach(mergedPending::remove);
+
+    return new PhasedChangeState(mergedNextId, mergedPending, mergedHistory);
   }
 }

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -79,10 +79,14 @@ message CompletedPhasedChange {
   google.protobuf.Timestamp completedAt = 4;
 }
 
-// Wrapper that holds at most one pending plan and the last completed change.
+// Wrapper that holds every currently pending plan (multiple may be pending
+// concurrently, targeting disjoint sub-configurations) plus a bounded window
+// of recently completed changes. nextId is the monotonic plan-id counter;
+// pending plan ids and history entry ids are always less than nextId.
 message PhasedChangeState {
-  PhasedChangePlan pendingPlan = 1;
-  CompletedPhasedChange lastChange = 2;
+  int64 nextId = 1;
+  repeated PhasedChangePlan pending = 2;
+  repeated CompletedPhasedChange history = 3;
 }
 
 // A single phase in a PhasedChangePlan; either global or per-group.

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -247,9 +247,8 @@ final class ClusterConfigurationManagerImplNewConfigTest {
     // then — the first phase's operation was applied, but the plan is not advanced to phase 2
     // since the local member is not the coordinator
     final var config = configuration(manager);
-    final var pending = config.phasedChangeState().pending();
-    assertThat(pending).isPresent();
-    assertThat(pending.get().currentPhaseIndex()).isZero();
+    final var pending = config.phasedChangeState().onlyPending();
+    assertThat(pending.currentPhaseIndex()).isZero();
     assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
   }
 
@@ -482,7 +481,7 @@ final class ClusterConfigurationManagerImplNewConfigTest {
             CurrentClusterConfiguration.INITIAL_VERSION,
             global,
             Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group),
-            new PhasedChangeState(Optional.of(plan), Optional.empty()));
+            new PhasedChangeState(plan.id() + 1, Map.of(plan.id(), plan), List.of()));
     manager.updateMultiConfiguration(ignored -> seeded).join();
 
     final var listenerCalled = new AtomicBoolean(false);
@@ -508,7 +507,7 @@ final class ClusterConfigurationManagerImplNewConfigTest {
             CurrentClusterConfiguration.INITIAL_VERSION,
             global,
             Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, groupWithoutMember0),
-            new PhasedChangeState(Optional.of(plan), Optional.empty()));
+            new PhasedChangeState(plan.id() + 1, Map.of(plan.id(), plan), List.of()));
     manager.onGossipReceivedCurrent(received);
 
     // then — the merge is applied (member 0 is gone from the group), but no inconsistency is

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -349,7 +349,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
         .updateMultiConfiguration(
             c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_1))))))
         .join();
-    final var changeId = configuration().phasedChangeState().pending().orElseThrow().id();
+    final var changeId = configuration().phasedChangeState().onlyPending().id();
 
     // when
     final var cancelled = coordinator.cancelChange(changeId).join();
@@ -383,7 +383,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionLeaveOperation(MEMBER_1, 1, 1)))))))
         .join();
-    final var changeId = configuration().phasedChangeState().pending().orElseThrow().id();
+    final var changeId = configuration().phasedChangeState().onlyPending().id();
 
     // when
     coordinator.cancelChange(changeId).join();
@@ -417,7 +417,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
         .updateMultiConfiguration(
             c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_1))))))
         .join();
-    final var changeId = configuration().phasedChangeState().pending().orElseThrow().id();
+    final var changeId = configuration().phasedChangeState().onlyPending().id();
 
     // when — cancelling a different id
     final var cancelFuture = coordinator.cancelChange(changeId + 1);
@@ -427,6 +427,144 @@ final class NewModelConfigurationChangeCoordinatorTest {
         .failsWithin(Duration.ofSeconds(5))
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(InvalidRequest.class);
-    assertThat(configuration().phasedChangeState().pending()).isPresent();
+    assertThat(configuration().phasedChangeState().pending()).isNotEmpty();
+  }
+
+  @Test
+  void shouldRunConcurrentChangesOnDisjointPartitionGroupsAndCancelIndependently() {
+    // given — a cluster with two independent partition groups: "default" and "tenanta". A change
+    // is started on "default" that never drains on its own (its operation targets member 1)
+    wire(MEMBER_0, twoMemberClusterWithSecondGroup());
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(new PartitionLeaveOperation(MEMBER_1, 1, 1)))))))
+        .join();
+    final var defaultChangeId = configuration().phasedChangeState().onlyPending().id();
+
+    // when — a second, independent change is admitted concurrently on "tenanta"
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                "tenanta", List.of(new PartitionLeaveOperation(MEMBER_0, 2, 1)))))))
+        .join();
+    final var pendingAfterBothStarted = configuration().phasedChangeState().pending();
+    final var tenantaChangeId =
+        pendingAfterBothStarted.keySet().stream()
+            .filter(id -> id != defaultChangeId)
+            .findFirst()
+            .orElseThrow();
+
+    // then — both plans are pending concurrently, each with its own distinct id
+    assertThat(pendingAfterBothStarted).containsOnlyKeys(defaultChangeId, tenantaChangeId);
+
+    // when — only the default-group change is cancelled
+    coordinator.cancelChange(defaultChangeId).join();
+
+    // then — the default group's change is gone, but tenanta's change is untouched and still
+    // pending — cancelling one concurrent change must not affect the other
+    final var afterCancellingDefault = configuration();
+    assertThat(afterCancellingDefault.phasedChangeState().pending())
+        .containsOnlyKeys(tenantaChangeId);
+    assertThat(
+            afterCancellingDefault
+                .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                .hasPendingChanges())
+        .isFalse();
+    assertThat(afterCancellingDefault.partitionGroup("tenanta").hasPendingChanges()).isTrue();
+
+    // and — the remaining tenanta change can independently be cancelled too
+    coordinator.cancelChange(tenantaChangeId).join();
+    assertThat(configuration().phasedChangeState().pending()).isEmpty();
+    assertThat(configuration().partitionGroup("tenanta").hasPendingChanges()).isFalse();
+  }
+
+  @Test
+  void shouldAllowApplyingANewRequestOnADisjointPartitionGroupWhileOneIsPending() {
+    // given — a plan already pending on "tenanta", never draining on its own (no appliers are
+    // registered for "tenanta" in this test's wiring)
+    wire(MEMBER_0, twoMemberClusterWithSecondGroup());
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                "tenanta", List.of(new PartitionLeaveOperation(MEMBER_0, 2, 1)))))))
+        .join();
+    final var tenantaChangeId = configuration().phasedChangeState().onlyPending().id();
+    final ConfigurationChangeRequest request =
+        current -> Either.right(List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)));
+
+    // when — a request targeting the disjoint "default" group is applied through the real
+    // coordinator
+    final var result = coordinator.applyOperations(request).join();
+
+    // then — admitted with its own distinct id and drains to completion; the tenanta plan is
+    // untouched throughout
+    assertThat(result.changeId()).isNotEqualTo(tenantaChangeId);
+    final var config = configuration();
+    assertThat(config.phasedChangeState().pending()).containsOnlyKeys(tenantaChangeId);
+    assertThat(config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).hasPendingChanges())
+        .isFalse();
+    assertThat(config.partitionGroup("tenanta").hasPendingChanges()).isTrue();
+  }
+
+  @Test
+  void shouldRejectGlobalScopedRequestWhilePartitionGroupChangeIsPending() {
+    // given — a plan pending on the default group only
+    wire(MEMBER_0, twoMemberCluster());
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(new PartitionLeaveOperation(MEMBER_1, 1, 1)))))))
+        .join();
+    final ConfigurationChangeRequest request =
+        current -> Either.right(List.of(new MemberLeaveOperation(MEMBER_1)));
+
+    // when — a global-scoped request is applied while the group-scoped one is still pending
+    final var applyFuture = coordinator.applyOperations(request);
+
+    // then — rejected: a global-scoped change conflicts with everything, even a disjoint group
+    assertThat(applyFuture)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(ConcurrentModificationException.class);
+  }
+
+  @Test
+  void shouldRejectPartitionGroupRequestWhileGlobalChangeIsPending() {
+    // given — a global-scoped plan is pending
+    wire(MEMBER_0, twoMemberCluster());
+    manager
+        .updateMultiConfiguration(
+            c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_1))))))
+        .join();
+    final ConfigurationChangeRequest request =
+        current -> Either.right(List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)));
+
+    // when — a group-scoped request is applied while the global one is still pending
+    final var applyFuture = coordinator.applyOperations(request);
+
+    // then — rejected: everything conflicts with a pending global-scoped change
+    assertThat(applyFuture)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(ConcurrentModificationException.class);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -614,7 +614,7 @@ final class NewModelManagementApiEndpointsTest {
             c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberLeaveOperation(ID_1))))))
         .join();
     final var changeId =
-        manager.getMultiConfiguration().join().phasedChangeState().pending().orElseThrow().id();
+        manager.getMultiConfiguration().join().phasedChangeState().onlyPending().id();
 
     // when — cancelled via the management API endpoint
     final var response = handler.cancelTopologyChange(new CancelChangeRequest(changeId)).join();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
@@ -236,7 +236,7 @@ final class PartitionGroupExporterStateInitializerTest {
                         CurrentClusterConfiguration.DEFAULT_GROUP,
                         List.of(new UpdateRoutingState(LOCAL_MEMBER_ID, Optional.empty()))))),
             Instant.EPOCH);
-    return new PhasedChangeState(Optional.of(plan), Optional.empty());
+    return new PhasedChangeState(1L, Map.of(plan.id(), plan), List.of());
   }
 
   private static PartitionGroupConfiguration groupWithMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -460,7 +460,7 @@ final class ProtoBufSerializerTest {
             CurrentClusterConfiguration.INITIAL_VERSION,
             GlobalConfiguration.init(),
             Map.of(),
-            new PhasedChangeState(Optional.of(plan), Optional.empty()));
+            new PhasedChangeState(2L, Map.of(plan.id(), plan), List.of()));
 
     // when
     final var encoded = protoBufSerializer.encodeCurrentClusterConfiguration(configuration);
@@ -491,7 +491,7 @@ final class ProtoBufSerializerTest {
             CurrentClusterConfiguration.INITIAL_VERSION,
             GlobalConfiguration.init(),
             Map.of(),
-            new PhasedChangeState(Optional.of(plan), Optional.empty()));
+            new PhasedChangeState(2L, Map.of(plan.id(), plan), List.of()));
 
     // when
     final var encoded = protoBufSerializer.encodeCurrentClusterConfiguration(configuration);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -164,7 +164,7 @@ class CurrentClusterConfigurationTest {
       final var migrated = CurrentClusterConfiguration.fromLegacy(legacy).activatePendingPhase();
 
       // then — the ops become three phases in order: [global], [default: 2 partition ops], [global]
-      final var plan = migrated.phasedChangeState().pending().orElseThrow();
+      final var plan = migrated.phasedChangeState().onlyPending();
       assertThat(plan.id()).isEqualTo(9);
       assertThat(plan.currentPhaseIndex()).isZero();
       assertThat(plan.phases())
@@ -224,11 +224,11 @@ class CurrentClusterConfigurationTest {
       final var migrated = CurrentClusterConfiguration.fromLegacy(legacy).activatePendingPhase();
 
       // when — advance to phase 1, exactly as would happen for a plan started via initPlan
-      final var advanced = migrated.activateNextPhase();
+      final var advanced =
+          migrated.activateNextPhase(migrated.phasedChangeState().onlyPending().id());
 
       // then — phase 1 (the default-group phase) is now activated
-      assertThat(advanced.phasedChangeState().pending().orElseThrow().currentPhaseIndex())
-          .isEqualTo(1);
+      assertThat(advanced.phasedChangeState().onlyPending().currentPhaseIndex()).isEqualTo(1);
       assertThat(
               advanced.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).pendingChanges())
           .isPresent();
@@ -278,7 +278,7 @@ class CurrentClusterConfigurationTest {
       // group, endlessly restarting an already in-progress plan from scratch — this was a real
       // regression caught by ExporterEnableTest once a broker/gateway kept re-deriving its topology
       // from repeated legacy gossip.
-      assertThat(migrated.phasedChangeState().pending()).isPresent();
+      assertThat(migrated.phasedChangeState().pending()).isNotEmpty();
       assertThat(
               migrated
                   .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
@@ -364,7 +364,7 @@ class CurrentClusterConfigurationTest {
       final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — the pending plan is assigned the new model's own restore sentinel id
-      final var plan = migrated.phasedChangeState().pending().orElseThrow();
+      final var plan = migrated.phasedChangeState().onlyPending();
       assertThat(plan.id()).isEqualTo(PhasedChangePlan.RESTORED_PLAN_ID);
       assertThat(plan.hasRestorePlanId()).isTrue();
     }
@@ -458,7 +458,7 @@ class CurrentClusterConfigurationTest {
       assertThat(migrated.phasedChangeState().lastChange().orElseThrow().id()).isEqualTo(0);
       final var withPlan =
           migrated.initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
-      assertThat(withPlan.phasedChangeState().pending().orElseThrow().id()).isEqualTo(1);
+      assertThat(withPlan.phasedChangeState().onlyPending().id()).isEqualTo(1);
     }
 
     @Test
@@ -477,7 +477,7 @@ class CurrentClusterConfigurationTest {
       final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — a single GlobalPhase holds both, in order
-      assertThat(migrated.phasedChangeState().pending().orElseThrow().phases())
+      assertThat(migrated.phasedChangeState().onlyPending().phases())
           .containsExactly(new GlobalPhase(List.of(join, leave)));
     }
 
@@ -497,7 +497,7 @@ class CurrentClusterConfigurationTest {
       final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — a single default-group phase holds both, in order
-      assertThat(migrated.phasedChangeState().pending().orElseThrow().phases())
+      assertThat(migrated.phasedChangeState().onlyPending().phases())
           .containsExactly(
               new PartitionGroupParallelPhase(
                   Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, List.of(join, leave))));
@@ -555,7 +555,7 @@ class CurrentClusterConfigurationTest {
       final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — startedAt of the pending plan and both timestamps of the last change are preserved
-      assertThat(migrated.phasedChangeState().pending().orElseThrow().startedAt())
+      assertThat(migrated.phasedChangeState().onlyPending().startedAt())
           .isEqualTo(pendingStartedAt);
       final var lastChange = migrated.phasedChangeState().lastChange().orElseThrow();
       assertThat(lastChange.startedAt()).isEqualTo(Instant.ofEpochSecond(100));
@@ -666,14 +666,16 @@ class CurrentClusterConfigurationTest {
       // given — no pending plan, but different last completed changes
       final var older =
           new PhasedChangeState(
-              Optional.empty(),
-              Optional.of(
+              3L,
+              Map.of(),
+              List.of(
                   new CompletedPhasedChange(
                       2, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH)));
       final var newer =
           new PhasedChangeState(
-              Optional.empty(),
-              Optional.of(
+              6L,
+              Map.of(),
+              List.of(
                   new CompletedPhasedChange(
                       5, PhasedChangePlanStatus.FAILED, Instant.EPOCH, Instant.EPOCH)));
       final var left = config(global(1, Map.of()), Map.of(), older);
@@ -691,9 +693,7 @@ class CurrentClusterConfigurationTest {
       // given — same plan id, this at phase 0, other at phase 1
       final List<Phase> phases = List.of(new GlobalPhase(List.of()), new GlobalPhase(List.of()));
       final var atPhase0 = PhasedChangeState.empty().initPlan(phases);
-      final var atPhase1 =
-          new PhasedChangeState(
-              Optional.of(atPhase0.pending().orElseThrow().withNextPhase()), Optional.empty());
+      final var atPhase1 = atPhase0.withAdvancedPlan(atPhase0.onlyPending().withNextPhase());
       final var left = config(global(1, Map.of()), Map.of(), atPhase0);
       final var right = config(global(1, Map.of()), Map.of(), atPhase1);
 
@@ -701,8 +701,7 @@ class CurrentClusterConfigurationTest {
       final var merged = left.merge(right);
 
       // then — higher phase index wins (delegated to PhasedChangeState/PhasedChangePlan merge)
-      assertThat(merged.phasedChangeState().pending().orElseThrow().currentPhaseIndex())
-          .isEqualTo(1);
+      assertThat(merged.phasedChangeState().onlyPending().currentPhaseIndex()).isEqualTo(1);
     }
   }
 
@@ -781,9 +780,9 @@ class CurrentClusterConfigurationTest {
       final var updated = config.initPlan(List.of(globalPhase()));
 
       // then — the plan is pending at phase 0 (id derived by PhasedChangeState) and activated
-      assertThat(updated.phasedChangeState().pending()).isPresent();
-      assertThat(updated.phasedChangeState().pending().orElseThrow().currentPhaseIndex()).isZero();
-      assertThat(updated.phasedChangeState().pending().orElseThrow().id()).isEqualTo(1);
+      assertThat(updated.phasedChangeState().pending()).isNotEmpty();
+      assertThat(updated.phasedChangeState().onlyPending().currentPhaseIndex()).isZero();
+      assertThat(updated.phasedChangeState().onlyPending().id()).isEqualTo(1);
       assertThat(updated.globalConfiguration().hasPendingChanges()).isTrue();
     }
 
@@ -805,11 +804,10 @@ class CurrentClusterConfigurationTest {
               .initPlan(List.of(globalPhase(), parallelPhase("a")));
 
       // when
-      final var updated = config.activateNextPhase();
+      final var updated = config.activateNextPhase(config.phasedChangeState().onlyPending().id());
 
       // then — now on phase 1, and group "a" has the activated change
-      assertThat(updated.phasedChangeState().pending().orElseThrow().currentPhaseIndex())
-          .isEqualTo(1);
+      assertThat(updated.phasedChangeState().onlyPending().currentPhaseIndex()).isEqualTo(1);
       assertThat(updated.partitionGroup("a").hasPendingChanges()).isTrue();
     }
 
@@ -817,9 +815,11 @@ class CurrentClusterConfigurationTest {
     void shouldThrowWhenActivatingNextPhaseOnLastPhase() {
       // given — a single-phase plan
       final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
+      final var planId = config.phasedChangeState().onlyPending().id();
 
       // when / then
-      assertThatThrownBy(config::activateNextPhase).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> config.activateNextPhase(planId))
+          .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -828,7 +828,8 @@ class CurrentClusterConfigurationTest {
       final var config = CurrentClusterConfiguration.init();
 
       // when / then
-      assertThatThrownBy(config::activateNextPhase).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> config.activateNextPhase(1L))
+          .isInstanceOf(IllegalStateException.class);
     }
 
     @ParameterizedTest
@@ -838,7 +839,8 @@ class CurrentClusterConfigurationTest {
       final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
 
       // when
-      final var completed = config.completePlan(status);
+      final var completed =
+          config.completePlan(config.phasedChangeState().onlyPending().id(), status);
 
       // then — the pending plan is moved into the last completed change with the given status
       assertThat(completed.phasedChangeState().pending()).isEmpty();
@@ -863,7 +865,7 @@ class CurrentClusterConfigurationTest {
       final var config = CurrentClusterConfiguration.init();
 
       // when / then
-      assertThatThrownBy(() -> config.completePlan(PhasedChangePlanStatus.COMPLETED))
+      assertThatThrownBy(() -> config.completePlan(1L, PhasedChangePlanStatus.COMPLETED))
           .isInstanceOf(IllegalStateException.class);
     }
 
@@ -909,7 +911,7 @@ class CurrentClusterConfigurationTest {
       final var config = CurrentClusterConfiguration.init();
 
       // when
-      final var cancelled = config.cancelPendingChanges();
+      final var cancelled = config.cancelPendingChanges(1L);
 
       // then
       assertThat(cancelled).isEqualTo(config);
@@ -921,10 +923,10 @@ class CurrentClusterConfigurationTest {
       final var config =
           CurrentClusterConfiguration.init()
               .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
-      final var changeId = config.phasedChangeState().pending().orElseThrow().id();
+      final var changeId = config.phasedChangeState().onlyPending().id();
 
       // when
-      final var cancelled = config.cancelPendingChanges();
+      final var cancelled = config.cancelPendingChanges(changeId);
 
       // then
       assertThat(cancelled.globalConfiguration().hasPendingChanges()).isFalse();
@@ -951,9 +953,10 @@ class CurrentClusterConfigurationTest {
                               List.of(new DeleteHistoryOperation(MEMBER_0)),
                               "b",
                               List.of(new DeleteHistoryOperation(MEMBER_0))))));
+      final var changeId = config.phasedChangeState().onlyPending().id();
 
       // when
-      final var cancelled = config.cancelPendingChanges();
+      final var cancelled = config.cancelPendingChanges(changeId);
 
       // then
       assertThat(cancelled.partitionGroup("a").hasPendingChanges()).isFalse();
@@ -978,9 +981,10 @@ class CurrentClusterConfigurationTest {
                           Map.of("a", List.of(new DeleteHistoryOperation(MEMBER_0)))),
                       new PartitionGroupParallelPhase(
                           Map.of("b", List.of(new DeleteHistoryOperation(MEMBER_0))))));
+      final var changeId = config.phasedChangeState().onlyPending().id();
 
       // when — cancel while phase 0 is still active
-      final var cancelled = config.cancelPendingChanges();
+      final var cancelled = config.cancelPendingChanges(changeId);
 
       // then — only the already-activated group "a" is cleared; "b" is untouched, still at its
       // original version since it was never activated

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeStateTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeStateTest.java
@@ -12,10 +12,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -23,64 +25,87 @@ class PhasedChangeStateTest {
 
   private static final MemberId MEMBER_1 = MemberId.from("1");
 
-  private final GlobalPhase phase0 = new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_1)));
-  private final GlobalPhase phase1 = new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_1)));
+  private final GlobalPhase globalPhase =
+      new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_1)));
+  private final List<PhasedChangePlan.Phase> twoGlobalPhases = List.of(globalPhase, globalPhase);
 
-  private final List<PhasedChangePlan.Phase> twoPhases = List.of(phase0, phase1);
+  private List<PhasedChangePlan.Phase> groupPhase(final String groupId) {
+    return List.of(
+        new PartitionGroupParallelPhase(
+            Map.of(groupId, List.of(new UpdateIncarnationNumberOperation(MEMBER_1)))));
+  }
 
   @Nested
   class InitPlan {
 
     @Test
-    void shouldStartWithIdOneWhenNoPreviousChange() {
+    void shouldStartWithIdOneWhenEmpty() {
       // given
       final var state = PhasedChangeState.empty();
 
       // when
-      final var next = state.initPlan(twoPhases);
+      final var next = state.initPlan(twoGlobalPhases);
 
       // then
-      assertThat(next.pending()).isPresent();
-      assertThat(next.pending().get().id()).isEqualTo(1L);
+      assertThat(next.pending()).containsOnlyKeys(1L);
+      assertThat(next.pending().get(1L).id()).isEqualTo(1L);
     }
 
     @Test
-    void shouldDeriveNextIdFromLastChange() {
-      // given
-      final var lastChange =
-          new CompletedPhasedChange(
-              7L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH);
-      final var state = new PhasedChangeState(Optional.empty(), Optional.of(lastChange));
+    void shouldIssueIdsFromMonotonicCounterNotFromHistory() {
+      // given — nextId only ever advances forward, independent of what's in history
+      final var state =
+          PhasedChangeState.empty()
+              .initPlan(twoGlobalPhases)
+              .completePlan(1L, PhasedChangePlanStatus.COMPLETED, 10);
 
       // when
-      final var next = state.initPlan(twoPhases);
+      final var next = state.initPlan(twoGlobalPhases);
 
       // then
-      assertThat(next.pending().get().id()).isEqualTo(8L);
+      assertThat(next.pending().keySet()).containsExactly(2L);
     }
 
     @Test
-    void shouldRetainLastChangeAfterInitPlan() {
+    void shouldAllowConcurrentPendingPlansWithDisjointGroupScopes() {
       // given
-      final var lastChange =
-          new CompletedPhasedChange(
-              3L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH);
-      final var state = new PhasedChangeState(Optional.empty(), Optional.of(lastChange));
+      final var withTenantA = PhasedChangeState.empty().initPlan(groupPhase("tenantA"));
 
-      // when
-      final var next = state.initPlan(twoPhases);
+      // when — a second, non-conflicting plan for a different tenant
+      final var withBoth = withTenantA.initPlan(groupPhase("tenantB"));
 
       // then
-      assertThat(next.lastChange()).contains(lastChange);
+      assertThat(withBoth.pending()).containsOnlyKeys(1L, 2L);
     }
 
     @Test
-    void shouldThrowWhenPlanAlreadyPending() {
+    void shouldRejectSecondPlanTargetingSameGroup() {
       // given
-      final var state = PhasedChangeState.empty().initPlan(twoPhases);
+      final var withTenantA = PhasedChangeState.empty().initPlan(groupPhase("tenantA"));
 
       // when / then
-      assertThatThrownBy(() -> state.initPlan(twoPhases)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> withTenantA.initPlan(groupPhase("tenantA")))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRejectGlobalPlanWhileAnyPlanIsPending() {
+      // given
+      final var withTenantA = PhasedChangeState.empty().initPlan(groupPhase("tenantA"));
+
+      // when / then
+      assertThatThrownBy(() -> withTenantA.initPlan(twoGlobalPhases))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRejectGroupPlanWhileGlobalPlanIsPending() {
+      // given
+      final var withGlobal = PhasedChangeState.empty().initPlan(twoGlobalPhases);
+
+      // when / then
+      assertThatThrownBy(() -> withGlobal.initPlan(groupPhase("tenantA")))
+          .isInstanceOf(IllegalStateException.class);
     }
   }
 
@@ -88,42 +113,110 @@ class PhasedChangeStateTest {
   class CompletePlan {
 
     @Test
-    void shouldMovePendingToLastChange() {
-      // given
-      final var state = PhasedChangeState.empty().initPlan(twoPhases);
-      final long planId = state.pending().get().id();
+    void shouldMoveOnlyTheCompletedPlanToHistory() {
+      // given — two concurrently pending plans
+      final var state =
+          PhasedChangeState.empty().initPlan(groupPhase("tenantA")).initPlan(groupPhase("tenantB"));
 
       // when
-      final var completed = state.completePlan(PhasedChangePlanStatus.COMPLETED);
+      final var completed = state.completePlan(1L, PhasedChangePlanStatus.COMPLETED, 10);
 
-      // then
-      assertThat(completed.pending()).isEmpty();
-      assertThat(completed.lastChange()).isPresent();
-      assertThat(completed.lastChange().get().id()).isEqualTo(planId);
-      assertThat(completed.lastChange().get().status()).isEqualTo(PhasedChangePlanStatus.COMPLETED);
+      // then — tenantA resolved, tenantB still pending and untouched
+      assertThat(completed.pending()).containsOnlyKeys(2L);
+      assertThat(completed.history()).extracting(CompletedPhasedChange::id).containsExactly(1L);
+      assertThat(completed.history().get(0).status()).isEqualTo(PhasedChangePlanStatus.COMPLETED);
     }
 
     @Test
-    void shouldPreserveStartedAtTimestamp() {
-      // given
-      final var state = PhasedChangeState.empty().initPlan(twoPhases);
-      final var expectedStartedAt = state.pending().get().startedAt();
+    void shouldTrimHistoryToTheConfiguredLimit() {
+      // given / when — five plans completed one at a time, history capped at 2
+      var state = PhasedChangeState.empty();
+      for (int i = 0; i < 5; i++) {
+        final long id = state.nextId();
+        state =
+            state.initPlan(twoGlobalPhases).completePlan(id, PhasedChangePlanStatus.COMPLETED, 2);
+      }
 
-      // when
-      final var completed = state.completePlan(PhasedChangePlanStatus.COMPLETED);
-
-      // then
-      assertThat(completed.lastChange().get().startedAt()).isEqualTo(expectedStartedAt);
+      // then — only the two most recent completions survive
+      assertThat(state.history()).extracting(CompletedPhasedChange::id).containsExactly(4L, 5L);
     }
 
     @Test
-    void shouldThrowWhenNoPlanPending() {
+    void shouldThrowWhenPlanNotPending() {
       // given
       final var state = PhasedChangeState.empty();
 
       // when / then
-      assertThatThrownBy(() -> state.completePlan(PhasedChangePlanStatus.COMPLETED))
+      assertThatThrownBy(() -> state.completePlan(1L, PhasedChangePlanStatus.COMPLETED, 10))
           .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldEvictByCompletionOrderNotById() {
+      // given — two concurrently pending plans; tenantB (id=2, admitted second) completes first
+      final var bothPending =
+          PhasedChangeState.empty().initPlan(groupPhase("tenantA")).initPlan(groupPhase("tenantB"));
+      final var tenantBCompletedFirst =
+          bothPending.completePlan(2L, PhasedChangePlanStatus.COMPLETED, 1);
+
+      // when — tenantA (id=1, admitted first but slower) completes chronologically later, with
+      // the history capped to a single entry
+      final var tenantACompletedSecond =
+          tenantBCompletedFirst.completePlan(1L, PhasedChangePlanStatus.COMPLETED, 1);
+
+      // then — the entry retained is the one that finished most recently (id=1), not the lower id
+      assertThat(tenantACompletedSecond.history())
+          .extracting(CompletedPhasedChange::id)
+          .containsExactly(1L);
+    }
+  }
+
+  @Nested
+  class LastChange {
+
+    @Test
+    void shouldOrderByCompletedAtNotById() {
+      // given — id=1 (tenant A, admitted first) finishes later than id=2 (tenant B, admitted
+      // after A but faster)
+      final var tenantA =
+          new CompletedPhasedChange(
+              1L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.ofEpochSecond(100));
+      final var tenantB =
+          new CompletedPhasedChange(
+              2L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.ofEpochSecond(50));
+      final var state = new PhasedChangeState(3L, Map.of(), List.of(tenantA, tenantB));
+
+      // when / then — the change that finished later (tenantA, id=1) is "last", not the higher id
+      assertThat(state.lastChange()).contains(tenantA);
+    }
+  }
+
+  @Nested
+  class WasIssued {
+
+    @Test
+    void shouldReportPendingIdAsIssued() {
+      final var state = PhasedChangeState.empty().initPlan(twoGlobalPhases);
+      assertThat(state.wasIssued(1L)).isTrue();
+    }
+
+    @Test
+    void shouldReportResolvedIdAsIssuedEvenAfterAgingOutOfHistory() {
+      var state = PhasedChangeState.empty();
+      for (int i = 0; i < 5; i++) {
+        final long id = state.nextId();
+        state =
+            state.initPlan(twoGlobalPhases).completePlan(id, PhasedChangePlanStatus.COMPLETED, 1);
+      }
+      // id=1 is long gone from the bounded history window, but it was issued
+      assertThat(state.history()).extracting(CompletedPhasedChange::id).doesNotContain(1L);
+      assertThat(state.wasIssued(1L)).isTrue();
+    }
+
+    @Test
+    void shouldReportNeverIssuedIdAsNotIssued() {
+      final var state = PhasedChangeState.empty().initPlan(twoGlobalPhases);
+      assertThat(state.wasIssued(99L)).isFalse();
     }
   }
 
@@ -132,97 +225,98 @@ class PhasedChangeStateTest {
 
     @Test
     void shouldReturnEmptyWhenBothEmpty() {
-      // given
-      final var a = PhasedChangeState.empty();
-      final var b = PhasedChangeState.empty();
-
-      // when
-      final var merged = a.merge(b);
-
-      // then
+      final var merged = PhasedChangeState.empty().merge(PhasedChangeState.empty());
       assertThat(merged.pending()).isEmpty();
-      assertThat(merged.lastChange()).isEmpty();
+      assertThat(merged.history()).isEmpty();
+      assertThat(merged.nextId()).isEqualTo(PhasedChangePlan.INITIAL_PLAN_ID);
     }
 
     @Test
-    void shouldAdoptPendingPlanFromOtherWhenThisHasNone() {
-      // given
-      final var withPlan = PhasedChangeState.empty().initPlan(twoPhases);
-      final var withoutPlan = PhasedChangeState.empty();
+    void shouldUnionDisjointPendingPlansFromBothSides() {
+      // given — the coordinator (the single admission point, so ids are always distinct) admits
+      // two concurrent, non-conflicting plans; one node's local state has only observed the first
+      // gossip update (tenantA) and the other has observed both
+      final var withOnlyTenantA = PhasedChangeState.empty().initPlan(groupPhase("tenantA"));
+      final var withBoth = withOnlyTenantA.initPlan(groupPhase("tenantB"));
 
       // when
-      final var merged = withoutPlan.merge(withPlan);
+      final var merged = withOnlyTenantA.merge(withBoth);
 
-      // then
-      assertThat(merged.pending()).isEqualTo(withPlan.pending());
+      // then — both survive with their own distinct ids, and the counter takes the max
+      assertThat(merged.pending()).containsOnlyKeys(1L, 2L);
+      assertThat(merged.nextId()).isEqualTo(3L);
     }
 
     @Test
-    void shouldUsePlanMergeSemanticForPendingPlans() {
-      // given — same plan ID, this is at phase 0, other is at phase 1
-      final var earlier = PhasedChangeState.empty().initPlan(twoPhases);
-      final var planId = earlier.pending().get().id();
-      final var advancedPlan = earlier.pending().get().withNextPhase();
-      final var later = new PhasedChangeState(Optional.of(advancedPlan), Optional.empty());
+    void shouldTakeHigherPhaseIndexForSamePlanIdOnMerge() {
+      // given — same plan id, one side advanced further
+      final var earlier = PhasedChangeState.empty().initPlan(twoGlobalPhases);
+      final var advancedPlan = earlier.pending().get(1L).withNextPhase();
+      final var later = earlier.withAdvancedPlan(advancedPlan);
 
       // when
       final var merged = earlier.merge(later);
 
-      // then — higher phase index wins
-      assertThat(merged.pending().get().currentPhaseIndex()).isEqualTo(1);
-      assertThat(merged.pending().get().id()).isEqualTo(planId);
+      // then
+      assertThat(merged.pending().get(1L).currentPhaseIndex()).isEqualTo(1);
     }
 
     @Test
-    void shouldTakeLastChangeWithHigherId() {
-      // given
-      final var older =
-          new CompletedPhasedChange(
-              2L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH);
-      final var newer =
-          new CompletedPhasedChange(
-              5L, PhasedChangePlanStatus.FAILED, Instant.EPOCH, Instant.EPOCH);
-      final var a = new PhasedChangeState(Optional.empty(), Optional.of(older));
-      final var b = new PhasedChangeState(Optional.empty(), Optional.of(newer));
-
-      // when / then
-      assertThat(a.merge(b).lastChange()).contains(newer);
-      assertThat(b.merge(a).lastChange()).contains(newer);
-    }
-
-    @Test
-    void shouldAdoptLastChangeFromOtherWhenThisHasNone() {
-      // given
-      final var lastChange =
-          new CompletedPhasedChange(
-              1L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH);
-      final var withLast = new PhasedChangeState(Optional.empty(), Optional.of(lastChange));
-      final var withoutLast = PhasedChangeState.empty();
+    void shouldDropPendingPlanSupersededByHistoryOnMerge() {
+      // given — one side still thinks plan 1 is pending; the other already completed it
+      final var stillPending = PhasedChangeState.empty().initPlan(twoGlobalPhases);
+      final var alreadyCompleted =
+          stillPending.completePlan(1L, PhasedChangePlanStatus.COMPLETED, 10);
 
       // when
-      final var merged = withoutLast.merge(withLast);
+      final var merged = stillPending.merge(alreadyCompleted);
 
       // then
-      assertThat(merged.lastChange()).contains(lastChange);
+      assertThat(merged.pending()).isEmpty();
+      assertThat(merged.history()).extracting(CompletedPhasedChange::id).containsExactly(1L);
     }
-  }
-
-  @Nested
-  class IdMonotonicity {
 
     @Test
-    void shouldAlwaysIncreaseIdAcrossInitAndComplete() {
-      // given / when — three consecutive init+complete cycles
-      var state = PhasedChangeState.empty();
-      long previousId = 0L;
+    void shouldUnionHistoryEntriesFromBothSides() {
+      final var withOne =
+          PhasedChangeState.empty()
+              .initPlan(groupPhase("tenantA"))
+              .completePlan(1L, PhasedChangePlanStatus.COMPLETED, 10);
+      final var withTwo =
+          withOne
+              .initPlan(groupPhase("tenantA"))
+              .completePlan(2L, PhasedChangePlanStatus.FAILED, 10);
 
-      for (int i = 0; i < 3; i++) {
-        state = state.initPlan(twoPhases);
-        final long currentId = state.pending().get().id();
-        assertThat(currentId).isGreaterThan(previousId);
-        previousId = currentId;
-        state = state.completePlan(PhasedChangePlanStatus.COMPLETED);
-      }
+      final var merged = withOne.merge(withTwo);
+
+      assertThat(merged.history()).extracting(CompletedPhasedChange::id).containsExactly(1L, 2L);
+    }
+
+    @Test
+    void shouldTrimUnionedHistoryBackToTheLargerSidesSize() {
+      // given — the left side was trimmed to 1 entry (id=2); the right side still has 2 entries
+      // (id=1 and id=2) from before it last trimmed
+      final var older =
+          new CompletedPhasedChange(
+              1L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.ofEpochSecond(1));
+      final var newer =
+          new CompletedPhasedChange(
+              2L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.ofEpochSecond(2));
+      final var left = new PhasedChangeState(3L, Map.of(), List.of(newer));
+      final var right = new PhasedChangeState(3L, Map.of(), List.of(older, newer));
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — the union (2 entries) is trimmed back to the larger side's size (2), so nothing is
+      // dropped here, but repeated merges never grow history past what either side already holds
+      assertThat(merged.history()).extracting(CompletedPhasedChange::id).containsExactly(1L, 2L);
+
+      // and — merging a much smaller, unrelated history back in does not let the result balloon
+      // past the larger side
+      final var third = new PhasedChangeState(3L, Map.of(), List.of(newer));
+      final var mergedAgain = merged.merge(third);
+      assertThat(mergedAgain.history()).hasSizeLessThanOrEqualTo(2);
     }
   }
 
@@ -230,53 +324,23 @@ class PhasedChangeStateTest {
   class Invariants {
 
     @Test
-    void shouldThrowWhenPendingIdEqualsLastChangeId() {
-      // given
-      final var plan = PhasedChangePlan.init(3L, twoPhases, Instant.EPOCH);
-      final var completed =
-          new CompletedPhasedChange(
-              3L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH);
-
-      // when / then
-      assertThatThrownBy(() -> new PhasedChangeState(Optional.of(plan), Optional.of(completed)))
+    void shouldThrowWhenNextIdIsBelowInitialPlanId() {
+      assertThatThrownBy(() -> new PhasedChangeState(0L, Map.of(), List.of()))
           .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void shouldThrowWhenPendingIdIsLowerThanLastChangeId() {
-      // given
-      final var plan = PhasedChangePlan.init(2L, twoPhases, Instant.EPOCH);
-      final var completed =
-          new CompletedPhasedChange(
-              5L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH);
-
-      // when / then
-      assertThatThrownBy(() -> new PhasedChangeState(Optional.of(plan), Optional.of(completed)))
+    void shouldThrowWhenPendingKeyDoesNotMatchPlanId() {
+      final var plan = PhasedChangePlan.init(1L, twoGlobalPhases, Instant.EPOCH);
+      assertThatThrownBy(() -> new PhasedChangeState(2L, Map.of(2L, plan), List.of()))
           .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void shouldDropPendingPlanSupersededByLastChangeOnMerge() {
-      // given — one side has pending plan id=3 (previously completed by the other side)
-      final var stateWithPending =
-          new PhasedChangeState(
-              Optional.of(PhasedChangePlan.init(3L, twoPhases, Instant.EPOCH)),
-              Optional.of(
-                  new CompletedPhasedChange(
-                      2L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH)));
-      final var stateWithCompleted =
-          new PhasedChangeState(
-              Optional.empty(),
-              Optional.of(
-                  new CompletedPhasedChange(
-                      3L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH)));
-
-      // when
-      final var merged = stateWithPending.merge(stateWithCompleted);
-
-      // then — the pending plan is superseded by the completed change
-      assertThat(merged.pending()).isEmpty();
-      assertThat(merged.lastChange().get().id()).isEqualTo(3L);
+    void shouldThrowWhenPendingIdIsNotBelowNextId() {
+      final var plan = PhasedChangePlan.init(3L, twoGlobalPhases, Instant.EPOCH);
+      assertThatThrownBy(() -> new PhasedChangeState(3L, Map.of(3L, plan), List.of()))
+          .isInstanceOf(IllegalArgumentException.class);
     }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeStateTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeStateTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncar
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
@@ -293,30 +294,158 @@ class PhasedChangeStateTest {
     }
 
     @Test
-    void shouldTrimUnionedHistoryBackToTheLargerSidesSize() {
-      // given — the left side was trimmed to 1 entry (id=2); the right side still has 2 entries
-      // (id=1 and id=2) from before it last trimmed
-      final var older =
-          new CompletedPhasedChange(
-              1L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.ofEpochSecond(1));
-      final var newer =
-          new CompletedPhasedChange(
-              2L, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.ofEpochSecond(2));
-      final var left = new PhasedChangeState(3L, Map.of(), List.of(newer));
-      final var right = new PhasedChangeState(3L, Map.of(), List.of(older, newer));
+    void shouldTrimUnionedHistoryToTheFixedDefaultLimitRegardlessOfEitherSidesSize() {
+      // given — 11 completions (one more than DEFAULT_HISTORY_LIMIT), split so neither side alone
+      // exceeds the limit, but their union does
+      final var all = completedChangesWithSequentialCompletionTimes(11);
+      final var left = historyOnlyState(11L, all.subList(0, 5));
+      final var right = historyOnlyState(11L, all.subList(5, 11));
 
       // when
       final var merged = left.merge(right);
 
-      // then — the union (2 entries) is trimmed back to the larger side's size (2), so nothing is
-      // dropped here, but repeated merges never grow history past what either side already holds
-      assertThat(merged.history()).extracting(CompletedPhasedChange::id).containsExactly(1L, 2L);
+      // then — trimmed to exactly DEFAULT_HISTORY_LIMIT entries, dropping only the very oldest
+      // (id=0); this is a FIXED cap, not derived from either side's size (5 and 6, neither of
+      // which is 10)
+      assertThat(merged.history())
+          .extracting(CompletedPhasedChange::id)
+          .containsExactly(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
+    }
 
-      // and — merging a much smaller, unrelated history back in does not let the result balloon
-      // past the larger side
-      final var third = new PhasedChangeState(3L, Map.of(), List.of(newer));
-      final var mergedAgain = merged.merge(third);
-      assertThat(mergedAgain.history()).hasSizeLessThanOrEqualTo(2);
+    @Test
+    void shouldConvergeHistoryToTheSameResultRegardlessOfMergeOrder() {
+      // given — 11 completions split three ways across nodes A, B, C
+      final var all = completedChangesWithSequentialCompletionTimes(11);
+      final var a = historyOnlyState(11L, all.subList(0, 4));
+      final var b = historyOnlyState(11L, all.subList(4, 7));
+      final var c = historyOnlyState(11L, all.subList(7, 11));
+
+      // when — merged in every possible pairwise order
+      final var abThenC = a.merge(b).merge(c);
+      final var acThenB = a.merge(c).merge(b);
+      final var bcThenA = b.merge(c).merge(a);
+      final var baThenC = b.merge(a).merge(c);
+
+      // then — every order converges to the identical trimmed history; a size-derived cap (the
+      // previous behaviour) would make this depend on which nodes happened to merge first
+      assertThat(abThenC.history()).isEqualTo(acThenB.history());
+      assertThat(abThenC.history()).isEqualTo(bcThenA.history());
+      assertThat(abThenC.history()).isEqualTo(baThenC.history());
+    }
+
+    @Test
+    void shouldDropStaleResurrectedPendingEntryEvenAfterItHasAgedOutOfHistory() {
+      // given — a broker went offline while plan 1 (tenantA) was pending, then stayed offline
+      // through 11 unrelated completions elsewhere, long enough for plan 1's own completion record
+      // to age out of the (fixed, DEFAULT_HISTORY_LIMIT-sized) history window entirely
+      var upToDate =
+          PhasedChangeState.empty()
+              .initPlan(groupPhase("tenantA"))
+              .completePlan(
+                  1L, PhasedChangePlanStatus.COMPLETED, PhasedChangeState.DEFAULT_HISTORY_LIMIT);
+      for (int i = 0; i < PhasedChangeState.DEFAULT_HISTORY_LIMIT; i++) {
+        final long id = upToDate.nextId();
+        upToDate =
+            upToDate
+                .initPlan(twoGlobalPhases)
+                .completePlan(
+                    id, PhasedChangePlanStatus.COMPLETED, PhasedChangeState.DEFAULT_HISTORY_LIMIT);
+      }
+      assertThat(upToDate.history()).extracting(CompletedPhasedChange::id).doesNotContain(1L);
+      final var staleBroker =
+          new PhasedChangeState(2L, Map.of(1L, planFor(1L, groupPhase("tenantA"))), List.of());
+
+      // when
+      final var merged = upToDate.merge(staleBroker);
+
+      // then — plan 1 does not resurrect: upToDate's own nextId/pending already prove it resolved,
+      // independent of whether history still remembers it
+      assertThat(merged.pending()).doesNotContainKey(1L);
+    }
+
+    @Test
+    void shouldDropTheStaleEntryButKeepALegitimateConcurrentPlanForTheSameGroup() {
+      // given — same resurrection as above, but tenantA now also has a genuinely live change (12)
+      // running concurrently
+      final var upToDate =
+          new PhasedChangeState(13L, Map.of(12L, planFor(12L, groupPhase("tenantA"))), List.of());
+      final var staleBroker =
+          new PhasedChangeState(2L, Map.of(1L, planFor(1L, groupPhase("tenantA"))), List.of());
+
+      // when
+      final var merged = upToDate.merge(staleBroker);
+
+      // then — the stale, lower-id entry for tenantA is dropped; the legitimate one survives.
+      // Without this fix both would coexist, violating "one pending plan per group".
+      assertThat(merged.pending()).containsOnlyKeys(12L);
+    }
+
+    @Test
+    void shouldNotDropAPendingEntryWhenTheOtherSideHasNotWitnessedThatFarYet() {
+      // given — a fresh/lagging node that has never witnessed id 6 being admitted at all (its own
+      // nextId is still 1), merging with a node for which plan 6 is genuinely, currently pending
+      final var withPlanSix =
+          new PhasedChangeState(7L, Map.of(6L, planFor(6L, groupPhase("tenantB"))), List.of());
+      final var lagging = PhasedChangeState.empty();
+
+      // when
+      final var merged = withPlanSix.merge(lagging);
+
+      // then — id 6 is kept: the lagging side's absence of it proves nothing, since it hasn't
+      // witnessed far enough for that absence to mean "resolved" rather than "not yet known"
+      assertThat(merged.pending()).containsOnlyKeys(6L);
+    }
+
+    @Test
+    void shouldFallBackToHistoryToResolveAStaleRestoredPlanId() {
+      // given — RESTORED_PLAN_ID (0) bypasses the nextId counter entirely (assigned directly
+      // during legacy migration), so nextId alone can never prove it resolved: every state's
+      // nextId is already >= INITIAL_PLAN_ID (1), i.e. trivially "past" id 0, even for a state
+      // that has never witnessed it. The bounded history is the only signal available for this
+      // one id, which is acceptable since a restore happens at most once per cluster lifetime.
+      final var restorePlan = PhasedChangePlan.initForRestore(groupPhase("tenantA"), Instant.EPOCH);
+      final var resolvedRestore =
+          new CompletedPhasedChange(
+              PhasedChangePlan.RESTORED_PLAN_ID,
+              PhasedChangePlanStatus.COMPLETED,
+              Instant.EPOCH,
+              Instant.EPOCH);
+      final var upToDate = new PhasedChangeState(5L, Map.of(), List.of(resolvedRestore));
+      final var staleBroker =
+          new PhasedChangeState(
+              1L, Map.of(PhasedChangePlan.RESTORED_PLAN_ID, restorePlan), List.of());
+
+      // when
+      final var merged = upToDate.merge(staleBroker);
+
+      // then
+      assertThat(merged.pending()).doesNotContainKey(PhasedChangePlan.RESTORED_PLAN_ID);
+    }
+
+    /**
+     * Returns {@code count} completed changes with ids {@code 0..count-1} and strictly increasing
+     * {@code completedAt} timestamps (so id order and completion order coincide, for readable test
+     * assertions), all with distinct {@code startedAt} to avoid incidental equality.
+     */
+    private List<CompletedPhasedChange> completedChangesWithSequentialCompletionTimes(
+        final int count) {
+      final List<CompletedPhasedChange> result = new ArrayList<>();
+      for (int i = 0; i < count; i++) {
+        result.add(
+            new CompletedPhasedChange(
+                i, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH.plusSeconds(i)));
+      }
+      return result;
+    }
+
+    /** A state with no pending plans, only the given (already-resolved) history entries. */
+    private PhasedChangeState historyOnlyState(
+        final long nextId, final List<CompletedPhasedChange> history) {
+      return new PhasedChangeState(nextId, Map.of(), history);
+    }
+
+    private PhasedChangePlan planFor(final long id, final List<PhasedChangePlan.Phase> phases) {
+      return PhasedChangePlan.init(id, phases, Instant.EPOCH);
     }
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -40,7 +40,9 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPar
 import io.camunda.zeebe.util.ReflectUtil;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
@@ -274,27 +276,36 @@ public final class ClusterTopologyDomain extends DomainContextBase {
 
   @Provide
   Arbitrary<PhasedChangeState> phasedChangeStates() {
-    return completedPhasedChanges()
-        .optional()
-        .flatMap(
-            lastChange -> {
-              // Pending plan id must be positive and greater than the last completed change id.
-              final long minPendingId = lastChange.map(c -> c.id() + 1).orElse(1L);
-              return phasedChangePlans(minPendingId)
-                  .optional()
-                  .map(pending -> new PhasedChangeState(pending, lastChange));
-            });
-  }
-
-  Arbitrary<PhasedChangePlan> phasedChangePlans(final long minId) {
-    final var id = Arbitraries.longs().between(minId, minId + 1000);
-    final var phases = phases().list().ofMinSize(1).ofMaxSize(4);
-    return Combinators.combine(id, phases, nanoPrecisionInstants())
+    // History ids are reassigned sequentially from 0, and an optional pending plan (if any) gets
+    // the next id after that — this keeps every id below nextId, satisfying PhasedChangeState's
+    // invariant, while still exercising arbitrary statuses/timestamps/phases via the existing
+    // completedPhasedChanges()/phases() generators.
+    final var rawHistory = completedPhasedChanges().list().ofMaxSize(3);
+    final var maybePhaseList = phases().list().ofMinSize(1).ofMaxSize(4).optional();
+    return Combinators.combine(rawHistory, maybePhaseList, nanoPrecisionInstants())
         .flatAs(
-            (planId, phaseList, startedAt) ->
-                Arbitraries.integers()
-                    .between(0, phaseList.size() - 1)
-                    .map(index -> new PhasedChangePlan(planId, index, phaseList, startedAt)));
+            (raw, maybePhases, pendingStartedAt) -> {
+              final List<CompletedPhasedChange> history = new ArrayList<>();
+              for (int i = 0; i < raw.size(); i++) {
+                final var c = raw.get(i);
+                history.add(
+                    new CompletedPhasedChange(i, c.status(), c.startedAt(), c.completedAt()));
+              }
+              final long pendingId = Math.max(history.size(), PhasedChangePlan.INITIAL_PLAN_ID);
+              if (maybePhases.isEmpty()) {
+                return Arbitraries.just(new PhasedChangeState(pendingId, Map.of(), history));
+              }
+              final var phaseList = maybePhases.get();
+              return Arbitraries.integers()
+                  .between(0, phaseList.size() - 1)
+                  .map(
+                      index -> {
+                        final var plan =
+                            new PhasedChangePlan(pendingId, index, phaseList, pendingStartedAt);
+                        return new PhasedChangeState(
+                            pendingId + 1, Map.of(pendingId, plan), history);
+                      });
+            });
   }
 
   @Provide

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/startup/VolumeDataRestorationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/startup/VolumeDataRestorationIT.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -36,6 +37,10 @@ import org.junit.jupiter.api.io.TempDir;
  *   <li>Verify the broker can activate and complete the pending job
  * </ol>
  */
+// Re-enable after a new SNAPSHOT image is generated after
+// https://github.com/camunda/camunda/pull/59859
+@Disabled(
+    "Temporarily disabled as there is a breaking change from previous SNAPSHOT that cause this test to fail.")
 class VolumeDataRestorationIT {
 
   private static final String PROCESS_ID = "volume-restore-test";


### PR DESCRIPTION
## Summary

**Problem**

`PhasedChangeState` held at most one pending `PhasedChangePlan` for the entire cluster, so a change on one physical tenant's partition group blocked any change on every other tenant, and cancelling had no way to target a specific change once several could be in flight.

**Solution**
- Reshapes `PhasedChangeState` to a monotonic id counter + map of concurrently pending plans keyed by id + a bounded, completion-time-ordered window of recently completed changes. 
   -  `record PhasedChangeState(long nextId, Map<Long, PhasedChangePlan> pending, List<CompletedPhasedChange> history)`
   - Keeps a longer history of completed changes, so that the completed changes from independent/concurrent requests are available to query for a longer time.

-  Accepting a new configuration change is done via a single scope-conflict rule 
    - Conflict detected if the scope for the new and any of the pending plans overlaps.
   
| New request scope | Pending plans | Conflict? | Result |
|---|---|---|---|
| `Groups(tenantA)` | `Groups(tenantB)`, `Groups(tenantC)` | No overlap with either | **Accepted** — runs concurrently |
| `Groups(tenantB)` | `Groups(tenantB)`, `Groups(tenantC)` | Overlaps `tenantB` | **Rejected** — `ConcurrentModificationException` |
| `Groups(tenantA, tenantB)` | `Groups(tenantB)` | Overlaps `tenantB` | **Rejected** |
| `Global` | `Groups(tenantB)` | `Global` conflicts with everything | **Rejected** |
| `Groups(tenantA)` | `Global` | Everything conflicts with `Global` | **Rejected** |
| `Global` | *(none pending)* | No pending plans | **Accepted** |

- Cancellation is keyed by id and only touches the target plan's own sub-configuration(s).

BREAKING CHANGE: Changes the protobuf for PhasedChangeState. This is acceptable as the previous schema is not released yet. 

closes #58502.
