### PR TITLE
fix: give npm ci room to finish and keep its retry meaningful

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -176,7 +176,7 @@ jobs:
     needs: [fe-unit-tests]
     name: "Unit - Front End - Merge Reports"
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
@@ -195,7 +195,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -210,7 +210,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - TypeScript Type Check"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -231,7 +231,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - run: npm run ts-check
         name: Type checks
       - name: Observe build status
@@ -249,7 +249,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -270,7 +270,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - run: npm run lint:eslint
         name: ESLint
       - name: Observe build status
@@ -287,7 +287,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -308,7 +308,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - run: npm run lint:prettier
         name: Prettier
       - name: Observe build status
@@ -435,7 +435,7 @@ jobs:
     needs: [operate-fe-visual-regression-tests]
     name: "Unit / Front End - Visual Regression - Merge Reports"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
@@ -457,7 +457,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -80,7 +80,7 @@ jobs:
 
   fe-type-check:
     if: inputs.runFeTests
-    name: "Tool /  Front End - Type check"
+    name: "Tool / Front End - Type check"
     runs-on: ubuntu-latest
     timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -82,7 +82,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool /  Front End - Type check"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -103,7 +103,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - run: npm run ts-check
         name: Type checks
       - name: Observe build status
@@ -120,7 +120,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -141,7 +141,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - run: npm run lint:eslint
         name: ESLint
       - name: Observe build status
@@ -158,7 +158,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Stylelint"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -178,7 +178,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - run: npm run lint:stylelint
         name: Stylelint
       - name: Observe build status
@@ -195,7 +195,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -216,7 +216,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - run: npm run lint:prettier
         name: Prettier
       - name: Observe build status

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -18,7 +18,7 @@ jobs:
   typecheck:
     name: "Type check"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -38,7 +38,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - name: Type check
         run: npm run typecheck
       - name: Observe build status
@@ -54,7 +54,7 @@ jobs:
   eslint:
     name: "ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -74,7 +74,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - name: ESLint
         run: npm run lint:eslint
       - name: Observe build status
@@ -90,7 +90,7 @@ jobs:
   knip:
     name: "Knip"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -110,7 +110,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - name: Knip
         run: npm run lint:knip
       - name: Observe build status
@@ -126,7 +126,7 @@ jobs:
   prettier:
     name: "Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -146,7 +146,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
       - name: Prettier
         run: npm run lint:prettier
       - name: Observe build status


### PR DESCRIPTION
## Problem

[INC-7085](https://app.incident.io/camunda/incidents/7085) ([#inc-7085-…](https://camunda.slack.com/archives/C0BQ1G63Y1E))
failed `Webapp Client / Knip` on `main` with no test failure and no npm failure of its own —
[run 31392591996](https://github.com/camunda/camunda/actions/runs/31392591996), step *Install dependencies*:

```
Cache not found for input keys: github-hosted-Linux-npm-shared-8d9e8094…
##[warning]Attempt 1 failed. Reason: Timeout of 120000ms hit
##[error]Final attempt failed. Timeout of 120000ms hit
```

The npm cache missed, `npm ci` ran long, and both attempts were SIGTERMed at exactly 120 s.

npm does report `npm error process terminated` / `npm error signal SIGTERM`, plus `ENOTEMPTY` cleanup
warnings as it rolls back a half-written `node_modules`. That is npm reporting that it *was killed* —
not npm failing on its own. The block belongs to **attempt 1**: its debug log is
`_logs/2026-08-10T13_23_37_835Z-debug-0.log` and attempt 1 started at `13:23:37.7`; the output is
simply flushed after attempt 2's group header opened at `13:25:44`. The `inflight` / `glob`
deprecation warnings in the same excerpt are pre-existing dependency noise, unrelated to the failure.

## How tight 120 s actually is

Every `Install dependencies` step across the last 15 CI runs on `main` (n=390):

| p50 | p90 | p99 | max | over 60 s |
| --- | --- | --- | --- | --- |
| 30 s | 42 s | 46 s | 59 s | 0 |

So the cap sat at roughly **2.5× the worst normal run** — fine for ordinary variance, not for a cache
miss during a slow spell. The value came from the call sites, not the action:

https://github.com/camunda/camunda/blob/5cfc45ed767aea810d1efb1fd953cd7d8dc13282/.github/workflows/ci-webapp-client.yml#L108-L113

## Fix

Raise the per-attempt cap to **3 minutes** (3× the worst normal run), and raise the job timeout from
**7 to 8 minutes** on the jobs that needed it.

```diff
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "2"
+          timeout_minutes: "3"
```

### Why the job timeout has to move too

This is the part worth reviewing. A retry is only worth having if the second attempt can actually run,
which requires two full attempts to fit inside the job's own budget:

    job timeout − (checkout + setup + cache restore) − (work after install)

Measured against the worst observed preamble and post-install work per job:

| Job timeout | Install budget | Two 3-min attempts need 360 s |
| --- | --- | --- |
| 7 min | 339–392 s | ✗ one job short, tightest cleared by **1 s** |
| 8 min | 421–452 s | ✓ at least **61 s** of slack |
| 12 min | 500–642 s | ✓ already fine, untouched |
| 15 min | 440–712 s | ✓ already fine, untouched |

At the old 7 minutes the retry was decorative in the tight jobs: a slow attempt 1 would consume the
whole job budget and attempt 2 would never start. At 8 minutes it is real.

All **13** jobs in these three workflows that were on a 7-minute timeout run an install step, so the
bump covers exactly the affected jobs and no others.

`max_attempts` stays at 2 — the point of this change is to make that 2 mean something.

## Scope

22 install steps across three workflows: `ci-webapp-client.yml`, `ci-operate.yml`, `ci-tasklist.yml`.
13 were at `"2"` and are raised to `"3"`; 9 were already at `"3"`. Plus the 13 job timeouts.
26 lines changed, no additions or deletions of steps.

## Verification

- `actionlint` on the three files: **3 findings before, 3 after** — the same pre-existing
  `runner-label` warnings for `gcp-*` self-hosted labels. No new findings.
- All 22 install steps now report `timeout_minutes: "3"`; no `timeout-minutes: 7` remains in the three
  files; every other timeout in the repo is untouched.
- The budget table above is computed from 297 real job/step timing samples, not estimated.
- **Not verified:** that a cache-miss install now completes. INC-7085's true install duration is
  unknown — only that it exceeded 120 s twice — so 3 minutes is a measured multiple of normal, not a
  proven fit. If a >3 min install appears later, that is evidence to raise again.

## Alternative considered

Deleting the overrides entirely and inheriting the action's 10-minute default. Rejected: with
`max_attempts: "2"` the per-step budget would exceed every job timeout, so a slow attempt 1 would eat
the job and the retry would never fire — trading a clear `Timeout of 180000ms hit` for a vaguer
`job has exceeded the maximum execution time`.

## Also in this PR

`4464b09747e` removes a double space from the `fe-type-check` job display name in `ci-tasklist.yml`
(`"Tool /  Front End - Type check"`), raised by review. It was the only such name in the repository.
Kept as a separate commit so it can be reverted independently.

Note for whoever finds the graph later: job display names are the grouping key for the `ci-job-trends`
dashboard and the `base-branch-unsuccessful-job` alerts, so this job's history splits at the rename.
Merge gating is unaffected — no ruleset or branch protection rule requires this job as a status check.

## Not in scope

INC-7090, which fired against the same runs, is an unrelated jib manifest-push timeout to
`registry.camunda.cloud` and needs its own change.
