### PR TITLE
fix: exercise upgrading from an older setup-code version in smoke tests

### DIFF
--- a/.github/workflows/camunda-load-test-smoke-dispatch.yml
+++ b/.github/workflows/camunda-load-test-smoke-dispatch.yml
@@ -58,3 +58,4 @@ jobs:
       target-version: ${{ matrix.version }}
       orchestration-tag: ${{ matrix.orchestration-tag }}
       ref: ${{ github.event.pull_request.head.ref }}
+      base-ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -1,13 +1,12 @@
 # description: Smoke-tests the load-test setup on every push that touches load-test infra.
 #              Runs two independent chains in parallel, each in its own namespace:
-#              install (deploys the PR ref from scratch, then re-applies it to check the
-#              update is idempotent) and upgrade (deploys base-ref, then updates to the PR
-#              ref, to exercise upgrading from an older setup-code version). Both chains wait
-#              for pod readiness and gateway connectivity after each deploy, then delete their
-#              namespace.
+#              - install (deploys the PR ref from scratch to check the installation)
+#              - upgrade (deploys the base-ref first, then updates to the PR ref to check upgrading from an older setup-code version).
+#              Both chains wait for pod readiness and gateway connectivity after each deploy,
+#              then delete their namespace.
 # calls: camunda-load-test.yml (scenario: realistic),
-#        camunda-verify-and-cleanup-load-test.yml (verify + delete namespace)
-# notifications: Slack (#reliability-testing-alerts) on failure only
+#        camunda-verify-load-test.yml (verify connectivity),
+#        camunda-delete-load-test.yml (delete namespace)
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda Smoke Load Test

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -151,7 +151,7 @@ jobs:
 
   cleanup-install:
     name: Cleanup (install chain)
-    needs: [sanitize-branch-name]
+    needs: [sanitize-branch-name, verify-install]
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -1,6 +1,10 @@
 # description: Smoke-tests the load-test setup on every push that touches load-test infra.
-#              Deploys a minimal load test from the PR head ref, for supported secondary storages,
-#              waits for pod readiness and gateway connectivity, then deletes the namespace.
+#              Runs two independent chains in parallel, each in its own namespace:
+#              install (deploys the PR ref from scratch, then re-applies it to check the
+#              update is idempotent) and upgrade (deploys base-ref, then updates to the PR
+#              ref, to exercise upgrading from an older setup-code version). Both chains wait
+#              for pod readiness and gateway connectivity after each deploy, then delete their
+#              namespace.
 # calls: camunda-load-test.yml (scenario: realistic),
 #        camunda-verify-and-cleanup-load-test.yml (verify + delete namespace)
 # notifications: Slack (#reliability-testing-alerts) on failure only
@@ -25,6 +29,11 @@ on:
         type: string
         default: ""
         required: false
+      base-ref:
+        description: 'Git ref used as the "old" version for the upgrade chain. Defaults to main.'
+        type: string
+        default: "main"
+        required: false
   workflow_dispatch:
     inputs:
       target-version:
@@ -41,6 +50,11 @@ on:
         description: 'Git ref to checkout for the smoke test (branch or SHA)'
         type: string
         default: ""
+        required: false
+      base-ref:
+        description: 'Git ref used as the "old" version for the upgrade chain. Defaults to main.'
+        type: string
+        default: "main"
         required: false
 
 concurrency:
@@ -100,13 +114,19 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  # ---------------------------------------------------------------------------
+  # Install chain: deploys the PR's own setup code from scratch, then re-applies
+  # it unchanged to check that updates are idempotent (e.g. don't regenerate
+  # credentials on every update, which can cause downtime and failed updates).
+  # ---------------------------------------------------------------------------
+
   smoke-install:
     name: Smoke Install
     needs: sanitize-branch-name
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
-      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-install
       ref: ${{ github.event.pull_request.head.ref || inputs.ref || github.event.inputs.ref }}
       scenario: realistic
       secondary-storage-type: elasticsearch
@@ -127,42 +147,36 @@ jobs:
     uses: ./.github/workflows/camunda-verify-load-test.yml
     secrets: inherit
     with:
-      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-install
 
-  # This is to validate whether the load test can be updated successfully, without issues in the update process itself.
-  # To prevent regressions like regenerating credentials on every update, which can cause downtime and failed updates.
-  smoke-update:
-    name: Smoke update
+  smoke-reapply:
+    name: Smoke Reapply (idempotency)
     needs: [sanitize-branch-name, verify-install]
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
-      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-install
       ref: ${{ github.event.pull_request.head.ref || inputs.ref || github.event.inputs.ref }}
       scenario: realistic
       secondary-storage-type: elasticsearch
-      # Short TTL acts as a safety net; verify-and-cleanup deletes the namespace explicitly.
       ttl: 1
       target-version: ${{ inputs.target-version || 'main' }}
-      # We make use of the official docker image (SNAPSHOT TAG) this is to reduce CI runtime and feedback cycle.
-      # Setting the focus only on the installation and connectivity part of the load test.
-      # Issues with the load test applications, should ideally catched with integration tests.
       orchestration-tag: ${{ inputs.orchestration-tag || 'SNAPSHOT' }}
 
-  verify-update:
-    name: Verify update
-    needs: [sanitize-branch-name, smoke-update]
+  verify-reapply:
+    name: Verify Reapply
+    needs: [sanitize-branch-name, smoke-reapply]
     permissions:
       contents: 'read'
       id-token: 'write'
     uses: ./.github/workflows/camunda-verify-load-test.yml
     secrets: inherit
     with:
-      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-install
 
