### PR TITLE
Export AgentDefinition records to ES/OS via CamundaExporter

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupServiceRegistryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupServiceRegistryConfiguration.java
@@ -33,6 +33,7 @@ import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio2Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
@@ -266,6 +267,7 @@ public class BackupServiceRegistryConfiguration {
             new AuditLogCleanupIndex(indexPrefix, isElasticsearch),
             new AuditLogTemplate(indexPrefix, isElasticsearch),
             // CAMUNDA
+            new AgentDefinitionIndex(indexPrefix, isElasticsearch),
             new AgentHistoryTemplate(indexPrefix, isElasticsearch),
             new ClusterVariableIndex(indexPrefix, isElasticsearch),
             new DeployedResourceIndex(indexPrefix, isElasticsearch),

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -186,6 +186,7 @@ class BackupPrioritiesTest {
             "camunda-user-8.8.0_",
             "camunda-usage-metric-8.8.0_",
             "camunda-usage-metric-tu-8.8.0_",
+            "camunda-agent-definition-8.10.0_",
             "camunda-agent-history-8.10.0_",
             "camunda-audit-log-8.9.0_",
             "camunda-audit-log-cleanup-8.9.0_",

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1027,6 +1027,7 @@ public class SchemaManagerIT {
             newPrefix + "-camunda-history-deletion-8.9.0_",
             newPrefix + "-camunda-agent-instance-8.10.0_",
             newPrefix + "-camunda-agent-history-8.10.0_",
+            newPrefix + "-camunda-agent-definition-8.10.0_",
             newPrefix + "-camunda-deployed-resource-8.10.0_",
             newPrefix + "-operate-batch-operation-1.0.0_",
             newPrefix + "-operate-decision-8.3.0_",

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.webapps.schema.descriptors;
 
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
@@ -98,7 +99,8 @@ public class IndexDescriptors {
                 new GlobalListenerIndex(indexPrefix, isElasticsearch),
                 new DeployedResourceIndex(indexPrefix, isElasticsearch),
                 new AgentInstanceTemplate(indexPrefix, isElasticsearch),
-                new AgentHistoryTemplate(indexPrefix, isElasticsearch))
+                new AgentHistoryTemplate(indexPrefix, isElasticsearch),
+                new AgentDefinitionIndex(indexPrefix, isElasticsearch))
             .collect(Collectors.toMap(Object::getClass, Function.identity()));
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/AgentDefinitionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/AgentDefinitionIndex.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.index;
+
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import java.util.Optional;
+
+/** Index descriptor for the {@code agent-definition} index. */
+public class AgentDefinitionIndex extends AbstractIndexDescriptor implements Prio4Backup {
+
+  public static final String INDEX_NAME = "agent-definition";
+  public static final String INDEX_VERSION = "8.10.0";
+
+  public static final String ID = "id";
+  public static final String KEY = "key";
+  public static final String AGENT_TYPE = "agentType";
+  public static final String NAME = "name";
+  public static final String ELEMENT_ID = "elementId";
+  public static final String BPMN_PROCESS_ID = "bpmnProcessId";
+  public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
+  public static final String PROCESS_DEFINITION_VERSION_TAG = "processDefinitionVersionTag";
+  public static final String TENANT_ID = "tenantId";
+
+  public AgentDefinitionIndex(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public Optional<String> getTenantIdField() {
+    return Optional.of(TENANT_ID);
+  }
+
+  @Override
+  public String getVersion() {
+    return INDEX_VERSION;
+  }
+
+  @Override
+  public String getComponentName() {
+    return ComponentNames.CAMUNDA.toString();
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentdefinition/AgentDefinitionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentdefinition/AgentDefinitionEntity.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.agentdefinition;
+
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.Objects;
+
+/** Secondary-storage entity for AGENT_DEFINITION records. */
+public final class AgentDefinitionEntity
+    implements ExporterEntity<AgentDefinitionEntity>, TenantOwned {
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String id;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long key;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private AgentDefinitionType agentType;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String name;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String elementId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String bpmnProcessId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long processDefinitionKey;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private int processDefinitionVersion;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String processDefinitionVersionTag;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String tenantId;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public AgentDefinitionEntity setId(final String id) {
+    this.id = id;
+    return this;
+  }
+
+  public long getKey() {
+    return key;
+  }
+
+  public AgentDefinitionEntity setKey(final long key) {
+    this.key = key;
+    return this;
+  }
+
+  public AgentDefinitionType getAgentType() {
+    return agentType;
+  }
+
+  public AgentDefinitionEntity setAgentType(final AgentDefinitionType agentType) {
+    this.agentType = agentType;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public AgentDefinitionEntity setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getElementId() {
+    return elementId;
+  }
+
+  public AgentDefinitionEntity setElementId(final String elementId) {
+    this.elementId = elementId;
+    return this;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public AgentDefinitionEntity setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+    return this;
+  }
+
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public AgentDefinitionEntity setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  public AgentDefinitionEntity setProcessDefinitionVersion(final int processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+    return this;
+  }
+
+  public String getProcessDefinitionVersionTag() {
+    return processDefinitionVersionTag;
+  }
+
+  public AgentDefinitionEntity setProcessDefinitionVersionTag(
+      final String processDefinitionVersionTag) {
+    this.processDefinitionVersionTag = processDefinitionVersionTag;
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public AgentDefinitionEntity setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        key,
+        agentType,
+        name,
+        elementId,
+        bpmnProcessId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        processDefinitionVersionTag,
+        tenantId);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+    final var that = (AgentDefinitionEntity) obj;
+    return Objects.equals(id, that.id)
+        && key == that.key
+        && agentType == that.agentType
+        && Objects.equals(name, that.name)
+        && Objects.equals(elementId, that.elementId)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && processDefinitionKey == that.processDefinitionKey
+        && processDefinitionVersion == that.processDefinitionVersion
+        && Objects.equals(processDefinitionVersionTag, that.processDefinitionVersionTag)
+        && Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public String toString() {
+    return "AgentDefinitionEntity{"
+        + "id='"
+        + id
+        + '\''
+        + ", key="
+        + key
+        + ", agentType="
+        + agentType
+        + ", name='"
+        + name
+        + '\''
+        + ", elementId='"
+        + elementId
+        + '\''
+        + ", bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", processDefinitionVersion="
+        + processDefinitionVersion
+        + ", processDefinitionVersionTag='"
+        + processDefinitionVersionTag
+        + '\''
+        + ", tenantId='"
+        + tenantId
+        + '\''
+        + '}';
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentdefinition/AgentDefinitionType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentdefinition/AgentDefinitionType.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.agentdefinition;
+
+/**
+ * Secondary-storage counterpart of {@code
+ * io.camunda.zeebe.protocol.record.value.AgentDefinitionType}.
+ */
+public enum AgentDefinitionType {
+  AI_AGENT_SUB_PROCESS,
+  AI_AGENT_TASK,
+  EXTERNAL_AGENT
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-agent-definition.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-agent-definition.json
@@ -1,0 +1,37 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "agentType": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "elementId": {
+        "type": "keyword"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processDefinitionVersion": {
+        "type": "integer"
+      },
+      "processDefinitionVersionTag": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-agent-definition.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-agent-definition.json
@@ -1,0 +1,37 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "agentType": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "elementId": {
+        "type": "keyword"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processDefinitionVersion": {
+        "type": "integer"
+      },
+      "processDefinitionVersionTag": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import static io.camunda.zeebe.protocol.record.ValueType.AGENT_DEFINITION;
 import static io.camunda.zeebe.protocol.record.ValueType.AGENT_HISTORY;
 import static io.camunda.zeebe.protocol.record.ValueType.AGENT_INSTANCE;
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
@@ -436,6 +437,7 @@ public class CamundaExporter implements Exporter {
             GLOBAL_LISTENER,
             AGENT_INSTANCE,
             AGENT_HISTORY,
+            AGENT_DEFINITION,
             TIMER,
             SIGNAL_SUBSCRIPTION,
             CONDITIONAL_SUBSCRIPTION);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.errorhandling.ErrorHandler;
 import io.camunda.exporter.errorhandling.ErrorHandlers;
+import io.camunda.exporter.handlers.AgentDefinitionHandler;
 import io.camunda.exporter.handlers.AgentHistoryHandler;
 import io.camunda.exporter.handlers.AgentInstanceHandler;
 import io.camunda.exporter.handlers.AuthorizationCreatedUpdatedHandler;
@@ -110,6 +111,7 @@ import io.camunda.exporter.index.TargetIndex;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
@@ -261,6 +263,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new DecisionHandler(
                 indexDescriptors.get(DecisionIndex.class).getFullQualifiedName(),
                 decisionRequirementsCache),
+            new AgentDefinitionHandler(
+                indexDescriptors.get(AgentDefinitionIndex.class).getFullQualifiedName()),
             new ListViewProcessInstanceFromProcessInstanceHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(), processCache),
             new ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentDefinitionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentDefinitionHandler.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 /** Exports {@code AgentDefinition:CREATED} records. */
 public class AgentDefinitionHandler
-    implements ExportHandler<AgentDefinitionEntity, AgentDefinitionRecordValue> {
+    implements MainIndexExporterHandler<AgentDefinitionEntity, AgentDefinitionRecordValue> {
 
   private static final Set<AgentDefinitionIntent> HANDLED_INTENTS =
       Set.of(AgentDefinitionIntent.CREATED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentDefinitionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentDefinitionHandler.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity;
+import io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionRecordValue;
+import java.util.List;
+import java.util.Set;
+
+/** Exports {@code AgentDefinition:CREATED} records. */
+public class AgentDefinitionHandler
+    implements ExportHandler<AgentDefinitionEntity, AgentDefinitionRecordValue> {
+
+  private static final Set<AgentDefinitionIntent> HANDLED_INTENTS =
+      Set.of(AgentDefinitionIntent.CREATED);
+
+  private final String indexName;
+
+  public AgentDefinitionHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.AGENT_DEFINITION;
+  }
+
+  @Override
+  public Class<AgentDefinitionEntity> getEntityType() {
+    return AgentDefinitionEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<AgentDefinitionRecordValue> record) {
+    final AgentDefinitionIntent intent = (AgentDefinitionIntent) record.getIntent();
+    return HANDLED_INTENTS.contains(intent);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<AgentDefinitionRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getAgentDefinitionKey()));
+  }
+
+  @Override
+  public AgentDefinitionEntity createNewEntity(final String id) {
+    return new AgentDefinitionEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<AgentDefinitionRecordValue> record, final AgentDefinitionEntity entity) {
+    final AgentDefinitionRecordValue value = record.getValue();
+    entity
+        .setId(String.valueOf(value.getAgentDefinitionKey()))
+        .setKey(value.getAgentDefinitionKey())
+        .setAgentType(mapAgentType(value.getAgentType()))
+        .setName(value.getName())
+        .setElementId(value.getElementId())
+        .setBpmnProcessId(value.getBpmnProcessId())
+        .setProcessDefinitionKey(value.getProcessDefinitionKey())
+        .setProcessDefinitionVersion(value.getProcessDefinitionVersion())
+        .setProcessDefinitionVersionTag(
+            ExporterUtil.emptyToNull(value.getProcessDefinitionVersionTag()))
+        .setTenantId(value.getTenantId());
+  }
+
+  @Override
+  public void flush(
+      final TargetIndex index,
+      final AgentDefinitionEntity entity,
+      final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  /**
+   * Maps the protocol {@code AgentDefinitionType} to the secondary-storage {@link
+   * AgentDefinitionType}.
+   */
+  private static AgentDefinitionType mapAgentType(
+      final io.camunda.zeebe.protocol.record.value.AgentDefinitionType protocolAgentType) {
+    return switch (protocolAgentType) {
+      case AI_AGENT_SUB_PROCESS -> AgentDefinitionType.AI_AGENT_SUB_PROCESS;
+      case AI_AGENT_TASK -> AgentDefinitionType.AI_AGENT_TASK;
+      case EXTERNAL_AGENT -> AgentDefinitionType.EXTERNAL_AGENT;
+      case UNSPECIFIED ->
+          throw new IllegalStateException(
+              "Received unexpected AgentDefinitionType.UNSPECIFIED; the broker must never emit "
+                  + "this value. If a new AgentDefinitionType was intentionally added, extend "
+                  + AgentDefinitionType.class.getName()
+                  + " and this mapping accordingly.");
+    };
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentDefinitionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentDefinitionHandlerTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
+import io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity;
+import io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentDefinitionRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+final class AgentDefinitionHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = AgentDefinitionIndex.INDEX_NAME;
+  private final AgentDefinitionHandler underTest = new AgentDefinitionHandler(indexName);
+
+  @Test
+  void shouldReturnCorrectHandlerMetadata() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.AGENT_DEFINITION);
+    assertThat(underTest.getEntityType()).isEqualTo(AgentDefinitionEntity.class);
+    assertThat(underTest.getIndexName()).isEqualTo(indexName);
+  }
+
+  @ParameterizedTest(name = "[{index}] Should handle ''{0}'' record")
+  @EnumSource(
+      value = AgentDefinitionIntent.class,
+      names = {"CREATED"},
+      mode = Mode.INCLUDE)
+  void shouldHandleRecord(final AgentDefinitionIntent intent) {
+    assertThat(underTest.handlesRecord(generateRecord(intent))).isTrue();
+  }
+
+  @ParameterizedTest(name = "[{index}] Should not handle ''{0}'' record")
+  @EnumSource(
+      value = AgentDefinitionIntent.class,
+      names = {"CREATED"},
+      mode = Mode.EXCLUDE)
+  void shouldNotHandleRecord(final AgentDefinitionIntent intent) {
+    assertThat(underTest.handlesRecord(generateRecord(intent))).isFalse();
+  }
+
+  @Test
+  void shouldGenerateIdFromAgentDefinitionKey() {
+    // given
+    final long expectedKey = 123L;
+    final AgentDefinitionRecordValue recordValue =
+        ImmutableAgentDefinitionRecordValue.builder()
+            .from(factory.generateObject(AgentDefinitionRecordValue.class))
+            .withAgentDefinitionKey(expectedKey)
+            .build();
+    final Record<AgentDefinitionRecordValue> record =
+        generateRecord(AgentDefinitionIntent.CREATED, recordValue);
+
+    // when
+    final var idList = underTest.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(expectedKey));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final AgentDefinitionRecordValue recordValue =
+        ImmutableAgentDefinitionRecordValue.builder()
+            .from(factory.generateObject(AgentDefinitionRecordValue.class))
+            .withAgentDefinitionKey(123L)
+            .withAgentType(io.camunda.zeebe.protocol.record.value.AgentDefinitionType.AI_AGENT_TASK)
+            .withName("agentName")
+            .withElementId("elementId")
+            .withBpmnProcessId("bpmnProcessId")
+            .withProcessDefinitionKey(456L)
+            .withProcessDefinitionVersion(2)
+            .withProcessDefinitionVersionTag("versionTag")
+            .withTenantId("tenantId")
+            .build();
+    final Record<AgentDefinitionRecordValue> record =
+        generateRecord(AgentDefinitionIntent.CREATED, recordValue);
+
+    // when
+    final AgentDefinitionEntity entity = new AgentDefinitionEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo("123");
+    assertThat(entity.getKey()).isEqualTo(123L);
+    assertThat(entity.getAgentType()).isEqualTo(AgentDefinitionType.AI_AGENT_TASK);
+    assertThat(entity.getName()).isEqualTo("agentName");
+    assertThat(entity.getElementId()).isEqualTo("elementId");
+    assertThat(entity.getBpmnProcessId()).isEqualTo("bpmnProcessId");
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(456L);
+    assertThat(entity.getProcessDefinitionVersion()).isEqualTo(2);
+    assertThat(entity.getProcessDefinitionVersionTag()).isEqualTo("versionTag");
+    assertThat(entity.getTenantId()).isEqualTo("tenantId");
+  }
+
+  @Test
+  void shouldMapEmptyProcessDefinitionVersionTagToNull() {
+    // given
+    final AgentDefinitionRecordValue recordValue =
+        ImmutableAgentDefinitionRecordValue.builder()
+            .from(factory.generateObject(AgentDefinitionRecordValue.class))
+            .withProcessDefinitionVersionTag("")
+            .build();
+    final Record<AgentDefinitionRecordValue> record =
+        generateRecord(AgentDefinitionIntent.CREATED, recordValue);
+
+    // when
+    final AgentDefinitionEntity entity = new AgentDefinitionEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getProcessDefinitionVersionTag()).isNull();
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final AgentDefinitionEntity inputEntity = new AgentDefinitionEntity().setId("111");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(index, inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(index, inputEntity);
+  }
+
+  @ParameterizedTest(name = "[{index}] Should map protocol agent type ''{0}'' to entity agent type")
+  @EnumSource(
+      value = io.camunda.zeebe.protocol.record.value.AgentDefinitionType.class,
+      // The broker should never emit UNSPECIFIED;
+      // all other protocol agent types must map to an exporter agent type.
+      names = {"UNSPECIFIED"},
+      mode = Mode.EXCLUDE)
+  void shouldMapAllProtocolAgentTypes(
+      final io.camunda.zeebe.protocol.record.value.AgentDefinitionType protocolAgentType) {
+    // given
+    final AgentDefinitionRecordValue recordValue =
+        ImmutableAgentDefinitionRecordValue.builder()
+            .from(factory.generateObject(AgentDefinitionRecordValue.class))
+            .withAgentType(protocolAgentType)
+            .build();
+    final Record<AgentDefinitionRecordValue> record =
+        generateRecord(AgentDefinitionIntent.CREATED, recordValue);
+    final AgentDefinitionEntity entity = new AgentDefinitionEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getAgentType()).isNotNull();
+    assertThat(entity.getAgentType().name())
+        .as(
+            """
+            Protocol agent type '%s' has no explicit mapping in \
+            'AgentDefinitionHandler.mapAgentType()' — add '%s' to '%s' and handle it \
+            explicitly in the switch.\
+            """,
+            protocolAgentType, protocolAgentType, AgentDefinitionType.class.getName())
+        .isEqualTo(protocolAgentType.name());
+  }
+
+  @Test
+  void shouldThrowWhenProtocolAgentTypeIsUnspecified() {
+    // given — UNSPECIFIED is not explicitly mapped and must never be emitted by the broker
+    final AgentDefinitionRecordValue recordValue =
+        ImmutableAgentDefinitionRecordValue.builder()
+            .from(factory.generateObject(AgentDefinitionRecordValue.class))
+            .withAgentType(io.camunda.zeebe.protocol.record.value.AgentDefinitionType.UNSPECIFIED)
+            .build();
+    final Record<AgentDefinitionRecordValue> record =
+        generateRecord(AgentDefinitionIntent.CREATED, recordValue);
+    final AgentDefinitionEntity entity = new AgentDefinitionEntity();
+
+    // when - then
+    assertThatThrownBy(() -> underTest.updateEntity(record, entity))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("UNSPECIFIED");
+  }
+
+  private Record<AgentDefinitionRecordValue> generateRecord(final AgentDefinitionIntent intent) {
+    return factory.generateRecord(ValueType.AGENT_DEFINITION, r -> r.withIntent(intent));
+  }
+
+  private Record<AgentDefinitionRecordValue> generateRecord(
+      final AgentDefinitionIntent intent, final AgentDefinitionRecordValue value) {
+    return factory.generateRecord(
+        ValueType.AGENT_DEFINITION, r -> r.withIntent(intent).withValue(value));
+  }
+}


### PR DESCRIPTION
## Description

Agent definitions (`AgentDefinition:CREATED` records, produced by the engine when an AI-agent sub-process/task or external-agent definition is deployed) were not exported to secondary storage. Without an ES/OS representation, they could not be indexed by `CamundaExporter`, could not be backed up/restored, and could not be served by the upcoming `AgentDefinition` search/get REST endpoints (`zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml`).

This PR adds the missing ES/OS export path end-to-end, so that agent definitions become queryable secondary-storage data:

- **Schema** (`webapps-schema`): `AgentDefinitionEntity`, `AgentDefinitionType`, `AgentDefinitionIndex` (a plain index, not a template, since agent definitions are immutable deploy-time data written once), and ES/OS mappings, registered in `IndexDescriptors`.
- **Export** (`camunda-exporter`): `AgentDefinitionHandler` maps `AgentDefinition:CREATED` records to `AgentDefinitionEntity` documents; registered in `DefaultExporterResourceProvider` and in `CamundaExporter.CamundaExporterRecordFilter#VALUE_TYPES_2_EXPORT` (both registrations are required — the record filter is a separate allow-list that gates records before they ever reach a handler).
- **Backup** (`dist`): `AgentDefinitionIndex` registered in `BackupServiceRegistryConfiguration`'s `prio4` list, alongside its fellow deploy-time definitions, so it is backed up and restored in the correct order relative to runtime data that may reference it.

### Notable design decisions

- `AgentDefinitionEntity#processDefinitionVersionTag` uses the full, unambiguous name rather than the shorter `versionTag`, because this entity also carries `processDefinitionKey`/`processDefinitionVersion`, where the short name would be ambiguous about which definition it refers to.
- `AgentDefinitionHandler#mapAgentType` exhaustively maps every protocol `AgentDefinitionType` value except `UNSPECIFIED`, which throws `IllegalStateException` instead of silently falling back — the broker must never emit `UNSPECIFIED`, so failing loudly surfaces such a bug immediately instead of persisting an ambiguous value.

### Out of scope

- The REST API layer (`GET`/search `AgentDefinition` endpoints) — this PR only makes the data available in secondary storage; wiring the REST controllers/service layer to read from the new `agent-definition` index is tracked separately.
- RDBMS export (`db/rdbms`) — this PR covers Elasticsearch/OpenSearch via `CamundaExporter` only.

### What this unblocks

- Implementing the `AgentDefinition` search/get REST endpoints and reader which need a queryable ES/OS index to read from.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59071
