### PR TITLE
fix: retry the jattach download when the TLS connection to github.com fails

### DIFF
--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -48,10 +48,10 @@ ARG JATTACH_VERSION
 ARG JATTACH_CHECKSUM_AMD64
 ARG JATTACH_CHECKSUM_ARM64
 
-# hadolint ignore=DL4006,DL3018
 # --retry-all-errors is what makes the retry apply to a dropped or refused TLS
 # connection to github.com; without it curl only retries timeouts and 5xx, and
 # an SSL connect error (exit 35) fails the build on the first attempt.
+# hadolint ignore=DL4006,DL3018
 RUN apk add -q --no-cache curl && \
     if [ "${TARGETARCH}" = "amd64" ]; then \
       BINARY="linux-x64"; \

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -49,8 +49,10 @@ ARG JATTACH_CHECKSUM_AMD64
 ARG JATTACH_CHECKSUM_ARM64
 
 # hadolint ignore=DL4006,DL3018
-RUN --mount=type=cache,target=/root/.jattach,rw \
-    apk add -q --no-cache curl && \
+# --retry-all-errors is what makes the retry apply to a dropped or refused TLS
+# connection to github.com; without it curl only retries timeouts and 5xx, and
+# an SSL connect error (exit 35) fails the build on the first attempt.
+RUN apk add -q --no-cache curl && \
     if [ "${TARGETARCH}" = "amd64" ]; then \
       BINARY="linux-x64"; \
       CHECKSUM="${JATTACH_CHECKSUM_AMD64}"; \
@@ -58,7 +60,7 @@ RUN --mount=type=cache,target=/root/.jattach,rw \
       BINARY="linux-arm64"; \
       CHECKSUM="${JATTACH_CHECKSUM_ARM64}"; \
     fi && \
-    curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
+    curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
       "https://github.com/jattach/jattach/releases/download/${JATTACH_VERSION}/jattach-${BINARY}.tgz" \
       -o jattach.tgz && \
     echo "${CHECKSUM} jattach.tgz" | sha256sum -c && \

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -49,8 +49,9 @@ ARG JATTACH_CHECKSUM_AMD64
 ARG JATTACH_CHECKSUM_ARM64
 
 # --retry-all-errors is what makes the retry apply to a dropped or refused TLS
-# connection to github.com; without it curl only retries timeouts and 5xx, and
-# an SSL connect error (exit 35) fails the build on the first attempt.
+# connection to github.com. On its own --retry covers a timeout and the HTTP
+# 408, 429, 500, 502, 503 and 504 responses, none of which an SSL connect error
+# (exit 35) is, so without it the download fails on the first attempt.
 # hadolint ignore=DL4006,DL3018
 RUN apk add -q --no-cache curl && \
     if [ "${TARGETARCH}" = "amd64" ]; then \


### PR DESCRIPTION
## Problem

The `jattach` stage of `camunda.Dockerfile` downloads a release tarball from github.com. When that
connection is dropped or refused, the build fails immediately:

```
#16 ERROR: process "/bin/sh -c apk add -q --no-cache curl && ... curl -fsSL --retry 3 --retry-delay 5
  --retry-connrefused https://github.com/jattach/jattach/releases/download/${JATTACH_VERSION}/jattach-${BINARY}.tgz ..."
  did not complete successfully: exit code: 35
```

Exit 35 is curl's SSL connect error. Two CI incidents have this failure:

| Incident | Job | Slack |
| --- | --- | --- |
| [INC-6721](https://app.incident.io/camunda/incidents/6721) | `integration-tests/root` on `main` | [#inc-6721-…](https://camunda.slack.com/archives/C0BK6ME1S79) |
| [INC-7066](https://app.incident.io/camunda/incidents/7066) | `integration-tests/zeebe-ds-integration` on `main` | [#inc-7066-…](https://camunda.slack.com/archives/C0BNK0N0FP1) |

Because `build-platform-docker` backs every image build in the repository, each occurrence costs a
manual re-run.

## Root cause

https://github.com/camunda/camunda/blob/a3757dfaeb420e71ece1ae4551041f48d9921cc4/camunda.Dockerfile#L61-L63

The call looks like it already retried and gave up. It did not — it never retried once.

`--retry` covers a timeout and the HTTP 408, 429, 500, 502, 503 and 504 responses (plus FTP 4xx).
`--retry-connrefused` extends that to `ECONNREFUSED` and nothing else. A TLS-level connect error is in
neither set, so curl returned on the first attempt and `--retry 3 --retry-delay 5` had no effect on
the failure they were added for.

## Fix

`--retry-all-errors` makes every error class retryable, which is the behaviour the existing flags
were meant to provide. It supersedes `--retry-connrefused`, so that flag goes. Attempts go 3 → 5;
they only cost wall-clock when the download is genuinely failing.

The `sha256sum -c` check is untouched and still gates what lands in the image, so retrying cannot
widen what is accepted — a retry either produces the pinned checksum or the build still fails.

### The cache mount is removed because it never cached anything

https://github.com/camunda/camunda/blob/a3757dfaeb420e71ece1ae4551041f48d9921cc4/camunda.Dockerfile#L52

`curl -o jattach.tgz` writes into the working directory, not into `/root/.jattach`, so the mount was
empty on every build. Buildkit cache mounts are also not carried by the registry or GHA cache
backends, so on the ephemeral CI runners it could not have survived a job even if the path had
matched. Repeat builds are served by the layer cache, which this does not touch.

Making the mount work instead — writing the tarball into it and skipping the download when present —
was the alternative. It buys nothing on the runners for the reason above, and adds a
staleness-vs-`JATTACH_VERSION` question that the layer cache already answers correctly.

## Why not mirror jattach internally

Considered and rejected. Two occurrences do not pay for an upload pipeline, per-arch artifacts, a
version-bump process, buildkit auth for the mirror, `JATTACH_VERSION` dropping out of Renovate's
view, and a new failure mode when the mirror is down.

## Relation to #59827

#59827 wraps the whole `Build Docker image` step in `Wandalen/wretry.action`, so this failure was
already going to be re-attempted at the step level. That PR called this class out explicitly as
failing inside the action for a different reason and not expected to be resolved by it. This fixes
it at the layer where it happens, which is both cheaper (only the failed `curl`, not the whole build
step) and effective on the call sites regardless.

## Verification

- The stage builds green with the change: `docker build --target jattach --build-arg TARGETARCH=amd64
  -f camunda.Dockerfile .` → `jattach.tgz: OK`, checksum verified against the pinned
  `JATTACH_CHECKSUM_AMD64`.
- The retry path itself is **not** exercised — a TLS connect error to github.com cannot be forced on
  demand. What is verified is that the flag is accepted and the happy path is unchanged; that
  exit 35 now falls inside curl's retry set follows from `--retry-all-errors` covering all error
  classes.

## Not in scope

`optimize.Dockerfile` fetches `wait-for-it.sh` from raw.githubusercontent.com with no retry at all:

https://github.com/camunda/camunda/blob/a3757dfaeb420e71ece1ae4551041f48d9921cc4/optimize.Dockerfile#L89

Same exposure, but `wget` there is ambiguous between busybox and GNU on that base image and the flags
differ, so it wants its own change rather than a guess bundled into this one.
