### PR TITLE
ci: adjust build process to resolve artifact race conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2787,7 +2787,7 @@ jobs:
     name: Deploy snapshot Optimize Docker image
     needs: [ check-results, build-platform-frontend, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-optimize-docker-snapshot ]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
     permissions: { }  # GITHUB_TOKEN unused in this job
     if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
@@ -2812,12 +2812,8 @@ jobs:
         with:
           name: fe-optimize-${{ github.run_id }}
           path: optimize/client/dist
-      # Optimize needs io.camunda artifacts from search/* and zeebe/* that deploy-snapshots
-      # publishes concurrently. Resolving them from Nexus fails both when a freshly bumped
-      # X.Y.Z-SNAPSHOT is not published yet (release back-merge) and when snapshot retention
-      # deletes a timestamped JAR its own metadata still advertises. A full-reactor install puts
-      # them all in the local repository, matching deploy-camunda-docker-snapshot. -Dquickly
-      # excludes optimize itself, which the next step builds with the assembly profile.
+      # Builds io.camunda deps from source instead of Nexus to avoid a race with deploy-snapshots.
+      # See https://github.com/camunda/camunda/pull/59937 for details.
       - uses: ./.github/actions/build-zeebe
         with:
           maven-extra-args: -Dquickly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2787,7 +2787,7 @@ jobs:
     name: Deploy snapshot Optimize Docker image
     needs: [ check-results, build-platform-frontend, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-optimize-docker-snapshot ]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
@@ -2812,11 +2812,15 @@ jobs:
         with:
           name: fe-optimize-${{ github.run_id }}
           path: optimize/client/dist
-      # -am fixes a race with deploy-snapshots by building reactor deps from source instead of Nexus
-      - name: Build zeebe-protocol from source
-        uses: ./.github/actions/run-maven
+      # Optimize needs io.camunda artifacts from search/* and zeebe/* that deploy-snapshots
+      # publishes concurrently. Resolving them from Nexus fails both when a freshly bumped
+      # X.Y.Z-SNAPSHOT is not published yet (release back-merge) and when snapshot retention
+      # deletes a timestamped JAR its own metadata still advertises. A full-reactor install puts
+      # them all in the local repository, matching deploy-camunda-docker-snapshot. -Dquickly
+      # excludes optimize itself, which the next step builds with the assembly profile.
+      - uses: ./.github/actions/build-zeebe
         with:
-          parameters: install -pl zeebe/protocol -am -Dquickly
+          maven-extra-args: -Dquickly
       - name: Generate Optimize production .tar.gz
         uses: ./.github/actions/run-maven
         with:


### PR DESCRIPTION
## Description

`deploy-optimize-docker-snapshot` resolves several `io.camunda` artifacts (e.g.
`camunda-search-client-connect`, `camunda-search-client-plugin`, `zeebe-test-util`) from Nexus
instead of building them from source. This races the `deploy-snapshots` job that publishes them,
and fails in two ways:

- **Cold start**: the first push after a release version bump resolves a `X.Y.Z-SNAPSHOT` that
  has never been published anywhere yet (deterministic — reproduced on `stable/8.9` in
  [run 31528458782](https://github.com/camunda/camunda/actions/runs/31528458782/job/93908860728)).
- **Cleanup race**: snapshot retention deletes a timestamped JAR that the job's own resolved
  metadata still points to (intermittent — reproduced on `main` in
  [run 31493428860](https://github.com/camunda/camunda/actions/runs/31493428860/job/93792145679)).

This is the same failure class as [#58520](https://github.com/camunda/camunda/pull/58520)
(INC-6627), which added `-am` to build `zeebe-protocol`'s reactor deps from source. That fix only
covered `zeebe-protocol`'s own closure (`camunda-security-protocol`, `zeebe-build-tools`) — it
didn't reach `search/*` or `zeebe/test-util`, which is why the race resurfaced on different
artifacts (INC-6841, INC-7101, and the stable/8.9 occurrence above).

This PR replaces the narrow `install -pl zeebe/protocol -am -Dquickly` step with a full-reactor
`build-zeebe` install (`-Dquickly`), matching `deploy-camunda-docker-snapshot`'s own approach. Every
`io.camunda` dependency Optimize needs is now built from source and installed locally before the
Optimize assembly step runs, so neither failure mode can reach it. `-Dquickly` still excludes
`optimize` itself (via the `include-optimize` profile), so the following step is unaffected.
`timeout-minutes` raised 20→30 for headroom on a cold Maven cache (the cache key hashes
`**/pom.xml`, and a version bump — precisely when the cold-start race fires — invalidates it).

Related incidents: INC-6627, INC-6841, INC-7101.

### How this was tested

`deploy-optimize-docker-snapshot` only runs on `push` to `main`/`stable/*` (see its own `if:`), so
it cannot be exercised in PR CI at all — pull-request events never satisfy that condition. Real
validation only accumulates over time, on pushes after this merges. Locally, I reproduced the
defect and disproved it in isolation with an A/B: same two Maven commands the job actually runs,
before and after the fix, against a version bumped to `8.10.999-SNAPSHOT` (never published anywhere,
reproducing the cold-start failure mode deterministically).

```bash
# 1. Bump to a version that exists nowhere (repo root is bom/pom.xml's version chain)
./mvnw versions:set -DnewVersion=8.10.999-SNAPSHOT -DgenerateBackupPoms=false -DprocessAllModules=true -f bom/pom.xml

# 2. Before this fix — fails:
./mvnw install -pl zeebe/protocol -am -Dquickly
./mvnw install -f optimize -DskipTests -Dskip.docker -PskipFrontendBuild,runAssembly -T1
# Could not resolve dependencies for project io.camunda.optimize:optimize-commons:jar:8.10.999-SNAPSHOT
#   Could not find artifact io.camunda:camunda-search-client-connect:jar:8.10.999-SNAPSHOT in ...

# 3. After this fix — succeeds:
./mvnw clean install -Dquickly   # matches build-zeebe's own command
./mvnw install -f optimize -DskipTests -Dskip.docker -PskipFrontendBuild,runAssembly -T1
# BUILD SUCCESS — Optimize Commons and Optimize Backend both resolve every io.camunda
# dependency from the local repository (confirmed via maven-metadata-local.xml, no remote fetch)
```

Revert the version bump afterwards with `git checkout -- .` (or `versions:revert` if backup poms
were kept).

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) — `backport stable/8.8` and `backport stable/8.9` labels added (same race hit stable/8.9 during this investigation; #58520 backported to both for the same job).

## Related issues

related to [#inc-7101](https://camunda.slack.com/archives/C0BPHSSM6E5)
