### PR TITLE
fix: resolve type in SecondaryStorageInterceptor using Unified Configuration

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/BasicAuthenticationNoDbConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/BasicAuthenticationNoDbConfiguration.java
@@ -16,8 +16,8 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * Provides fail-fast behavior when Basic Authentication is configured but secondary storage is
- * disabled (camunda.database.type=none). This prevents misleading security flows and produces a
- * clear error message at context startup.
+ * disabled (camunda.data.secondary-storage.type=none). This prevents misleading security flows and
+ * produces a clear error message at context startup.
  */
 @Configuration
 @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)

--- a/authentication/src/main/java/io/camunda/authentication/exception/BasicAuthenticationNotSupportedException.java
+++ b/authentication/src/main/java/io/camunda/authentication/exception/BasicAuthenticationNotSupportedException.java
@@ -8,7 +8,7 @@
 package io.camunda.authentication.exception;
 
 import static io.camunda.spring.utils.DatabaseTypeUtils.CAMUNDA_DATABASE_TYPE_NONE;
-import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 /** Exception thrown when Basic Authentication is configured but secondary storage is disabled. */
 public class BasicAuthenticationNotSupportedException extends RuntimeException {
@@ -17,11 +17,11 @@ public class BasicAuthenticationNotSupportedException extends RuntimeException {
         """
           Basic Authentication is not supported when secondary storage is disabled (
           %s=%s). Basic Authentication requires access to user data stored in secondary storage.
-          Please either enable secondary storage by configuring %s to a supported database type,
+          Please either enable secondary storage by configuring '%s' to a supported database type,
           or use another authentication method by updating the camunda.security.authentication.method configuration."""
             .formatted(
-                PROPERTY_CAMUNDA_DATABASE_TYPE,
+                UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE,
                 CAMUNDA_DATABASE_TYPE_NONE,
-                PROPERTY_CAMUNDA_DATABASE_TYPE));
+                UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE));
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/pt/DatabaseTypeProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/DatabaseTypeProviderConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.pt;
+
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.search.connect.configuration.DatabaseType;
+import java.util.function.Function;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides the per-physical-tenant secondary storage type, consulted by {@code
+ * SecondaryStorageInterceptor} to reject requests for tenants with no secondary storage. Resolved
+ * directly from {@link PhysicalTenantResolver} (unconditionally available) rather than from any
+ * storage-specific configuration, so a bean exists for every secondary storage type, including
+ * rdbms and none.
+ */
+@Configuration(proxyBeanMethods = false)
+public class DatabaseTypeProviderConfiguration {
+
+  @Bean
+  public Function<String, DatabaseType> databaseTypeProvider(
+      final PhysicalTenantResolver physicalTenantResolver) {
+    return tenantId ->
+        DatabaseType.from(
+            physicalTenantResolver
+                .forPhysicalTenant(tenantId)
+                .getData()
+                .getSecondaryStorage()
+                .getType()
+                .name());
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/pt/DatabaseTypeProviderConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/DatabaseTypeProviderConfigurationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.pt;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.search.connect.configuration.DatabaseType;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class DatabaseTypeProviderConfigurationTest {
+
+  private static final String TENANT_A = "tenanta";
+
+  @BeforeAll
+  @AfterAll
+  static void clearStaticEnvironment() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldResolveElasticsearchType() {
+    assertThat(
+            databaseTypeProviderFor(SecondaryStorageType.elasticsearch)
+                .apply(DEFAULT_PHYSICAL_TENANT_ID))
+        .isEqualTo(DatabaseType.ELASTICSEARCH);
+  }
+
+  @Test
+  void shouldResolveOpensearchType() {
+    assertThat(
+            databaseTypeProviderFor(SecondaryStorageType.opensearch)
+                .apply(DEFAULT_PHYSICAL_TENANT_ID))
+        .isEqualTo(DatabaseType.OPENSEARCH);
+  }
+
+  @Test
+  void shouldResolveRdbmsType() {
+    assertThat(
+            databaseTypeProviderFor(SecondaryStorageType.rdbms).apply(DEFAULT_PHYSICAL_TENANT_ID))
+        .isEqualTo(DatabaseType.RDBMS);
+  }
+
+  @Test
+  void shouldResolveNoneType() {
+    assertThat(databaseTypeProviderFor(SecondaryStorageType.none).apply(DEFAULT_PHYSICAL_TENANT_ID))
+        .isEqualTo(DatabaseType.NONE);
+  }
+
+  @Test
+  void shouldResolveDatabaseTypePerPhysicalTenant() {
+    // given the default tenant on elasticsearch and a second, explicitly-declared tenant on
+    // opensearch (both document-store types, so the cross-tenant homogeneity validation permits
+    // the mix)
+    final Camunda camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+    final MockEnvironment environment = new MockEnvironment();
+    final String base = "camunda.physical-tenants." + TENANT_A + ".";
+    environment.setProperty(base + "data.secondary-storage.type", "opensearch");
+    environment.setProperty(
+        base + "security.initialization.default-roles.admin.users[0]", TENANT_A + "-admin");
+    final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(environment, camunda);
+
+    // when
+    final var databaseTypeProvider =
+        new DatabaseTypeProviderConfiguration().databaseTypeProvider(resolver);
+
+    // then each tenant resolves its own configured type
+    assertThat(databaseTypeProvider.apply(DEFAULT_PHYSICAL_TENANT_ID))
+        .isEqualTo(DatabaseType.ELASTICSEARCH);
+    assertThat(databaseTypeProvider.apply(TENANT_A)).isEqualTo(DatabaseType.OPENSEARCH);
+  }
+
+  @Test
+  void shouldThrowForUnknownPhysicalTenant() {
+    final var databaseTypeProvider = databaseTypeProviderFor(SecondaryStorageType.elasticsearch);
+
+    assertThatThrownBy(() -> databaseTypeProvider.apply("unknown-tenant"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private static Function<String, DatabaseType> databaseTypeProviderFor(
+      final SecondaryStorageType secondaryStorageType) {
+    final Camunda camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setType(secondaryStorageType);
+    final PhysicalTenantResolver resolver =
+        PhysicalTenantResolver.of(new MockEnvironment(), camunda);
+    return new DatabaseTypeProviderConfiguration().databaseTypeProvider(resolver);
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/pt/SecondaryStorageInterceptorConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/SecondaryStorageInterceptorConfigurationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.pt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.service.exception.SecondaryStorageUnavailableException;
+import io.camunda.spring.utils.PhysicalTenantContext;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.interceptor.SecondaryStorageInterceptor;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.method.HandlerMethod;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  DatabaseTypeProviderConfiguration.class,
+  SecondaryStorageInterceptor.class,
+  SecondaryStorageInterceptorConfigurationTest.TestConfiguration.class,
+})
+class SecondaryStorageInterceptorConfigurationTest {
+
+  @Autowired private SecondaryStorageInterceptor secondaryStorageInterceptor;
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  private static HttpServletRequest requestDispatch() {
+    final var request = mock(HttpServletRequest.class);
+    when(request.getDispatcherType()).thenReturn(DispatcherType.REQUEST);
+    when(request.getAttribute(PhysicalTenantContext.REQUEST_ATTRIBUTE_PHYSICAL_TENANT_ID))
+        .thenReturn(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    return request;
+  }
+
+  private static HandlerMethod requiresSecondaryStorageHandler() {
+    final var handlerMethod = mock(HandlerMethod.class);
+    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
+    return handlerMethod;
+  }
+
+  @Configuration
+  static class TestConfiguration {
+    @Bean
+    PhysicalTenantResolver physicalTenantResolver(
+        final Environment environment, final Camunda camunda) {
+      return PhysicalTenantResolver.of(environment, camunda);
+    }
+
+    @Bean
+    SecondaryStorageReadiness secondaryStorageReadiness() {
+      return SecondaryStorageReadiness.ALWAYS_READY;
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=rdbms"})
+  class WithMatchingLegacyAndUnifiedRdbmsType {
+    @Test
+    void shouldAllowRequestsRequiringSecondaryStorageWhenBothPropertiesAgree() {
+      final boolean result =
+          secondaryStorageInterceptor.preHandle(
+              requestDispatch(),
+              mock(HttpServletResponse.class),
+              requiresSecondaryStorageHandler());
+
+      assertThat(result).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=none"})
+  class WithMatchingLegacyAndUnifiedNoneType {
+    @Test
+    void shouldRejectRequestsRequiringSecondaryStorageWhenBothPropertiesAgree() {
+      assertThatThrownBy(
+              () ->
+                  secondaryStorageInterceptor.preHandle(
+                      requestDispatch(),
+                      mock(HttpServletResponse.class),
+                      requiresSecondaryStorageHandler()))
+          .isInstanceOf(SecondaryStorageUnavailableException.class);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = "camunda.database.type=elasticsearch")
+  class WithOnlyLegacySetMatchingUnifiedDefault {
+    @Test
+    void shouldAllowRequestsRequiringSecondaryStorage() {
+      final boolean result =
+          secondaryStorageInterceptor.preHandle(
+              requestDispatch(),
+              mock(HttpServletResponse.class),
+              requiresSecondaryStorageHandler());
+
+      assertThat(result).isTrue();
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoAuthNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoAuthNoSecondaryStorageTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.it.nodb;
 
-import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -34,7 +34,7 @@ public class NoAuthNoSecondaryStorageTest {
   private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
           .withUnauthenticatedAccess()
-          .withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, "none")
+          .withProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, "none")
           .withProperty("spring.profiles.active", "broker");
 
   @AutoClose private CamundaClient camundaClient;
@@ -159,7 +159,7 @@ public class NoAuthNoSecondaryStorageTest {
         .hasMessageContaining(
             String.format(
                 "Secondary storage can be configured using the '%s' property",
-                PROPERTY_CAMUNDA_DATABASE_TYPE))
+                UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE))
         .hasMessageContaining("FORBIDDEN")
         .hasMessageContaining("status: 403");
   }

--- a/search/search-domain/src/main/java/io/camunda/search/exception/NoSecondaryStorageException.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/NoSecondaryStorageException.java
@@ -7,14 +7,13 @@
  */
 package io.camunda.search.exception;
 
-import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 public class NoSecondaryStorageException extends CamundaSearchException {
 
   public static final String NO_SECONDARY_STORAGE_MESSAGE =
-      "This endpoint requires a secondary storage, but none is set. Secondary storage can be configured using the"
-          + PROPERTY_CAMUNDA_DATABASE_TYPE
-          + " property.";
+      "This endpoint requires a secondary storage, but none is set. Secondary storage can be configured using the '%s' property."
+          .formatted(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE);
   private static final long serialVersionUID = 1L;
 
   public NoSecondaryStorageException() {

--- a/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
+++ b/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
@@ -8,7 +8,7 @@
 package io.camunda.service.exception;
 
 import static io.camunda.service.exception.ServiceException.Status.*;
-import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import io.atomix.cluster.messaging.MessagingException;
@@ -80,9 +80,8 @@ public class ErrorMapper {
       }
       case SECONDARY_STORAGE_NOT_SET -> {
         final String detail =
-            "The search client requires a secondary storage, but none is set. Secondary storage can be configured using the '"
-                + PROPERTY_CAMUNDA_DATABASE_TYPE
-                + "' property";
+            "The search client requires a secondary storage, but none is set. Secondary storage can be configured using the '%s' property"
+                .formatted(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE);
         LOGGER.debug(detail, cse);
         yield new ServiceException(detail, FORBIDDEN);
       }

--- a/service/src/main/java/io/camunda/service/exception/SecondaryStorageUnavailableException.java
+++ b/service/src/main/java/io/camunda/service/exception/SecondaryStorageUnavailableException.java
@@ -7,14 +7,18 @@
  */
 package io.camunda.service.exception;
 
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
+
 /**
- * Thrown when secondary storage is not configured at all ({@code camunda.database.type=none}). HTTP
- * 403 — contrast with {@link SecondaryStorageDegradedException}, which is HTTP 503 for a configured
- * but currently-degraded physical tenant.
+ * Thrown when secondary storage is not configured at all ({@code
+ * camunda.data.secondary-storage.type=none}). HTTP 403 — contrast with {@link
+ * SecondaryStorageDegradedException}, which is HTTP 503 for a configured but currently-degraded
+ * physical tenant.
  */
 public class SecondaryStorageUnavailableException extends ServiceException {
   public static final String NO_SECONDARY_STORAGE_MESSAGE =
-      "This endpoint requires a secondary storage, but none is set. Secondary storage can be configured using the 'camunda.database.type' property.";
+      "This endpoint requires a secondary storage, but none is set. Secondary storage can be configured using the '%s' property."
+          .formatted(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE);
 
   public SecondaryStorageUnavailableException() {
     super(NO_SECONDARY_STORAGE_MESSAGE, ServiceException.Status.FORBIDDEN);

--- a/spring-utils/src/main/java/io/camunda/spring/utils/ConditionalOnSecondaryStorageDisabled.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/ConditionalOnSecondaryStorageDisabled.java
@@ -22,7 +22,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
  * Conditional annotation that activates beans only when secondary storage is disabled
- * (camunda.database.type=none).
+ * (camunda.data.secondary-storage.type=none).
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})

--- a/spring-utils/src/main/java/io/camunda/spring/utils/DatabaseTypeUtils.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/DatabaseTypeUtils.java
@@ -12,7 +12,6 @@ import org.springframework.core.env.Environment;
 
 public final class DatabaseTypeUtils {
   public static final String CAMUNDA_DATABASE_TYPE_NONE = "none";
-  public static final String PROPERTY_CAMUNDA_DATABASE_TYPE = "camunda.database.type";
   public static final String UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE =
       "camunda.data.secondary-storage.type";
 

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -143,6 +143,11 @@
       <artifactId>camunda-security-library-validation</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-connect</artifactId>
+    </dependency>
+
     <!-- rest api dependencies -->
     <dependency>
       <groupId>org.springframework</groupId>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/RequiresSecondaryStorage.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/RequiresSecondaryStorage.java
@@ -15,8 +15,8 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to mark controllers or methods that require secondary storage to be enabled. When
- * secondary storage is not configured (camunda.database.type=none), endpoints with this annotation
- * will return HTTP 403 Forbidden with a clear error message.
+ * secondary storage is not configured (camunda.data.secondary-storage.type=none), endpoints with
+ * this annotation will return HTTP 403 Forbidden with a clear error message.
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
@@ -7,9 +7,8 @@
  */
 package io.camunda.zeebe.gateway.rest.interceptor;
 
-import static io.camunda.spring.utils.DatabaseTypeUtils.CAMUNDA_DATABASE_TYPE_NONE;
-
 import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.service.exception.SecondaryStorageDegradedException;
 import io.camunda.service.exception.SecondaryStorageUnavailableException;
 import io.camunda.spring.utils.PhysicalTenantContext;
@@ -17,7 +16,7 @@ import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Value;
+import java.util.function.Function;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
@@ -28,8 +27,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
  * with {@link RequiresSecondaryStorage}.
  *
  * <ul>
- *   <li>HTTP 403 Forbidden when secondary storage is not configured at all (camunda.database.type =
- *       none).
+ *   <li>HTTP 403 Forbidden when secondary storage is not configured at all
+ *       (camunda.data.secondary-storage.type = none).
  *   <li>HTTP 503 Service Unavailable, with a {@code Retry-After} hint, when secondary storage is
  *       configured but the request's physical tenant's secondary storage is currently degraded (see
  *       {@link SecondaryStorageReadiness}).
@@ -44,13 +43,13 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
    */
   private static final String RETRY_AFTER_SECONDS = "5";
 
-  private final boolean secondaryStorageDisabled;
+  private final Function<String, DatabaseType> databaseTypeProvider;
   private final SecondaryStorageReadiness secondaryStorageReadiness;
 
   public SecondaryStorageInterceptor(
-      @Value("${camunda.database.type:elasticsearch}") final String databaseType,
+      final Function<String, DatabaseType> databaseTypeProvider,
       final SecondaryStorageReadiness secondaryStorageReadiness) {
-    secondaryStorageDisabled = CAMUNDA_DATABASE_TYPE_NONE.equalsIgnoreCase(databaseType);
+    this.databaseTypeProvider = databaseTypeProvider;
     this.secondaryStorageReadiness = secondaryStorageReadiness;
   }
 
@@ -73,7 +72,8 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
 
   private void validateSecondaryStorageReady(
       final HttpServletRequest request, final HttpServletResponse response) {
-    if (secondaryStorageDisabled) {
+    final String physicalTenantId = PhysicalTenantContext.current();
+    if (databaseTypeProvider.apply(physicalTenantId) == DatabaseType.NONE) {
       throw new SecondaryStorageUnavailableException();
     }
     // Only checked on the initial dispatch: CompletableFuture-returning controllers resume on an
@@ -82,7 +82,7 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
     if (request.getDispatcherType() != DispatcherType.REQUEST) {
       return;
     }
-    final String physicalTenantId = PhysicalTenantContext.current();
+
     if (!secondaryStorageReadiness.isReady(physicalTenantId)) {
       // Set before throwing: the exception handler only writes status and problem-detail body, so
       // headers already set on the response survive.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorProblemDetailTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorProblemDetailTest.java
@@ -17,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.service.exception.SecondaryStorageDegradedException;
 import io.camunda.zeebe.gateway.rest.GlobalControllerExceptionHandler;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
@@ -40,7 +41,8 @@ class SecondaryStorageInterceptorProblemDetailTest {
     // given
     final var readiness = mock(SecondaryStorageReadiness.class);
     when(readiness.isReady(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(false);
-    final var interceptor = new SecondaryStorageInterceptor("elasticsearch", readiness);
+    final var interceptor =
+        new SecondaryStorageInterceptor(t -> DatabaseType.ELASTICSEARCH, readiness);
     final MockMvc mockMvc =
         MockMvcBuilders.standaloneSetup(new TestController())
             .addInterceptors(interceptor)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.zeebe.gateway.rest.interceptor;
 
-import static io.camunda.spring.utils.DatabaseTypeUtils.CAMUNDA_DATABASE_TYPE_NONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.service.exception.SecondaryStorageDegradedException;
 import io.camunda.service.exception.SecondaryStorageUnavailableException;
 import io.camunda.spring.utils.PhysicalTenantContext;
@@ -56,7 +56,8 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
 
     final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", SecondaryStorageReadiness.ALWAYS_READY);
+        new SecondaryStorageInterceptor(
+            t -> DatabaseType.ELASTICSEARCH, SecondaryStorageReadiness.ALWAYS_READY);
     final boolean result = interceptor.preHandle(request, response, handlerMethod);
     assertThat(result).isTrue();
   }
@@ -67,7 +68,8 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     final var readiness = mock(SecondaryStorageReadiness.class);
 
-    final var interceptor = new SecondaryStorageInterceptor("elasticsearch", readiness);
+    final var interceptor =
+        new SecondaryStorageInterceptor(t -> DatabaseType.ELASTICSEARCH, readiness);
     interceptor.preHandle(request, response, handlerMethod);
 
     verifyNoInteractions(readiness);
@@ -80,7 +82,8 @@ class SecondaryStorageInterceptorTest {
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", SecondaryStorageReadiness.ALWAYS_READY);
+        new SecondaryStorageInterceptor(
+            t -> DatabaseType.ELASTICSEARCH, SecondaryStorageReadiness.ALWAYS_READY);
     final boolean result = interceptor.preHandle(request, response, handlerMethod);
     assertThat(result).isTrue();
   }
@@ -89,10 +92,11 @@ class SecondaryStorageInterceptorTest {
   void shouldThrowWhenSecondaryStorageDisabledAndAnnotationPresent() {
     when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
         new SecondaryStorageInterceptor(
-            CAMUNDA_DATABASE_TYPE_NONE, SecondaryStorageReadiness.ALWAYS_READY);
+            t -> DatabaseType.NONE, SecondaryStorageReadiness.ALWAYS_READY);
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
   }
@@ -104,7 +108,7 @@ class SecondaryStorageInterceptorTest {
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
-        new SecondaryStorageInterceptor(CAMUNDA_DATABASE_TYPE_NONE, degraded(PHYSICAL_TENANT_ID));
+        new SecondaryStorageInterceptor(t -> DatabaseType.NONE, degraded(PHYSICAL_TENANT_ID));
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
   }
@@ -116,7 +120,8 @@ class SecondaryStorageInterceptorTest {
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", degraded(PHYSICAL_TENANT_ID));
+        new SecondaryStorageInterceptor(
+            t -> DatabaseType.ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageDegradedException.class);
   }
@@ -128,7 +133,8 @@ class SecondaryStorageInterceptorTest {
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", degraded(PHYSICAL_TENANT_ID));
+        new SecondaryStorageInterceptor(
+            t -> DatabaseType.ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageDegradedException.class);
 
@@ -139,10 +145,11 @@ class SecondaryStorageInterceptorTest {
   void shouldNotHintRetryAfterWhenSecondaryStorageDisabled() {
     when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
         new SecondaryStorageInterceptor(
-            CAMUNDA_DATABASE_TYPE_NONE, SecondaryStorageReadiness.ALWAYS_READY);
+            t -> DatabaseType.NONE, SecondaryStorageReadiness.ALWAYS_READY);
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
 
@@ -154,9 +161,11 @@ class SecondaryStorageInterceptorTest {
     when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
     when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     when(request.getDispatcherType()).thenReturn(DispatcherType.ASYNC);
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
 
     final var interceptor =
-        new SecondaryStorageInterceptor("elasticsearch", degraded(PHYSICAL_TENANT_ID));
+        new SecondaryStorageInterceptor(
+            t -> DatabaseType.ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
     final boolean result = interceptor.preHandle(request, response, handlerMethod);
     assertThat(result).isTrue();
   }


### PR DESCRIPTION
## Description

Resolves the secondary storage type, in `SecondaryStorageInterceptor`via the canonical `SecondaryStorage#getType()` accessor, instead of the legacy `@Value("${camunda.database.type}")` that ignores the UC value (`camunda.data.secodary-storage.type)`
It is also resolves the configuration for a given physical tenant, via the `databaseTypeResolver`, as it is possible to configure opensearch/elasticsearch different types for different PTs
It will be backported to 8.8 and 8.9 (without the PT part)
Replaces #59303, which fixed the same underlying issue #58953

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to #58953
