### PR TITLE
refactor: execute history deletion through the per-partition-group executor

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.camunda.zeebe.broker.partitioning.topology.ClusterChangeExecutorImpl;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.DynamicClusterConfigurationService;
@@ -36,14 +34,7 @@ public class ClusterConfigurationManagerStep
     final ClusterChangeExecutor clusterChangeExecutor =
         new ClusterChangeExecutorImpl(
             brokerStartupContext.getConcurrencyControl(),
-            // Temp: use the default physical tenant engine context to get the exporter repository.
-            // This is a temporary solution until we support multiple physical tenants in dynamic
-            // cluster config module.
-            brokerStartupContext
-                .getPhysicalTenantContext(DEFAULT_PHYSICAL_TENANT_ID)
-                .exporterRepository(),
             brokerStartupContext.getNodeIdProvider(),
-            brokerStartupContext.getMeterRegistry(),
             Optional.ofNullable(
                 brokerStartupContext.getBrokerConfiguration().getCluster().getZone()));
     final ClusterConfigurationService clusterConfigurationService =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/ExporterHistoryPurger.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/ExporterHistoryPurger.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter;
+
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.exporter.context.ExporterContext;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.dynamic.config.changes.ExporterPurgeException;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.stream.api.StreamClock;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Purges the history exported by one physical tenant, by invoking {@link Exporter#purge()} on every
+ * exporter configured for that tenant.
+ */
+public final class ExporterHistoryPurger {
+  private static final Logger LOG = LoggerFactory.getLogger(ExporterHistoryPurger.class);
+
+  private final String physicalTenantId;
+  private final ExporterRepository exporterRepository;
+  private final MeterRegistry meterRegistry;
+
+  public ExporterHistoryPurger(
+      final String physicalTenantId,
+      final ExporterRepository exporterRepository,
+      final MeterRegistry meterRegistry) {
+    this.physicalTenantId = physicalTenantId;
+    this.exporterRepository = exporterRepository;
+    this.meterRegistry = meterRegistry;
+  }
+
+  /**
+   * Purges the history of every exporter of this physical tenant.
+   *
+   * @throws ExporterPurgeException if an exporter fails to purge, in which case an unknown subset
+   *     of the exporters has been purged already
+   */
+  public void purgeAll() {
+    exporterRepository.getExporters().forEach(this::purgeExporter);
+  }
+
+  private void purgeExporter(final String id, final ExporterDescriptor descriptor) {
+    final Exporter exporter = descriptor.newInstance();
+
+    final var exporterContext =
+        new ExporterContext(
+            Loggers.getExporterLogger(descriptor.getId()),
+            descriptor.getConfiguration(),
+            new PartitionId(physicalTenantId, 1),
+            "",
+            exporterRepository.getLicenseKey(),
+            meterRegistry,
+            StreamClock.system());
+
+    try {
+      exporter.configure(exporterContext);
+      exporter.purge();
+      LOG.info("Purged history of physical tenant {} for {}", physicalTenantId, id);
+      exporter.close();
+    } catch (final Exception e) {
+      throw new ExporterPurgeException(
+          "Failed to purge C8 data from exporter %s of type %s; operation will be retried."
+              .formatted(id, exporter.getClass()),
+          e);
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/ExporterHistoryPurger.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/ExporterHistoryPurger.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.changes.ExporterPurgeException;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,10 @@ public final class ExporterHistoryPurger {
   private void purgeExporter(final String id, final ExporterDescriptor descriptor) {
     final Exporter exporter = descriptor.newInstance();
 
-    final var exporterContext =
+    // The exporter is closed before the context, as closing it may deregister meters from the
+    // context's registry. Both are released even when purging fails, because the operation is
+    // retried until it succeeds and an exporter may well have opened clients before failing.
+    try (final var exporterContext =
         new ExporterContext(
             Loggers.getExporterLogger(descriptor.getId()),
             descriptor.getConfiguration(),
@@ -60,18 +64,21 @@ public final class ExporterHistoryPurger {
             "",
             exporterRepository.getLicenseKey(),
             meterRegistry,
-            StreamClock.system());
-
-    try {
-      exporter.configure(exporterContext);
-      exporter.purge();
-      LOG.info("Purged history of physical tenant {} for {}", physicalTenantId, id);
-      exporter.close();
-    } catch (final Exception e) {
-      throw new ExporterPurgeException(
-          "Failed to purge C8 data from exporter %s of type %s; operation will be retried."
-              .formatted(id, exporter.getClass()),
-          e);
+            StreamClock.system())) {
+      try {
+        exporter.configure(exporterContext);
+        exporter.purge();
+        LOG.info("Purged history of physical tenant {} for {}", physicalTenantId, id);
+      } catch (final Exception e) {
+        throw new ExporterPurgeException(
+            "Failed to purge C8 data from exporter %s of type %s; operation will be retried."
+                .formatted(id, exporter.getClass()),
+            e);
+      } finally {
+        CloseHelper.close(
+            error -> LOG.warn("Failed to close exporter {} after purging; ignoring", id, error),
+            exporter::close);
+      }
     }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
+import io.camunda.zeebe.broker.exporter.ExporterHistoryPurger;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.partitioning.scaling.BrokerClientPartitionScalingExecutor;
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
@@ -88,6 +89,7 @@ public final class PartitionManagerImpl
   private final MeterRegistry brokerMeterRegistry;
   private final PartitionScalingChangeExecutor scalingExecutor;
   private final AtomixServerTransport gatewayBrokerTransport;
+  private final ExporterHistoryPurger exporterHistoryPurger;
 
   public PartitionManagerImpl(
       final String partitionGroup,
@@ -127,6 +129,8 @@ public final class PartitionManagerImpl
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     scalingExecutor = new BrokerClientPartitionScalingExecutor(brokerClient, concurrencyControl);
     brokerMeterRegistry = meterRegistry;
+    exporterHistoryPurger =
+        new ExporterHistoryPurger(partitionGroup, exporterRepository, meterRegistry);
 
     final List<PartitionListener> listeners = new ArrayList<>(partitionListeners);
     listeners.add(topologyManager);
@@ -555,6 +559,21 @@ public final class PartitionManagerImpl
         .map(partitionId -> setExportingState(partitionId, exportingState))
         .collect(new ActorFutureCollector<Void>(concurrencyControl))
         .thenAccept(ignored -> unit());
+  }
+
+  @Override
+  public ActorFuture<Void> deleteHistory() {
+    final var result = concurrencyControl.<Void>createFuture();
+    concurrencyControl.run(
+        () -> {
+          try {
+            exporterHistoryPurger.purgeAll();
+            result.complete(null);
+          } catch (final Exception e) {
+            result.completeExceptionally(e);
+          }
+        });
+    return result;
   }
 
   private ActorFuture<Void> setExportingState(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
@@ -683,6 +683,12 @@ public final class RecoveryPartitionManager
   }
 
   @Override
+  public ActorFuture<Void> deleteHistory() {
+    return CompletableActorFuture.completedExceptionally(
+        new IllegalStateException("Cannot perform deleteHistory on a recovering partition"));
+  }
+
+  @Override
   public ActorFuture<Void> initiateScaleUp(final int desiredPartitionCount) {
     return CompletableActorFuture.completedExceptionally(
         new IllegalStateException("Cannot perform scaleUp on a recovering partition"));

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -8,34 +8,24 @@
 package io.camunda.zeebe.broker.partitioning.topology;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.exporter.context.ExporterContext;
-import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.ExporterHistoryPurger;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
-import io.camunda.zeebe.dynamic.config.changes.ExporterPurgeException;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
-import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.stream.api.StreamClock;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
-  private static final Logger LOG = LoggerFactory.getLogger(ClusterChangeExecutorImpl.class);
 
   private final ConcurrencyControl concurrencyControl;
-  private final ExporterRepository exporterRepository;
   private final NodeIdProvider nodeIdProvider;
-  private final MeterRegistry meterRegistry;
   private final Optional<String> zone;
+  private final ExporterHistoryPurger exporterHistoryPurger;
 
   public ClusterChangeExecutorImpl(
       final ConcurrencyControl concurrencyControl,
@@ -44,10 +34,11 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
       final MeterRegistry meterRegistry,
       final Optional<String> zone) {
     this.concurrencyControl = concurrencyControl;
-    this.exporterRepository = exporterRepository;
     this.nodeIdProvider = Objects.requireNonNull(nodeIdProvider);
-    this.meterRegistry = meterRegistry;
     this.zone = zone;
+    exporterHistoryPurger =
+        new ExporterHistoryPurger(
+            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, exporterRepository, meterRegistry);
   }
 
   @Override
@@ -56,7 +47,7 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
     concurrencyControl.run(
         () -> {
           try {
-            exporterRepository.getExporters().forEach(this::purgeExporter);
+            exporterHistoryPurger.purgeAll();
             result.complete(null);
           } catch (final Exception e) {
             result.completeExceptionally(e);
@@ -129,31 +120,5 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
   private int membersInZone(final Set<MemberId> clusterMembers) {
     return (int)
         clusterMembers.stream().filter(m -> Optional.ofNullable(m.zone()).equals(zone)).count();
-  }
-
-  private void purgeExporter(final String id, final ExporterDescriptor descriptor) {
-    final Exporter exporter = descriptor.newInstance();
-
-    final var exporterContext =
-        new ExporterContext(
-            Loggers.getExporterLogger(descriptor.getId()),
-            descriptor.getConfiguration(),
-            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
-            "",
-            exporterRepository.getLicenseKey(),
-            meterRegistry,
-            StreamClock.system());
-
-    try {
-      exporter.configure(exporterContext);
-      exporter.purge();
-      LOG.info("Purged history for {}", id);
-      exporter.close();
-    } catch (final Exception e) {
-      throw new ExporterPurgeException(
-          "Failed to purge C8 data from exporter %s of type %s; operation will be retried."
-              .formatted(id, exporter.getClass()),
-          e);
-    }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -8,14 +8,10 @@
 package io.camunda.zeebe.broker.partitioning.topology;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.zeebe.broker.exporter.ExporterHistoryPurger;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -25,36 +21,14 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
   private final ConcurrencyControl concurrencyControl;
   private final NodeIdProvider nodeIdProvider;
   private final Optional<String> zone;
-  private final ExporterHistoryPurger exporterHistoryPurger;
 
   public ClusterChangeExecutorImpl(
       final ConcurrencyControl concurrencyControl,
-      final ExporterRepository exporterRepository,
       final NodeIdProvider nodeIdProvider,
-      final MeterRegistry meterRegistry,
       final Optional<String> zone) {
     this.concurrencyControl = concurrencyControl;
     this.nodeIdProvider = Objects.requireNonNull(nodeIdProvider);
     this.zone = zone;
-    exporterHistoryPurger =
-        new ExporterHistoryPurger(
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, exporterRepository, meterRegistry);
-  }
-
-  @Override
-  public ActorFuture<Void> deleteHistory() {
-    final ActorFuture<Void> result = concurrencyControl.createFuture();
-    concurrencyControl.run(
-        () -> {
-          try {
-            exporterHistoryPurger.purgeAll();
-            result.complete(null);
-          } catch (final Exception e) {
-            result.completeExceptionally(e);
-          }
-        });
-
-    return result;
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/ExporterHistoryPurgerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/ExporterHistoryPurgerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.dynamic.config.changes.ExporterPurgeException;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.protocol.record.Record;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class ExporterHistoryPurgerTest {
+
+  private static final String PHYSICAL_TENANT_ID = "tenant-a";
+
+  private final ExporterRepository repository = new ExporterRepository();
+
+  @BeforeEach
+  void resetAudits() {
+    clearAudits();
+    FailingExporter.purgeCalls = 0;
+  }
+
+  @Test
+  void shouldRunPurgeForEveryExporter() throws ExporterLoadException {
+    // given
+    register("test-1", AuditExporter.class);
+    register("test-2", AuditExporter.class);
+    final var purger = purger();
+
+    // when
+    purger.purgeAll();
+
+    // then
+    assertThat(AuditExporter.AUDITS)
+        .containsSubsequence("configure-test-1", "purge-test-1", "close-test-1")
+        .containsSubsequence("configure-test-2", "purge-test-2", "close-test-2")
+        .doesNotContainAnyElementsOf(
+            Arrays.asList("open-test-1", "export-test-1", "open-test-2", "export-test-2"));
+  }
+
+  @Test
+  void shouldPurgeInTheContextOfItsOwnPhysicalTenant() throws ExporterLoadException {
+    // given
+    register("test-1", AuditExporter.class);
+    final var purger = purger();
+
+    // when
+    purger.purgeAll();
+
+    // then
+    assertThat(AuditExporter.PHYSICAL_TENANT_IDS).containsExactly(PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  void shouldWrapPurgeFailure() throws ExporterLoadException {
+    // given
+    register("failing", FailingExporter.class);
+    final var purger = purger();
+
+    // when
+    assertThatThrownBy(purger::purgeAll)
+        // then
+        .isInstanceOf(ExporterPurgeException.class)
+        .hasMessageContaining("failing")
+        .hasRootCauseMessage("purge failed");
+    assertThat(FailingExporter.purgeCalls).isOne();
+  }
+
+  private ExporterHistoryPurger purger() {
+    return new ExporterHistoryPurger(PHYSICAL_TENANT_ID, repository, new SimpleMeterRegistry());
+  }
+
+  /**
+   * Registers an exporter and discards the audit trail of the validation that {@link
+   * ExporterRepository} performs on registration, so that the assertions only see what purging did.
+   */
+  private void register(final String id, final Class<? extends Exporter> exporterClass)
+      throws ExporterLoadException {
+    repository.validateAndAddExporterDescriptor(id, exporterClass, null);
+    clearAudits();
+  }
+
+  private static void clearAudits() {
+    AuditExporter.AUDITS.clear();
+    AuditExporter.PHYSICAL_TENANT_IDS.clear();
+  }
+
+  public static class AuditExporter implements Exporter {
+    static final List<String> AUDITS = new ArrayList<>();
+    static final List<String> PHYSICAL_TENANT_IDS = new ArrayList<>();
+    String exporterId;
+
+    @Override
+    public void configure(final Context context) {
+      exporterId = context.getConfiguration().getId();
+      PHYSICAL_TENANT_IDS.add(context.getPhysicalTenantId());
+      audit("configure");
+    }
+
+    @Override
+    public void close() {
+      audit("close");
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      audit("export");
+    }
+
+    @Override
+    public void purge() throws Exception {
+      audit("purge");
+      Exporter.super.purge();
+    }
+
+    private void audit(final String name) {
+      AUDITS.add(name + "-" + (exporterId != null ? exporterId : "unknown"));
+    }
+  }
+
+  public static class FailingExporter implements Exporter {
+    static int purgeCalls;
+
+    @Override
+    public void export(final Record<?> record) {}
+
+    @Override
+    public void purge() {
+      purgeCalls++;
+      throw new RuntimeException("purge failed");
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/ExporterHistoryPurgerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/ExporterHistoryPurgerTest.java
@@ -32,7 +32,6 @@ final class ExporterHistoryPurgerTest {
   @BeforeEach
   void resetAudits() {
     clearAudits();
-    FailingExporter.purgeCalls = 0;
   }
 
   @Test
@@ -81,13 +80,28 @@ final class ExporterHistoryPurgerTest {
     assertThat(FailingExporter.purgeCalls).isOne();
   }
 
+  @Test
+  void shouldReleaseExporterWhenPurgeFails() throws ExporterLoadException {
+    // given
+    register("failing", FailingExporter.class);
+    final var purger = purger();
+
+    // when
+    assertThatThrownBy(purger::purgeAll).isInstanceOf(ExporterPurgeException.class);
+
+    // then — the purge is retried until it succeeds, so anything the exporter opened before
+    // failing has to be released rather than leaked once per attempt
+    assertThat(FailingExporter.closeCalls).isOne();
+  }
+
   private ExporterHistoryPurger purger() {
     return new ExporterHistoryPurger(PHYSICAL_TENANT_ID, repository, new SimpleMeterRegistry());
   }
 
   /**
    * Registers an exporter and discards the audit trail of the validation that {@link
-   * ExporterRepository} performs on registration, so that the assertions only see what purging did.
+   * ExporterRepository} performs on registration — it configures and closes one instance — so that
+   * the assertions only see what purging did.
    */
   private void register(final String id, final Class<? extends Exporter> exporterClass)
       throws ExporterLoadException {
@@ -98,6 +112,8 @@ final class ExporterHistoryPurgerTest {
   private static void clearAudits() {
     AuditExporter.AUDITS.clear();
     AuditExporter.PHYSICAL_TENANT_IDS.clear();
+    FailingExporter.purgeCalls = 0;
+    FailingExporter.closeCalls = 0;
   }
 
   public static class AuditExporter implements Exporter {
@@ -135,6 +151,12 @@ final class ExporterHistoryPurgerTest {
 
   public static class FailingExporter implements Exporter {
     static int purgeCalls;
+    static int closeCalls;
+
+    @Override
+    public void close() {
+      closeCalls++;
+    }
 
     @Override
     public void export(final Record<?> record) {}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
@@ -14,93 +14,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
-import io.camunda.zeebe.exporter.api.Exporter;
-import io.camunda.zeebe.exporter.api.context.Context;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class ClusterChangeExecutorImplTest {
-
-  public static class AuditExporter implements Exporter {
-    static final List<String> AUDITS = new ArrayList<>();
-    String exporterId;
-
-    @Override
-    public void configure(final Context context) throws Exception {
-      exporterId = context.getConfiguration().getId();
-      audit("configure");
-    }
-
-    @Override
-    public void close() {
-      audit("close");
-    }
-
-    @Override
-    public void export(final Record<?> record) {
-      audit("export");
-    }
-
-    @Override
-    public void purge() throws Exception {
-      audit("purge");
-      Exporter.super.purge();
-    }
-
-    private void audit(final String name) {
-      AUDITS.add(name + "-" + (exporterId != null ? exporterId : "unknown"));
-    }
-  }
-
-  @Nested
-  class DeleteHistoryTest {
-    @Test
-    void shouldRunPurgeForEveryExporter() {
-      // given
-      final ExporterRepository repository = new ExporterRepository();
-      try {
-        repository.validateAndAddExporterDescriptor("test-1", AuditExporter.class, null);
-        repository.validateAndAddExporterDescriptor("test-2", AuditExporter.class, null);
-      } catch (final ExporterLoadException e) {
-        Assertions.fail(e);
-      }
-
-      final var executor =
-          new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(),
-              repository,
-              mock(NodeIdProvider.class),
-              new SimpleMeterRegistry(),
-              Optional.empty());
-
-      // when
-      final Future<Void> result = executor.deleteHistory();
-
-      // then
-      Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
-      Assertions.assertThat(AuditExporter.AUDITS)
-          .containsSubsequence("configure-test-1", "purge-test-1", "close-test-1")
-          .containsSubsequence("configure-test-2", "purge-test-2", "close-test-2")
-          .doesNotContainAnyElementsOf(
-              Arrays.asList("open-test-1", "export-test-1", "open-test-2", "export-test-2"));
-    }
-  }
 
   @Nested
   class PreScalingTest {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import java.time.Duration;
@@ -38,11 +37,7 @@ public class ClusterChangeExecutorImplTest {
       when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(),
-              new ExporterRepository(),
-              nodeIdProvider,
-              null,
-              Optional.empty());
+              new TestConcurrencyControl(), nodeIdProvider, Optional.empty());
 
       // when
       final var result =
@@ -61,11 +56,7 @@ public class ClusterChangeExecutorImplTest {
       when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(),
-              new ExporterRepository(),
-              nodeIdProvider,
-              null,
-              Optional.empty());
+              new TestConcurrencyControl(), nodeIdProvider, Optional.empty());
 
       // when
       final var result = executor.preScaling(3, Set.of(MemberId.from("0"), MemberId.from("1")));
@@ -83,11 +74,7 @@ public class ClusterChangeExecutorImplTest {
           .thenReturn(CompletableFuture.failedFuture(new RuntimeException("scale failed")));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(),
-              new ExporterRepository(),
-              nodeIdProvider,
-              null,
-              Optional.empty());
+              new TestConcurrencyControl(), nodeIdProvider, Optional.empty());
 
       // when
       final var result =
@@ -113,11 +100,7 @@ public class ClusterChangeExecutorImplTest {
       when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(),
-              new ExporterRepository(),
-              nodeIdProvider,
-              null,
-              Optional.empty());
+              new TestConcurrencyControl(), nodeIdProvider, Optional.empty());
 
       // when
       final var result =
@@ -136,11 +119,7 @@ public class ClusterChangeExecutorImplTest {
           .thenReturn(CompletableFuture.failedFuture(new RuntimeException("scale failed")));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(),
-              new ExporterRepository(),
-              nodeIdProvider,
-              null,
-              Optional.empty());
+              new TestConcurrencyControl(), nodeIdProvider, Optional.empty());
 
       // when
       final var result =

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -543,7 +543,6 @@ public final class ClusterConfigurationManagerService
                 new PartitionGroupConfigurationChangeAppliersImpl(
                     partitionChangeExecutor,
                     partitionScalingChangeExecutor,
-                    clusterChangeExecutor,
                     modeChangeExecutor,
                     restoreChangeExecutor));
           }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
@@ -15,19 +15,6 @@ import java.util.Set;
 public interface ClusterChangeExecutor {
 
   /**
-   * This method will start an asynchronous deletion of the history storage, returning a future
-   * indicating success/failure.
-   *
-   * <p>When the future is completed successfully, all history data will have been purged. When a
-   * future is completed exceptionally, then not all (but none or some) may have been purged.
-   *
-   * <p>This operation should be idempotent, as it may be retried multiple times until successful.
-   *
-   * @return future when the operation is completed
-   */
-  ActorFuture<Void> deleteHistory();
-
-  /**
    * This method will start an asynchronous pre-scaling operation, preparing the member for a
    * cluster scaling event.
    *
@@ -51,11 +38,6 @@ public interface ClusterChangeExecutor {
   ActorFuture<Void> postScaling(Set<MemberId> clusterMembers);
 
   final class NoopClusterChangeExecutor implements ClusterChangeExecutor {
-    @Override
-    public ActorFuture<Void> deleteHistory() {
-      return CompletableActorFuture.completed(null);
-    }
-
     @Override
     public ActorFuture<Void> preScaling(
         final int currentClusterSize, final Set<MemberId> clusterMembers) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -126,7 +126,7 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               restoreOperation.backupIds(),
               restoreChangeExecutor);
       case final DeleteHistoryOperation deleteHistoryOperation ->
-          new DeleteHistoryApplier(deleteHistoryOperation.memberId(), clusterChangeExecutor);
+          new DeleteHistoryApplier(deleteHistoryOperation.memberId(), partitionChangeExecutor);
       case final ScaleUpOperation scaleUpOperation ->
           switch (scaleUpOperation) {
             case StartPartitionScaleUp(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -344,7 +344,6 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
           new PartitionGroupConfigurationChangeAppliersImpl(
               new NoopPartitionChangeExecutor(),
               new NoopPartitionScalingChangeExecutor(),
-              new NoopClusterChangeExecutor(),
               new NoopModeChangeExecutor(),
               new NoopRestoreChangeExecutor());
       try {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplier.java
@@ -16,11 +16,11 @@ import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
 
 final class DeleteHistoryApplier implements ClusterOperationApplier {
-  private final ClusterChangeExecutor clusterChangeExecutor;
+  private final PartitionChangeExecutor partitionChangeExecutor;
 
   public DeleteHistoryApplier(
-      final MemberId memberId, final ClusterChangeExecutor clusterChangeExecutor) {
-    this.clusterChangeExecutor = clusterChangeExecutor;
+      final MemberId memberId, final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionChangeExecutor = partitionChangeExecutor;
   }
 
   @Override
@@ -39,7 +39,7 @@ final class DeleteHistoryApplier implements ClusterOperationApplier {
   @Override
   public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
     final var result = new CompletableActorFuture<UnaryOperator<ClusterConfiguration>>();
-    clusterChangeExecutor
+    partitionChangeExecutor
         .deleteHistory()
         .onComplete(
             (ignore, error) -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
@@ -73,4 +73,9 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
   public ActorFuture<Void> setExportingState(final ExportingState exportingState) {
     return CompletableActorFuture.completed(null);
   }
+
+  @Override
+  public ActorFuture<Void> deleteHistory() {
+    return CompletableActorFuture.completed(null);
+  }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
@@ -119,4 +119,18 @@ public interface PartitionChangeExecutor {
    * @return a future that completes when the exporting state has been applied to all partitions
    */
   ActorFuture<Void> setExportingState(final ExportingState exportingState);
+
+  /**
+   * Starts an asynchronous deletion of the history exported by this partition group, returning a
+   * future indicating success/failure.
+   *
+   * <p>When the future is completed successfully, all history data of this partition group will
+   * have been purged. When the future is completed exceptionally, then not all (but none or some)
+   * may have been purged.
+   *
+   * <p>This operation must be idempotent, as it may be retried multiple times until successful.
+   *
+   * @return a future that completes when the history has been deleted
+   */
+  ActorFuture<Void> deleteHistory();
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -54,19 +54,16 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
 
   private final PartitionChangeExecutor partitionChangeExecutor;
   private final PartitionScalingChangeExecutor partitionScalingChangeExecutor;
-  private final ClusterChangeExecutor clusterChangeExecutor;
   private final ModeChangeExecutor modeChangeExecutor;
   private final RestoreChangeExecutor restoreChangeExecutor;
 
   public PartitionGroupConfigurationChangeAppliersImpl(
       final PartitionChangeExecutor partitionChangeExecutor,
       final PartitionScalingChangeExecutor partitionScalingChangeExecutor,
-      final ClusterChangeExecutor clusterChangeExecutor,
       final ModeChangeExecutor modeChangeExecutor,
       final RestoreChangeExecutor restoreChangeExecutor) {
     this.partitionChangeExecutor = partitionChangeExecutor;
     this.partitionScalingChangeExecutor = partitionScalingChangeExecutor;
-    this.clusterChangeExecutor = clusterChangeExecutor;
     this.modeChangeExecutor = modeChangeExecutor;
     this.restoreChangeExecutor = restoreChangeExecutor;
   }
@@ -121,7 +118,8 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
       case final UpdateRoutingState op ->
           new UpdateRoutingStateApplier(op, partitionScalingChangeExecutor);
       case final UpdateIncarnationNumberOperation ignored -> new UpdateIncarnationNumberApplier();
-      case final DeleteHistoryOperation ignored -> new DeleteHistoryApplier(clusterChangeExecutor);
+      case final DeleteHistoryOperation ignored ->
+          new DeleteHistoryApplier(partitionChangeExecutor);
       case final ModeChangeOperation op ->
           switch (op.mode()) {
             case RECOVERING -> new EnterRecoveryApplier(op.memberId(), modeChangeExecutor);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/DeleteHistoryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/DeleteHistoryApplier.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
-import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
@@ -21,15 +21,15 @@ import java.util.function.UnaryOperator;
  * single named {@link PartitionGroupConfiguration} as a whole. Mirrors the legacy {@code
  * DeleteHistoryApplier} in {@code changes/}, which this does not replace or modify.
  *
- * <p>Ported against the current, unsplit {@link ClusterChangeExecutor} (same as the legacy applier)
- * — the split into a per-group history-deletion executor is Phase 3 scope, tracked separately.
+ * <p>History deletion is executed through the {@link PartitionChangeExecutor} of this partition
+ * group, so that only the history exported by this group is purged.
  */
 public final class DeleteHistoryApplier implements PartitionGroupConfigurationChangeApplier {
 
-  private final ClusterChangeExecutor clusterChangeExecutor;
+  private final PartitionChangeExecutor partitionChangeExecutor;
 
-  public DeleteHistoryApplier(final ClusterChangeExecutor clusterChangeExecutor) {
-    this.clusterChangeExecutor = clusterChangeExecutor;
+  public DeleteHistoryApplier(final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionChangeExecutor = partitionChangeExecutor;
   }
 
   @Override
@@ -48,7 +48,7 @@ public final class DeleteHistoryApplier implements PartitionGroupConfigurationCh
   @Override
   public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
     final var result = new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
-    clusterChangeExecutor
+    partitionChangeExecutor
         .deleteHistory()
         .onComplete(
             (ignore, error) -> {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -95,7 +95,6 @@ final class ClusterConfigurationManagerImplNewConfigTest {
         new PartitionGroupConfigurationChangeAppliersImpl(
             new NoopPartitionChangeExecutor(),
             new NoopPartitionScalingChangeExecutor(),
-            new NoopClusterChangeExecutor(),
             new NoopModeChangeExecutor(),
             new NoopRestoreChangeExecutor()));
     return manager;
@@ -638,7 +637,6 @@ final class ClusterConfigurationManagerImplNewConfigTest {
         new PartitionGroupConfigurationChangeAppliersImpl(
             new FailingExecutor(1),
             new NoopPartitionScalingChangeExecutor(),
-            new NoopClusterChangeExecutor(),
             new NoopModeChangeExecutor(),
             new NoopRestoreChangeExecutor()));
 
@@ -833,6 +831,11 @@ final class ClusterConfigurationManagerImplNewConfigTest {
 
     @Override
     public ActorFuture<Void> setExportingState(final ExportingState exportingState) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> deleteHistory() {
       return mayBeFail();
     }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -91,7 +91,6 @@ final class NewModelConfigurationChangeCoordinatorTest {
         new PartitionGroupConfigurationChangeAppliersImpl(
             new NoopPartitionChangeExecutor(),
             new NoopPartitionScalingChangeExecutor(),
-            new NoopClusterChangeExecutor(),
             new NoopModeChangeExecutor(),
             new NoopRestoreChangeExecutor()));
     coordinator = new ConfigurationChangeCoordinatorImpl(manager, localMemberId, executor);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -126,7 +126,6 @@ final class NewModelManagementApiEndpointsTest {
         new PartitionGroupConfigurationChangeAppliersImpl(
             new NoopPartitionChangeExecutor(),
             new NoopPartitionScalingChangeExecutor(),
-            new NoopClusterChangeExecutor(),
             new NoopModeChangeExecutor(),
             new NoopRestoreChangeExecutor()));
     final var coordinator = new ConfigurationChangeCoordinatorImpl(manager, ID_0, executor);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplierTest.java
@@ -26,9 +26,8 @@ public class DeleteHistoryApplierTest {
   void shouldSuccessDeleteHistoryOnInitIfNoPartitionExists() {
     // given
     final MemberId memberId = MemberId.from("1");
-    final ClusterChangeExecutor clusterChangeExecutor =
-        new ClusterChangeExecutor.NoopClusterChangeExecutor();
-    final var deleteHistoryApplier = new DeleteHistoryApplier(memberId, clusterChangeExecutor);
+    final PartitionChangeExecutor partitionChangeExecutor = new NoopPartitionChangeExecutor();
+    final var deleteHistoryApplier = new DeleteHistoryApplier(memberId, partitionChangeExecutor);
 
     final ClusterConfiguration clusterConfigurationWithMember =
         ClusterConfiguration.init().addMember(memberId, MemberState.initializeAsActive(Map.of()));
@@ -45,9 +44,8 @@ public class DeleteHistoryApplierTest {
     // given
     final MemberId memberId = MemberId.from("1");
     final int partitionId = 2;
-    final ClusterChangeExecutor clusterChangeExecutor =
-        new ClusterChangeExecutor.NoopClusterChangeExecutor();
-    final var deleteHistoryApplier = new DeleteHistoryApplier(memberId, clusterChangeExecutor);
+    final PartitionChangeExecutor partitionChangeExecutor = new NoopPartitionChangeExecutor();
+    final var deleteHistoryApplier = new DeleteHistoryApplier(memberId, partitionChangeExecutor);
 
     final ClusterConfiguration clusterConfigWithPartition =
         ClusterConfiguration.init()
@@ -76,14 +74,13 @@ public class DeleteHistoryApplierTest {
     // given
     final MemberId member1Id = MemberId.from("1");
     final MemberId member2Id = MemberId.from("2");
-    final ClusterChangeExecutor clusterChangeExecutor =
-        new ClusterChangeExecutor.NoopClusterChangeExecutor();
+    final PartitionChangeExecutor partitionChangeExecutor = new NoopPartitionChangeExecutor();
 
     final ClusterConfiguration initialConfiguration =
         ClusterConfiguration.init()
             .addMember(member1Id, MemberState.initializeAsActive(Map.of()))
             .addMember(member2Id, MemberState.initializeAsActive(Map.of()));
-    final var deleteHistoryApplier = new DeleteHistoryApplier(member1Id, clusterChangeExecutor);
+    final var deleteHistoryApplier = new DeleteHistoryApplier(member1Id, partitionChangeExecutor);
     final var initializedConfiguration =
         deleteHistoryApplier.init(initialConfiguration).get().apply(initialConfiguration);
     final var updater = deleteHistoryApplier.apply().join();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PostScalingApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PostScalingApplierTest.java
@@ -98,11 +98,6 @@ final class PostScalingApplierTest {
     final var failingExecutor =
         new ClusterChangeExecutor() {
           @Override
-          public ActorFuture<Void> deleteHistory() {
-            return null;
-          }
-
-          @Override
           public ActorFuture<Void> preScaling(
               final int currentClusterSize, final Set<MemberId> clusterMembers) {
             return null;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplierTest.java
@@ -98,11 +98,6 @@ final class PreScalingApplierTest {
     final var failingExecutor =
         new ClusterChangeExecutor() {
           @Override
-          public ActorFuture<Void> deleteHistory() {
-            return null;
-          }
-
-          @Override
           public ActorFuture<Void> preScaling(
               final int currentClusterSize, final Set<MemberId> clusterMembers) {
             return CompletableActorFuture.completedExceptionally(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/DeleteHistoryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/DeleteHistoryApplierTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
@@ -30,7 +30,8 @@ import org.junit.jupiter.api.Test;
 
 final class DeleteHistoryApplierTest {
 
-  private final ClusterChangeExecutor clusterChangeExecutor = mock(ClusterChangeExecutor.class);
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
   private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
@@ -55,7 +56,7 @@ final class DeleteHistoryApplierTest {
 
     // when
     final var result =
-        new DeleteHistoryApplier(clusterChangeExecutor).init(globalConfiguration, group);
+        new DeleteHistoryApplier(partitionChangeExecutor).init(globalConfiguration, group);
 
     // then
     assertThat(result).isLeft();
@@ -68,8 +69,9 @@ final class DeleteHistoryApplierTest {
   void shouldExecuteDeleteHistoryCallback() {
     // given
     final var group = groupWithMembers(Map.of());
-    final var applier = new DeleteHistoryApplier(clusterChangeExecutor);
-    when(clusterChangeExecutor.deleteHistory()).thenReturn(CompletableActorFuture.completed(null));
+    final var applier = new DeleteHistoryApplier(partitionChangeExecutor);
+    when(partitionChangeExecutor.deleteHistory())
+        .thenReturn(CompletableActorFuture.completed(null));
 
     // when
     final var initResult = applier.init(globalConfiguration, group);
@@ -77,6 +79,6 @@ final class DeleteHistoryApplierTest {
     applier.apply().join();
 
     // then
-    verify(clusterChangeExecutor, times(1)).deleteHistory();
+    verify(partitionChangeExecutor, times(1)).deleteHistory();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Deleting exported history is a per-partition-group operation — each physical tenant has its own exporter repository, so purging one tenant's history must not touch another's. It was declared on `ClusterChangeExecutor`, the cluster-wide executor, of which the broker builds exactly one. That forced it to reach for the default physical tenant's exporter repository at bootstrap and hard-code that tenant when purging, so with more than one physical tenant a purge of any group would purge the default group's history instead of its own.

This moves `deleteHistory()` to `PartitionChangeExecutor`, which the broker registers once per partition group. `PartitionManagerImpl` already knows its group and receives that group's exporter repository, so it purges exactly the history its own group exported. `RecoveryPartitionManager` rejects the operation like it rejects every other partition change while recovering — a group that cannot serve partition operations cannot serve a purge either, and the leave operations that must precede a purge would already have failed.

## Related issues

closes #58532
