### PR TITLE
feat: make secret cache hits, evictions and size observable per store

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -15,7 +15,6 @@ import io.camunda.configuration.Secrets.FileStore;
 import io.camunda.configuration.Secrets.GcpSecretManagerStore;
 import io.camunda.configuration.Secrets.Stores;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
-import io.camunda.secretstore.CaffeineSecretCache;
 import io.camunda.secretstore.NoopSecretStore;
 import io.camunda.secretstore.SecretCacheFactory;
 import io.camunda.secretstore.SecretStore;
@@ -189,9 +188,8 @@ public class SecretStoreConfiguration {
       final Secrets.Cache config,
       final InstantSource timeSource,
       final MeterRegistry meterRegistry) {
-    return storeId ->
-        CaffeineSecretCache.create(
-            config.getMaxSize(), config.getTtl(), timeSource, meterRegistry, storeId);
+    return SecretCacheFactory.metered(
+        config.getMaxSize(), config.getTtl(), timeSource, meterRegistry);
   }
 
   private static void closeAll(final List<SecretStore> stores) {

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -26,6 +26,10 @@ import io.camunda.secretstore.file.FileBasedSecretStore;
 import io.camunda.secretstore.gcp.GcpSecretManagerSecretStore;
 import io.camunda.secretstore.gcp.GcpSecretManagerStoreConfig;
 import io.camunda.zeebe.shared.management.ActorClockService;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.InstantSource;
@@ -62,23 +66,44 @@ public class SecretStoreConfiguration {
           new StoreBinding<>(
               "gcp", "GCP Secret Manager", Stores::getGcp, SecretStoreConfiguration::gcpStore));
 
+  /**
+   * @param meterRegistry the cluster-wide registry each physical tenant's secret cache meters are
+   *     forwarded to. Each tenant gets its own {@link MicrometerUtil#wrap wrapped registry} tagging
+   *     them with {@link PartitionKeyNames#PHYSICAL_TENANT}, as {@code RdbmsDataSources} does for
+   *     its pools — a store ID is unique only within a tenant, and {@link SecretStoreRegistry}'s
+   *     four-argument constructor documents what sharing a series between two would do.
+   */
   @Bean
   public SecretStoreRegistries secretStoreRegistries(
-      final PhysicalTenantResolver resolver, final ActorClockService clockService) {
+      final PhysicalTenantResolver resolver,
+      final ActorClockService clockService,
+      final MeterRegistry meterRegistry) {
     final Map<String, SecretStoreRegistry> registries = new LinkedHashMap<>();
     // tracks every store successfully constructed across all tenants processed so far, so a
     // failure partway through (e.g. a later tenant's AWS store failing to build) can close
     // them instead of leaking their underlying clients/connections
     final List<SecretStore> created = new ArrayList<>();
+    // tracked for the same reason: a wrapped registry left behind by a failed startup would keep
+    // publishing the meters of a cache nothing resolves through
+    final List<MeterRegistry> tenantMeterRegistries = new ArrayList<>();
     final var timeSource = new ActorClockInstantSource(clockService);
     try {
       resolver
           .mapValues(Camunda::getSecrets)
           .forEach(
               (tenantId, secrets) ->
-                  registries.put(tenantId, buildRegistry(tenantId, secrets, created, timeSource)));
+                  registries.put(
+                      tenantId,
+                      buildRegistry(
+                          tenantId,
+                          secrets,
+                          created,
+                          timeSource,
+                          meterRegistry,
+                          tenantMeterRegistries)));
     } catch (final RuntimeException e) {
       closeAll(created);
+      tenantMeterRegistries.forEach(MicrometerUtil::close);
       throw e;
     }
     return new SecretStoreRegistries(Map.copyOf(registries));
@@ -88,7 +113,9 @@ public class SecretStoreConfiguration {
       final String tenantId,
       final Secrets secrets,
       final List<SecretStore> created,
-      final InstantSource timeSource) {
+      final InstantSource timeSource,
+      final MeterRegistry meterRegistry,
+      final List<MeterRegistry> tenantMeterRegistries) {
     final Stores config = secrets.getStores();
     // cap is one store total per tenant, counted across all store types combined
     final long totalStores =
@@ -128,9 +155,20 @@ public class SecretStoreConfiguration {
     if (stores.isEmpty()) {
       stores.put(SecretStoreRegistry.DEFAULT_STORE_ID, NOOP_STORE);
       LOG.info("No secret stores configured for physical tenant '{}', using noop store", tenantId);
+      // the three-argument constructor leaves the default cache publishing nothing: the noop store
+      // caches nothing, so its hit rate would read 0% forever against no TTL or size to tune
+      return new SecretStoreRegistry(Map.copyOf(stores), Map.of(), timeSource);
     }
+    // wrapped only now that the tenant is known to have a store worth measuring, so a tenant that
+    // fails the rules above never leaves a registry behind either
+    final var tenantMeterRegistry =
+        MicrometerUtil.wrap(
+            meterRegistry, Tags.of(PartitionKeyNames.PHYSICAL_TENANT.asString(), tenantId));
+    tenantMeterRegistries.add(tenantMeterRegistry);
     return new SecretStoreRegistry(
-        Map.copyOf(stores), caches(stores.keySet(), cacheConfig, timeSource), timeSource);
+        Map.copyOf(stores),
+        caches(stores.keySet(), cacheConfig, timeSource, tenantMeterRegistry),
+        timeSource);
   }
 
   /**
@@ -144,15 +182,23 @@ public class SecretStoreConfiguration {
    * cached and it resolves none — but covering it keeps this a single loop over the finalized store
    * IDs, with no branch that could later leave a real store on the registry's own cache defaults
    * instead of the configured ttl and max-size.
+   *
+   * <p>Each cache is instrumented here rather than by the registry, which only meters the default
+   * caches it builds itself: a cache handed to it is used as it is. The registry is already wrapped
+   * per tenant, so the meters carry both the tenant and the store ID they belong to.
    */
   private static Map<String, SecretCache> caches(
-      final Set<String> storeIds, final Secrets.Cache config, final InstantSource timeSource) {
+      final Set<String> storeIds,
+      final Secrets.Cache config,
+      final InstantSource timeSource,
+      final MeterRegistry meterRegistry) {
     final Map<String, SecretCache> caches = new LinkedHashMap<>();
     storeIds.forEach(
         storeId ->
             caches.put(
                 storeId,
-                CaffeineSecretCache.create(config.getMaxSize(), config.getTtl(), timeSource)));
+                CaffeineSecretCache.create(
+                    config.getMaxSize(), config.getTtl(), timeSource, meterRegistry, storeId)));
     return Map.copyOf(caches);
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -17,7 +17,7 @@ import io.camunda.configuration.Secrets.Stores;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.secretstore.CaffeineSecretCache;
 import io.camunda.secretstore.NoopSecretStore;
-import io.camunda.secretstore.SecretCache;
+import io.camunda.secretstore.SecretCacheFactory;
 import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.aws.AwsSecretsManagerSecretStore;
