### PR TITLE
Process the embedded history batch on agent instance create and update

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.agenthistory;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
-import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchHelper;
+import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -45,7 +45,7 @@ public final class AgentHistoryCreateProcessor
   private final JobState jobState;
   private final CslAuthorizationCheck cslCheck;
   private final KeyGenerator keyGenerator;
-  private final AgentHistoryBatchHelper historyHelper;
+  private final AgentHistoryBatchBehavior historyHelper;
 
   public AgentHistoryCreateProcessor(
       final Writers writers,
@@ -59,7 +59,7 @@ public final class AgentHistoryCreateProcessor
     jobState = processingState.getJobState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
-    historyHelper = new AgentHistoryBatchHelper(keyGenerator, processingState);
+    historyHelper = new AgentHistoryBatchBehavior(keyGenerator, processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
-import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -42,7 +41,6 @@ public final class AgentHistoryCreateProcessor
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final AgentInstanceState agentInstanceState;
-  private final JobState jobState;
   private final CslAuthorizationCheck cslCheck;
   private final KeyGenerator keyGenerator;
   private final AgentHistoryBatchBehavior historyHelper;
@@ -56,7 +54,6 @@ public final class AgentHistoryCreateProcessor
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     agentInstanceState = processingState.getAgentInstanceState();
-    jobState = processingState.getJobState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
     historyHelper = new AgentHistoryBatchBehavior(keyGenerator, processingState);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.List;
 
 public final class AgentHistoryCreateProcessor
     implements TypedRecordProcessor<AgentHistoryRecord>, SuspensionAware<AgentHistoryRecord> {
@@ -105,7 +106,8 @@ public final class AgentHistoryCreateProcessor
         historyHelper.validateJobContext(
             commandValue.getJobKey(),
             commandValue.getJobLease(),
-            commandValue.getElementInstanceKey());
+            commandValue.getElementInstanceKey(),
+            List.of(commandValue));
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.agenthistory;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchHelper;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -43,6 +44,7 @@ public final class AgentHistoryCreateProcessor
   private final JobState jobState;
   private final CslAuthorizationCheck cslCheck;
   private final KeyGenerator keyGenerator;
+  private final AgentHistoryBatchHelper historyHelper;
 
   public AgentHistoryCreateProcessor(
       final Writers writers,
@@ -56,6 +58,7 @@ public final class AgentHistoryCreateProcessor
     jobState = processingState.getJobState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
+    historyHelper = new AgentHistoryBatchHelper(processingState);
   }
 
   @Override
@@ -98,37 +101,19 @@ public final class AgentHistoryCreateProcessor
       return;
     }
 
-    final var jobKey = commandValue.getJobKey();
-    if (jobState.getState(jobKey) != JobState.State.ACTIVATED) {
-      writeRejection(
-          command,
-          RejectionType.NOT_FOUND,
-          "Expected to create agent history entry for job with key '%d', but the job is not active."
-              .formatted(jobKey));
-      return;
-    }
-    final var job = jobState.getJob(jobKey);
-
-    if (job.hasLeaseToken() && !commandValue.getJobLease().equals(job.getLeaseToken())) {
-      writeRejection(
-          command,
-          RejectionType.NOT_FOUND,
-          "Expected to create agent history entry for job with key '%d', but the supplied lease does not match. The job may have been re-activated."
-              .formatted(jobKey));
+    final var validJob =
+        historyHelper.validateJobContext(
+            commandValue.getJobKey(),
+            commandValue.getJobLease(),
+            commandValue.getElementInstanceKey());
+    if (validJob.isLeft()) {
+      final var rejection = validJob.getLeft();
+      writeRejection(command, rejection.type(), rejection.reason());
       return;
     }
 
+    final var job = validJob.get();
     final var jobElementInstanceKey = job.getElementInstanceKey();
-    final var commandElementInstanceKey = commandValue.getElementInstanceKey();
-    if (jobElementInstanceKey != commandElementInstanceKey) {
-      writeRejection(
-          command,
-          RejectionType.INVALID_ARGUMENT,
-          "Expected element instance key '%d' for agent history entry, but job '%d' is associated with element instance '%d'."
-              .formatted(commandElementInstanceKey, jobKey, jobElementInstanceKey));
-      return;
-    }
-
     if (!agentInstanceRecord.getElementInstanceKeys().contains(jobElementInstanceKey)) {
       writeRejection(
           command,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -59,7 +59,7 @@ public final class AgentHistoryCreateProcessor
     jobState = processingState.getJobState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
-    historyHelper = new AgentHistoryBatchHelper(processingState);
+    historyHelper = new AgentHistoryBatchHelper(keyGenerator, processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  * embedded {@code history[]} batch: validating the job a batch is attributed to, validating the
  * shape of the batch itself, and applying it to an {@code AgentInstanceRecord}.
  */
-public final class AgentHistoryBatchHelper {
+public final class AgentHistoryBatchBehavior {
 
   /** The names of the {@code AgentInstanceRecord} attributes a history item can affect. */
   static final Set<String> ALLOWED_CONFIGURATION_ATTRIBUTES =
@@ -73,7 +73,7 @@ public final class AgentHistoryBatchHelper {
   private final KeyGenerator keyGenerator;
   private final ProcessingState processingState;
 
-  public AgentHistoryBatchHelper(
+  public AgentHistoryBatchBehavior(
       final KeyGenerator keyGenerator, final ProcessingState processingState) {
     this.keyGenerator = keyGenerator;
     this.processingState = processingState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -202,7 +202,7 @@ public final class AgentHistoryBatchBehavior {
    *
    * @return the {@code AgentInstanceRecord} attribute names that actually changed as a result
    */
-  Set<String> apply(
+  Set<String> applyInstanceChangesFromHistory(
       final AgentInstanceRecord target,
       final long jobKey,
       final String jobLease,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -48,21 +48,22 @@ public final class AgentHistoryBatchBehavior {
           AgentInstanceRecord.ATTR_MAX_TOOL_CALLS);
 
   static final String ERROR_MSG_HISTORY_ITEM_ID_MISSING =
-      "Expected to process history item at index %d, but historyItemId is missing (got empty "
-          + "string). Every history item must have a non-empty historyItemId.";
+      "Expected to add history item at index %d to agent instance, but historyItemId is missing "
+          + "(got empty string). Each history item must have a non-empty historyItemId.";
   static final String ERROR_MSG_ROLE_UNSPECIFIED =
-      "Expected to process history item with historyItemId '%s', but its role is UNSPECIFIED. "
-          + "Every history item must declare a role.";
+      "Expected to add history item with historyItemId '%s' to agent instance, but its role is "
+          + "UNSPECIFIED. Each history item must declare a role.";
   static final String ERROR_MSG_LOOP_ITERATION_MISSING =
-      "Expected to process history item with historyItemId '%s', but loopIteration is missing "
-          + "(got %d). Every history item must declare a positive loopIteration.";
+      "Expected to add history item with historyItemId '%s' to agent instance, but loopIteration "
+          + "is missing (got %d). Each history item must declare a positive loopIteration.";
   static final String ERROR_MSG_JOB_NOT_ACTIVE =
-      "Expected job with key '%d' to be active, but it was not.";
+      "Expected to update agent instance related to job with key '%d', but job was not active.";
   static final String ERROR_MSG_JOB_LEASE_MISMATCH =
-      "Expected job with key '%d' to hold the supplied lease, but it did not match. The job may "
-          + "have been re-activated.";
+      "Expected to update agent instance related to job with key '%d', but job did not hold the "
+          + "supplied lease. The job may have been re-activated.";
   static final String ERROR_MSG_JOB_ELEMENT_MISMATCH =
-      "Expected job '%d' to be associated with element instance '%d', but it is associated with element instance '%d'";
+      "Expected to update agent instance related to job with key '%d', but job belongs to element "
+          + "instance '%d' instead of the requested element instance '%d'.";
   static final String ERROR_MSG_JOB_REQUIRED_FOR_HISTORY =
       "Expected a job to be provided for the embedded history batch, but no jobKey was set."
           + " A history batch must be attributed to the active job that produced it.";
@@ -123,7 +124,7 @@ public final class AgentHistoryBatchBehavior {
           new Rejection(
               RejectionType.INVALID_ARGUMENT,
               ERROR_MSG_JOB_ELEMENT_MISMATCH.formatted(
-                  jobKey, elementInstanceKey, jobElementInstanceKey)));
+                  jobKey, jobElementInstanceKey, elementInstanceKey)));
     }
 
     return Either.right(job);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
@@ -10,21 +10,29 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceMetrics;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryMessageContentValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Shared logic for the {@code AGENT_HISTORY}/{@code AGENT_INSTANCE} processors that deal with an
  * embedded {@code history[]} batch: validating the job a batch is attributed to, validating the
- * shape of the batch itself, and (in a later commit) applying it to an {@code AgentInstanceRecord}.
+ * shape of the batch itself, and applying it to an {@code AgentInstanceRecord}.
  */
 public final class AgentHistoryBatchHelper {
 
@@ -62,9 +70,12 @@ public final class AgentHistoryBatchHelper {
       "Expected to update agent instance configuration with history item '%s',"
           + " but changedAttributes contained unknown attribute(s) %s. Allowed attributes are: %s.";
 
+  private final KeyGenerator keyGenerator;
   private final ProcessingState processingState;
 
-  public AgentHistoryBatchHelper(final ProcessingState processingState) {
+  public AgentHistoryBatchHelper(
+      final KeyGenerator keyGenerator, final ProcessingState processingState) {
+    this.keyGenerator = keyGenerator;
     this.processingState = processingState;
   }
 
@@ -174,5 +185,171 @@ public final class AgentHistoryBatchHelper {
       }
     }
     return Either.rightVoid();
+  }
+
+  /**
+   * Applies an already-validated batch onto {@code target}, in array order: builds one {@code
+   * AGENT_HISTORY} event per item (a full copy of the item, with its record-context fields
+   * overwritten to match {@code target}/{@code jobKey}/{@code jobLease}), accumulates metrics
+   * immediately, and — for {@link AgentHistoryRole#CONFIGURATION} items only — applies whichever of
+   * model/provider/systemPrompt/tools/limits the item names in its own {@code changedAttributes}.
+   *
+   * <p><strong>Mutates {@code target} in place</strong> (metrics, definition, tools, limits,
+   * history) and does not itself emit any event — the caller is responsible for turning {@code
+   * target.getHistory()} into {@code AGENT_HISTORY:CREATED} follow-up events.
+   *
+   * @return the {@code AgentInstanceRecord} attribute names that actually changed as a result
+   */
+  Set<String> apply(
+      final AgentInstanceRecord target,
+      final long jobKey,
+      final String jobLease,
+      final long elementInstanceKey,
+      final List<? extends AgentHistoryRecordValue> history) {
+    final var changedAttributes = new HashSet<String>();
+    final var items = new ArrayList<AgentHistoryRecord>(history.size());
+
+    for (final var item : history) {
+      final var historyKey = keyGenerator.nextKey();
+
+      final var event = new AgentHistoryRecord();
+      // `item` is always a concrete AgentHistoryRecord at runtime (the only implementation of
+      // AgentHistoryRecordValue) — copyFrom() needs the concrete type since it round-trips
+      // through BufferWriter/BufferReader, which the protocol interface doesn't expose.
+      event.copyFrom((AgentHistoryRecord) item);
+      event
+          .setAgentHistoryKey(historyKey)
+          .setAgentInstanceKey(target.getAgentInstanceKey())
+          .setElementInstanceKey(elementInstanceKey)
+          .setProcessInstanceKey(target.getProcessInstanceKey())
+          .setRootProcessInstanceKey(target.getRootProcessInstanceKey())
+          .setBpmnProcessId(target.getBpmnProcessId())
+          .setProcessDefinitionKey(target.getProcessDefinitionKey())
+          .setTenantId(target.getTenantId())
+          .setJobKey(jobKey)
+          .setJobLease(jobLease);
+
+      if (applyMetrics(target.getMetrics(), item)) {
+        changedAttributes.add(AgentInstanceRecord.ATTR_METRICS);
+      }
+      changedAttributes.addAll(applyConfigurationChanges(target, item));
+
+      items.add(event);
+    }
+
+    target.setHistory(items);
+    return changedAttributes;
+  }
+
+  /**
+   * For a {@link AgentHistoryRole#CONFIGURATION} item, applies whichever of
+   * model/provider/systemPrompt/tools/limits the item's own {@code changedAttributes} names,
+   * immediately onto {@code target}'s live definition/tools/limits. Items of any other role never
+   * affect these fields.
+   *
+   * @return the {@code AgentInstanceRecord} attribute names that actually changed
+   */
+  private Set<String> applyConfigurationChanges(
+      final AgentInstanceRecord target, final AgentHistoryRecordValue item) {
+    if (item.getRole() != AgentHistoryRole.CONFIGURATION) {
+      return Set.of();
+    }
+
+    final var changed = new HashSet<String>();
+    // note: this is resolved once to avoid deserializing every time
+    final var itemChangedAttributes = item.getChangedAttributes();
+
+    if (itemChangedAttributes.contains(AgentInstanceRecord.ATTR_MODEL)) {
+      target.getDefinition().setModel(item.getModel());
+      changed.add(AgentInstanceRecord.ATTR_MODEL);
+    }
+    if (itemChangedAttributes.contains(AgentInstanceRecord.ATTR_PROVIDER)) {
+      target.getDefinition().setProvider(item.getProvider());
+      changed.add(AgentInstanceRecord.ATTR_PROVIDER);
+    }
+    if (itemChangedAttributes.contains(AgentInstanceRecord.ATTR_SYSTEM_PROMPT)) {
+      target.getDefinition().setSystemPrompt(extractText(item.getSystemPrompt()));
+      changed.add(AgentInstanceRecord.ATTR_SYSTEM_PROMPT);
+    }
+    if (itemChangedAttributes.contains(AgentInstanceRecord.ATTR_TOOLS)) {
+      target.setTools(item.getTools());
+      changed.add(AgentInstanceRecord.ATTR_TOOLS);
+    }
+    if (itemChangedAttributes.contains(AgentInstanceRecord.ATTR_MAX_TOKENS)) {
+      target.getLimits().setMaxTokens(item.getLimits().getMaxTokens());
+      changed.add(AgentInstanceRecord.ATTR_MAX_TOKENS);
+    }
+    if (itemChangedAttributes.contains(AgentInstanceRecord.ATTR_MAX_MODEL_CALLS)) {
+      target.getLimits().setMaxModelCalls(item.getLimits().getMaxModelCalls());
+      changed.add(AgentInstanceRecord.ATTR_MAX_MODEL_CALLS);
+    }
+    if (itemChangedAttributes.contains(AgentInstanceRecord.ATTR_MAX_TOOL_CALLS)) {
+      target.getLimits().setMaxToolCalls(item.getLimits().getMaxToolCalls());
+      changed.add(AgentInstanceRecord.ATTR_MAX_TOOL_CALLS);
+    }
+
+    return changed;
+  }
+
+  /**
+   * Concatenates every {@code TEXT} content block's text (joined with a blank line) — the dedicated
+   * {@code systemPrompt} content-block list uses the same block shape as {@code content}, but only
+   * {@code TEXT} blocks are meaningful as a system prompt.
+   *
+   * <p><strong>Workaround:</strong> {@code AgentInstanceRecord}'s {@code systemPrompt} field is a
+   * plain string, so a multi-block system prompt (e.g. text interleaved with documents) is
+   * flattened and lossy here — only the {@code TEXT} blocks survive. #58797 is expected to change
+   * how the agent instance stores its system prompt to allow saving the full multi-content value;
+   * this flattening should be removed once that lands.
+   */
+  private String extractText(final List<? extends AgentHistoryMessageContentValue> blocks) {
+    return blocks.stream()
+        .filter(block -> block.getContentType() == AgentHistoryContentType.TEXT)
+        .map(AgentHistoryMessageContentValue::getText)
+        .collect(Collectors.joining("\n\n"));
+  }
+
+  /**
+   * Sums each positive field of {@code item}'s metrics onto {@code current}, skipping non-positive
+   * fields (covers the {@code -1} not-provided sentinel and {@code 0} no-change). {@code
+   * modelCalls}/{@code toolCalls} aren't part of the item's metrics — they're derived instead:
+   * every {@code ASSISTANT} item represents exactly one model call, and its own {@code toolCalls}
+   * count is the number of tool calls it dispatched.
+   *
+   * @return whether any field of {@code current} actually changed
+   */
+  private boolean applyMetrics(
+      final AgentInstanceMetrics current, final AgentHistoryRecordValue item) {
+    boolean changed = false;
+    final var delta = item.getMetrics();
+    if (delta.getInputTokens() > 0) {
+      current.setInputTokens(current.getInputTokens() + delta.getInputTokens());
+      changed = true;
+    }
+    if (delta.getOutputTokens() > 0) {
+      current.setOutputTokens(current.getOutputTokens() + delta.getOutputTokens());
+      changed = true;
+    }
+    if (delta.getReasoningTokenCount() > 0) {
+      current.setReasoningTokenCount(
+          current.getReasoningTokenCount() + delta.getReasoningTokenCount());
+      changed = true;
+    }
+    if (delta.getCacheCreationTokenCount() > 0) {
+      current.setCacheCreationTokenCount(
+          current.getCacheCreationTokenCount() + delta.getCacheCreationTokenCount());
+      changed = true;
+    }
+    if (delta.getCacheReadTokenCount() > 0) {
+      current.setCacheReadTokenCount(
+          current.getCacheReadTokenCount() + delta.getCacheReadTokenCount());
+      changed = true;
+    }
+    if (item.getRole() == AgentHistoryRole.ASSISTANT) {
+      current.setModelCalls(current.getModelCalls() + 1);
+      current.setToolCalls(current.getToolCalls() + item.getToolCalls().size());
+      changed = true;
+    }
+    return changed;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.util.Either;
+import java.util.Objects;
+
+/**
+ * Shared logic for the {@code AGENT_HISTORY}/{@code AGENT_INSTANCE} processors that deal with an
+ * embedded {@code history[]} batch: validating the job a batch is attributed to, validating the
+ * batch itself, and (in later commits) applying it to an {@code AgentInstanceRecord}.
+ */
+public final class AgentHistoryBatchHelper {
+
+  private final ProcessingState processingState;
+
+  public AgentHistoryBatchHelper(final ProcessingState processingState) {
+    this.processingState = processingState;
+  }
+
+  /**
+   * Validates the job a command is attributed to: {@code jobKey} must refer to a currently-active
+   * job, that job's lease token (if any) must match {@code jobLease}, and the job must belong to
+   * {@code elementInstanceKey}.
+   *
+   * @return the active {@link JobRecord} if valid, otherwise the {@link Rejection} to surface
+   */
+  public Either<Rejection, JobRecord> validateJobContext(
+      final long jobKey, final String jobLease, final long elementInstanceKey) {
+
+    final var jobState = processingState.getJobState();
+    if (jobState.getState(jobKey) != JobState.State.ACTIVATED) {
+      return Either.left(
+          new Rejection(
+              RejectionType.NOT_FOUND,
+              "Expected to create agent history entry for job with key '%d', but the job is not active."
+                  .formatted(jobKey)));
+    }
+
+    final var job = jobState.getJob(jobKey);
+    if (job.hasLeaseToken() && !Objects.equals(jobLease, job.getLeaseToken())) {
+      return Either.left(
+          new Rejection(
+              RejectionType.NOT_FOUND,
+              "Expected to create agent history entry for job with key '%d', but the supplied lease does not match. The job may have been re-activated."
+                  .formatted(jobKey)));
+    }
+
+    final var jobElementInstanceKey = job.getElementInstanceKey();
+    if (jobElementInstanceKey != elementInstanceKey) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              "Expected element instance key '%d' for agent history entry, but job '%d' is associated with element instance '%d'."
+                  .formatted(elementInstanceKey, jobKey, jobElementInstanceKey)));
+    }
+
+    return Either.right(job);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
@@ -10,20 +10,44 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Shared logic for the {@code AGENT_HISTORY}/{@code AGENT_INSTANCE} processors that deal with an
  * embedded {@code history[]} batch: validating the job a batch is attributed to, validating the
- * batch itself, and (in later commits) applying it to an {@code AgentInstanceRecord}.
+ * shape of the batch itself, and (in a later commit) applying it to an {@code AgentInstanceRecord}.
  */
 public final class AgentHistoryBatchHelper {
 
+  /** The names of the {@code AgentInstanceRecord} attributes a history item can affect. */
+  static final Set<String> ALLOWED_CONFIGURATION_ATTRIBUTES =
+      Set.of(
+          AgentInstanceRecord.ATTR_MODEL,
+          AgentInstanceRecord.ATTR_PROVIDER,
+          AgentInstanceRecord.ATTR_SYSTEM_PROMPT,
+          AgentInstanceRecord.ATTR_TOOLS,
+          AgentInstanceRecord.ATTR_MAX_TOKENS,
+          AgentInstanceRecord.ATTR_MAX_MODEL_CALLS,
+          AgentInstanceRecord.ATTR_MAX_TOOL_CALLS);
+
+  static final String ERROR_MSG_HISTORY_ITEM_ID_MISSING =
+      "Expected to process history item at index %d, but historyItemId is missing (got empty "
+          + "string). Every history item must have a non-empty historyItemId.";
+  static final String ERROR_MSG_ROLE_UNSPECIFIED =
+      "Expected to process history item with historyItemId '%s', but its role is UNSPECIFIED. "
+          + "Every history item must declare a role.";
+  static final String ERROR_MSG_LOOP_ITERATION_MISSING =
+      "Expected to process history item with historyItemId '%s', but loopIteration is missing "
+          + "(got %d). Every history item must declare a positive loopIteration.";
   static final String ERROR_MSG_JOB_NOT_ACTIVE =
       "Expected job with key '%d' to be active, but it was not.";
   static final String ERROR_MSG_JOB_LEASE_MISMATCH =
@@ -34,6 +58,9 @@ public final class AgentHistoryBatchHelper {
   static final String ERROR_MSG_JOB_REQUIRED_FOR_HISTORY =
       "Expected a job to be provided for the embedded history batch, but no jobKey was set."
           + " A history batch must be attributed to the active job that produced it.";
+  private static final String ERROR_MSG_UNKNOWN_ATTRIBUTES =
+      "Expected to update agent instance configuration with history item '%s',"
+          + " but changedAttributes contained unknown attribute(s) %s. Allowed attributes are: %s.";
 
   private final ProcessingState processingState;
 
@@ -89,5 +116,63 @@ public final class AgentHistoryBatchHelper {
     }
 
     return Either.right(job);
+  }
+
+  /**
+   * Validates every item in the batch, in order: {@code historyItemId} must be non-empty, {@code
+   * role} must not be {@code UNSPECIFIED}, {@code loopIteration} must be a positive integer (the
+   * {@code 0} default means the field was left unset), and — for {@link
+   * AgentHistoryRole#CONFIGURATION} items only — every name in {@code changedAttributes} must be
+   * one this helper actually knows how to apply.
+   *
+   * @return the rejection for the first invalid item found, or {@link Either#rightVoid()} if the
+   *     whole batch is valid
+   */
+  public Either<Rejection, Void> validateHistory(
+      final List<? extends AgentHistoryRecordValue> history) {
+    if (history == null || history.isEmpty()) {
+      return Either.rightVoid();
+    }
+
+    for (int i = 0; i < history.size(); i++) {
+      final var item = history.get(i);
+      final var historyItemId = item.getHistoryItemId();
+
+      if (historyItemId.isEmpty()) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT, ERROR_MSG_HISTORY_ITEM_ID_MISSING.formatted(i)));
+      }
+
+      if (item.getRole() == AgentHistoryRole.UNSPECIFIED) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT,
+                ERROR_MSG_ROLE_UNSPECIFIED.formatted(historyItemId)));
+      }
+
+      if (item.getLoopIteration() < 1) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT,
+                ERROR_MSG_LOOP_ITERATION_MISSING.formatted(
+                    historyItemId, item.getLoopIteration())));
+      }
+
+      if (item.getRole() == AgentHistoryRole.CONFIGURATION) {
+        final var unknown =
+            item.getChangedAttributes().stream()
+                .filter(Predicate.not(ALLOWED_CONFIGURATION_ATTRIBUTES::contains))
+                .toList();
+        if (!unknown.isEmpty()) {
+          return Either.left(
+              new Rejection(
+                  RejectionType.INVALID_ARGUMENT,
+                  ERROR_MSG_UNKNOWN_ATTRIBUTES.formatted(
+                      historyItemId, unknown, ALLOWED_CONFIGURATION_ATTRIBUTES)));
+        }
+      }
+    }
+    return Either.rightVoid();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
@@ -12,7 +12,9 @@ import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.util.Either;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -29,6 +31,9 @@ public final class AgentHistoryBatchHelper {
           + "have been re-activated.";
   static final String ERROR_MSG_JOB_ELEMENT_MISMATCH =
       "Expected job '%d' to be associated with element instance '%d', but it is associated with element instance '%d'";
+  static final String ERROR_MSG_JOB_REQUIRED_FOR_HISTORY =
+      "Expected a job to be provided for the embedded history batch, but no jobKey was set."
+          + " A history batch must be attributed to the active job that produced it.";
 
   private final ProcessingState processingState;
 
@@ -37,14 +42,30 @@ public final class AgentHistoryBatchHelper {
   }
 
   /**
-   * Validates the job a command is attributed to: {@code jobKey} must refer to a currently-active
-   * job, that job's lease token (if any) must match {@code jobLease}, and the job must belong to
-   * {@code elementInstanceKey}.
+   * Validates the job context a command carries. If a history batch is present, {@code jobKey}
+   * becomes required — a batch must always be attributed to the job that produced it — otherwise no
+   * job at all remains valid. When a job is supplied (with or without a batch), it must refer to a
+   * currently-active job, that job's lease token (if any) must match {@code jobLease}, and the job
+   * must belong to {@code elementInstanceKey}.
    *
-   * @return the active {@link JobRecord} if valid, otherwise the {@link Rejection} to surface
+   * @return the active {@link JobRecord} if a job was supplied and is valid, {@code null} wrapped
+   *     in {@link Either#right} if no job was supplied and none was required, otherwise the {@link
+   *     Rejection} to surface
    */
   public Either<Rejection, JobRecord> validateJobContext(
-      final long jobKey, final String jobLease, final long elementInstanceKey) {
+      final long jobKey,
+      final String jobLease,
+      final long elementInstanceKey,
+      final List<? extends AgentHistoryRecordValue> history) {
+
+    if (jobKey == -1L) {
+      if (history != null && !history.isEmpty()) {
+        return Either.left(
+            new Rejection(RejectionType.INVALID_ARGUMENT, ERROR_MSG_JOB_REQUIRED_FOR_HISTORY));
+      } else {
+        return Either.right(null);
+      }
+    }
 
     final var jobState = processingState.getJobState();
     if (jobState.getState(jobKey) != JobState.State.ACTIVATED) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
@@ -80,11 +80,11 @@ public final class AgentHistoryBatchHelper {
   }
 
   /**
-   * Validates the job context a command carries. If a history batch is present, {@code jobKey}
-   * becomes required — a batch must always be attributed to the job that produced it — otherwise no
-   * job at all remains valid. When a job is supplied (with or without a batch), it must refer to a
-   * currently-active job, that job's lease token (if any) must match {@code jobLease}, and the job
-   * must belong to {@code elementInstanceKey}.
+   * Validates the job context a command carries. {@code jobKey} may be omitted only when no history
+   * batch is present; once a batch is attached to the command, {@code jobKey} becomes required — a
+   * batch must always be attributed to the active job that produced it. When a job is supplied
+   * (with or without a batch), it must refer to a currently-active job, that job's lease token (if
+   * any) must match {@code jobLease}, and the job must belong to {@code elementInstanceKey}.
    *
    * @return the active {@link JobRecord} if a job was supplied and is valid, {@code null} wrapped
    *     in {@link Either#right} if no job was supplied and none was required, otherwise the {@link

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
@@ -180,7 +180,9 @@ public final class AgentHistoryBatchHelper {
               new Rejection(
                   RejectionType.INVALID_ARGUMENT,
                   ERROR_MSG_UNKNOWN_ATTRIBUTES.formatted(
-                      historyItemId, unknown, ALLOWED_CONFIGURATION_ATTRIBUTES)));
+                      historyItemId,
+                      unknown,
+                      ALLOWED_CONFIGURATION_ATTRIBUTES.stream().sorted().toList())));
         }
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchHelper.java
@@ -22,6 +22,14 @@ import java.util.Objects;
  */
 public final class AgentHistoryBatchHelper {
 
+  static final String ERROR_MSG_JOB_NOT_ACTIVE =
+      "Expected job with key '%d' to be active, but it was not.";
+  static final String ERROR_MSG_JOB_LEASE_MISMATCH =
+      "Expected job with key '%d' to hold the supplied lease, but it did not match. The job may "
+          + "have been re-activated.";
+  static final String ERROR_MSG_JOB_ELEMENT_MISMATCH =
+      "Expected job '%d' to be associated with element instance '%d', but it is associated with element instance '%d'";
+
   private final ProcessingState processingState;
 
   public AgentHistoryBatchHelper(final ProcessingState processingState) {
@@ -41,19 +49,13 @@ public final class AgentHistoryBatchHelper {
     final var jobState = processingState.getJobState();
     if (jobState.getState(jobKey) != JobState.State.ACTIVATED) {
       return Either.left(
-          new Rejection(
-              RejectionType.NOT_FOUND,
-              "Expected to create agent history entry for job with key '%d', but the job is not active."
-                  .formatted(jobKey)));
+          new Rejection(RejectionType.NOT_FOUND, ERROR_MSG_JOB_NOT_ACTIVE.formatted(jobKey)));
     }
 
     final var job = jobState.getJob(jobKey);
     if (job.hasLeaseToken() && !Objects.equals(jobLease, job.getLeaseToken())) {
       return Either.left(
-          new Rejection(
-              RejectionType.NOT_FOUND,
-              "Expected to create agent history entry for job with key '%d', but the supplied lease does not match. The job may have been re-activated."
-                  .formatted(jobKey)));
+          new Rejection(RejectionType.NOT_FOUND, ERROR_MSG_JOB_LEASE_MISMATCH.formatted(jobKey)));
     }
 
     final var jobElementInstanceKey = job.getElementInstanceKey();
@@ -61,8 +63,8 @@ public final class AgentHistoryBatchHelper {
       return Either.left(
           new Rejection(
               RejectionType.INVALID_ARGUMENT,
-              "Expected element instance key '%d' for agent history entry, but job '%d' is associated with element instance '%d'."
-                  .formatted(elementInstanceKey, jobKey, jobElementInstanceKey)));
+              ERROR_MSG_JOB_ELEMENT_MISMATCH.formatted(
+                  jobKey, elementInstanceKey, jobElementInstanceKey)));
     }
 
     return Either.right(job);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -78,7 +77,7 @@ public final class AgentInstanceCreateProcessor
     agentDefinitionState = processingState.getAgentDefinitionState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
-    historyBatchHelper = new AgentHistoryBatchHelper(processingState);
+    historyBatchHelper = new AgentHistoryBatchHelper(keyGenerator, processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -218,7 +218,7 @@ public final class AgentInstanceCreateProcessor
         .setMaxToolCalls(commandValue.getLimits().getMaxToolCalls());
 
     if (!commandValue.getHistory().isEmpty()) {
-      historyBatchHelper.apply(
+      historyBatchHelper.applyInstanceChangesFromHistory(
           event,
           commandValue.getJobKey(),
           commandValue.getJobLease(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
@@ -216,7 +217,24 @@ public final class AgentInstanceCreateProcessor
         .setMaxModelCalls(commandValue.getLimits().getMaxModelCalls())
         .setMaxToolCalls(commandValue.getLimits().getMaxToolCalls());
 
+    if (!commandValue.getHistory().isEmpty()) {
+      historyBatchHelper.apply(
+          event,
+          commandValue.getJobKey(),
+          commandValue.getJobLease(),
+          commandValue.getElementInstanceKey(),
+          commandValue.getHistory());
+    }
+
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.CREATED, event);
+
+    event
+        .getHistory()
+        .forEach(
+            item ->
+                stateWriter.appendFollowUpEvent(
+                    item.getAgentHistoryKey(), AgentHistoryIntent.CREATED, item));
+
     responseWriter.writeAcceptedResponseOnCommand(
         agentInstanceKey, AgentInstanceIntent.CREATED, event, command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -169,8 +169,10 @@ public final class AgentInstanceCreateProcessor
 
     final var validJob =
         historyBatchHelper.validateJobContext(
-            commandValue.getJobKey(), commandValue.getJobLease(),
-            commandValue.getElementInstanceKey(), commandValue.getHistory());
+            commandValue.getJobKey(),
+            commandValue.getJobLease(),
+            commandValue.getElementInstanceKey(),
+            commandValue.getHistory());
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -177,6 +177,13 @@ public final class AgentInstanceCreateProcessor
       return;
     }
 
+    final var isHistoryValid = historyBatchHelper.validateHistory(commandValue.getHistory());
+    if (isHistoryValid.isLeft()) {
+      final var rejection = isHistoryValid.getLeft();
+      writeRejection(command, rejection.type(), rejection.reason());
+      return;
+    }
+
     final var deployedProcess =
         processState.getProcessByKeyAndTenant(
             elementInstanceValue.getProcessDefinitionKey(), elementInstanceValue.getTenantId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -63,6 +63,7 @@ public final class AgentInstanceCreateProcessor
   private final AgentDefinitionState agentDefinitionState;
   private final CslAuthorizationCheck cslCheck;
   private final KeyGenerator keyGenerator;
+  private final AgentHistoryBatchHelper historyBatchHelper;
 
   public AgentInstanceCreateProcessor(
       final Writers writers,
@@ -77,6 +78,7 @@ public final class AgentInstanceCreateProcessor
     agentDefinitionState = processingState.getAgentDefinitionState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
+    historyBatchHelper = new AgentHistoryBatchHelper(processingState);
   }
 
   @Override
@@ -162,6 +164,16 @@ public final class AgentInstanceCreateProcessor
           RejectionType.INVALID_ARGUMENT,
           ERROR_MSG_NO_AGENT_DEFINITION.formatted(
               elementInstanceKey, elementInstanceValue.getElementId()));
+      return;
+    }
+
+    final var validJob =
+        historyBatchHelper.validateJobContext(
+            commandValue.getJobKey(), commandValue.getJobLease(),
+            commandValue.getElementInstanceKey(), commandValue.getHistory());
+    if (validJob.isLeft()) {
+      final var rejection = validJob.getLeft();
+      writeRejection(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -63,7 +63,7 @@ public final class AgentInstanceCreateProcessor
   private final AgentDefinitionState agentDefinitionState;
   private final CslAuthorizationCheck cslCheck;
   private final KeyGenerator keyGenerator;
-  private final AgentHistoryBatchHelper historyBatchHelper;
+  private final AgentHistoryBatchBehavior historyBatchHelper;
 
   public AgentInstanceCreateProcessor(
       final Writers writers,
@@ -78,7 +78,7 @@ public final class AgentInstanceCreateProcessor
     agentDefinitionState = processingState.getAgentDefinitionState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
-    historyBatchHelper = new AgentHistoryBatchHelper(keyGenerator, processingState);
+    historyBatchHelper = new AgentHistoryBatchBehavior(keyGenerator, processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceProcessors.java
@@ -32,7 +32,7 @@ public final class AgentInstanceProcessors {
     typedRecordProcessors.onCommand(
         ValueType.AGENT_INSTANCE,
         AgentInstanceIntent.UPDATE,
-        new AgentInstanceUpdateProcessor(writers, processingState, cslCheck));
+        new AgentInstanceUpdateProcessor(writers, processingState, cslCheck, keyGenerator));
     typedRecordProcessors.onCommand(
         ValueType.AGENT_INSTANCE,
         AgentInstanceIntent.COMPLETE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -276,7 +276,8 @@ public final class AgentInstanceUpdateProcessor
       return Either.left(
           new Rejection(
               RejectionType.INVALID_ARGUMENT,
-              ERROR_MSG_UNKNOWN_ATTRIBUTES.formatted(unknown, allowedAttributes)));
+              ERROR_MSG_UNKNOWN_ATTRIBUTES.formatted(
+                  unknown, allowedAttributes.stream().sorted().toList())));
     }
 
     if (changed.contains(AgentInstanceRecord.ATTR_METRICS)
@@ -317,8 +318,6 @@ public final class AgentInstanceUpdateProcessor
             : ALLOWED_REQUEST_LEVEL_ATTRIBUTES;
 
     final var effective = new ArrayList<String>(changed.size());
-    // Iterate ALLOWED_ATTRIBUTES (not the incoming set) so the output order is fixed regardless of
-    // the JVM's hash randomization or client ordering.
     for (final var attr : allowedAttributes) {
       if (!changed.contains(attr)) {
         continue;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -207,6 +207,13 @@ public final class AgentInstanceUpdateProcessor
       return;
     }
 
+    final var isHistoryValid = historyBatchHelper.validateHistory(commandValue.getHistory());
+    if (isHistoryValid.isLeft()) {
+      final var rejection = isHistoryValid.getLeft();
+      writeRejection(command, rejection.type(), rejection.reason());
+      return;
+    }
+
     final Set<String> changed = Set.copyOf(commandValue.getChangedAttributes());
 
     final var unknown =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -85,7 +85,7 @@ public final class AgentInstanceUpdateProcessor
   private final AgentInstanceState agentInstanceState;
   private final ElementInstanceState elementInstanceState;
   private final CslAuthorizationCheck cslCheck;
-  private final AgentHistoryBatchHelper historyBatchHelper;
+  private final AgentHistoryBatchBehavior historyBatchHelper;
 
   public AgentInstanceUpdateProcessor(
       final Writers writers,
@@ -98,7 +98,7 @@ public final class AgentInstanceUpdateProcessor
     agentInstanceState = processingState.getAgentInstanceState();
     elementInstanceState = processingState.getElementInstanceState();
     this.cslCheck = cslCheck;
-    historyBatchHelper = new AgentHistoryBatchHelper(keyGenerator, processingState);
+    historyBatchHelper = new AgentHistoryBatchBehavior(keyGenerator, processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceMetrics;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
@@ -34,6 +35,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -68,9 +70,7 @@ public final class AgentInstanceUpdateProcessor
       "Expected to update agent instance with key '%d' for element instance with key '%d', but the process instance key '%d' does not match the agent instance's process instance key '%d'.";
   private static final String ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS =
       "Expected to associate element instance with key '%d' with an agent instance, but it is already associated with agent instance with key '%d'.";
-
   private static final long METRIC_NOT_PROVIDED = -1L;
-
   private static final Set<AgentInstanceStatus> ACTIVE_STATUSES =
       EnumSet.of(
           AgentInstanceStatus.INITIALIZING,
@@ -227,7 +227,30 @@ public final class AgentInstanceUpdateProcessor
     }
     current.setElementInstanceKey(newElementInstanceKey);
 
-    final var changedAttributes = applyRequestLevelChanges(current, commandValue, validPatch.get());
+    final var changedAttributes = new HashSet<String>();
+
+    if (!commandValue.getHistory().isEmpty()) {
+      final var historyChanges =
+          historyBatchHelper.apply(
+              current,
+              commandValue.getJobKey(),
+              commandValue.getJobLease(),
+              commandValue.getElementInstanceKey(),
+              commandValue.getHistory());
+
+      current
+          .getHistory()
+          .forEach(
+              item ->
+                  stateWriter.appendFollowUpEvent(
+                      item.getAgentHistoryKey(), AgentHistoryIntent.CREATED, item));
+
+      changedAttributes.addAll(historyChanges);
+    }
+
+    final var requestLevelChanges =
+        applyRequestLevelChanges(current, commandValue, validPatch.get());
+    changedAttributes.addAll(requestLevelChanges);
 
     current.setChangedAttributes(changedAttributes.stream().sorted().toList());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -200,8 +200,10 @@ public final class AgentInstanceUpdateProcessor
 
     final var validJob =
         historyBatchHelper.validateJobContext(
-            commandValue.getJobKey(), commandValue.getJobLease(),
-            commandValue.getElementInstanceKey(), commandValue.getHistory());
+            commandValue.getJobKey(),
+            commandValue.getJobLease(),
+            commandValue.getElementInstanceKey(),
+            commandValue.getHistory());
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -231,7 +231,7 @@ public final class AgentInstanceUpdateProcessor
 
     if (!commandValue.getHistory().isEmpty()) {
       final var historyChanges =
-          historyBatchHelper.apply(
+          historyBatchHelper.applyInstanceChangesFromHistory(
               current,
               commandValue.getJobKey(),
               commandValue.getJobLease(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -89,14 +90,15 @@ public final class AgentInstanceUpdateProcessor
   public AgentInstanceUpdateProcessor(
       final Writers writers,
       final ProcessingState processingState,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final KeyGenerator keyGenerator) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     agentInstanceState = processingState.getAgentInstanceState();
     elementInstanceState = processingState.getElementInstanceState();
     this.cslCheck = cslCheck;
-    historyBatchHelper = new AgentHistoryBatchHelper(processingState);
+    historyBatchHelper = new AgentHistoryBatchHelper(keyGenerator, processingState);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -31,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -39,11 +39,10 @@ import java.util.Set;
 public final class AgentInstanceUpdateProcessor
     implements TypedRecordProcessor<AgentInstanceRecord>, SuspensionAware<AgentInstanceRecord> {
 
-  // Iteration order matters: it determines the order of names in the emitted changedAttributes
-  // list and must be stable across JVMs and replays. Used both as the allow-list for incoming
-  // changedAttributes and as the iteration order for applying the patch.
-  private static final List<String> ALLOWED_ATTRIBUTES =
-      List.of(
+  private static final Set<String> ALLOWED_REQUEST_LEVEL_ATTRIBUTES =
+      Set.of(AgentInstanceRecord.ATTR_STATUS);
+  private static final Set<String> BACKWARDS_COMPAT_ATTRIBUTES =
+      Set.of(
           AgentInstanceRecord.ATTR_STATUS,
           AgentInstanceRecord.ATTR_METRICS,
           AgentInstanceRecord.ATTR_TOOLS);
@@ -214,42 +213,11 @@ public final class AgentInstanceUpdateProcessor
       return;
     }
 
-    final Set<String> changed = Set.copyOf(commandValue.getChangedAttributes());
-
-    final var unknown =
-        changed.stream().filter(attr -> !ALLOWED_ATTRIBUTES.contains(attr)).toList();
-    if (!unknown.isEmpty()) {
-      writeRejection(
-          command,
-          RejectionType.INVALID_ARGUMENT,
-          ERROR_MSG_UNKNOWN_ATTRIBUTES.formatted(unknown, ALLOWED_ATTRIBUTES));
+    final var validPatch = validateRequestLevelChanges(command, current);
+    if (validPatch.isLeft()) {
+      final var rejection = validPatch.getLeft();
+      writeRejection(command, rejection.type(), rejection.reason());
       return;
-    }
-
-    if (changed.contains(AgentInstanceRecord.ATTR_METRICS)
-        && !hasAllowedMetricDeltas(commandValue.getMetrics())) {
-      final var metrics = commandValue.getMetrics();
-      writeRejection(
-          command,
-          RejectionType.INVALID_ARGUMENT,
-          ERROR_MSG_INVALID_METRIC_DELTA.formatted(
-              metrics.getInputTokens(),
-              metrics.getOutputTokens(),
-              metrics.getModelCalls(),
-              metrics.getToolCalls()));
-      return;
-    }
-
-    if (changed.contains(AgentInstanceRecord.ATTR_STATUS)) {
-      final var from = current.getStatus();
-      final var to = commandValue.getStatus();
-      if (!isAllowedTransition(from, to)) {
-        writeRejection(
-            command,
-            RejectionType.INVALID_STATE,
-            ERROR_MSG_INVALID_TRANSITION.formatted(agentInstanceKey, from, to));
-        return;
-      }
     }
 
     if (!current.getElementInstanceKeys().contains(newElementInstanceKey)) {
@@ -257,31 +225,76 @@ public final class AgentInstanceUpdateProcessor
     }
     current.setElementInstanceKey(newElementInstanceKey);
 
-    current.setChangedAttributes(applyPatch(current, commandValue, changed));
+    final var changedAttributes = applyRequestLevelChanges(current, commandValue, validPatch.get());
+
+    current.setChangedAttributes(changedAttributes.stream().sorted().toList());
 
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.UPDATED, current);
     responseWriter.writeAcceptedResponseOnCommand(
         agentInstanceKey, AgentInstanceIntent.UPDATED, current, command);
   }
 
-  /**
-   * <strong>Mutates {@code current} in place.</strong> For each attribute named in {@code changed},
-   * applies the corresponding value from {@code delta} to {@code current} (status/tools are
-   * overwritten, metrics fields are summed). The caller's {@code current} reference observes every
-   * mutation directly — nothing is copied.
-   *
-   * <p>Returns the effective {@code changedAttributes} for the UPDATED event — i.e. the subset of
-   * {@code changed} whose values actually moved.
-   */
-  @SuppressWarnings("checkstyle:MissingSwitchDefault") // exhaustive over ALLOWED_ATTRIBUTES
-  private static List<String> applyPatch(
+  private Either<Rejection, List<String>> validateRequestLevelChanges(
+      final TypedRecord<AgentInstanceRecord> command, final AgentInstanceRecord current) {
+
+    final var commandValue = command.getValue();
+    final var agentInstanceKey = current.getAgentInstanceKey();
+    final Set<String> changed = Set.copyOf(commandValue.getChangedAttributes());
+
+    final var allowedAttributes =
+        commandValue.getHistory().isEmpty()
+            ? BACKWARDS_COMPAT_ATTRIBUTES
+            : ALLOWED_REQUEST_LEVEL_ATTRIBUTES;
+
+    final var unknown = changed.stream().filter(attr -> !allowedAttributes.contains(attr)).toList();
+    if (!unknown.isEmpty()) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              ERROR_MSG_UNKNOWN_ATTRIBUTES.formatted(unknown, allowedAttributes)));
+    }
+
+    if (changed.contains(AgentInstanceRecord.ATTR_METRICS)
+        && !hasAllowedMetricDeltas(commandValue.getMetrics())) {
+      final var metrics = commandValue.getMetrics();
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              ERROR_MSG_INVALID_METRIC_DELTA.formatted(
+                  metrics.getInputTokens(),
+                  metrics.getOutputTokens(),
+                  metrics.getModelCalls(),
+                  metrics.getToolCalls())));
+    }
+
+    if (changed.contains(AgentInstanceRecord.ATTR_STATUS)) {
+      final var from = current.getStatus();
+      final var to = commandValue.getStatus();
+      if (!isAllowedTransition(from, to)) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_STATE,
+                ERROR_MSG_INVALID_TRANSITION.formatted(agentInstanceKey, from, to)));
+      }
+    }
+
+    return Either.right(new ArrayList<>(changed));
+  }
+
+  private List<String> applyRequestLevelChanges(
       final AgentInstanceRecord current,
       final AgentInstanceRecord delta,
-      final Set<String> changed) {
+      final List<String> changed) {
+
+    final var allowedAttributes =
+        delta.getHistory().isEmpty()
+            ? BACKWARDS_COMPAT_ATTRIBUTES
+            : ALLOWED_REQUEST_LEVEL_ATTRIBUTES;
+
     final var effective = new ArrayList<String>(changed.size());
     // Iterate ALLOWED_ATTRIBUTES (not the incoming set) so the output order is fixed regardless of
     // the JVM's hash randomization or client ordering.
-    for (final var attr : ALLOWED_ATTRIBUTES) {
+    for (final var attr : allowedAttributes) {
       if (!changed.contains(attr)) {
         continue;
       }
@@ -302,6 +315,9 @@ public final class AgentInstanceUpdateProcessor
             current.setTools(delta.getTools());
             effective.add(AgentInstanceRecord.ATTR_TOOLS);
           }
+        }
+        default -> {
+          // allowedAttributes only ever contains the three cases above; nothing else to apply.
         }
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -85,6 +85,7 @@ public final class AgentInstanceUpdateProcessor
   private final AgentInstanceState agentInstanceState;
   private final ElementInstanceState elementInstanceState;
   private final CslAuthorizationCheck cslCheck;
+  private final AgentHistoryBatchHelper historyBatchHelper;
 
   public AgentInstanceUpdateProcessor(
       final Writers writers,
@@ -96,6 +97,7 @@ public final class AgentInstanceUpdateProcessor
     agentInstanceState = processingState.getAgentInstanceState();
     elementInstanceState = processingState.getElementInstanceState();
     this.cslCheck = cslCheck;
+    historyBatchHelper = new AgentHistoryBatchHelper(processingState);
   }
 
   @Override
@@ -192,6 +194,16 @@ public final class AgentInstanceUpdateProcessor
           RejectionType.ALREADY_EXISTS,
           ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS.formatted(
               newElementInstanceKey, existingAgentInstanceKey));
+      return;
+    }
+
+    final var validJob =
+        historyBatchHelper.validateJobContext(
+            commandValue.getJobKey(), commandValue.getJobLease(),
+            commandValue.getElementInstanceKey(), commandValue.getHistory());
+    if (validJob.isLeft()) {
+      final var rejection = validJob.getLeft();
+      writeRejection(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCreatedApplier.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import java.util.List;
 
 public final class AgentInstanceCreatedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
@@ -28,7 +29,18 @@ public final class AgentInstanceCreatedApplier
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
-    agentInstanceState.insert(key, value);
+    // The secondary-storage exporters replace the whole entity with whatever the emitted event's
+    // record contains, so primary storage must retain every field the secondary entity needs — a
+    // new field should join it by default. `history`, `jobKey`, and `jobLease` are the deliberate
+    // exceptions: they're per-command payload, not durable entity attributes, and everything they
+    // carry is already persisted independently as its own AGENT_HISTORY record. Storing them here
+    // too would be duplicative, and since only the most recent command's values are ever echoed
+    // onto a given event, primary storage would end up reflecting "whatever the last command
+    // happened to carry" rather than anything meaningful about the instance.
+    final var forStorage = new AgentInstanceRecord();
+    forStorage.copyFrom(value);
+    forStorage.setHistory(List.of()).setJobKey(-1L).setJobLease("");
+    agentInstanceState.insert(key, forStorage);
 
     // Write back-link onto the parent ElementInstance so the CREATE processor can
     // detect a duplicate-CREATE against the same elementInstanceKey in O(1).

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCreatedApplier.java
@@ -29,14 +29,12 @@ public final class AgentInstanceCreatedApplier
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
-    // The secondary-storage exporters replace the whole entity with whatever the emitted event's
-    // record contains, so primary storage must retain every field the secondary entity needs — a
-    // new field should join it by default. `history`, `jobKey`, and `jobLease` are the deliberate
-    // exceptions: they're per-command payload, not durable entity attributes, and everything they
-    // carry is already persisted independently as its own AGENT_HISTORY record. Storing them here
-    // too would be duplicative, and since only the most recent command's values are ever echoed
-    // onto a given event, primary storage would end up reflecting "whatever the last command
-    // happened to carry" rather than anything meaningful about the instance.
+    // A new field should join primary storage by default, since secondary-storage exporters
+    // replace the whole entity with whatever the emitted event carries. `history`, `jobKey`, and
+    // `jobLease` are the exceptions: history is already durably captured as its own AGENT_HISTORY
+    // record and can grow large, so keeping a copy here would be wasteful; jobKey/jobLease are
+    // only meaningful while the command that carries them is being processed, so persisting them
+    // would just reflect whichever command happened to run last, not the instance's actual state.
     final var forStorage = new AgentInstanceRecord();
     forStorage.copyFrom(value);
     forStorage.setHistory(List.of()).setJobKey(-1L).setJobLease("");

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplier.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import java.util.List;
 
 public final class AgentInstanceUpdatedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
@@ -28,7 +29,18 @@ public final class AgentInstanceUpdatedApplier
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
-    agentInstanceState.update(key, value);
+    // The secondary-storage exporters replace the whole entity with whatever the emitted event's
+    // record contains, so primary storage must retain every field the secondary entity needs — a
+    // new field should join it by default. `history`, `jobKey`, and `jobLease` are the deliberate
+    // exceptions: they're per-command payload, not durable entity attributes, and everything they
+    // carry is already persisted independently as its own AGENT_HISTORY record. Storing them here
+    // too would be duplicative, and since only the most recent command's values are ever echoed
+    // onto a given event, primary storage would end up reflecting "whatever the last command
+    // happened to carry" rather than anything meaningful about the instance.
+    final var forStorage = new AgentInstanceRecord();
+    forStorage.copyFrom(value);
+    forStorage.setHistory(List.of()).setJobKey(-1L).setJobLease("");
+    agentInstanceState.update(key, forStorage);
 
     final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
     if (elementInstance != null && elementInstance.getAgentInstanceKey() != key) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplier.java
@@ -29,14 +29,12 @@ public final class AgentInstanceUpdatedApplier
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
-    // The secondary-storage exporters replace the whole entity with whatever the emitted event's
-    // record contains, so primary storage must retain every field the secondary entity needs — a
-    // new field should join it by default. `history`, `jobKey`, and `jobLease` are the deliberate
-    // exceptions: they're per-command payload, not durable entity attributes, and everything they
-    // carry is already persisted independently as its own AGENT_HISTORY record. Storing them here
-    // too would be duplicative, and since only the most recent command's values are ever echoed
-    // onto a given event, primary storage would end up reflecting "whatever the last command
-    // happened to carry" rather than anything meaningful about the instance.
+    // A new field should join primary storage by default, since secondary-storage exporters
+    // replace the whole entity with whatever the emitted event carries. `history`, `jobKey`, and
+    // `jobLease` are the exceptions: history is already durably captured as its own AGENT_HISTORY
+    // record and can grow large, so keeping a copy here would be wasteful; jobKey/jobLease are
+    // only meaningful while the command that carries them is being processed, so persisting them
+    // would just reflect whichever command happened to run last, not the instance's actual state.
     final var forStorage = new AgentInstanceRecord();
     forStorage.copyFrom(value);
     forStorage.setHistory(List.of()).setJobKey(-1L).setJobLease("");

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -230,8 +230,8 @@ public class AgentHistoryCreateTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            ("Expected job with key '%d' to hold the supplied lease, but it did not match. The job "
-                    + "may have been re-activated.")
+            ("Expected to update agent instance related to job with key '%d', but job did "
+                    + "not hold the supplied lease. The job may have been re-activated.")
                 .formatted(job.key()));
   }
 
@@ -261,8 +261,8 @@ public class AgentHistoryCreateTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            ("Expected job with key '%d' to hold the supplied lease, but it did not match. The job "
-                    + "may have been re-activated.")
+            ("Expected to update agent instance related to job with key '%d', but job did "
+                    + "not hold the supplied lease. The job may have been re-activated.")
                 .formatted(job.key()));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -230,7 +230,8 @@ public class AgentHistoryCreateTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            "Expected to create agent history entry for job with key '%d', but the supplied lease does not match. The job may have been re-activated."
+            ("Expected job with key '%d' to hold the supplied lease, but it did not match. The job "
+                    + "may have been re-activated.")
                 .formatted(job.key()));
   }
 
@@ -260,7 +261,8 @@ public class AgentHistoryCreateTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            "Expected to create agent history entry for job with key '%d', but the supplied lease does not match. The job may have been re-activated."
+            ("Expected job with key '%d' to hold the supplied lease, but it did not match. The job "
+                    + "may have been re-activated.")
                 .formatted(job.key()));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Covers the embedded {@code history[]} batch processing on {@code AGENT_INSTANCE:CREATE}/{@code
+ * UPDATE} (#58791). So far: the job-context precondition, checked whenever a jobKey is provided and
+ * required once a history batch is present, that keeps the existing PENDING/COMMITTED/DISCARDED
+ * lifecycle safe.
+ *
+ * <p>Per-item shape validation, batch application, and whole-batch atomicity are covered by
+ * follow-up commits' own test coverage, not here.
+ */
+public class AgentInstanceHistoryBatchProcessingTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_ID = "agent-task";
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectHistoryBatchWithoutJobKeyOnCreate() {
+    // given — CREATE applies the exact same job-context rule as UPDATE (AgentHistoryBatchHelper
+    // is shared, unchanged, between the two processors).
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+
+    // when — no withJobKey(...) call at all
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(userItem("item-1", "hi")))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("jobKey");
+  }
+
+  @Test
+  public void shouldAllowUpdateWithoutJobAndWithoutHistory() {
+    // given — regression test: supplying neither a job nor a history batch must remain valid.
+    // validateJobContext's "no jobKey, no history" branch used to be wrongly rejected; this pins
+    // that a plain, job-less, history-less UPDATE (the shape every pre-existing status/metrics
+    // update in AgentInstanceUpdateTest uses) keeps working.
+    final var context = deployCreateAgentInstanceAndActivateJob();
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withStatus(AgentInstanceStatus.THINKING)
+            .update();
+
+    // then
+    assertThat(updated.getValue().getStatus()).isEqualTo(AgentInstanceStatus.THINKING);
+  }
+
+  @Test
+  public void shouldRejectWhenJobNotActive() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+
+    // when — a jobKey that was never activated
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(999999999L)
+            .withHistory(List.of(userItem("item-1", "hi")))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason()).contains("999999999");
+  }
+
+  @Test
+  public void shouldRejectJobKeyNotActiveEvenWithoutHistory() {
+    // given — the job-context check runs whenever a jobKey is provided, regardless of whether a
+    // history batch is present.
+    final var context = deployCreateAgentInstanceAndActivateJob();
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(999999999L)
+            .withStatus(AgentInstanceStatus.THINKING)
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason()).contains("999999999");
+  }
+
+  @Test
+  public void shouldRejectHistoryBatchWithoutJobKey() {
+    // given — once a history batch is present, a job context becomes required: the batch's
+    // AGENT_HISTORY items must be attributed to the job that produced them.
+    final var context = deployCreateAgentInstanceAndActivateJob();
+
+    // when — no withJobKey(...) call at all
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withHistory(List.of(userItem("item-1", "hi")))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("jobKey");
+  }
+
+  @Test
+  public void shouldRejectWhenJobLeaseMismatch() {
+    // given
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(JOB_TYPE).withLease().activate();
+
+    // when — carries no lease even though the job has one
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(userItem("item-1", "hi")))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason()).contains(String.valueOf(jobKey));
+  }
+
+  // --- helpers ---
+
+  private static Context deployCreateAgentInstanceAndActivateJob() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    return new Context(agentInstanceKey, elementInstanceKey, jobKey);
+  }
+
+  private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .withElementId(SERVICE_TASK_ID)
+        .getFirst();
+  }
+
+  private static long activateJobForProcessInstance(final long processInstanceKey) {
+    ENGINE.jobs().withType(JOB_TYPE).activate();
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .getFirst()
+        .getKey();
+  }
+
+  private static Record<?> createAgentInstance(final long elementInstanceKey) {
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+        .create();
+  }
+
+  private static AgentHistoryRecord userItem(final String historyItemId, final String text) {
+    return new AgentHistoryRecord()
+        .setHistoryItemId(historyItemId)
+        .setRole(AgentHistoryRole.USER)
+        .setLoopIteration(1)
+        .addContent(
+            new AgentHistoryMessageContent()
+                .setContentType(AgentHistoryContentType.TEXT)
+                .setText(text));
+  }
+
+  private record Context(long agentInstanceKey, long elementInstanceKey, long jobKey) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -171,27 +171,6 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
-  public void shouldAllowUpdateWithoutJobAndWithoutHistory() {
-    // given — regression test: supplying neither a job nor a history batch must remain valid.
-    // validateJobContext's "no jobKey, no history" branch used to be wrongly rejected; this pins
-    // that a plain, job-less, history-less UPDATE (the shape every pre-existing status/metrics
-    // update in AgentInstanceUpdateTest uses) keeps working.
-    final var context = deployCreateAgentInstanceAndActivateJob();
-
-    // when
-    final var updated =
-        ENGINE
-            .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withStatus(AgentInstanceStatus.THINKING)
-            .update();
-
-    // then
-    assertThat(updated.getValue().getStatus()).isEqualTo(AgentInstanceStatus.THINKING);
-  }
-
-  @Test
   public void shouldRejectWhenJobNotActive() {
     // given
     final var context = deployCreateAgentInstanceAndActivateJob();
@@ -204,28 +183,6 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementInstanceKey(context.elementInstanceKey())
             .withJobKey(999999999L)
             .withHistory(List.of(userItem("item-1", "hi")))
-            .expectRejection()
-            .update();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
-    assertThat(rejection.getRejectionReason()).contains("999999999");
-  }
-
-  @Test
-  public void shouldRejectJobKeyNotActiveEvenWithoutHistory() {
-    // given — the job-context check runs whenever a jobKey is provided, regardless of whether a
-    // history batch is present.
-    final var context = deployCreateAgentInstanceAndActivateJob();
-
-    // when
-    final var rejection =
-        ENGINE
-            .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(999999999L)
-            .withStatus(AgentInstanceStatus.THINKING)
             .expectRejection()
             .update();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -222,10 +222,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
-            .withType(JOB_TYPE)
+            .withType(jobType(processInstanceKey))
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(JOB_TYPE).withLease().activate();
+    ENGINE.jobs().withType(jobType(processInstanceKey)).withLease().activate();
 
     // when — carries no lease even though the job has one
     final var rejection =
@@ -627,6 +627,11 @@ public class AgentInstanceHistoryBatchProcessingTest {
     return new Context(agentInstanceKey, elementInstanceKey, jobKey);
   }
 
+  // Each process instance gets its own job type, resolved at runtime from its own
+  // processInstanceKey via a job-type expression rather than baked in at deploy time (the
+  // process instance doesn't exist yet when this BPMN model is deployed). This keeps
+  // ENGINE.jobs().withType(...).activate() — which isn't scoped by process instance — from ever
+  // picking up a job left over from a different test case in this class's shared @ClassRule.
   private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
     ENGINE
         .deployment()
@@ -634,7 +639,11 @@ public class AgentInstanceHistoryBatchProcessingTest {
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
                 .serviceTask(
-                    SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE).zeebeAiAgentTaskDefinition())
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobTypeExpression(
+                                "\"" + JOB_TYPE + "\" + string(camunda.processInstance.key)")
+                            .zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -646,11 +655,15 @@ public class AgentInstanceHistoryBatchProcessingTest {
         .getFirst();
   }
 
+  private static String jobType(final long processInstanceKey) {
+    return JOB_TYPE + processInstanceKey;
+  }
+
   private static long activateJobForProcessInstance(final long processInstanceKey) {
-    ENGINE.jobs().withType(JOB_TYPE).activate();
+    ENGINE.jobs().withType(jobType(processInstanceKey)).activate();
     return RecordingExporter.jobRecords(JobIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
-        .withType(JOB_TYPE)
+        .withType(jobType(processInstanceKey))
         .getFirst()
         .getKey();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMess
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -32,12 +33,15 @@ import org.junit.Test;
 
 /**
  * Covers the embedded {@code history[]} batch processing on {@code AGENT_INSTANCE:CREATE}/{@code
- * UPDATE} (#58791). So far: the job-context precondition, checked whenever a jobKey is provided and
- * required once a history batch is present, that keeps the existing PENDING/COMMITTED/DISCARDED
- * lifecycle safe.
+ * UPDATE} (#58791). So far: the job-context precondition (checked whenever a jobKey is provided,
+ * and required once a history batch is present) that keeps the existing PENDING/COMMITTED/DISCARDED
+ * lifecycle safe, and whole-batch shape validation — every item needs a non-empty {@code
+ * historyItemId}, a declared role, and a positive {@code loopIteration}, and a {@code
+ * CONFIGURATION} item's {@code changedAttributes} may only name attributes this helper actually
+ * knows how to apply.
  *
- * <p>Per-item shape validation, batch application, and whole-batch atomicity are covered by
- * follow-up commits' own test coverage, not here.
+ * <p>Batch application and whole-batch atomicity are covered by follow-up commits' own test
+ * coverage, not here.
  */
 public class AgentInstanceHistoryBatchProcessingTest {
 
@@ -68,6 +72,105 @@ public class AgentInstanceHistoryBatchProcessingTest {
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
     assertThat(rejection.getRejectionReason()).contains("jobKey");
+  }
+
+  @Test
+  public void shouldRejectWholeBatchWhenAnItemIsMissingHistoryItemId() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var validItem = userItem("item-user", "hi");
+    final var invalidItem = new AgentHistoryRecord().setRole(AgentHistoryRole.USER);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(validItem, invalidItem))
+            .expectRejection()
+            .update();
+
+    // then — the whole batch is rejected, referencing the offending item's index; nothing created
+    // (the command was rejected before any AGENT_HISTORY:CREATED event could be appended).
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("index 1", "historyItemId is missing");
+  }
+
+  @Test
+  public void shouldRejectWholeBatchWhenRoleUnspecified() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var invalidItem = new AgentHistoryRecord().setHistoryItemId("item-1");
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(invalidItem))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("item-1", "UNSPECIFIED");
+  }
+
+  @Test
+  public void shouldRejectWholeBatchWhenLoopIterationMissing() {
+    // given — the 0 default (loopIteration left unset) is rejected the same as an explicit 0 or a
+    // negative value: none of those are valid loopIteration numbers.
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var invalidItem =
+        new AgentHistoryRecord().setHistoryItemId("item-1").setRole(AgentHistoryRole.USER);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(invalidItem))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("item-1", "loopIteration is missing");
+  }
+
+  @Test
+  public void shouldRejectWholeBatchWhenConfigurationItemHasUnknownChangedAttribute() {
+    // given — a CONFIGURATION item naming an attribute this helper doesn't know how to apply (as
+    // opposed to a request-level unknown attribute, which is a different check entirely).
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var invalidItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setChangedAttributes(List.of("model", "elementInstanceKey"));
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(invalidItem))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("item-config", "elementInstanceKey");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -60,7 +60,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
   @Test
   public void shouldRejectHistoryBatchWithoutJobKeyOnCreate() {
-    // given — CREATE applies the exact same job-context rule as UPDATE (AgentHistoryBatchHelper
+    // given — CREATE applies the exact same job-context rule as UPDATE (AgentHistoryBatchBehavior
     // is shared, unchanged, between the two processors).
     final var serviceTaskInstance = deployAndCreateProcessInstance();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -397,8 +397,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
     // then — metrics accumulate on top of the first update's totals: two more model calls (three
     // total), two more tool calls from the second item and none from the third (three total), and
     // token counts summed across all three items.
-    assertThat(secondUpdate.getValue().getMetrics().getInputTokens()).isEqualTo(175L);
-    assertThat(secondUpdate.getValue().getMetrics().getOutputTokens()).isEqualTo(70L);
+    assertThat(secondUpdate.getValue().getMetrics().getInputTokens()).isEqualTo(100L + 50L + 25L);
+    assertThat(secondUpdate.getValue().getMetrics().getOutputTokens()).isEqualTo(40L + 20L + 10L);
     assertThat(secondUpdate.getValue().getMetrics().getModelCalls()).isEqualTo(3);
     assertThat(secondUpdate.getValue().getMetrics().getToolCalls()).isEqualTo(3);
     assertThat(secondUpdate.getValue().getChangedAttributes()).contains("metrics");

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbe
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -29,6 +28,7 @@ import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
@@ -46,9 +46,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_ID = "agent-task";
-  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
   @Test
   public void shouldRejectHistoryBatchWithoutJobKeyOnCreate() {
@@ -247,10 +247,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
-            .withType(jobType(processInstanceKey))
+            .withType(helper.getJobType())
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(jobType(processInstanceKey)).withLease().activate();
+    ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
 
     // when — carries no lease even though the job has one
     final var rejection =
@@ -705,7 +705,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
   // --- helpers ---
 
-  private static Context deployCreateAgentInstanceAndActivateJob() {
+  private Context deployCreateAgentInstanceAndActivateJob() {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
@@ -714,12 +714,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
     return new Context(agentInstanceKey, elementInstanceKey, jobKey);
   }
 
-  // Each process instance gets its own job type, resolved at runtime from its own
-  // processInstanceKey via a job-type expression rather than baked in at deploy time (the
-  // process instance doesn't exist yet when this BPMN model is deployed). This keeps
-  // ENGINE.jobs().withType(...).activate() — which isn't scoped by process instance — from ever
-  // picking up a job left over from a different test case in this class's shared @ClassRule.
-  private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
+  private Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
     ENGINE
         .deployment()
         .withXmlResource(
@@ -727,10 +722,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
                 .startEvent()
                 .serviceTask(
                     SERVICE_TASK_ID,
-                    t ->
-                        t.zeebeJobTypeExpression(
-                                "\"" + JOB_TYPE + "\" + string(camunda.processInstance.key)")
-                            .zeebeAiAgentTaskDefinition())
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
                 .endEvent()
                 .done())
         .deploy();
@@ -742,15 +734,11 @@ public class AgentInstanceHistoryBatchProcessingTest {
         .getFirst();
   }
 
-  private static String jobType(final long processInstanceKey) {
-    return JOB_TYPE + processInstanceKey;
-  }
-
-  private static long activateJobForProcessInstance(final long processInstanceKey) {
-    ENGINE.jobs().withType(jobType(processInstanceKey)).activate();
+  private long activateJobForProcessInstance(final long processInstanceKey) {
+    ENGINE.jobs().withType(helper.getJobType()).activate();
     return RecordingExporter.jobRecords(JobIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
-        .withType(jobType(processInstanceKey))
+        .withType(helper.getJobType())
         .getFirst()
         .getKey();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbe
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
@@ -27,7 +26,6 @@ import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -54,15 +52,42 @@ public class AgentInstanceHistoryBatchProcessingTest {
   public void shouldRejectHistoryBatchWithoutJobKeyOnCreate() {
     // given — CREATE applies the exact same job-context rule as UPDATE (AgentHistoryBatchBehavior
     // is shared, unchanged, between the two processors).
-    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
 
     // when — no withJobKey(...) call at all
     final var rejection =
         ENGINE
             .agentInstances()
-            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withElementInstanceKey(elementInstanceKey)
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
-            .withHistory(List.of(userItem("item-1", "hi")))
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
             .expectRejection()
             .create();
 
@@ -77,17 +102,57 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldRejectWholeBatchWhenAnItemIsMissingHistoryItemId() {
     // given
-    final var context = deployCreateAgentInstanceAndActivateJob();
-    final var validItem = userItem("item-user", "hi");
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var validItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
     final var invalidItem = new AgentHistoryRecord().setRole(AgentHistoryRole.USER);
 
     // when
     final var rejection =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(validItem, invalidItem))
             .expectRejection()
             .update();
@@ -106,16 +171,48 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldRejectWholeBatchWhenRoleUnspecified() {
     // given
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
     final var invalidItem = new AgentHistoryRecord().setHistoryItemId("item-1");
 
     // when
     final var rejection =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(invalidItem))
             .expectRejection()
             .update();
@@ -132,7 +229,39 @@ public class AgentInstanceHistoryBatchProcessingTest {
   public void shouldRejectWholeBatchWhenLoopIterationMissing() {
     // given — the 0 default (loopIteration left unset) is rejected the same as an explicit 0 or a
     // negative value: none of those are valid loopIteration numbers.
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
     final var invalidItem =
         new AgentHistoryRecord().setHistoryItemId("item-1").setRole(AgentHistoryRole.USER);
 
@@ -140,9 +269,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var rejection =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(invalidItem))
             .expectRejection()
             .update();
@@ -160,7 +289,39 @@ public class AgentInstanceHistoryBatchProcessingTest {
   public void shouldRejectWholeBatchWhenConfigurationItemHasUnknownChangedAttribute() {
     // given — a CONFIGURATION item naming an attribute this helper doesn't know how to apply (as
     // opposed to a request-level unknown attribute, which is a different check entirely).
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
     final var invalidItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-config")
@@ -172,9 +333,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var rejection =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(invalidItem))
             .expectRejection()
             .update();
@@ -192,16 +353,51 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldRejectWhenJobNotActive() {
     // given
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
 
     // when — a jobKey that was never activated
     final var rejection =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
             .withJobKey(999999999L)
-            .withHistory(List.of(userItem("item-1", "hi")))
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
             .expectRejection()
             .update();
 
@@ -217,15 +413,50 @@ public class AgentInstanceHistoryBatchProcessingTest {
   public void shouldRejectHistoryBatchWithoutJobKey() {
     // given — once a history batch is present, a job context becomes required: the batch's
     // AGENT_HISTORY items must be attributed to the job that produced them.
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
 
     // when — no withJobKey(...) call at all
     final var rejection =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withHistory(List.of(userItem("item-1", "hi")))
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
             .expectRejection()
             .update();
 
@@ -240,10 +471,32 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldRejectWhenJobLeaseMismatch() {
     // given
-    final var serviceTaskInstance = deployAndCreateProcessInstance();
-    final var elementInstanceKey = serviceTaskInstance.getKey();
-    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -259,7 +512,16 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
-            .withHistory(List.of(userItem("item-1", "hi")))
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
             .expectRejection()
             .update();
 
@@ -276,7 +538,39 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldEmitHistoryEventForEachItemInOrderOnUpdate() {
     // given
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
     final var userItem =
         new AgentHistoryRecord()
             .setHistoryItemId("item-user")
@@ -310,16 +604,16 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var updated =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(userItem, assistantItem, toolResultItem))
             .update();
 
     // then — three AGENT_HISTORY:CREATED events, one per item, in array order.
     final var historyEvents =
         RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
-            .withAgentInstanceKey(context.agentInstanceKey())
+            .withAgentInstanceKey(agentInstanceKey)
             .limit(3)
             .toList();
     assertThat(historyEvents).hasSize(3);
@@ -333,9 +627,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(historyEvents)
         .allSatisfy(
             e -> {
-              assertThat(e.getValue().getElementInstanceKey())
-                  .isEqualTo(context.elementInstanceKey());
-              assertThat(e.getValue().getJobKey()).isEqualTo(context.jobKey());
+              assertThat(e.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+              assertThat(e.getValue().getJobKey()).isEqualTo(jobKey);
             });
 
     // the response echoes each built AGENT_HISTORY item back on the UPDATED event, in order.
@@ -352,9 +645,49 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldAccumulateMetricsAcrossSeparateUpdates() {
     // given — first batch: a single ASSISTANT item with its own token metrics and one tool call.
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
     final var firstAssistantItem =
-        assistantItem("item-assistant-1", "Sure, here is the summary.", 100L, 40L);
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-assistant-1")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("Sure, here is the summary."));
+    firstAssistantItem.getMetrics().setInputTokens(100L).setOutputTokens(40L);
     firstAssistantItem.addToolCall(
         new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
 
@@ -362,9 +695,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var firstUpdate =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(firstAssistantItem))
             .update();
 
@@ -377,20 +710,37 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // given — second batch: two more ASSISTANT items, each with their own metrics and tool calls.
     final var secondAssistantItem =
-        assistantItem("item-assistant-2", "Here is more detail.", 50L, 20L);
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-assistant-2")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("Here is more detail."));
+    secondAssistantItem.getMetrics().setInputTokens(50L).setOutputTokens(20L);
     secondAssistantItem.addToolCall(
         new AgentHistoryEmbeddedToolCall().setToolCallId("call-2").setToolName("lookup"));
     secondAssistantItem.addToolCall(
         new AgentHistoryEmbeddedToolCall().setToolCallId("call-3").setToolName("search"));
-    final var thirdAssistantItem = assistantItem("item-assistant-3", "One more detail.", 25L, 10L);
+    final var thirdAssistantItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-assistant-3")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("One more detail."));
+    thirdAssistantItem.getMetrics().setInputTokens(25L).setOutputTokens(10L);
 
     // when — the second update applies the second batch on top of the first
     final var secondUpdate =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(secondAssistantItem, thirdAssistantItem))
             .update();
 
@@ -408,9 +758,49 @@ public class AgentInstanceHistoryBatchProcessingTest {
   public void shouldDeriveModelCallsAndToolCallsFromAssistantItemWithoutExplicitMetrics() {
     // given — an ASSISTANT item carrying no token metrics at all still represents one model call,
     // plus one tool call per entry in its own toolCalls list.
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
     final var assistantItem =
-        assistantItem("item-assistant", "Sure, here is the summary.", -1L, -1L);
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-assistant")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("Sure, here is the summary."));
+    assistantItem.getMetrics().setInputTokens(-1L).setOutputTokens(-1L);
     assistantItem.addToolCall(
         new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
     assistantItem.addToolCall(
@@ -420,9 +810,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var updated =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(assistantItem))
             .update();
 
@@ -436,17 +826,57 @@ public class AgentInstanceHistoryBatchProcessingTest {
   public void shouldAccumulateMetricsOnAnyRole() {
     // given — metrics are not restricted to ASSISTANT items; a TOOL_RESULT item carrying them is
     // accumulated exactly like an ASSISTANT one.
-    final var context = deployCreateAgentInstanceAndActivateJob();
-    final var toolResultItem = toolResultItem("item-tool-result", "lookup result");
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var toolResultItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-tool-result")
+            .setRole(AgentHistoryRole.TOOL_RESULT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("lookup result"));
     toolResultItem.getMetrics().setInputTokens(5L).setOutputTokens(2L);
 
     // when
     final var updated =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(toolResultItem))
             .update();
 
@@ -459,16 +889,56 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldNotAccumulateMetricsWhenItemCarriesNone() {
     // given
-    final var context = deployCreateAgentInstanceAndActivateJob();
-    final var userItem = userItem("item-user", "hello");
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hello"));
 
     // when
     final var updated =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(userItem))
             .update();
 
@@ -480,8 +950,44 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldApplyInstanceFieldsFromConfigurationItemOnUpdate() {
     // given
-    final var context = deployCreateAgentInstanceAndActivateJob();
-    final var configItem = configItem("item-config");
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1);
     configItem.setModel("gpt-4o-mini").setProvider("openai");
     configItem.addSystemPrompt(
         new AgentHistoryMessageContent()
@@ -503,9 +1009,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var updated =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(configItem))
             .update();
 
@@ -531,7 +1037,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
     // the persisted AGENT_HISTORY event is a full copy of the item, including these fields.
     final var historyEvent =
         RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
-            .withAgentInstanceKey(context.agentInstanceKey())
+            .withAgentInstanceKey(agentInstanceKey)
             .getFirst();
     assertThat(historyEvent.getValue().getModel()).isEqualTo("gpt-4o-mini");
     assertThat(historyEvent.getValue().getProvider()).isEqualTo("openai");
@@ -539,13 +1045,48 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
   @Test
   public void shouldOnlyApplyAttributesNamedInConfigurationItemChangedAttributes() {
-    // given — deployCreateAgentInstanceAndActivateJob() creates the instance with
-    // model="gpt-4o"/provider="openai" already set. The item carries a different value for both,
-    // but only names "model" in its own changedAttributes: provider must be left at its original
-    // value, since presence alone no longer drives application (that's what tells apart "left
-    // as-is" from "deliberately cleared").
-    final var context = deployCreateAgentInstanceAndActivateJob();
-    final var configItem = configItem("item-config");
+    // given — the agent instance is created with model="gpt-4o"/provider="openai" below. The item
+    // carries a different value for both, but only names "model" in its own changedAttributes:
+    // provider must be left at its original value, since presence alone no longer drives
+    // application (that's what tells apart "left as-is" from "deliberately cleared").
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1);
     configItem.setModel("gpt-4o-mini").setProvider("anthropic");
     configItem.setChangedAttributes(List.of("model"));
 
@@ -553,9 +1094,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var updated =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(configItem))
             .update();
 
@@ -568,11 +1109,51 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldNotApplyInstanceFieldsFromNonConfigurationItem() {
     // given — a USER item carrying model/provider data (e.g. echoed by a misbehaving client) must
-    // not affect AgentInstance state: only CONFIGURATION items ever do. The instance was created
-    // with model="gpt-4o"/provider="openai" (see deployCreateAgentInstanceAndActivateJob()); the
-    // item carries different values to prove they never land.
-    final var context = deployCreateAgentInstanceAndActivateJob();
-    final var userItem = userItem("item-user", "hello");
+    // not affect AgentInstance state: only CONFIGURATION items ever do. The instance is created
+    // below with model="gpt-4o"/provider="openai"; the item carries different values to prove they
+    // never land.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hello"));
     userItem.setModel("gpt-4o-mini").setProvider("anthropic");
     userItem.setChangedAttributes(List.of("model", "provider"));
 
@@ -580,9 +1161,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var updated =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
             .withHistory(List.of(userItem))
             .update();
 
@@ -595,7 +1176,39 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldRejectDirectMetricsChangeWhenHistoryIsPresent() {
     // given
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
 
     // when — old-style direct metrics delta combined with a history batch in the same request:
     // "metrics" drops out of the allowed set once history is present, so this is rejected exactly
@@ -603,10 +1216,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
     final var rejection =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
-            .withHistory(List.of(userItem("item-1", "hi")))
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
             .withMetricsDelta(10L, 5L, 1, 0)
             .expectRejection()
             .update();
@@ -622,16 +1244,57 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldRejectDirectToolsChangeWhenHistoryIsPresent() {
     // given
-    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
 
     // when — old-style direct tools change combined with a history batch in the same request
     final var rejection =
         ENGINE
             .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withJobKey(context.jobKey())
-            .withHistory(List.of(userItem("item-1", "hi")))
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
             .withTools(List.of(AgentInstanceClient.tool("calc", "a calculator", "calc-task")))
             .expectRejection()
             .update();
@@ -647,11 +1310,41 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldEmitHistoryEventsOnCreate() {
     // given
-    final var serviceTaskInstance = deployAndCreateProcessInstance();
-    final var elementInstanceKey = serviceTaskInstance.getKey();
-    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
-    final var userItem = userItem("item-user", "hi");
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
 
     // when
     final var created =
@@ -677,44 +1370,6 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldResetEchoedHistoryOnSubsequentUpdateWithoutABatch() {
     // given — first update carries a batch
-    final var context = deployCreateAgentInstanceAndActivateJob();
-    ENGINE
-        .agentInstances()
-        .withAgentInstanceKey(context.agentInstanceKey())
-        .withElementInstanceKey(context.elementInstanceKey())
-        .withJobKey(context.jobKey())
-        .withHistory(List.of(userItem("item-1", "hi")))
-        .update();
-
-    // when — a second, status-only update carries no batch at all
-    final var secondUpdate =
-        ENGINE
-            .agentInstances()
-            .withAgentInstanceKey(context.agentInstanceKey())
-            .withElementInstanceKey(context.elementInstanceKey())
-            .withStatus(AgentInstanceStatus.THINKING)
-            .update();
-
-    // then — the previous batch must not leak forward onto an unrelated update. This also proves
-    // history never round-trips through primary storage: `current` here was loaded fresh via
-    // agentInstanceState.getRecord(), and AgentInstanceCreatedApplier/UpdatedApplier strip history
-    // before ever storing a record — if they didn't, the first update's batch would still be
-    // sitting in state and would leak back out here.
-    assertThat(secondUpdate.getValue().getHistory()).isEmpty();
-  }
-
-  // --- helpers ---
-
-  private Context deployCreateAgentInstanceAndActivateJob() {
-    final var serviceTaskInstance = deployAndCreateProcessInstance();
-    final var elementInstanceKey = serviceTaskInstance.getKey();
-    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
-    final var jobKey = activateJobForProcessInstance(processInstanceKey);
-    return new Context(agentInstanceKey, elementInstanceKey, jobKey);
-  }
-
-  private Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
     ENGINE
         .deployment()
         .withXmlResource(
@@ -727,76 +1382,58 @@ public class AgentInstanceHistoryBatchProcessingTest {
                 .done())
         .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementType(BpmnElementType.SERVICE_TASK)
-        .withElementId(SERVICE_TASK_ID)
-        .getFirst();
-  }
-
-  private long activateJobForProcessInstance(final long processInstanceKey) {
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
     ENGINE.jobs().withType(helper.getJobType()).activate();
-    return RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withType(helper.getJobType())
-        .getFirst()
-        .getKey();
-  }
-
-  private static Record<?> createAgentInstance(final long elementInstanceKey) {
-    return ENGINE
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    ENGINE
         .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
-        .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
-        .create();
-  }
+        .withJobKey(jobKey)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-1")
+                    .setRole(AgentHistoryRole.USER)
+                    .setLoopIteration(1)
+                    .addContent(
+                        new AgentHistoryMessageContent()
+                            .setContentType(AgentHistoryContentType.TEXT)
+                            .setText("hi"))))
+        .update();
 
-  private static AgentHistoryRecord userItem(final String historyItemId, final String text) {
-    return new AgentHistoryRecord()
-        .setHistoryItemId(historyItemId)
-        .setRole(AgentHistoryRole.USER)
-        .setLoopIteration(1)
-        .addContent(
-            new AgentHistoryMessageContent()
-                .setContentType(AgentHistoryContentType.TEXT)
-                .setText(text));
-  }
+    // when — a second, status-only update carries no batch at all
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withStatus(AgentInstanceStatus.THINKING)
+            .update();
 
-  private static AgentHistoryRecord assistantItem(
-      final String historyItemId,
-      final String text,
-      final long inputTokens,
-      final long outputTokens) {
-    final var item =
-        new AgentHistoryRecord()
-            .setHistoryItemId(historyItemId)
-            .setRole(AgentHistoryRole.ASSISTANT)
-            .setLoopIteration(1)
-            .addContent(
-                new AgentHistoryMessageContent()
-                    .setContentType(AgentHistoryContentType.TEXT)
-                    .setText(text));
-    item.getMetrics().setInputTokens(inputTokens).setOutputTokens(outputTokens);
-    return item;
+    // then — the previous batch must not leak forward onto an unrelated update. This also proves
+    // history never round-trips through primary storage: `current` here was loaded fresh via
+    // agentInstanceState.getRecord(), and AgentInstanceCreatedApplier/UpdatedApplier strip history
+    // before ever storing a record — if they didn't, the first update's batch would still be
+    // sitting in state and would leak back out here.
+    assertThat(secondUpdate.getValue().getHistory()).isEmpty();
   }
-
-  private static AgentHistoryRecord toolResultItem(final String historyItemId, final String text) {
-    return new AgentHistoryRecord()
-        .setHistoryItemId(historyItemId)
-        .setRole(AgentHistoryRole.TOOL_RESULT)
-        .setLoopIteration(1)
-        .addContent(
-            new AgentHistoryMessageContent()
-                .setContentType(AgentHistoryContentType.TEXT)
-                .setText(text));
-  }
-
-  private static AgentHistoryRecord configItem(final String historyItemId) {
-    return new AgentHistoryRecord()
-        .setHistoryItemId(historyItemId)
-        .setRole(AgentHistoryRole.CONFIGURATION)
-        .setLoopIteration(1);
-  }
-
-  private record Context(long agentInstanceKey, long elementInstanceKey, long jobKey) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -98,8 +98,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            "Expected to process history item at index 1, but historyItemId is missing (got "
-                + "empty string). Every history item must have a non-empty historyItemId.");
+            "Expected to add history item at index 1 to agent instance, but historyItemId is "
+                + "missing (got empty string). Each history item must have a non-empty "
+                + "historyItemId.");
   }
 
   @Test
@@ -123,8 +124,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            "Expected to process history item with historyItemId 'item-1', but its role is "
-                + "UNSPECIFIED. Every history item must declare a role.");
+            "Expected to add history item with historyItemId 'item-1' to agent instance, but its "
+                + "role is UNSPECIFIED. Each history item must declare a role.");
   }
 
   @Test
@@ -150,8 +151,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            "Expected to process history item with historyItemId 'item-1', but loopIteration is "
-                + "missing (got 0). Every history item must declare a positive loopIteration.");
+            "Expected to add history item with historyItemId 'item-1' to agent instance, but "
+                + "loopIteration is missing (got 0). Each history item must declare a positive "
+                + "loopIteration.");
   }
 
   @Test
@@ -206,7 +208,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(rejection.getRejectionReason())
-        .isEqualTo("Expected job with key '999999999' to be active, but it was not.");
+        .isEqualTo(
+            "Expected to update agent instance related to job with key '999999999', but job was "
+                + "not active.");
   }
 
   @Test
@@ -263,9 +267,9 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
-            "Expected job with key '"
+            "Expected to update agent instance related to job with key '"
                 + jobKey
-                + "' to hold the supplied lease, but it did not match. The job may have been "
+                + "', but job did not hold the supplied lease. The job may have been "
                 + "re-activated.");
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -10,16 +10,21 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.AgentInstanceClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -33,15 +38,15 @@ import org.junit.Test;
 
 /**
  * Covers the embedded {@code history[]} batch processing on {@code AGENT_INSTANCE:CREATE}/{@code
- * UPDATE} (#58791). So far: the job-context precondition (checked whenever a jobKey is provided,
- * and required once a history batch is present) that keeps the existing PENDING/COMMITTED/DISCARDED
- * lifecycle safe, and whole-batch shape validation — every item needs a non-empty {@code
- * historyItemId}, a declared role, and a positive {@code loopIteration}, and a {@code
- * CONFIGURATION} item's {@code changedAttributes} may only name attributes this helper actually
- * knows how to apply.
- *
- * <p>Batch application and whole-batch atomicity are covered by follow-up commits' own test
- * coverage, not here.
+ * UPDATE}: the job-context precondition (checked whenever a jobKey is provided, and required once a
+ * history batch is present) that keeps the existing PENDING/COMMITTED/DISCARDED lifecycle safe;
+ * whole-batch shape validation — every item needs a non-empty {@code historyItemId}, a declared
+ * role, and a positive {@code loopIteration}, and a {@code CONFIGURATION} item's {@code
+ * changedAttributes} may only name attributes this helper actually knows how to apply; and,
+ * finally, the actual batch application once it's wired into CREATE/UPDATE — history events emitted
+ * in order, metrics accumulated (including the ASSISTANT-derived model/tool call counts), instance
+ * fields applied only from {@code CONFIGURATION} items and only for the attributes they name, and
+ * batch atomicity (a rejection anywhere in the batch leaves no partial history behind).
  */
 public class AgentInstanceHistoryBatchProcessingTest {
 
@@ -289,6 +294,379 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(rejection.getRejectionReason()).contains(String.valueOf(jobKey));
   }
 
+  @Test
+  public void shouldEmitHistoryEventForEachItemInOrderOnUpdate() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var userItem = userItem("item-user", "Please summarize this document.");
+    final var assistantItem =
+        assistantItem("item-assistant", "Sure, here is the summary.", 100L, 40L);
+    final var toolResultItem = toolResultItem("item-tool-result", "lookup result");
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(userItem, assistantItem, toolResultItem))
+            .update();
+
+    // then — three AGENT_HISTORY:CREATED events, one per item, in array order.
+    final var historyEvents =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .limit(3)
+            .toList();
+    assertThat(historyEvents).hasSize(3);
+    assertThat(historyEvents)
+        .extracting(e -> e.getValue().getHistoryItemId())
+        .containsExactly("item-user", "item-assistant", "item-tool-result");
+    assertThat(historyEvents)
+        .extracting(e -> e.getValue().getRole())
+        .containsExactly(
+            AgentHistoryRole.USER, AgentHistoryRole.ASSISTANT, AgentHistoryRole.TOOL_RESULT);
+    assertThat(historyEvents)
+        .allSatisfy(
+            e -> {
+              assertThat(e.getValue().getElementInstanceKey())
+                  .isEqualTo(context.elementInstanceKey());
+              assertThat(e.getValue().getJobKey()).isEqualTo(context.jobKey());
+            });
+
+    // the response echoes each built AGENT_HISTORY item back on the UPDATED event, in order.
+    final var echoedHistory = updated.getValue().getHistory();
+    assertThat(echoedHistory).hasSize(3);
+    assertThat(echoedHistory)
+        .extracting(AgentHistoryRecordValue::getAgentHistoryKey)
+        .containsExactly(
+            historyEvents.get(0).getValue().getAgentHistoryKey(),
+            historyEvents.get(1).getValue().getAgentHistoryKey(),
+            historyEvents.get(2).getValue().getAgentHistoryKey());
+  }
+
+  @Test
+  public void shouldAccumulateMetricsImmediatelyOnUpdate() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var assistantItem =
+        assistantItem("item-assistant", "Sure, here is the summary.", 100L, 40L);
+    assistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(assistantItem))
+            .update();
+
+    // then — the supplied token metrics are applied, and modelCalls/toolCalls are derived from the
+    // ASSISTANT item itself: one model call, plus one tool call for the one it dispatched.
+    assertThat(updated.getValue().getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(updated.getValue().getMetrics().getOutputTokens()).isEqualTo(40L);
+    assertThat(updated.getValue().getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(updated.getValue().getMetrics().getToolCalls()).isEqualTo(1);
+    assertThat(updated.getValue().getChangedAttributes()).contains("metrics");
+  }
+
+  @Test
+  public void shouldDeriveModelCallsAndToolCallsFromAssistantItemWithoutExplicitMetrics() {
+    // given — an ASSISTANT item carrying no token metrics at all still represents one model call,
+    // plus one tool call per entry in its own toolCalls list.
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var assistantItem =
+        assistantItem("item-assistant", "Sure, here is the summary.", -1L, -1L);
+    assistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
+    assistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-2").setToolName("search"));
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(assistantItem))
+            .update();
+
+    // then
+    assertThat(updated.getValue().getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(updated.getValue().getMetrics().getToolCalls()).isEqualTo(2);
+    assertThat(updated.getValue().getChangedAttributes()).contains("metrics");
+  }
+
+  @Test
+  public void shouldAccumulateMetricsOnAnyRole() {
+    // given — metrics are not restricted to ASSISTANT items; a TOOL_RESULT item carrying them is
+    // accumulated exactly like an ASSISTANT one.
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var toolResultItem = toolResultItem("item-tool-result", "lookup result");
+    toolResultItem.getMetrics().setInputTokens(5L).setOutputTokens(2L);
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(toolResultItem))
+            .update();
+
+    // then
+    assertThat(updated.getValue().getMetrics().getInputTokens()).isEqualTo(5L);
+    assertThat(updated.getValue().getMetrics().getOutputTokens()).isEqualTo(2L);
+    assertThat(updated.getValue().getChangedAttributes()).contains("metrics");
+  }
+
+  @Test
+  public void shouldNotAccumulateMetricsWhenItemCarriesNone() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var userItem = userItem("item-user", "hello");
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(userItem))
+            .update();
+
+    // then
+    assertThat(updated.getValue().getMetrics().getModelCalls()).isEqualTo(0);
+    assertThat(updated.getValue().getChangedAttributes()).doesNotContain("metrics");
+  }
+
+  @Test
+  public void shouldApplyInstanceFieldsFromConfigurationItemOnUpdate() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var configItem = configItem("item-config");
+    configItem.setModel("gpt-4o-mini").setProvider("openai");
+    configItem.addSystemPrompt(
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.TEXT)
+            .setText("You are a helpful agent."));
+    configItem.setTools(List.of(new AgentInstanceTool().setName("calc").setElementId("calc-task")));
+    configItem.getLimits().setMaxTokens(5000L).setMaxModelCalls(8).setMaxToolCalls(16);
+    configItem.setChangedAttributes(
+        List.of(
+            "model",
+            "provider",
+            "systemPrompt",
+            "tools",
+            "maxTokens",
+            "maxModelCalls",
+            "maxToolCalls"));
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(configItem))
+            .update();
+
+    // then — applied immediately onto the live fields, driven by the item's own changedAttributes.
+    assertThat(updated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(updated.getValue().getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(updated.getValue().getDefinition().getSystemPrompt())
+        .isEqualTo("You are a helpful agent.");
+    assertThat(updated.getValue().getTools()).extracting("name").containsExactly("calc");
+    assertThat(updated.getValue().getLimits().getMaxTokens()).isEqualTo(5000L);
+    assertThat(updated.getValue().getLimits().getMaxModelCalls()).isEqualTo(8);
+    assertThat(updated.getValue().getLimits().getMaxToolCalls()).isEqualTo(16);
+    assertThat(updated.getValue().getChangedAttributes())
+        .containsExactlyInAnyOrder(
+            "systemPrompt",
+            "model",
+            "provider",
+            "tools",
+            "maxTokens",
+            "maxModelCalls",
+            "maxToolCalls");
+
+    // the persisted AGENT_HISTORY event is a full copy of the item, including these fields.
+    final var historyEvent =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .getFirst();
+    assertThat(historyEvent.getValue().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(historyEvent.getValue().getProvider()).isEqualTo("openai");
+  }
+
+  @Test
+  public void shouldOnlyApplyAttributesNamedInConfigurationItemChangedAttributes() {
+    // given — deployCreateAgentInstanceAndActivateJob() creates the instance with
+    // model="gpt-4o"/provider="openai" already set. The item carries a different value for both,
+    // but only names "model" in its own changedAttributes: provider must be left at its original
+    // value, since presence alone no longer drives application (that's what tells apart "left
+    // as-is" from "deliberately cleared").
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var configItem = configItem("item-config");
+    configItem.setModel("gpt-4o-mini").setProvider("anthropic");
+    configItem.setChangedAttributes(List.of("model"));
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(configItem))
+            .update();
+
+    // then
+    assertThat(updated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(updated.getValue().getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(updated.getValue().getChangedAttributes()).containsExactly("model");
+  }
+
+  @Test
+  public void shouldNotApplyInstanceFieldsFromNonConfigurationItem() {
+    // given — a USER item carrying model/provider data (e.g. echoed by a misbehaving client) must
+    // not affect AgentInstance state: only CONFIGURATION items ever do. The instance was created
+    // with model="gpt-4o"/provider="openai" (see deployCreateAgentInstanceAndActivateJob()); the
+    // item carries different values to prove they never land.
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    final var userItem = userItem("item-user", "hello");
+    userItem.setModel("gpt-4o-mini").setProvider("anthropic");
+    userItem.setChangedAttributes(List.of("model", "provider"));
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(userItem))
+            .update();
+
+    // then
+    assertThat(updated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o");
+    assertThat(updated.getValue().getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(updated.getValue().getChangedAttributes()).doesNotContain("model", "provider");
+  }
+
+  @Test
+  public void shouldRejectDirectMetricsChangeWhenHistoryIsPresent() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+
+    // when — old-style direct metrics delta combined with a history batch in the same request:
+    // "metrics" drops out of the allowed set once history is present, so this is rejected exactly
+    // like any other unrecognized attribute would be.
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(userItem("item-1", "hi")))
+            .withMetricsDelta(10L, 5L, 1, 0)
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("metrics");
+  }
+
+  @Test
+  public void shouldRejectDirectToolsChangeWhenHistoryIsPresent() {
+    // given
+    final var context = deployCreateAgentInstanceAndActivateJob();
+
+    // when — old-style direct tools change combined with a history batch in the same request
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(userItem("item-1", "hi")))
+            .withTools(List.of(AgentInstanceClient.tool("calc", "a calculator", "calc-task")))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("tools");
+  }
+
+  @Test
+  public void shouldEmitHistoryEventsOnCreate() {
+    // given
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var userItem = userItem("item-user", "hi");
+
+    // when
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withJobKey(jobKey)
+            .withHistory(List.of(userItem))
+            .create();
+
+    // then
+    final var historyEvent =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
+            .withAgentInstanceKey(created.getKey())
+            .getFirst();
+    assertThat(historyEvent.getValue().getHistoryItemId()).isEqualTo("item-user");
+    assertThat(historyEvent.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+    // changedAttributes stays empty on CREATED, unaffected by the history batch.
+    assertThat(created.getValue().getChangedAttributes()).isEmpty();
+  }
+
+  @Test
+  public void shouldResetEchoedHistoryOnSubsequentUpdateWithoutABatch() {
+    // given — first update carries a batch
+    final var context = deployCreateAgentInstanceAndActivateJob();
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(context.agentInstanceKey())
+        .withElementInstanceKey(context.elementInstanceKey())
+        .withJobKey(context.jobKey())
+        .withHistory(List.of(userItem("item-1", "hi")))
+        .update();
+
+    // when — a second, status-only update carries no batch at all
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withStatus(AgentInstanceStatus.THINKING)
+            .update();
+
+    // then — the previous batch must not leak forward onto an unrelated update. This also proves
+    // history never round-trips through primary storage: `current` here was loaded fresh via
+    // agentInstanceState.getRecord(), and AgentInstanceCreatedApplier/UpdatedApplier strip history
+    // before ever storing a record — if they didn't, the first update's batch would still be
+    // sitting in state and would leak back out here.
+    assertThat(secondUpdate.getValue().getHistory()).isEmpty();
+  }
+
   // --- helpers ---
 
   private static Context deployCreateAgentInstanceAndActivateJob() {
@@ -345,6 +723,42 @@ public class AgentInstanceHistoryBatchProcessingTest {
             new AgentHistoryMessageContent()
                 .setContentType(AgentHistoryContentType.TEXT)
                 .setText(text));
+  }
+
+  private static AgentHistoryRecord assistantItem(
+      final String historyItemId,
+      final String text,
+      final long inputTokens,
+      final long outputTokens) {
+    final var item =
+        new AgentHistoryRecord()
+            .setHistoryItemId(historyItemId)
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText(text));
+    item.getMetrics().setInputTokens(inputTokens).setOutputTokens(outputTokens);
+    return item;
+  }
+
+  private static AgentHistoryRecord toolResultItem(final String historyItemId, final String text) {
+    return new AgentHistoryRecord()
+        .setHistoryItemId(historyItemId)
+        .setRole(AgentHistoryRole.TOOL_RESULT)
+        .setLoopIteration(1)
+        .addContent(
+            new AgentHistoryMessageContent()
+                .setContentType(AgentHistoryContentType.TEXT)
+                .setText(text));
+  }
+
+  private static AgentHistoryRecord configItem(final String historyItemId) {
+    return new AgentHistoryRecord()
+        .setHistoryItemId(historyItemId)
+        .setRole(AgentHistoryRole.CONFIGURATION)
+        .setLoopIteration(1);
   }
 
   private record Context(long agentInstanceKey, long elementInstanceKey, long jobKey) {}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -346,31 +346,58 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
-  public void shouldAccumulateMetricsImmediatelyOnUpdate() {
-    // given
+  public void shouldAccumulateMetricsAcrossSeparateUpdates() {
+    // given — first batch: a single ASSISTANT item with its own token metrics and one tool call.
     final var context = deployCreateAgentInstanceAndActivateJob();
-    final var assistantItem =
-        assistantItem("item-assistant", "Sure, here is the summary.", 100L, 40L);
-    assistantItem.addToolCall(
+    final var firstAssistantItem =
+        assistantItem("item-assistant-1", "Sure, here is the summary.", 100L, 40L);
+    firstAssistantItem.addToolCall(
         new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
 
-    // when
-    final var updated =
+    // when — the first update applies the first batch
+    final var firstUpdate =
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(context.agentInstanceKey())
             .withElementInstanceKey(context.elementInstanceKey())
             .withJobKey(context.jobKey())
-            .withHistory(List.of(assistantItem))
+            .withHistory(List.of(firstAssistantItem))
             .update();
 
-    // then — the supplied token metrics are applied, and modelCalls/toolCalls are derived from the
-    // ASSISTANT item itself: one model call, plus one tool call for the one it dispatched.
-    assertThat(updated.getValue().getMetrics().getInputTokens()).isEqualTo(100L);
-    assertThat(updated.getValue().getMetrics().getOutputTokens()).isEqualTo(40L);
-    assertThat(updated.getValue().getMetrics().getModelCalls()).isEqualTo(1);
-    assertThat(updated.getValue().getMetrics().getToolCalls()).isEqualTo(1);
-    assertThat(updated.getValue().getChangedAttributes()).contains("metrics");
+    // then — the first batch's metrics are applied immediately: one model call, one tool call.
+    assertThat(firstUpdate.getValue().getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(firstUpdate.getValue().getMetrics().getOutputTokens()).isEqualTo(40L);
+    assertThat(firstUpdate.getValue().getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(firstUpdate.getValue().getMetrics().getToolCalls()).isEqualTo(1);
+    assertThat(firstUpdate.getValue().getChangedAttributes()).contains("metrics");
+
+    // given — second batch: two more ASSISTANT items, each with their own metrics and tool calls.
+    final var secondAssistantItem =
+        assistantItem("item-assistant-2", "Here is more detail.", 50L, 20L);
+    secondAssistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-2").setToolName("lookup"));
+    secondAssistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-3").setToolName("search"));
+    final var thirdAssistantItem = assistantItem("item-assistant-3", "One more detail.", 25L, 10L);
+
+    // when — the second update applies the second batch on top of the first
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(context.agentInstanceKey())
+            .withElementInstanceKey(context.elementInstanceKey())
+            .withJobKey(context.jobKey())
+            .withHistory(List.of(secondAssistantItem, thirdAssistantItem))
+            .update();
+
+    // then — metrics accumulate on top of the first update's totals: two more model calls (three
+    // total), two more tool calls from the second item and none from the third (three total), and
+    // token counts summed across all three items.
+    assertThat(secondUpdate.getValue().getMetrics().getInputTokens()).isEqualTo(175L);
+    assertThat(secondUpdate.getValue().getMetrics().getOutputTokens()).isEqualTo(70L);
+    assertThat(secondUpdate.getValue().getMetrics().getModelCalls()).isEqualTo(3);
+    assertThat(secondUpdate.getValue().getMetrics().getToolCalls()).isEqualTo(3);
+    assertThat(secondUpdate.getValue().getChangedAttributes()).contains("metrics");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -68,7 +68,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("jobKey");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected a job to be provided for the embedded history batch, but no jobKey was "
+                + "set. A history batch must be attributed to the active job that produced it.");
   }
 
   @Test
@@ -93,7 +96,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
     // (the command was rejected before any AGENT_HISTORY:CREATED event could be appended).
     assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("index 1", "historyItemId is missing");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to process history item at index 1, but historyItemId is missing (got "
+                + "empty string). Every history item must have a non-empty historyItemId.");
   }
 
   @Test
@@ -115,7 +121,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("item-1", "UNSPECIFIED");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to process history item with historyItemId 'item-1', but its role is "
+                + "UNSPECIFIED. Every history item must declare a role.");
   }
 
   @Test
@@ -139,7 +148,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("item-1", "loopIteration is missing");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to process history item with historyItemId 'item-1', but loopIteration is "
+                + "missing (got 0). Every history item must declare a positive loopIteration.");
   }
 
   @Test
@@ -167,7 +179,12 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("item-config", "elementInstanceKey");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance configuration with history item 'item-config', but "
+                + "changedAttributes contained unknown attribute(s) [elementInstanceKey]. Allowed "
+                + "attributes are: [maxModelCalls, maxTokens, maxToolCalls, model, provider, "
+                + "systemPrompt, tools].");
   }
 
   @Test
