### PR TITLE
fix: allow incident resolution without content type

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -163,7 +163,9 @@ public class ProcessInstanceController {
   }
 
   @RequiresSecondaryStorage
-  @CamundaPostMapping(path = "/{processInstanceKey}/incident-resolution")
+  @CamundaPostMapping(
+      path = "/{processInstanceKey}/incident-resolution",
+      consumes = {})
   public CompletableFuture<ResponseEntity<Object>> resolveProcessInstanceIncidents(
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final long processInstanceKey) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -2547,6 +2547,38 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldResolveProcessInstanceIncidentsWithoutContentType() {
+    // given
+    final long processInstanceKey = 123L;
+    final var record =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(456L)
+            .setBatchOperationType(BatchOperationType.RESOLVE_INCIDENT);
+
+    when(processInstanceServices.resolveProcessInstanceIncidents(eq(processInstanceKey), any()))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/{processInstanceKey}/incident-resolution", processInstanceKey)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+                {"batchOperationKey":"456","batchOperationType":"RESOLVE_INCIDENT"}
+              """,
+            JsonCompareMode.STRICT);
+
+    verify(processInstanceServices).resolveProcessInstanceIncidents(eq(processInstanceKey), any());
+  }
+
+  @Test
   void shouldCancelProcessInstanceBatchOperation() {
     // given
     final var record = new BatchOperationCreationRecord();


### PR DESCRIPTION
## Description

The process-instance incident-resolution endpoint does not accept a request body, but it inherited the `application/json` consumes constraint from `CamundaPostMapping`. As a result, bodyless requests without a `Content-Type` header were rejected with 415 before reaching the controller.

This removes the consumes constraint for this endpoint and adds a controller regression test for requests without a `Content-Type` header.

Changing the default behavior of `CamundaPostMapping` was not chosen because other POST endpoints consume JSON request bodies.

## Testing

- `./mvnw verify -pl zeebe/gateway-rest -Dquickly -DskipTests=false -T1C`
- `./mvnw install -Dquickly -T1C`

## Checklist

- [x] Requested a backport to stable/8.9; a maintainer must add the label.

## Related issues

Closes #59757