### PR TITLE
feat: purge the history of every physical tenant, not just the default one

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -908,9 +908,6 @@
               <excludes>
                 <exclude>${identity-packages}</exclude>
                 <exclude>**/*$*.java</exclude>
-                <!-- Cluster purge is not routed to the per-tenant secondary store, so purged
-                     entities still surface in tenant-scoped search. -->
-                <exclude>**/ClusterPurgeMultiDbIT.java</exclude>
                 <!-- MCP server search/audit not yet validated under physical-tenant mode. -->
                 <exclude>**/mcp/authentication/BasicAuthMcpServerIT.java</exclude>
                 <exclude>**/mcp/authentication/OidcMcpServerIT.java</exclude>

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
@@ -100,11 +101,22 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
    * Builds the purge plan of a single partition group: all members leave their partitions, the
    * history exported by this group is deleted, the group's incarnation number is bumped, and the
    * partitions are bootstrapped and joined again with their original priorities and configuration.
+   *
+   * <p>The history deletion and the incarnation bump are assigned to the lowest-id member that
+   * actually replicates a partition of this group. A member can be present with an empty partition
+   * map — transiently, while it is being removed from the group — and such a member is not active
+   * in the group at all (see {@link PartitionGroupConfiguration}), so it holds none of the group's
+   * exporter state and must not be the one to purge it. A group no member replicates has nothing to
+   * tear down or re-bootstrap and yields no operations.
    */
   private List<PartitionGroupOperation> purgeOperationsFor(
       final PartitionGroupConfiguration group) {
-    final var firstMember = group.members().keySet().stream().findFirst();
-    if (firstMember.isEmpty()) {
+    final var replicatingMember =
+        group.members().entrySet().stream()
+            .filter(member -> !member.getValue().partitions().isEmpty())
+            .map(Entry::getKey)
+            .findFirst();
+    if (replicatingMember.isEmpty()) {
       return List.of();
     }
 
@@ -133,8 +145,8 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
       }
     }
 
-    operations.add(new DeleteHistoryOperation(firstMember.get()));
-    operations.add(new UpdateIncarnationNumberOperation(firstMember.get()));
+    operations.add(new DeleteHistoryOperation(replicatingMember.get()));
+    operations.add(new UpdateIncarnationNumberOperation(replicatingMember.get()));
 
     operations.addAll(primaries.values());
     followers.values().forEach(operations::addAll);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -175,6 +175,76 @@ final class ClusterConfigurationManagerImplNewConfigTest {
   }
 
   @Test
