### PR TITLE
feat: suppress timer, signal, and ad-hoc triggers while suspended

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -92,7 +92,12 @@ public final class BpmnProcessors {
     final var keyGenerator = processingState.getKeyGenerator();
 
     addProcessInstanceCommandProcessor(
-        writers, typedRecordProcessors, processingState, asyncRequestBehavior, cslCheck);
+        writers,
+        typedRecordProcessors,
+        processingState,
+        asyncRequestBehavior,
+        cslCheck,
+        timerChecker);
     addProcessInstanceBufferedCommandProcessor(writers, typedRecordProcessors, processingState);
 
     final var bpmnStreamProcessor =
@@ -167,7 +172,8 @@ public final class BpmnProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final DueDateTimerCheckScheduler timerChecker) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.CANCEL,
@@ -183,7 +189,8 @@ public final class BpmnProcessors {
         new ProcessInstanceCompleteResumingProcessor(
             processingState.getElementInstanceState(),
             processingState.getSuspensionState(),
-            writers));
+            writers,
+            timerChecker));
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.SUSPEND,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -15,6 +15,8 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -35,7 +37,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 
 public class AdHocSubProcessInstructionActivateProcessor
-    implements TypedRecordProcessor<AdHocSubProcessInstructionRecord> {
+    implements TypedRecordProcessor<AdHocSubProcessInstructionRecord>,
+        SuspensionAware<AdHocSubProcessInstructionRecord> {
 
   private static final String ERROR_MSG_AD_HOC_SUB_PROCESS_NOT_FOUND =
       "Expected to activate activities for ad-hoc sub-process but no ad-hoc sub-process instance found with key '%s'.";
@@ -177,6 +180,14 @@ public class AdHocSubProcessInstructionActivateProcessor
 
     responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), AdHocSubProcessInstructionIntent.ACTIVATED, command.getValue(), command);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<AdHocSubProcessInstructionRecord> record) {
+    // external commands are rejected, not buffered: buffering intercepts before authorize() runs,
+    // so a queued external command would replay as internal on drain and skip authorization
+    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
   }
 
   private void writeRejectionError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionCompleteProcessor.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnAdHocSubProcessBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -29,7 +31,8 @@ import io.camunda.zeebe.util.Either;
 
 @ExcludeAuthorizationCheck
 public class AdHocSubProcessInstructionCompleteProcessor
-    implements TypedRecordProcessor<AdHocSubProcessInstructionRecord> {
+    implements TypedRecordProcessor<AdHocSubProcessInstructionRecord>,
+        SuspensionAware<AdHocSubProcessInstructionRecord> {
 
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -66,6 +69,12 @@ public class AdHocSubProcessInstructionCompleteProcessor
             },
             rejection ->
                 rejectionWriter.appendRejection(record, rejection.type(), rejection.reason()));
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<AdHocSubProcessInstructionRecord> record) {
+    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
   }
 
   private BpmnElementContext createBpmnElementContext(final ElementInstance elementInstance) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
@@ -11,9 +11,11 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -51,18 +53,23 @@ public final class ProcessInstanceCompleteResumingProcessor
           + "by the ending lifecycle.";
 
   private final StateWriter stateWriter;
+  private final SideEffectWriter sideEffectWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final ElementInstanceState elementInstanceState;
   private final SuspensionState suspensionState;
+  private final DueDateTimerCheckScheduler timerChecker;
 
   public ProcessInstanceCompleteResumingProcessor(
       final ElementInstanceState elementInstanceState,
       final SuspensionState suspensionState,
-      final Writers writers) {
+      final Writers writers,
+      final DueDateTimerCheckScheduler timerChecker) {
     stateWriter = writers.state();
+    sideEffectWriter = writers.sideEffect();
     rejectionWriter = writers.rejection();
     this.elementInstanceState = elementInstanceState;
     this.suspensionState = suspensionState;
+    this.timerChecker = timerChecker;
   }
 
   @Override
