### PR TITLE
fix: queue concurrent runs against shared CI resources instead of dropping them

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -647,6 +647,7 @@ jobs:
     concurrency:
       group: release-snyk-${{ inputs.releaseVersion }}
       cancel-in-progress: false
+      queue: max
     uses: ./.github/workflows/zeebe-snyk.yml
     with:
       # Can't reference env.RELEASE_BRANCH directly due to https://github.com/actions/runner/issues/2372

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -435,6 +435,7 @@ jobs:
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-load-test.outputs.concurrency_group_name }}
       cancel-in-progress: false
+      queue: max
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -477,6 +478,7 @@ jobs:
     concurrency:
       group: deploy-snyk-projects
       cancel-in-progress: false
+      queue: max
     uses: ./.github/workflows/zeebe-snyk.yml
     with:
       monitor: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2646,6 +2646,7 @@ jobs:
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-maven-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -2724,6 +2725,7 @@ jobs:
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-docker-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -2794,6 +2796,7 @@ jobs:
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-optimize-docker-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false
+      queue: max
     env:
       TEST_OWNER: '@camunda/core-features'
     steps:

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -37,6 +37,7 @@ jobs:
     concurrency:
       group: aws-opensearch-${{ inputs.os_version }}
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -82,6 +83,7 @@ jobs:
     concurrency:
       group: aws-opensearch-${{ inputs.os_version }}
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -135,6 +137,7 @@ jobs:
     concurrency:
       group: aws-opensearch-${{ inputs.os_version }}
       cancel-in-progress: false
+      queue: max
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

GitHub Actions [now supports `queue: max`](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/) on `concurrency:` blocks: instead of holding at most one pending run per group (where a new run silently cancels the previously-pending one), up to 100 runs can queue and execute FIFO.

This matters for concurrency groups that serialize access to a **shared, stateful resource**, where `cancel-in-progress: false` is already set because every run must eventually execute against that resource — not just the latest one. Without `queue: max`, a burst of triggers (rapid merges to `main`/`stable/*`, or several matrix legs racing against the same external resource) silently drops runs instead of queuing them.

This PR adds `queue: max` to the concurrency blocks guarding:
- The shared AWS OpenSearch cluster used across `check-opensearch-version`, `cleanup-opensearch-indices`, and `integration-tests` in `zeebe-aws-os-integration-tests-reusable.yml` (already documented in comments as wanting queue-not-drop semantics).
- The shared Maven/Docker/Optimize-Docker snapshot deploy targets in `ci.yml`.
- The shared load-test image build and Snyk project deploy targets in `ci-zeebe.yml`.
- The shared per-version Snyk project target in `camunda-platform-release.yml`.

Per-PR/per-ref groups using `cancel-in-progress: true` (the "cancel superseded CI run" pattern) are intentionally left unchanged — `queue: max` is mutually exclusive with `cancel-in-progress: true` and doesn't apply to that use case. Docs-related concurrency groups are handled separately in #59886, and the auto-generated `ci-cost-analysis.lock.yml` (gh-aw) is left untouched.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

N/A — no tracked issue; found and fixed proactively.


---
_Generated by [Claude Code](https://claude.ai/code/session_017RCvgn9KCKpnvRrfuCk3Ln)_