### PR TITLE
fix: survive registry hangs when pushing the load-test images

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -453,10 +453,26 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -D skipTests -D skipChecks -pl load-tests/load-tester -am install
+      # registry.camunda.cloud intermittently stops answering the manifest PUT at the end of the
+      # push. jib's own retries all fall inside a ~5 minute window, so they re-hit the same bad
+      # spell and the job fails. Each attempt here is capped well above the ~15s a healthy push
+      # takes, so a hung one is abandoned quickly and the registry is sampled again a minute later.
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ env.IMAGE_TAG }}"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 60
+          timeout_minutes: 2
+          shell: bash
+          command: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ env.IMAGE_TAG }}"
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ env.IMAGE_TAG }}"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 60
+          timeout_minutes: 2
+          shell: bash
+          command: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ env.IMAGE_TAG }}"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -457,6 +457,10 @@ jobs:
       # push. jib's own retries all fall inside a ~5 minute window, so they re-hit the same bad
       # spell and the job fails. Each attempt here is capped well above the ~15s a healthy push
       # takes, so a hung one is abandoned quickly and the registry is sampled again a minute later.
+      #
+      # This is mitigation, not a fix — it makes a hanging registry survivable, it does not stop it
+      # hanging. Drop both wrappers once these images are published to GAR instead
+      # (camunda/team-infrastructure#992), which removes the dependency on this registry altogether.
       - name: Build Starter Image
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:


### PR DESCRIPTION
## Problem

[INC-7090](https://app.incident.io/camunda/incidents/7090) ([#inc-7090-…](https://camunda.slack.com/archives/C0BP55TRK4M))
fired as *"CI: scan"* on `main`, but the run's actual failure is *Zeebe / Build load test Starter and
Worker*. (*Zeebe / Deploy Snyk development projects / Snyk Scan* was cancelled in the same run, but it
is **not** downstream of the image build — it `needs: [test-summary]` only, started five minutes
*after* the image build had already failed, and ran for 15 minutes before being cancelled for a reason
this PR does not establish.):

```
[WARNING] PUT https://registry.camunda.cloud/v2/team-zeebe/worker/manifests/SNAPSHOT failed and will be retried   (×5)
[WARNING] PUT https://registry.camunda.cloud/v2/team-zeebe/worker/manifests/SNAPSHOT failed and will NOT be retried
[ERROR]   java.net.SocketTimeoutException: Read timed out
[ERROR] Failed to execute goal com.google.cloud.tools:jib-maven-plugin:3.5.2:build (default-cli) on project camunda-load-tester
```

**This is not a one-off.** Of the last 12 CI runs on `main` where this job ran, **4 failed this way**:

| Job | When |
| --- | --- |
| [94033798343](https://github.com/camunda/camunda/actions/runs/31571211129/job/94033798343) | 2026-08-12 06:47 |
| [94029017380](https://github.com/camunda/camunda/actions/runs/31570566831/job/94029017380) | 2026-08-12 06:22 |
| [93850312536](https://github.com/camunda/camunda/actions/runs/31533812625/job/93850312536) | 2026-08-11 16:30 |
| [93823060099](https://github.com/camunda/camunda/actions/runs/31528087088/job/93823060099) | 2026-08-11 15:00 |

plus the two behind INC-7090 on 2026-08-10. Every single one died on the **manifest PUT**, never on a
layer upload.

## Why jib's own retries do not help

jib does retry — five times — but all five land inside the same ~5 minute window, so they re-hit the
same bad spell. The cost is visible in the step timings: a failing *Build Worker Image* burns **~295 s**
before giving up, while the same step takes **13–18 s** when the registry is healthy.

That gap is the useful signal. The registry's behaviour is **bimodal**: a healthy push completes the
entire Maven goal in ~15 s, and a bad one never answers at all.

## Fix

Wrap both push steps in `nick-fields/retry` — already used elsewhere in this repository and already on
the [allowed third-party action list](https://github.com/camunda/camunda/blob/5cfc45ed767aea810d1efb1fd953cd7d8dc13282/docs/monorepo-docs/ci.md#L577) —
and spread the attempts over time rather than bunching them:

```yaml
      - name: Build Worker Image
        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
        with:
          max_attempts: 3
          retry_wait_seconds: 60
          timeout_minutes: 2
          shell: bash
          command: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="..."
```

The 2-minute per-attempt cap is **8× a healthy push**, so a hung attempt is abandoned quickly instead
of waiting out jib's internal retries, and the 60 s wait means the registry is sampled at roughly
**t, t+3 and t+6 minutes**.

### Why not `-Djib.httpTimeout`

It was the obvious alternative and it does not fit the evidence. Raising the per-request timeout helps
when requests are *slow*; here they either return in well under a second or never return at all. A
longer timeout would only make each doomed attempt sit there longer.

### Budget

A failing step ends the job, so only one step can ever exhaust its attempts. Worst case is ~620 s of
the job's 20-minute `timeout-minutes`, against ~450 s for a single failure today. The 3-minute
preamble (checkout, setup-build, `mvnw install`) is unchanged.

## Verification

- `actionlint`: **4 findings before, 4 after** — unchanged, all pre-existing.
- `conftest` with both repo policies (`conftest-unified-ci-rules.rego`, `conftest-gha-best-practices.rego`,
  run with `--rego-version v0`): **identical before and after** — 10/11 pass with one pre-existing
  `print-metadata` warning, and 8/8 pass respectively.
- Action is SHA-pinned with a version comment, matching the repo convention.
- **Not verified:** that a retry actually rescues a hung push. That needs the registry to hang on
  demand. What is established is the failure rate, that every failure is the manifest PUT, and the
  ~295 s vs ~15 s timing split.

## This is mitigation, not a fix

`registry.camunda.cloud` hanging on manifest PUT is the actual defect and belongs to whoever owns that
registry. This only stops it taking the load-test image publishing down with it.

**The proper fix is the GAR migration** ([camunda/team-infrastructure#992](https://github.com/camunda/team-infrastructure/issues/992)).
These are throwaway `SNAPSHOT` images consumed by load tests running in GKE, so publishing them to GAR
removes the dependency on this registry altogether rather than working around it. Once that lands,
**both retry wrappers should be deleted** — the workflow carries a comment saying so, so this does not
quietly become permanent. The same epic is the durable answer to the npm cache misses behind
[#59924](https://github.com/camunda/camunda/pull/59924), which is where @kellervater raised it.

