### PR TITLE
Slim the Optimize smoke job's Chrome setup and bound it against slow apt mirrors

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -449,43 +449,32 @@ jobs:
       - name: Print metadata
         uses: ./.github/actions/print-metadata
 
-      - name: Setup CI runtime (TestCafe + Chrome + Xvfb)
-        run: |
-          set -euo pipefail
+      - name: Install Google Chrome
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 15
+          timeout_minutes: 5
+          shell: bash
+          command: |
+            set -euo pipefail
 
-          sudo apt-get update
+            if ! command -v google-chrome >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends wget gnupg ca-certificates
 
-          # ----------------------------
-          # Core system dependencies
-          # ----------------------------
-          sudo apt-get install -y --no-install-recommends \
-            wget gnupg ca-certificates xdg-utils curl \
-            fonts-dejavu fonts-noto fonts-liberation \
-            xvfb ffmpeg \
-            libgbm1 libnss3 libatk1.0-0 libatk-bridge2.0-0 \
-            libgtk-3-0 libxcomposite1 libxrandr2 libxdamage1 libxfixes3 \
-            libasound2t64 libpangocairo-1.0-0
+              wget -qO- https://dl.google.com/linux/linux_signing_key.pub \
+                | sudo gpg --dearmor --yes -o /usr/share/keyrings/google-chrome.gpg
 
-          # ----------------------------
-          # Google Chrome install
-          # ----------------------------
-          if ! command -v google-chrome >/dev/null 2>&1; then
-            wget -qO- https://dl.google.com/linux/linux_signing_key.pub \
-              | sudo gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+              echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+                | sudo tee /etc/apt/sources.list.d/google-chrome.list >/dev/null
 
-            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
-              | sudo tee /etc/apt/sources.list.d/google-chrome.list >/dev/null
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends google-chrome-stable
+            fi
 
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends google-chrome-stable
-          fi
-
-          google-chrome --version
-
-          # ----------------------------
-          # Sanity check (CI debug safety)
-          # ----------------------------
-          xvfb-run -a google-chrome --version
+            google-chrome --version
+            google-chrome --headless=new --no-sandbox --disable-gpu --dump-dom about:blank >/dev/null
 
       - name: "Parse pom.xml for versions"
         id: "pom_info"


### PR DESCRIPTION
## Description

The `Optimize / E2E / Self-Managed (Smoke)` job spent its first step installing **228 packages / 147 MB** from `archive.ubuntu.com` before it could start Chrome. The step had no bound of its own, so when that mirror degraded it just ran until the 45-minute job timeout killed it — [run 30921188815](https://github.com/camunda/camunda/actions/runs/30921188815/job/92033787098) fetched roughly 65 of those packages in 45 minutes at ~20 kB/s and was cancelled before the tests started. This landed on `push` to `main`, so it went straight to a red `check-results`.

Almost none of that install was needed.

**`google-chrome-stable` already declares every library in the "core system dependencies" list as a `Depends`**, so apt pulls them either way. Verified on a clean `ubuntu:24.04` amd64 image — installing Chrome alone leaves no unresolved shared libraries:

```
$ ldd /opt/google/chrome/chrome | grep "not found"
NONE
```

Of what's left:

- **`ffmpeg`** — TestCafe only shells out to it for `--video`, which no script passes. It's also what drags in `libav*`, `libcodec2` (9 MB) and the GTK common tree. The job's own artifact upload confirms nothing is produced: the last green run reports *"there will be 1 file uploaded"* (just `backendLogs.log`).
- **`xvfb`** — the suite runs `chrome:headless`. The only Xvfb consumer was the step's own closing line, `xvfb-run -a google-chrome --version`.
- **`fonts-noto` / `fonts-dejavu`** — glyph coverage only. The smoke run is `--test-meta type=smoke`; the pixel-comparison tests are `type=visual` and excluded. `fonts-noto-core` alone is 13.3 MB and was one of the packages that stalled.

Dropping the block removes 138 packages and cuts the `archive.ubuntu.com` share from ~162 MB to ~72 MB. The 140 MB Chrome deb is unaffected — it comes from `dl.google.com`, which the same failing run clocked at `Fetched 140 MB in 1s (135 MB/s)`.

Mirror throughput stays outside our control either way, so the install is now wrapped in `nick-fields/retry` with a **five-minute per-attempt cap** — the pattern already used for apt in [`.github/actions/validate-pom-metadata`](https://github.com/camunda/camunda/blob/main/.github/actions/validate-pom-metadata/action.yml#L15). A degraded mirror now fails one attempt and retries instead of consuming the whole job budget. This follows `ci.md` §"Workflow Inclusion Criteria" — *"retry them 3-5 times while staying in the timeout"*; three attempts fit inside the existing **45-minute `timeout-minutes`, which is unchanged**.

Two smaller things:

- `gpg --dearmor` gains `--yes`, otherwise a retry fails on the keyring the previous attempt wrote.
- The sanity check now launches Chrome headless (`--headless=new … --dump-dom about:blank`), matching how the tests actually drive it, instead of checking `--version` under an X server they never use.

## Verification

- Dependency sufficiency proven against a real amd64 `ubuntu:24.04` apt tree (above), which is stronger evidence than `act` could give — this job needs a self-hosted GCP runner, Vault and Docker Compose, so it isn't `act`-reproducible.
- `actionlint`: 3 findings before and after, all pre-existing `runner-label` warnings for the `gcp-*` self-hosted labels.
- Conftest policies are all job-level (`timeout-minutes`, `permissions`, `needs`, `print-metadata`, `start-build-monitor`, `observe-build-status`); only a step body changed here.
- Spotless is a no-op — the root `pom.xml` config covers `**/*.md` only.

The real proof is this job running green on this PR.

## Backports

Labelled `backport stable/8.9`, per `ci.md` §"When to backport CI changes": *reliability … **SHOULD** backport to all `stable/*` branches*.

**Not** labelled for `stable/8.8` — that branch has the `optimize-e2e-smoke` job but no apt/Chrome setup step at all, so there is nothing there to slim and the backport would only conflict.

## Note for the reviewer

The upload step still lists `build/screenshots/`, `build/videos/` and `build/smoke-test-results.txt`, all of which are dead paths today. `videos/` is dead for the same reason ffmpeg goes; the other two are dead for unrelated reasons, so I left the whole block alone rather than widen this diff. Happy to clean it up here or separately.

## Related issues

No tracking issue — filed straight off the failing run.