@@ -70,8 +70,9 @@ public class SecretStoreConfiguration {
    * @param meterRegistry the cluster-wide registry each physical tenant's secret cache meters are
    *     forwarded to. Each tenant gets its own {@link MicrometerUtil#wrap wrapped registry} tagging
    *     them with {@link PartitionKeyNames#PHYSICAL_TENANT}, as {@code RdbmsDataSources} does for
-   *     its pools — a store ID is unique only within a tenant, and {@link SecretStoreRegistry}'s
-   *     four-argument constructor documents what sharing a series between two would do.
+   *     its pools — a store ID is unique only within a tenant, so without that tag two tenants
+   *     using the same store ID would register the same series twice: Micrometer hands back the
+   *     meter that already exists, and the two caches silently share it.
    */
   @Bean
   public SecretStoreRegistries secretStoreRegistries(
@@ -166,40 +167,31 @@ public class SecretStoreConfiguration {
             meterRegistry, Tags.of(PartitionKeyNames.PHYSICAL_TENANT.asString(), tenantId));
     tenantMeterRegistries.add(tenantMeterRegistry);
     return new SecretStoreRegistry(
-        Map.copyOf(stores),
-        caches(stores.keySet(), cacheConfig, timeSource, tenantMeterRegistry),
-        timeSource);
+        Map.copyOf(stores), cacheFactory(cacheConfig, timeSource, tenantMeterRegistry));
   }
 
   /**
-   * One cache per store, keyed by the same store IDs the registry is given. Building from the
-   * finalized store IDs with a fresh instance per ID is what keeps {@link SecretStoreRegistry} from
-   * rejecting the map: no cache for a store nothing is configured for, and no instance shared by
-   * two store IDs (a cache is keyed by the bare secret name, so a shared one would let one store's
-   * value answer for another store's secret of the same name).
+   * Builds one cache per store the registry wraps, at the configured ttl and max-size, publishing
+   * what it does under the store ID it was built for. A fresh instance per call is what the factory
+   * contract requires: a cache is keyed by the bare secret name, so an instance shared by two
+   * stores would let one store's value answer for another store's secret of the same name.
    *
-   * <p>The noop fallback store is covered too. It never caches anything — only a resolved value is
-   * cached and it resolves none — but covering it keeps this a single loop over the finalized store
-   * IDs, with no branch that could later leave a real store on the registry's own cache defaults
-   * instead of the configured ttl and max-size.
+   * <p>Handed to the registry rather than applied to a map of prebuilt caches so that a store that
+   * caches natively never reaches this at all. Only the registry knows it leaves such a store
+   * unwrapped, so building a cache for every configured store ID here would register the meters of
+   * a cache nothing ever resolves through — seven series stuck at zero, for a store {@link
+   * io.camunda.secretstore.SecretCacheMetricsDoc} promises emits none.
    *
-   * <p>Each cache is instrumented here rather than by the registry, which only meters the default
-   * caches it builds itself: a cache handed to it is used as it is. The registry is already wrapped
-   * per tenant, so the meters carry both the tenant and the store ID they belong to.
+   * <p>The registry is already wrapped per tenant, so the meters carry both the tenant and the
+   * store ID they belong to.
    */
-  private static Map<String, SecretCache> caches(
-      final Set<String> storeIds,
+  private static SecretCacheFactory cacheFactory(
       final Secrets.Cache config,
       final InstantSource timeSource,
       final MeterRegistry meterRegistry) {
-    final Map<String, SecretCache> caches = new LinkedHashMap<>();
-    storeIds.forEach(
-        storeId ->
-            caches.put(
-                storeId,
-                CaffeineSecretCache.create(
-                    config.getMaxSize(), config.getTtl(), timeSource, meterRegistry, storeId)));
-    return Map.copyOf(caches);
+    return storeId ->
+        CaffeineSecretCache.create(
+            config.getMaxSize(), config.getTtl(), timeSource, meterRegistry, storeId);
   }
 
   private static void closeAll(final List<SecretStore> stores) {

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -19,6 +19,9 @@ import io.camunda.configuration.Secrets;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.secretstore.CaffeineSecretCache;
 import io.camunda.secretstore.LocallyCachedSecretStore;
+import io.camunda.secretstore.SecretCacheMetricsDoc;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheResult;
 import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
@@ -30,6 +33,10 @@ import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.shared.management.ActorClockEndpoint;
 import io.camunda.zeebe.shared.management.ActorClockService;
 import io.camunda.zeebe.shared.management.ControlledActorClockService;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -280,6 +287,87 @@ class SecretStoreConfigurationTest {
   }
 
   @Test
+  void shouldKeepTheCacheMetersOfTwoPhysicalTenantsApart(@TempDir final Path secretsRoot)
+      throws IOException {
+    // given two tenants whose stores both carry the id 'default', the only supported one
+    final var tenantASecrets = Files.createDirectory(secretsRoot.resolve("tenanta"));
+    Files.writeString(tenantASecrets.resolve("token"), "a");
+    final var tenantBSecrets = Files.createDirectory(secretsRoot.resolve("tenantb"));
+    Files.writeString(tenantBSecrets.resolve("token"), "b");
+    final var resolver =
+        resolverFor(
+            Map.of(
+                "camunda.physical-tenants.tenanta.secrets.stores.file.default.path",
+                tenantASecrets.toString(),
+                "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+                "tenanta-admin",
+                "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta",
+                "camunda.physical-tenants.tenantb.secrets.stores.file.default.path",
+                tenantBSecrets.toString(),
+                "camunda.physical-tenants.tenantb.security.initialization.default-roles.admin.users[0]",
+                "tenantb-admin",
+                "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                "tenantb"));
+    // the meter has to survive the same nesting it does in production — a per-tenant wrapped
+    // registry inside the composite Spring injects, which forwards to the backend — because
+    // MicrometerUtil.wrap does not forward tags more than two levels down. Asserting against a bare
+    // leaf registry would leave that hop, and so the collision this test is about, untested
+    final var backend = new SimpleMeterRegistry();
+    final var clusterRegistry = new CompositeMeterRegistry();
+    clusterRegistry.add(backend);
+    final var registries =
+        CONFIG.secretStoreRegistries(resolver, CLOCK_SERVICE, clusterRegistry).byPhysicalTenant();
+
+    // when only one tenant resolves the name both stores hold
+    registries
+        .get("tenanta")
+        .getStores()
+        .get(SecretStoreRegistry.DEFAULT_STORE_ID)
+        .resolve(Set.of("token"));
+
+    // then the physical tenant tag tells the two caches apart, all the way down to the registry
+    // that would export them — the store id alone cannot, so the two would share one series
+    assertThat(cacheMisses(backend, "tenanta")).isOne();
+    assertThat(cacheMisses(backend, "tenantb")).isZero();
+  }
+
+  @Test
+  void shouldPublishNothingForATenantLeftOnTheNoopStore() {
+    // given a tenant with no store configured at all, so it falls back to the noop store
+    final var resolver = resolverFor(Map.of());
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var registries =
+        CONFIG.secretStoreRegistries(resolver, CLOCK_SERVICE, meterRegistry).byPhysicalTenant();
+
+    // when it is resolved through
+    registries
+        .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        .getStores()
+        .get(SecretStoreRegistry.DEFAULT_STORE_ID)
+        .resolve(Set.of("token"));
+
+    // then no cache meter exists for it: the noop store caches nothing, so its hit rate would read
+    // 0% forever against no TTL or maximum an operator could change
+    assertThat(
+            meterRegistry.getMeters().stream()
+                .map(meter -> meter.getId().getName())
+                .filter(name -> name.startsWith("camunda.secret.cache.")))
+        .isEmpty();
+  }
+
+  private static double cacheMisses(
+      final MeterRegistry meterRegistry, final String physicalTenantId) {
+    return meterRegistry
+        .get(SecretCacheMetricsDoc.CACHE_RESULT.getName())
+        .tag(PartitionKeyNames.PHYSICAL_TENANT.asString(), physicalTenantId)
+        .tag(SecretCacheKeyNames.STORE.asString(), SecretStoreRegistry.DEFAULT_STORE_ID)
+        .tag(SecretCacheKeyNames.RESULT.asString(), SecretCacheResult.MISS.name())
+        .counter()
+        .count();
+  }
+
+  @Test
   void shouldBuildAwsSecretsManagerStoreEvenWithoutReachableCredentials() {
     // given — AwsSecretsManagerSecretStore.fromConfig() only probes connectivity/credentials
     // best-effort, logging a warning rather than failing, so wiring an aws-secrets-manager store
@@ -316,7 +404,10 @@ class SecretStoreConfigurationTest {
     final var resolver =
         resolverFor(Map.of("camunda.secrets.stores.file.default.path", secretsDir.toString()));
     final var clockService = new ControlledActorClockService(new ControlledActorClock());
-    final var registries = CONFIG.secretStoreRegistries(resolver, clockService).byPhysicalTenant();
+    final var registries =
+        CONFIG
+            .secretStoreRegistries(resolver, clockService, new SimpleMeterRegistry())
+            .byPhysicalTenant();
     final var store =
         registries
             .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
@@ -493,7 +584,10 @@ class SecretStoreConfigurationTest {
                     "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
                     "tenantb")));
     final var clockService = new ControlledActorClockService(new ControlledActorClock());
-    final var registries = CONFIG.secretStoreRegistries(resolver, clockService).byPhysicalTenant();
+    final var registries =
+        CONFIG
+            .secretStoreRegistries(resolver, clockService, new SimpleMeterRegistry())
+            .byPhysicalTenant();
     final var tenanta =
         registries.get("tenanta").getStores().get(SecretStoreRegistry.DEFAULT_STORE_ID);
     final var tenantb =
@@ -628,7 +722,7 @@ class SecretStoreConfigurationTest {
   private static LocallyCachedSecretStore defaultTenantStore(
       final PhysicalTenantResolver resolver, final ActorClockService clockService) {
     return CONFIG
-        .secretStoreRegistries(resolver, clockService)
+        .secretStoreRegistries(resolver, clockService, new SimpleMeterRegistry())
         .byPhysicalTenant()
         .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
         .getStores()
@@ -647,7 +741,7 @@ class SecretStoreConfigurationTest {
   }
 
   private static SecretStoreRegistries registries(final PhysicalTenantResolver resolver) {
-    return CONFIG.secretStoreRegistries(resolver, CLOCK_SERVICE);
+    return CONFIG.secretStoreRegistries(resolver, CLOCK_SERVICE, new SimpleMeterRegistry());
   }
 
   private static PhysicalTenantResolver resolverFor(final Map<String, Object> properties) {

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -491,16 +491,24 @@ class SecretStoreConfigurationTest {
                   "tenantb-admin",
                   "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
                   "tenantb"));
+      final var meterRegistry = new SimpleMeterRegistry();
 
       // when / then — the build fails and the failure propagates (Mockito wraps the construction
       // failure, but it is still a RuntimeException the rollback path catches)
-      assertThatThrownBy(() -> registries(resolver))
+      assertThatThrownBy(() -> CONFIG.secretStoreRegistries(resolver, CLOCK_SERVICE, meterRegistry))
           .isInstanceOf(RuntimeException.class)
           .hasRootCauseInstanceOf(IllegalStateException.class);
 
       // then — the first tenant's already-built store is rolled back (closed) so its client does
       // not leak
       verify(construction.constructed().get(0)).close();
+      // and so is the registry its cache meters were published on: a failed startup that left them
+      // behind would keep exporting the hit rate and size of a cache nothing resolves through
+      assertThat(
+              meterRegistry.getMeters().stream()
+                  .map(meter -> meter.getId().getName())
+                  .filter(name -> name.startsWith("camunda.secret.cache.")))
+          .isEmpty();
     }
   }
 

--- a/secret-store/secret-store-api/pom.xml
+++ b/secret-store/secret-store-api/pom.xml
@@ -24,6 +24,14 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CaffeineSecretCache.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CaffeineSecretCache.java
@@ -11,7 +11,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.Optional;
@@ -46,14 +45,6 @@ public final class CaffeineSecretCache implements SecretCache {
   public static final Duration DEFAULT_TTL = Duration.ofMinutes(20);
   public static final int DEFAULT_MAX_SIZE = 1000;
 
-  /**
-   * The store ID a cache publishing nothing is tagged with. Never reaches a metrics endpoint, and
-   * deliberately not spellable as a store ID — those are property-path segments under {@code
-   * camunda.secrets.stores.<type>.<id>} — so it cannot be mistaken for a configured store if one
-   * ever does.
-   */
-  private static final String UNMETERED_STORE_ID = "<unmetered>";
-
   private final Cache<String, String> cache;
   private final SecretCacheMetrics metrics;
 
@@ -72,38 +63,13 @@ public final class CaffeineSecretCache implements SecretCache {
       final InstantSource timeSource,
       final MeterRegistry meterRegistry,
       final String storeId) {
-    final var metrics = new SecretCacheMetrics(meterRegistry, storeId);
-    final Cache<String, String> cache =
-        Caffeine.newBuilder()
-            .maximumSize(maxSize)
-            .expireAfterWrite(ttl)
-            .ticker(toTicker(timeSource))
-            // hits, misses and the evictions Caffeine performs itself are reported from here, so
-            // they need no call site of their own
-            .recordStats(() -> metrics)
-            .build();
-    metrics.registerSizeGauge(cache);
-    return new CaffeineSecretCache(cache, metrics);
+    return create(maxSize, ttl, timeSource, new SecretCacheMetrics(meterRegistry, storeId));
   }
 
-  /**
-   * Creates a cache as the five-argument factory does, but publishing nothing: the meters are
-   * registered on a registry that is discarded with the cache.
-   */
+  /** Creates a cache as the five-argument factory does, but publishing nothing. */
   public static CaffeineSecretCache create(
       final int maxSize, final Duration ttl, final InstantSource timeSource) {
-    return create(maxSize, ttl, timeSource, discardedRegistry(), UNMETERED_STORE_ID);
-  }
-
-  /**
-   * Creates a new cache with {@link #DEFAULT_MAX_SIZE} and {@link #DEFAULT_TTL}, publishing what it
-   * does on the given registry under the given store ID.
-   *
-   * @return a new cache
-   */
-  public static CaffeineSecretCache createDefault(
-      final InstantSource timeSource, final MeterRegistry meterRegistry, final String storeId) {
-    return create(DEFAULT_MAX_SIZE, DEFAULT_TTL, timeSource, meterRegistry, storeId);
+    return create(maxSize, ttl, timeSource, SecretCacheMetrics.none());
   }
 
   /**
@@ -116,13 +82,22 @@ public final class CaffeineSecretCache implements SecretCache {
     return create(DEFAULT_MAX_SIZE, DEFAULT_TTL, timeSource);
   }
 
-  /**
-   * A registry that discards everything registered on it — Micrometer's own way to spell "no
-   * metrics". One per cache rather than a shared static, so the meters it holds are collected along
-   * with the cache that registered them.
-   */
-  private static MeterRegistry discardedRegistry() {
-    return new CompositeMeterRegistry();
+  private static CaffeineSecretCache create(
+      final int maxSize,
+      final Duration ttl,
+      final InstantSource timeSource,
+      final SecretCacheMetrics metrics) {
+    final Cache<String, String> cache =
+        Caffeine.newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(ttl)
+            .ticker(toTicker(timeSource))
+            // hits, misses and the evictions Caffeine performs itself are reported from here, so
+            // they need no call site of their own
+            .recordStats(() -> metrics)
+            .build();
+    metrics.registerSizeGauge(cache);
+    return new CaffeineSecretCache(cache, metrics);
   }
 
   private static Ticker toTicker(final InstantSource timeSource) {

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CaffeineSecretCache.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CaffeineSecretCache.java
@@ -10,7 +10,6 @@ package io.camunda.secretstore;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.Optional;
@@ -38,7 +37,10 @@ import java.util.concurrent.TimeUnit;
  * synchronously, which is only useful in tests that need to observe the bound immediately.
  *
  * <p>What the cache does is published on {@link SecretCacheMetricsDoc}'s meters, tagged with the
- * store the cache belongs to; the factories that take no {@link MeterRegistry} publish nothing.
+ * store the cache belongs to; the factories that take no {@link SecretCacheMetrics} publish
+ * nothing. {@link SecretCacheFactory#metered} is the entry point that builds one from a {@link
+ * io.micrometer.core.instrument.MeterRegistry}, so this class itself has no dependency on
+ * Micrometer's registry type.
  */
 public final class CaffeineSecretCache implements SecretCache {
 
@@ -53,20 +55,7 @@ public final class CaffeineSecretCache implements SecretCache {
     this.metrics = metrics;
   }
 
-  /**
-   * Creates a cache bounded by the given size and expiring entries the given duration after write,
-   * publishing what it does on the given registry under the given store ID.
-   */
-  public static CaffeineSecretCache create(
-      final int maxSize,
-      final Duration ttl,
-      final InstantSource timeSource,
-      final MeterRegistry meterRegistry,
-      final String storeId) {
-    return create(maxSize, ttl, timeSource, new SecretCacheMetrics(meterRegistry, storeId));
-  }
-
-  /** Creates a cache as the five-argument factory does, but publishing nothing. */
+  /** Creates a cache as the four-argument factory does, but publishing nothing. */
   public static CaffeineSecretCache create(
       final int maxSize, final Duration ttl, final InstantSource timeSource) {
     return create(maxSize, ttl, timeSource, SecretCacheMetrics.none());
@@ -82,7 +71,10 @@ public final class CaffeineSecretCache implements SecretCache {
     return create(DEFAULT_MAX_SIZE, DEFAULT_TTL, timeSource);
   }
 
-  private static CaffeineSecretCache create(
+  /**
+   * Creates a cache bounded by the given size and expiring entries the given duration after write.
+   */
+  static CaffeineSecretCache create(
       final int maxSize,
       final Duration ttl,
       final InstantSource timeSource,

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CaffeineSecretCache.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/CaffeineSecretCache.java
@@ -10,6 +10,8 @@ package io.camunda.secretstore;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.Optional;
@@ -35,38 +37,92 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Eviction of expired or excess entries happens asynchronously; {@link #cleanUp()} forces it
  * synchronously, which is only useful in tests that need to observe the bound immediately.
+ *
+ * <p>What the cache does is published on {@link SecretCacheMetricsDoc}'s meters, tagged with the
+ * store the cache belongs to; the factories that take no {@link MeterRegistry} publish nothing.
  */
 public final class CaffeineSecretCache implements SecretCache {
 
   public static final Duration DEFAULT_TTL = Duration.ofMinutes(20);
   public static final int DEFAULT_MAX_SIZE = 1000;
 
-  private final Cache<String, String> cache;
+  /**
+   * The store ID a cache publishing nothing is tagged with. Never reaches a metrics endpoint, and
+   * deliberately not spellable as a store ID — those are property-path segments under {@code
+   * camunda.secrets.stores.<type>.<id>} — so it cannot be mistaken for a configured store if one
+   * ever does.
+   */
+  private static final String UNMETERED_STORE_ID = "<unmetered>";
 
-  private CaffeineSecretCache(final Cache<String, String> cache) {
+  private final Cache<String, String> cache;
+  private final SecretCacheMetrics metrics;
+
+  private CaffeineSecretCache(final Cache<String, String> cache, final SecretCacheMetrics metrics) {
     this.cache = cache;
+    this.metrics = metrics;
   }
 
   /**
-   * Creates a cache bounded by the given size and expiring entries the given duration after write.
+   * Creates a cache bounded by the given size and expiring entries the given duration after write,
+   * publishing what it does on the given registry under the given store ID.
    */
   public static CaffeineSecretCache create(
-      final int maxSize, final Duration ttl, final InstantSource timeSource) {
-    return new CaffeineSecretCache(
+      final int maxSize,
+      final Duration ttl,
+      final InstantSource timeSource,
+      final MeterRegistry meterRegistry,
+      final String storeId) {
+    final var metrics = new SecretCacheMetrics(meterRegistry, storeId);
+    final Cache<String, String> cache =
         Caffeine.newBuilder()
             .maximumSize(maxSize)
             .expireAfterWrite(ttl)
             .ticker(toTicker(timeSource))
-            .build());
+            // hits, misses and the evictions Caffeine performs itself are reported from here, so
+            // they need no call site of their own
+            .recordStats(() -> metrics)
+            .build();
+    metrics.registerSizeGauge(cache);
+    return new CaffeineSecretCache(cache, metrics);
   }
 
   /**
-   * Creates a new cache with {@link #DEFAULT_MAX_SIZE} and {@link #DEFAULT_TTL}.
+   * Creates a cache as the five-argument factory does, but publishing nothing: the meters are
+   * registered on a registry that is discarded with the cache.
+   */
+  public static CaffeineSecretCache create(
+      final int maxSize, final Duration ttl, final InstantSource timeSource) {
+    return create(maxSize, ttl, timeSource, discardedRegistry(), UNMETERED_STORE_ID);
+  }
+
+  /**
+   * Creates a new cache with {@link #DEFAULT_MAX_SIZE} and {@link #DEFAULT_TTL}, publishing what it
+   * does on the given registry under the given store ID.
+   *
+   * @return a new cache
+   */
+  public static CaffeineSecretCache createDefault(
+      final InstantSource timeSource, final MeterRegistry meterRegistry, final String storeId) {
+    return create(DEFAULT_MAX_SIZE, DEFAULT_TTL, timeSource, meterRegistry, storeId);
+  }
+
+  /**
+   * Creates a new cache with {@link #DEFAULT_MAX_SIZE} and {@link #DEFAULT_TTL}, publishing
+   * nothing.
    *
    * @return a new cache
    */
   public static CaffeineSecretCache createDefault(final InstantSource timeSource) {
     return create(DEFAULT_MAX_SIZE, DEFAULT_TTL, timeSource);
+  }
+
+  /**
+   * A registry that discards everything registered on it — Micrometer's own way to spell "no
+   * metrics". One per cache rather than a shared static, so the meters it holds are collected along
+   * with the cache that registered them.
+   */
+  private static MeterRegistry discardedRegistry() {
+    return new CompositeMeterRegistry();
   }
 
   private static Ticker toTicker(final InstantSource timeSource) {
@@ -83,9 +139,21 @@ public final class CaffeineSecretCache implements SecretCache {
     cache.put(name, value);
   }
 
+  /**
+   * Removes the name from the cache, counting an eviction only if a value was actually removed —
+   * Caffeine reports the evictions it performs itself but never a removal by name.
+   *
+   * <p>Goes through the map view rather than {@code invalidate} because that reports whether a
+   * value was there, atomically and without recording the hit or miss a lookup would. Both matter:
+   * {@link CachingSecretStore} removes a name on every permanent failure from its store, so
+   * counting the calls rather than the removals would turn {@link
+   * SecretCacheMetricsDoc#CACHE_EVICTIONS} into a count of failing lookups.
+   */
   @Override
   public void remove(final String name) {
-    cache.invalidate(name);
+    if (cache.asMap().remove(name) != null) {
+      metrics.recordExplicitEviction();
+    }
   }
 
   /**

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheFactory.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheFactory.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.secretstore;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.time.InstantSource;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -31,4 +34,22 @@ public interface SecretCacheFactory {
    * @param storeId the ID the store is configured under, unique within one physical tenant
    */
   SecretCache create(String storeId);
+
+  /**
+   * Returns a factory building a {@link CaffeineSecretCache} bounded by the given size and TTL for
+   * every store ID, publishing what each one does on the given registry tagged with that store ID.
+   *
+   * <p>The sole place that hands a {@link MeterRegistry} to a {@link CaffeineSecretCache}: that
+   * class itself only knows {@link SecretCacheMetrics}, so a caller outside this package cannot
+   * construct one directly and reaches the cache through here instead.
+   */
+  static SecretCacheFactory metered(
+      final int maxSize,
+      final Duration ttl,
+      final InstantSource timeSource,
+      final MeterRegistry meterRegistry) {
+    return storeId ->
+        CaffeineSecretCache.create(
+            maxSize, ttl, timeSource, new SecretCacheMetrics(meterRegistry, storeId));
+  }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheFactory.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Builds the {@link SecretCache} one store caches in, given the ID that store is configured under.
+ *
+ * <p>{@link SecretStoreRegistry} calls this at most once per configured store, and only for a store
+ * that is actually wrapped in a {@link CachingSecretStore} — a store that caches natively is left
+ * as it is, so no cache is built for it. That is what keeps a caller instrumenting the caches it
+ * hands out from publishing meters for a store no cache of theirs ever serves.
+ *
+ * <p>Must return a fresh cache per store ID: a cache is keyed by the bare secret name, so an
+ * instance shared by two stores would let one store's value answer for another store's secret of
+ * the same name.
+ */
+@FunctionalInterface
+@NullMarked
+public interface SecretCacheFactory {
+
+  /**
+   * Returns the cache the store under {@code storeId} holds what it resolves in.
+   *
+   * @param storeId the ID the store is configured under, unique within one physical tenant
+   */
+  SecretCache create(String storeId);
+}

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheMetrics.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheMetrics.java
@@ -17,6 +17,7 @@ import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheResult;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
@@ -38,6 +39,14 @@ import java.util.Objects;
  */
 final class SecretCacheMetrics implements StatsCounter {
 
+  /**
+   * The store ID a counter publishing nothing is tagged with. Never reaches a metrics endpoint, and
+   * deliberately not spellable as a store ID — those are property-path segments under {@code
+   * camunda.secrets.stores.<type>.<id>} — so it cannot be mistaken for a configured store if one
+   * ever does.
+   */
+  private static final String UNMETERED_STORE_ID = "<unmetered>";
+
   private final MeterRegistry registry;
   private final String storeId;
   private final Counter hits;
@@ -53,6 +62,17 @@ final class SecretCacheMetrics implements StatsCounter {
     for (final var cause : SecretCacheEvictionCause.values()) {
       evictions.put(cause, registerEvictionCounter(cause));
     }
+  }
+
+  /**
+   * A counter that records everything and publishes nothing, for a cache no caller named a registry
+   * for. Spelled as a {@link CompositeMeterRegistry} with nothing behind it — Micrometer's own way
+   * to say "no metrics" — rather than as a second {@link StatsCounter} implementation, so the cache
+   * takes the same code path either way. One per cache rather than a shared static, so the meters
+   * it holds are collected along with the cache that registered them.
+   */
+  static SecretCacheMetrics none() {
+    return new SecretCacheMetrics(new CompositeMeterRegistry(), UNMETERED_STORE_ID);
   }
 
   @Override

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheMetrics.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheMetrics.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.StatsCounter;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheEvictionCause;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheResult;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Records what one store's {@link CaffeineSecretCache} does, as the {@link StatsCounter} Caffeine
+ * itself drives. Hits, misses and the evictions Caffeine performs on its own therefore need no call
+ * site of their own: the cache reports them as it serves lookups.
+ *
+ * <p>Every meter is registered here in the constructor with its {@code store} tag already fixed. A
+ * cache is created once per configured store while the application starts, so there is no tag value
+ * discovered at runtime and nothing to bound.
+ *
+ * <p>{@code CaffeineCacheStatsCounter} does the same job for the exporter and process caches, and
+ * is deliberately not reused: it lives in {@code zeebe-util}, whose dependency set is the one
+ * {@link SecretCacheMetricsDoc} already declines to pull into this module and every secret store
+ * built on it. The two are worth sharing only once that adapter has a home light enough for both —
+ * until then a third copy is the thing to avoid, not this one.
+ */
+final class SecretCacheMetrics implements StatsCounter {
+
+  private final MeterRegistry registry;
+  private final String storeId;
+  private final Counter hits;
+  private final Counter misses;
+  private final Map<SecretCacheEvictionCause, Counter> evictions =
+      new EnumMap<>(SecretCacheEvictionCause.class);
+
+  SecretCacheMetrics(final MeterRegistry registry, final String storeId) {
+    this.registry = registry;
+    this.storeId = storeId;
+    hits = resultCounter(SecretCacheResult.HIT);
+    misses = resultCounter(SecretCacheResult.MISS);
+    for (final var cause : SecretCacheEvictionCause.values()) {
+      evictions.put(cause, registerEvictionCounter(cause));
+    }
+  }
+
+  @Override
+  public void recordHits(final int count) {
+    hits.increment(count);
+  }
+
+  @Override
+  public void recordMisses(final int count) {
+    misses.increment(count);
+  }
+
+  @Override
+  public void recordLoadSuccess(final long loadTime) {
+    // the secret cache is not a LoadingCache: a miss is answered by the caching store reading the
+    // secret store itself, and that read is already timed by camunda.secret.resolution.duration
+  }
+
+  @Override
+  public void recordLoadFailure(final long loadTime) {
+    // see recordLoadSuccess
+  }
+
+  @Override
+  public void recordEviction(final int weight, final RemovalCause cause) {
+    evictionCounter(SecretCacheEvictionCause.from(cause)).increment();
+  }
+
+  @Override
+  public CacheStats snapshot() {
+    // the meters are the readable form of these numbers; nothing asks the cache for its own stats,
+    // and keeping a second set of counters just to answer this would double the work per lookup
+    return CacheStats.empty();
+  }
+
+  /**
+   * Records one entry removed by name. Caffeine calls {@link #recordEviction} only for a cause
+   * where {@code RemovalCause.wasEvicted()} holds, which excludes removal by name, so {@link
+   * CaffeineSecretCache#remove} calls this instead — and only when a value was actually removed.
+   */
+  void recordExplicitEviction() {
+    evictionCounter(SecretCacheEvictionCause.EXPLICIT).increment();
+  }
+
+  /**
+   * Publishes the cache's entry count. Registered from the cache's factory rather than here,
+   * because the gauge needs the built {@link Cache} and this counter is what builds it.
+   *
+   * <p>Micrometer holds the cache weakly, which is what a gauge over a live object requires: the
+   * cache outlives this registration for as long as the store that owns it is in use, and the gauge
+   * stops reporting once it does not. Weakly is also what is wanted here, unlike the {@code
+   * strongReference(true)} the repository's supplier gauges are built with: a strong reference
+   * would pin the cache — and so up to {@link CaffeineSecretCache#DEFAULT_MAX_SIZE} secret values —
+   * in memory for as long as the registry holds the meter, outliving the store they were read from.
+   */
+  void registerSizeGauge(final Cache<?, ?> cache) {
+    final var meterDoc = SecretCacheMetricsDoc.CACHE_SIZE;
+    Gauge.builder(meterDoc.getName(), cache, Cache::estimatedSize)
+        .description(meterDoc.getDescription())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .register(registry);
+  }
+
+  private Counter resultCounter(final SecretCacheResult result) {
+    final var meterDoc = SecretCacheMetricsDoc.CACHE_RESULT;
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .tag(SecretCacheKeyNames.RESULT.asString(), result.name())
+        .register(registry);
+  }
+
+  private Counter evictionCounter(final SecretCacheEvictionCause cause) {
+    return Objects.requireNonNull(evictions.get(cause));
+  }
+
+  private Counter registerEvictionCounter(final SecretCacheEvictionCause cause) {
+    final var meterDoc = SecretCacheMetricsDoc.CACHE_EVICTIONS;
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .tag(SecretCacheKeyNames.CAUSE.asString(), cause.name())
+        .register(registry);
+  }
+}

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheMetricsDoc.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheMetricsDoc.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.docs.MeterDocumentation;
+
+/**
+ * Meters for the {@link CaffeineSecretCache} each configured secret store resolves through.
+ * Together with {@code camunda.secret.resolution.*} in the engine, they say whether a slow
+ * resolution is a slow store or a cache that is not holding what callers ask for.
+ *
+ * <p>These meters exist only for a cache this module created. A {@link SecretStore} that implements
+ * {@link LocallyCachedSecretStore} natively caches inside its own SDK and is never wrapped, so it
+ * emits none of them — an absent series for such a store is not a broken cache. {@link
+ * InMemorySecretCache} is likewise uninstrumented: it exists for callers and tests that want no
+ * eviction at all, so there is nothing here to observe. A tenant left on the noop store — the
+ * fallback when no store is configured at all — emits none of them either: that store answers every
+ * name permanently missing, so its cache can never hold a value and a hit rate published for it
+ * would read 0% forever against nothing an operator could tune.
+ *
+ * <p>No meter here is tagged by secret name or value. The cache is keyed by the bare secret name,
+ * so such a tag would be both unbounded cardinality and customer data on the metrics endpoint. That
+ * bounds what these meters disclose without making it nothing: the values still say how many
+ * secrets a physical tenant holds and how often they stop resolving, so this endpoint stays as
+ * operator-facing as the rest of it.
+ *
+ * <p>Implements Micrometer's own {@link MeterDocumentation} rather than the {@code
+ * ExtendedMeterDocumentation} the rest of the repository uses: that interface lives in {@code
+ * zeebe-util}, whose dependency set (guava, kryo, agrona, {@code zeebe-protocol}) is far larger
+ * than this module and every secret store implementation built on it should carry. {@link
+ * #getDescription()} is declared here instead, so a meter reads the same way it does elsewhere.
+ */
+@SuppressWarnings("NullableProblems")
+public enum SecretCacheMetricsDoc implements MeterDocumentation {
+  /** Secret cache lookups, split by whether the cache held the value */
+  CACHE_RESULT {
+    @Override
+    public String getDescription() {
+      return "Number of secret cache lookups, per store and per result, so the hit rate is "
+          + "HIT / (HIT + MISS). Every lookup a caller makes is counted exactly once. Both reads "
+          + "land here: the cache-first resolution path, and the job-activation lookup that only "
+          + "ever reads the cache. The counter cannot tell those apart, so a falling hit rate says "
+          + "the cache is not holding what callers ask for without saying which caller pays for it. "
+          + "Nor does a MISS mean the value could have been held: a name the store answers "
+          + "permanently — deleted, denied, or an invalid reference — is never cached, so every "
+          + "lookup of it misses for as long as it is referenced, once per job activation attempt "
+          + "on the activation path. Read a low hit rate against "
+          + "camunda.secret.resolution.outcome first: misses concentrated on references that never "
+          + "resolve are not a cache to tune. The cache is held in memory only, so every restart "
+          + "starts the rate at zero and climbs as callers warm it: alert on a rate that stays low, "
+          + "not on the value shortly after a deployment.";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.secret.cache.result";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {SecretCacheKeyNames.STORE, SecretCacheKeyNames.RESULT};
+    }
+  },
+
+  /** Entries removed from a secret cache, split by what removed them */
+  CACHE_EVICTIONS {
+    @Override
+    public String getDescription() {
+      return "Number of entries removed from a secret cache, per store and per cause. SIZE and "
+          + "EXPIRED are what say the bound no longer fits the workload: sustained SIZE evictions "
+          + "mean the per-store maximum of "
+          + CaffeineSecretCache.DEFAULT_MAX_SIZE
+          + " entries is smaller than the working set, while a high EXPIRED rate together with a "
+          + "low hit rate means the "
+          + CaffeineSecretCache.DEFAULT_TTL.toMinutes()
+          + "-minute TTL is shorter than the interval callers resolve at. Neither is configurable "
+          + "today, so both are worth reporting rather than tuning against. A forward jump of the "
+          + "cluster clock is the one EXPIRED spike that means nothing: expiry follows that clock, "
+          + "so time travel through /actuator/clock expires the whole cache at once. EXPLICIT "
+          + "counts the invalidation the caching store performs when a store answers a secret "
+          + "permanently — deleted, denied, or an invalid reference — so it tracks secrets "
+          + "disappearing rather than the cache running out of room. Replacing the value of a name "
+          + "already cached is not counted at all: the caching store writes over an existing name "
+          + "on every re-resolve, so counting that would bury the causes that mean something.";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.secret.cache.evictions";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {SecretCacheKeyNames.STORE, SecretCacheKeyNames.CAUSE};
+    }
+  },
+
+  /** Entries a secret cache currently holds */
+  CACHE_SIZE {
+    @Override
+    public String getDescription() {
+      return "Estimated number of entries a secret cache currently holds, per store, out of a "
+          + "per-store maximum of "
+          + CaffeineSecretCache.DEFAULT_MAX_SIZE
+          + " entries. Estimated because eviction is asynchronous, so the value can briefly sit "
+          + "above that maximum and can lag a removal: read it as a level to compare against it, "
+          + "not as an exact count. The maximum is fixed rather than configured, and is stated here "
+          + "because it is published on no meter of its own. Sitting at the maximum with a healthy "
+          + "hit rate is fine; sitting there while camunda.secret.cache.evictions with cause=SIZE "
+          + "keeps rising is the signal that the cache is too small.";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.secret.cache.size";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    // deliberately no base unit: Micrometer appends it to the meter name, so declaring `entries`
+    // would publish camunda_secret_cache_size_entries and break every dashboard built on the name
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {SecretCacheKeyNames.STORE};
+    }
+  };
+
+  /** Returns the description (also known as {@code help} in some systems) for the given meter. */
+  public abstract String getDescription();
+
+  @SuppressWarnings("NullableProblems")
+  public enum SecretCacheKeyNames implements KeyName {
+    /**
+     * The ID of the secret store whose cache this is, as the operator configured it under {@code
+     * camunda.secrets.stores.<type>.<id>}.
+     *
+     * <p>Bounded by configuration, unlike the identically named tag on {@code
+     * camunda.secret.resolution.*}, which carries whatever store ID a secret reference names and so
+     * needs a bound of its own. The two use the same key so a dashboard can join on it.
+     *
+     * <p>A store ID is only unique within one physical tenant. Nothing in this module knows about
+     * tenants, so whoever registers these meters for more than one tenant has to keep them apart —
+     * the Spring wiring does it by giving each tenant a registry tagged with its physical tenant
+     * ID.
+     */
+    STORE("store"),
+    /**
+     * Whether a lookup found the value in the cache. A {@link SecretCacheResult}.
+     *
+     * <p>Keyed {@code result} rather than the {@code type} that {@code CaffeineCacheStatsCounter}
+     * in {@code zeebe-util} uses for the same hit/miss split on the exporter and process caches.
+     * This is not an oversight to correct: a dashboard for this feature joins these meters with
+     * {@code camunda.secret.resolution.*}, whose result tag is also {@code result}, and renaming
+     * this to match the generic caches would break the join that is actually used to read it.
+     */
+    RESULT("result"),
+    /** What removed an entry from the cache. A {@link SecretCacheEvictionCause}. */
+    CAUSE("cause");
+
+    private final String key;
+
+    SecretCacheKeyNames(final String key) {
+      this.key = key;
+    }
+
+    @Override
+    public String asString() {
+      return key;
+    }
+  }
+
+  /**
+   * The value domain of the {@link SecretCacheKeyNames#RESULT} tag on {@link #CACHE_RESULT}.
+   *
+   * <p>Every value counts one lookup, so the two can be summed and divided by one another — which
+   * is the whole point, since the hit rate is derived rather than published.
+   */
+  public enum SecretCacheResult {
+    /** The cache held a value for the name */
+    HIT,
+    /** The cache held no value for the name, so the caller had to reach the store or give up */
+    MISS
+  }
+
+  /**
+   * The value domain of the {@link SecretCacheKeyNames#CAUSE} tag on {@link #CACHE_EVICTIONS}.
+   *
+   * <p>Mirrors the subset of Caffeine's {@link RemovalCause} that removes an entry, rather than
+   * exposing that type as a tag value: a library constant renamed upstream would otherwise silently
+   * rename a metric tag value. {@link RemovalCause#REPLACED} has no counterpart here on purpose —
+   * see {@link #from(RemovalCause)}.
+   *
+   * <p>Every value counts one entry leaving one cache, so all four share a unit and can be summed
+   * across the tag.
+   */
+  public enum SecretCacheEvictionCause {
+    /** The cache was full, so it dropped an entry to make room for another */
+    SIZE,
+    /** The entry's TTL elapsed */
+    EXPIRED,
+    /**
+     * Something removed the entry by name. In practice this is {@link CachingSecretStore}
+     * invalidating a name its store answered permanently — deleted, access denied, or not a valid
+     * reference for that store.
+     */
+    EXPLICIT,
+    /**
+     * The entry's key or value was garbage collected. Unreachable as this cache is built today (it
+     * uses neither weak keys nor soft values), and carried only so that enabling either later
+     * cannot make evictions vanish from the counter without anyone noticing.
+     */
+    COLLECTED;
+
+    /**
+     * Maps Caffeine's removal cause onto the tag value.
+     *
+     * <p>Exhaustive and without a {@code default} branch on purpose, so a constant added to {@link
+     * RemovalCause} upstream is a compile error here rather than an eviction silently bucketed
+     * under an existing tag value.
+     *
+     * @throws IllegalArgumentException for {@link RemovalCause#REPLACED}, which is not a removal at
+     *     all — the entry stays and only its value changes, which {@link CachingSecretStore} does
+     *     on every re-resolve. Caffeine never reports it as an eviction, so reaching this is a bug
+     *     rather than a state to fold into some other cause.
+     */
+    public static SecretCacheEvictionCause from(final RemovalCause cause) {
+      return switch (cause) {
+        case SIZE -> SIZE;
+        case EXPIRED -> EXPIRED;
+        case EXPLICIT -> EXPLICIT;
+        case COLLECTED -> COLLECTED;
+        case REPLACED ->
+            throw new IllegalArgumentException(
+                "Expected a cause that removes a cache entry, but got REPLACED, which only "
+                    + "overwrites the value of a name that stays cached");
+      };
+    }
+  }
+}

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.secretstore;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -54,9 +52,10 @@ public final class SecretStoreRegistry {
    * constructor to drive the default cache's expiry from another time source (production wiring
    * passes the actor clock, so {@code /actuator/clock} time travel reaches it).
    *
-   * <p>A cache given here is used as it is and is not instrumented: only the default cache this
-   * registry builds itself reports on {@link SecretCacheMetricsDoc}'s meters, since an arbitrary
-   * {@link SecretCache} exposes nothing to measure.
+   * <p>A cache given here is used as it is and is not instrumented: whether it reports on {@link
+   * SecretCacheMetricsDoc}'s meters is the caller's business, and an arbitrary {@link SecretCache}
+   * exposes nothing to measure. See the {@link SecretCacheFactory} constructor for the seam a
+   * caller that does instrument its caches has to use.
    *
    * @throws IllegalArgumentException if a cache is given for a store ID nothing is configured for,
    *     or if two store IDs are given the same cache instance — the cache is keyed by the bare
@@ -69,39 +68,43 @@ public final class SecretStoreRegistry {
   }
 
   /**
-   * Creates a registry as the two-argument constructor does, but drives the default cache's expiry
-   * from {@code timeSource} instead of the system clock — the choice of default cache is already
-   * the registry's job, and that default is now time-driven.
+   * Creates a registry as the {@code Map}-and-{@code Map} constructor does, but drives the default
+   * cache's expiry from {@code timeSource} instead of the system clock — the choice of default
+   * cache is already the registry's job, and that default is now time-driven.
    *
-   * <p>The default caches publish nothing: see the four-argument constructor to have them report on
-   * a registry.
+   * <p>The default caches publish nothing on {@link SecretCacheMetricsDoc}'s meters: see the {@link
+   * SecretCacheFactory} constructor for the seam that builds instrumented ones.
    */
   public SecretStoreRegistry(
       final Map<String, SecretStore> stores,
       final Map<String, SecretCache> caches,
       final InstantSource timeSource) {
-    this(stores, caches, timeSource, new CompositeMeterRegistry());
+    rejectUnusableCaches(stores, caches);
+    this.stores =
+        locallyCachedStores(
+            stores,
+            storeId -> {
+              final var configured = caches.get(storeId);
+              return configured != null
+                  ? configured
+                  : CaffeineSecretCache.createDefault(timeSource);
+            });
   }
 
   /**
-   * Creates a registry as the three-argument constructor does, and has each default cache publish
-   * what it does on {@code meterRegistry}, tagged with the store ID it was built for. Choosing the
-   * default cache is the registry's job, so registering its meters is too — no caller can reach a
-   * cache to instrument it afterwards.
+   * Creates a registry whose stores cache in whatever {@code cacheFactory} builds for them. This is
+   * the seam for a caller that instruments the caches it builds: the factory is called only for a
+   * store this registry actually wraps, so a store that caches natively — for which no cache is
+   * built at all — shows up on none of {@link SecretCacheMetricsDoc}'s meters, as they document.
    *
-   * <p>A store ID is unique only within one physical tenant, and this registry knows nothing about
-   * tenants. A caller that builds one registry per tenant must therefore pass a registry that
-   * already carries the tenant as a tag, otherwise two tenants using the same store ID register the
-   * same series twice: Micrometer hands back the meter that already exists, and the two caches
-   * silently share it.
+   * <p>Both rules the {@code Map}-based constructors validate hold by construction here: the
+   * factory is called once per configured store, so it can neither be given a cache for a store
+   * nothing is configured for nor share one instance between two store IDs — as long as it returns
+   * a fresh cache per ID, which is its documented contract.
    */
   public SecretStoreRegistry(
-      final Map<String, SecretStore> stores,
-      final Map<String, SecretCache> caches,
-      final InstantSource timeSource,
-      final MeterRegistry meterRegistry) {
-    rejectUnusableCaches(stores, caches);
-    this.stores = locallyCachedStores(stores, caches, timeSource, meterRegistry);
+      final Map<String, SecretStore> stores, final SecretCacheFactory cacheFactory) {
+    this.stores = locallyCachedStores(stores, cacheFactory);
   }
 
   /**
@@ -148,41 +151,27 @@ public final class SecretStoreRegistry {
   }
 
   private static Map<String, LocallyCachedSecretStore> locallyCachedStores(
-      final Map<String, SecretStore> stores,
-      final Map<String, SecretCache> caches,
-      final InstantSource timeSource,
-      final MeterRegistry meterRegistry) {
+      final Map<String, SecretStore> stores, final SecretCacheFactory cacheFactory) {
     final Map<String, LocallyCachedSecretStore> locallyCached = new LinkedHashMap<>();
     stores.forEach(
         (storeId, store) ->
-            locallyCached.put(
-                storeId, locallyCached(storeId, store, caches, timeSource, meterRegistry)));
+            locallyCached.put(storeId, locallyCached(storeId, store, cacheFactory)));
     return Collections.unmodifiableMap(locallyCached);
   }
 
   /**
    * Returns the store itself when it caches natively — wrapping it would put a second cache in
-   * front of its own — and otherwise the store behind the cache configured for it, or a fresh
-   * time-and-size-bounded one when the configured caches do not cover it.
+   * front of its own — and otherwise the store behind the cache the factory builds for it.
    *
-   * <p>Only that fresh cache is instrumented, which is also why a natively caching store shows up
-   * on none of {@link SecretCacheMetricsDoc}'s meters: there is no cache here to measure, and its
-   * own is the SDK's business.
+   * <p>The factory is not called at all for a natively caching store, which is what keeps such a
+   * store off {@link SecretCacheMetricsDoc}'s meters however the caller instruments the caches it
+   * builds: there is no cache here to measure, and its own is the SDK's business.
    */
   private static LocallyCachedSecretStore locallyCached(
-      final String storeId,
-      final SecretStore store,
-      final Map<String, SecretCache> caches,
-      final InstantSource timeSource,
-      final MeterRegistry meterRegistry) {
+      final String storeId, final SecretStore store, final SecretCacheFactory cacheFactory) {
     if (store instanceof final LocallyCachedSecretStore locallyCached) {
       return locallyCached;
     }
-    final var configured = caches.get(storeId);
-    return new CachingSecretStore(
-        store,
-        configured != null
-            ? configured
-            : CaffeineSecretCache.createDefault(timeSource, meterRegistry, storeId));
+    return new CachingSecretStore(store, cacheFactory.create(storeId));
   }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStoreRegistry.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.secretstore;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,6 +54,10 @@ public final class SecretStoreRegistry {
    * constructor to drive the default cache's expiry from another time source (production wiring
    * passes the actor clock, so {@code /actuator/clock} time travel reaches it).
    *
+   * <p>A cache given here is used as it is and is not instrumented: only the default cache this
+   * registry builds itself reports on {@link SecretCacheMetricsDoc}'s meters, since an arbitrary
+   * {@link SecretCache} exposes nothing to measure.
+   *
    * @throws IllegalArgumentException if a cache is given for a store ID nothing is configured for,
    *     or if two store IDs are given the same cache instance — the cache is keyed by the bare
    *     secret name, so a shared instance would let one store's value answer for another store's
@@ -66,13 +72,36 @@ public final class SecretStoreRegistry {
    * Creates a registry as the two-argument constructor does, but drives the default cache's expiry
    * from {@code timeSource} instead of the system clock — the choice of default cache is already
    * the registry's job, and that default is now time-driven.
+   *
+   * <p>The default caches publish nothing: see the four-argument constructor to have them report on
+   * a registry.
    */
   public SecretStoreRegistry(
       final Map<String, SecretStore> stores,
       final Map<String, SecretCache> caches,
       final InstantSource timeSource) {
+    this(stores, caches, timeSource, new CompositeMeterRegistry());
+  }
+
+  /**
+   * Creates a registry as the three-argument constructor does, and has each default cache publish
+   * what it does on {@code meterRegistry}, tagged with the store ID it was built for. Choosing the
+   * default cache is the registry's job, so registering its meters is too — no caller can reach a
+   * cache to instrument it afterwards.
+   *
+   * <p>A store ID is unique only within one physical tenant, and this registry knows nothing about
+   * tenants. A caller that builds one registry per tenant must therefore pass a registry that
+   * already carries the tenant as a tag, otherwise two tenants using the same store ID register the
+   * same series twice: Micrometer hands back the meter that already exists, and the two caches
+   * silently share it.
+   */
+  public SecretStoreRegistry(
+      final Map<String, SecretStore> stores,
+      final Map<String, SecretCache> caches,
+      final InstantSource timeSource,
+      final MeterRegistry meterRegistry) {
     rejectUnusableCaches(stores, caches);
-    this.stores = locallyCachedStores(stores, caches, timeSource);
+    this.stores = locallyCachedStores(stores, caches, timeSource, meterRegistry);
   }
 
   /**
@@ -121,11 +150,13 @@ public final class SecretStoreRegistry {
   private static Map<String, LocallyCachedSecretStore> locallyCachedStores(
       final Map<String, SecretStore> stores,
       final Map<String, SecretCache> caches,
-      final InstantSource timeSource) {
+      final InstantSource timeSource,
+      final MeterRegistry meterRegistry) {
     final Map<String, LocallyCachedSecretStore> locallyCached = new LinkedHashMap<>();
     stores.forEach(
         (storeId, store) ->
-            locallyCached.put(storeId, locallyCached(storeId, store, caches, timeSource)));
+            locallyCached.put(
+                storeId, locallyCached(storeId, store, caches, timeSource, meterRegistry)));
     return Collections.unmodifiableMap(locallyCached);
   }
 
@@ -133,17 +164,25 @@ public final class SecretStoreRegistry {
    * Returns the store itself when it caches natively — wrapping it would put a second cache in
    * front of its own — and otherwise the store behind the cache configured for it, or a fresh
    * time-and-size-bounded one when the configured caches do not cover it.
+   *
+   * <p>Only that fresh cache is instrumented, which is also why a natively caching store shows up
+   * on none of {@link SecretCacheMetricsDoc}'s meters: there is no cache here to measure, and its
+   * own is the SDK's business.
    */
   private static LocallyCachedSecretStore locallyCached(
       final String storeId,
       final SecretStore store,
       final Map<String, SecretCache> caches,
-      final InstantSource timeSource) {
+      final InstantSource timeSource,
+      final MeterRegistry meterRegistry) {
     if (store instanceof final LocallyCachedSecretStore locallyCached) {
       return locallyCached;
     }
     final var configured = caches.get(storeId);
     return new CachingSecretStore(
-        store, configured != null ? configured : CaffeineSecretCache.createDefault(timeSource));
+        store,
+        configured != null
+            ? configured
+            : CaffeineSecretCache.createDefault(timeSource, meterRegistry, storeId));
   }
 }

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
@@ -369,8 +369,7 @@ class CachingSecretStoreTest {
         CaffeineSecretCache.DEFAULT_MAX_SIZE,
         Duration.ofMinutes(20),
         new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
-        registry,
-        STORE_ID);
+        new SecretCacheMetrics(registry, STORE_ID));
   }
 
   private static double evictions(

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
@@ -10,7 +10,6 @@ package io.camunda.secretstore;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheEvictionCause;
-import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -376,12 +375,7 @@ class CachingSecretStoreTest {
 
   private static double evictions(
       final SimpleMeterRegistry registry, final SecretCacheEvictionCause cause) {
-    return registry
-        .get(SecretCacheMetricsDoc.CACHE_EVICTIONS.getName())
-        .tag(SecretCacheKeyNames.STORE.asString(), STORE_ID)
-        .tag(SecretCacheKeyNames.CAUSE.asString(), cause.name())
-        .counter()
-        .count();
+    return SecretCacheMeters.evictions(registry, STORE_ID, cause);
   }
 
   private static final class RecordingSecretStore implements SecretStore {

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CachingSecretStoreTest.java
@@ -9,8 +9,11 @@ package io.camunda.secretstore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheEvictionCause;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -21,6 +24,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class CachingSecretStoreTest {
+
+  private static final String STORE_ID = "default";
 
   private final RecordingSecretStore store = new RecordingSecretStore();
   private final InMemorySecretCache cache = new InMemorySecretCache();
@@ -308,6 +313,75 @@ class CachingSecretStoreTest {
     // restart required
     assertThat(ttlStore.resolve(Set.of("token")).get("token")).isEqualTo(new Resolved("v2"));
     assertThat(store.resolveCalls).containsExactly(Set.of("token"), Set.of("token"));
+  }
+
+  @Test
+  void shouldCountInvalidatingACachedValueAsAnEviction() {
+    // given a cached value that the store now fails authoritatively, held in a metered cache
+    // instead of the in-memory fake the other tests use
+    final var registry = new SimpleMeterRegistry();
+    final var meteredStore = new CachingSecretStore(store, meteredCache(registry));
+    store.holds("token", "cached-value");
+    meteredStore.resolve(Set.of("token"));
+    store.fails("token", SecretErrorCode.ACCESS_DENIED);
+
+    // when
+    meteredStore.resolveFromStore(Set.of("token"));
+
+    // then dropping a secret the store no longer serves is visible as an eviction, which is what
+    // tells that case apart from a cache that simply ran out of room
+    assertThat(evictions(registry, SecretCacheEvictionCause.EXPLICIT)).isOne();
+  }
+
+  @Test
+  void shouldNotCountAPermanentFailureForANameThatWasNotCached() {
+    // given a name that was never resolved, so nothing is held for it
+    final var registry = new SimpleMeterRegistry();
+    final var meteredStore = new CachingSecretStore(store, meteredCache(registry));
+    store.fails("token", SecretErrorCode.NOT_FOUND);
+
+    // when
+    meteredStore.resolveFromStore(Set.of("token"));
+
+    // then nothing was evicted: a permanent failure is attempted for every such name, and counting
+    // the attempts would turn the eviction series into a count of failing lookups
+    assertThat(evictions(registry, SecretCacheEvictionCause.EXPLICIT)).isZero();
+  }
+
+  @Test
+  void shouldNotCountATransientFailureAsAnEviction() {
+    // given a cached value the store can no longer read due to a transient error
+    final var registry = new SimpleMeterRegistry();
+    final var meteredStore = new CachingSecretStore(store, meteredCache(registry));
+    store.holds("token", "cached-value");
+    meteredStore.resolve(Set.of("token"));
+    store.fails("token", SecretErrorCode.UNREADABLE);
+
+    // when
+    meteredStore.resolveFromStore(Set.of("token"));
+
+    // then the stale value stays, so nothing left the cache to count
+    assertThat(meteredStore.lookupLocal("token")).contains("cached-value");
+    assertThat(evictions(registry, SecretCacheEvictionCause.EXPLICIT)).isZero();
+  }
+
+  private static CaffeineSecretCache meteredCache(final SimpleMeterRegistry registry) {
+    return CaffeineSecretCache.create(
+        CaffeineSecretCache.DEFAULT_MAX_SIZE,
+        Duration.ofMinutes(20),
+        new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
+        registry,
+        STORE_ID);
+  }
+
+  private static double evictions(
+      final SimpleMeterRegistry registry, final SecretCacheEvictionCause cause) {
+    return registry
+        .get(SecretCacheMetricsDoc.CACHE_EVICTIONS.getName())
+        .tag(SecretCacheKeyNames.STORE.asString(), STORE_ID)
+        .tag(SecretCacheKeyNames.CAUSE.asString(), cause.name())
+        .counter()
+        .count();
   }
 
   private static final class RecordingSecretStore implements SecretStore {

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CaffeineSecretCacheMetricsTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CaffeineSecretCacheMetricsTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheEvictionCause;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheResult;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/** What {@link CaffeineSecretCache} publishes while it serves lookups and drops entries. */
+final class CaffeineSecretCacheMetricsTest {
+
+  private static final String STORE_ID = "store-a";
+  private static final Duration TTL = Duration.ofMinutes(20);
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final ControlledInstantSource timeSource =
+      new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z"));
+  private final CaffeineSecretCache cache =
+      CaffeineSecretCache.create(
+          CaffeineSecretCache.DEFAULT_MAX_SIZE, TTL, timeSource, registry, STORE_ID);
+
+  @Test
+  void shouldCountALookupThatTheCacheAnswers() {
+    // given
+    cache.put("token", "secret-value");
+
+    // when
+    cache.get("token");
+
+    // then
+    assertThat(results(SecretCacheResult.HIT)).isOne();
+    assertThat(results(SecretCacheResult.MISS)).isZero();
+  }
+
+  @Test
+  void shouldCountALookupThatTheCacheCannotAnswer() {
+    // when
+    cache.get("token");
+
+    // then
+    assertThat(results(SecretCacheResult.MISS)).isOne();
+    assertThat(results(SecretCacheResult.HIT)).isZero();
+  }
+
+  @Test
+  void shouldCountEveryLookupExactlyOnce() {
+    // given
+    cache.put("token", "secret-value");
+
+    // when the same name is looked up twice and an absent one once
+    cache.get("token");
+    cache.get("token");
+    cache.get("absent");
+
+    // then the hit rate is derivable, which is the only reason the two values share a meter
+    assertThat(results(SecretCacheResult.HIT)).isEqualTo(2);
+    assertThat(results(SecretCacheResult.MISS)).isOne();
+  }
+
+  @Test
+  void shouldCountAnEntryDroppedBecauseItsTtlElapsed() {
+    // given
+    cache.put("token", "secret-value");
+
+    // when the TTL elapses and pending maintenance runs — eviction is asynchronous, so nothing is
+    // counted until Caffeine gets to it
+    timeSource.advance(TTL);
+    cache.cleanUp();
+
+    // then
+    assertThat(evictions(SecretCacheEvictionCause.EXPIRED)).isOne();
+  }
+
+  @Test
+  void shouldCountEntriesDroppedBecauseTheCacheIsFull() {
+    // given a cache bounded to a small size
+    final var bounded = CaffeineSecretCache.create(10, TTL, timeSource, registry, "store-b");
+
+    // when more distinct names are written than the bound allows
+    for (int i = 0; i < 100; i++) {
+      bounded.put("secret-" + i, "value-" + i);
+    }
+    bounded.cleanUp();
+
+    // then everything that did not fit is counted, so a working set larger than the bound is
+    // visible as a rate rather than only as a low hit rate
+    assertThat(evictions("store-b", SecretCacheEvictionCause.SIZE)).isEqualTo(90);
+  }
+
+  @Test
+  void shouldCountAnEntryRemovedByName() {
+    // given
+    cache.put("token", "secret-value");
+
+    // when
+    cache.remove("token");
+
+    // then Caffeine never reports this itself, so the cache counts it: it is how a secret the store
+    // answered permanently — deleted, denied, or invalid — leaves the cache
+    assertThat(evictions(SecretCacheEvictionCause.EXPLICIT)).isOne();
+  }
+
+  @Test
+  void shouldNotCountRemovingANameThatWasNotCached() {
+    // when
+    cache.remove("never-cached");
+
+    // then nothing was evicted. CachingSecretStore removes a name on every permanent failure from
+    // its store, and most of those were never cached, so counting the calls would turn this series
+    // into a count of failing lookups
+    assertThat(evictions(SecretCacheEvictionCause.EXPLICIT)).isZero();
+  }
+
+  @Test
+  void shouldNotCountRemovingANameAsALookup() {
+    // given
+    cache.put("token", "secret-value");
+
+    // when
+    cache.remove("token");
+
+    // then the removal did not read the cache, and counting it as one would dilute the hit rate
+    // with lookups no caller made
+    assertThat(results(SecretCacheResult.HIT)).isZero();
+    assertThat(results(SecretCacheResult.MISS)).isZero();
+  }
+
+  @Test
+  void shouldNotCountOverwritingAValueAsAnEviction() {
+    // given
+    cache.put("token", "old-value");
+
+    // when the same name is written again
+    cache.put("token", "new-value");
+    cache.cleanUp();
+
+    // then nothing was evicted: the entry stayed and only its value changed, which the caching
+    // store does on every re-resolve. Counting it would bury the causes that mean something
+    assertThat(Arrays.stream(SecretCacheEvictionCause.values()).mapToDouble(this::evictions).sum())
+        .isZero();
+  }
+
+  @Test
+  void shouldPublishHowManyEntriesTheCacheHolds() {
+    // given
+    cache.put("token", "token-value");
+    cache.put("apiKey", "api-key-value");
+
+    // when
+    cache.remove("token");
+
+    // then
+    assertThat(size(STORE_ID)).isOne();
+  }
+
+  @Test
+  void shouldKeepTheMetersOfTwoStoresApart() {
+    // given two caches on one registry, as one registry per physical tenant holds
+    final var other = CaffeineSecretCache.create(10, TTL, timeSource, registry, "store-b");
+    cache.put("token", "value");
+
+    // when each is looked up a different number of times
+    cache.get("token");
+    other.get("token");
+    other.get("token");
+
+    // then the store tag keeps them apart rather than letting one cache's numbers answer for the
+    // other's
+    assertThat(results(STORE_ID, SecretCacheResult.HIT)).isOne();
+    assertThat(results("store-b", SecretCacheResult.MISS)).isEqualTo(2);
+  }
+
+  @Test
+  void shouldPublishNothingWhenCreatedWithoutARegistry() {
+    // given a cache created by a caller that named no registry
+    final var unmetered = CaffeineSecretCache.create(10, TTL, timeSource);
+
+    // when it is used
+    unmetered.put("token", "value");
+    unmetered.get("token");
+    unmetered.remove("token");
+
+    // then it registered nothing here — every meter on this registry still belongs to the cache
+    // that named it. A caller that does not want metrics must not have to name a registry, and must
+    // not end up publishing into someone else's
+    assertThat(registry.getMeters())
+        .isNotEmpty()
+        .allSatisfy(
+            meter ->
+                assertThat(meter.getId().getTag(SecretCacheKeyNames.STORE.asString()))
+                    .isEqualTo(STORE_ID));
+  }
+
+  @Test
+  void shouldNotTagAnyMeterWithASecretNameOrValue() {
+    // given a cache exercised through every path that could tag a meter
+    cache.put("api-token", "sk-live-1234");
+    cache.get("api-token");
+    cache.get("other-secret");
+    cache.remove("api-token");
+    timeSource.advance(TTL);
+    cache.cleanUp();
+
+    // when
+    final var tagValues =
+        registry.getMeters().stream()
+            .flatMap(meter -> meter.getId().getTags().stream())
+            .map(Tag::getValue)
+            .toList();
+
+    // then neither the name nor the value of a secret reaches the metrics endpoint. The cache is
+    // keyed by the bare secret name, so such a tag would be unbounded cardinality and customer data
+    // at once
+    assertThat(tagValues).doesNotContain("api-token", "other-secret", "sk-live-1234");
+  }
+
+  private double results(final SecretCacheResult result) {
+    return results(STORE_ID, result);
+  }
+
+  private double results(final String storeId, final SecretCacheResult result) {
+    return registry
+        .get(SecretCacheMetricsDoc.CACHE_RESULT.getName())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .tag(SecretCacheKeyNames.RESULT.asString(), result.name())
+        .counter()
+        .count();
+  }
+
+  private double evictions(final SecretCacheEvictionCause cause) {
+    return evictions(STORE_ID, cause);
+  }
+
+  private double evictions(final String storeId, final SecretCacheEvictionCause cause) {
+    return registry
+        .get(SecretCacheMetricsDoc.CACHE_EVICTIONS.getName())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .tag(SecretCacheKeyNames.CAUSE.asString(), cause.name())
+        .counter()
+        .count();
+  }
+
+  private double size(final String storeId) {
+    return registry
+        .get(SecretCacheMetricsDoc.CACHE_SIZE.getName())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .gauge()
+        .value();
+  }
+}

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CaffeineSecretCacheMetricsTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CaffeineSecretCacheMetricsTest.java
@@ -232,12 +232,7 @@ final class CaffeineSecretCacheMetricsTest {
   }
 
   private double results(final String storeId, final SecretCacheResult result) {
-    return registry
-        .get(SecretCacheMetricsDoc.CACHE_RESULT.getName())
-        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
-        .tag(SecretCacheKeyNames.RESULT.asString(), result.name())
-        .counter()
-        .count();
+    return SecretCacheMeters.results(registry, storeId, result);
   }
 
   private double evictions(final SecretCacheEvictionCause cause) {
@@ -245,19 +240,10 @@ final class CaffeineSecretCacheMetricsTest {
   }
 
   private double evictions(final String storeId, final SecretCacheEvictionCause cause) {
-    return registry
-        .get(SecretCacheMetricsDoc.CACHE_EVICTIONS.getName())
-        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
-        .tag(SecretCacheKeyNames.CAUSE.asString(), cause.name())
-        .counter()
-        .count();
+    return SecretCacheMeters.evictions(registry, storeId, cause);
   }
 
   private double size(final String storeId) {
-    return registry
-        .get(SecretCacheMetricsDoc.CACHE_SIZE.getName())
-        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
-        .gauge()
-        .value();
+    return SecretCacheMeters.size(registry, storeId);
   }
 }

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CaffeineSecretCacheMetricsTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/CaffeineSecretCacheMetricsTest.java
@@ -28,9 +28,7 @@ final class CaffeineSecretCacheMetricsTest {
   private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
   private final ControlledInstantSource timeSource =
       new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z"));
-  private final CaffeineSecretCache cache =
-      CaffeineSecretCache.create(
-          CaffeineSecretCache.DEFAULT_MAX_SIZE, TTL, timeSource, registry, STORE_ID);
+  private final CaffeineSecretCache cache = meteredCache(STORE_ID);
 
   @Test
   void shouldCountALookupThatTheCacheAnswers() {
@@ -87,7 +85,9 @@ final class CaffeineSecretCacheMetricsTest {
   @Test
   void shouldCountEntriesDroppedBecauseTheCacheIsFull() {
     // given a cache bounded to a small size
-    final var bounded = CaffeineSecretCache.create(10, TTL, timeSource, registry, "store-b");
+    final var bounded =
+        CaffeineSecretCache.create(
+            10, TTL, timeSource, new SecretCacheMetrics(registry, "store-b"));
 
     // when more distinct names are written than the bound allows
     for (int i = 0; i < 100; i++) {
@@ -169,7 +169,9 @@ final class CaffeineSecretCacheMetricsTest {
   @Test
   void shouldKeepTheMetersOfTwoStoresApart() {
     // given two caches on one registry, as one registry per physical tenant holds
-    final var other = CaffeineSecretCache.create(10, TTL, timeSource, registry, "store-b");
+    final var other =
+        CaffeineSecretCache.create(
+            10, TTL, timeSource, new SecretCacheMetrics(registry, "store-b"));
     cache.put("token", "value");
 
     // when each is looked up a different number of times
@@ -245,5 +247,13 @@ final class CaffeineSecretCacheMetricsTest {
 
   private double size(final String storeId) {
     return SecretCacheMeters.size(registry, storeId);
+  }
+
+  private CaffeineSecretCache meteredCache(final String storeId) {
+    return CaffeineSecretCache.create(
+        CaffeineSecretCache.DEFAULT_MAX_SIZE,
+        TTL,
+        timeSource,
+        new SecretCacheMetrics(registry, storeId));
   }
 }

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretCacheMeters.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretCacheMeters.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheEvictionCause;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheResult;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.List;
+
+/**
+ * Reads {@link SecretCacheMetricsDoc}'s meters back off a registry, so a test asserts on what an
+ * operator would see rather than on the counters a cache holds.
+ *
+ * <p>Every lookup names the {@code store} tag: {@code RequiredSearch} treats a tag as required
+ * rather than exhaustive, so a search without it would silently answer with whichever store's meter
+ * matched first once a test meters two stores into one registry.
+ */
+final class SecretCacheMeters {
+
+  private SecretCacheMeters() {}
+
+  static double results(
+      final MeterRegistry registry, final String storeId, final SecretCacheResult result) {
+    return registry
+        .get(SecretCacheMetricsDoc.CACHE_RESULT.getName())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .tag(SecretCacheKeyNames.RESULT.asString(), result.name())
+        .counter()
+        .count();
+  }
+
+  static double evictions(
+      final MeterRegistry registry, final String storeId, final SecretCacheEvictionCause cause) {
+    return registry
+        .get(SecretCacheMetricsDoc.CACHE_EVICTIONS.getName())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .tag(SecretCacheKeyNames.CAUSE.asString(), cause.name())
+        .counter()
+        .count();
+  }
+
+  static double size(final MeterRegistry registry, final String storeId) {
+    return registry
+        .get(SecretCacheMetricsDoc.CACHE_SIZE.getName())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .gauge()
+        .value();
+  }
+
+  /**
+   * The names of every secret cache meter on the registry, so a test can assert a cache published
+   * nothing at all — a meter search would throw instead of reporting an absence.
+   */
+  static List<String> cacheMeterNames(final MeterRegistry registry) {
+    return registry.getMeters().stream()
+        .map(meter -> meter.getId().getName())
+        .filter(name -> name.startsWith("camunda.secret.cache."))
+        .toList();
+  }
+}

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretCacheMetricsDocTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretCacheMetricsDocTest.java
@@ -141,6 +141,16 @@ final class SecretCacheMetricsDocTest {
   }
 
   @Test
+  void shouldMapARemovalByNameToExplicit() {
+    // when/then — Caffeine reports this cause to no StatsCounter
+    // (RemovalCause.EXPLICIT.wasEvicted()
+    // is false), so CaffeineSecretCache.remove counts it itself and nothing else exercises this
+    // arm. Without this it could be mapped to any other cause and every test would still pass
+    assertThat(SecretCacheEvictionCause.from(RemovalCause.EXPLICIT))
+        .isEqualTo(SecretCacheEvictionCause.EXPLICIT);
+  }
+
+  @Test
   void shouldRejectAReplacedValueAsAnEviction() {
     // when/then — the entry stays and only its value changes, which CachingSecretStore does on
     // every re-resolve. Folding it into a cause would bury the evictions that mean something

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretCacheMetricsDocTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretCacheMetricsDocTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheEvictionCause;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheResult;
+import io.micrometer.core.instrument.Meter.Type;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The doc enum is the documentation for these meters, so it is worth asserting on. Renaming a meter
+ * or a tag key silently breaks every dashboard and alert built on it, and there is no repo-wide
+ * check for that.
+ */
+final class SecretCacheMetricsDocTest {
+
+  @Test
+  void shouldBeNamedAndDocumentedConsistently() {
+    // given
+    final var meters = SecretCacheMetricsDoc.values();
+
+    // when/then
+    assertThat(meters)
+        .isNotEmpty()
+        .allSatisfy(
+            meter -> {
+              assertThat(meter.getName())
+                  .startsWith("camunda.secret.cache.")
+                  .doesNotContain("..")
+                  .doesNotContain("-")
+                  .doesNotContain("_");
+              assertThat(meter.getDescription()).isNotBlank();
+              // every meter belongs to exactly one store's cache, and nothing else distinguishes
+              // two caches from one another
+              assertThat(meter.getKeyNames()).contains(SecretCacheKeyNames.STORE);
+            });
+  }
+
+  @Test
+  void shouldDocumentTheResultAsACounterTaggedByStoreAndResult() {
+    // given
+    final var meter = SecretCacheMetricsDoc.CACHE_RESULT;
+
+    // when/then
+    assertThat(meter.getName()).isEqualTo("camunda.secret.cache.result");
+    assertThat(meter.getType()).isEqualTo(Type.COUNTER);
+    assertThat(meter.getKeyNames())
+        .containsExactly(SecretCacheKeyNames.STORE, SecretCacheKeyNames.RESULT);
+    // the hit rate is derived rather than published, which only works if both values count the
+    // same thing — one lookup
+    assertThat(SecretCacheResult.values())
+        .extracting(Enum::name)
+        .containsExactlyInAnyOrder("HIT", "MISS");
+  }
+
+  @Test
+  void shouldPointAtTheResolutionOutcomeForMissesNoTuningCanFix() {
+    // given/when/then — a reference the store answers permanently is never cached, so it misses on
+    // every lookup. Without the cross-reference an operator reads that as a cache to tune and
+    // reaches for a TTL or a maximum that cannot move it
+    assertThat(SecretCacheMetricsDoc.CACHE_RESULT.getDescription())
+        .contains("camunda.secret.resolution.outcome");
+  }
+
+  @Test
+  void shouldDocumentTheEvictionsAsACounterTaggedByStoreAndCause() {
+    // given
+    final var meter = SecretCacheMetricsDoc.CACHE_EVICTIONS;
+
+    // when/then
+    assertThat(meter.getName()).isEqualTo("camunda.secret.cache.evictions");
+    assertThat(meter.getType()).isEqualTo(Type.COUNTER);
+    assertThat(meter.getKeyNames())
+        .containsExactly(SecretCacheKeyNames.STORE, SecretCacheKeyNames.CAUSE);
+  }
+
+  @Test
+  void shouldDocumentTheSizeAsAGaugeWithoutABaseUnit() {
+    // given
+    final var meter = SecretCacheMetricsDoc.CACHE_SIZE;
+
+    // when/then — Micrometer appends the base unit to the meter name, so declaring one here would
+    // publish camunda_secret_cache_size_entries instead of the documented name
+    assertThat(meter.getName()).isEqualTo("camunda.secret.cache.size");
+    assertThat(meter.getType()).isEqualTo(Type.GAUGE);
+    assertThat(meter.getBaseUnit()).isNull();
+    assertThat(meter.getKeyNames()).containsExactly(SecretCacheKeyNames.STORE);
+  }
+
+  @Test
+  void shouldStateTheBoundsTheCacheActuallyRunsWith() {
+    // given/when/then — neither bound is configurable, and neither is published on a meter of
+    // its own, so these descriptions are the only place an operator can read them. Asserting
+    // the live constants rather than literals keeps a changed default from making them lie
+    assertThat(SecretCacheMetricsDoc.CACHE_SIZE.getDescription())
+        .contains(String.valueOf(CaffeineSecretCache.DEFAULT_MAX_SIZE));
+    assertThat(SecretCacheMetricsDoc.CACHE_EVICTIONS.getDescription())
+        .contains(String.valueOf(CaffeineSecretCache.DEFAULT_MAX_SIZE))
+        .contains(String.valueOf(CaffeineSecretCache.DEFAULT_TTL.toMinutes()));
+  }
+
+  @Test
+  void shouldDocumentThatTheSizeIsAnEstimate() {
+    // given/when/then — eviction is asynchronous, so a reader who takes the value as exact will
+    // see it sit above the configured maximum and call it a bug
+    assertThat(SecretCacheMetricsDoc.CACHE_SIZE.getDescription()).contains("Estimated");
+  }
+
+  @Test
+  void shouldCountOneCacheEntryPerEvictionCauseValue() {
+    // given/when/then — all four values count one entry leaving one cache, so they share a unit
+    // and can be summed across the tag. A quantity measured per anything else would have to go on
+    // its own meter
+    assertThat(SecretCacheEvictionCause.values())
+        .extracting(Enum::name)
+        .containsExactlyInAnyOrder("SIZE", "EXPIRED", "EXPLICIT", "COLLECTED");
+  }
+
+  @Test
+  void shouldMapEveryEvictingRemovalCauseToItsOwnValue() {
+    // given every cause Caffeine reports as an eviction
+    final var evicting = Stream.of(RemovalCause.values()).filter(RemovalCause::wasEvicted).toList();
+
+    // when
+    final var causes = evicting.stream().map(SecretCacheEvictionCause::from).toList();
+
+    // then no two of them are folded onto one tag value, which would make a cache that is too small
+    // indistinguishable from one whose TTL is too short
+    assertThat(causes).doesNotHaveDuplicates().hasSameSizeAs(evicting);
+  }
+
+  @Test
+  void shouldRejectAReplacedValueAsAnEviction() {
+    // when/then — the entry stays and only its value changes, which CachingSecretStore does on
+    // every re-resolve. Folding it into a cause would bury the evictions that mean something
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> SecretCacheEvictionCause.from(RemovalCause.REPLACED))
+        .withMessageContaining("REPLACED");
+  }
+
+  @Test
+  void shouldUseTheSameStoreTagKeyAsTheResolutionMeters() {
+    // when/then — the engine's camunda.secret.resolution.* meters tag `store` too, and a dashboard
+    // correlating a low hit rate with slow resolutions has to be able to join on it
+    assertThat(SecretCacheKeyNames.STORE.asString()).isEqualTo("store");
+  }
+}

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
 import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheResult;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
@@ -247,15 +246,13 @@ class SecretStoreRegistryTest {
   }
 
   @Test
-  void shouldPublishWhatTheDefaultCacheOfEachStoreDoes() {
-    // given two stores, each on a default cache built by the registry
+  void shouldPublishWhatTheCacheOfEachStoreDoes() {
+    // given two stores, each on a cache the factory built for its own store ID
     final var meterRegistry = new SimpleMeterRegistry();
     final var registry =
         new SecretStoreRegistry(
             Map.of("store-a", storeHolding("token", "a"), "store-b", storeHolding("token", "b")),
-            Map.of(),
-            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
-            meterRegistry);
+            meteredCacheFactory(meterRegistry));
 
     // when only one of them resolves the name
     registry.getStores().get("store-a").resolve(Set.of("token"));
@@ -263,66 +260,62 @@ class SecretStoreRegistryTest {
 
     // then each cache reports under its own store ID, so one store's numbers never answer for
     // another's — the registry is the only place that knows which cache belongs to which store
-    assertThat(cacheResults(meterRegistry, "store-a", SecretCacheResult.MISS)).isOne();
-    assertThat(cacheResults(meterRegistry, "store-a", SecretCacheResult.HIT)).isOne();
-    assertThat(cacheResults(meterRegistry, "store-b", SecretCacheResult.MISS)).isZero();
+    assertThat(SecretCacheMeters.results(meterRegistry, "store-a", SecretCacheResult.MISS)).isOne();
+    assertThat(SecretCacheMeters.results(meterRegistry, "store-a", SecretCacheResult.HIT)).isOne();
+    assertThat(SecretCacheMeters.results(meterRegistry, "store-b", SecretCacheResult.MISS))
+        .isZero();
   }
 
   @Test
-  void shouldPublishNothingForAStoreThatCachesNatively() {
-    // given a store that holds what it resolves itself, so the registry builds it no cache
+  void shouldBuildNoCacheForAStoreThatCachesNatively() {
+    // given a store that holds what it resolves itself
     final var meterRegistry = new SimpleMeterRegistry();
+    final var storeIdsBuiltFor = new ArrayList<String>();
     final var registry =
         new SecretStoreRegistry(
             Map.of("default", new NativelyCachingSecretStore()),
-            Map.of(),
-            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
-            meterRegistry);
+            storeId -> {
+              storeIdsBuiltFor.add(storeId);
+              return meteredCacheFactory(meterRegistry).create(storeId);
+            });
 
     // when it is resolved through
     registry.getStores().get("default").resolve(Set.of("token"));
 
-    // then no cache meter exists for it at all: there is nothing here to measure, its cache being
-    // its SDK's business
-    assertThat(cacheMeterNames(meterRegistry)).isEmpty();
+    // then the factory was never called for it, so no cache meter exists either: wrapping such a
+    // store would put a second cache in front of its own, and meters registered for a cache it
+    // never resolves through would sit at zero forever
+    assertThat(storeIdsBuiltFor).isEmpty();
+    assertThat(SecretCacheMeters.cacheMeterNames(meterRegistry)).isEmpty();
   }
 
   @Test
   void shouldPublishNothingForACacheTheCallerSupplied() {
-    // given a store whose cache the caller chose instead of the default one
+    // given a store whose cache the caller chose instead of an instrumented one
     final var meterRegistry = new SimpleMeterRegistry();
     final var registry =
         new SecretStoreRegistry(
             Map.of("default", storeHolding("token", "value")),
             Map.of("default", new InMemorySecretCache()),
-            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
-            meterRegistry);
+            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")));
 
     // when it is resolved through
     registry.getStores().get("default").resolve(Set.of("token"));
 
     // then nothing is published: an arbitrary SecretCache exposes nothing to measure, so this seam
     // stays a plain test double rather than half-instrumenting one
-    assertThat(cacheMeterNames(meterRegistry)).isEmpty();
+    assertThat(SecretCacheMeters.cacheMeterNames(meterRegistry)).isEmpty();
   }
 
-  private static List<String> cacheMeterNames(final SimpleMeterRegistry meterRegistry) {
-    return meterRegistry.getMeters().stream()
-        .map(meter -> meter.getId().getName())
-        .filter(name -> name.startsWith("camunda.secret.cache."))
-        .toList();
-  }
-
-  private static double cacheResults(
-      final SimpleMeterRegistry meterRegistry,
-      final String storeId,
-      final SecretCacheResult result) {
-    return meterRegistry
-        .get(SecretCacheMetricsDoc.CACHE_RESULT.getName())
-        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
-        .tag(SecretCacheKeyNames.RESULT.asString(), result.name())
-        .counter()
-        .count();
+  /** A factory building the instrumented cache the Spring wiring builds, as it builds it. */
+  private static SecretCacheFactory meteredCacheFactory(final SimpleMeterRegistry meterRegistry) {
+    return storeId ->
+        CaffeineSecretCache.create(
+            CaffeineSecretCache.DEFAULT_MAX_SIZE,
+            CaffeineSecretCache.DEFAULT_TTL,
+            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
+            meterRegistry,
+            storeId);
   }
 
   private static Optional<String> lookupLocal(

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
@@ -11,8 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
+import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheResult;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -241,6 +244,85 @@ class SecretStoreRegistryTest {
     // then the rotated value is picked up, with no restart required
     assertThat(lookupLocal(registry, "default", "token")).contains("v2");
     assertThat(store.resolveCalls).containsExactly(Set.of("token"), Set.of("token"));
+  }
+
+  @Test
+  void shouldPublishWhatTheDefaultCacheOfEachStoreDoes() {
+    // given two stores, each on a default cache built by the registry
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeHolding("token", "a"), "store-b", storeHolding("token", "b")),
+            Map.of(),
+            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
+            meterRegistry);
+
+    // when only one of them resolves the name
+    registry.getStores().get("store-a").resolve(Set.of("token"));
+    registry.getStores().get("store-a").lookupLocal("token");
+
+    // then each cache reports under its own store ID, so one store's numbers never answer for
+    // another's — the registry is the only place that knows which cache belongs to which store
+    assertThat(cacheResults(meterRegistry, "store-a", SecretCacheResult.MISS)).isOne();
+    assertThat(cacheResults(meterRegistry, "store-a", SecretCacheResult.HIT)).isOne();
+    assertThat(cacheResults(meterRegistry, "store-b", SecretCacheResult.MISS)).isZero();
+  }
+
+  @Test
+  void shouldPublishNothingForAStoreThatCachesNatively() {
+    // given a store that holds what it resolves itself, so the registry builds it no cache
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("default", new NativelyCachingSecretStore()),
+            Map.of(),
+            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
+            meterRegistry);
+
+    // when it is resolved through
+    registry.getStores().get("default").resolve(Set.of("token"));
+
+    // then no cache meter exists for it at all: there is nothing here to measure, its cache being
+    // its SDK's business
+    assertThat(cacheMeterNames(meterRegistry)).isEmpty();
+  }
+
+  @Test
+  void shouldPublishNothingForACacheTheCallerSupplied() {
+    // given a store whose cache the caller chose instead of the default one
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("default", storeHolding("token", "value")),
+            Map.of("default", new InMemorySecretCache()),
+            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
+            meterRegistry);
+
+    // when it is resolved through
+    registry.getStores().get("default").resolve(Set.of("token"));
+
+    // then nothing is published: an arbitrary SecretCache exposes nothing to measure, so this seam
+    // stays a plain test double rather than half-instrumenting one
+    assertThat(cacheMeterNames(meterRegistry)).isEmpty();
+  }
+
+  private static List<String> cacheMeterNames(final SimpleMeterRegistry meterRegistry) {
+    return meterRegistry.getMeters().stream()
+        .map(meter -> meter.getId().getName())
+        .filter(name -> name.startsWith("camunda.secret.cache."))
+        .toList();
+  }
+
+  private static double cacheResults(
+      final SimpleMeterRegistry meterRegistry,
+      final String storeId,
+      final SecretCacheResult result) {
+    return meterRegistry
+        .get(SecretCacheMetricsDoc.CACHE_RESULT.getName())
+        .tag(SecretCacheKeyNames.STORE.asString(), storeId)
+        .tag(SecretCacheKeyNames.RESULT.asString(), result.name())
+        .counter()
+        .count();
   }
 
   private static Optional<String> lookupLocal(

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretStoreRegistryTest.java
@@ -309,13 +309,11 @@ class SecretStoreRegistryTest {
 
   /** A factory building the instrumented cache the Spring wiring builds, as it builds it. */
   private static SecretCacheFactory meteredCacheFactory(final SimpleMeterRegistry meterRegistry) {
-    return storeId ->
-        CaffeineSecretCache.create(
-            CaffeineSecretCache.DEFAULT_MAX_SIZE,
-            CaffeineSecretCache.DEFAULT_TTL,
-            new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
-            meterRegistry,
-            storeId);
+    return SecretCacheFactory.metered(
+        CaffeineSecretCache.DEFAULT_MAX_SIZE,
+        CaffeineSecretCache.DEFAULT_TTL,
+        new ControlledInstantSource(Instant.parse("2026-01-01T00:00:00Z")),
+        meterRegistry);
   }
 
   private static Optional<String> lookupLocal(


### PR DESCRIPTION
## Description

Part two of #59315, stacked on #59468 (part one: resolution duration, outcome and cycle errors)

Adds three meters, published by `CaffeineSecretCache` itself and tagged by store id (plus `physicalTenant`, added by the Spring wiring):

| Meter | Type | Tags |
|---|---|---|
| `camunda.secret.cache.result` | counter | `store`, `result=HIT\|MISS` |
| `camunda.secret.cache.evictions` | counter | `store`, `cause=SIZE\|EXPIRED\|EXPLICIT\|COLLECTED` |
| `camunda.secret.cache.size` | gauge | `store` |

Hit rate is derived on the dashboard from the result counter, as every other cache in this repo is consumed.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
