### PR TITLE
feat: add per-physical-tenant history backup REST endpoints

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupServiceRegistryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupServiceRegistryConfiguration.java
@@ -150,6 +150,11 @@ public class BackupServiceRegistryConfiguration {
     return new BackupServiceRegistry(backups);
   }
 
+  @Bean
+  public RegistryHistoryBackupApi registryHistoryBackupApi(final BackupServiceRegistry registry) {
+    return new RegistryHistoryBackupApi(registry);
+  }
+
   private static BackupRepository backupRepository(
       final String physicalTenantId,
       final SearchClients searchClients,

--- a/dist/src/main/java/io/camunda/application/commons/backup/RegistryHistoryBackupApi.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/RegistryHistoryBackupApi.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.backup;
+
+import io.camunda.application.commons.backup.BackupServiceRegistry.PhysicalTenantBackup;
+import io.camunda.service.backup.HistoryBackupApi;
+import io.camunda.service.backup.HistoryBackupSnapshot;
+import io.camunda.service.backup.HistoryBackupState;
+import io.camunda.service.backup.HistoryBackupStateCode;
+import io.camunda.service.backup.HistoryBackupTaken;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.webapps.backup.BackupException;
+import io.camunda.webapps.backup.BackupException.BackupAlreadyRunningException;
+import io.camunda.webapps.backup.BackupException.BackupRepositoryConnectionException;
+import io.camunda.webapps.backup.BackupException.DuplicateBackupIdException;
+import io.camunda.webapps.backup.BackupException.IndexNotFoundException;
+import io.camunda.webapps.backup.BackupException.InvalidRequestException;
+import io.camunda.webapps.backup.BackupException.MissingRepositoryException;
+import io.camunda.webapps.backup.BackupException.ResourceNotFoundException;
+import io.camunda.webapps.backup.BackupStateDto;
+import io.camunda.webapps.backup.GetBackupStateResponseDetailDto;
+import io.camunda.webapps.backup.GetBackupStateResponseDto;
+import io.camunda.webapps.backup.TakeBackupRequestDto;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Serves {@link HistoryBackupApi} from the per-physical-tenant {@link BackupServiceRegistry}.
+ *
+ * <p>Registered by {@link BackupServiceRegistryConfiguration}, which is already conditional on an
+ * Elasticsearch or OpenSearch secondary storage — that is where this bean's ES/OS-only availability
+ * comes from. On other storages the bean is absent, and the endpoints are rejected by the
+ * {@code @RequiresSecondaryStorage} interceptor before any handler runs.
+ *
+ * <p>Translates {@link BackupException} into {@link ServiceException} so the gateway's error mapper
+ * produces the right status. Note the deliberate divergence from the {@code backupHistory}
+ * actuator: a repository connection failure maps to 503 here, not 502, because 503 is what the
+ * {@code /v2/backups/*} spec documents.
+ */
+@NullMarked
+public class RegistryHistoryBackupApi implements HistoryBackupApi {
+
+  private final BackupServiceRegistry registry;
+
+  public RegistryHistoryBackupApi(final BackupServiceRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public HistoryBackupTaken takeBackup(final String physicalTenantId, final long backupId) {
+    final var backup = backupFor(physicalTenantId);
+    final var response =
+        mapErrors(
+            () ->
+                backup
+                    .backupService()
+                    .takeBackup(new TakeBackupRequestDto().setBackupId(backupId)));
+    // The take-backup response carries only the snapshot names, so the id is echoed from the
+    // request rather than read back from the store.
+    return new HistoryBackupTaken(backupId, response.getScheduledSnapshots());
+  }
+
+  @Override
+  public HistoryBackupState getBackupState(final String physicalTenantId, final long backupId) {
+    final var backup = backupFor(physicalTenantId);
+    return toState(mapErrors(() -> backup.backupService().getBackupState(backupId)));
+  }
+
+  @Override
+  public List<HistoryBackupState> getBackups(
+      final String physicalTenantId, final boolean verbose, final @Nullable String prefix) {
+    final var backup = backupFor(physicalTenantId);
+    return mapErrors(() -> backup.backupService().getBackups(verbose, prefix)).stream()
+        .map(RegistryHistoryBackupApi::toState)
+        .toList();
+  }
+
+  @Override
+  public void deleteBackup(final String physicalTenantId, final long backupId) {
+    final var backup = backupFor(physicalTenantId);
+    mapErrors(
+        () -> {
+          backup.backupService().deleteBackup(backupId);
+          return null;
+        });
+  }
+
+  /**
+   * Resolves the tenant's backup wiring and rejects a tenant with no snapshot repository, which the
+   * actuator equally treats as a bad request rather than a server error.
+   */
+  private PhysicalTenantBackup backupFor(final String physicalTenantId) {
+    final PhysicalTenantBackup backup;
+    try {
+      backup = registry.forPhysicalTenant(physicalTenantId);
+    } catch (final IllegalArgumentException e) {
+      throw new ServiceException(e.getMessage(), Status.NOT_FOUND);
+    }
+    final var repositoryName = backup.repositoryProps().repositoryName();
+    if (repositoryName == null || repositoryName.isBlank()) {
+      throw new ServiceException(
+          "No backup repository configured for physical tenant '%s'".formatted(physicalTenantId),
+          Status.INVALID_ARGUMENT);
+    }
+    return backup;
+  }
+
+  private static <T> T mapErrors(final Supplier<T> call) {
+    try {
+      return call.get();
+    } catch (final BackupException e) {
+      throw new ServiceException(e.getMessage(), statusOf(e));
+    }
+  }
+
+  private static Status statusOf(final BackupException e) {
+    return switch (e) {
+      case final DuplicateBackupIdException ignored -> Status.ALREADY_EXISTS;
+      case final BackupAlreadyRunningException ignored -> Status.INVALID_STATE;
+      case final InvalidRequestException ignored -> Status.INVALID_ARGUMENT;
+      case final ResourceNotFoundException ignored -> Status.NOT_FOUND;
+      case final MissingRepositoryException ignored -> Status.NOT_FOUND;
+      case final BackupRepositoryConnectionException ignored -> Status.UNAVAILABLE;
+      case final IndexNotFoundException ignored -> Status.INTERNAL;
+      default -> Status.INTERNAL;
+    };
+  }
+
+  private static HistoryBackupState toState(final GetBackupStateResponseDto dto) {
+    final var details = dto.getDetails();
+    return new HistoryBackupState(
+        dto.getBackupId(),
+        toStateCode(dto.getState()),
+        dto.getFailureReason(),
+        details == null
+            ? List.of()
+            : details.stream().map(RegistryHistoryBackupApi::toSnapshot).toList());
+  }
+
+  private static HistoryBackupSnapshot toSnapshot(final GetBackupStateResponseDetailDto detail) {
+    final var failures = detail.getFailures();
+    return new HistoryBackupSnapshot(
+        detail.getSnapshotName(),
+        detail.getState(),
+        detail.getStartTime(),
+        failures == null ? List.of() : Arrays.asList(failures));
+  }
+
+  private static HistoryBackupStateCode toStateCode(final BackupStateDto state) {
+    return switch (state) {
+      case IN_PROGRESS -> HistoryBackupStateCode.IN_PROGRESS;
+      case INCOMPLETE -> HistoryBackupStateCode.INCOMPLETE;
+      case COMPLETED -> HistoryBackupStateCode.COMPLETED;
+      case FAILED -> HistoryBackupStateCode.FAILED;
+      case INCOMPATIBLE -> HistoryBackupStateCode.INCOMPATIBLE;
+    };
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -43,6 +43,7 @@ import io.camunda.service.ExpressionServices;
 import io.camunda.service.FormServices;
 import io.camunda.service.GlobalListenerServices;
 import io.camunda.service.GroupServices;
+import io.camunda.service.HistoryBackupServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.ManagementServices;
@@ -63,6 +64,7 @@ import io.camunda.service.UsageMetricsServices;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.VariableServices;
+import io.camunda.service.backup.HistoryBackupApi;
 import io.camunda.service.cache.ProcessCache;
 import io.camunda.service.registry.DefaultServiceRegistry;
 import io.camunda.service.registry.ServiceRegistry;
@@ -140,6 +142,7 @@ public class CamundaServicesConfiguration {
       final Environment environment,
       final ManagementServices managementServices,
       final ObjectProvider<SecondaryStorageReadiness> secondaryStorageReadiness,
+      final ObjectProvider<HistoryBackupApi> historyBackupApi,
       final ApiServicesExecutorProvider executor,
       final SecretStoreRegistries secretStoreRegistries) {
 
@@ -512,6 +515,17 @@ public class CamundaServicesConfiguration {
                           converter))
                   .userTaskServices(tenantId, userTask)
                   .variableServices(tenantId, variable);
+
+              historyBackupApi.ifAvailable(
+                  historyBackup ->
+                      builder.historyBackupServices(
+                          tenantId,
+                          new HistoryBackupServices(
+                              tenantId,
+                              historyBackup,
+                              authorizationChecker,
+                              tenantSecurity.getAuthorizations(),
+                              executor)));
             });
 
     // The readiness bean must be resolved lazily, not injected directly: on Elasticsearch and

--- a/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
@@ -256,6 +256,11 @@ public class BackupController {
       errorCode =
           switch (exception) {
             case final InvalidRequestException ignored -> WebEndpointResponse.STATUS_BAD_REQUEST;
+            // Split out of InvalidRequestException for the v2 endpoints, which answer 409. The
+            // actuator keeps its 400 so the split is not observable here.
+            case final DuplicateBackupIdException ignored -> WebEndpointResponse.STATUS_BAD_REQUEST;
+            case final BackupAlreadyRunningException ignored ->
+                WebEndpointResponse.STATUS_BAD_REQUEST;
             case final ResourceNotFoundException ignored -> WebEndpointResponse.STATUS_NOT_FOUND;
             case final MissingRepositoryException ignored -> WebEndpointResponse.STATUS_NOT_FOUND;
             case final BackupRepositoryConnectionException ignored -> 502;

--- a/dist/src/test/java/io/camunda/application/commons/backup/RegistryHistoryBackupApiTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/RegistryHistoryBackupApiTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.application.commons.backup.BackupServiceRegistry.PhysicalTenantBackup;
+import io.camunda.service.backup.HistoryBackupStateCode;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.webapps.backup.BackupException;
+import io.camunda.webapps.backup.BackupException.BackupAlreadyRunningException;
+import io.camunda.webapps.backup.BackupException.BackupRepositoryConnectionException;
+import io.camunda.webapps.backup.BackupException.DuplicateBackupIdException;
+import io.camunda.webapps.backup.BackupException.IndexNotFoundException;
+import io.camunda.webapps.backup.BackupException.InvalidRequestException;
+import io.camunda.webapps.backup.BackupException.MissingRepositoryException;
+import io.camunda.webapps.backup.BackupException.ResourceNotFoundException;
+import io.camunda.webapps.backup.BackupService;
+import io.camunda.webapps.backup.BackupStateDto;
+import io.camunda.webapps.backup.GetBackupStateResponseDetailDto;
+import io.camunda.webapps.backup.GetBackupStateResponseDto;
+import io.camunda.webapps.backup.TakeBackupRequestDto;
+import io.camunda.webapps.backup.TakeBackupResponseDto;
+import io.camunda.webapps.backup.repository.BackupRepositoryProps;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+class RegistryHistoryBackupApiTest {
+
+  private static final String TENANT_ID = "tenanta";
+  private static final OffsetDateTime START_TIME =
+      OffsetDateTime.of(2026, 8, 11, 9, 30, 0, 0, ZoneOffset.UTC);
+
+  private BackupService backupService;
+  private BackupRepositoryProps repositoryProps;
+  private RegistryHistoryBackupApi api;
+
+  @BeforeEach
+  void setUp() {
+    backupService = mock(BackupService.class);
+    repositoryProps = mock(BackupRepositoryProps.class);
+    when(repositoryProps.repositoryName()).thenReturn("repo");
+    api = apiFor(new PhysicalTenantBackup(TENANT_ID, backupService, repositoryProps));
+  }
+
+  @Test
+  void shouldEchoTheRequestedBackupIdAlongsideTheScheduledSnapshots() {
+    // given the take-backup response carries only snapshot names
+    when(backupService.takeBackup(any()))
+        .thenReturn(new TakeBackupResponseDto().setScheduledSnapshots(List.of("part-1", "part-2")));
+
+    // when
+    final var taken = api.takeBackup(TENANT_ID, 42L);
+
+    // then
+    assertThat(taken.backupId()).isEqualTo(42L);
+    assertThat(taken.scheduledSnapshots()).containsExactly("part-1", "part-2");
+  }
+
+  @Test
+  void shouldNotSkipTheSchemaCheckWhenTakingABackup() {
+    // given
+    when(backupService.takeBackup(any())).thenReturn(new TakeBackupResponseDto());
+
+    // when
+    api.takeBackup(TENANT_ID, 42L);
+
+    // then
+    final var request = captureTakeBackupRequest();
+    assertThat(request.getBackupId()).isEqualTo(42L);
+    assertThat(request.isSkipSchemaCheck()).isFalse();
+  }
+
+  @Test
+  void shouldMapBackupStateAndSnapshotDetails() {
+    // given
+    when(backupService.getBackupState(42L))
+        .thenReturn(
+            new GetBackupStateResponseDto(42L)
+                .setState(BackupStateDto.FAILED)
+                .setFailureReason("out of disk space")
+                .setDetails(
+                    List.of(
+                        new GetBackupStateResponseDetailDto()
+                            .setSnapshotName("part-1")
+                            .setState("PARTIAL")
+                            .setStartTime(START_TIME)
+                            .setFailures(new String[] {"shard 0 failed"}))));
+
+    // when
+    final var state = api.getBackupState(TENANT_ID, 42L);
+
+    // then
+    assertThat(state.backupId()).isEqualTo(42L);
+    assertThat(state.state()).isEqualTo(HistoryBackupStateCode.FAILED);
+    assertThat(state.failureReason()).isEqualTo("out of disk space");
+    assertThat(state.snapshots())
+        .singleElement()
+        .satisfies(
+            snapshot -> {
+              assertThat(snapshot.snapshotName()).isEqualTo("part-1");
+              assertThat(snapshot.state()).isEqualTo("PARTIAL");
+              assertThat(snapshot.startTime()).isEqualTo(START_TIME);
+              assertThat(snapshot.failures()).containsExactly("shard 0 failed");
+            });
+  }
+
+  /**
+   * Absent detail is normal when a backup is read without snapshot detail, so it must map to empty
+   * collections rather than nulls the response mapper would have to defend against.
+   */
+  @Test
+  void shouldMapAbsentDetailsAndFailuresToEmptyLists() {
+    // given
+    when(backupService.getBackupState(42L))
+        .thenReturn(
+            new GetBackupStateResponseDto(42L)
+                .setState(BackupStateDto.COMPLETED)
+                .setDetails(
+                    List.of(new GetBackupStateResponseDetailDto().setSnapshotName("part-1"))));
+
+    // when
+    final var state = api.getBackupState(TENANT_ID, 42L);
+
+    // then
+    assertThat(state.snapshots())
+        .singleElement()
+        .satisfies(s -> assertThat(s.failures()).isEmpty());
+  }
+
+  @Test
+  void shouldMapEveryBackupStateCode() {
+    for (final BackupStateDto dto : BackupStateDto.values()) {
+      // given
+      when(backupService.getBackupState(1L))
+          .thenReturn(new GetBackupStateResponseDto(1L).setState(dto).setDetails(List.of()));
+
+      // when / then
+      assertThat(api.getBackupState(TENANT_ID, 1L).state())
+          .isEqualTo(HistoryBackupStateCode.valueOf(dto.name()));
+    }
+  }
+
+  @Test
+  void shouldListBackupsWithTheRequestedVerbosityAndPrefix() {
+    // given
+    when(backupService.getBackups(false, "17*"))
+        .thenReturn(
+            List.of(
+                new GetBackupStateResponseDto(17L)
+                    .setState(BackupStateDto.COMPLETED)
+                    .setDetails(List.of())));
+
+    // when
+    final var states = api.getBackups(TENANT_ID, false, "17*");
+
+    // then
+    assertThat(states).singleElement().satisfies(s -> assertThat(s.backupId()).isEqualTo(17L));
+    verify(backupService).getBackups(false, "17*");
+  }
+
+  @Test
+  void shouldDeleteBackup() {
+    // when
+    api.deleteBackup(TENANT_ID, 42L);
+
+    // then
+    verify(backupService).deleteBackup(42L);
+  }
+
+  @Test
+  void shouldReportAnUnknownBackupAsNotFound() {
+    // given
+    when(backupService.getBackupState(42L)).thenThrow(new ResourceNotFoundException("no such id"));
+
+    // when / then
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(() -> api.getBackupState(TENANT_ID, 42L))
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND));
+  }
+
+  /**
+   * Every operation, not just one: {@code BackupServiceImpl.getBackups} does not call {@code
+   * validateRepositoryExists} the way take and delete do, so this pre-check is the only guard on
+   * the list path.
+   */
+  @ParameterizedTest
+  @MethodSource("allOperations")
+  void shouldRejectATenantWithoutAConfiguredRepository(
+      final String name, final Consumer<RegistryHistoryBackupApi> operation) {
+    // given
+    when(repositoryProps.repositoryName()).thenReturn("  ");
+
+    // when / then
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(() -> operation.accept(api))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
+              assertThat(e.getMessage()).contains(TENANT_ID);
+            });
+  }
+
+  private static Stream<Arguments> allOperations() {
+    return Stream.of(
+        Arguments.of(
+            "take", (Consumer<RegistryHistoryBackupApi>) a -> a.takeBackup(TENANT_ID, 42L)),
+        Arguments.of(
+            "get", (Consumer<RegistryHistoryBackupApi>) a -> a.getBackupState(TENANT_ID, 42L)),
+        Arguments.of(
+            "list", (Consumer<RegistryHistoryBackupApi>) a -> a.getBackups(TENANT_ID, true, "*")),
+        Arguments.of(
+            "delete", (Consumer<RegistryHistoryBackupApi>) a -> a.deleteBackup(TENANT_ID, 42L)));
+  }
+
+  @Test
+  void shouldReportAnUnknownPhysicalTenantAsNotFound() {
+    // when / then
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(() -> api.getBackupState("no-such-tenant", 42L))
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND));
+  }
+
+  /**
+   * Asserts the exception-to-status mapping only. {@code BackupAlreadyRunningException} in
+   * particular says nothing about concurrency: the check behind it is node-local and best-effort.
+   */
+  @ParameterizedTest
+  @MethodSource("backupExceptions")
+  void shouldMapBackupExceptionsToTheirServiceStatus(
+      final BackupException exception, final Status expectedStatus) {
+    // given
+    when(backupService.takeBackup(any())).thenThrow(exception);
+
+    // when / then
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(() -> api.takeBackup(TENANT_ID, 42L))
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(expectedStatus));
+  }
+
+  private static Stream<Arguments> backupExceptions() {
+    return Stream.of(
+        Arguments.of(new DuplicateBackupIdException("duplicate"), Status.ALREADY_EXISTS),
+        Arguments.of(new BackupAlreadyRunningException("running"), Status.INVALID_STATE),
+        Arguments.of(new InvalidRequestException("invalid"), Status.INVALID_ARGUMENT),
+        Arguments.of(new ResourceNotFoundException("missing"), Status.NOT_FOUND),
+        Arguments.of(new MissingRepositoryException("no repo"), Status.NOT_FOUND),
+        Arguments.of(new BackupRepositoryConnectionException("unreachable"), Status.UNAVAILABLE),
+        Arguments.of(new IndexNotFoundException(List.of("index-1")), Status.INTERNAL),
+        Arguments.of(new BackupException("something else"), Status.INTERNAL));
+  }
+
+  @Test
+  void shouldMapBackupExceptionsRaisedByDelete() {
+    // given delete returns void, so it needs its own stubbing route
+    doThrow(new BackupRepositoryConnectionException("unreachable"))
+        .when(backupService)
+        .deleteBackup(anyLong());
+
+    // when / then
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(() -> api.deleteBackup(TENANT_ID, 42L))
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE));
+  }
+
+  @Test
+  void shouldMapBackupExceptionsRaisedByList() {
+    // given
+    when(backupService.getBackups(anyBoolean(), any()))
+        .thenThrow(new MissingRepositoryException("no repo"));
+
+    // when / then
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(() -> api.getBackups(TENANT_ID, true, "*"))
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND));
+  }
+
+  private static RegistryHistoryBackupApi apiFor(final PhysicalTenantBackup backup) {
+    return new RegistryHistoryBackupApi(new BackupServiceRegistry(List.of(backup)));
+  }
+
+  private TakeBackupRequestDto captureTakeBackupRequest() {
+    final var captor = ArgumentCaptor.forClass(TakeBackupRequestDto.class);
+    verify(backupService).takeBackup(captor.capture());
+    return captor.getValue();
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/pt/SecondaryStorageInterceptorConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/SecondaryStorageInterceptorConfigurationTest.java
@@ -63,10 +63,16 @@ class SecondaryStorageInterceptorConfigurationTest {
     return request;
   }
 
-  private static HandlerMethod requiresSecondaryStorageHandler() {
-    final var handlerMethod = mock(HandlerMethod.class);
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
-    return handlerMethod;
+  private static HandlerMethod requiresSecondaryStorageHandler() throws NoSuchMethodException {
+    final var controller = new SecondaryStorageEndpoint();
+    return new HandlerMethod(controller, controller.getClass().getMethod("handle"));
+  }
+
+  @RequiresSecondaryStorage
+  static class SecondaryStorageEndpoint {
+    public String handle() {
+      return "ok";
+    }
   }
 
   @Configuration
@@ -87,7 +93,7 @@ class SecondaryStorageInterceptorConfigurationTest {
   @TestPropertySource(properties = {"camunda.data.secondary-storage.type=rdbms"})
   class WithMatchingLegacyAndUnifiedRdbmsType {
     @Test
-    void shouldAllowRequestsRequiringSecondaryStorageWhenBothPropertiesAgree() {
+    void shouldAllowRequestsRequiringSecondaryStorageWhenBothPropertiesAgree() throws Exception {
       final boolean result =
           secondaryStorageInterceptor.preHandle(
               requestDispatch(),
@@ -102,7 +108,7 @@ class SecondaryStorageInterceptorConfigurationTest {
   @TestPropertySource(properties = {"camunda.data.secondary-storage.type=none"})
   class WithMatchingLegacyAndUnifiedNoneType {
     @Test
-    void shouldRejectRequestsRequiringSecondaryStorageWhenBothPropertiesAgree() {
+    void shouldRejectRequestsRequiringSecondaryStorageWhenBothPropertiesAgree() throws Exception {
       assertThatThrownBy(
               () ->
                   secondaryStorageInterceptor.preHandle(
@@ -117,7 +123,7 @@ class SecondaryStorageInterceptorConfigurationTest {
   @TestPropertySource(properties = "camunda.database.type=elasticsearch")
   class WithOnlyLegacySetMatchingUnifiedDefault {
     @Test
-    void shouldAllowRequestsRequiringSecondaryStorage() {
+    void shouldAllowRequestsRequiringSecondaryStorage() throws Exception {
       final boolean result =
           secondaryStorageInterceptor.preHandle(
               requestDispatch(),

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -419,6 +419,7 @@ class CamundaServicesConfigurationTest {
         new MockEnvironment(),
         new ManagementServices(new CamundaLicense(null)),
         readinessProvider(),
+        mock(ObjectProvider.class),
         new ApiServicesExecutorProvider(Executors.newSingleThreadExecutor()),
         secretStoreRegistries);
   }

--- a/dist/src/test/java/io/camunda/webapps/controllers/BackupControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/BackupControllerTest.java
@@ -27,7 +27,9 @@ import io.camunda.management.backups.HistoryBackupInfo;
 import io.camunda.management.backups.HistoryBackupTenantInfo;
 import io.camunda.management.backups.HistoryStateCode;
 import io.camunda.management.backups.TakeBackupHistoryResponse;
+import io.camunda.webapps.backup.BackupException.BackupAlreadyRunningException;
 import io.camunda.webapps.backup.BackupException.BackupRepositoryConnectionException;
+import io.camunda.webapps.backup.BackupException.DuplicateBackupIdException;
 import io.camunda.webapps.backup.BackupException.ResourceNotFoundException;
 import io.camunda.webapps.backup.BackupService;
 import io.camunda.webapps.backup.BackupStateDto;
@@ -134,6 +136,14 @@ public abstract sealed class BackupControllerTest {
 
   private void mockGenericException() {
     mockErrorWith(new RuntimeException("generic error"));
+  }
+
+  private void mockDuplicateBackupId() {
+    mockErrorWith(new DuplicateBackupIdException("A backup with ID [11] already exists"));
+  }
+
+  private void mockBackupAlreadyRunning() {
+    mockErrorWith(new BackupAlreadyRunningException("Another backup is running at the moment"));
   }
 
   private void mockRepositoryNotSet() {
@@ -351,6 +361,26 @@ public abstract sealed class BackupControllerTest {
   class RepositoryNotSet extends ErrorTest {
     RepositoryNotSet() {
       super(400, BackupControllerTest.this::mockRepositoryNotSet);
+    }
+  }
+
+  /**
+   * Both types were split out of {@link
+   * io.camunda.webapps.backup.BackupException.InvalidRequestException} so the v2 endpoints can
+   * answer 409. The actuator's 400 must not move with them — {@code mapErrorResponse} falls through
+   * to 500 for any subtype it does not name, so these pin the mapping.
+   */
+  @Nested
+  class DuplicateBackupIdError extends ErrorTest {
+    DuplicateBackupIdError() {
+      super(400, BackupControllerTest.this::mockDuplicateBackupId);
+    }
+  }
+
+  @Nested
+  class BackupAlreadyRunningError extends ErrorTest {
+    BackupAlreadyRunningError() {
+      super(400, BackupControllerTest.this::mockBackupAlreadyRunning);
     }
   }
 

--- a/docs/adr/management/003-physical-tenant-management-endpoint-inventory.md
+++ b/docs/adr/management/003-physical-tenant-management-endpoint-inventory.md
@@ -40,22 +40,22 @@ The only exception to that rule is the `/v2/status` endpoint, see [ADR 001 D3](.
 Exporting pause/resume is included here because it is part of the overall backup procedure.
 Restore endpoints are not fully implemented yet but should follow the same pattern.
 
-|                Endpoint                 |                       Behavior                       |
-|-----------------------------------------|------------------------------------------------------|
-| `GET /v2/exporting`                     | Aggregate exporting status of the physical tenant.   |
-| `POST /v2/exporting/pause?soft=`        | Pause exporting.                                     |
-| `POST /v2/exporting/resume`             | Resume exporting.                                    |
-| `POST /v2/backups/runtime`              | Trigger runtime backup.                              |
-| `GET /v2/backups/runtime/{backupId}`    | Status of one runtime backup.                        |
-| `GET /v2/backups/runtime?prefix=`       | List runtime backups, optionally filtered by prefix. |
-| `DELETE /v2/backups/runtime/{backupId}` | Delete runtime backup.                               |
-| `GET /v2/backups/runtime/state`         | Query runtime backup ranges.                         |
-| `POST /v2/backups/runtime/state/sync`   | Force write state to the backup store.               |
-| `DELETE /v2/backups/runtime/state`      | Delete the runtime backup state.                     |
-| `POST /v2/backups/history`              | Trigger history backup                               |
-| `GET /v2/backups/history/{backupId}`    | Status of history backup.                            |
-| `GET /v2/backups/history?pattern=`      | List history backups.                                |
-| `DELETE /v2/backups/history/{backupId}` | Delete history backup.                               |
+|                  Endpoint                  |                       Behavior                       |
+|--------------------------------------------|------------------------------------------------------|
+| `GET /v2/exporting`                        | Aggregate exporting status of the physical tenant.   |
+| `POST /v2/exporting/pause?soft=`           | Pause exporting.                                     |
+| `POST /v2/exporting/resume`                | Resume exporting.                                    |
+| `POST /v2/backups/runtime`                 | Trigger runtime backup.                              |
+| `GET /v2/backups/runtime/{backupId}`       | Status of one runtime backup.                        |
+| `GET /v2/backups/runtime?prefix=`          | List runtime backups, optionally filtered by prefix. |
+| `DELETE /v2/backups/runtime/{backupId}`    | Delete runtime backup.                               |
+| `GET /v2/backups/runtime/state`            | Query runtime backup ranges.                         |
+| `POST /v2/backups/runtime/state/sync`      | Force write state to the backup store.               |
+| `DELETE /v2/backups/runtime/state`         | Delete the runtime backup state.                     |
+| `POST /v2/backups/history`                 | Trigger history backup                               |
+| `GET /v2/backups/history/{backupId}`       | Status of history backup.                            |
+| `GET /v2/backups/history?prefix=&verbose=` | List history backups, optionally filtered by prefix. |
+| `DELETE /v2/backups/history/{backupId}`    | Delete history backup.                               |
 
 ### D2. Cluster-wide REST management endpoints
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/PhysicalTenantHistoryBackupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/PhysicalTenantHistoryBackupIT.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.backup;
+
+import static io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.it.document.DocumentClient;
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.stream.StreamSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+@ZeebeIntegration
+final class PhysicalTenantHistoryBackupIT {
+
+  private static final String REPOSITORY_NAME_DEFAULT = "history-backup-it";
+  private static final String REPOSITORY_NAME_TENANT_A = "tenant-a-history-backup-it";
+  private static final String TENANT_A = "tenanta";
+  private static final String DEFAULT_INDEX_PREFIX = "defaulthistorybackupit";
+  private static final String TENANT_A_INDEX_PREFIX = "tenantahistorybackupit";
+
+  private static final long DEFAULT_BACKUP_ID = 101L;
+  private static final long TENANT_A_BACKUP_ID = 202L;
+
+  private static final Duration BACKUP_TIMEOUT = Duration.ofSeconds(60);
+  private static final ObjectMapper JSON = new ObjectMapper();
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+  private static ElasticsearchContainer elasticsearch;
+  private static PhysicalTenantsITHelper tenants;
+
+  @AutoClose private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withUnauthenticatedAccess().withCreateSchema(true);
+
+  @BeforeAll
+  static void startBrokerAgainstSharedElasticsearch() throws Exception {
+    elasticsearch =
+        TestSearchContainers.createDefaultElasticsearchContainer()
+            .withStartupTimeout(Duration.ofMinutes(5))
+            // filesystem snapshot repositories are only allowed under a registered path
+            .withEnv("path.repo", "~/");
+    elasticsearch.start();
+
+    final String url = "http://" + elasticsearch.getHttpHostAddress();
+    createSnapshotRepository(url, REPOSITORY_NAME_DEFAULT);
+    createSnapshotRepository(url, REPOSITORY_NAME_TENANT_A);
+
+    tenants =
+        PhysicalTenantsITHelper.builder()
+            .withTenant(DEFAULT_TENANT_ID, Storage.elasticsearch(url, DEFAULT_INDEX_PREFIX))
+            .withTenant(TENANT_A, Storage.elasticsearch(url, TENANT_A_INDEX_PREFIX))
+            .build();
+    tenants.configure(BROKER);
+
+    // one repository for both tenants, on purpose — see the class javadoc
+    BROKER.withUnifiedConfig(
+        camunda ->
+            camunda
+                .getData()
+                .getSecondaryStorage()
+                .getElasticsearch()
+                .getBackup()
+                .setRepositoryName(REPOSITORY_NAME_DEFAULT));
+    BROKER.withPtConfig(
+        TENANT_A,
+        camunda ->
+            camunda
+                .getData()
+                .getSecondaryStorage()
+                .getElasticsearch()
+                .getBackup()
+                .setRepositoryName(REPOSITORY_NAME_TENANT_A));
+
+    BROKER.start();
+  }
+
+  @AfterAll
+  static void stopElasticsearch() {
+    if (elasticsearch != null) {
+      elasticsearch.stop();
+    }
+  }
+
+  @Test
+  void shouldTakeGetListAndDeleteABackupPerPhysicalTenant() throws Exception {
+    // given a backup taken on each tenant, through both path forms
+    final var defaultTaken = takeBackup(DEFAULT_TENANT_ID, DEFAULT_BACKUP_ID);
+    assertStatus(defaultTaken, 202);
+    final var tenantATaken = takeBackup(TENANT_A, TENANT_A_BACKUP_ID);
+    assertStatus(tenantATaken, 202);
+
+    // then each tenant's snapshots carry its own name prefix
+    assertThat(scheduledSnapshots(defaultTaken))
+        .isNotEmpty()
+        .allSatisfy(name -> assertThat(name).startsWith("camunda_webapps_"));
+    assertThat(scheduledSnapshots(tenantATaken))
+        .isNotEmpty()
+        .allSatisfy(name -> assertThat(name).startsWith(TENANT_A + "_camunda_webapps_"));
+
+    // and each backup completes on its own tenant
+    awaitBackupState(DEFAULT_TENANT_ID, DEFAULT_BACKUP_ID, "COMPLETED");
+    awaitBackupState(TENANT_A, TENANT_A_BACKUP_ID, "COMPLETED");
+
+    // and neither tenant sees the other's backup, although they share one repository
+    assertThat(listedBackupIds(DEFAULT_TENANT_ID))
+        .contains(DEFAULT_BACKUP_ID)
+        .doesNotContain(TENANT_A_BACKUP_ID);
+    assertThat(listedBackupIds(TENANT_A))
+        .contains(TENANT_A_BACKUP_ID)
+        .doesNotContain(DEFAULT_BACKUP_ID);
+    assertThat(getBackup(TENANT_A, DEFAULT_BACKUP_ID).statusCode()).isEqualTo(404);
+    assertThat(getBackup(DEFAULT_TENANT_ID, TENANT_A_BACKUP_ID).statusCode()).isEqualTo(404);
+
+    // when each backup is deleted on its own tenant
+    assertThat(deleteBackup(DEFAULT_TENANT_ID, DEFAULT_BACKUP_ID).statusCode()).isEqualTo(204);
+    assertThat(deleteBackup(TENANT_A, TENANT_A_BACKUP_ID).statusCode()).isEqualTo(204);
+
+    // then it is gone
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              assertThat(getBackup(DEFAULT_TENANT_ID, DEFAULT_BACKUP_ID).statusCode())
+                  .isEqualTo(404);
+              assertThat(getBackup(TENANT_A, TENANT_A_BACKUP_ID).statusCode()).isEqualTo(404);
+            });
+  }
+
+  @Test
+  void shouldRejectADuplicateBackupIdWithConflict() throws Exception {
+    // given a backup already exists
+    final long backupId = 303L;
+    assertStatus(takeBackup(DEFAULT_TENANT_ID, backupId), 202);
+    awaitBackupState(DEFAULT_TENANT_ID, backupId, "COMPLETED");
+
+    try {
+      // when the same id is requested again
+      final var response = takeBackup(DEFAULT_TENANT_ID, backupId);
+
+      // then it is a conflict, not a bad request
+      assertThat(response.statusCode()).isEqualTo(409);
+    } finally {
+      deleteBackup(DEFAULT_TENANT_ID, backupId);
+    }
+  }
+
+  /** Includes the problem detail in the failure message: a bare status tells you nothing. */
+  private static void assertStatus(final HttpResponse<String> response, final int expected) {
+    assertThat(response.statusCode()).as("response body: %s", response.body()).isEqualTo(expected);
+  }
+
+  private static void awaitBackupState(
+      final String tenantId, final long backupId, final String expectedState) {
+    Awaitility.await(
+            "backup %d of tenant %s reaches %s".formatted(backupId, tenantId, expectedState))
+        .atMost(BACKUP_TIMEOUT)
+        .pollInterval(ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              final var response = getBackup(tenantId, backupId);
+              assertStatus(response, 200);
+              assertThat(JSON.readTree(response.body()).get("state").asText())
+                  .isEqualTo(expectedState);
+            });
+  }
+
+  private static List<Long> listedBackupIds(final String tenantId) throws Exception {
+    final var response = send("GET", uri(tenantId, ""), null);
+    assertThat(response.statusCode()).isEqualTo(200);
+    return StreamSupport.stream(JSON.readTree(response.body()).spliterator(), false)
+        .map(node -> node.get("backupId").asLong())
+        .toList();
+  }
+
+  private static List<String> scheduledSnapshots(final HttpResponse<String> response)
+      throws Exception {
+    return StreamSupport.stream(
+            JSON.readTree(response.body()).get("scheduledSnapshots").spliterator(), false)
+        .map(JsonNode::asText)
+        .toList();
+  }
+
+  private static HttpResponse<String> takeBackup(final String tenantId, final long backupId)
+      throws Exception {
+    return send("POST", uri(tenantId, ""), "{\"backupId\": " + backupId + "}");
+  }
+
+  private static HttpResponse<String> getBackup(final String tenantId, final long backupId)
+      throws Exception {
+    return send("GET", uri(tenantId, "/" + backupId), null);
+  }
+
+  private static HttpResponse<String> deleteBackup(final String tenantId, final long backupId)
+      throws Exception {
+    return send("DELETE", uri(tenantId, "/" + backupId), null);
+  }
+
+  /**
+   * The {@code default} tenant is addressed on the unprefixed path, every other tenant on its
+   * {@code /physical-tenants/{id}} form — both must reach the same controller.
+   */
+  private static URI uri(final String tenantId, final String suffix) {
+    final var base = BROKER.restAddress().toString().replaceAll("/$", "");
+    final var prefix = DEFAULT_TENANT_ID.equals(tenantId) ? "" : "/physical-tenants/" + tenantId;
+    return URI.create(base + prefix + "/v2/backups/history" + suffix);
+  }
+
+  private static HttpResponse<String> send(final String method, final URI uri, final String body)
+      throws Exception {
+    final var builder = HttpRequest.newBuilder(uri);
+    if (body != null) {
+      builder.header("Content-Type", "application/json");
+      builder.method(method, BodyPublishers.ofString(body));
+    } else {
+      builder.method(method, BodyPublishers.noBody());
+    }
+    return HTTP.send(builder.build(), BodyHandlers.ofString());
+  }
+
+  private static void createSnapshotRepository(
+      final String elasticsearchUrl, final String repositoryName) throws Exception {
+    try (final var documentClient =
+        DocumentClient.create(elasticsearchUrl, DatabaseType.ELASTICSEARCH, EXECUTOR)) {
+      documentClient.createRepository(repositoryName);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/HistoryBackupServices.java
+++ b/service/src/main/java/io/camunda/service/HistoryBackupServices.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static io.camunda.service.authorization.Authorizations.BACKUP_CREATE_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.BACKUP_DELETE_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.BACKUP_READ_AUTHORIZATION;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationScope;
+import io.camunda.security.api.model.config.AuthorizationsConfiguration;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.service.backup.HistoryBackupApi;
+import io.camunda.service.backup.HistoryBackupState;
+import io.camunda.service.backup.HistoryBackupTaken;
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.exception.ServiceException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * History (secondary-storage snapshot) backup operations for a single physical tenant.
+ *
+ * <p>Deliberately not a {@code PhysicalTenantScopedApiServices}: that base class exists to tag
+ * broker requests with a partition group, and history backups never reach the broker.
+ *
+ * <p>{@link HistoryBackupApi} is synchronous and blocks on secondary-storage round-trips, so every
+ * call is offloaded to the shared API executor. Without that, {@code RequestExecutor} would hand
+ * the already-completed future to the async servlet and a Tomcat thread would block for the whole
+ * call.
+ */
+@NullMarked
+public final class HistoryBackupServices {
+
+  /** Matches the wildcard the runtime backup endpoints use for "every backup". */
+  private static final String WILDCARD = "*";
+
+  private final String physicalTenantId;
+  private final HistoryBackupApi api;
+  private final AuthorizationChecker authorizationChecker;
+  private final AuthorizationsConfiguration authorizationsConfig;
+  private final Executor executor;
+
+  public HistoryBackupServices(
+      final String physicalTenantId,
+      final HistoryBackupApi api,
+      final AuthorizationChecker authorizationChecker,
+      final AuthorizationsConfiguration authorizationsConfig,
+      final ApiServicesExecutorProvider executorProvider) {
+    this.physicalTenantId = physicalTenantId;
+    this.api = api;
+    this.authorizationChecker = authorizationChecker;
+    this.authorizationsConfig = authorizationsConfig;
+    executor = executorProvider.getExecutor();
+  }
+
+  /**
+   * @param backupId nullable because the request body may omit it; unlike runtime backups, history
+   *     backups have no generated-id mode, so an absent id is a bad request rather than a signal
+   */
+  public CompletableFuture<HistoryBackupTaken> takeBackup(
+      final @Nullable Long backupId, final CamundaAuthentication authentication) {
+    if (!hasPermission(BACKUP_CREATE_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_CREATE_AUTHORIZATION);
+    }
+    if (backupId == null || backupId <= 0) {
+      return invalidArgument("A backupId must be provided and it must be > 0");
+    }
+
+    return callAsync(() -> api.takeBackup(physicalTenantId, backupId));
+  }
+
+  public CompletableFuture<HistoryBackupState> getBackupState(
+      final long backupId, final CamundaAuthentication authentication) {
+    if (!hasPermission(BACKUP_READ_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_READ_AUTHORIZATION);
+    }
+    if (backupId <= 0) {
+      return invalidArgument("A backupId must be provided and it must be > 0");
+    }
+
+    return callAsync(() -> api.getBackupState(physicalTenantId, backupId));
+  }
+
+  public CompletableFuture<List<HistoryBackupState>> listBackups(
+      final @Nullable String prefix,
+      final boolean verbose,
+      final CamundaAuthentication authentication) {
+    if (!hasPermission(BACKUP_READ_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_READ_AUTHORIZATION);
+    }
+    if (prefix != null && !prefix.endsWith(WILDCARD)) {
+      return invalidArgument("Expected a prefix ending with '*', but got '%s'".formatted(prefix));
+    }
+
+    return callAsync(
+        () -> api.getBackups(physicalTenantId, verbose, prefix != null ? prefix : WILDCARD));
+  }
+
+  public CompletableFuture<Void> deleteBackup(
+      final long backupId, final CamundaAuthentication authentication) {
+    if (!hasPermission(BACKUP_DELETE_AUTHORIZATION, authentication)) {
+      return failedFuture(BACKUP_DELETE_AUTHORIZATION);
+    }
+    if (backupId <= 0) {
+      return invalidArgument("A backupId must be provided and it must be > 0");
+    }
+
+    return callAsync(
+        () -> {
+          api.deleteBackup(physicalTenantId, backupId);
+          return null;
+        });
+  }
+
+  /**
+   * Runs a blocking port call on the shared API executor and maps any failure to a {@link
+   * ServiceException}, so {@code GatewayErrorMapper} can translate it to the right HTTP status.
+   */
+  private <T> CompletableFuture<T> callAsync(final Supplier<T> call) {
+    return CompletableFuture.supplyAsync(call, executor)
+        .handle(
+            (value, error) -> {
+              if (error != null) {
+                throw new CompletionException(ErrorMapper.mapError(error));
+              }
+              return value;
+            });
+  }
+
+  private <T> CompletableFuture<T> invalidArgument(final String message) {
+    return CompletableFuture.failedFuture(
+        new ServiceException(message, ServiceException.Status.INVALID_ARGUMENT));
+  }
+
+  private <T> CompletableFuture<T> failedFuture(
+      final RequiredAuthorization<?> requiredAuthorization) {
+    return CompletableFuture.failedFuture(
+        ErrorMapper.createForbiddenException(requiredAuthorization));
+  }
+
+  private boolean hasPermission(
+      final RequiredAuthorization<?> requiredAuthorization,
+      final CamundaAuthentication authentication) {
+    if (!authorizationsConfig.isEnabled()) {
+      return true;
+    }
+
+    return authorizationChecker
+        .collectPermissionTypes(
+            AuthorizationScope.WILDCARD_CHAR, requiredAuthorization.resourceType(), authentication)
+        .contains(requiredAuthorization.permissionType());
+  }
+}

--- a/service/src/main/java/io/camunda/service/backup/HistoryBackupApi.java
+++ b/service/src/main/java/io/camunda/service/backup/HistoryBackupApi.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.backup;
+
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Narrow port onto history (secondary-storage snapshot) backups, implemented in {@code dist} over
+ * the per-physical-tenant {@code BackupServiceRegistry}.
+ *
+ * <p>The port exists so this module stays storage-agnostic: the real implementation lives in {@code
+ * webapps-backup}, whose dependency tree pulls in the Elasticsearch and OpenSearch clients, the
+ * Camunda exporter and the webapps schema. Mirrors the relationship {@code RuntimeBackupServices}
+ * has with {@code BackupApi}.
+ *
+ * <p>Implementations are synchronous and block on secondary-storage round-trips; {@link
+ * io.camunda.service.HistoryBackupServices} is responsible for moving the call off the request
+ * thread. One shared instance serves every physical tenant, which is passed explicitly.
+ *
+ * <p>Failures are reported as {@code io.camunda.service.exception.ServiceException} so the
+ * gateway's error mapper can translate them without a parallel exception hierarchy.
+ */
+@NullMarked
+public interface HistoryBackupApi {
+
+  /** Schedules a backup of the tenant's history and returns the snapshots it scheduled. */
+  HistoryBackupTaken takeBackup(String physicalTenantId, long backupId);
+
+  /** Returns the state of a single backup, failing with NOT_FOUND if it does not exist. */
+  HistoryBackupState getBackupState(String physicalTenantId, long backupId);
+
+  /**
+   * Returns every backup whose id matches {@code prefix}, most recent first by snapshot start time.
+   *
+   * @param verbose whether to ask the store for snapshot-level detail; when {@code false} the store
+   *     reports neither snapshot state nor start time, so the aggregated state and the ordering are
+   *     incomplete
+   * @param prefix a backup-id prefix ending in {@code *}, or {@code null} for all backups
+   */
+  List<HistoryBackupState> getBackups(
+      String physicalTenantId, boolean verbose, @Nullable String prefix);
+
+  /** Deletes every snapshot making up the given backup. */
+  void deleteBackup(String physicalTenantId, long backupId);
+}

--- a/service/src/main/java/io/camunda/service/backup/HistoryBackupSnapshot.java
+++ b/service/src/main/java/io/camunda/service/backup/HistoryBackupSnapshot.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.backup;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A single snapshot making up a history backup.
+ *
+ * <p>{@code state} stays a store-reported string rather than an enum: Elasticsearch and OpenSearch
+ * report different vocabularies. It and {@code startTime} are absent when the backup was read
+ * without snapshot detail.
+ */
+@NullMarked
+public record HistoryBackupSnapshot(
+    String snapshotName,
+    @Nullable String state,
+    @Nullable OffsetDateTime startTime,
+    List<String> failures) {}

--- a/service/src/main/java/io/camunda/service/backup/HistoryBackupState.java
+++ b/service/src/main/java/io/camunda/service/backup/HistoryBackupState.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.backup;
+
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/** The state of a single history backup, aggregated over the snapshots that make it up. */
+@NullMarked
+public record HistoryBackupState(
+    long backupId,
+    HistoryBackupStateCode state,
+    @Nullable String failureReason,
+    List<HistoryBackupSnapshot> snapshots) {}

--- a/service/src/main/java/io/camunda/service/backup/HistoryBackupStateCode.java
+++ b/service/src/main/java/io/camunda/service/backup/HistoryBackupStateCode.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.backup;
+
+/** The aggregated state of a history backup. Mirrors the store-side {@code BackupStateDto} 1:1. */
+public enum HistoryBackupStateCode {
+  IN_PROGRESS,
+  COMPLETED,
+  FAILED,
+  INCOMPLETE,
+  INCOMPATIBLE
+}

--- a/service/src/main/java/io/camunda/service/backup/HistoryBackupTaken.java
+++ b/service/src/main/java/io/camunda/service/backup/HistoryBackupTaken.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.backup;
+
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The outcome of scheduling a history backup: the requested id echoed back alongside the snapshot
+ * names the store scheduled for it.
+ *
+ * <p>The id is echoed by the adapter from the request, not read back from the store — the
+ * underlying take-backup response carries only the snapshot names.
+ */
+@NullMarked
+public record HistoryBackupTaken(long backupId, List<String> scheduledSnapshots) {}

--- a/service/src/main/java/io/camunda/service/exception/SecondaryStorageTypeNotSupportedException.java
+++ b/service/src/main/java/io/camunda/service/exception/SecondaryStorageTypeNotSupportedException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.exception;
+
+import java.util.List;
+
+/**
+ * Thrown when an endpoint supports only some secondary storages and the request's physical tenant
+ * is configured with a different one. HTTP 403 — contrast with {@link
+ * SecondaryStorageUnavailableException}, which covers no secondary storage at all, and {@link
+ * SecondaryStorageDegradedException}, which is HTTP 503 for a configured but currently-degraded
+ * physical tenant.
+ *
+ * <p>The message names both sides so an operator on, say, an RDBMS tenant learns why the endpoint
+ * is refused rather than reading a bare 403 as a permissions problem.
+ */
+public class SecondaryStorageTypeNotSupportedException extends ServiceException {
+
+  public static final String UNSUPPORTED_SECONDARY_STORAGE_TYPE_MESSAGE =
+      "This endpoint requires one of the following secondary storages: %s, but the configured "
+          + "secondary storage is '%s'. Secondary storage is configured using the "
+          + "'camunda.data.secondary-storage.type' property.";
+
+  public SecondaryStorageTypeNotSupportedException(
+      final List<String> supportedTypes, final String configuredType) {
+    super(
+        UNSUPPORTED_SECONDARY_STORAGE_TYPE_MESSAGE.formatted(
+            String.join(", ", supportedTypes), configuredType),
+        Status.FORBIDDEN);
+  }
+}

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -27,6 +27,7 @@ import io.camunda.service.ExpressionServices;
 import io.camunda.service.FormServices;
 import io.camunda.service.GlobalListenerServices;
 import io.camunda.service.GroupServices;
+import io.camunda.service.HistoryBackupServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.ManagementServices;
@@ -77,6 +78,7 @@ public record DefaultServiceRegistry(
     Map<String, FormServices> formByTenant,
     Map<String, GlobalListenerServices> globalListenerByTenant,
     Map<String, GroupServices> groupByTenant,
+    Map<String, HistoryBackupServices> historyBackupByTenant,
     Map<String, IncidentServices> incidentByTenant,
     Map<String, JobServices<?>> jobByTenant,
     Map<String, MappingRuleServices> mappingRuleByTenant,
@@ -206,6 +208,11 @@ public record DefaultServiceRegistry(
   @Override
   public GroupServices groupServices(final String physicalTenantId) {
     return byTenant(groupByTenant, physicalTenantId);
+  }
+
+  @Override
+  public HistoryBackupServices historyBackupServices(final String physicalTenantId) {
+    return byTenant(historyBackupByTenant, physicalTenantId);
   }
 
   @Override
@@ -366,6 +373,7 @@ public record DefaultServiceRegistry(
     private final Map<String, FormServices> formByTenant = new HashMap<>();
     private final Map<String, GlobalListenerServices> globalListenerByTenant = new HashMap<>();
     private final Map<String, GroupServices> groupByTenant = new HashMap<>();
+    private final Map<String, HistoryBackupServices> historyBackupByTenant = new HashMap<>();
     private final Map<String, IncidentServices> incidentByTenant = new HashMap<>();
     private final Map<String, JobServices<?>> jobByTenant = new HashMap<>();
     private final Map<String, MappingRuleServices> mappingRuleByTenant = new HashMap<>();
@@ -499,6 +507,12 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder historyBackupServices(
+        final String tenantId, final HistoryBackupServices service) {
+      historyBackupByTenant.put(tenantId, service);
+      return this;
+    }
+
     public Builder incidentServices(final String tenantId, final IncidentServices service) {
       incidentByTenant.put(tenantId, service);
       return this;
@@ -624,6 +638,7 @@ public record DefaultServiceRegistry(
           Map.copyOf(formByTenant),
           Map.copyOf(globalListenerByTenant),
           Map.copyOf(groupByTenant),
+          Map.copyOf(historyBackupByTenant),
           Map.copyOf(incidentByTenant),
           Map.copyOf(jobByTenant),
           Map.copyOf(mappingRuleByTenant),

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -27,6 +27,7 @@ import io.camunda.service.ExpressionServices;
 import io.camunda.service.FormServices;
 import io.camunda.service.GlobalListenerServices;
 import io.camunda.service.GroupServices;
+import io.camunda.service.HistoryBackupServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.ManagementServices;
@@ -98,6 +99,8 @@ public interface ServiceRegistry {
   GlobalListenerServices globalListenerServices(String physicalTenantId);
 
   GroupServices groupServices(String physicalTenantId);
+
+  HistoryBackupServices historyBackupServices(String physicalTenantId);
 
   IncidentServices incidentServices(String physicalTenantId);
 

--- a/service/src/test/java/io/camunda/service/HistoryBackupServicesTest.java
+++ b/service/src/test/java/io/camunda/service/HistoryBackupServicesTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.security.api.model.config.AuthorizationsConfiguration;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.service.backup.HistoryBackupApi;
+import io.camunda.service.backup.HistoryBackupState;
+import io.camunda.service.backup.HistoryBackupStateCode;
+import io.camunda.service.backup.HistoryBackupTaken;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HistoryBackupServicesTest {
+
+  private static final String PHYSICAL_TENANT_ID = "testtenant";
+
+  private final HistoryBackupApi api = mock(HistoryBackupApi.class);
+  private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
+  private final AuthorizationsConfiguration authorizationsConfig =
+      new AuthorizationsConfiguration();
+  private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+
+  private ExecutorService executor;
+  private HistoryBackupServices services;
+
+  @BeforeEach
+  public void before() {
+    authorizationsConfig.setEnabled(false);
+    executor = Executors.newSingleThreadExecutor();
+    // A bare executor, not `new ApiServicesExecutorProvider(executor)`: the provider wraps it in
+    // the
+    // physical-tenant propagating decorator, whose spring-web dependency is not on this module's
+    // test classpath. Propagation is not what this test is about.
+    final var executorProvider = mock(ApiServicesExecutorProvider.class);
+    when(executorProvider.getExecutor()).thenReturn(executor);
+    services =
+        new HistoryBackupServices(
+            PHYSICAL_TENANT_ID, api, authorizationChecker, authorizationsConfig, executorProvider);
+  }
+
+  @AfterEach
+  public void after() {
+    executor.shutdownNow();
+  }
+
+  @Test
+  public void shouldTakeBackupForItsOwnPhysicalTenant() {
+    // given
+    when(api.takeBackup(PHYSICAL_TENANT_ID, 42L))
+        .thenReturn(new HistoryBackupTaken(42L, List.of("snapshot-1")));
+
+    // when
+    final var future = services.takeBackup(42L, authentication);
+
+    // then
+    assertThat(future)
+        .succeedsWithin(Duration.ofSeconds(1))
+        .isEqualTo(new HistoryBackupTaken(42L, List.of("snapshot-1")));
+    verify(api).takeBackup(PHYSICAL_TENANT_ID, 42L);
+  }
+
+  @Test
+  public void shouldRejectNonPositiveBackupIdOnTake() {
+    // when
+    final var future = services.takeBackup(0L, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.INVALID_ARGUMENT);
+    verify(api, never()).takeBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldRejectMissingBackupIdOnTake() {
+    // when history backups have no generated-id mode, so an absent id is a bad request
+    final var future = services.takeBackup(null, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.INVALID_ARGUMENT);
+    verify(api, never()).takeBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldRejectNonPositiveBackupIdOnGet() {
+    // when
+    final var future = services.getBackupState(-1L, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.INVALID_ARGUMENT);
+    verify(api, never()).getBackupState(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldRejectNonPositiveBackupIdOnDelete() {
+    // when
+    final var future = services.deleteBackup(0L, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.INVALID_ARGUMENT);
+    verify(api, never()).deleteBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldGetBackupStateForItsOwnPhysicalTenant() {
+    // given
+    final var state = completedState(42L);
+    when(api.getBackupState(PHYSICAL_TENANT_ID, 42L)).thenReturn(state);
+
+    // when
+    final var future = services.getBackupState(42L, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1)).isEqualTo(state);
+  }
+
+  @Test
+  public void shouldListBackupsWithTheGivenPrefixAndVerbosity() {
+    // given
+    when(api.getBackups(PHYSICAL_TENANT_ID, false, "17*")).thenReturn(List.of(completedState(17L)));
+
+    // when
+    final var future = services.listBackups("17*", false, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+    verify(api).getBackups(PHYSICAL_TENANT_ID, false, "17*");
+  }
+
+  @Test
+  public void shouldListAllBackupsWhenPrefixIsOmitted() {
+    // given
+    when(api.getBackups(PHYSICAL_TENANT_ID, true, "*")).thenReturn(List.of());
+
+    // when
+    final var future = services.listBackups(null, true, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+    verify(api).getBackups(PHYSICAL_TENANT_ID, true, "*");
+  }
+
+  @Test
+  public void shouldRejectPrefixNotEndingInWildcard() {
+    // when
+    final var future = services.listBackups("17", true, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.INVALID_ARGUMENT);
+    verify(api, never()).getBackups(anyString(), anyBoolean(), any());
+  }
+
+  @Test
+  public void shouldDeleteBackupForItsOwnPhysicalTenant() {
+    // when
+    final var future = services.deleteBackup(42L, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+    verify(api).deleteBackup(PHYSICAL_TENANT_ID, 42L);
+  }
+
+  @Test
+  public void shouldMapPortFailuresToTheirServiceStatus() {
+    // given
+    when(api.getBackupState(PHYSICAL_TENANT_ID, 42L))
+        .thenThrow(new ServiceException("gone", Status.NOT_FOUND));
+
+    // when
+    final var future = services.getBackupState(42L, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectTakeWhenUserHasNoCreatePermission() {
+    // given
+    grantBackupPermissions(PermissionType.READ, PermissionType.DELETE);
+
+    // when
+    final var future = services.takeBackup(42L, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.FORBIDDEN);
+    verify(api, never()).takeBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldTakeWhenUserHasCreatePermission() {
+    // given
+    grantBackupPermissions(PermissionType.CREATE);
+    when(api.takeBackup(PHYSICAL_TENANT_ID, 42L))
+        .thenReturn(new HistoryBackupTaken(42L, List.of()));
+
+    // when
+    final var future = services.takeBackup(42L, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldRejectGetWhenUserHasNoReadPermission() {
+    // given
+    grantBackupPermissions(PermissionType.CREATE, PermissionType.DELETE);
+
+    // when
+    final var future = services.getBackupState(42L, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.FORBIDDEN);
+    verify(api, never()).getBackupState(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldRejectListWhenUserHasNoReadPermission() {
+    // given
+    grantBackupPermissions(PermissionType.CREATE, PermissionType.DELETE);
+
+    // when
+    final var future = services.listBackups(null, true, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.FORBIDDEN);
+    verify(api, never()).getBackups(anyString(), anyBoolean(), any());
+  }
+
+  @Test
+  public void shouldRejectDeleteWhenUserHasNoDeletePermission() {
+    // given
+    grantBackupPermissions(PermissionType.READ, PermissionType.CREATE);
+
+    // when
+    final var future = services.deleteBackup(42L, authentication);
+
+    // then
+    assertServiceExceptionStatus(future, Status.FORBIDDEN);
+    verify(api, never()).deleteBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldDeleteWhenUserHasDeletePermission() {
+    // given
+    grantBackupPermissions(PermissionType.DELETE);
+
+    // when
+    final var future = services.deleteBackup(42L, authentication);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+    verify(api).deleteBackup(PHYSICAL_TENANT_ID, 42L);
+  }
+
+  private static HistoryBackupState completedState(final long backupId) {
+    return new HistoryBackupState(backupId, HistoryBackupStateCode.COMPLETED, null, List.of());
+  }
+
+  /**
+   * Enables authorizations and grants the given permissions on the {@code BACKUP} resource type
+   * only, so that a check against any other resource type resolves to "no permissions".
+   */
+  private void grantBackupPermissions(final PermissionType... permissions) {
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Collections.emptySet());
+    when(authorizationChecker.collectPermissionTypes(
+            any(), eq(AuthorizationResourceType.BACKUP), any()))
+        .thenReturn(Set.of(permissions));
+  }
+
+  private void assertServiceExceptionStatus(
+      final CompletableFuture<?> future, final Status expectedStatus) {
+    final var exception = catchThrowable(future::join).getCause();
+    assertThat(exception).isInstanceOf(ServiceException.class);
+    assertThat(((ServiceException) exception).getStatus()).isEqualTo(expectedStatus);
+  }
+}

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupException.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupException.java
@@ -24,6 +24,27 @@ public sealed class BackupException extends RuntimeException {
     }
   }
 
+  /**
+   * A backup with the requested id already exists. Split out of {@link InvalidRequestException} so
+   * callers can answer 409 instead of a generic 400; the actuator keeps mapping it to 400.
+   */
+  public static final class DuplicateBackupIdException extends BackupException {
+    public DuplicateBackupIdException(final String message) {
+      super(message);
+    }
+  }
+
+  /**
+   * Another backup is already running. Split out of {@link InvalidRequestException} for the same
+   * reason as {@link DuplicateBackupIdException}. The underlying check is node-local and
+   * best-effort, so this signals a likely conflict rather than a guaranteed one.
+   */
+  public static final class BackupAlreadyRunningException extends BackupException {
+    public BackupAlreadyRunningException(final String message) {
+      super(message);
+    }
+  }
+
   public static final class ResourceNotFoundException extends BackupException {
     public ResourceNotFoundException(final String message) {
       super(message);

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
@@ -88,7 +88,7 @@ public class BackupServiceImpl implements BackupService {
     // NOTE: The following checks are non-locking on purpose to be quick.
 
     if (!requestsQueue.isEmpty()) {
-      throw new InvalidRequestException(ANOTHER_BACKUP_RUNS_MSG);
+      throw new BackupAlreadyRunningException(ANOTHER_BACKUP_RUNS_MSG);
     }
 
     if (!request.isSkipSchemaCheck()) {
@@ -101,7 +101,7 @@ public class BackupServiceImpl implements BackupService {
 
     synchronized (requestsQueue) {
       if (!requestsQueue.isEmpty()) {
-        throw new InvalidRequestException(ANOTHER_BACKUP_RUNS_MSG);
+        throw new BackupAlreadyRunningException(ANOTHER_BACKUP_RUNS_MSG);
       }
 
       return scheduleSnapshots(request);

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -25,6 +25,7 @@ import co.elastic.clients.elasticsearch.snapshot.SnapshotShardFailure;
 import co.elastic.clients.elasticsearch.snapshot.SnapshotSort;
 import io.camunda.webapps.backup.BackupException;
 import io.camunda.webapps.backup.BackupException.BackupRepositoryConnectionException;
+import io.camunda.webapps.backup.BackupException.DuplicateBackupIdException;
 import io.camunda.webapps.backup.BackupException.InvalidRequestException;
 import io.camunda.webapps.backup.BackupException.MissingRepositoryException;
 import io.camunda.webapps.backup.BackupException.ResourceNotFoundException;
@@ -151,7 +152,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
                 "A backup with ID [%s] already exists. Found snapshots: [%s]",
                 backupId,
                 response.snapshots().stream().map(SnapshotInfo::snapshot).collect(joining(", ")));
-        throw new InvalidRequestException(reason);
+        throw new DuplicateBackupIdException(reason);
       }
     } catch (final IOException ex) {
       final String reason =

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -159,7 +159,7 @@ public class OpensearchBackupRepository implements BackupRepository {
               "A backup with ID [%s] already exists. Found snapshots: [%s]",
               backupId,
               response.snapshots().stream().map(SnapshotInfo::uuid).collect(joining(", ")));
-      throw new InvalidRequestException(reason);
+      throw new DuplicateBackupIdException(reason);
     }
   }
 

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/BackupServiceImplTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/BackupServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.webapps.backup.BackupException.BackupAlreadyRunningException;
 import io.camunda.webapps.backup.BackupException.IndexNotFoundException;
 import io.camunda.webapps.backup.BackupService.SnapshotRequest;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -67,12 +69,17 @@ public class BackupServiceImplTest {
       };
 
   public BackupServiceImpl makeBackupService(final BackupPriorities backupPriorities) {
+    return makeBackupService(backupPriorities, executor);
+  }
+
+  public BackupServiceImpl makeBackupService(
+      final BackupPriorities backupPriorities, final Executor snapshotExecutor) {
     final ConnectConfiguration connectConfiguration = new ConnectConfiguration();
     final SearchEngineConfiguration searchEngineConfiguration =
         new SearchEngineConfiguration(connectConfiguration, null, null, null);
 
     return new BackupServiceImpl(
-        executor,
+        snapshotExecutor,
         new BackupWiring(backupPriorities, backupRepositoryProps, backupRepository),
         searchEngineConfiguration,
         List.of(),
@@ -163,6 +170,22 @@ public class BackupServiceImplTest {
             "camunda_webapps_1_*_part_1_of_3",
             "camunda_webapps_1_*_part_2_of_3",
             "camunda_webapps_1_*_part_3_of_3");
+  }
+
+  @Test
+  public void shouldRejectABackupWhileAnotherIsRunning() {
+    // given a backup whose snapshots stay queued, because the executor never runs them
+    backupService = makeBackupService(DEFAULT_BACKUP_PRIORITIES, command -> {});
+    backupService.takeBackup(new TakeBackupRequestDto().setBackupId(1L).setSkipSchemaCheck(true));
+
+    // when
+    assertThatThrownBy(
+            () ->
+                backupService.takeBackup(
+                    new TakeBackupRequestDto().setBackupId(2L).setSkipSchemaCheck(true)))
+        // then
+        .isInstanceOf(BackupAlreadyRunningException.class)
+        .hasMessage("Another backup is running at the moment");
   }
 
   private void waitForAllTasks() {

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
@@ -34,7 +34,9 @@ import co.elastic.clients.elasticsearch.snapshot.GetSnapshotResponse;
 import co.elastic.clients.elasticsearch.snapshot.SnapshotInfo;
 import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.util.ObjectBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.webapps.backup.BackupException.DuplicateBackupIdException;
 import io.camunda.webapps.backup.BackupException.ResourceNotFoundException;
 import io.camunda.webapps.backup.BackupService.SnapshotRequest;
 import io.camunda.webapps.backup.BackupStateDto;
@@ -56,6 +58,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -298,6 +301,30 @@ public class ElasticsearchBackupRepositoryTest {
       ctx.updateLoggers();
       appender.stop();
     }
+  }
+
+  @Test
+  void shouldRejectADuplicateBackupId() throws IOException {
+    // given a snapshot already exists for the requested backup id
+    final var existingSnapshot = mock(SnapshotInfo.class);
+    when(existingSnapshot.snapshot()).thenReturn(snapshotName);
+    final var snapshotResponse = mock(GetSnapshotResponse.class);
+    when(snapshotResponse.snapshots()).thenReturn(List.of(existingSnapshot));
+    // validateNoDuplicateBackupId builds its request with a lambda, so the Function overload is the
+    // one that has to be stubbed here — not the GetSnapshotRequest one the other tests use.
+    when(esClient
+            .snapshot()
+            .get(
+                ArgumentMatchers
+                    .<Function<GetSnapshotRequest.Builder, ObjectBuilder<GetSnapshotRequest>>>
+                        any()))
+        .thenReturn(snapshotResponse);
+
+    // when / then
+    assertThatExceptionOfType(DuplicateBackupIdException.class)
+        .isThrownBy(() -> backupRepository.validateNoDuplicateBackupId(repositoryName, backupId))
+        .withMessage(
+            "A backup with ID [%d] already exists. Found snapshots: [%s]", backupId, snapshotName);
   }
 
   @Test

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.webapps.backup.BackupException;
-import io.camunda.webapps.backup.BackupException.InvalidRequestException;
+import io.camunda.webapps.backup.BackupException.DuplicateBackupIdException;
 import io.camunda.webapps.backup.BackupService;
 import io.camunda.webapps.backup.BackupService.SnapshotRequest;
 import io.camunda.webapps.backup.BackupStateDto;
@@ -369,7 +369,7 @@ class OpensearchBackupRepositoryTest {
                                             .uuid("test"))))));
 
     final var exception =
-        assertThatExceptionOfType(InvalidRequestException.class)
+        assertThatExceptionOfType(DuplicateBackupIdException.class)
             .isThrownBy(() -> repository.validateNoDuplicateBackupId("repo", 42L))
             .actual();
     assertThat(exception.getMessage())

--- a/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
@@ -273,7 +273,218 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
 
+  /backups/history:
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: takeHistoryBackup
+      x-required-permissions:
+        - { resourceType: BACKUP, permissionType: CREATE }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Take a history backup
+      description: |
+        Triggers a backup of the physical tenant's history, by scheduling a snapshot of every
+        secondary storage index it owns.
+
+        Unlike runtime backups, history backups have no generated-id mode: `backupId` is always
+        required.
+
+        Only available on clusters whose secondary storage is Elasticsearch or OpenSearch.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TakeHistoryBackupRequest'
+      responses:
+        "202":
+          description: The backup has been successfully scheduled.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TakeHistoryBackupResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/HistoryBackupForbidden'
+        "409":
+          description: |
+            A backup with the given id already exists, or another backup is already running.
+
+            The "already running" check is best-effort and node-local: it only observes backups
+            started by the gateway that serves the request. Two concurrent requests reaching
+            different gateways are narrowed by the duplicate-id check alone.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: listHistoryBackups
+      x-required-permissions:
+        - { resourceType: BACKUP, permissionType: READ }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: List history backups
+      description: |
+        Returns a list of all available history backups of the physical tenant, with their state
+        and additional info, most recent first by snapshot start time.
+
+        Only available on clusters whose secondary storage is Elasticsearch or OpenSearch.
+      parameters:
+        - name: prefix
+          in: query
+          required: false
+          description: |
+            A prefix that backup ids must match, ending in a single '*'. If omitted, all
+            backups are returned.
+          schema:
+            $ref: '#/components/schemas/BackupIdPrefix'
+        - name: verbose
+          in: query
+          required: false
+          description: |
+            Whether to ask the secondary storage for snapshot-level detail. Setting this to
+            `false` makes the query cheaper, but the store then reports neither snapshot state
+            nor start time, so both the per-snapshot `details` and the aggregated `state` are
+            incomplete and the listing order is unspecified.
+          schema:
+            type: boolean
+            default: true
+      responses:
+        "200":
+          description: The list of history backups.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HistoryBackupInfo'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/HistoryBackupForbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
+  /backups/history/{backupId}:
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: getHistoryBackup
+      x-required-permissions:
+        - { resourceType: BACKUP, permissionType: READ }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Get history backup
+      description: |
+        Returns detailed status of the history backup with the given id.
+
+        Only available on clusters whose secondary storage is Elasticsearch or OpenSearch.
+      parameters:
+        - name: backupId
+          in: path
+          required: true
+          description: The id of the backup.
+          schema:
+            $ref: '#/components/schemas/BackupId'
+      responses:
+        "200":
+          description: The history backup.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistoryBackupInfo'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/HistoryBackupForbidden'
+        "404":
+          description: A backup with the given id does not exist.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+    delete:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: deleteHistoryBackup
+      x-required-permissions:
+        - { resourceType: BACKUP, permissionType: DELETE }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Delete history backup
+      description: |
+        Deletes the history backup with the given id, by deleting every snapshot that makes it
+        up.
+
+        Only available on clusters whose secondary storage is Elasticsearch or OpenSearch.
+      parameters:
+        - name: backupId
+          in: path
+          required: true
+          description: The id of the backup.
+          schema:
+            $ref: '#/components/schemas/BackupId'
+      responses:
+        "204":
+          description: The backup has been successfully deleted.
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/HistoryBackupForbidden'
+        "404":
+          description: A backup with the given id does not exist.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
 components:
+  responses:
+    HistoryBackupForbidden:
+      description: |
+        The request is forbidden, either because the authenticated caller lacks the required
+        `BACKUP` permission, or because the cluster's secondary storage is neither Elasticsearch
+        nor OpenSearch and therefore cannot serve history backups. The problem detail says which
+        of the two applies.
+      content:
+        application/problem+json:
+          schema:
+            $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+
   schemas:
     BackupId:
       title: Backup ID
@@ -619,3 +830,135 @@ components:
         - checkpointStates
         - backupStates
         - ranges
+
+    HistoryBackupStateCode:
+      title: History Backup State
+      description: |
+        The aggregated state of a history backup, computed from the state of each of its
+        snapshots.
+      type: string
+      enum:
+        - IN_PROGRESS
+        - COMPLETED
+        - FAILED
+        - INCOMPLETE
+        - INCOMPATIBLE
+      example: IN_PROGRESS
+
+    TakeHistoryBackupRequest:
+      title: TakeHistoryBackupRequest
+      description: Request body for taking a history backup.
+      type: object
+      properties:
+        backupId:
+          description: The id of the backup to take.
+          allOf:
+            - $ref: '#/components/schemas/BackupId'
+      required:
+        - backupId
+
+    TakeHistoryBackupResponse:
+      title: TakeHistoryBackupResponse
+      description: Response body for taking a history backup.
+      type: object
+      properties:
+        backupId:
+          description: The id of the backup that has been scheduled.
+          allOf:
+            - $ref: '#/components/schemas/BackupId'
+        scheduledSnapshots:
+          description: The names of the snapshots that have been scheduled for this backup.
+          type: array
+          items:
+            type: string
+            description: The name of a scheduled snapshot.
+            example: camunda_webapps_1_8.10.0_part_1_of_6
+      required:
+        - backupId
+        - scheduledSnapshots
+
+    HistoryBackupInfo:
+      title: History Backup Info
+      description: |
+        Detailed status of a history backup. The aggregated state is computed from the state of
+        each of its snapshots as:
+        - If every expected snapshot exists and all are complete, the overall state is
+          'COMPLETED'.
+        - If one snapshot failed or is partial, the overall state is 'FAILED'.
+        - Otherwise, if one snapshot is incompatible, the overall state is 'INCOMPATIBLE'.
+        - Otherwise, if one snapshot is still running, the overall state is 'IN_PROGRESS'.
+        - Otherwise, if snapshots are missing and the backup has not progressed within the
+          configured timeout, the overall state is 'INCOMPLETE'.
+      type: object
+      properties:
+        backupId:
+          description: The id of the backup.
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/BackupId'
+        state:
+          description: The aggregated state of the backup.
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/HistoryBackupStateCode'
+        failureReason:
+          description: Reason for failure if the state is 'FAILED'.
+          type: string
+          nullable: true
+          example: ""
+        details:
+          readOnly: true
+          description: |
+            Detailed status of the backup per snapshot. Always lists every snapshot found for
+            the backup; when the backup was read without snapshot detail, each entry carries
+            only its name.
+          type: array
+          items:
+            $ref: '#/components/schemas/HistoryBackupSnapshotInfo'
+      required:
+        - backupId
+        - state
+        - failureReason
+        - details
+
+    HistoryBackupSnapshotInfo:
+      title: History Backup Snapshot Info
+      description: Detailed info of a single snapshot making up a history backup.
+      type: object
+      properties:
+        snapshotName:
+          description: The name of the snapshot.
+          readOnly: true
+          type: string
+          example: camunda_webapps_1_8.10.0_part_1_of_6
+        state:
+          description: |
+            The state of the snapshot, reported verbatim by the secondary storage (for example
+            'SUCCESS', 'IN_PROGRESS' or 'PARTIAL'). Deliberately not a closed set: Elasticsearch
+            and OpenSearch report different vocabularies. Not reported when the backup was
+            listed without snapshot detail.
+          readOnly: true
+          type: string
+          nullable: true
+          example: SUCCESS
+        startTime:
+          description: |
+            The timestamp at which the snapshot was started. Not reported when the backup was
+            listed without snapshot detail.
+          readOnly: true
+          type: string
+          format: date-time
+          nullable: true
+          example: "2022-09-15T13:10:38.176514094Z"
+        failures:
+          description: The failures reported for this snapshot. Empty if there were none.
+          readOnly: true
+          type: array
+          items:
+            type: string
+            description: A failure reported by the secondary storage for this snapshot.
+      required:
+        - snapshotName
+        - state
+        - startTime
+        - failures

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -132,6 +132,10 @@ paths:
     $ref: 'backups.yaml#/paths/~1backups~1runtime~1state~1sync'
   /backups/runtime/{backupId}:
     $ref: 'backups.yaml#/paths/~1backups~1runtime~1{backupId}'
+  /backups/history:
+    $ref: 'backups.yaml#/paths/~1backups~1history'
+  /backups/history/{backupId}:
+    $ref: 'backups.yaml#/paths/~1backups~1history~1{backupId}'
 
   # Batch operation endpoints
   /batch-operation-items/search:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/RequiresSecondaryStorage.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/RequiresSecondaryStorage.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.annotation;
 
+import io.camunda.search.connect.configuration.DatabaseType;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -17,8 +18,15 @@ import java.lang.annotation.Target;
  * Annotation to mark controllers or methods that require secondary storage to be enabled. When
  * secondary storage is not configured (camunda.data.secondary-storage.type=none), endpoints with
  * this annotation will return HTTP 403 Forbidden with a clear error message.
+ *
+ * <p>{@link #value()} narrows this to endpoints that only work on some secondary storages; those
+ * also return HTTP 403 on a physical tenant configured with any other storage.
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface RequiresSecondaryStorage {}
+public @interface RequiresSecondaryStorage {
+
+  /** Secondary storages this endpoint supports. Empty means any configured secondary storage. */
+  DatabaseType[] value() default {};
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/HistoryBackupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/HistoryBackupController.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH;
+import static io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH;
+
+import io.camunda.gateway.protocol.model.TakeHistoryBackupRequest;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.mapper.BackupResponseMapper;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * History (secondary-storage snapshot) backups for a single physical tenant.
+ *
+ * <p>The bean is registered unconditionally; {@link RequiresSecondaryStorage} makes the interceptor
+ * answer 403 on a cluster whose secondary storage cannot serve these endpoints, and 503 while the
+ * request's tenant's storage is degraded. The {@code /physical-tenants/{id}/v2/...} form of every
+ * path comes from the physical-tenant request mapping, not from a second mapping here.
+ */
+@CamundaRestController
+@RequiresSecondaryStorage({ELASTICSEARCH, OPENSEARCH})
+@RequestMapping("/v2/backups/history")
+public class HistoryBackupController {
+
+  private final ServiceRegistry serviceRegistry;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public HistoryBackupController(
+      final ServiceRegistry serviceRegistry,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.serviceRegistry = serviceRegistry;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @CamundaPostMapping
+  public CompletableFuture<ResponseEntity<Object>> takeBackup(
+      @PhysicalTenantId final String physicalTenantId,
+      @RequestBody final TakeHistoryBackupRequest request) {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .historyBackupServices(physicalTenantId)
+                .takeBackup(request.getBackupId(), authentication),
+        BackupResponseMapper::toTakeHistoryBackupResponse,
+        HttpStatus.ACCEPTED);
+  }
+
+  @CamundaGetMapping
+  public CompletableFuture<ResponseEntity<Object>> listBackups(
+      @PhysicalTenantId final String physicalTenantId,
+      @RequestParam(required = false) final String prefix,
+      @RequestParam(required = false, defaultValue = "true") final boolean verbose) {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .historyBackupServices(physicalTenantId)
+                .listBackups(prefix, verbose, authentication),
+        BackupResponseMapper::toHistoryBackupInfoList,
+        HttpStatus.OK);
+  }
+
+  @CamundaGetMapping(path = "/{backupId}")
+  public CompletableFuture<ResponseEntity<Object>> getBackup(
+      @PhysicalTenantId final String physicalTenantId, @PathVariable final long backupId) {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .historyBackupServices(physicalTenantId)
+                .getBackupState(backupId, authentication),
+        BackupResponseMapper::toHistoryBackupInfo,
+        HttpStatus.OK);
+  }
+
+  @CamundaDeleteMapping(path = "/{backupId}")
+  public CompletableFuture<ResponseEntity<Object>> deleteBackup(
+      @PhysicalTenantId final String physicalTenantId, @PathVariable final long backupId) {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () ->
+            serviceRegistry
+                .historyBackupServices(physicalTenantId)
+                .deleteBackup(backupId, authentication));
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
@@ -10,13 +10,16 @@ package io.camunda.zeebe.gateway.rest.interceptor;
 import io.camunda.cluster.SecondaryStorageReadiness;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.service.exception.SecondaryStorageDegradedException;
+import io.camunda.service.exception.SecondaryStorageTypeNotSupportedException;
 import io.camunda.service.exception.SecondaryStorageUnavailableException;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
@@ -29,6 +32,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
  * <ul>
  *   <li>HTTP 403 Forbidden when secondary storage is not configured at all
  *       (camunda.data.secondary-storage.type = none).
+ *   <li>HTTP 403 Forbidden when the endpoint declares the secondary storages it supports and the
+ *       tenant's configured one is not among them.
  *   <li>HTTP 503 Service Unavailable, with a {@code Retry-After} hint, when secondary storage is
  *       configured but the request's physical tenant's secondary storage is currently degraded (see
  *       {@link SecondaryStorageReadiness}).
@@ -57,25 +62,42 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
   public boolean preHandle(
       final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
 
-    if (handler instanceof final HandlerMethod handlerMethod
-        && requiresSecondaryStorage(handlerMethod)) {
-      validateSecondaryStorageReady(request, response);
+    if (handler instanceof final HandlerMethod handlerMethod) {
+      final var annotation = requiresSecondaryStorage(handlerMethod);
+      if (annotation != null) {
+        final String physicalTenantId = PhysicalTenantContext.current();
+        validateSecondaryStorageType(annotation, databaseTypeProvider.apply(physicalTenantId));
+        validateSecondaryStorageReady(request, response, physicalTenantId);
+      }
     }
 
     return true;
   }
 
-  private static boolean requiresSecondaryStorage(final HandlerMethod handlerMethod) {
-    return handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)
-        || handlerMethod.getBeanType().isAnnotationPresent(RequiresSecondaryStorage.class);
+  private static @Nullable RequiresSecondaryStorage requiresSecondaryStorage(
+      final HandlerMethod handlerMethod) {
+    final var methodAnnotation = handlerMethod.getMethodAnnotation(RequiresSecondaryStorage.class);
+    return methodAnnotation != null
+        ? methodAnnotation
+        : handlerMethod.getBeanType().getAnnotation(RequiresSecondaryStorage.class);
+  }
+
+  private static void validateSecondaryStorageType(
+      final RequiresSecondaryStorage annotation, final DatabaseType databaseType) {
+    if (databaseType == DatabaseType.NONE) {
+      throw new SecondaryStorageUnavailableException();
+    }
+    final var supported = List.of(annotation.value());
+    if (!supported.isEmpty() && !supported.contains(databaseType)) {
+      throw new SecondaryStorageTypeNotSupportedException(
+          supported.stream().map(DatabaseType::toString).toList(), databaseType.toString());
+    }
   }
 
   private void validateSecondaryStorageReady(
-      final HttpServletRequest request, final HttpServletResponse response) {
-    final String physicalTenantId = PhysicalTenantContext.current();
-    if (databaseTypeProvider.apply(physicalTenantId) == DatabaseType.NONE) {
-      throw new SecondaryStorageUnavailableException();
-    }
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final String physicalTenantId) {
     // Only checked on the initial dispatch: CompletableFuture-returning controllers resume on an
     // ASYNC re-dispatch, at which point the result is already computed and must not be rejected a
     // second time based on the (possibly since-changed) readiness state.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/BackupResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/BackupResponseMapper.java
@@ -11,14 +11,21 @@ import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.protocol.model.BackupInfo;
 import io.camunda.gateway.protocol.model.BackupType;
 import io.camunda.gateway.protocol.model.CheckpointType;
+import io.camunda.gateway.protocol.model.HistoryBackupInfo;
+import io.camunda.gateway.protocol.model.HistoryBackupSnapshotInfo;
+import io.camunda.gateway.protocol.model.HistoryBackupStateCode;
 import io.camunda.gateway.protocol.model.PartitionBackupInfo;
 import io.camunda.gateway.protocol.model.PartitionBackupRange;
 import io.camunda.gateway.protocol.model.PartitionBackupState;
 import io.camunda.gateway.protocol.model.PartitionCheckpointState;
 import io.camunda.gateway.protocol.model.RuntimeBackupState;
 import io.camunda.gateway.protocol.model.StateCode;
+import io.camunda.gateway.protocol.model.TakeHistoryBackupResponse;
 import io.camunda.gateway.protocol.model.TakeRuntimeBackupResponse;
 import io.camunda.service.RuntimeBackupServices;
+import io.camunda.service.backup.HistoryBackupSnapshot;
+import io.camunda.service.backup.HistoryBackupState;
+import io.camunda.service.backup.HistoryBackupTaken;
 import io.camunda.zeebe.backup.client.api.BackupStatus;
 import io.camunda.zeebe.backup.client.api.PartitionBackupStatus;
 import io.camunda.zeebe.backup.client.api.State;
@@ -212,5 +219,48 @@ public final class BackupResponseMapper {
 
   private static String toDateString(final Instant instant) {
     return ResponseMapper.formatDate(OffsetDateTime.ofInstant(instant, ZoneId.of("UTC")));
+  }
+
+  public static TakeHistoryBackupResponse toTakeHistoryBackupResponse(
+      final HistoryBackupTaken taken) {
+    return TakeHistoryBackupResponse.Builder.create()
+        .backupId(taken.backupId())
+        .scheduledSnapshots(taken.scheduledSnapshots())
+        .build();
+  }
+
+  public static HistoryBackupInfo toHistoryBackupInfo(final HistoryBackupState state) {
+    return HistoryBackupInfo.Builder.create()
+        .backupId(state.backupId())
+        .state(toHistoryBackupStateCode(state.state()))
+        .failureReason(state.failureReason())
+        .details(state.snapshots().stream().map(BackupResponseMapper::toSnapshotInfo).toList())
+        .build();
+  }
+
+  public static List<HistoryBackupInfo> toHistoryBackupInfoList(
+      final List<HistoryBackupState> states) {
+    return states.stream().map(BackupResponseMapper::toHistoryBackupInfo).toList();
+  }
+
+  private static HistoryBackupSnapshotInfo toSnapshotInfo(final HistoryBackupSnapshot snapshot) {
+    return HistoryBackupSnapshotInfo.Builder.create()
+        .snapshotName(snapshot.snapshotName())
+        .state(snapshot.state())
+        .startTime(
+            snapshot.startTime() == null ? null : ResponseMapper.formatDate(snapshot.startTime()))
+        .failures(snapshot.failures())
+        .build();
+  }
+
+  private static HistoryBackupStateCode toHistoryBackupStateCode(
+      final io.camunda.service.backup.HistoryBackupStateCode state) {
+    return switch (state) {
+      case IN_PROGRESS -> HistoryBackupStateCode.IN_PROGRESS;
+      case COMPLETED -> HistoryBackupStateCode.COMPLETED;
+      case FAILED -> HistoryBackupStateCode.FAILED;
+      case INCOMPLETE -> HistoryBackupStateCode.INCOMPLETE;
+      case INCOMPATIBLE -> HistoryBackupStateCode.INCOMPATIBLE;
+    };
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/HistoryBackupControllerStorageGatingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/HistoryBackupControllerStorageGatingTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.service.HistoryBackupServices;
+import io.camunda.service.exception.SecondaryStorageTypeNotSupportedException;
+import io.camunda.service.exception.SecondaryStorageUnavailableException;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.GlobalControllerExceptionHandler;
+import io.camunda.zeebe.gateway.rest.interceptor.SecondaryStorageInterceptor;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Asserts that {@link HistoryBackupController} is actually gated to Elasticsearch and OpenSearch.
+ *
+ * <p>Deliberately not a {@code @WebMvcTest} slice: {@code RestControllerTest} replaces {@link
+ * SecondaryStorageInterceptor} with a mock that permits every request, so a status assertion there
+ * would only be testing that mock. This wires the real interceptor to the real controller, which is
+ * what catches the annotation going missing.
+ */
+class HistoryBackupControllerStorageGatingTest {
+
+  @Test
+  void shouldRejectAStorageThatCannotServeHistoryBackups() throws Exception {
+    // given
+    final var mockMvc = mockMvcFor(DatabaseType.RDBMS);
+
+    // when - then
+    mockMvc
+        .perform(get("/v2/backups/history"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.title").value("FORBIDDEN"))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    SecondaryStorageTypeNotSupportedException
+                        .UNSUPPORTED_SECONDARY_STORAGE_TYPE_MESSAGE
+                        .formatted("elasticsearch, opensearch", "rdbms")));
+  }
+
+  /**
+   * A tenant with no secondary storage is refused with the same 403 but the "none configured"
+   * detail, which is the generic {@link SecondaryStorageInterceptor} behaviour rather than anything
+   * this endpoint declares.
+   */
+  @Test
+  void shouldRejectWhenTheTenantHasNoSecondaryStorage() throws Exception {
+    // given
+    final var mockMvc = mockMvcFor(DatabaseType.NONE);
+
+    // when - then
+    mockMvc
+        .perform(get("/v2/backups/history"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.title").value("FORBIDDEN"))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(SecondaryStorageUnavailableException.NO_SECONDARY_STORAGE_MESSAGE));
+  }
+
+  /**
+   * Asserts the request started async rather than its status: the handler returns a {@code
+   * CompletableFuture}, so an un-dispatched 200 would also be the result of never reaching it.
+   */
+  @ParameterizedTest
+  @EnumSource(
+      value = DatabaseType.class,
+      names = {"ELASTICSEARCH", "OPENSEARCH"})
+  void shouldReachTheHandlerOnADocumentStorage(final DatabaseType storageType) throws Exception {
+    // given
+    final var mockMvc = mockMvcFor(storageType);
+
+    // when - then
+    mockMvc.perform(get("/v2/backups/history")).andExpect(request().asyncStarted());
+  }
+
+  private static MockMvc mockMvcFor(final DatabaseType secondaryStorageType) {
+    final var historyBackupServices = mock(HistoryBackupServices.class);
+    when(historyBackupServices.listBackups(any(), anyBoolean(), any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    final var serviceRegistry = mock(ServiceRegistry.class);
+    when(serviceRegistry.historyBackupServices(any())).thenReturn(historyBackupServices);
+    final var authenticationProvider = mock(CamundaAuthenticationProvider.class);
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(mock(CamundaAuthentication.class));
+
+    final var interceptor =
+        new SecondaryStorageInterceptor(
+            tenantId -> secondaryStorageType, SecondaryStorageReadiness.ALWAYS_READY);
+    return MockMvcBuilders.standaloneSetup(
+            new HistoryBackupController(serviceRegistry, authenticationProvider))
+        .addInterceptors(interceptor)
+        .setControllerAdvice(new GlobalControllerExceptionHandler())
+        .build();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/HistoryBackupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/HistoryBackupControllerTest.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.HistoryBackupServices;
+import io.camunda.service.backup.HistoryBackupSnapshot;
+import io.camunda.service.backup.HistoryBackupState;
+import io.camunda.service.backup.HistoryBackupStateCode;
+import io.camunda.service.backup.HistoryBackupTaken;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(HistoryBackupController.class)
+public class HistoryBackupControllerTest extends RestControllerTest {
+
+  private static final String BASE_URL = "/v2/backups/history";
+  private static final OffsetDateTime START_TIME =
+      OffsetDateTime.of(2026, 8, 11, 9, 30, 0, 0, ZoneOffset.UTC);
+
+  @MockitoBean private HistoryBackupServices historyBackupServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean private ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setup() {
+    when(serviceRegistry.historyBackupServices(any())).thenReturn(historyBackupServices);
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void takeBackupShouldReturnAcceptedWithTheScheduledSnapshots() {
+    // given
+    when(historyBackupServices.takeBackup(eq(17L), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new HistoryBackupTaken(17L, List.of("part-1", "part-2"))));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.ACCEPTED)
+        .expectBody()
+        .jsonPath("$.backupId")
+        .isEqualTo(17)
+        .jsonPath("$.scheduledSnapshots")
+        .isEqualTo(List.of("part-1", "part-2"));
+
+    verify(historyBackupServices).takeBackup(eq(17L), any());
+  }
+
+  @Test
+  void takeBackupShouldReturnBadRequestWhenBackupIdIsMissing() {
+    // given unlike runtime backups, history backups have no generated-id mode
+    when(historyBackupServices.takeBackup(isNull(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("A backupId must be provided", Status.INVALID_ARGUMENT)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verify(historyBackupServices).takeBackup(isNull(), any());
+  }
+
+  @Test
+  void takeBackupShouldReturnConflictOnDuplicateId() {
+    // given
+    when(historyBackupServices.takeBackup(anyLong(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("already exists", Status.ALREADY_EXISTS)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  void takeBackupShouldReturnConflictWhenAnotherBackupIsRunning() {
+    // given
+    when(historyBackupServices.takeBackup(anyLong(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("another backup is running", Status.INVALID_STATE)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  void takeBackupShouldReturnForbiddenWhenUnauthorized() {
+    // given
+    when(historyBackupServices.takeBackup(anyLong(), any()))
+        .thenReturn(CompletableFuture.failedFuture(new ServiceException("nope", Status.FORBIDDEN)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  void getBackupShouldReturnTheBackupWithItsSnapshots() {
+    // given
+    when(historyBackupServices.getBackupState(eq(17L), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new HistoryBackupState(
+                    17L,
+                    HistoryBackupStateCode.FAILED,
+                    "out of disk space",
+                    List.of(
+                        new HistoryBackupSnapshot(
+                            "part-1", "PARTIAL", START_TIME, List.of("shard 0 failed"))))));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.backupId")
+        .isEqualTo(17)
+        .jsonPath("$.state")
+        .isEqualTo("FAILED")
+        .jsonPath("$.failureReason")
+        .isEqualTo("out of disk space")
+        .jsonPath("$.details[0].snapshotName")
+        .isEqualTo("part-1")
+        .jsonPath("$.details[0].state")
+        .isEqualTo("PARTIAL")
+        .jsonPath("$.details[0].failures[0]")
+        .isEqualTo("shard 0 failed");
+  }
+
+  @Test
+  void getBackupShouldReturnNotFoundForAnUnknownId() {
+    // given
+    when(historyBackupServices.getBackupState(eq(17L), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(new ServiceException("no such id", Status.NOT_FOUND)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  void getBackupShouldReturnServiceUnavailableWhenTheStoreIsUnreachable() {
+    // given
+    when(historyBackupServices.getBackupState(eq(17L), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("unreachable", Status.UNAVAILABLE)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void listBackupsShouldDefaultToVerboseAndNoPrefix() {
+    // given
+    when(historyBackupServices.listBackups(isNull(), anyBoolean(), any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(historyBackupServices).listBackups(isNull(), eq(true), any());
+  }
+
+  @Test
+  void listBackupsShouldForwardPrefixAndVerbose() {
+    // given
+    when(historyBackupServices.listBackups(eq("17*"), anyBoolean(), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(
+                    new HistoryBackupState(
+                        17L, HistoryBackupStateCode.COMPLETED, null, List.of()))));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "?prefix=17*&verbose=false")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$[0].backupId")
+        .isEqualTo(17)
+        .jsonPath("$[0].state")
+        .isEqualTo("COMPLETED");
+
+    verify(historyBackupServices).listBackups(eq("17*"), eq(false), any());
+  }
+
+  @Test
+  void listBackupsShouldReturnBadRequestOnInvalidPrefix() {
+    // given
+    when(historyBackupServices.listBackups(any(), anyBoolean(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("must end with '*'", Status.INVALID_ARGUMENT)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "?prefix=17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void deleteBackupShouldReturnNoContent() {
+    // given
+    when(historyBackupServices.deleteBackup(eq(17L), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when - then
+    webClient
+        .delete()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(historyBackupServices).deleteBackup(eq(17L), any());
+  }
+
+  @Test
+  void deleteBackupShouldReturnNotFoundForAnUnknownId() {
+    // given
+    when(historyBackupServices.deleteBackup(eq(17L), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(new ServiceException("no such id", Status.NOT_FOUND)));
+
+    // when - then
+    webClient
+        .delete()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorProblemDetailTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorProblemDetailTest.java
@@ -19,6 +19,7 @@ import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.cluster.SecondaryStorageReadiness;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.service.exception.SecondaryStorageDegradedException;
+import io.camunda.service.exception.SecondaryStorageTypeNotSupportedException;
 import io.camunda.zeebe.gateway.rest.GlobalControllerExceptionHandler;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import org.junit.jupiter.api.Test;
@@ -30,8 +31,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Asserts the HTTP 503 problem-detail body shape produced when {@link SecondaryStorageInterceptor}
- * rejects a request because its physical tenant is degraded, exercised end-to-end through {@link
+ * Asserts the problem-detail body shapes produced when {@link SecondaryStorageInterceptor} rejects
+ * a request — 503 because its physical tenant is degraded, 403 because the tenant's secondary
+ * storage is not one the endpoint declares — exercised end-to-end through {@link
  * GlobalControllerExceptionHandler} via MockMvc (no Spring context).
  */
 class SecondaryStorageInterceptorProblemDetailTest {
@@ -43,11 +45,7 @@ class SecondaryStorageInterceptorProblemDetailTest {
     when(readiness.isReady(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(false);
     final var interceptor =
         new SecondaryStorageInterceptor(t -> DatabaseType.ELASTICSEARCH, readiness);
-    final MockMvc mockMvc =
-        MockMvcBuilders.standaloneSetup(new TestController())
-            .addInterceptors(interceptor)
-            .setControllerAdvice(new GlobalControllerExceptionHandler())
-            .build();
+    final MockMvc mockMvc = mockMvcFor(new TestController(), interceptor);
 
     // when/then
     mockMvc
@@ -63,10 +61,49 @@ class SecondaryStorageInterceptorProblemDetailTest {
                         PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)));
   }
 
+  @Test
+  void shouldReturnForbiddenProblemDetailWhenConfiguredStorageIsNotDeclared() throws Exception {
+    // given
+    final var interceptor =
+        new SecondaryStorageInterceptor(
+            t -> DatabaseType.RDBMS, SecondaryStorageReadiness.ALWAYS_READY);
+    final MockMvc mockMvc = mockMvcFor(new DocumentStorageController(), interceptor);
+
+    // when/then
+    mockMvc
+        .perform(get("/test-document-storage-endpoint"))
+        .andExpect(status().isForbidden())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(jsonPath("$.title").value("FORBIDDEN"))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    SecondaryStorageTypeNotSupportedException
+                        .UNSUPPORTED_SECONDARY_STORAGE_TYPE_MESSAGE
+                        .formatted("elasticsearch, opensearch", "rdbms")));
+  }
+
+  private static MockMvc mockMvcFor(
+      final Object controller, final SecondaryStorageInterceptor interceptor) {
+    return MockMvcBuilders.standaloneSetup(controller)
+        .addInterceptors(interceptor)
+        .setControllerAdvice(new GlobalControllerExceptionHandler())
+        .build();
+  }
+
   @RestController
   @RequiresSecondaryStorage
   static class TestController {
     @GetMapping("/test-secondary-storage-endpoint")
+    String get() {
+      return "ok";
+    }
+  }
+
+  @RestController
+  @RequiresSecondaryStorage({DatabaseType.ELASTICSEARCH, DatabaseType.OPENSEARCH})
+  static class DocumentStorageController {
+    @GetMapping("/test-document-storage-endpoint")
     String get() {
       return "ok";
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.zeebe.gateway.rest.interceptor;
 
+import static io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH;
+import static io.camunda.search.connect.configuration.DatabaseType.NONE;
+import static io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH;
+import static io.camunda.search.connect.configuration.DatabaseType.RDBMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -14,6 +18,7 @@ import static org.mockito.Mockito.*;
 import io.camunda.cluster.SecondaryStorageReadiness;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.service.exception.SecondaryStorageDegradedException;
+import io.camunda.service.exception.SecondaryStorageTypeNotSupportedException;
 import io.camunda.service.exception.SecondaryStorageUnavailableException;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
@@ -28,20 +33,25 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.method.HandlerMethod;
 
-@SuppressWarnings({"unchecked", "rawtypes"})
 class SecondaryStorageInterceptorTest {
 
   private static final String PHYSICAL_TENANT_ID = "tenanta";
 
+  /** Handlers are built from real annotated classes so annotation lookup is not stubbed away. */
+  private static final HandlerMethod UNANNOTATED = handlerMethodFor(new Unannotated());
+
+  private static final HandlerMethod ANY_STORAGE = handlerMethodFor(new AnyStorage());
+  private static final HandlerMethod DOCUMENT_STORAGE_ONLY =
+      handlerMethodFor(new DocumentStorageOnly());
+  private static final HandlerMethod METHOD_OVERRIDE = handlerMethodFor(new MethodOverride());
+
   private HttpServletRequest request;
   private HttpServletResponse response;
-  private HandlerMethod handlerMethod;
 
   @BeforeEach
   void setUp() {
     request = mock(HttpServletRequest.class);
     response = mock(HttpServletResponse.class);
-    handlerMethod = mock(HandlerMethod.class);
     when(request.getDispatcherType()).thenReturn(DispatcherType.REQUEST);
   }
 
@@ -52,90 +62,66 @@ class SecondaryStorageInterceptorTest {
 
   @Test
   void shouldAllowWhenNoAnnotation() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(false);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
+    final var interceptor = interceptor(ELASTICSEARCH, SecondaryStorageReadiness.ALWAYS_READY);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            t -> DatabaseType.ELASTICSEARCH, SecondaryStorageReadiness.ALWAYS_READY);
-    final boolean result = interceptor.preHandle(request, response, handlerMethod);
+    final boolean result = interceptor.preHandle(request, response, UNANNOTATED);
+
     assertThat(result).isTrue();
   }
 
   @Test
   void shouldNotConsultReadinessWhenNoAnnotation() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(false);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     final var readiness = mock(SecondaryStorageReadiness.class);
+    final var interceptor = interceptor(ELASTICSEARCH, readiness);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(t -> DatabaseType.ELASTICSEARCH, readiness);
-    interceptor.preHandle(request, response, handlerMethod);
+    interceptor.preHandle(request, response, UNANNOTATED);
 
     verifyNoInteractions(readiness);
   }
 
   @Test
   void shouldAllowWhenSecondaryStorageEnabledAndTenantServiceable() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(ELASTICSEARCH, SecondaryStorageReadiness.ALWAYS_READY);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            t -> DatabaseType.ELASTICSEARCH, SecondaryStorageReadiness.ALWAYS_READY);
-    final boolean result = interceptor.preHandle(request, response, handlerMethod);
+    final boolean result = interceptor.preHandle(request, response, ANY_STORAGE);
+
     assertThat(result).isTrue();
   }
 
   @Test
   void shouldThrowWhenSecondaryStorageDisabledAndAnnotationPresent() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(NONE, SecondaryStorageReadiness.ALWAYS_READY);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            t -> DatabaseType.NONE, SecondaryStorageReadiness.ALWAYS_READY);
-    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, ANY_STORAGE))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
   }
 
   @Test
   void shouldRejectWithForbiddenEvenWhenTenantDegradedAndSecondaryStorageDisabled() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(NONE, degraded(PHYSICAL_TENANT_ID));
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(t -> DatabaseType.NONE, degraded(PHYSICAL_TENANT_ID));
-    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, ANY_STORAGE))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
   }
 
   @Test
   void shouldThrowWhenPhysicalTenantDegraded() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            t -> DatabaseType.ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
-    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, ANY_STORAGE))
         .isInstanceOf(SecondaryStorageDegradedException.class);
   }
 
   @Test
   void shouldHintRetryAfterWhenPhysicalTenantDegraded() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            t -> DatabaseType.ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
-    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, ANY_STORAGE))
         .isInstanceOf(SecondaryStorageDegradedException.class);
 
     verify(response).setHeader(HttpHeaders.RETRY_AFTER, "5");
@@ -143,14 +129,10 @@ class SecondaryStorageInterceptorTest {
 
   @Test
   void shouldNotHintRetryAfterWhenSecondaryStorageDisabled() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(NONE, SecondaryStorageReadiness.ALWAYS_READY);
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            t -> DatabaseType.NONE, SecondaryStorageReadiness.ALWAYS_READY);
-    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, ANY_STORAGE))
         .isInstanceOf(SecondaryStorageUnavailableException.class);
 
     verifyNoInteractions(response);
@@ -158,16 +140,72 @@ class SecondaryStorageInterceptorTest {
 
   @Test
   void shouldSkipDegradedCheckOnAsyncDispatch() {
-    when(handlerMethod.hasMethodAnnotation(RequiresSecondaryStorage.class)).thenReturn(true);
-    when(handlerMethod.getBeanType()).thenReturn((Class) Object.class);
     when(request.getDispatcherType()).thenReturn(DispatcherType.ASYNC);
     bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
 
-    final var interceptor =
-        new SecondaryStorageInterceptor(
-            t -> DatabaseType.ELASTICSEARCH, degraded(PHYSICAL_TENANT_ID));
-    final boolean result = interceptor.preHandle(request, response, handlerMethod);
+    final boolean result = interceptor.preHandle(request, response, ANY_STORAGE);
+
     assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldAllowWhenTenantStorageIsDeclared() {
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(OPENSEARCH, SecondaryStorageReadiness.ALWAYS_READY);
+
+    final boolean result = interceptor.preHandle(request, response, DOCUMENT_STORAGE_ONLY);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldThrowWhenTenantStorageIsNotDeclared() {
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(RDBMS, SecondaryStorageReadiness.ALWAYS_READY);
+
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, DOCUMENT_STORAGE_ONLY))
+        .isInstanceOf(SecondaryStorageTypeNotSupportedException.class)
+        .hasMessageContaining("elasticsearch, opensearch")
+        .hasMessageContaining("'rdbms'");
+  }
+
+  /**
+   * A tenant with no secondary storage is reported as unavailable rather than as an unsupported
+   * type, even on an endpoint that declares a set: "none" is the absence of storage, not a storage
+   * the endpoint could have supported.
+   */
+  @Test
+  void shouldReportNoSecondaryStorageAsUnavailableRatherThanUnsupportedType() {
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(NONE, SecondaryStorageReadiness.ALWAYS_READY);
+
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, DOCUMENT_STORAGE_ONLY))
+        .isInstanceOf(SecondaryStorageUnavailableException.class);
+  }
+
+  @Test
+  void shouldPreferMethodAnnotationOverClassAnnotation() {
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var interceptor = interceptor(RDBMS, SecondaryStorageReadiness.ALWAYS_READY);
+
+    // the class declares ELASTICSEARCH, the method declares RDBMS — the method wins
+    final boolean result = interceptor.preHandle(request, response, METHOD_OVERRIDE);
+
+    assertThat(result).isTrue();
+  }
+
+  private static SecondaryStorageInterceptor interceptor(
+      final DatabaseType databaseType, final SecondaryStorageReadiness readiness) {
+    return new SecondaryStorageInterceptor(tenantId -> databaseType, readiness);
+  }
+
+  private static HandlerMethod handlerMethodFor(final Object controller) {
+    try {
+      return new HandlerMethod(controller, controller.getClass().getMethod("handle"));
+    } catch (final NoSuchMethodException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   private static void bindPhysicalTenant(final String physicalTenantId) {
@@ -181,5 +219,33 @@ class SecondaryStorageInterceptorTest {
     final var readiness = mock(SecondaryStorageReadiness.class);
     when(readiness.isReady(physicalTenantId)).thenReturn(false);
     return readiness;
+  }
+
+  public static class Unannotated {
+    public String handle() {
+      return "ok";
+    }
+  }
+
+  @RequiresSecondaryStorage
+  public static class AnyStorage {
+    public String handle() {
+      return "ok";
+    }
+  }
+
+  @RequiresSecondaryStorage({ELASTICSEARCH, OPENSEARCH})
+  public static class DocumentStorageOnly {
+    public String handle() {
+      return "ok";
+    }
+  }
+
+  @RequiresSecondaryStorage(ELASTICSEARCH)
+  public static class MethodOverride {
+    @RequiresSecondaryStorage(RDBMS)
+    public String handle() {
+      return "ok";
+    }
   }
 }


### PR DESCRIPTION
## Description

Adds history backup endpoints to /v2 public api

| Method | Path | Permission | Success |
|---|---|---|---|
| `POST` | `/v2/backups/history` | `BACKUP` `CREATE` | 202 |
| `GET` | `/v2/backups/history/{backupId}` | `BACKUP` `READ` | 200 |
| `GET` | `/v2/backups/history?prefix=&verbose=` | `BACKUP` `READ` | 200 |
| `DELETE` | `/v2/backups/history/{backupId}` | `BACKUP` `DELETE` | 204 |

These endpoints are also backed by `/physical-tenants/{id}/v2/...` prefixed endpoints.

The actuator is untouched and keeps a cluster-wide history backups (fans-out for all physical tenants of the cluster)

### How it is put together

`gateway-rest` reaches the backup services through a narrow `HistoryBackupApi` port in `service/`, implemented by `RegistryHistoryBackupApi` in `dist` over the existing per-tenant `BackupServiceRegistry`. The implementation lives in `webapps-backup`. This mirrors `RuntimeBackupServices` → `BackupApi`.

The port is synchronous and blocks on store round-trips, so `HistoryBackupServices` offloads every call to the shared API executor.

The endpoints are gated to Elasticsearch and OpenSearch by extending `@RequiresSecondaryStorage` with the storages an endpoint supports. On an RDBMS tenant the interceptor answers **403** with a problem detail naming the storages it needs; on a tenant with no secondary storage, the same 403 with the existing "none configured" detail.

Two divergences from the actuator endpoint:
- a repository connection failure maps to **503** rather than 502
- duplicate id or a concurrent run answers **409** rather than 400.

## Related issues

closes #57013
