### PR TITLE
feat: re-resolve agentDefinitionKey and validate AgentDefinitionType on AgentInstance migration

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -189,6 +189,67 @@ public class AgentInstanceMigrationIT {
         .hasMessageContaining("different agent definition type");
   }
 
+  @Test
+  void shouldRejectMigrationWhenOrphanedAgentInstanceChangesAgentDefinitionType() {
+    // given — the agentic job completes (and the process moves on to "nextTask") before migration,
+    // orphaning the still-active agent instance; the orphaned instance's element "agentTask" is
+    // mapped onto an external agent task, changing the agent definition type for an instance that
+    // is no longer part of the migrated element tree
+    final String sourceElementId = "agentTask";
+    final String targetElementId = "agentTask2";
+    final String sourceNextElementId = "nextTask";
+    final String targetNextElementId = "nextTask2";
+    final String agentJobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+    final var sourceProcess =
+        deployProcessAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess("migration-agent-orphaned-type-change_v1")
+                .startEvent()
+                .serviceTask(
+                    sourceElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
+                .userTask(sourceNextElementId)
+                .endEvent()
+                .done(),
+            "migration-agent-orphaned-type-change_v1.bpmn");
+    final var targetProcess =
+        deployProcessAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess("migration-agent-orphaned-type-change_v2")
+                .startEvent()
+                .serviceTask(
+                    targetElementId,
+                    t -> t.zeebeJobType(agentJobType).zeebeExternalAgentDefinition())
+                .userTask(targetNextElementId)
+                .endEvent()
+                .done(),
+            "migration-agent-orphaned-type-change_v2.bpmn");
+
+    final var processInstanceKey =
+        startProcessInstance(client, sourceProcess.getBpmnProcessId()).getProcessInstanceKey();
+    createAgentInstance(processInstanceKey, sourceElementId);
+
+    // complete the agentic job so its owning element completes and the agent instance is orphaned
+    activateAndCompleteJobs(client, agentJobType, "test-worker", 1);
+    waitForElementInstances(
+        client, f -> f.elementId(sourceNextElementId).processInstanceKey(processInstanceKey), 1);
+
+    // when / then — the orphaned agent instance is validated too, so the type change is rejected
+    assertThatThrownBy(
+            () ->
+                client
+                    .newMigrateProcessInstanceCommand(processInstanceKey)
+                    .migrationPlan(
+                        MigrationPlan.newBuilder()
+                            .withTargetProcessDefinitionKey(targetProcess.getProcessDefinitionKey())
+                            .addMappingInstruction(sourceElementId, targetElementId)
+                            .addMappingInstruction(sourceNextElementId, targetNextElementId)
+                            .build())
+                    .execute())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("different agent definition type");
+  }
+
   private long createAgentInstance(final long processInstanceKey, final String elementId) {
     waitForElementInstances(
         client, f -> f.elementId(elementId).processInstanceKey(processInstanceKey), 1);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -13,13 +13,11 @@ import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.MigrationPlan;
-import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.Process;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -62,7 +60,8 @@ public class AgentInstanceMigrationIT {
             client,
             Bpmn.createExecutableProcess("migration-agent-service-task_v2")
                 .startEvent()
-                .serviceTask(targetElementId, t -> t.zeebeJobType(agentJobType))
+                .serviceTask(
+                    targetElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
                 .userTask(targetNextElementId)
                 .endEvent()
                 .done(),
@@ -116,6 +115,7 @@ public class AgentInstanceMigrationIT {
                 .startEvent()
                 .adHocSubProcess(targetElementId, p -> p.task("agentTask2"))
                 .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeAiAgentSubProcessDefinition()
                 .endEvent()
                 .done(),
             "migration-agent-ahsp_v2.bpmn");
@@ -136,118 +136,6 @@ public class AgentInstanceMigrationIT {
 
     // then
     assertAgentInstanceMigratedTo(agentInstanceKey, targetProcess, targetElementId);
-  }
-
-  @Test
-  void shouldRejectMigrationWhenAgentDefinitionTypeChanges() {
-    // given — an active AI agent task is mapped onto an external agent task; both are service
-    // tasks, so the element type is unchanged and only the agent definition type differs
-    final String sourceElementId = "agentTask";
-    final String targetElementId = "agentTask2";
-    final String agentJobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
-
-    final var sourceProcess =
-        deployProcessAndWaitForIt(
-            client,
-            Bpmn.createExecutableProcess("migration-agent-type-change_v1")
-                .startEvent()
-                .serviceTask(
-                    sourceElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done(),
-            "migration-agent-type-change_v1.bpmn");
-    final var targetProcess =
-        deployProcessAndWaitForIt(
-            client,
-            Bpmn.createExecutableProcess("migration-agent-type-change_v2")
-                .startEvent()
-                .serviceTask(
-                    targetElementId,
-                    t -> t.zeebeJobType(agentJobType).zeebeExternalAgentDefinition())
-                .endEvent()
-                .done(),
-            "migration-agent-type-change_v2.bpmn");
-
-    final var processInstanceKey =
-        startProcessInstance(client, sourceProcess.getBpmnProcessId()).getProcessInstanceKey();
-    // the agent instance's job is left running so its owning element stays active and is part of
-    // the migrated element tree that gets validated
-    createAgentInstance(processInstanceKey, sourceElementId);
-
-    // when / then — the migration is rejected because the agent definition type changes
-    assertThatThrownBy(
-            () ->
-                client
-                    .newMigrateProcessInstanceCommand(processInstanceKey)
-                    .migrationPlan(
-                        MigrationPlan.newBuilder()
-                            .withTargetProcessDefinitionKey(targetProcess.getProcessDefinitionKey())
-                            .addMappingInstruction(sourceElementId, targetElementId)
-                            .build())
-                    .execute())
-        .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("different agent definition type");
-  }
-
-  @Test
-  void shouldRejectMigrationWhenOrphanedAgentInstanceChangesAgentDefinitionType() {
-    // given — the agentic job completes (and the process moves on to "nextTask") before migration,
-    // orphaning the still-active agent instance; the orphaned instance's element "agentTask" is
-    // mapped onto an external agent task, changing the agent definition type for an instance that
-    // is no longer part of the migrated element tree
-    final String sourceElementId = "agentTask";
-    final String targetElementId = "agentTask2";
-    final String sourceNextElementId = "nextTask";
-    final String targetNextElementId = "nextTask2";
-    final String agentJobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
-
-    final var sourceProcess =
-        deployProcessAndWaitForIt(
-            client,
-            Bpmn.createExecutableProcess("migration-agent-orphaned-type-change_v1")
-                .startEvent()
-                .serviceTask(
-                    sourceElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
-                .userTask(sourceNextElementId)
-                .endEvent()
-                .done(),
-            "migration-agent-orphaned-type-change_v1.bpmn");
-    final var targetProcess =
-        deployProcessAndWaitForIt(
-            client,
-            Bpmn.createExecutableProcess("migration-agent-orphaned-type-change_v2")
-                .startEvent()
-                .serviceTask(
-                    targetElementId,
-                    t -> t.zeebeJobType(agentJobType).zeebeExternalAgentDefinition())
-                .userTask(targetNextElementId)
-                .endEvent()
-                .done(),
-            "migration-agent-orphaned-type-change_v2.bpmn");
-
-    final var processInstanceKey =
-        startProcessInstance(client, sourceProcess.getBpmnProcessId()).getProcessInstanceKey();
-    createAgentInstance(processInstanceKey, sourceElementId);
-
-    // complete the agentic job so its owning element completes and the agent instance is orphaned
-    activateAndCompleteJobs(client, agentJobType, "test-worker", 1);
-    waitForElementInstances(
-        client, f -> f.elementId(sourceNextElementId).processInstanceKey(processInstanceKey), 1);
-
-    // when / then — the orphaned agent instance is validated too, so the type change is rejected
-    assertThatThrownBy(
-            () ->
-                client
-                    .newMigrateProcessInstanceCommand(processInstanceKey)
-                    .migrationPlan(
-                        MigrationPlan.newBuilder()
-                            .withTargetProcessDefinitionKey(targetProcess.getProcessDefinitionKey())
-                            .addMappingInstruction(sourceElementId, targetElementId)
-                            .addMappingInstruction(sourceNextElementId, targetNextElementId)
-                            .build())
-                    .execute())
-        .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("different agent definition type");
   }
 
   private long createAgentInstance(final long processInstanceKey, final String elementId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -13,11 +13,13 @@ import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.Process;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -134,6 +136,57 @@ public class AgentInstanceMigrationIT {
 
     // then
     assertAgentInstanceMigratedTo(agentInstanceKey, targetProcess, targetElementId);
+  }
+
+  @Test
+  void shouldRejectMigrationWhenAgentDefinitionTypeChanges() {
+    // given — an active AI agent task is mapped onto an external agent task; both are service
+    // tasks, so the element type is unchanged and only the agent definition type differs
+    final String sourceElementId = "agentTask";
+    final String targetElementId = "agentTask2";
+    final String agentJobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+    final var sourceProcess =
+        deployProcessAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess("migration-agent-type-change_v1")
+                .startEvent()
+                .serviceTask(
+                    sourceElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done(),
+            "migration-agent-type-change_v1.bpmn");
+    final var targetProcess =
+        deployProcessAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess("migration-agent-type-change_v2")
+                .startEvent()
+                .serviceTask(
+                    targetElementId,
+                    t -> t.zeebeJobType(agentJobType).zeebeExternalAgentDefinition())
+                .endEvent()
+                .done(),
+            "migration-agent-type-change_v2.bpmn");
+
+    final var processInstanceKey =
+        startProcessInstance(client, sourceProcess.getBpmnProcessId()).getProcessInstanceKey();
+    // the agent instance's job is left running so its owning element stays active and is part of
+    // the migrated element tree that gets validated
+    createAgentInstance(processInstanceKey, sourceElementId);
+
+    // when / then — the migration is rejected because the agent definition type changes
+    assertThatThrownBy(
+            () ->
+                client
+                    .newMigrateProcessInstanceCommand(processInstanceKey)
+                    .migrationPlan(
+                        MigrationPlan.newBuilder()
+                            .withTargetProcessDefinitionKey(targetProcess.getProcessDefinitionKey())
+                            .addMappingInstruction(sourceElementId, targetElementId)
+                            .build())
+                    .execute())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("different agent definition type");
   }
 
   private long createAgentInstance(final long processInstanceKey, final String elementId) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor.SafetyCheckFailedException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.AgentDefinitionState;
 import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -17,17 +18,24 @@ import java.util.Map;
 
 public class ProcessInstanceMigrationAgentInstanceBehavior {
 
+  private static final long UNSET_AGENT_DEFINITION_KEY = -1L;
+
   private final StateWriter stateWriter;
   private final AgentInstanceState agentInstanceState;
+  private final AgentDefinitionState agentDefinitionState;
 
   public ProcessInstanceMigrationAgentInstanceBehavior(
-      final StateWriter stateWriter, final AgentInstanceState agentInstanceState) {
+      final StateWriter stateWriter,
+      final AgentInstanceState agentInstanceState,
+      final AgentDefinitionState agentDefinitionState) {
     this.stateWriter = stateWriter;
     this.agentInstanceState = agentInstanceState;
+    this.agentDefinitionState = agentDefinitionState;
   }
 
   /**
-   * Re-points every agent instance of the given process instance at the target process definition.
+   * Re-points every agent instance of the given process instance at the target process definition,
+   * re-resolving its {@code agentDefinitionKey} to the target version's agent definition.
    *
    * @param mappedElementIds the source-to-target element id mapping resolved for this migration; an
    *     agent instance whose {@code elementId} has no entry keeps its current id
@@ -73,6 +81,21 @@ public class ProcessInstanceMigrationAgentInstanceBehavior {
             .setProcessDefinitionVersion(targetProcessDefinition.getVersion())
             .setBpmnProcessId(BufferUtil.bufferAsString(targetProcessDefinition.getBpmnProcessId()))
             .setVersionTag(targetProcessDefinition.getVersionTag())
-            .setElementId(targetElementId));
+            .setElementId(targetElementId)
+            .setAgentDefinitionKey(
+                resolveAgentDefinitionKey(targetProcessDefinition, targetElementId)));
+  }
+
+  /**
+   * Resolves the agent definition key the migrated agent instance should point at in the target
+   * process definition. Returns {@code -1} when the target element carries no agent definition,
+   * which is the allowed case of migrating an agent element onto a plain (non-agent) element.
+   */
+  private long resolveAgentDefinitionKey(
+      final DeployedProcess targetProcessDefinition, final String targetElementId) {
+    final var targetKey =
+        agentDefinitionState.getAgentDefinitionKey(
+            targetProcessDefinition.getKey(), BufferUtil.wrapString(targetElementId));
+    return targetKey == null ? UNSET_AGENT_DEFINITION_KEY : targetKey;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
@@ -18,8 +18,6 @@ import java.util.Map;
 
 public class ProcessInstanceMigrationAgentInstanceBehavior {
 
-  private static final long UNSET_AGENT_DEFINITION_KEY = -1L;
-
   private final StateWriter stateWriter;
   private final AgentInstanceState agentInstanceState;
   private final AgentDefinitionState agentDefinitionState;
@@ -34,10 +32,12 @@ public class ProcessInstanceMigrationAgentInstanceBehavior {
   }
 
   /**
-   * Rejects the migration when it would change the {@code AgentDefinitionType} backing any agent
-   * instance of the process instance. Every agent instance is validated, including orphaned ones
-   * whose owning element already completed and is therefore no longer part of the migrated element
-   * tree that {@link ProcessInstanceMigrationMigrateProcessor}'s per-element validation walks.
+   * Rejects the migration when it would leave any agent instance of the process instance without a
+   * backing agent definition of the same {@code AgentDefinitionType} — because an agent instance
+   * must always belong to an agent definition, and its type must not change. Every agent instance
+   * is validated, including orphaned ones whose owning element already completed and is therefore
+   * no longer part of the migrated element tree that {@link
+   * ProcessInstanceMigrationMigrateProcessor}'s per-element validation walks.
    *
    * @param mappedElementIds the source-to-target element id mapping resolved for this migration; an
    *     agent instance whose {@code elementId} has no entry keeps its current id
@@ -72,7 +72,7 @@ public class ProcessInstanceMigrationAgentInstanceBehavior {
     }
     final var sourceElementId = record.getElementId();
     final var targetElementId = mappedElementIds.getOrDefault(sourceElementId, sourceElementId);
-    ProcessInstanceMigrationPreconditions.requireSameAgentDefinitionType(
+    ProcessInstanceMigrationPreconditions.requireCompatibleAgentDefinition(
         sourceProcessDefinition,
         targetProcessDefinition,
         sourceElementId,
@@ -130,19 +130,37 @@ public class ProcessInstanceMigrationAgentInstanceBehavior {
             .setVersionTag(targetProcessDefinition.getVersionTag())
             .setElementId(targetElementId)
             .setAgentDefinitionKey(
-                resolveAgentDefinitionKey(targetProcessDefinition, targetElementId)));
+                resolveAgentDefinitionKey(
+                    targetProcessDefinition,
+                    targetElementId,
+                    agentInstanceKey,
+                    processInstanceKey)));
   }
 
   /**
    * Resolves the agent definition key the migrated agent instance should point at in the target
-   * process definition. Returns {@code -1} when the target element carries no agent definition,
-   * which is the allowed case of migrating an agent element onto a plain (non-agent) element.
+   * process definition. An agent instance must always belong to an agent definition, so the target
+   * element having none is a broken state that the migration preconditions already reject; if it is
+   * still reached here it is a bug rather than a rejectable user error.
    */
   private long resolveAgentDefinitionKey(
-      final DeployedProcess targetProcessDefinition, final String targetElementId) {
+      final DeployedProcess targetProcessDefinition,
+      final String targetElementId,
+      final long agentInstanceKey,
+      final long processInstanceKey) {
     final var targetKey =
         agentDefinitionState.getAgentDefinitionKey(
             targetProcessDefinition.getKey(), BufferUtil.wrapString(targetElementId));
-    return targetKey == null ? UNSET_AGENT_DEFINITION_KEY : targetKey;
+    if (targetKey == null) {
+      throw new SafetyCheckFailedException(
+          String.format(
+              """
+              Expected to migrate agent instance with key '%d' of process instance with key '%d' \
+              to target element with id '%s', but that element has no agent definition. \
+              An agent instance must always belong to an agent definition. \
+              Please report this as a bug""",
+              agentInstanceKey, processInstanceKey, targetElementId));
+    }
+    return targetKey;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
@@ -34,6 +34,53 @@ public class ProcessInstanceMigrationAgentInstanceBehavior {
   }
 
   /**
+   * Rejects the migration when it would change the {@code AgentDefinitionType} backing any agent
+   * instance of the process instance. Every agent instance is validated, including orphaned ones
+   * whose owning element already completed and is therefore no longer part of the migrated element
+   * tree that {@link ProcessInstanceMigrationMigrateProcessor}'s per-element validation walks.
+   *
+   * @param mappedElementIds the source-to-target element id mapping resolved for this migration; an
+   *     agent instance whose {@code elementId} has no entry keeps its current id
+   */
+  public void validateAgentInstanceMigrations(
+      final long processInstanceKey,
+      final DeployedProcess sourceProcessDefinition,
+      final DeployedProcess targetProcessDefinition,
+      final Map<String, String> mappedElementIds) {
+    agentInstanceState
+        .getAgentInstanceKeysByProcessInstanceKey(processInstanceKey)
+        .forEach(
+            agentInstanceKey ->
+                validateAgentInstanceMigration(
+                    agentInstanceKey,
+                    processInstanceKey,
+                    sourceProcessDefinition,
+                    targetProcessDefinition,
+                    mappedElementIds));
+  }
+
+  private void validateAgentInstanceMigration(
+      final long agentInstanceKey,
+      final long processInstanceKey,
+      final DeployedProcess sourceProcessDefinition,
+      final DeployedProcess targetProcessDefinition,
+      final Map<String, String> mappedElementIds) {
+    final var record = agentInstanceState.getRecord(agentInstanceKey);
+    if (record == null) {
+      // a missing record is surfaced as a bug by the re-resolution pass; nothing to validate here
+      return;
+    }
+    final var sourceElementId = record.getElementId();
+    final var targetElementId = mappedElementIds.getOrDefault(sourceElementId, sourceElementId);
+    ProcessInstanceMigrationPreconditions.requireSameAgentDefinitionType(
+        sourceProcessDefinition,
+        targetProcessDefinition,
+        sourceElementId,
+        targetElementId,
+        processInstanceKey);
+  }
+
+  /**
    * Re-points every agent instance of the given process instance at the target process definition,
    * re-resolving its {@code agentDefinitionKey} to the target version's agent definition.
    *

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -468,6 +468,12 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireNonNullTargetElementId(targetElementId, processInstanceKey, elementId);
     requireSameElementType(
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
+    requireSameAgentDefinitionType(
+        sourceProcessDefinition,
+        targetProcessDefinition,
+        elementId,
+        targetElementId,
+        processInstanceKey);
     requireSupportedUserTaskMigration(
         sourceProcessDefinition,
         targetProcessDefinition,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -199,6 +199,9 @@ public class ProcessInstanceMigrationMigrateProcessor
         mapElementIds(
             mappingInstructions, processInstance, sourceProcessDefinition, targetProcessDefinition);
 
+    migrationAgentInstanceBehaviour.validateAgentInstanceMigrations(
+        processInstanceKey, sourceProcessDefinition, targetProcessDefinition, mappedElementIds);
+
     // avoid stackoverflow using a queue to iterate over the descendants instead of recursion
     final var elementInstances = new ArrayDeque<>(List.of(processInstance));
     while (!elementInstances.isEmpty()) {
@@ -468,12 +471,6 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireNonNullTargetElementId(targetElementId, processInstanceKey, elementId);
     requireSameElementType(
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
-    requireSameAgentDefinitionType(
-        sourceProcessDefinition,
-        targetProcessDefinition,
-        elementId,
-        targetElementId,
-        processInstanceKey);
     requireSupportedUserTaskMigration(
         sourceProcessDefinition,
         targetProcessDefinition,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -136,7 +136,9 @@ public class ProcessInstanceMigrationMigrateProcessor
             keyGenerator, stateWriter, elementInstanceState);
     migrationAgentInstanceBehaviour =
         new ProcessInstanceMigrationAgentInstanceBehavior(
-            stateWriter, processingState.getAgentInstanceState());
+            stateWriter,
+            processingState.getAgentInstanceState(),
+            processingState.getAgentDefinitionState());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -145,12 +145,18 @@ public final class ProcessInstanceMigrationPreconditions {
       but active element with id '%s' and type '%s' is mapped to \
       an element with id '%s' and different type '%s'. \
       Elements must be mapped to elements of the same type.""";
+  private static final String ERROR_AGENT_INSTANCE_MISSING_AGENT_DEFINITION =
+      """
+      Expected to migrate process instance '%s' \
+      but the agent instance with element id '%s' would be migrated to element '%s' \
+      that has no agent definition. \
+      An agent instance must always belong to an agent definition.""";
   private static final String ERROR_AGENT_DEFINITION_TYPE_CHANGED =
       """
       Expected to migrate process instance '%s' \
       but the agent instance element with id '%s' has agent definition type '%s' \
       while the mapped target element with id '%s' has a different agent definition type '%s'. \
-      An agent instance's agent definition type must not change on migration.""";
+      An agent instance's type must not change on migration.""";
   private static final String ERROR_DEPRECATED_USER_TASK_IMPLEMENTATION =
       """
       Expected to migrate process instance '%s' \
@@ -607,12 +613,11 @@ public final class ProcessInstanceMigrationPreconditions {
   }
 
   /**
-   * Checks whether the agent definition type is unchanged for an agent instance across the
-   * migration. An agent instance whose element carries an agent definition may only be migrated
-   * onto an element with the same agent definition type, or onto a plain element without an agent
-   * definition (in either direction). Migrating between two different agent definition types is
-   * rejected, because the migrated agent instance could not be re-resolved to a compatible agent
-   * definition on the target.
+   * Checks that the agent definition backing an agent instance is preserved across the migration.
+   * The method is only called for elements that already have an agent instance, so the source
+   * element always carries an agent definition. The migration is rejected when the mapped target
+   * element carries no agent definition (an agent instance must always belong to one) or carries an
+   * agent definition of a different type (an agent instance's type must not change).
    *
    * @param sourceProcessDefinition source process definition to resolve the source agent type
    * @param targetProcessDefinition target process definition to resolve the target agent type
@@ -620,7 +625,7 @@ public final class ProcessInstanceMigrationPreconditions {
    * @param targetElementId the mapped target element id
    * @param processInstanceKey process instance key to be logged
    */
-  public static void requireSameAgentDefinitionType(
+  public static void requireCompatibleAgentDefinition(
       final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
       final String sourceElementId,
@@ -631,20 +636,28 @@ public final class ProcessInstanceMigrationPreconditions {
     final AgentDefinitionType targetType =
         resolveAgentDefinitionType(targetProcessDefinition, targetElementId);
 
-    if (sourceType == AgentDefinitionType.UNSPECIFIED
-        || targetType == AgentDefinitionType.UNSPECIFIED
-        || sourceType == targetType) {
+    if (sourceType == targetType) {
       return;
     }
 
-    final String reason =
-        String.format(
-            ERROR_AGENT_DEFINITION_TYPE_CHANGED,
-            processInstanceKey,
-            sourceElementId,
-            sourceType,
-            targetElementId,
-            targetType);
+    final String reason;
+    if (targetType == AgentDefinitionType.UNSPECIFIED) {
+      reason =
+          String.format(
+              ERROR_AGENT_INSTANCE_MISSING_AGENT_DEFINITION,
+              processInstanceKey,
+              sourceElementId,
+              targetElementId);
+    } else {
+      reason =
+          String.format(
+              ERROR_AGENT_DEFINITION_TYPE_CHANGED,
+              processInstanceKey,
+              sourceElementId,
+              sourceType,
+              targetElementId,
+              targetType);
+    }
     throw new ProcessInstanceMigrationPreconditionFailedException(
         reason, RejectionType.INVALID_STATE);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue.ProcessInstanceMigrationMappingInstructionValue;
@@ -143,6 +145,12 @@ public final class ProcessInstanceMigrationPreconditions {
       but active element with id '%s' and type '%s' is mapped to \
       an element with id '%s' and different type '%s'. \
       Elements must be mapped to elements of the same type.""";
+  private static final String ERROR_AGENT_DEFINITION_TYPE_CHANGED =
+      """
+      Expected to migrate process instance '%s' \
+      but active element with id '%s' has agent definition type '%s' \
+      while the mapped target element with id '%s' has a different agent definition type '%s'. \
+      Agent elements must be mapped to elements of the same agent definition type.""";
   private static final String ERROR_DEPRECATED_USER_TASK_IMPLEMENTATION =
       """
       Expected to migrate process instance '%s' \
@@ -596,6 +604,65 @@ public final class ProcessInstanceMigrationPreconditions {
             targetElementType);
     throw new ProcessInstanceMigrationPreconditionFailedException(
         reason, RejectionType.INVALID_STATE);
+  }
+
+  /**
+   * Checks whether the agent definition type is unchanged across the migration. An agent element
+   * (one carrying an agent definition) may only be mapped to an element with the same agent
+   * definition type, or to a plain element without an agent definition (in either direction).
+   * Mapping between two different agent definition types is rejected, because the migrated agent
+   * instance could not be re-resolved to a compatible agent definition on the target.
+   *
+   * @param sourceProcessDefinition source process definition to resolve the source agent type
+   * @param targetProcessDefinition target process definition to resolve the target agent type
+   * @param sourceElementId source element id
+   * @param targetElementId target element id
+   * @param processInstanceKey process instance key to be logged
+   */
+  public static void requireSameAgentDefinitionType(
+      final DeployedProcess sourceProcessDefinition,
+      final DeployedProcess targetProcessDefinition,
+      final String sourceElementId,
+      final String targetElementId,
+      final long processInstanceKey) {
+    final AgentDefinitionType sourceType =
+        resolveAgentDefinitionType(sourceProcessDefinition, sourceElementId);
+    final AgentDefinitionType targetType =
+        resolveAgentDefinitionType(targetProcessDefinition, targetElementId);
+
+    if (sourceType == AgentDefinitionType.UNSPECIFIED
+        || targetType == AgentDefinitionType.UNSPECIFIED
+        || sourceType == targetType) {
+      return;
+    }
+
+    final String reason =
+        String.format(
+            ERROR_AGENT_DEFINITION_TYPE_CHANGED,
+            processInstanceKey,
+            sourceElementId,
+            sourceType,
+            targetElementId,
+            targetType);
+    throw new ProcessInstanceMigrationPreconditionFailedException(
+        reason, RejectionType.INVALID_STATE);
+  }
+
+  private static AgentDefinitionType resolveAgentDefinitionType(
+      final DeployedProcess processDefinition, final String elementId) {
+    final AbstractFlowElement element = processDefinition.getProcess().getElementById(elementId);
+    if (element == null) {
+      return AgentDefinitionType.UNSPECIFIED;
+    }
+    // the agent definition marker sits on the job worker element itself; unwrap a multi-instance
+    // body to reach it, mirroring how the agent definition is minted at deploy time
+    final ExecutableFlowElement activity =
+        element instanceof final ExecutableMultiInstanceBody multiInstanceBody
+            ? multiInstanceBody.getInnerActivity()
+            : element;
+    return activity instanceof final ExecutableJobWorkerElement jobWorkerElement
+        ? jobWorkerElement.getAgentDefinitionType()
+        : AgentDefinitionType.UNSPECIFIED;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -148,9 +148,9 @@ public final class ProcessInstanceMigrationPreconditions {
   private static final String ERROR_AGENT_DEFINITION_TYPE_CHANGED =
       """
       Expected to migrate process instance '%s' \
-      but active element with id '%s' has agent definition type '%s' \
+      but the agent instance element with id '%s' has agent definition type '%s' \
       while the mapped target element with id '%s' has a different agent definition type '%s'. \
-      Agent elements must be mapped to elements of the same agent definition type.""";
+      An agent instance's agent definition type must not change on migration.""";
   private static final String ERROR_DEPRECATED_USER_TASK_IMPLEMENTATION =
       """
       Expected to migrate process instance '%s' \
@@ -607,16 +607,17 @@ public final class ProcessInstanceMigrationPreconditions {
   }
 
   /**
-   * Checks whether the agent definition type is unchanged across the migration. An agent element
-   * (one carrying an agent definition) may only be mapped to an element with the same agent
-   * definition type, or to a plain element without an agent definition (in either direction).
-   * Mapping between two different agent definition types is rejected, because the migrated agent
-   * instance could not be re-resolved to a compatible agent definition on the target.
+   * Checks whether the agent definition type is unchanged for an agent instance across the
+   * migration. An agent instance whose element carries an agent definition may only be migrated
+   * onto an element with the same agent definition type, or onto a plain element without an agent
+   * definition (in either direction). Migrating between two different agent definition types is
+   * rejected, because the migrated agent instance could not be re-resolved to a compatible agent
+   * definition on the target.
    *
    * @param sourceProcessDefinition source process definition to resolve the source agent type
    * @param targetProcessDefinition target process definition to resolve the target agent type
-   * @param sourceElementId source element id
-   * @param targetElementId target element id
+   * @param sourceElementId the agent instance's source element id
+   * @param targetElementId the mapped target element id
    * @param processInstanceKey process instance key to be logged
    */
   public static void requireSameAgentDefinitionType(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -72,7 +72,8 @@ public class MigrateAgentInstanceTest {
                 Bpmn.createExecutableProcess(targetProcessId)
                     .versionTag("v2")
                     .startEvent()
-                    .serviceTask("A2", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .serviceTask(
+                        "A2", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                     .userTask("B2")
                     .endEvent()
                     .done())
@@ -134,13 +135,11 @@ public class MigrateAgentInstanceTest {
   }
 
   @Test
-  public void shouldKeepStaleElementIdWhenOwningElementIsRemovedFromTargetProcessDefinition() {
-    // given — service task "A" completes before a new version (v2) of the *same* process
-    // definition is deployed, dropping "A" entirely (a common case: requirements changed while
-    // instances were already running past it); since "A" has no active element instance at
-    // migration time, no mapping instruction is required or provided for it, and the target
-    // version does not define an element with this id either. This documents the current
-    // fallback behavior: the agent instance keeps its stale, no-longer-existing elementId
+  public void shouldRejectMigrationWhenOrphanedAgentInstanceOwningElementIsRemoved() {
+    // given — service task "A" completes, then a new v2 of the same process definition is deployed
+    // that drops "A". The agent instance created on "A" stays active (orphaned), but "A" no longer
+    // exists in v2 and is not mapped, so the orphaned instance could not keep an agent definition
+    // after migration — which an agent instance must always have
     final String processId = helper.getBpmnProcessId();
 
     engine
@@ -162,12 +161,7 @@ public class MigrateAgentInstanceTest {
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .getFirst();
-    final long agentInstanceKey =
-        engine
-            .agentInstances()
-            .withElementInstanceKey(agentTaskInstance.getKey())
-            .create()
-            .getKey();
+    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
 
     RecordingExporter.jobRecords(JobIntent.CREATED).withType(AGENT_JOB_TYPE).await();
     engine.jobs().withType(AGENT_JOB_TYPE).activate();
@@ -181,9 +175,7 @@ public class MigrateAgentInstanceTest {
         .describedAs("The owning service task has completed before migration")
         .isTrue();
 
-    // deploy v2 of the same process definition only now, after "A" has already completed, to
-    // mirror the realistic sequence: the process model is corrected/simplified while instances
-    // are already running past the removed element
+    // deploy v2 of the same process definition, which no longer contains "A"
     final var deployment =
         engine
             .deployment()
@@ -198,34 +190,30 @@ public class MigrateAgentInstanceTest {
     final long targetProcessDefinitionKey =
         extractProcessDefinitionKeyByProcessId(deployment, processId);
 
-    // when — no mapping instruction is provided for "A" since it has no active element instance;
-    // v2 of the process definition does not define an element with id "A" either
-    engine
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("B", "B2")
-        .migrate();
+    // when — "A" is not mapped: it has no active element instance and v2 has no "A" to map it to
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("B", "B2")
+            .expectRejection()
+            .migrate();
 
-    // then — the agent instance still migrates to version 2 of the process definition, but its
-    // elementId is left unchanged and now refers to an element that no longer exists in v2
-    Assertions.assertThat(
-            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
-                .withRecordKey(agentInstanceKey)
-                .getFirst()
-                .getValue())
-        .describedAs(
-            "Definition fields are updated to point at version 2 of the (same) process "
-                + "definition")
-        .hasProcessDefinitionKey(targetProcessDefinitionKey)
-        .hasBpmnProcessId(processId)
-        .hasProcessDefinitionVersion(2)
-        .hasVersionTag("v2")
-        .describedAs(
-            "elementId keeps its stale value \"A\" since no mapping instruction was provided and "
-                + "v2 of the process definition no longer contains an element with this id")
-        .hasElementId("A");
+    // then — the orphaned agent instance is validated even though "A" is not part of the migrated
+    // element tree, so the migration is rejected
+    Assertions.assertThat(rejection)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to migrate process instance '%d' \
+                but the agent instance with element id 'A' would be migrated to element 'A' \
+                that has no agent definition. \
+                An agent instance must always belong to an agent definition.""",
+                processInstanceKey));
   }
 
   @Test
@@ -261,11 +249,13 @@ public class MigrateAgentInstanceTest {
                     .versionTag("v2")
                     .startEvent()
                     .parallelGateway("fork2")
-                    .serviceTask("A2", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .serviceTask(
+                        "A2", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                     .parallelGateway("join2")
                     .endEvent()
                     .moveToNode("fork2")
-                    .serviceTask("B", t -> t.zeebeJobType(otherJobType))
+                    .serviceTask(
+                        "B", t -> t.zeebeJobType(otherJobType).zeebeAiAgentTaskDefinition())
                     .connectTo("join2")
                     .done())
             .deploy();
@@ -387,6 +377,7 @@ public class MigrateAgentInstanceTest {
                     .adHocSubProcess(
                         "ahsp2",
                         ahsp -> {
+                          ahsp.zeebeAiAgentSubProcessDefinition();
                           ahsp.task("tool2");
                           ahsp.zeebeJobType(AGENT_JOB_TYPE);
                         })
@@ -577,9 +568,9 @@ public class MigrateAgentInstanceTest {
   }
 
   @Test
-  public void shouldResetAgentDefinitionKeyWhenTargetElementHasNoAgentDefinition() {
+  public void shouldRejectMigratingAgentInstanceToElementWithoutAgentDefinition() {
     // given — an agent-marked service task "A" is migrated onto a plain service task "A2" that
-    // carries no agent definition, the allowed agent-to-non-agent direction
+    // carries no agent definition; an agent instance must always belong to an agent definition
     final String processId = helper.getBpmnProcessId();
     final String targetProcessId = helper.getBpmnProcessId() + "2";
 
@@ -610,32 +601,31 @@ public class MigrateAgentInstanceTest {
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .getFirst();
-    final long agentInstanceKey =
-        engine
-            .agentInstances()
-            .withElementInstanceKey(agentTaskInstance.getKey())
-            .create()
-            .getKey();
+    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
 
     // when
-    engine
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A2")
-        .migrate();
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A2")
+            .expectRejection()
+            .migrate();
 
-    // then — the agent instance no longer references any agent definition
-    Assertions.assertThat(
-            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
-                .withRecordKey(agentInstanceKey)
-                .getFirst()
-                .getValue())
-        .hasElementId("A2")
-        .describedAs(
-            "agentDefinitionKey is reset because the target element has no agent definition")
-        .hasAgentDefinitionKey(-1L);
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to migrate process instance '%d' \
+                but the agent instance with element id 'A' would be migrated to element 'A2' \
+                that has no agent definition. \
+                An agent instance must always belong to an agent definition.""",
+                processInstanceKey));
   }
 
   private long agentDefinitionKey(final long processDefinitionKey, final String elementId) {
@@ -686,18 +676,18 @@ public class MigrateAgentInstanceTest {
     engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
 
     // when
-    engine
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A2")
-        .expectRejection()
-        .migrate();
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A2")
+            .expectRejection()
+            .migrate();
 
     // then
-    Assertions.assertThat(
-            RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst())
+    Assertions.assertThat(rejection)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
@@ -707,7 +697,7 @@ public class MigrateAgentInstanceTest {
                 but the agent instance element with id 'A' has agent definition type 'AI_AGENT_TASK' \
                 while the mapped target element with id 'A2' has a different agent definition \
                 type 'EXTERNAL_AGENT'. \
-                An agent instance's agent definition type must not change on migration.""",
+                An agent instance's type must not change on migration.""",
                 processInstanceKey));
   }
 
@@ -767,20 +757,20 @@ public class MigrateAgentInstanceTest {
         .isTrue();
 
     // when
-    engine
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A2")
-        .addMappingInstruction("B", "B2")
-        .expectRejection()
-        .migrate();
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A2")
+            .addMappingInstruction("B", "B2")
+            .expectRejection()
+            .migrate();
 
     // then — the orphaned agent instance is validated even though "A" is not part of the migrated
     // element tree, so the type change is rejected
-    Assertions.assertThat(
-            RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst())
+    Assertions.assertThat(rejection)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
@@ -790,14 +780,14 @@ public class MigrateAgentInstanceTest {
                 but the agent instance element with id 'A' has agent definition type 'AI_AGENT_TASK' \
                 while the mapped target element with id 'A2' has a different agent definition \
                 type 'EXTERNAL_AGENT'. \
-                An agent instance's agent definition type must not change on migration.""",
+                An agent instance's type must not change on migration.""",
                 processInstanceKey));
   }
 
   @Test
-  public void shouldAllowMigrationFromNonAgentToAgentElement() {
-    // given — a plain service task "A" (no agent definition) is mapped to an AI agent task "A2";
-    // the no-type-to-type direction must be allowed
+  public void shouldAllowMigratingElementWithoutAgentInstanceToAgentElement() {
+    // given — a plain service task "A" (no agent definition, no agent instance) is mapped to an AI
+    // agent task "A2". With no agent instance to preserve, the migration is allowed
     final String processId = helper.getBpmnProcessId();
     final String targetProcessId = helper.getBpmnProcessId() + "2";
 
@@ -843,7 +833,8 @@ public class MigrateAgentInstanceTest {
                     ProcessInstanceMigrationIntent.MIGRATED)
                 .withRecordKey(processInstanceKey)
                 .getFirst())
-        .describedAs("migrating a plain element onto an agent element is allowed")
+        .describedAs(
+            "migrating an element without an agent instance onto an agent element is allowed")
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
   }
 
@@ -890,18 +881,18 @@ public class MigrateAgentInstanceTest {
     engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
 
     // when
-    engine
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A2")
-        .expectRejection()
-        .migrate();
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A2")
+            .expectRejection()
+            .migrate();
 
     // then
-    Assertions.assertThat(
-            RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst())
+    Assertions.assertThat(rejection)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
@@ -911,7 +902,7 @@ public class MigrateAgentInstanceTest {
                 but the agent instance element with id 'A' has agent definition type 'AI_AGENT_TASK' \
                 while the mapped target element with id 'A2' has a different agent definition \
                 type 'EXTERNAL_AGENT'. \
-                An agent instance's agent definition type must not change on migration.""",
+                An agent instance's type must not change on migration.""",
                 processInstanceKey));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceDefinition;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -423,5 +424,217 @@ public class MigrateAgentInstanceTest {
         .hasProcessDefinitionKey(targetProcessDefinitionKey)
         .hasBpmnProcessId(targetProcessId)
         .hasElementId("ahsp2");
+  }
+
+  @Test
+  public void shouldReResolveAgentDefinitionKeyWhenElementIsRemapped() {
+    // given — an agent-marked service task "A" is remapped to an agent-marked service task "A2" in
+    // a different target process definition, so the target element has its own, distinct agent
+    // definition minted at deploy time
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "A2", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+    final long targetAgentDefinitionKey = agentDefinitionKey(targetProcessDefinitionKey, "A2");
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    final long agentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(agentTaskInstance.getKey())
+            .create()
+            .getKey();
+    final long sourceAgentDefinitionKey =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.CREATED)
+            .withRecordKey(agentInstanceKey)
+            .getFirst()
+            .getValue()
+            .getAgentDefinitionKey();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .migrate();
+
+    // then — the agent instance points at the target element's own agent definition, not the
+    // source one it was created with
+    Assertions.assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
+                .withRecordKey(agentInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("elementId is remapped to the target element")
+        .hasElementId("A2")
+        .describedAs(
+            "agentDefinitionKey is re-resolved to the remapped target element's definition")
+        .hasAgentDefinitionKey(targetAgentDefinitionKey);
+    assertThat(targetAgentDefinitionKey)
+        .describedAs("the target agent definition differs from the source one")
+        .isNotEqualTo(sourceAgentDefinitionKey);
+  }
+
+  @Test
+  public void shouldReResolveAgentDefinitionKeyWhenElementKeepsItsId() {
+    // given — an agent-marked service task "A" is migrated to another process definition that keeps
+    // the same element id "A" (a self-mapping); the target still mints its own agent definition
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+    final long targetAgentDefinitionKey = agentDefinitionKey(targetProcessDefinitionKey, "A");
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    final long agentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(agentTaskInstance.getKey())
+            .create()
+            .getKey();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .migrate();
+
+    // then — even without an element id change, the key is re-resolved to the target definition's
+    // own agent definition
+    Assertions.assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
+                .withRecordKey(agentInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasElementId("A")
+        .describedAs(
+            "agentDefinitionKey is re-resolved to the target definition's agent definition")
+        .hasAgentDefinitionKey(targetAgentDefinitionKey);
+  }
+
+  @Test
+  public void shouldResetAgentDefinitionKeyWhenTargetElementHasNoAgentDefinition() {
+    // given — an agent-marked service task "A" is migrated onto a plain service task "A2" that
+    // carries no agent definition, the allowed agent-to-non-agent direction
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A2", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    final long agentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(agentTaskInstance.getKey())
+            .create()
+            .getKey();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .migrate();
+
+    // then — the agent instance no longer references any agent definition
+    Assertions.assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
+                .withRecordKey(agentInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasElementId("A2")
+        .describedAs(
+            "agentDefinitionKey is reset because the target element has no agent definition")
+        .hasAgentDefinitionKey(-1L);
+  }
+
+  private long agentDefinitionKey(final long processDefinitionKey, final String elementId) {
+    return RecordingExporter.agentDefinitionRecords(AgentDefinitionIntent.CREATED)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .withElementId(elementId)
+        .getFirst()
+        .getValue()
+        .getAgentDefinitionKey();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -15,10 +15,12 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceDefinition;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
@@ -636,5 +638,119 @@ public class MigrateAgentInstanceTest {
         .getFirst()
         .getValue()
         .getAgentDefinitionKey();
+  }
+
+  @Test
+  public void shouldRejectMigrationWhenAgentDefinitionTypeChanges() {
+    // given — an AI agent task "A" is mapped to an external agent task "A2"; both are service
+    // tasks, so the element type is unchanged and only the agent definition type differs
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "A2", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeExternalAgentDefinition())
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .expectRejection()
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst())
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to migrate process instance '%d' \
+                but active element with id 'A' has agent definition type 'AI_AGENT_TASK' \
+                while the mapped target element with id 'A2' has a different agent definition \
+                type 'EXTERNAL_AGENT'. \
+                Agent elements must be mapped to elements of the same agent definition type.""",
+                processInstanceKey));
+  }
+
+  @Test
+  public void shouldAllowMigrationFromNonAgentToAgentElement() {
+    // given — a plain service task "A" (no agent definition) is mapped to an AI agent task "A2";
+    // the no-type-to-type direction must be allowed
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "A2", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .migrate();
+
+    // then — the migration is accepted
+    Assertions.assertThat(
+            RecordingExporter.processInstanceMigrationRecords(
+                    ProcessInstanceMigrationIntent.MIGRATED)
+                .withRecordKey(processInstanceKey)
+                .getFirst())
+        .describedAs("migrating a plain element onto an agent element is allowed")
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -36,6 +36,13 @@ public class MigrateAgentInstanceTest {
 
   private static final String AGENT_JOB_TYPE = "agent-job";
 
+  /**
+   * {@code zeebe:modelerTemplate} id the deploy-time transformer maps to {@code AI_AGENT_TASK} as a
+   * fallback when no explicit {@code zeebe:agentDefinition} marker is present.
+   */
+  private static final String AI_AGENT_TASK_TEMPLATE_ID =
+      "io.camunda.connectors.agenticai.aiagent.v1";
+
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
@@ -837,6 +844,137 @@ public class MigrateAgentInstanceTest {
                 .withRecordKey(processInstanceKey)
                 .getFirst())
         .describedAs("migrating a plain element onto an agent element is allowed")
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
+  }
+
+  @Test
+  public void shouldRejectMigrationWhenTemplateBasedAgentDefinitionTypeChanges() {
+    // given — the source agent element declares its type via a recognized zeebe:modelerTemplate
+    // (the fallback path, no explicit zeebe:agentDefinition marker), resolving to AI_AGENT_TASK; it
+    // is mapped onto an external agent task. This proves the modeler-template fallback type is
+    // honored on migration: were it not, the source would resolve to UNSPECIFIED and wrongly pass
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "A",
+                        t ->
+                            t.zeebeJobType(AGENT_JOB_TYPE)
+                                .zeebeModelerTemplate(AI_AGENT_TASK_TEMPLATE_ID))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "A2", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeExternalAgentDefinition())
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .expectRejection()
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst())
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to migrate process instance '%d' \
+                but the agent instance element with id 'A' has agent definition type 'AI_AGENT_TASK' \
+                while the mapped target element with id 'A2' has a different agent definition \
+                type 'EXTERNAL_AGENT'. \
+                An agent instance's agent definition type must not change on migration.""",
+                processInstanceKey));
+  }
+
+  @Test
+  public void shouldAllowMigrationBetweenTemplateAndMarkerOfSameAgentType() {
+    // given — the source agent element declares AI_AGENT_TASK via a zeebe:modelerTemplate fallback
+    // while the target declares the same type via an explicit zeebe:agentDefinition marker;
+    // switching element templates (or template <-> marker) is allowed as long as the resolved agent
+    // definition type is unchanged
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "A",
+                        t ->
+                            t.zeebeJobType(AGENT_JOB_TYPE)
+                                .zeebeModelerTemplate(AI_AGENT_TASK_TEMPLATE_ID))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "A2", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .migrate();
+
+    // then — the migration is accepted since both sides resolve to AI_AGENT_TASK
+    Assertions.assertThat(
+            RecordingExporter.processInstanceMigrationRecords(
+                    ProcessInstanceMigrationIntent.MIGRATED)
+                .withRecordKey(processInstanceKey)
+                .getFirst())
+        .describedAs(
+            "migrating between an element template and an explicit marker of the same agent "
+                + "definition type is allowed")
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -670,10 +670,13 @@ public class MigrateAgentInstanceTest {
 
     final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
 
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("A")
-        .await();
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    // create an agent instance and leave its job running so its owning element stays active
+    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
 
     // when
     engine
@@ -694,10 +697,93 @@ public class MigrateAgentInstanceTest {
             String.format(
                 """
                 Expected to migrate process instance '%d' \
-                but active element with id 'A' has agent definition type 'AI_AGENT_TASK' \
+                but the agent instance element with id 'A' has agent definition type 'AI_AGENT_TASK' \
                 while the mapped target element with id 'A2' has a different agent definition \
                 type 'EXTERNAL_AGENT'. \
-                Agent elements must be mapped to elements of the same agent definition type.""",
+                An agent instance's agent definition type must not change on migration.""",
+                processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectMigrationWhenOrphanedAgentInstanceChangesAgentDefinitionType() {
+    // given — an agent instance whose owning service task "A" (AI agent) completes before migration
+    // while the agent instance itself stays active (orphaned); "A" is mapped to an external agent
+    // task "A2", so the agent definition type would change for an instance that is no longer part
+    // of the active element tree
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "A", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "A2", t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeExternalAgentDefinition())
+                    .userTask("B2")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    engine.agentInstances().withElementInstanceKey(agentTaskInstance.getKey()).create();
+
+    // complete the agentic job so "A" completes and the process moves on to "B", orphaning the
+    // still-active agent instance
+    RecordingExporter.jobRecords(JobIntent.CREATED).withType(AGENT_JOB_TYPE).await();
+    engine.jobs().withType(AGENT_JOB_TYPE).activate();
+    engine.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("A")
+                .exists())
+        .describedAs("The owning service task has completed before migration")
+        .isTrue();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .addMappingInstruction("B", "B2")
+        .expectRejection()
+        .migrate();
+
+    // then — the orphaned agent instance is validated even though "A" is not part of the migrated
+    // element tree, so the type change is rejected
+    Assertions.assertThat(
+            RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst())
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to migrate process instance '%d' \
+                but the agent instance element with id 'A' has agent definition type 'AI_AGENT_TASK' \
+                while the mapped target element with id 'A2' has a different agent definition \
+                type 'EXTERNAL_AGENT'. \
+                An agent instance's agent definition type must not change on migration.""",
                 processInstanceKey));
   }
 


### PR DESCRIPTION
## Description

When a process instance is migrated, `AgentInstance` records now correctly reflect the target process version through two complementary changes:

### 1. Re-resolving `agentDefinitionKey`

Every migrated `AgentInstance` is updated to point at the agent definition minted for the **target** process definition. This applies to:
- **Remapped elements**: the key resolves to the mapped target element's own agent definition.
- **Self-mapped elements**: the key is re-resolved to the target version's agent definition even when the element id is unchanged.

Previously, the `agentDefinitionKey` was left pointing at the *source* definition's agent definition after migration, breaking the link between the migrated agent instance and its new definition.

### 2. Validating `AgentDefinitionType` invariance

Migration is rejected (`INVALID_STATE`) when any `AgentInstance` would end up without an agent definition or with a different `AgentDefinitionType` after migration. Specifically:

- **No agent definition on the target element**: migration is rejected — an agent instance must always belong to an agent definition. This includes orphaned agent instances whose owning element was already dropped in the target process definition.
- **Different agent definition type**: migration is rejected when the source element's `AgentDefinitionType` (e.g. `AI_AGENT_TASK`) differs from the target element's type (e.g. `EXTERNAL_AGENT`). This complements `requireSameElementType` by distinguishing agent types that share a BPMN element type.
- **No agent instance on the source**: migration is *allowed* — elements with no existing agent instance can freely migrate onto an agent element (or vice versa).

The `AgentDefinitionType` is resolved correctly for both explicit `zeebe:agentDefinition` markers and the `zeebe:modelerTemplate` fallback (used by agents authored from element templates before the explicit marker existed).

### Validation scope

Validation runs as an upfront **per-agent-instance pass** over *all* agent instances of the process instance — active and orphaned alike — before the element-tree walk. This ensures orphaned instances (whose owning element already completed) are not silently migrated with an incompatible definition.

When the safety check is passed but the target element unexpectedly has no agent definition during re-resolution, a `SafetyCheckFailedException` is thrown (treated as a bug, not a user error).

## Related issues

Closes #59093