### PR TITLE
fix: treat empty resource version tags as missing

### DIFF
--- a/db/rdbms/src/main/resources/mapper/DeployedResourceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DeployedResourceMapper.xml
@@ -108,6 +108,26 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
+  <sql id="versionTagOperationCondition">
+    <choose>
+      <when test="operation.operator.name().equals('EXISTS')">
+        (VERSION_TAG IS NOT NULL AND VERSION_TAG != '')
+      </when>
+      <when test="operation.operator.name().equals('NOT_EXISTS')">
+        (VERSION_TAG IS NULL OR VERSION_TAG = '')
+      </when>
+      <otherwise>
+        VERSION_TAG
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </otherwise>
+    </choose>
+  </sql>
+
+  <sql id="versionTagOperationCondition" databaseId="oracle">
+    VERSION_TAG
+    <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+  </sql>
+
   <sql id="searchFilter">
     <where>
       <!-- authorization filters -->
@@ -157,8 +177,9 @@
       </if>
       <if test="filter.versionTagOperations != null and !filter.versionTagOperations.isEmpty()">
         <foreach collection="filter.versionTagOperations" item="operation">
-          AND VERSION_TAG
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+          AND
+          <include
+            refid="io.camunda.db.rdbms.sql.DeployedResourceMapper.versionTagOperationCondition"/>
         </foreach>
       </if>
       <if test="filter.deploymentKeyOperations != null and !filter.deploymentKeyOperations.isEmpty()">

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2099,7 +2099,7 @@ public final class SearchQueryResponseMapper {
     return ResourceResult.Builder.create()
         .resourceName(entity.resourceName())
         .version(entity.version())
-        .versionTag(entity.versionTag())
+        .versionTag(emptyToNull(entity.versionTag()))
         .resourceId(entity.resourceId())
         .tenantId(entity.tenantId())
         .resourceKey(keyToString(entity.resourceKey()))

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -50,6 +50,7 @@ import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
+import io.camunda.search.entities.DeployedResourceEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
@@ -82,6 +83,28 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class SearchQueryResponseMapperTest {
+
+  @Test
+  void shouldMapEmptyResourceVersionTagToNull() {
+    // given
+    final var entity =
+        new DeployedResourceEntity.Builder()
+            .resourceKey(123L)
+            .resourceId("resource-id")
+            .resourceName("resource.txt")
+            .resourceType("txt")
+            .version(1)
+            .versionTag("")
+            .deploymentKey(456L)
+            .tenantId("tenant")
+            .build();
+
+    // when
+    final var response = SearchQueryResponseMapper.toResource(entity);
+
+    // then
+    assertThat(response.getVersionTag()).isNull();
+  }
 
   @Test
   void shouldConvertBatchOperationItemEntity() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceIT.java
@@ -237,6 +237,77 @@ public class DeployedResourceIT {
   }
 
   @TestTemplate
+  public void shouldTreatEmptyVersionTagAsMissing(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
+
+    final Long deploymentKey = nextKey();
+    final DeployedResourceDbModel resourceWithEmptyVersionTag =
+        createAndSaveDeployedResource(
+            rdbmsWriters, b -> b.deploymentKey(deploymentKey).versionTag(""));
+    final DeployedResourceDbModel resourceWithNullVersionTag =
+        createAndSaveDeployedResource(
+            rdbmsWriters, b -> b.deploymentKey(deploymentKey).versionTag(null));
+    createAndSaveDeployedResource(
+        rdbmsWriters, b -> b.deploymentKey(deploymentKey).versionTag("v1"));
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(
+                            f ->
+                                f.deploymentKeyOperations(Operation.eq(deploymentKey))
+                                    .versionTagOperations(Operation.exists(false)))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.items())
+        .extracting(DeployedResourceEntity::resourceKey)
+        .containsExactlyInAnyOrder(
+            resourceWithEmptyVersionTag.resourceKey(), resourceWithNullVersionTag.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldTreatOnlyNonEmptyVersionTagAsExisting(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
+
+    final Long deploymentKey = nextKey();
+    createAndSaveDeployedResource(rdbmsWriters, b -> b.deploymentKey(deploymentKey).versionTag(""));
+    createAndSaveDeployedResource(
+        rdbmsWriters, b -> b.deploymentKey(deploymentKey).versionTag(null));
+    final DeployedResourceDbModel resourceWithVersionTag =
+        createAndSaveDeployedResource(
+            rdbmsWriters, b -> b.deploymentKey(deploymentKey).versionTag("v1"));
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(
+                            f ->
+                                f.deploymentKeyOperations(Operation.eq(deploymentKey))
+                                    .versionTagOperations(Operation.exists(true)))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.items())
+        .extracting(DeployedResourceEntity::resourceKey)
+        .containsExactly(resourceWithVersionTag.resourceKey());
+  }
+
+  @TestTemplate
   public void shouldFindDeployedResourceByTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DeployedResourceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DeployedResourceFilterTransformer.java
@@ -8,10 +8,14 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.exists;
 import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.not;
+import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DeployedResourceIndex.DEPLOYMENT_KEY;
 import static io.camunda.webapps.schema.descriptors.index.DeployedResourceIndex.RESOURCE_ID;
@@ -69,7 +73,15 @@ public class DeployedResourceFilterTransformer
   }
 
   private List<SearchQuery> getVersionTagsQuery(final List<Operation<String>> versionTags) {
-    return stringOperations(VERSION_TAG, versionTags);
+    final var queries = new ArrayList<SearchQuery>();
+    for (final var operation : versionTags) {
+      switch (operation.operator()) {
+        case EXISTS -> queries.add(and(exists(VERSION_TAG), not(term(VERSION_TAG, ""))));
+        case NOT_EXISTS -> queries.add(or(not(exists(VERSION_TAG)), term(VERSION_TAG, "")));
+        default -> queries.addAll(stringOperations(VERSION_TAG, List.of(operation)));
+      }
+    }
+    return queries;
   }
 
   @Override

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DeployedResourceFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DeployedResourceFilterTransformerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchExistsQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
+import org.junit.jupiter.api.Test;
+
+class DeployedResourceFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldTreatEmptyVersionTagAsMissing() {
+    // given
+    // A missing version tag has two possible representations in the search index:
+    // the field is absent, or the field exists but contains an empty string.
+    final var filter =
+        FilterBuilders.deployedResource(
+            builder -> builder.versionTagOperations(Operation.exists(false)));
+
+    // when
+    final var query = transformQuery(filter);
+
+    // then
+    // The expected query is: NOT EXISTS versionTag OR versionTag = "".
+    // queryOption() unwraps the generic SearchQuery so its concrete query type can be verified.
+    assertThat(query.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            anyMissingVersionTag -> {
+              // A bool query's "should" clauses represent the two OR alternatives.
+              assertThat(anyMissingVersionTag.should()).hasSize(2);
+
+              // First alternative: the versionTag field does not exist.
+              assertThat(anyMissingVersionTag.should().getFirst().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchBoolQuery.class,
+                      missingField ->
+                          assertThat(missingField.mustNot())
+                              .singleElement()
+                              .extracting(nested -> nested.queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchExistsQuery.class,
+                                  exists -> assertThat(exists.field()).isEqualTo("versionTag")));
+
+              // Second alternative: the versionTag field exists with an empty value.
+              assertThat(anyMissingVersionTag.should().getLast().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      emptyValue -> {
+                        assertThat(emptyValue.field()).isEqualTo("versionTag");
+                        assertThat(emptyValue.value().stringValue()).isEmpty();
+                      });
+            });
+  }
+
+  @Test
+  void shouldNotTreatEmptyVersionTagAsExisting() {
+    // given
+    // A version tag should count as existing only when it contains a non-empty value.
+    final var filter =
+        FilterBuilders.deployedResource(
+            builder -> builder.versionTagOperations(Operation.exists(true)));
+
+    // when
+    final var query = transformQuery(filter);
+
+    // then
+    // The expected query is: EXISTS versionTag AND NOT versionTag = "".
+    assertThat(query.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            existingNonEmptyVersionTag -> {
+              // A bool query's "must" clauses represent the two required AND conditions.
+              assertThat(existingNonEmptyVersionTag.must()).hasSize(2);
+
+              // First condition: the versionTag field exists.
+              assertThat(existingNonEmptyVersionTag.must().getFirst().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchExistsQuery.class,
+                      exists -> assertThat(exists.field()).isEqualTo("versionTag"));
+
+              // Second condition: exclude documents whose versionTag is empty.
+              assertThat(existingNonEmptyVersionTag.must().getLast().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchBoolQuery.class,
+                      nonEmptyValue ->
+                          assertThat(nonEmptyValue.mustNot())
+                              .singleElement()
+                              .extracting(nested -> nested.queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchTermQuery.class,
+                                  emptyValue -> {
+                                    assertThat(emptyValue.field()).isEqualTo("versionTag");
+                                    assertThat(emptyValue.value().stringValue()).isEmpty();
+                                  }));
+            });
+  }
+}


### PR DESCRIPTION
## Description

Resources deployed without a version tag retain an empty-string default. Resource search therefore returned an empty string instead of `null`, and version tag existence filters could not find those resources.

This change maps empty version tags to `null` in API responses and treats both missing fields and empty strings as absent in document and relational searches. Handling the existing representation at the search and API boundaries keeps previously stored resources compatible.

## Testing

- Gateway mapping tests: 350 passed
- Search query transformer tests: 985 passed
- RDBMS module tests: 1,607 passed, 1 skipped
- Version tag regression tests: 12 passed across H2, PostgreSQL, MariaDB, MySQL, Oracle, and SQL Server
- Full repository fast compilation: 149 modules passed

## Checklist

- [x] Backports are not required because the issue affects 8.10 only.

## Related issues

Closes #59832