### PR TITLE
Support job leases on the streaming (push) path (1/3)

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -203,7 +203,8 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
         mutable.fetchVariables(),
         mutable.tenantIds(),
         mutable.tenantFilter(),
-        mutable.claims());
+        mutable.claims(),
+        mutable.withLease());
   }
 
   @Override
@@ -217,7 +218,8 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
       Collection<DirectBuffer> fetchVariables,
       Collection<String> tenantIds,
       TenantFilter tenantFilter,
-      Map<String, Object> claims)
+      Map<String, Object> claims,
+      boolean withLease)
       implements JobActivationProperties {
 
     @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -218,6 +218,9 @@ final class JobStreamServiceStepTest {
           .containsExactlyInAnyOrder(BufferUtil.wrapString("foo"), BufferUtil.wrapString("bar"));
       assertThat(immutable.tenantIds()).containsExactlyInAnyOrder("tenant1", "tenant2");
       assertThat(immutable.tenantFilter()).isEqualTo(TenantFilter.ASSIGNED);
+      assertThat(immutable.withLease())
+          .describedAs("decodes an omitted withLease key as false")
+          .isFalse();
     }
   }
 }

--- a/zeebe/docs/adr/0005-810-job-lease.md
+++ b/zeebe/docs/adr/0005-810-job-lease.md
@@ -108,6 +108,14 @@ condition. Two thinner layers align with standard practice: older log records de
 empty lease, and exporters strip the token from previous-version job records so the previous
 minor's strict indices keep accepting documents.
 
+The same absence of mechanism holds at a second boundary: broker-to-broker stream registration.
+Registration properties (worker, timeout, tenant IDs, and now `withLease`) travel between brokers
+as a self-describing msgpack map inside an SBE envelope; SBE governs only the envelope, so adding a
+field is absorbed by msgpack rather than by the envelope schema. `withLease` declares an explicit
+default, so a payload omitting the key decodes as non-leasing, and a decoder predating the field
+ignores it. Either direction of skew degrades the opt-in to `false` rather than failing the
+registration, converging on the same worker-side null check.
+
 **D8. The token is exported to secondary storage; surfacing it in the Get/Search job APIs is the
 intended end state.**
 The token is not a secret (per the threat model in Context), so exporting it costs nothing

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.job.JobSecretLookup;
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup.Secret;
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup.SecretCheckResult;
 import io.camunda.zeebe.engine.processing.job.JobVariablesCollector;
