### PR TITLE
feat: migrate tasklist login page to unified webapp

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as AuthIndexRouteImport } from './routes/_auth/index'
 import { Route as AuthAdminRouteRouteImport } from './routes/_auth/admin/route'
 import { Route as AuthOperateRouteRouteImport } from './routes/_auth/operate/route'
 import { Route as AuthTasklistRouteRouteImport } from './routes/_auth/tasklist/route'
+import { Route as TasklistLoginRouteImport } from './routes/tasklist.login'
 import { Route as AuthAdminIndexRouteImport } from './routes/_auth/admin/index'
 import { Route as AuthOperateIndexRouteImport } from './routes/_auth/operate/index'
 import { Route as AuthOperateBatchOperationsRouteImport } from './routes/_auth/operate/batch-operations'
@@ -61,6 +62,11 @@ const AuthTasklistRouteRoute = AuthTasklistRouteRouteImport.update({
   id: '/tasklist',
   path: '/tasklist',
   getParentRoute: () => AuthRouteRoute,
+} as any)
+const TasklistLoginRoute = TasklistLoginRouteImport.update({
+  id: '/tasklist/login',
+  path: '/tasklist/login',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuthAdminIndexRoute = AuthAdminIndexRouteImport.update({
   id: '/',
@@ -164,6 +170,7 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AuthAdminRouteRouteWithChildren
   '/operate': typeof AuthOperateRouteRouteWithChildren
   '/tasklist': typeof AuthTasklistRouteRouteWithChildren
+  '/tasklist/login': typeof TasklistLoginRoute
   '/tasklist/processes': typeof AuthTasklistProcessesRouteRouteWithChildren
   '/operate/batch-operations': typeof AuthOperateBatchOperationsRoute
   '/operate/decisions': typeof AuthOperateDecisionsRouteWithChildren
@@ -184,6 +191,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/tasklist': typeof AuthTasklistTasksIndexRoute
+  '/tasklist/login': typeof TasklistLoginRoute
   '/': typeof AuthIndexRoute
   '/tasklist/processes': typeof AuthTasklistProcessesRouteRouteWithChildren
   '/operate/batch-operations': typeof AuthOperateBatchOperationsRoute
@@ -206,6 +214,7 @@ export interface FileRoutesById {
   '/_auth/admin': typeof AuthAdminRouteRouteWithChildren
   '/_auth/operate': typeof AuthOperateRouteRouteWithChildren
   '/_auth/tasklist': typeof AuthTasklistRouteRouteWithChildren
+  '/tasklist/login': typeof TasklistLoginRoute
   '/_auth/': typeof AuthIndexRoute
   '/_auth/tasklist/_tasks': typeof AuthTasklistTasksRouteRouteWithChildren
   '/_auth/tasklist/processes': typeof AuthTasklistProcessesRouteRouteWithChildren
@@ -233,6 +242,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/operate'
     | '/tasklist'
+    | '/tasklist/login'
     | '/tasklist/processes'
     | '/operate/batch-operations'
     | '/operate/decisions'
@@ -253,6 +263,7 @@ export interface FileRouteTypes {
   to:
     | '/login'
     | '/tasklist'
+    | '/tasklist/login'
     | '/'
     | '/tasklist/processes'
     | '/operate/batch-operations'
@@ -274,6 +285,7 @@ export interface FileRouteTypes {
     | '/_auth/admin'
     | '/_auth/operate'
     | '/_auth/tasklist'
+    | '/tasklist/login'
     | '/_auth/'
     | '/_auth/tasklist/_tasks'
     | '/_auth/tasklist/processes'
@@ -297,6 +309,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   AuthRouteRoute: typeof AuthRouteRouteWithChildren
   LoginRoute: typeof LoginRoute
+  TasklistLoginRoute: typeof TasklistLoginRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -342,6 +355,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/tasklist'
       preLoaderRoute: typeof AuthTasklistRouteRouteImport
       parentRoute: typeof AuthRouteRoute
+    }
+    '/tasklist/login': {
+      id: '/tasklist/login'
+      path: '/tasklist/login'
+      fullPath: '/tasklist/login'
+      preLoaderRoute: typeof TasklistLoginRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_auth/admin/': {
       id: '/_auth/admin/'
@@ -612,6 +632,7 @@ const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   AuthRouteRoute: AuthRouteRouteWithChildren,
   LoginRoute: LoginRoute,
+  TasklistLoginRoute: TasklistLoginRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx
@@ -16,6 +16,7 @@ import {fetchSaasToken} from '#/shared/c3/fetchSaasToken';
 import {Header} from '#/shared/header/components/Header';
 import {getBootConfig} from '#/shared/config/getBootConfig';
 import {NotFoundPage} from '#/shared/pages/NotFoundPage';
+import {isTasklistPath} from '#/shared/auth/isTasklistPath';
 
 const Route = createFileRoute('/_auth')({
 	beforeLoad: async ({location, context: {queryClient}}) => {
@@ -30,9 +31,11 @@ const Route = createFileRoute('/_auth')({
 		} catch {
 			queryClient.cancelQueries();
 			queryClient.clear();
+			const isTasklistIndex = location.href === '/tasklist';
+
 			throw redirect({
-				to: '/login',
-				search: location.href === '/' ? {} : {redirect: location.href},
+				to: isTasklistPath(location.pathname) ? '/tasklist/login' : '/login',
+				search: location.href === '/' || isTasklistIndex ? {} : {redirect: location.href},
 			});
 		}
 	},

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/tasklist.login.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/tasklist.login.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {LoginPage} from '#/shared/pages/LoginPage';
+import {createFileRoute, isRedirect, redirect} from '@tanstack/react-router';
+import {z} from 'zod';
+import {queries} from '#/shared/http/queries';
+
+export const Route = createFileRoute('/tasklist/login')({
+	validateSearch: z.object({
+		redirect: z
+			.string()
+			.refine(
+				(value) => /^\/tasklist(?:[/?#]|$)/.test(value) && !/^\/tasklist\/login(?:[/?#]|$)/.test(value),
+				'Redirect must be a Tasklist path',
+			)
+			.optional(),
+	}),
+	beforeLoad: async ({search, context: {queryClient}}) => {
+		try {
+			await queryClient.ensureQueryData(queries.getCurrentUser());
+			throw redirect({href: search.redirect ?? '/tasklist', replace: true});
+		} catch (error) {
+			if (isRedirect(error)) {
+				throw error;
+			}
+		}
+	},
+	component: () => <LoginPage title="Tasklist" />,
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/auth/components/SessionWatcher.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/auth/components/SessionWatcher.tsx
@@ -12,12 +12,14 @@ import {useEffect, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import {authenticationStore} from '#/shared/auth/authentication.store';
 import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {isTasklistPath} from '#/shared/auth/isTasklistPath';
 
 const SessionWatcher: React.FC = observer(() => {
 	const location = useLocation();
 	const {status} = authenticationStore;
 	const removeNotification = useRef<(() => void) | null>(null);
 	const {t} = useTranslation();
+	const isTasklistIndex = location.href === '/tasklist';
 
 	const isSessionExpired =
 		status === 'logged-out' ||
@@ -25,7 +27,7 @@ const SessionWatcher: React.FC = observer(() => {
 		(status === 'session-invalid' && location.pathname !== '/');
 
 	useEffect(() => {
-		if (location.pathname === '/login') {
+		if (location.pathname.endsWith('/login')) {
 			return;
 		}
 
@@ -36,7 +38,7 @@ const SessionWatcher: React.FC = observer(() => {
 				isDismissable: true,
 			});
 		}
-	}, [status, t, location.pathname]);
+	}, [location.pathname, status, t]);
 
 	useEffect(() => {
 		if (status === 'logged-in') {
@@ -45,7 +47,13 @@ const SessionWatcher: React.FC = observer(() => {
 	}, [status]);
 
 	if (isSessionExpired) {
-		return <Navigate to="/login" search={location.href === '/' ? {} : {redirect: location.href}} replace />;
+		return (
+			<Navigate
+				to={isTasklistPath(location.pathname) ? '/tasklist/login' : '/login'}
+				search={location.href === '/' || isTasklistIndex ? {} : {redirect: location.href}}
+				replace
+			/>
+		);
 	}
 
 	return null;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/auth/isTasklistPath.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/auth/isTasklistPath.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+function isTasklistPath(pathname: string) {
+	return pathname === '/tasklist' || pathname.startsWith('/tasklist/');
+}
+
+export {isTasklistPath};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/pages/LoginPage.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/pages/LoginPage.module.scss
@@ -25,6 +25,13 @@
 	padding-bottom: var(--cds-spacing-02);
 }
 
+.title {
+	padding-bottom: var(--cds-spacing-10);
+	text-align: center;
+	color: var(--cds-text-primary);
+	@include type.type-style('productive-heading-05');
+}
+
 .field {
 	min-height: layout.to-rem(84px);
 }

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/pages/LoginPage.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/pages/LoginPage.tsx
@@ -96,9 +96,7 @@ const LoginPage: React.FC<Props> = ({title}) => {
 								<div className={styles.logo}>
 									<CamundaLogo aria-label={t('loginLogoLabel')} />
 								</div>
-								<h1 className={title === undefined ? 'cds--visually-hidden' : styles.title}>
-									{title ?? 'Login'}
-								</h1>
+								<h1 className={title === undefined ? 'cds--visually-hidden' : styles.title}>{title ?? 'Login'}</h1>
 							</Stack>
 							<Stack gap={3}>
 								<div className={styles.error}>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/pages/LoginPage.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/pages/LoginPage.tsx
@@ -23,20 +23,23 @@ type FormValues = {
 	password: string;
 };
 
-const LoginPage: React.FC = () => {
+type Props = {
+	title?: string;
+};
+
+const LoginPage: React.FC<Props> = ({title}) => {
 	const router = useRouter();
 	const {t} = useTranslation();
 
 	return (
 		<Grid as="main" condensed className={styles.container}>
-			<h1 className="cds--visually-hidden">Login</h1>
 			<Form<FormValues>
 				onSubmit={async ({username, password}) => {
 					try {
 						const {error} = await authenticationStore.handleLogin(username, password);
 
 						if (error === null) {
-							// Re-triggers /login beforeLoad, which detects the active session and redirects
+							// Re-triggers the login route, which detects the active session and redirects
 							await router.invalidate();
 							return;
 						}
@@ -93,6 +96,9 @@ const LoginPage: React.FC = () => {
 								<div className={styles.logo}>
 									<CamundaLogo aria-label={t('loginLogoLabel')} />
 								</div>
+								<h1 className={title === undefined ? 'cds--visually-hidden' : styles.title}>
+									{title ?? 'Login'}
+								</h1>
 							</Stack>
 							<Stack gap={3}>
 								<div className={styles.error}>

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/header.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/header.test.ts
@@ -40,7 +40,7 @@ test.beforeEach(({network}) => {
 });
 
 test.describe('logout', () => {
-	test('should show a notification and redirect to login page after clicking logout', async ({
+	test('should show a notification and redirect to Tasklist login after clicking logout', async ({
 		network,
 		tasklistIndexPage,
 		page,
@@ -66,7 +66,7 @@ test.describe('logout', () => {
 		await expect(logoutNotification).toBeVisible();
 		await expect(logoutNotification).toContainText('You are being logged out...');
 
-		await expect(page).toHaveURL(/\/login/);
+		await expect(page).toHaveURL('/tasklist/login');
 	});
 });
 

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-login.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-login.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '#/pw-modules/test-extend';
+import {HttpResponse} from 'msw';
+import {
+	mockCurrentUserEndpoint,
+	mockLicenseEndpoint,
+	mockLoginEndpoint,
+	mockQueryProcessDefinitionsEndpoint,
+	mockQueryUserTasksEndpoint,
+	mockSystemConfigurationEndpoint,
+} from '#/shared-test-modules/mock-handlers';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {createLicense} from '#/shared-test-modules/api-mocks/license';
+import {createQueryProcessDefinitionsResponse} from '#/shared-test-modules/api-mocks/process-definitions';
+import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+import {createQueryUserTasksResponse} from '#/shared-test-modules/api-mocks/user-tasks';
+
+test.beforeEach(({network}) => {
+	network.use(
+		mockCurrentUserEndpoint({successResponse: new HttpResponse(null, {status: 401})}),
+		mockLoginEndpoint({successResponse: new HttpResponse(null, {status: 200})}),
+		mockSystemConfigurationEndpoint({
+			successResponse: HttpResponse.json(createSystemConfiguration({components: {active: ['tasklist']}})),
+		}),
+		mockLicenseEndpoint({successResponse: HttpResponse.json(createLicense())}),
+	);
+});
+
+test('should redirect the Tasklist index to Tasklist login and return after login', async ({
+	network,
+	page,
+	tasklistIndexPage,
+	tasklistLoginPage,
+}) => {
+	network.use(
+		mockQueryUserTasksEndpoint({successResponse: HttpResponse.json(createQueryUserTasksResponse({items: []}))}),
+	);
+
+	await tasklistIndexPage.goto();
+
+	await expect(page).toHaveURL('/tasklist/login');
+	await expect(tasklistLoginPage.title).toBeVisible();
+	await expect(tasklistLoginPage.usernameInput).toBeVisible();
+
+	network.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
+
+	await tasklistLoginPage.fillCredentials('demo', 'demo');
+	await tasklistLoginPage.submitButton.click();
+
+	await expect(page).toHaveURL('/tasklist');
+	await expect(tasklistIndexPage.tasksPanelHeading('All open tasks')).toBeVisible();
+});
+
+test('should preserve a nested Tasklist URL through login', async ({
+	network,
+	page,
+	tasklistLoginPage,
+	tasklistProcessesPage,
+}) => {
+	network.use(
+		mockQueryProcessDefinitionsEndpoint({
+			successResponse: HttpResponse.json(createQueryProcessDefinitionsResponse()),
+		}),
+	);
+
+	await tasklistProcessesPage.goto('?search=invoice');
+
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.pathname === '/tasklist/login' &&
+			url.searchParams.get('redirect') === '/tasklist/processes?search=invoice'
+		);
+	});
+	await expect(tasklistLoginPage.usernameInput).toBeVisible();
+
+	network.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}));
+
+	await tasklistLoginPage.fillCredentials('demo', 'demo');
+	await tasklistLoginPage.submitButton.click();
+
+	await expect(page).toHaveURL('/tasklist/processes?search=invoice');
+	await expect(tasklistProcessesPage.heading).toBeVisible();
+});
+
+test.describe('redirect validation', () => {
+	for (const redirect of [
+		'/operate',
+		'/tasklisting',
+		'//evil.example',
+		'https://evil.example',
+		'/tasklist/login',
+		'/tasklist/login?redirect=/tasklist',
+	]) {
+		test(`should reject ${redirect} as a Tasklist redirect`, async ({tasklistLoginPage}) => {
+			await tasklistLoginPage.goto(redirect);
+
+			await expect(tasklistLoginPage.genericErrorHeading).toBeVisible();
+		});
+	}
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-login.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-login.test.ts
@@ -74,8 +74,7 @@ test('should preserve a nested Tasklist URL through login', async ({
 
 	await expect(page).toHaveURL((url) => {
 		return (
-			url.pathname === '/tasklist/login' &&
-			url.searchParams.get('redirect') === '/tasklist/processes?search=invoice'
+			url.pathname === '/tasklist/login' && url.searchParams.get('redirect') === '/tasklist/processes?search=invoice'
 		);
 	});
 	await expect(tasklistLoginPage.usernameInput).toBeVisible();

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/TasklistLogin.page.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/TasklistLogin.page.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {LoginPage} from './Login.page';
+
+class TasklistLoginPage extends LoginPage {
+	override async goto(redirect?: string) {
+		const search = redirect === undefined ? '' : `?${new URLSearchParams({redirect})}`;
+		return this.page.goto(`/tasklist/login${search}`);
+	}
+
+	get genericErrorHeading() {
+		return this.page.getByRole('heading', {name: 'Something went wrong'});
+	}
+
+	get title() {
+		return this.page.getByRole('heading', {name: 'Tasklist'});
+	}
+}
+
+export {TasklistLoginPage};

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pw-modules/test-extend.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pw-modules/test-extend.ts
@@ -20,12 +20,14 @@ import {OperateProcessesPage} from '#/pages/OperateProcesses.page';
 import {AdminIndexPage} from '#/pages/AdminIndex.page';
 import {NotFoundPage} from '#/pages/NotFound.page';
 import {ForbiddenPage} from '#/pages/Forbidden.page';
+import {TasklistLoginPage} from '#/pages/TasklistLogin.page';
 
 type Fixtures = {
 	handlers: Array<AnyHandler>;
 	network: NetworkFixture;
 	makeAxeBuilder: () => AxeBuilder;
 	loginPage: LoginPage;
+	tasklistLoginPage: TasklistLoginPage;
 	tasklistIndexPage: TasklistIndexPage;
 	tasklistProcessesPage: TasklistProcessesPage;
 	taskDetailPage: TaskDetailPage;
@@ -44,6 +46,9 @@ const test = base.extend<Fixtures>({
 	},
 	loginPage: async ({page}, use) => {
 		await use(new LoginPage(page));
+	},
+	tasklistLoginPage: async ({page}, use) => {
+		await use(new TasklistLoginPage(page));
 	},
 	tasklistIndexPage: async ({page}, use) => {
 		await use(new TasklistIndexPage(page));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I'm migrating the Tasklist login page since it looks like Tasklist will be the only component unified in time for 8.10

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related https://github.com/camunda/camunda/issues/53950