+  void shouldApplyOneParallelPhaseToEveryPartitionGroupItTargets() {
+    // given — two partition groups (physical tenants), each with the local member replicating its
+    // own partition 1. A cluster purge plans one parallel phase spanning every group, so a phase
+    // that only drained in the default group would leave the other tenant untouched.
+    final var manager = newManager(MEMBER_0);
+    manager.registerPartitionGroupChangeAppliers(
+        "tenanta",
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+
+    final var group =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig))),
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(
+                    MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                    MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group, "tenanta", group),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    // when — one phase carries the local member's leave operation for both groups
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)),
+                                "tenanta",
+                                List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)))))))
+        .join();
+
+    // then — both groups drained their side of the phase
+    final var config = configuration(manager);
+    for (final var groupId : List.of(CurrentClusterConfiguration.DEFAULT_GROUP, "tenanta")) {
+      assertThat(config.partitionGroup(groupId).hasPendingChanges())
+          .describedAs("pending changes of group '%s'", groupId)
+          .isFalse();
+      assertThat(config.partitionGroup(groupId).hasMember(MEMBER_0))
+          .describedAs("member 0 left group '%s'", groupId)
+          .isFalse();
+    }
+  }
+
+  @Test
   void shouldNotApplyOperationForOtherMember() {
     // given — a plan whose only operation targets a different member
     final var manager = newManager(MEMBER_0);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -191,6 +191,48 @@ final class ClusterPurgeRequestTransformerTest {
   }
 
   @Test
+  void shouldDeleteHistoryOnAMemberThatReplicatesTheTenant() {
+    // given — the lowest-id member is present in the group but replicates nothing, which happens
+    // transiently while it is being removed from the group. It is not active in the group, so it
+    // holds none of the tenant's exporter state.
+    final var transformer = new PurgeRequestTransformer(Optional.of(TENANT_A));
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A,
+                group()
+                    .addMember(id0, member(Map.of()))
+                    .addMember(id1, member(Map.of(1, active(1))))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — the member that actually replicates partition 1 deletes the history
+    assertThat(operationsOf(result, TENANT_A))
+        .containsExactly(
+            new PartitionLeaveOperation(id1, 1, 0),
+            new DeleteHistoryOperation(id1),
+            new UpdateIncarnationNumberOperation(id1),
+            new PartitionBootstrapOperation(id1, 1, 1, Optional.of(partitionConfig), false));
+  }
+
+  @Test
+  void shouldNotPlanAnythingWhenNoMemberReplicatesThePhysicalTenant() {
+    // given — a member is listed for the tenant but holds no partition of it: there is nothing to
+    // tear down or re-bootstrap, and no member is responsible for the tenant's storage
+    final var transformer = new PurgeRequestTransformer(Optional.of(TENANT_A));
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, group().addMember(id0, member(Map.of()))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get()).isEmpty();
+  }
+
+  @Test
   void shouldBootstrapPartitionsWithTheirExporterConfig() {
     // given — the two partitions of the tenant have a different exporter configuration
     final var transformer = new PurgeRequestTransformer();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPurgeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPurgeIT.java
@@ -29,22 +29,25 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that the {@code cluster/purge} actuator's {@code physicalTenant} query parameter tears
- * down and re-bootstraps only the named tenant's partitions: after purging one tenant, its
- * processes are gone and it serves commands again on empty state, while another tenant keeps
- * everything it had.
+ * down and re-bootstraps only the named tenant's partitions and deletes only that tenant's exported
+ * history: after purging one tenant, its processes are gone from both the engine and its secondary
+ * storage and it serves commands again on empty state, while another tenant keeps everything it
+ * had.
  */
 @ZeebeIntegration
 final class PhysicalTenantPurgeIT {
 
+  private static final String DEFAULT = PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
   private static final String TENANT_A = "tenanta";
   private static final String PROCESS_ID = "purge-process";
 
-  // both tenants run broker-only (no secondary storage); declaring tenant A starts a second,
-  // fully isolated partition group for it
+  // Each tenant gets its own isolated in-memory RDBMS. Purging deletes the history a tenant
+  // exported, so without a secondary storage per tenant the deletion would run against an empty
+  // exporter repository and only the partition teardown would be covered.
   private static final PhysicalTenantsITHelper TENANTS =
       PhysicalTenantsITHelper.builder()
-          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
-          .withTenant(TENANT_A, Storage.none())
+          .withTenant(DEFAULT, Storage.rdbmsH2("purge-default"))
+          .withTenant(TENANT_A, Storage.rdbmsH2("purge-tenanta"))
           .build();
 
   @TestZeebe
@@ -56,18 +59,19 @@ final class PhysicalTenantPurgeIT {
 
   @BeforeEach
   void beforeEach() {
-    defaultClient =
-        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+    defaultClient = TENANTS.newClientBuilder(broker, DEFAULT).build();
     tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
   }
 
   @Test
   void shouldPurgeOnlyTheTargetedPhysicalTenant() {
-    // given - the same process deployed to, and runnable in, both physical tenants
+    // given - the same process deployed to, runnable in, and exported by both physical tenants
     deploy(defaultClient);
     deploy(tenantAClient);
     assertThat(createInstance(defaultClient)).isPositive();
     assertThat(createInstance(tenantAClient)).isPositive();
+    assertExportedHistory(defaultClient, DEFAULT, 1);
+    assertExportedHistory(tenantAClient, TENANT_A, 1);
 
     // when - purging tenant A only
     ClusterActuator.of(broker).purge(false, TENANT_A);
@@ -76,6 +80,10 @@ final class PhysicalTenantPurgeIT {
     await("tenant A no longer knows its process")
         .atMost(Duration.ofMinutes(2))
         .untilAsserted(() -> assertProcessNotFound(tenantAClient));
+
+    // and - the history tenant A exported is deleted, while the default tenant keeps its own
+    assertExportedHistory(tenantAClient, TENANT_A, 0);
+    assertExportedHistory(defaultClient, DEFAULT, 1);
 
     // and - tenant A serves commands again on empty state
     deploy(tenantAClient);
@@ -87,11 +95,13 @@ final class PhysicalTenantPurgeIT {
 
   @Test
   void shouldPurgeEveryPhysicalTenantWhenNoneIsGiven() {
-    // given - the same process deployed to, and runnable in, both physical tenants
+    // given - the same process deployed to, runnable in, and exported by both physical tenants
     deploy(defaultClient);
     deploy(tenantAClient);
     assertThat(createInstance(defaultClient)).isPositive();
     assertThat(createInstance(tenantAClient)).isPositive();
+    assertExportedHistory(defaultClient, DEFAULT, 1);
+    assertExportedHistory(tenantAClient, TENANT_A, 1);
 
     // when - purging without naming a physical tenant
     ClusterActuator.of(broker).purge(false);
@@ -103,6 +113,34 @@ final class PhysicalTenantPurgeIT {
             () -> {
               assertProcessNotFound(tenantAClient);
               assertProcessNotFound(defaultClient);
+            });
+
+    // and - every tenant's exported history is deleted from its own secondary storage
+    assertExportedHistory(tenantAClient, TENANT_A, 0);
+    assertExportedHistory(defaultClient, DEFAULT, 0);
+  }
+
+  /**
+   * Asserts that the tenant's secondary storage holds exactly the given number of exported process
+   * definitions and instances. Both exporting and purging are asynchronous, so the arrival and the
+   * disappearance of the data are awaited rather than sampled once.
+   */
+  private void assertExportedHistory(
+      final CamundaClient client, final String tenantId, final int expected) {
+    await(
+            "physical tenant '%s' has %d exported process definition(s) and instance(s)"
+                .formatted(tenantId, expected))
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(500))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertThat(client.newProcessDefinitionSearchRequest().send().join().items())
+                  .describedAs("exported process definitions of '%s'", tenantId)
+                  .hasSize(expected);
+              assertThat(client.newProcessInstanceSearchRequest().send().join().items())
+                  .describedAs("exported process instances of '%s'", tenantId)
+                  .hasSize(expected);
             });
   }
 


### PR DESCRIPTION
## Description

`ClusterPurgeMultiDbIT` was excluded from the physical-tenant acceptance profile because purged entities still surfaced in tenant-scoped search. Planning a purge per physical tenant landed separately (#59860), but the deletion it plans was still being attributed to the wrong broker, so a tenant's exported history survived the purge.

- `purgeOperationsFor` picked the first member of the partition group to carry the
- `DeleteHistoryOperation` and the `UpdateIncarnationNumberOperation`. A member can be listed in a group with an empty partition map — transiently, while it is being removed — and
- `PartitionGroupConfiguration` defines a broker as active in a group *iff* it is present with a non-empty partition map. Such a member holds none of the group's exporter state, so routing the deletion to it purges nothing.

Pick the lowest-id member that actually replicates a partition of the group instead. A group no member replicates has nothing to tear down or re-bootstrap and now yields no operations at all, rather than a plan naming a broker that does not participate in it.

With that fixed, `ClusterPurgeMultiDbIT` is re-enabled in the physical-tenant profile.

## Related issues

closes #56051 
