### PR TITLE
fix: accept application/octet-stream on resource binary content

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResourceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResourceController.java
@@ -106,7 +106,12 @@ public class ResourceController {
                 .body(ResponseMapper.toGetResourceContentResponse(entity)));
   }
 
-  @CamundaGetMapping(path = "/resources/{resourceKey}/content/binary")
+  @CamundaGetMapping(
+      path = "/resources/{resourceKey}/content/binary",
+      produces = {
+        MediaType.APPLICATION_OCTET_STREAM_VALUE,
+        MediaType.APPLICATION_PROBLEM_JSON_VALUE
+      })
   public CompletableFuture<ResponseEntity<Object>> getResourceContentBinary(
       @PhysicalTenantId final String physicalTenantId, @PathVariable final long resourceKey) {
     final var authentication = authenticationProvider.getCamundaAuthentication();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -645,6 +645,48 @@ public class ResourceControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldGetResourceContentBinaryWhenAcceptOctetStreamHeaderIsSet() {
+    // given
+    final var content =
+        """
+        {
+          "id": "test",
+          "name": "test RPA script",
+          "script": "foo"
+        }
+        """;
+    when(resourceServices.getContentByKey(eq(1L), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new DeployedResourceEntity(
+                    1L,
+                    "test",
+                    "test.rpa",
+                    "rpa",
+                    1,
+                    null,
+                    100L,
+                    "tenant",
+                    content.getBytes(StandardCharsets.UTF_8))));
+
+    // when / then
+    webClient
+        .get()
+        .uri(GET_RESOURCE_CONTENT_BINARY_ENDPOINT.formatted(1))
+        .accept(MediaType.APPLICATION_OCTET_STREAM)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+        .expectBody(byte[].class)
+        .consumeWith(
+            response ->
+                assertThat(response.getResponseBody())
+                    .isEqualTo(content.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
   void getResourceContentShouldYieldNotFoundWhenResourceNotFound() {
     // given
     when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any()))


### PR DESCRIPTION
## Description

GET /v2/resources/{resourceKey}/content/binary answered HTTP 406 to a request carrying the exact Accept header its own API specification documents (application/octet-stream). Any client honoring the spec — a generated OpenAPI client, a connector, or a call written from the docs — failed. It went unnoticed because the Java client and acceptance tests send no explicit Accept header, and an absent header (or */*) negotiates fine.

Root cause: the handler is mapped with a bare @CamundaGetMapping, whose default produces list is the three JSON media types. Spring content negotiation matches the Accept header against that list and rejects the request with 406 before the handler runs — even though the handler writes the body as application/octet-stream.

Override produces on the mapping to declare application/octet-stream for the success response and application/problem+json so 404/500 errors still negotiate, mirroring the XML content endpoints in DecisionDefinitionController and ProcessDefinitionController.

## Related issues

related to #59831