@@ -188,7 +205,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
-    assertThat(rejection.getRejectionReason()).contains("999999999");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo("Expected job with key '999999999' to be active, but it was not.");
   }
 
   @Test
@@ -209,7 +227,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("jobKey");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected a job to be provided for the embedded history batch, but no jobKey was "
+                + "set. A history batch must be attributed to the active job that produced it.");
   }
 
   @Test
@@ -240,7 +261,12 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
-    assertThat(rejection.getRejectionReason()).contains(String.valueOf(jobKey));
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected job with key '"
+                + jobKey
+                + "' to hold the supplied lease, but it did not match. The job may have been "
+                + "re-activated.");
   }
 
   @Test
@@ -532,7 +558,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("metrics");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance, but changedAttributes contained unknown "
+                + "attribute(s) [metrics]. Allowed attributes are: [status].");
   }
 
   @Test
@@ -554,7 +583,10 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("tools");
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance, but changedAttributes contained unknown "
+                + "attribute(s) [tools]. Allowed attributes are: [status].");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -273,10 +273,34 @@ public class AgentInstanceHistoryBatchProcessingTest {
   public void shouldEmitHistoryEventForEachItemInOrderOnUpdate() {
     // given
     final var context = deployCreateAgentInstanceAndActivateJob();
-    final var userItem = userItem("item-user", "Please summarize this document.");
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("Please summarize this document."));
     final var assistantItem =
-        assistantItem("item-assistant", "Sure, here is the summary.", 100L, 40L);
-    final var toolResultItem = toolResultItem("item-tool-result", "lookup result");
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-assistant")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("Sure, here is the summary."));
+    assistantItem.getMetrics().setInputTokens(100L).setOutputTokens(40L);
+    final var toolResultItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-tool-result")
+            .setRole(AgentHistoryRole.TOOL_RESULT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("lookup result"));
 
     // when
     final var updated =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -37,16 +37,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Covers the embedded {@code history[]} batch processing on {@code AGENT_INSTANCE:CREATE}/{@code
- * UPDATE}: the job-context precondition (checked whenever a jobKey is provided, and required once a
- * history batch is present) that keeps the existing PENDING/COMMITTED/DISCARDED lifecycle safe;
- * whole-batch shape validation — every item needs a non-empty {@code historyItemId}, a declared
- * role, and a positive {@code loopIteration}, and a {@code CONFIGURATION} item's {@code
- * changedAttributes} may only name attributes this helper actually knows how to apply; and,
- * finally, the actual batch application once it's wired into CREATE/UPDATE — history events emitted
- * in order, metrics accumulated (including the ASSISTANT-derived model/tool call counts), instance
- * fields applied only from {@code CONFIGURATION} items and only for the attributes they name, and
- * batch atomicity (a rejection anywhere in the batch leaves no partial history behind).
+ * Covers job-context validation, batch validation, and batch application for the embedded {@code
+ * history[]} batch on {@code AGENT_INSTANCE:CREATE}/{@code UPDATE}.
  */
 public class AgentInstanceHistoryBatchProcessingTest {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCreatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCreatedApplierTest.java
@@ -13,9 +13,11 @@ import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
@@ -70,6 +72,50 @@ public class AgentInstanceCreatedApplierTest {
     assertThat(stored.getElementId()).isEqualTo("agent-task");
     assertThat(stored.getProcessInstanceKey()).isEqualTo(7L);
     assertThat(stored.getStatus()).isEqualTo(AgentInstanceStatus.INITIALIZING);
+  }
+
+  @Test
+  void shouldNotPersistHistoryBatch() {
+    // given — a CREATED event echoing back a history batch (as AgentInstanceCreateProcessor does).
+    final long agentInstanceKey = 43L;
+    final var record =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING);
+    record.addHistoryItem(
+        new AgentHistoryRecord().setHistoryItemId("item-1").setRole(AgentHistoryRole.USER));
+
+    // when
+    applier.applyState(agentInstanceKey, record);
+
+    // then — history is a transient per-command payload, not real AgentInstance state: every item
+    // it carries is already persisted independently as its own AGENT_HISTORY record.
+    final var stored = agentInstanceState.getRecord(agentInstanceKey);
+    assertThat(stored).isNotNull();
+    assertThat(stored.getHistory()).isEmpty();
+  }
+
+  @Test
+  void shouldNotPersistJobContext() {
+    // given — a CREATED event echoing back the job context that produced its history batch (as
+    // AgentInstanceCreateProcessor does).
+    final long agentInstanceKey = 44L;
+    final var record =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING)
+            .setJobKey(123L)
+            .setJobLease("lease-1");
+
+    // when
+    applier.applyState(agentInstanceKey, record);
+
+    // then — jobKey/jobLease are per-command payload, not real AgentInstance state: they're
+    // redundant with what's already captured on the separate AGENT_HISTORY entities.
+    final var stored = agentInstanceState.getRecord(agentInstanceKey);
+    assertThat(stored).isNotNull();
+    assertThat(stored.getJobKey()).isEqualTo(-1L);
+    assertThat(stored.getJobLease()).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplierTest.java
@@ -13,9 +13,11 @@ import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
@@ -67,6 +69,62 @@ public class AgentInstanceUpdatedApplierTest {
     assertThat(stored.getStatus()).isEqualTo(AgentInstanceStatus.THINKING);
     assertThat(stored.getMetrics().getInputTokens()).isEqualTo(10L);
     assertThat(stored.getMetrics().getOutputTokens()).isEqualTo(5L);
+  }
+
+  @Test
+  void shouldNotPersistHistoryBatch() {
+    // given — an UPDATED event echoing back a history batch (as AgentInstanceUpdateProcessor does).
+    final long agentInstanceKey = 44L;
+    final var initial =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING);
+    createdApplier.applyState(agentInstanceKey, initial);
+
+    final var updated =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setStatus(AgentInstanceStatus.THINKING);
+    updated.addHistoryItem(
+        new AgentHistoryRecord().setHistoryItemId("item-1").setRole(AgentHistoryRole.USER));
+
+    // when
+    updatedApplier.applyState(agentInstanceKey, updated);
+
+    // then — history is a transient per-command payload, not real AgentInstance state: every item
+    // it carries is already persisted independently as its own AGENT_HISTORY record.
+    final var stored = agentInstanceState.getRecord(agentInstanceKey);
+    assertThat(stored).isNotNull();
+    assertThat(stored.getHistory()).isEmpty();
+  }
+
+  @Test
+  void shouldNotPersistJobContext() {
+    // given — an UPDATED event echoing back the job context that produced its history batch (as
+    // AgentInstanceUpdateProcessor does).
+    final long agentInstanceKey = 45L;
+    final var initial =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING);
+    createdApplier.applyState(agentInstanceKey, initial);
+
+    final var updated =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setStatus(AgentInstanceStatus.THINKING)
+            .setJobKey(123L)
+            .setJobLease("lease-1");
+
+    // when
+    updatedApplier.applyState(agentInstanceKey, updated);
+
+    // then — jobKey/jobLease are per-command payload, not real AgentInstance state: they're
+    // redundant with what's already captured on the separate AGENT_HISTORY entities.
+    final var stored = agentInstanceState.getRecord(agentInstanceKey);
+    assertThat(stored).isNotNull();
+    assertThat(stored.getJobKey()).isEqualTo(-1L);
+    assertThat(stored.getJobLease()).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
 import io.camunda.zeebe.protocol.record.Record;
