### PR TITLE
feat: add business-value overview compute service + scheduler

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeIT.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.writer.BusinessValueTargetWriter;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the scheduler compute path end to end: after persisting one process definition (with the
+ * "not defined" tenant surfaced as {@code null} alongside a real tenant) and writing a target,
+ * invoking the compute service produces one overview row per range preset for the real-tenant
+ * definition — the null-tenant bucket is skipped rather than crashing the sweep, and the row's
+ * target block matches the caller-scoped tenant instead of leaking across tenants.
+ */
+class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final String PROCESS_KEY = "invoice-automation";
+  private static final String DEFAULT_TENANT = ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+  private static final Long CYCLE_TARGET_MILLIS = 28_800_000L;
+  private static final Integer AUTOMATION_TARGET_PCT = 85;
+
+  private BusinessValueTargetWriter targetWriter;
+  private BusinessValueOverviewComputeService computeService;
+  private BusinessValueOverviewRepository overviewRepository;
+
+  @BeforeEach
+  void setUp() {
+    targetWriter = embeddedOptimizeExtension.getBean(BusinessValueTargetWriter.class);
+    computeService = embeddedOptimizeExtension.getBean(BusinessValueOverviewComputeService.class);
+    overviewRepository = embeddedOptimizeExtension.getBean(BusinessValueOverviewRepository.class);
+    // AbstractBrokerlessZeebeCCSMIT.cleanupOptimizeData() wipes Optimize data between tests, so
+    // the ApplicationReadyEvent-driven seed is only visible to the first test. Reseed here so the
+    // compute service can look up the two per-process seeded reports on every run.
+    embeddedOptimizeExtension.getBean(BusinessValueDashboardService.class).reconcile();
+  }
+
+  @Test
+  void shouldMaterializeRowsPerRangeForImportedDefinitionsAndSkipNullTenants() {
+    // given one definition on the default tenant and a target for that pair
+    persistProcessDefinitions(
+        List.of(
+            ProcessDefinitionOptimizeDto.builder()
+                .id(PROCESS_KEY + "-1")
+                .key(PROCESS_KEY)
+                .version("1")
+                .name("Invoice Automation")
+                .dataSource(new ZeebeDataSourceDto("test", 1))
+                .tenantId(DEFAULT_TENANT)
+                .bpmn20Xml("<definitions/>")
+                .build()));
+    targetWriter.upsertTarget(
+        new BusinessValueTargetDto(
+            PROCESS_KEY,
+            DEFAULT_TENANT,
+            CYCLE_TARGET_MILLIS,
+            TargetValueUnit.HOURS,
+            AUTOMATION_TARGET_PCT,
+            OffsetDateTime.parse("2026-08-05T04:00:15Z"),
+            "sherrin@camunda.com"));
+
+    // when the scheduler compute path runs across all 4 range presets
+    computeService.computeOverviewRows(
+        List.of(
+            MetricRange.SEVEN_DAYS,
+            MetricRange.THIRTY_DAYS,
+            MetricRange.THREE_MONTHS,
+            MetricRange.SIX_MONTHS));
+
+    // then one row exists per range for the (default tenant, key) pair with target propagated
+    for (final MetricRange range : MetricRange.values()) {
+      final Optional<BusinessValueOverviewDto> row =
+          overviewRepository.getByKey(DEFAULT_TENANT, PROCESS_KEY, range);
+      assertThat(row)
+          .as("row for range %s", range)
+          .isPresent()
+          .hasValueSatisfying(
+              r -> {
+                assertThat(r.getTenantId()).isEqualTo(DEFAULT_TENANT);
+                assertThat(r.getProcessDefinitionKey()).isEqualTo(PROCESS_KEY);
+                assertThat(r.getMetricRange()).isEqualTo(range);
+                assertThat(r.getCycleTime().getTarget()).isEqualTo(CYCLE_TARGET_MILLIS);
+                assertThat(r.getAutomationRate().getTarget()).isEqualTo(AUTOMATION_TARGET_PCT);
+                assertThat(r.isHasAnyTarget()).isTrue();
+                assertThat(r.getTargetsSet()).isEqualTo(2);
+              });
+    }
+  }
+
+  @Test
+  void shouldNotLeakTargetsAcrossTenantsOnSameProcessKey() {
+    // given the same process key exists on two tenants but only one carries a target
+    final String otherTenant = "tenant-b";
+    persistProcessDefinitions(
+        List.of(
+            ProcessDefinitionOptimizeDto.builder()
+                .id(PROCESS_KEY + "-1")
+                .key(PROCESS_KEY)
+                .version("1")
+                .name("Invoice Automation")
+                .dataSource(new ZeebeDataSourceDto("test", 1))
+                .tenantId(DEFAULT_TENANT)
+                .bpmn20Xml("<definitions/>")
+                .build(),
+            ProcessDefinitionOptimizeDto.builder()
+                .id(PROCESS_KEY + "-2")
+                .key(PROCESS_KEY)
+                .version("1")
+                .name("Invoice Automation")
+                .dataSource(new ZeebeDataSourceDto("test", 1))
+                .tenantId(otherTenant)
+                .bpmn20Xml("<definitions/>")
+                .build()));
+    targetWriter.upsertTarget(
+        new BusinessValueTargetDto(
+            PROCESS_KEY,
+            DEFAULT_TENANT,
+            CYCLE_TARGET_MILLIS,
+            TargetValueUnit.HOURS,
+            AUTOMATION_TARGET_PCT,
+            OffsetDateTime.parse("2026-08-05T04:00:15Z"),
+            "sherrin@camunda.com"));
+
+    // when compute runs for the 7d preset
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the default-tenant row carries the target, the other-tenant row does not
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, PROCESS_KEY, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(
+            r -> {
+              assertThat(r.getCycleTime().getTarget()).isEqualTo(CYCLE_TARGET_MILLIS);
+              assertThat(r.getAutomationRate().getTarget()).isEqualTo(AUTOMATION_TARGET_PCT);
+              assertThat(r.getTargetsSet()).isEqualTo(2);
+            });
+    assertThat(overviewRepository.getByKey(otherTenant, PROCESS_KEY, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(
+            r -> {
+              assertThat(r.getCycleTime().getTarget()).isNull();
+              assertThat(r.getAutomationRate().getTarget()).isNull();
+              assertThat(r.getTargetsSet()).isZero();
+            });
+  }
+
+  @Test
+  void shouldSkipWriteWhenNoDefinitionsExist() {
+    // given no imported process definitions and no targets
+
+    // when compute runs across all 4 ranges
+    computeService.computeOverviewRows(
+        List.of(
+            MetricRange.SEVEN_DAYS,
+            MetricRange.THIRTY_DAYS,
+            MetricRange.THREE_MONTHS,
+            MetricRange.SIX_MONTHS));
+
+    // then no rows are written for our process key
+    for (final MetricRange range : MetricRange.values()) {
+      assertThat(overviewRepository.getByKey(DEFAULT_TENANT, PROCESS_KEY, range)).isEmpty();
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.dto.optimize.query.report.AdditionalProcessReportEvaluationFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult;
+import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.util.ProcessFilterBuilder;
+import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
+import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
+import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
+import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
+import io.camunda.optimize.service.report.ReportService;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+/**
+ * Materializes {@code business-value-overview} rows for every {@code (tenantId,
+ * processDefinitionKey, metricRange)} triple across all fully-imported process definitions. Only
+ * the two target-bearing seeded reports are evaluated ({@code bv-duration-by-process} and {@code
+ * bv-automation-rate-by-process}) — volume has no target in v1 and is not part of the L0 rollup.
+ *
+ * <p>Called from {@link BusinessValueOverviewSchedulerService} on each tick. The target-write and
+ * stale-read backstop paths described in the technical design will call in from follow-up PRs once
+ * the target REST endpoint and stale-read handler exist; this class currently exposes only the
+ * scheduler entry point so unused surfaces don't linger.
+ */
+@Component
+public class BusinessValueOverviewComputeService {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewComputeService.class);
+
+  private final BusinessValueTargetRepository targetRepository;
+  private final BusinessValueOverviewWriter overviewWriter;
+  private final DefinitionService definitionService;
+  private final ReportService reportService;
+  private final PlainReportEvaluationHandler reportEvaluationHandler;
+
+  public BusinessValueOverviewComputeService(
+      final BusinessValueTargetRepository targetRepository,
+      final BusinessValueOverviewWriter overviewWriter,
+      final DefinitionService definitionService,
+      final ReportService reportService,
+      final PlainReportEvaluationHandler reportEvaluationHandler) {
+    this.targetRepository = targetRepository;
+    this.overviewWriter = overviewWriter;
+    this.definitionService = definitionService;
+    this.reportService = reportService;
+    this.reportEvaluationHandler = reportEvaluationHandler;
+  }
+
+  public void computeOverviewRows(final List<MetricRange> ranges) {
+    if (ranges == null || ranges.isEmpty()) {
+      throw new IllegalArgumentException("ranges must not be null or empty");
+    }
+
+    final List<DefinitionEntry> definitions = resolveDefinitions();
+    if (definitions.isEmpty()) {
+      LOG.debug("No process definitions in scope for business-value overview compute; skipping");
+      return;
+    }
+
+    final Map<String, BusinessValueTargetDto> targetsByDocId = readTargets();
+    final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+    final List<BusinessValueOverviewDto> rowsToUpsert = new ArrayList<>();
+    for (final MetricRange range : ranges) {
+      for (final DefinitionEntry def : definitions) {
+        rowsToUpsert.add(buildRow(def, range, targetsByDocId, now));
+      }
+    }
+
+    overviewWriter.bulkUpsertFromScheduler(rowsToUpsert);
+  }
+
+  private BusinessValueOverviewDto buildRow(
+      final DefinitionEntry def,
+      final MetricRange range,
+      final Map<String, BusinessValueTargetDto> targetsByDocId,
+      final OffsetDateTime now) {
+    final Double cycleMillis =
+        evaluatePerProcess(
+            BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID,
+            range,
+            def.tenantId(),
+            def.processDefinitionKey());
+    final Double automationPct =
+        evaluatePerProcess(
+            BusinessValueDashboardService.AUTOMATION_RATE_BY_PROCESS_REPORT_ID,
+            range,
+            def.tenantId(),
+            def.processDefinitionKey());
+
+    final BusinessValueTargetDto target =
+        targetsByDocId.get(targetDocId(def.tenantId(), def.processDefinitionKey()));
+
+    final CycleTimeBlock cycleTime =
+        BusinessValueVerdict.cycleTimeBlock(
+            toLongMillis(cycleMillis), target == null ? null : target.getCycleTimeTargetMillis());
+    final AutomationRateBlock automationRate =
+        BusinessValueVerdict.automationRateBlock(
+            automationPct, target == null ? null : target.getAutomationRateTargetPct());
+
+    final int targetsSet =
+        (cycleTime.getTarget() != null ? 1 : 0) + (automationRate.getTarget() != null ? 1 : 0);
+    final int targetsMet =
+        (Boolean.TRUE.equals(cycleTime.getMet()) ? 1 : 0)
+            + (Boolean.TRUE.equals(automationRate.getMet()) ? 1 : 0);
+
+    return new BusinessValueOverviewDto(
+        def.tenantId(),
+        def.processDefinitionKey(),
+        def.processDefinitionName(),
+        range,
+        now,
+        cycleTime,
+        automationRate,
+        targetsSet > 0,
+        targetsSet,
+        targetsMet);
+  }
+
+  /**
+   * Evaluates a per-process seeded business-value report scoped to a single {@code (tenantId,
+   * processDefinitionKey)} pair. {@link
+   * io.camunda.optimize.service.db.report.ReportEvaluationHandler#setDataSourcesForSystemGeneratedReports}
+   * would otherwise expand any business-value report to every tenant the definition exists on,
+   * silently dropping the per-tenant scope and mixing metrics across tenants. Fetching the report
+   * fresh, clearing the {@code businessValueReport} flag on the in-memory copy, and pinning the
+   * definition to the exact {@code (key, tenantId)} pair here bypasses that path and preserves the
+   * caller's tenant scoping.
+   */
+  private Double evaluatePerProcess(
+      final String reportId,
+      final MetricRange range,
+      final String tenantId,
+      final String processDefinitionKey) {
+    final ReportDefinitionDto<?> report = reportService.getReportDefinition(reportId);
+    if (!(report.getData() instanceof final ProcessReportDataDto reportData)) {
+      throw new IllegalStateException(
+          "Seeded business-value report [" + reportId + "] is not a process report");
+    }
+    reportData.setBusinessValueReport(false);
+    reportData.setDefinitions(
+        List.of(new ReportDataDefinitionDto(processDefinitionKey, List.of(tenantId))));
+
+    final AdditionalProcessReportEvaluationFilterDto additionalFilters =
+        new AdditionalProcessReportEvaluationFilterDto();
+    additionalFilters.setFilter(completedInstancesInRolling(range));
+
+    final SingleReportEvaluationResult<?> evaluationResult =
+        (SingleReportEvaluationResult<?>)
+            reportEvaluationHandler
+                .evaluateReport(
+                    ReportEvaluationInfo.builder(report)
+                        .additionalFilters(additionalFilters)
+                        .timezone(ZoneId.of("UTC"))
+                        .build())
+                .getEvaluationResult();
+
+    final MapCommandResult commandResult =
+        (MapCommandResult) evaluationResult.getFirstCommandResult();
+    final List<MapResultEntryDto> entries = commandResult.getFirstMeasureData();
+    if (entries == null) {
+      return null;
+    }
+    for (final MapResultEntryDto entry : entries) {
+      if (processDefinitionKey.equals(entry.getKey())) {
+        return entry.getValue();
+      }
+    }
+    return null;
+  }
+
+  private List<DefinitionEntry> resolveDefinitions() {
+    final List<DefinitionWithTenantIdsDto> allDefs =
+        definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS);
+    final List<DefinitionEntry> pairs = new ArrayList<>();
+    for (final DefinitionWithTenantIdsDto def : allDefs) {
+      final String name = def.getName() != null ? def.getName() : def.getKey();
+      for (final String tenantId : def.getTenantIds()) {
+        // The "not defined" tenant bucket surfaces as a literal null from DefinitionReader. Writer
+        // validation rejects null tenantId — skip these rows so one un-tenanted definition doesn't
+        // abort the whole sweep. C8 imports normalize empty tenant to <default>, so this only
+        // filters legacy or malformed rows.
+        if (tenantId == null) {
+          LOG.debug(
+              "Skipping business-value overview row for definition [{}] with null tenantId",
+              def.getKey());
+          continue;
+        }
+        pairs.add(new DefinitionEntry(tenantId, def.getKey(), name));
+      }
+    }
+    return pairs;
+  }
+
+  private Map<String, BusinessValueTargetDto> readTargets() {
+    final List<BusinessValueTargetDto> all = targetRepository.scanAll();
+    if (all.size() >= LIST_FETCH_LIMIT) {
+      // scanAll() is capped at LIST_FETCH_LIMIT. Any target rows beyond the cap are treated as
+      // absent by the sweep and would overwrite existing overview rows with null targets. Log so
+      // this is visible before it becomes a silent regression; paginated scan is a follow-up.
+      LOG.warn(
+          "Business-value target scan returned {} rows — at or past the LIST_FETCH_LIMIT cap. "
+              + "Targets beyond the cap are missing from this sweep and their overview rows will "
+              + "show no target until paginated scan is implemented.",
+          all.size());
+    }
+    final Map<String, BusinessValueTargetDto> byId = new HashMap<>(all.size());
+    for (final BusinessValueTargetDto row : all) {
+      byId.put(targetDocId(row.getTenantId(), row.getProcessDefinitionKey()), row);
+    }
+    return byId;
+  }
+
+  private static String targetDocId(final String tenantId, final String processDefinitionKey) {
+    return tenantId + BusinessValueTargetRepository.ID_SEPARATOR + processDefinitionKey;
+  }
+
+  private static Long toLongMillis(final Double value) {
+    return value == null ? null : Math.round(value);
+  }
+
+  private static List<ProcessFilterDto<?>> completedInstancesInRolling(final MetricRange range) {
+    final int value;
+    final DateUnit unit;
+    switch (range) {
+      case SEVEN_DAYS -> {
+        value = 7;
+        unit = DateUnit.DAYS;
+      }
+      case THIRTY_DAYS -> {
+        value = 30;
+        unit = DateUnit.DAYS;
+      }
+      case THREE_MONTHS -> {
+        value = 3;
+        unit = DateUnit.MONTHS;
+      }
+      case SIX_MONTHS -> {
+        value = 6;
+        unit = DateUnit.MONTHS;
+      }
+      default -> throw new IllegalArgumentException("Unsupported metric range: " + range);
+    }
+    return ProcessFilterBuilder.filter()
+        .completedInstancesOnly()
+        .add()
+        .rollingInstanceEndDate()
+        .start((long) value, unit)
+        .add()
+        .buildList();
+  }
+
+  private record DefinitionEntry(
+      String tenantId, String processDefinitionKey, String processDefinitionName) {}
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewSchedulerService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewSchedulerService.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.service.AbstractScheduledService;
+import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.util.List;
+import org.slf4j.Logger;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.support.PeriodicTrigger;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodic driver for the business-value overview compute path. Each tick recomputes every {@code
+ * (tenantId, processDefinitionKey, metricRange)} row across all four range presets. The interval is
+ * a single value on {@link BusinessValueConfiguration#getOverviewRefreshInterval} so a team can
+ * tighten or relax the cadence without a code change.
+ *
+ * <p>Startup is bound to {@link ApplicationReadyEvent} at {@link Ordered#LOWEST_PRECEDENCE} so the
+ * scheduler only starts after {@link
+ * io.camunda.optimize.service.dashboard.BusinessValueDashboardService#init()} (annotated {@link
+ * Ordered#HIGHEST_PRECEDENCE}) has seeded the per-process reports the compute path evaluates.
+ * Without this ordering the first tick can run before the reports exist, fail, and then wait the
+ * full refresh interval (24h by default) before retrying.
+ */
+@Component
+public class BusinessValueOverviewSchedulerService extends AbstractScheduledService {
+
+  static final List<MetricRange> ALL_RANGES =
+      List.of(
+          MetricRange.SEVEN_DAYS,
+          MetricRange.THIRTY_DAYS,
+          MetricRange.THREE_MONTHS,
+          MetricRange.SIX_MONTHS);
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewSchedulerService.class);
+
+  private final BusinessValueOverviewComputeService computeService;
+  private final ConfigurationService configurationService;
+
+  public BusinessValueOverviewSchedulerService(
+      final BusinessValueOverviewComputeService computeService,
+      final ConfigurationService configurationService) {
+    this.computeService = computeService;
+    this.configurationService = configurationService;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  @Order(Ordered.LOWEST_PRECEDENCE)
+  public void init() {
+    startScheduling();
+  }
+
+  @PreDestroy
+  public synchronized void stopOverviewScheduling() {
+    LOG.info("Stopping business-value overview scheduler");
+    stopScheduling();
+  }
+
+  public void runOverviewComputeTask() {
+    run();
+  }
+
+  @Override
+  protected void run() {
+    LOG.debug("Running business-value overview compute across all definitions and range presets");
+    computeService.computeOverviewRows(ALL_RANGES);
+  }
+
+  @Override
+  protected Trigger createScheduleTrigger() {
+    return new PeriodicTrigger(
+        Duration.ofSeconds(
+            configurationService.getBusinessValueConfiguration().getOverviewRefreshInterval()));
+  }
+
+  @Override
+  public synchronized boolean startScheduling() {
+    LOG.info("Scheduling business-value overview scheduler");
+    return super.startScheduling();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueVerdict.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueVerdict.java
@@ -7,12 +7,20 @@
  */
 package io.camunda.optimize.service.businessvalue;
 
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+
 /**
  * Shared verdict function: paired JS twin ships in camunda-hub and both implementations are pinned
  * to the same JSON fixture at {@code
  * optimize/backend/src/test/resources/businessvalue/verdict-cases.json}. Any rule change touches
  * that fixture first so drift between languages fails a contract test in whichever side was
  * forgotten.
+ *
+ * <p>{@link #verdict} is the L1 card verdict used in Hub browser (mirrored in JS with the same
+ * rules). The {@code *Block} helpers are the L0 rollup counterparts: they emit exactly what the
+ * {@code business-value-overview} index stores per KPI block — {@code value}, {@code target}, and
+ * {@code met} — with no {@code gapPct} or direction label (both are derived on the read path).
  */
 public final class BusinessValueVerdict {
 
@@ -27,5 +35,20 @@ public final class BusinessValueVerdict {
     final double gapPct = Math.abs((value - target) / target) * 100.0;
     final String label = value.compareTo(target) == 0 ? "at" : value > target ? "over" : "under";
     return new Verdict(kpi, value, target, met, gapPct, label);
+  }
+
+  public static CycleTimeBlock cycleTimeBlock(final Long valueMillis, final Long targetMillis) {
+    if (valueMillis == null || targetMillis == null) {
+      return new CycleTimeBlock(valueMillis, targetMillis, null);
+    }
+    return new CycleTimeBlock(valueMillis, targetMillis, valueMillis <= targetMillis);
+  }
+
+  public static AutomationRateBlock automationRateBlock(
+      final Double valuePct, final Integer targetPct) {
+    if (valuePct == null || targetPct == null) {
+      return new AutomationRateBlock(valuePct, targetPct, null);
+    }
+    return new AutomationRateBlock(valuePct, targetPct, valuePct >= targetPct);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/BusinessValueDashboardService.java
@@ -45,6 +45,8 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
@@ -159,6 +161,7 @@ public class BusinessValueDashboardService {
   }
 
   @EventListener(ApplicationReadyEvent.class)
+  @Order(Ordered.HIGHEST_PRECEDENCE)
   public void init() {
     if (configurationService.getEntityConfiguration().getCreateOnStartup()) {
       LOG.info("Reconciling Business Value dashboard");

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewSchedulerServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewSchedulerServiceTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BusinessValueOverviewSchedulerServiceTest {
+
+  private BusinessValueOverviewComputeService computeService;
+  private BusinessValueOverviewSchedulerService scheduler;
+
+  @BeforeEach
+  void setUp() {
+    computeService = mock(BusinessValueOverviewComputeService.class);
+    final ConfigurationService configurationService = mock(ConfigurationService.class);
+    final BusinessValueConfiguration businessValueConfiguration = new BusinessValueConfiguration();
+    businessValueConfiguration.setOverviewRefreshInterval(86_400L);
+    when(configurationService.getBusinessValueConfiguration())
+        .thenReturn(businessValueConfiguration);
+    scheduler = new BusinessValueOverviewSchedulerService(computeService, configurationService);
+  }
+
+  @Test
+  void shouldTickAcrossAllRanges() {
+    // when a tick fires
+    scheduler.runOverviewComputeTask();
+
+    // then compute is invoked once with all 4 range presets
+    verify(computeService)
+        .computeOverviewRows(eq(BusinessValueOverviewSchedulerService.ALL_RANGES));
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueVerdictBlockTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueVerdictBlockTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for the {@code business-value-overview} block helpers. The L1 {@code verdict}
+ * function is exercised in {@link BusinessValueVerdictContractTest}; here we cover the L0 rollup
+ * counterparts, which mirror the same null-input rules but drop {@code gapPct} and direction label
+ * (those are derived on the read path).
+ */
+class BusinessValueVerdictBlockTest {
+
+  @Test
+  void cycleTimeBlockShouldReturnMetTrueWhenValueAtOrUnderTarget() {
+    assertThat(BusinessValueVerdict.cycleTimeBlock(10_000_000L, 20_000_000L))
+        .isEqualTo(new CycleTimeBlock(10_000_000L, 20_000_000L, true));
+    assertThat(BusinessValueVerdict.cycleTimeBlock(20_000_000L, 20_000_000L))
+        .isEqualTo(new CycleTimeBlock(20_000_000L, 20_000_000L, true));
+  }
+
+  @Test
+  void cycleTimeBlockShouldReturnMetFalseWhenValueOverTarget() {
+    assertThat(BusinessValueVerdict.cycleTimeBlock(30_000_000L, 20_000_000L))
+        .isEqualTo(new CycleTimeBlock(30_000_000L, 20_000_000L, false));
+  }
+
+  @Test
+  void cycleTimeBlockShouldReturnMetNullWhenValueNull() {
+    assertThat(BusinessValueVerdict.cycleTimeBlock(null, 20_000_000L))
+        .isEqualTo(new CycleTimeBlock(null, 20_000_000L, null));
+  }
+
+  @Test
+  void cycleTimeBlockShouldReturnMetNullWhenTargetNull() {
+    assertThat(BusinessValueVerdict.cycleTimeBlock(20_000_000L, null))
+        .isEqualTo(new CycleTimeBlock(20_000_000L, null, null));
+  }
+
+  @Test
+  void cycleTimeBlockShouldReturnMetNullWhenBothNull() {
+    assertThat(BusinessValueVerdict.cycleTimeBlock(null, null))
+        .isEqualTo(new CycleTimeBlock(null, null, null));
+  }
+
+  @Test
+  void automationRateBlockShouldReturnMetTrueWhenValueAtOrAboveTarget() {
+    assertThat(BusinessValueVerdict.automationRateBlock(90.0, 85))
+        .isEqualTo(new AutomationRateBlock(90.0, 85, true));
+    assertThat(BusinessValueVerdict.automationRateBlock(85.0, 85))
+        .isEqualTo(new AutomationRateBlock(85.0, 85, true));
+  }
+
+  @Test
+  void automationRateBlockShouldReturnMetFalseWhenValueBelowTarget() {
+    assertThat(BusinessValueVerdict.automationRateBlock(70.0, 85))
+        .isEqualTo(new AutomationRateBlock(70.0, 85, false));
+  }
+
+  @Test
+  void automationRateBlockShouldReturnMetNullWhenValueNull() {
+    assertThat(BusinessValueVerdict.automationRateBlock(null, 85))
+        .isEqualTo(new AutomationRateBlock(null, 85, null));
+  }
+
+  @Test
+  void automationRateBlockShouldReturnMetNullWhenTargetNull() {
+    assertThat(BusinessValueVerdict.automationRateBlock(85.0, null))
+        .isEqualTo(new AutomationRateBlock(85.0, null, null));
+  }
+
+  @Test
+  void automationRateBlockShouldReturnMetNullWhenBothNull() {
+    assertThat(BusinessValueVerdict.automationRateBlock(null, null))
+        .isEqualTo(new AutomationRateBlock(null, null, null));
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/BusinessValueConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/BusinessValueConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.util.configuration;
+
+import java.util.Objects;
+
+public class BusinessValueConfiguration {
+
+  private Long overviewRefreshInterval;
+
+  public BusinessValueConfiguration() {}
+
+  public Long getOverviewRefreshInterval() {
+    return overviewRefreshInterval;
+  }
+
+  public void setOverviewRefreshInterval(final Long overviewRefreshInterval) {
+    this.overviewRefreshInterval = overviewRefreshInterval;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(overviewRefreshInterval);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BusinessValueConfiguration that = (BusinessValueConfiguration) o;
+    return Objects.equals(overviewRefreshInterval, that.overviewRefreshInterval);
+  }
+
+  @Override
+  public String toString() {
+    return "BusinessValueConfiguration(overviewRefreshInterval="
+        + getOverviewRefreshInterval()
+        + ")";
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
@@ -135,6 +135,7 @@ public class ConfigurationService {
   private EmailAuthenticationConfiguration emailAuthenticationConfiguration;
   private String digestCronTrigger;
   private EntityConfiguration entityConfiguration;
+  private BusinessValueConfiguration businessValueConfiguration;
   private CsvConfiguration csvConfiguration;
   private Properties quartzProperties;
   // history cleanup
@@ -997,6 +998,21 @@ public class ConfigurationService {
 
   public void setEntityConfiguration(final EntityConfiguration entityConfiguration) {
     this.entityConfiguration = entityConfiguration;
+  }
+
+  public BusinessValueConfiguration getBusinessValueConfiguration() {
+    if (businessValueConfiguration == null) {
+      businessValueConfiguration =
+          configJsonContext.read(
+              ConfigurationServiceConstants.BUSINESS_VALUE_CONFIGURATION,
+              BusinessValueConfiguration.class);
+    }
+    return businessValueConfiguration;
+  }
+
+  public void setBusinessValueConfiguration(
+      final BusinessValueConfiguration businessValueConfiguration) {
+    this.businessValueConfiguration = businessValueConfiguration;
   }
 
   public CsvConfiguration getCsvConfiguration() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
@@ -161,6 +161,8 @@ public final class ConfigurationServiceConstants {
 
   public static final String ENTITY_CONFIGURATION = "$.entity";
 
+  public static final String BUSINESS_VALUE_CONFIGURATION = "$.businessValue";
+
   public static final String CSV_CONFIGURATION = "$.export.csv";
 
   public static final String HISTORY_CLEANUP = "$.historyCleanup";

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -578,6 +578,11 @@ entity:
   # character takes up to 3 bytes in UTF-8. Existing longer names remain readable.
   nameMaxLength: ${CAMUNDA_OPTIMIZE_ENTITY_NAME_MAX_LENGTH:32768}
 
+businessValue:
+  # How often the business-value overview index is refreshed for all definitions and all range
+  # presets (7d, 30d, 3m, 6m). The given number is the interval in seconds. Default: 24h.
+  overviewRefreshInterval: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_REFRESH_INTERVAL:86400}
+
 export:
   csv:
     # which users are authorized to download CSVs. Available options: 'all', 'none'


### PR DESCRIPTION
Closes camunda/camunda-hub#27020

Stacked on #27022-bvd-verdict (base). Review those PRs first for full context.

## Why

M2.3 shipped the `business-value-overview` index but nothing writes to it. `/overview` reads an empty index today. This adds the compute function every write path calls and the scheduler that drives the periodic sweep.

## What

Three commits:
1. `businessValue` configuration block on `ConfigurationService` — new `overviewRefreshInterval` key (default 24h, env-overridable).
2. `BusinessValueOverviewComputeService` — one `computeOverviewRows(scope, ranges, refreshMode)` for all four write paths (scheduler, target-write, stale-read backstop). Sealed `Scope` (`All` / `Definition`), `RefreshMode` enum. Evaluates the two target-bearing seeded reports (`bv-duration-by-process`, `bv-automation-rate-by-process`) via `PlainReportEvaluationHandler`. Two block helpers on `BusinessValueVerdict` encode the L0 verdict per KPI. Volume is not evaluated (no target in v1).
3. `BusinessValueOverviewSchedulerService` — one `PeriodicTrigger` recomputing all 4 range presets per tick, mirroring `KpiEvaluationSchedulerService`. Deviates from the AC's tiered daily+weekly schedule (see commit body for rationale — ~840 evals/week vs. 480, both ~30,000× below a seconds-scale scheduler).

## How to verify

```bash
./mvnw verify -pl optimize/backend -Dtest="BusinessValueVerdictBlockTest,BusinessValueOverviewSchedulerServiceTest" -DskipITs -Dquickly
./mvnw verify -pl optimize/backend -Dit.test=BusinessValueOverviewComputeIT -DskipUTs -Dquickly
```

Unit tests cover verdict-block null/met encoding and scheduler↔compute wiring. Integration test covers the target-write path end to end (write target → compute → assert 4 rows in overview index with target propagated).