+import io.camunda.zeebe.engine.processing.job.LeaseTokens;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -46,7 +47,6 @@ import java.time.InstantSource;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -332,17 +332,8 @@ public class BpmnJobActivationBehavior {
     jobRecord.setDeadline(deadline);
     jobRecord.setWorker(properties.worker());
     if (properties.withLease()) {
-      jobRecord.setLeaseToken(generateLeaseToken());
+      jobRecord.setLeaseToken(LeaseTokens.generate());
     }
-  }
-
-  /**
-   * Generates a lease token for a single pushed job. The token is an opaque string that callers
-   * must not parse; it is random with enough entropy that collisions between leased jobs are
-   * negligible.
-   */
-  private static String generateLeaseToken() {
-    return UUID.randomUUID().toString();
   }
 
   private JobBatchRecord createJobBatchRecord(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -46,6 +46,7 @@ import java.time.InstantSource;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -330,6 +331,18 @@ public class BpmnJobActivationBehavior {
     final var deadline = clock.millis() + properties.timeout();
     jobRecord.setDeadline(deadline);
     jobRecord.setWorker(properties.worker());
+    if (properties.withLease()) {
+      jobRecord.setLeaseToken(generateLeaseToken());
+    }
+  }
+
+  /**
+   * Generates a lease token for a single pushed job. The token is an opaque string that callers
+   * must not parse; it is random with enough entropy that collisions between leased jobs are
+   * negligible.
+   */
+  private static String generateLeaseToken() {
+    return UUID.randomUUID().toString();
   }
 
   private JobBatchRecord createJobBatchRecord(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
@@ -144,7 +143,7 @@ final class JobBatchCollector {
           // adding it to the batch
           jobRecord.setDeadline(deadline).setWorker(value.getWorkerBuffer());
           if (value.isWithLease()) {
-            jobRecord.setLeaseToken(generateLeaseToken());
+            jobRecord.setLeaseToken(LeaseTokens.generate());
           }
           jobVariablesCollector.setJobVariables(requestedVariables, jobRecord);
 
@@ -219,15 +218,6 @@ final class JobBatchCollector {
     final JobRecord appendedJob = jobIterator.add();
     appendedJob.copyFrom(jobRecord);
     return appendedJob;
-  }
-
-  /**
-   * Generates a lease token for a single activated job. The token is an opaque string that callers
-   * must not parse; it is random with enough entropy that collisions between leased jobs are
-   * negligible.
-   */
-  private static String generateLeaseToken() {
-    return UUID.randomUUID().toString();
   }
 
   private Collection<DirectBuffer> collectVariableNames(final JobBatchRecord batchRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/LeaseTokens.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/LeaseTokens.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import java.util.UUID;
+
+/**
+ * Defines lease-token generation in one place. Per zeebe/docs/adr/0005-810-job-lease.md (D1), the
+ * token's opacity is deliberate so that the engine stays free to change how tokens are produced;
+ * keeping generation to one implementation means such a change only has one place to update.
+ *
+ * <p>Per the same ADR (D2), the token must be generated exactly once per job, at command-processing
+ * time, and written into the {@code ACTIVATED} event; replay restores it from that event rather
+ * than regenerating it. Call this only at command-processing time — never from an event applier or
+ * any other replay path, as a second generation site would break replay determinism.
+ */
+public final class LeaseTokens {
+
+  private LeaseTokens() {}
+
+  /**
+   * Returns an opaque token; callers must not parse it. Call once per activated job — never reuse
+   * one token across the jobs of a batch. Random with enough entropy that collisions between leased
+   * jobs are negligible.
+   */
+  public static String generate() {
+    return UUID.randomUUID().toString();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
@@ -19,6 +19,9 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordingJobStreamer;
 import io.camunda.zeebe.engine.util.RecordingJobStreamer.RecordingJobStream;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.Strings;
@@ -134,6 +137,32 @@ public final class ActivatableJobsPushWithLeaseTest {
     assertThat(timedOut.getLeaseToken())
         .describedAs("the lease token survives an engine restart and log replay")
         .isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldRejectCompleteWithLeaseTokenSupersededByPushReactivation() {
+    // given a job pushed with a lease, then failed with retries so it is immediately re-pushed
+    final RecordingJobStream jobStream = registerStream(true);
+    final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+    final String firstToken = jobStream.getActivatedJobs().getFirst().jobRecord().getLeaseToken();
+
+    ENGINE.job().withKey(jobKey).withLeaseToken(firstToken).withRetries(1).fail();
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(2));
+    final String secondToken = jobStream.getActivatedJobs().get(1).jobRecord().getLeaseToken();
+    assertThat(secondToken)
+        .describedAs("failing with retries re-pushes the job with a new, distinct lease token")
+        .isNotEmpty()
+        .isNotEqualTo(firstToken);
+
+    // when completing with the token from the superseded first push
+    final Record<JobRecordValue> rejection =
+        ENGINE.job().withKey(jobKey).withLeaseToken(firstToken).expectRejection().complete();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs("the lease from the first push no longer fences the job once it is re-pushed")
+        .hasRejectionType(RejectionType.INVALID_STATE);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static io.camunda.zeebe.protocol.record.intent.JobBatchIntent.ACTIVATED;
+import static io.camunda.zeebe.protocol.record.intent.JobIntent.TIMED_OUT;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobBatchRecords;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer.RecordingJobStream;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.List;
+import org.agrona.DirectBuffer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * The job streaming/push path's equivalent of the poll path's {@link ActivateJobsWithLeaseTest}.
+ */
+public final class ActivatableJobsPushWithLeaseTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final long TIMEOUT_MS = 30_000L;
+  private static final RecordingJobStreamer JOB_STREAMER = new RecordingJobStreamer();
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withJobStreamer(JOB_STREAMER);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private String jobType;
+  private DirectBuffer worker;
+
+  @Before
+  public void setup() {
+    jobType = Strings.newRandomValidBpmnId();
+    worker = BufferUtil.wrapString("test");
+  }
+
+  @Test
+  public void shouldPushJobWithNonEmptyLeaseTokenWhenStreamIsLeasing() {
+    // given
+    final RecordingJobStream jobStream = registerStream(true);
+
+    // when
+    ENGINE.createJob(jobType, PROCESS_ID);
+
+    // then
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+    assertThat(jobStream.getActivatedJobs().getFirst().jobRecord().getLeaseToken())
+        .describedAs("a job pushed to a leasing stream carries a non-empty lease token")
+        .isNotEmpty();
+  }
+
+  @Test
+  public void shouldPushDistinctLeaseTokensForEachJobOnLeasingStream() {
+    // given
+    final RecordingJobStream jobStream = registerStream(true);
+
+    // when
+    ENGINE.createJob(jobType, PROCESS_ID);
+    ENGINE.createJob(jobType, PROCESS_ID);
+
+    // then
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(2));
+    assertThat(jobStream.getActivatedJobs())
+        .extracting(activatedJob -> activatedJob.jobRecord().getLeaseToken())
+        .describedAs("each job pushed to a leasing stream carries a distinct lease token")
+        .allSatisfy(token -> assertThat(token).isNotEmpty())
+        .doesNotHaveDuplicates();
+  }
+
+  @Test
+  public void shouldPersistLeaseTokenMatchingPushedToken() {
+    // given
+    final RecordingJobStream jobStream = registerStream(true);
+
+    // when
+    ENGINE.createJob(jobType, PROCESS_ID);
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+
+    // then
+    final String wireToken = jobStream.getActivatedJobs().getFirst().jobRecord().getLeaseToken();
+    assertThat(wireToken)
+        .describedAs("the job pushed on the wire carries a non-empty lease token")
+        .isNotEmpty();
+
+    // non-empty asserted before equality: wire and state derive from separate code paths
+    final String stateToken = persistedLeaseToken();
+    assertThat(stateToken)
+        .describedAs("the token pushed on the wire equals the token persisted in state")
+        .isEqualTo(wireToken);
+  }
+
+  @Test
+  public void shouldRetainLeaseTokenAfterReplay() {
+    // given
+    registerStream(true);
+    ENGINE.createJob(jobType, PROCESS_ID);
+    jobBatchRecords(ACTIVATED).withType(jobType).await();
+    final String leaseToken = persistedLeaseToken();
+
+    // when
+    ENGINE.replay();
+
+    // then
+    // a fresh event triggered post-replay, not a re-read of re-exported log bytes
+    ENGINE.increaseTime(
+        Duration.ofMillis(TIMEOUT_MS)
+            .plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+    final JobRecordValue timedOut = jobRecords(TIMED_OUT).withType(jobType).getFirst().getValue();
+    assertThat(leaseToken).describedAs("the job was leased on push").isNotEmpty();
+    assertThat(timedOut.getLeaseToken())
+        .describedAs("the lease token survives an engine restart and log replay")
+        .isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotSetLeaseTokenWhenStreamIsNotLeasing() {
+    // given
+    final RecordingJobStream jobStream = registerStream(false);
+
+    // when
+    ENGINE.createJob(jobType, PROCESS_ID);
+
+    // then
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+    assertThat(jobStream.getActivatedJobs().getFirst().jobRecord().getLeaseToken())
+        .describedAs("a freshly created job pushed to a non-leasing stream carries no lease token")
+        .isEmpty();
+  }
+
+  private RecordingJobStream registerStream(final boolean withLease) {
+    final var properties =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(TIMEOUT_MS)
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .setWithLease(withLease);
+    return JOB_STREAMER.addJobStream(BufferUtil.wrapString(jobType), properties);
+  }
+
+  private String persistedLeaseToken() {
+    return jobBatchRecords(ACTIVATED)
+        .withType(jobType)
+        .getFirst()
+        .getValue()
+        .getJobs()
+        .getFirst()
+        .getLeaseToken();
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -541,7 +541,8 @@ public final class RequestMapper extends RequestUtil {
                 .collect(Collectors.toUnmodifiableSet()))
         .setTenantIds(tenantIds)
         .setTenantFilter(tenantFilter)
-        .setClaims(claims);
+        .setClaims(claims)
+        .setWithLease(request.getWithLease());
 
     return jobActivationProperties;
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -646,6 +646,41 @@ public class RequestMapperTest {
           .hasMessageContaining("Unrecognized tenantFilter option")
           .hasMessageContaining("expected one of ASSIGNED or PROVIDED");
     }
+
+    @Test
+    public void shouldMapStreamActivatedJobsRequestWithLease() {
+      // given
+      final var request =
+          StreamActivatedJobsRequest.newBuilder()
+              .setType("test-job")
+              .setWorker("test-worker")
+              .addTenantIds("tenant-a")
+              .setWithLease(true)
+              .build();
+
+      // when
+      final var properties = RequestMapper.toJobActivationProperties(request, EMPTY_CLAIMS);
+
+      // then
+      assertThat(properties.withLease()).isTrue();
+    }
+
+    @Test
+    public void shouldNotSetWithLeaseByDefault() {
+      // given
+      final var request =
+          StreamActivatedJobsRequest.newBuilder()
+              .setType("test-job")
+              .setWorker("test-worker")
+              .addTenantIds("tenant-a")
+              .build();
+
+      // when
+      final var properties = RequestMapper.toJobActivationProperties(request, EMPTY_CLAIMS);
+
+      // then
+      assertThat(properties.withLease()).isFalse();
+    }
   }
 
   @Nested

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -24,6 +24,13 @@ message StreamActivatedJobsRequest {
   repeated string tenantIds = 6;
   // the tenant filtering strategy - determines whether to use provided tenant IDs or assigned tenant IDs
   TenantFilter tenantFilter = 7;
+  // whether to stream jobs with a lease; when true, each job pushed on this stream is
+  // assigned a distinct, opaque lease token, returned as ActivatedJob.leaseToken. The lease
+  // fences the complete, fail, and throw-error commands against a superseded activation of
+  // the same job (e.g. after the job timed out or failed and was re-activated by another
+  // worker): a command carrying a stale lease token is rejected rather than racing with the
+  // newer activation. Defaults to false, which pushes jobs without a lease.
+  bool withLease = 8;
 }
 
 message ActivateJobsRequest {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
@@ -81,4 +81,13 @@ public interface JobActivationProperties extends BufferWriter {
    * @return a Map of authorization data for this record or an empty Map if not set.
    */
   Map<String, Object> claims();
+
+  /**
+   * Returns whether jobs pushed on this stream are leased. When {@code true}, each job pushed on
+   * this stream is assigned a distinct, opaque lease token, observable as {@link
+   * JobRecordValue#getLeaseToken()}. The token lets the engine distinguish items produced by this
+   * activation from those of a superseded one. Defaults to {@code false}, i.e. jobs are pushed
+   * without a lease.
+   */
+  boolean withLease();
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.stream.job;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -36,15 +37,17 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   private final DocumentProperty claimsProp = new DocumentProperty("claims");
   private final EnumProperty<TenantFilter> tenantFilterProp =
       new EnumProperty<>("tenantFilter", TenantFilter.class, TenantFilter.PROVIDED);
+  private final BooleanProperty withLeaseProp = new BooleanProperty("withLease", false);
 
   public JobActivationPropertiesImpl() {
-    super(6);
+    super(7);
     declareProperty(workerProp)
         .declareProperty(timeoutProp)
         .declareProperty(fetchVariablesProp)
         .declareProperty(tenantIdsProp)
         .declareProperty(claimsProp)
-        .declareProperty(tenantFilterProp);
+        .declareProperty(tenantFilterProp)
+        .declareProperty(withLeaseProp);
   }
 
   public JobActivationPropertiesImpl setWorker(
@@ -67,6 +70,11 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   public JobActivationPropertiesImpl setTenantIds(final Collection<String> tenantIds) {
     tenantIdsProp.reset();
     tenantIds.forEach(tenantId -> tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId)));
+    return this;
+  }
+
+  public JobActivationPropertiesImpl setWithLease(final boolean withLease) {
+    withLeaseProp.setValue(withLease);
     return this;
   }
 
@@ -98,6 +106,11 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   @Override
   public Map<String, Object> claims() {
     return MsgPackConverter.convertToMap(claimsProp.getValue());
+  }
+
+  @Override
+  public boolean withLease() {
+    return withLeaseProp.getValue();
   }
 
   public JobActivationPropertiesImpl setTenantFilter(final TenantFilter tenantFilter) {


### PR DESCRIPTION
## Description

Streams registered with `withLease` now receive a distinct lease token for every pushed job. This gives streamed activations the same completion/fail/throw-error fencing guarantee already provided for leased polling via `ActivateJobsRequest.withLease`.

No persistence changes are needed: streamed and polled activations already append the same `ACTIVATED` event through the same applier. The token is generated once, before that event is appended, so the persisted token remains stable across replay or push-side-effect retries. Token generation is now centralized in `LeaseTokens` for both paths.

This is PR 1 of the 3-PR stack for #56457.

### Deliberately deferred

Lease-aware stream matching is deliberately deferred to PR 2. Therefore, after this PR, a leased job can still be delivered to a non-leasing stream; PR 2 will make lease-ness participate in stream matching.

Java client opt-in and end-to-end client coverage are deferred to PR 3. That also includes gateway-facing coverage that `leaseToken` is absent for a non-leasing stream's `ActivatedJob`.

### Compatibility

The stream-registration boundary encodes `JobActivationProperties` as msgpack inside an SBE envelope. The new field relies on its declared msgpack default when absent; existing update compatibility coverage exercises that direction. This PR also corrects the corresponding compatibility rationale in ADR D7.

### Validation

Added `ActivatableJobsPushWithLeaseTest`, covering:

1. a lease token is present for leasing streams;
2. each pushed job receives a distinct token;
3. the wire token matches persisted job state;
4. the token survives replay; and
5. no token is sent for non-leasing streams.

Relevant existing streaming, priority, multi-tenancy, notification, request-mapping, and job-stream service tests remain green.

## Checklist

- [ ] Enable backports when necessary

## Related issues

Part of #56457