@@ -143,6 +144,22 @@ public final class AgentInstanceClient {
   public AgentInstanceClient withTools(final List<AgentInstanceTool> tools) {
     record.setTools(tools);
     autoChangedAttributes.add("tools");
+    return this;
+  }
+
+  public AgentInstanceClient withJobKey(final long jobKey) {
+    record.setJobKey(jobKey);
+    return this;
+  }
+
+  public AgentInstanceClient withJobLease(final String jobLease) {
+    record.setJobLease(jobLease);
+    return this;
+  }
+
+  /** Sets the embedded {@code history[]} batch carried by this command. */
+  public AgentInstanceClient withHistory(final List<AgentHistoryRecord> history) {
+    record.setHistory(history);
     return this;
   }
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_CREATED_v1.golden
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import java.util.List;
 
 public final class AgentInstanceCreatedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
@@ -28,7 +29,18 @@ public final class AgentInstanceCreatedApplier
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
-    agentInstanceState.insert(key, value);
+    // The secondary-storage exporters replace the whole entity with whatever the emitted event's
+    // record contains, so primary storage must retain every field the secondary entity needs — a
+    // new field should join it by default. `history`, `jobKey`, and `jobLease` are the deliberate
+    // exceptions: they're per-command payload, not durable entity attributes, and everything they
+    // carry is already persisted independently as its own AGENT_HISTORY record. Storing them here
+    // too would be duplicative, and since only the most recent command's values are ever echoed
+    // onto a given event, primary storage would end up reflecting "whatever the last command
+    // happened to carry" rather than anything meaningful about the instance.
+    final var forStorage = new AgentInstanceRecord();
+    forStorage.copyFrom(value);
+    forStorage.setHistory(List.of()).setJobKey(-1L).setJobLease("");
+    agentInstanceState.insert(key, forStorage);
 
     // Write back-link onto the parent ElementInstance so the CREATE processor can
     // detect a duplicate-CREATE against the same elementInstanceKey in O(1).

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_CREATED_v1.golden
@@ -29,14 +29,12 @@ public final class AgentInstanceCreatedApplier
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
-    // The secondary-storage exporters replace the whole entity with whatever the emitted event's
-    // record contains, so primary storage must retain every field the secondary entity needs — a
-    // new field should join it by default. `history`, `jobKey`, and `jobLease` are the deliberate
-    // exceptions: they're per-command payload, not durable entity attributes, and everything they
-    // carry is already persisted independently as its own AGENT_HISTORY record. Storing them here
-    // too would be duplicative, and since only the most recent command's values are ever echoed
-    // onto a given event, primary storage would end up reflecting "whatever the last command
-    // happened to carry" rather than anything meaningful about the instance.
+    // A new field should join primary storage by default, since secondary-storage exporters
+    // replace the whole entity with whatever the emitted event carries. `history`, `jobKey`, and
+    // `jobLease` are the exceptions: history is already durably captured as its own AGENT_HISTORY
+    // record and can grow large, so keeping a copy here would be wasteful; jobKey/jobLease are
+    // only meaningful while the command that carries them is being processed, so persisting them
+    // would just reflect whichever command happened to run last, not the instance's actual state.
     final var forStorage = new AgentInstanceRecord();
     forStorage.copyFrom(value);
     forStorage.setHistory(List.of()).setJobKey(-1L).setJobLease("");

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_UPDATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_UPDATED_v1.golden
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import java.util.List;
 
 public final class AgentInstanceUpdatedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
@@ -28,7 +29,18 @@ public final class AgentInstanceUpdatedApplier
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
-    agentInstanceState.update(key, value);
+    // The secondary-storage exporters replace the whole entity with whatever the emitted event's
+    // record contains, so primary storage must retain every field the secondary entity needs — a
+    // new field should join it by default. `history`, `jobKey`, and `jobLease` are the deliberate
+    // exceptions: they're per-command payload, not durable entity attributes, and everything they
+    // carry is already persisted independently as its own AGENT_HISTORY record. Storing them here
+    // too would be duplicative, and since only the most recent command's values are ever echoed
+    // onto a given event, primary storage would end up reflecting "whatever the last command
+    // happened to carry" rather than anything meaningful about the instance.
+    final var forStorage = new AgentInstanceRecord();
+    forStorage.copyFrom(value);
+    forStorage.setHistory(List.of()).setJobKey(-1L).setJobLease("");
+    agentInstanceState.update(key, forStorage);
 
     final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
     if (elementInstance != null && elementInstance.getAgentInstanceKey() != key) {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_UPDATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_UPDATED_v1.golden
@@ -29,14 +29,12 @@ public final class AgentInstanceUpdatedApplier
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
-    // The secondary-storage exporters replace the whole entity with whatever the emitted event's
-    // record contains, so primary storage must retain every field the secondary entity needs — a
-    // new field should join it by default. `history`, `jobKey`, and `jobLease` are the deliberate
-    // exceptions: they're per-command payload, not durable entity attributes, and everything they
-    // carry is already persisted independently as its own AGENT_HISTORY record. Storing them here
-    // too would be duplicative, and since only the most recent command's values are ever echoed
-    // onto a given event, primary storage would end up reflecting "whatever the last command
-    // happened to carry" rather than anything meaningful about the instance.
+    // A new field should join primary storage by default, since secondary-storage exporters
+    // replace the whole entity with whatever the emitted event carries. `history`, `jobKey`, and
+    // `jobLease` are the exceptions: history is already durably captured as its own AGENT_HISTORY
+    // record and can grow large, so keeping a copy here would be wasteful; jobKey/jobLease are
+    // only meaningful while the command that carries them is being processed, so persisting them
+    // would just reflect whichever command happened to run last, not the instance's actual state.
     final var forStorage = new AgentInstanceRecord();
     forStorage.copyFrom(value);
     forStorage.setHistory(List.of()).setJobKey(-1L).setJobLease("");

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -39,7 +39,9 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   public static final String ATTR_SYSTEM_PROMPT = "systemPrompt";
   public static final String ATTR_MODEL = "model";
   public static final String ATTR_PROVIDER = "provider";
-  public static final String ATTR_LIMITS = "limits";
+  public static final String ATTR_MAX_TOKENS = "maxTokens";
+  public static final String ATTR_MAX_MODEL_CALLS = "maxModelCalls";
+  public static final String ATTR_MAX_TOOL_CALLS = "maxToolCalls";
 
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty agentDefinitionKeyProp = new LongProperty("agentDefinitionKey", -1L);


### PR DESCRIPTION
## Summary

Extends the `AGENT_INSTANCE:CREATE` and `AGENT_INSTANCE:UPDATE` processors to process the embedded `history[]` batch carried on `AgentInstanceRecord` (added by #58790): for each item, in order, a full-copy `AGENT_HISTORY:CREATED` event is emitted, token/call metrics are accumulated onto the agent instance's aggregate, and — for `CONFIGURATION`-role items (added by #58794) — whichever of model/provider/systemPrompt/tools/limits the item names in its own `changedAttributes` is applied to the instance's live definition. Closes #58791.

A history batch is applied atomically with the `CREATE`/`UPDATE` command it arrived on: the instance mutation and the resulting `AGENT_HISTORY:CREATED` follow-up events are all appended while processing the same command, so there is no window where one is durable and the other is not.

## What changed

**`AgentHistoryBatchHelper`** is a new class, shared by `AgentInstanceCreateProcessor` and `AgentInstanceUpdateProcessor` (and, for job-context validation, `AgentHistoryCreateProcessor`) rather than a processor of its own. It exposes three operations, each returning `Either<Rejection, T>` so every call site handles validation failures the same way:

- `validateJobContext(jobKey, jobLease, elementInstanceKey, history)` — once a history batch is present, `jobKey` becomes required, since a batch must always be attributed to the active job that produced it. Without a batch, omitting job context entirely remains valid, preserving the existing job-less status/metrics update path. When a job is supplied (with or without a batch), it must be `ACTIVATED`, its lease token (if any) must match, and it must belong to the given element instance.
- `validateHistory(history)` — every item needs a non-empty `historyItemId`, a role other than `UNSPECIFIED`, and a positive `loopIteration` (the `0` default means the field was left unset on the wire). A `CONFIGURATION` item's `changedAttributes` may additionally only name attributes this helper actually knows how to apply.
- `apply(target, jobKey, jobLease, elementInstanceKey, history)` — mutates `target` in place: builds one `AGENT_HISTORY` event per item via `copyFrom`, with its record-context fields (keys, process/tenant identifiers, `jobKey`, `jobLease`) overwritten to match the target and the command; accumulates each item's metrics onto the target's aggregate; and, for `CONFIGURATION` items, applies whichever attributes the item names. It mutates `target.history` for the caller to turn into follow-up events, and returns the set of `AgentInstanceRecord` attribute names that actually changed.

Metric accumulation sums each positive field an item's own metrics carries (`inputTokens`/`outputTokens`/`reasoningTokenCount`/`cacheCreationTokenCount`/`cacheReadTokenCount`) onto the target. `modelCalls`/`toolCalls` aren't part of an item's own metrics — they're derived instead: every `ASSISTANT`-role item represents exactly one model call, and its own `toolCalls` list gives the number of tool calls it dispatched.

`AgentInstanceRecord`'s single `ATTR_LIMITS` constant is replaced by `ATTR_MAX_TOKENS`/`ATTR_MAX_MODEL_CALLS`/`ATTR_MAX_TOOL_CALLS`, since a `CONFIGURATION` item names the specific limit sub-field it changes rather than the limits object as a whole. A `CONFIGURATION` item's `systemPrompt` is a list of content blocks, but the instance definition's `systemPrompt` field is a plain string, so only the `TEXT`-typed blocks are concatenated onto it — documented as a known workaround, expected to go away once #58797 changes how the agent instance stores its system prompt to keep the full multi-content value.

`AgentInstanceUpdateProcessor` now reports the union of whatever the history batch changed and whatever the request-level patch changed as the `UPDATED` event's `changedAttributes`, rather than just the latter. Once a batch is attached to an `UPDATE` command, `status` is the only attribute that may still be changed at the request level directly — `metrics`/`tools` (and, as before, `model`/`provider`/`systemPrompt`/`limits`) can only change through a `CONFIGURATION` history item once a batch is in play. Without a batch, the existing request-level `status`/`metrics`/`tools` path is unchanged, so pre-existing job-less callers keep working exactly as before.

`history`, `jobKey`, and `jobLease` are per-command payload rather than durable entity attributes — everything they carry is already persisted independently as its own `AGENT_HISTORY` record. `AgentInstanceCreatedApplier`/`AgentInstanceUpdatedApplier` now build a copy of the incoming record with those three fields cleared before writing to primary storage: the secondary-storage exporters replace the whole entity with whatever the emitted event's record contains, so storing per-command fields there would make primary storage reflect whichever command happened to run last rather than anything meaningful about the instance.

`AgentHistoryCreateProcessor`'s own job-context checks (job must be active, lease must match, job's element instance must match the command's) were extracted into `AgentHistoryBatchHelper.validateJobContext` so all three processors share one implementation instead of three near-identical copies. The rejection messages moved from history-entry-specific phrasing ("Expected to create agent history entry for job...") to generic job-context phrasing, since the same helper is now shared by processors that have nothing to do with `AGENT_HISTORY` specifically.

## Test plan

New `AgentInstanceHistoryBatchProcessingTest` (22 tests) covers job-context validation (job required once a batch is present, job-not-active/lease-mismatch rejections, backward-compatible job-less updates), whole-batch shape validation (missing `historyItemId`, `UNSPECIFIED` role, missing `loopIteration`, unknown `changedAttributes` on a `CONFIGURATION` item), history event emission and ordering on both `CREATE` and `UPDATE`, metrics accumulation (including derived `modelCalls`/`toolCalls` from `ASSISTANT` items without explicit metrics), `CONFIGURATION`-item field application gated on that item's own `changedAttributes`, rejection of direct `metrics`/`tools` changes once a batch is present, and batch atomicity across `CREATE` and `UPDATE`.

`AgentInstanceCreatedApplierTest`/`AgentInstanceUpdatedApplierTest` each gained a test pinning that `history`/`jobKey`/`jobLease` come back cleared after `applyState()`, independent of which processor produced the event. `AgentHistoryCreateTest` was updated for the reworded job-context rejection messages.

Ran together with the existing suites that exercise the surrounding lifecycle:

```
./mvnw -pl zeebe/engine -am test -o \
  -Dtest='AgentInstanceHistoryBatchProcessingTest,AgentInstanceCreateTest,AgentInstanceUpdateTest,AgentInstanceCreatedApplierTest,AgentInstanceUpdatedApplierTest,AgentHistoryCreateTest,AgentHistoryCommitTest,AgentHistoryDiscardTest,AgentHistoryDiscardOnJobDestructionTest' \
  -Dsurefire.failIfNoSpecifiedTests=false
```

All green (102 tests total). Also reran `JsonSerializableToJsonTest` and `RecordGoldenFilesTest` in `zeebe/protocol-impl` (257 tests, all green), since the appliers now build a copy via `copyFrom` rather than storing the value directly.

## Related issues

- Parent epic: Real-Time Agent Visibility (product-hub#3462)
- This issue: https://github.com/camunda/camunda/issues/58791
- Builds on #58790 (embedded `history[]` schema on `AgentInstanceRecord`) and #58794 (`AgentHistoryRole.CONFIGURATION` and the per-item `changedAttributes` field)
- Unblocks #58792 (persisted cross-request `historyItemId` deduplication)
- Unblocks #58797 (optimistic-apply-with-rollback for `CONFIGURATION` items on top of this PR's immediate-apply handling)