@@ -88,6 +95,14 @@ public final class ProcessInstanceCompleteResumingProcessor
 
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceIntent.RESUMED, elementInstance.getValue());
+    // the instance is fully resumed now (the RESUMED applier clears the suspension marker), so
+    // any timer that came due and was rejected while suspended can finally fire; nudge the
+    // due-date checker rather than waiting for an unrelated future timer to wake it
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          timerChecker.scheduleTimer(-1);
+          return true;
+        });
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SignalSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.signal.SignalSubscription;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo.AuthDataFormat;
@@ -59,6 +60,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
   private final CslAuthorizationCheck cslCheck;
   private final CslTenantCheck tenantCheck;
   private final VariableBehavior variableBehavior;
+  private final SuspensionState suspensionState;
 
   public SignalBroadcastProcessor(
       final Writers writers,
@@ -81,6 +83,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     this.cslCheck = cslCheck;
     this.tenantCheck = tenantCheck;
     this.variableBehavior = variableBehavior;
+    suspensionState = processingState.getSuspensionState();
     eventHandle =
         new EventHandle(
             keyGenerator,
@@ -185,6 +188,13 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
 
   private void activateElement(
       final SignalSubscriptionRecord subscription, final DirectBuffer variables) {
+    // signal start events have no process instance yet to check, so skip only for non-start
+    // subscriptions
+    final var isStartEvent = subscription.getCatchEventInstanceKey() == -1;
+    if (!isStartEvent && suspensionState.isSuspended(subscription.getProcessInstanceKey())) {
+      return;
+    }
+
     final var processDefinitionKey = subscription.getProcessDefinitionKey();
     final var catchEventInstanceKey = subscription.getCatchEventInstanceKey();
     final var catchEventId = subscription.getCatchEventIdBuffer();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheck.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState.State;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.jspecify.annotations.NullMarked;
@@ -40,7 +41,8 @@ public final class SuspensionCheck {
    * Decides how to treat the command; commands whose processor is not {@link SuspensionAware}, or
    * whose target is not suspended, are always processed. The resolved target process instance key
    * is returned alongside the decision so callers reuse it rather than re-deriving it (external
-   * {@code JOB}/{@code INCIDENT}/{@code USER_TASK} commands don't carry it on the wire).
+   * {@code JOB}/{@code INCIDENT}/{@code USER_TASK}/{@code AD_HOC_SUB_PROCESS_INSTRUCTION} commands
+   * don't carry it on the wire).
    */
   public SuspensionResult resolve(
       final TypedRecord<?> command, final TypedRecordProcessor<?> processor) {
@@ -86,9 +88,9 @@ public final class SuspensionCheck {
 
   /**
    * Resolves the process instance a command targets. Most values carry their own {@code
-   * processInstanceKey}; external {@code JOB}, {@code INCIDENT} and {@code USER_TASK} commands only
-   * carry the entity key, so the persisted entity is consulted. Returns {@code -1} when it can't be
-   * resolved.
+   * processInstanceKey}; external {@code JOB}, {@code INCIDENT}, {@code USER_TASK} and {@code
+   * AD_HOC_SUB_PROCESS_INSTRUCTION} commands only carry the entity key, so the persisted entity is
+   * consulted. Returns {@code -1} when it can't be resolved.
    */
   private long resolveProcessInstanceKey(final TypedRecord<?> command) {
     if (command.getValue() instanceof final ProcessInstanceRelated processInstanceRelated) {
@@ -111,6 +113,14 @@ public final class SuspensionCheck {
       case USER_TASK -> {
         final var userTask = processingState.getUserTaskState().getUserTask(key);
         yield userTask != null ? userTask.getProcessInstanceKey() : -1;
+      }
+      case AD_HOC_SUB_PROCESS_INSTRUCTION -> {
+        final var adHocValue = (AdHocSubProcessInstructionRecordValue) command.getValue();
+        final var elementInstance =
+            processingState
+                .getElementInstanceState()
+                .getInstance(adHocValue.getAdHocSubProcessInstanceKey());
+        yield elementInstance != null ? elementInstance.getValue().getProcessInstanceKey() : -1;
       }
       default -> -1;
     };

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessSuspensionGateTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.adhocsubprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class AdHocSubProcessSuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBufferInternalAdHocSubProcessActivateWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final long processInstanceKey = deployAndStartProcessWithAdHocSubProcess(processId);
+    final long adHocSubProcessInstanceKey = getAdHocSubProcessInstanceKey(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - written directly rather than via the client: RecordToWrite carries no request
+    // metadata, so this is an internal command (isInternalCommand() == true), which is the only
+    // case that buffers
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessInstruction(
+                AdHocSubProcessInstructionIntent.ACTIVATE,
+                activateInstruction(adHocSubProcessInstanceKey)));
+
+    // then - the command is buffered rather than executed
+    assertThat(bufferedCommandIntent(processInstanceKey))
+        .isEqualTo(AdHocSubProcessInstructionIntent.ACTIVATE);
+  }
+
+  @Test
+  public void shouldRejectExternalAdHocSubProcessActivateWhileSuspended() {
+    // given - external commands are rejected rather than buffered: buffering happens before
+    // authorization runs, so a queued external command would replay as internal on drain and skip
+    // its authorization check
+    final String processId = Strings.newRandomValidBpmnId();
+    final long processInstanceKey = deployAndStartProcessWithAdHocSubProcess(processId);
+    final long adHocSubProcessInstanceKey = getAdHocSubProcessInstanceKey(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - activate(username) stamps request metadata, marking the command external; the
+    // plain activate() carries no request metadata and would be internal, unable to exercise this
+    final var rejection =
+        ENGINE
+            .adHocSubProcessActivity()
+            .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
+            .withElementIds("A")
+            .expectRejection()
+            .activate("test-user");
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+  }
+
+  @Test
+  public void shouldBufferAdHocSubProcessCompleteWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final long processInstanceKey = deployAndStartProcessWithAdHocSubProcess(processId);
+    final long adHocSubProcessInstanceKey = getAdHocSubProcessInstanceKey(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - COMPLETE is internal-only (JobCompleteProcessor) and unreachable while suspended since
+    // JOB.COMPLETE is already rejected, so it is written directly to exercise its gate
+    // classification
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessInstruction(
+                AdHocSubProcessInstructionIntent.COMPLETE,
+                new AdHocSubProcessInstructionRecord()
+                    .setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)));
+
+    // then - the command is buffered rather than completing activities while suspended
+    assertThat(bufferedCommandIntent(processInstanceKey))
+        .isEqualTo(AdHocSubProcessInstructionIntent.COMPLETE);
+  }
+
+  @Test
+  public void shouldDrainAndActivateAdHocSubProcessAfterResume() {
+    // given - an activate command buffered while suspended
+    final String processId = Strings.newRandomValidBpmnId();
+    final long processInstanceKey = deployAndStartProcessWithAdHocSubProcess(processId);
+    final long adHocSubProcessInstanceKey = getAdHocSubProcessInstanceKey(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessInstruction(
+                AdHocSubProcessInstructionIntent.ACTIVATE,
+                activateInstruction(adHocSubProcessInstanceKey)));
+    bufferedCommand(processInstanceKey);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - the drained command activates the requested element
+    assertThat(
+            RecordingExporter.adHocSubProcessInstructionRecords()
+                .withIntent(AdHocSubProcessInstructionIntent.ACTIVATED)
+                .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
+                .exists())
+        .isTrue();
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("A")
+                .exists())
+        .isTrue();
+  }
+
+  private static AdHocSubProcessInstructionRecord activateInstruction(
+      final long adHocSubProcessInstanceKey) {
+    final var instruction =
+        new AdHocSubProcessInstructionRecord()
+            .setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey);
+    instruction.activateElements().add().setElementId("A");
+    return instruction;
+  }
+
+  private static AdHocSubProcessInstructionIntent bufferedCommandIntent(
+      final long processInstanceKey) {
+    return (AdHocSubProcessInstructionIntent)
+        ((ProcessInstanceBufferedCommandRecordValue) bufferedCommand(processInstanceKey).getValue())
+            .getIntent();
+  }
+
+  private static Record<RecordValue> bufferedCommand(final long processInstanceKey) {
+    return RecordingExporter.records()
+        .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+        .withIntent(ProcessInstanceBufferedCommandIntent.BUFFERED)
+        .filter(
+            r ->
+                ((ProcessInstanceBufferedCommandRecordValue) r.getValue()).getProcessInstanceKey()
+                    == processInstanceKey)
+        .getFirst();
+  }
+
+  private long deployAndStartProcessWithAdHocSubProcess(final String processId) {
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .adHocSubProcess(
+                "ad-hoc",
+                adHocSubProcess -> {
+                  adHocSubProcess.task("A");
+                  adHocSubProcess.task("B");
+                })
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    return ENGINE.processInstance().ofBpmnProcessId(processId).create();
+  }
+
+  private long getAdHocSubProcessInstanceKey(final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+        .getFirst()
+        .getKey();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
@@ -16,9 +16,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
@@ -27,6 +29,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.api.SideEffectProducer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,7 +41,9 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
   private ElementInstanceState elementInstanceState;
   private SuspensionState suspensionState;
   private StateWriter stateWriter;
+  private SideEffectWriter sideEffectWriter;
   private TypedRejectionWriter rejectionWriter;
+  private DueDateTimerCheckScheduler timerChecker;
   private ProcessInstanceCompleteResumingProcessor processor;
 
   @BeforeEach
@@ -46,15 +51,18 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
     elementInstanceState = mock(ElementInstanceState.class);
     suspensionState = mock(SuspensionState.class);
     stateWriter = mock(StateWriter.class);
+    sideEffectWriter = mock(SideEffectWriter.class);
     rejectionWriter = mock(TypedRejectionWriter.class);
+    timerChecker = mock(DueDateTimerCheckScheduler.class);
 
     final var writers = mock(Writers.class);
     when(writers.state()).thenReturn(stateWriter);
+    when(writers.sideEffect()).thenReturn(sideEffectWriter);
     when(writers.rejection()).thenReturn(rejectionWriter);
 
     processor =
         new ProcessInstanceCompleteResumingProcessor(
-            elementInstanceState, suspensionState, writers);
+            elementInstanceState, suspensionState, writers, timerChecker);
 
     // default: the common case of an active instance still marked RESUMING
     when(suspensionState.getSuspensionState(PROCESS_INSTANCE_KEY))
@@ -75,6 +83,23 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
         .appendFollowUpEvent(
             eq(PROCESS_INSTANCE_KEY), eq(ProcessInstanceIntent.RESUMED), eq(record));
     verify(rejectionWriter, never()).appendRejection(any(), any(), any());
+  }
+
+  @Test
+  void shouldNudgeDueDateTimerCheckerWhenResumeCompletes() {
+    // given - resume must nudge the checker so a timer stranded during suspension fires promptly
+    // instead of waiting for the next unrelated timer
+    seedActiveInstance(new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
+
+    // when
+    processor.processRecord(continueResumingCommand());
+
+    // then
+    final var sideEffectCaptor = ArgumentCaptor.forClass(SideEffectProducer.class);
+    verify(sideEffectWriter).appendSideEffect(sideEffectCaptor.capture());
+    sideEffectCaptor.getValue().flush();
+
+    verify(timerChecker).scheduleTimer(-1);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -181,6 +181,72 @@ public class BroadcastSignalMultiplePartitionsTest {
   }
 
   @Test
+  // Regression for the NPE in SignalBroadcastProcessor#activateElement introduced while adding
+  // suspension gating (#57523): a distributed BROADCAST that has BOTH a signal start event
+  // subscription (catchEventInstanceKey == -1) AND a suspended catch-event subscription for the
+  // SAME signal used to dereference a null element instance when resolving the suspension state
+  // for the start-event subscription.
+  public void shouldTriggerSignalStartEventWhileAnotherInstanceIsSuspended() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var signalName = newRandomSignal();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .signal(signalName)
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+    waitForSignalSubscriptions(signalName, PARTITION_COUNT);
+
+    // a second process subscribed to the SAME signal, then suspended, so this one broadcast
+    // fans out to both a start-event subscription and a suspended catch-event subscription
+    final String suspendedProcessId = Strings.newRandomValidBpmnId();
+    deployProcess(suspendedProcessId, "catch_suspended", signalName);
+    final long suspendedInstanceKey = createProcessInstance(suspendedProcessId);
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withBpmnProcessId(suspendedProcessId)
+        .await();
+    ENGINE
+        .processInstance()
+        .withInstanceKey(suspendedInstanceKey)
+        .suspend(DEFAULT_USER.getUsername());
+
+    // when
+    final var broadcastedSignal =
+        ENGINE.signal().withSignalName(signalName).broadcast(DEFAULT_USER.getUsername());
+
+    // then - no NPE on any partition, and the start event still activates exactly once
+    assertThat(
+            RecordingExporter.records()
+                .limit(
+                    r ->
+                        r.getKey() == broadcastedSignal.getKey()
+                            && r.getIntent().equals(CommandDistributionIntent.FINISHED))
+                .processInstanceRecords()
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .hasSize(1)
+        .extracting(r -> r.getValue().getElementId(), Record::getPartitionId)
+        .containsOnly(tuple(processId, 1));
+
+    // and - the suspended instance's catch event is skipped, not activated
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processInstanceRecords()
+                        .withProcessInstanceKey(suspendedInstanceKey)
+                        .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETING)
+                        .withElementId("catch_suspended")
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
   public void shouldAuthorizeOnAllPartitions() {
     // given
     final String signalName = newRandomSignal();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalSuspensionGateTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.signal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.SuspensionState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class SignalSuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String ELEMENT_ID = "catch";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldSkipSignalActivationForSuspendedTarget() {
+    // given - an instance waiting on a signal catch event, then suspended
+    final String processId = Strings.newRandomValidBpmnId();
+    final String signalName = Strings.newRandomValidBpmnId();
+    final long processInstanceKey =
+        deployAndStartProcessWithSignalCatchEvent(processId, signalName);
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(signalName)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<?> broadcast = ENGINE.signal().withSignalName(signalName).broadcast();
+
+    // then - the broadcast still succeeds
+    Assertions.assertThat(broadcast).hasIntent(SignalIntent.BROADCASTED);
+
+    // and - the catch event, already ACTIVATED on start while entering the wait state, never
+    // completes: completion is what a signal trigger would have caused
+    assertThat(catchEventCompleted(processInstanceKey)).isFalse();
+  }
+
+  @Test
+  public void shouldActivateSignalForActiveTargetWhenAnotherTargetSuspended() {
+    // given - two instances of different processes waiting on the same signal, one suspended
+    final String signalName = Strings.newRandomValidBpmnId();
+    final String suspendedProcessId = Strings.newRandomValidBpmnId();
+    final String activeProcessId = Strings.newRandomValidBpmnId();
+    final long suspendedInstanceKey =
+        deployAndStartProcessWithSignalCatchEvent(suspendedProcessId, signalName);
+    final long activeInstanceKey =
+        deployAndStartProcessWithSignalCatchEvent(activeProcessId, signalName);
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withBpmnProcessId(suspendedProcessId)
+        .await();
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withBpmnProcessId(activeProcessId)
+        .await();
+    ENGINE.processInstance().withInstanceKey(suspendedInstanceKey).suspend();
+
+    // when
+    ENGINE.signal().withSignalName(signalName).broadcast();
+
+    // then - the active instance's catch event fires and the process completes
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(activeInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // and - the suspended instance's catch event is skipped
+    assertThat(catchEventCompleted(suspendedInstanceKey)).isFalse();
+  }
+
+  @Test
+  public void shouldSkipSignalActivationForResumingTarget() {
+    // given - the marker is seeded directly at RESUMING to catch the drain window deterministically
+    // (a real drain that starts and finishes immediately never exposes it since there is nothing
+    // buffered here to drain)
+    final String processId = Strings.newRandomValidBpmnId();
+    final String signalName = Strings.newRandomValidBpmnId();
+    final long processInstanceKey =
+        deployAndStartProcessWithSignalCatchEvent(processId, signalName);
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(signalName)
+        .await();
+    ((MutableProcessingState) ENGINE.getProcessingState())
+        .getSuspensionState()
+        .setSuspensionState(processInstanceKey, State.RESUMING);
+
+    // when
+    final Record<?> broadcast = ENGINE.signal().withSignalName(signalName).broadcast();
+
+    // then - the broadcast still succeeds, but activating inline would race the buffered-command
+    // drain, so the catch event is skipped just like while SUSPENDED
+    Assertions.assertThat(broadcast).hasIntent(SignalIntent.BROADCASTED);
+    assertThat(catchEventCompleted(processInstanceKey)).isFalse();
+  }
+
+  @Test
+  public void shouldReceiveSignalAfterSuspendAndResume() {
+    // given - an instance suspended and then resumed while waiting on a signal catch event
+    final String processId = Strings.newRandomValidBpmnId();
+    final String signalName = Strings.newRandomValidBpmnId();
+    final long processInstanceKey =
+        deployAndStartProcessWithSignalCatchEvent(processId, signalName);
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(signalName)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // when - a signal is broadcast after resume
+    ENGINE.signal().withSignalName(signalName).broadcast();
+
+    // then - the catch event fires and the process completes normally
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  private static boolean catchEventCompleted(final long processInstanceKey) {
+    return RecordingExporter.<Boolean>expectNoMatchingRecords(
+        records ->
+            records
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETING)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(ELEMENT_ID)
+                .exists());
+  }
+
+  private long deployAndStartProcessWithSignalCatchEvent(
+      final String processId, final String signalName) {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent(ELEMENT_ID)
+                .signal(signalName)
+                .endEvent()
+                .done())
+        .deploy();
+    return ENGINE.processInstance().ofBpmnProcessId(processId).create();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheckTest.java
@@ -14,13 +14,17 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState.State;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +36,7 @@ final class SuspensionCheckTest {
 
   private static final long PROCESS_INSTANCE_KEY = 42L;
   private static final long JOB_KEY = 7L;
+  private static final long AD_HOC_SUB_PROCESS_ELEMENT_INSTANCE_KEY = 13L;
 
   private ProcessingState processingState;
   private SuspensionState suspensionState;
@@ -172,6 +177,60 @@ final class SuspensionCheckTest {
     // then - the real process instance key is resolved via job state and returned to the caller
     assertThat(result.outcome()).isEqualTo(SuspensionBehavior.REJECT);
     assertThat(result.processInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
+  }
+
+  @Test
+  void shouldResolveProcessInstanceKeyFromStateForAdHocSubProcessInstructionCommand() {
+    // given - an AD_HOC_SUB_PROCESS_INSTRUCTION command whose value carries the ad-hoc sub-process
+    // instance key, not the process instance key
+    final var elementInstanceState = mock(ElementInstanceState.class);
+    when(processingState.getElementInstanceState()).thenReturn(elementInstanceState);
+    final var elementInstance =
+        new ElementInstance(
+            AD_HOC_SUB_PROCESS_ELEMENT_INSTANCE_KEY,
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
+    when(elementInstanceState.getInstance(AD_HOC_SUB_PROCESS_ELEMENT_INSTANCE_KEY))
+        .thenReturn(elementInstance);
+    markerIs(State.SUSPENDED);
+    final var command = mock(TypedRecord.class);
+    when(command.getValue())
+        .thenReturn(
+            new AdHocSubProcessInstructionRecord()
+                .setAdHocSubProcessInstanceKey(AD_HOC_SUB_PROCESS_ELEMENT_INSTANCE_KEY));
+    when(command.getValueType()).thenReturn(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION);
+
+    // when
+    final var result =
+        suspensionCheck.resolve(command, overridingProcessor(SuspensionBehavior.BUFFER));
+
+    // then - the real process instance key is resolved via the element instance state and returned
+    // to the caller
+    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.BUFFER);
+    assertThat(result.processInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
+  }
+
+  @Test
+  void shouldProcessAdHocSubProcessInstructionCommandWhenElementInstanceNotFound() {
+    // given - the ad-hoc sub-process instance no longer exists (e.g. already completed/terminated)
+    final var elementInstanceState = mock(ElementInstanceState.class);
+    when(processingState.getElementInstanceState()).thenReturn(elementInstanceState);
+    when(elementInstanceState.getInstance(AD_HOC_SUB_PROCESS_ELEMENT_INSTANCE_KEY))
+        .thenReturn(null);
+    final var command = mock(TypedRecord.class);
+    when(command.getValue())
+        .thenReturn(
+            new AdHocSubProcessInstructionRecord()
+                .setAdHocSubProcessInstanceKey(AD_HOC_SUB_PROCESS_ELEMENT_INSTANCE_KEY));
+    when(command.getValueType()).thenReturn(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION);
+
+    // when
+    final var result =
+        suspensionCheck.resolve(command, overridingProcessor(SuspensionBehavior.BUFFER));
+
+    // then - the key can't be resolved (-1), so the command is processed rather than gated
+    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.PROCESS);
+    assertThat(result.processInstanceKey()).isEqualTo(-1);
   }
 
   private void markerIs(final @Nullable State state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerSuspensionGateTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.timer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class TimerSuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldTriggerStrandedTimerAfterResume() {
+    // given - an instance with a timer that came due while suspended; the due-date checker's
+    // resulting TRIGGER is rejected instead of firing, because the instance is suspended
+    final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    ENGINE.increaseTime(Duration.ofSeconds(1));
+    final var rejection =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGER)
+            .onlyCommandRejections()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+
+    // when - the instance resumes; no clock advance follows, so a TRIGGERED event can only come
+    // from the resume-triggered rescan, not from the checker's regular polling
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - the stranded timer fires
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldFireTimerThatBecomesDueAfterResume() {
+    // given - an instance suspended and resumed before its timer is due
+    final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // when - the timer becomes due after resume
+    ENGINE.increaseTime(Duration.ofSeconds(1));
+
+    // then - it fires through the normal path and the process completes
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  private long deployAndStartProcessWithTimer(final String processId) {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent("timer", c -> c.timerWithDuration("PT1S"))
+                .endEvent()
+                .done())
+        .deploy();
+    return ENGINE.processInstance().ofBpmnProcessId(processId).create();
+  }
+}


### PR DESCRIPTION
## Description

Closes the timer, signal, and ad-hoc sub-process gaps left after the primary suspension gate (#57521):

- **Timers**: `ProcessInstanceCompleteResumingProcessor` nudges `DueDateTimerCheckScheduler` right after writing `RESUMED` — the point where the suspension marker actually clears — so a timer that got `REJECT`ed while suspended fires promptly instead of waiting on an unrelated future timer.
- **Ad-hoc subprocess**: `SuspensionCheck` resolves `AD_HOC_SUB_PROCESS_INSTRUCTION`'s target process instance via `ElementInstanceState` (the wire key is the ad-hoc subprocess's element instance key, not a process instance key). `AdHocSubProcessInstructionCompleteProcessor` is internal-only and classifies unconditionally as `BUFFER`. `AdHocSubProcessInstructionActivateProcessor` is also externally reachable and runs an authorization check in `processRecord`, so it classifies as `isInternalCommand() ? BUFFER : REJECT` instead — an unconditional `BUFFER` would let buffering intercept the command before that check ever runs, and a drained buffered command replays as an internal follow-up command, which skips authorization entirely. Caught by Copilot review; matches the same split already used by `BpmnStreamProcessor`/`IncidentResolveProcessor`/`ProcessInstanceModificationModifyProcessor`.
- **Signals**: `SignalBroadcastProcessor` checks each subscription's target suspension state before calling `EventHandle.activateElement`, so a suspended (or still-draining, `RESUMING`) target's activation is skipped while the broadcast still proceeds normally for every other, active subscription. Uses `isSuspended()` (not just `== SUSPENDED`) so a target mid-drain doesn't race ahead of its buffered commands — same reasoning `MessageCorrelationCorrelateProcessor` already applies for its own, structurally identical fan-out. This is a deliberate drop, not a buffer: signal fan-out has no per-subscription command to buffer without new protocol, so a skipped trigger is not replayed on resume.

Also fixes an NPE (found during review) in `SignalBroadcastProcessor#activateElement`: a distributed `BROADCAST` for a signal start-event subscription (`catchEventInstanceKey == -1`, no process instance exists yet) dereferenced a null element instance. Regression test in `BroadcastSignalMultiplePartitionsTest` exercises a start-event subscription and a suspended catch-event subscription in the same broadcast.

Tests cover suspend-time gating, real end-to-end drain on resume (ad-hoc `ACTIVATE`/`COMPLETE`), rejection of an external `ACTIVATE` while suspended, and that signals/timers work normally again after a suspend→resume cycle.

## Checklist

- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57523