-  cleanup:
-    name: Cleanup
-    needs: [sanitize-branch-name, verify-update]
+  cleanup-install:
+    name: Cleanup (install chain)
+    needs: [sanitize-branch-name, verify-reapply]
     if: always()
     permissions:
       contents: read
@@ -170,4 +184,73 @@ jobs:
     uses: ./.github/workflows/camunda-delete-load-test.yml
     secrets: inherit
     with:
-      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-install
+
+  # ---------------------------------------------------------------------------
+  # Upgrade chain: deploys base-ref's setup code (the version already on main
+  # before this PR), then updates it to the PR ref. This exercises upgrading
+  # from an older setup-code version, which the install chain above cannot
+  # catch since it only ever deploys the PR's own code.
+  # ---------------------------------------------------------------------------
+
+  smoke-upgrade-install:
+    name: Smoke Upgrade - Install (base ref)
+    needs: sanitize-branch-name
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-upgrade
+      ref: ${{ inputs.base-ref || 'main' }}
+      scenario: realistic
+      secondary-storage-type: elasticsearch
+      ttl: 1
+      target-version: ${{ inputs.target-version || 'main' }}
+      orchestration-tag: ${{ inputs.orchestration-tag || 'SNAPSHOT' }}
+
+  verify-upgrade-install:
+    name: Verify Upgrade Install
+    needs: [sanitize-branch-name, smoke-upgrade-install]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/camunda-verify-load-test.yml
+    secrets: inherit
+    with:
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-upgrade
+
+  smoke-upgrade-update:
+    name: Smoke Upgrade - Update (PR ref)
+    needs: [sanitize-branch-name, verify-upgrade-install]
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-upgrade
+      ref: ${{ github.event.pull_request.head.ref || inputs.ref || github.event.inputs.ref }}
+      scenario: realistic
+      secondary-storage-type: elasticsearch
+      ttl: 1
+      target-version: ${{ inputs.target-version || 'main' }}
+      orchestration-tag: ${{ inputs.orchestration-tag || 'SNAPSHOT' }}
+
+  verify-upgrade-update:
+    name: Verify Upgrade Update
+    needs: [sanitize-branch-name, smoke-upgrade-update]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/camunda-verify-load-test.yml
+    secrets: inherit
+    with:
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-upgrade
+
+  cleanup-upgrade:
+    name: Cleanup (upgrade chain)
+    needs: [sanitize-branch-name, verify-upgrade-update]
+    if: always()
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/camunda-delete-load-test.yml
+    secrets: inherit
+    with:
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-upgrade

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -149,34 +149,9 @@ jobs:
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-install
 
-  smoke-reapply:
-    name: Smoke Reapply (idempotency)
-    needs: [sanitize-branch-name, verify-install]
-    uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
-    with:
-      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-install
-      ref: ${{ github.event.pull_request.head.ref || inputs.ref || github.event.inputs.ref }}
-      scenario: realistic
-      secondary-storage-type: elasticsearch
-      ttl: 1
-      target-version: ${{ inputs.target-version || 'main' }}
-      orchestration-tag: ${{ inputs.orchestration-tag || 'SNAPSHOT' }}
-
-  verify-reapply:
-    name: Verify Reapply
-    needs: [sanitize-branch-name, smoke-reapply]
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
-    secrets: inherit
-    with:
-      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}-install
-
   cleanup-install:
     name: Cleanup (install chain)
-    needs: [sanitize-branch-name, verify-reapply]
+    needs: [sanitize-branch-name]
     if: always()
     permissions:
       contents: read


### PR DESCRIPTION
## Description

The smoke test's `smoke-install` and `smoke-update` jobs in `camunda-load-test-smoke.yml` always deployed the **same** PR ref for both steps, so `smoke-update` only ever re-applied a namespace to itself. This left a real class of regression invisible to CI: a namespace created by an *older* version of `load-tests/setup/**` breaking when upgraded to a newer version.

That gap let a real regression through: commit bdcb7d0 (#57992, "embedded the Prometheus exporter for Elasticsearch") moved deployment of the ES Prometheus exporter from an always-recomputed `make install` step to a flag baked in once at namespace-scaffold time. On a namespace that already existed with Helm state from the *old* setup code, the previously standalone `elasticsearch-exporter` Helm release was silently orphaned - never upgraded, never removed. Part of the root cause under investigation in INC-7100.

### What changed

Split the workflow into two independent, parallel chains, each in its own namespace:

- **install**: deploys the PR ref from scratch, then re-applies the same ref unchanged to check updates are idempotent (the original intent of the old `smoke-update` job - e.g. not regenerating credentials on every update).
- **upgrade**: deploys `base-ref` (new input, defaults to `main`, i.e. the PR's base state) first, then updates to the PR ref. This exercises the actual upgrade transition each PR introduces, and would have caught the INC-7100 regression.

No pinned commit or extra tag-tracking automation needed - `base-ref` defaults to `main`, so every PR is automatically tested for "does upgrading from current main to my change work."

### How to verify

Opening this PR against `load-tests/setup/main/**` triggers `camunda-load-test-smoke-dispatch.yml` → `camunda-load-test-smoke.yml`, which will now run both the install and upgrade chains. Confirm both complete (2 namespaces created and cleaned up instead of 1).

## Checklist

- [x] Enable backports when necessary - not applicable, `camunda-load-test-smoke.yml` has no per-stable-branch copy (only `load-tests/setup/**` itself is versioned; this workflow file lives on `main` only).
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run. Not applicable, no changes under `qa/`.

## Related issues

closes #59865
Part of #56474 (which will make this - now more meaningful - smoke test a required CI check as a follow-up PR)

---

> [!NOTE]
> This PR description was drafted with the assistance of Claude Code.