### PR TITLE
docs: forbid viewport pinning as a nightly-fix-agent responsive-UI fix

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -579,6 +579,19 @@ a specific assertion or action. Typical patterns:
   one exists in `utils/`, or split into smaller steps.
 - **Auth / cookie state lost between describes** — check `beforeEach` for a
   missing `context.clearCookies()` or login step.
+- **Header/toolbar collapses into a menu, or a column disappears, at the
+  suite's default viewport** — the product added or changed a responsive
+  breakpoint (e.g. a Carbon `MenuButton` replacing individual buttons below
+  `xlg`, or a table column that is conditionally unmounted, not just hidden,
+  below some width). This is a UI change, not a regression: find and use the
+  real replacement — open the collapsed menu and click the item by its
+  accessible name, scroll to reveal content that is genuinely present but
+  off-screen, or use an always-visible equivalent (a different filter, tab,
+  or list column) instead of the collapsed control. Verify which case you're
+  in by reading the component source or inspecting the live app — element
+  merely hidden by CSS vs. actually removed from the DOM call for different
+  fixes. Never pin or widen `test.use({viewport})` / `page.setViewportSize()`
+  to route around this — see Constraints.
 - **API response shape change** — only a test-side fix is in scope if the
   test was asserting on a field that legitimately moved/renamed. If the
   endpoint regressed, this is a product bug — see Step 4.
@@ -676,6 +689,7 @@ skipping.
 - **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`, `kubectl`, `helm`, `npm install`, `npm run build`, `npm run test`, `npx playwright test`. The fix agent does **not** execute tests — it fixes from artifact evidence only. Verification is delegated to the on-demand workflows triggered by the calling workflow.
 - **Skipping is forbidden EXCEPT for a confirmed product bug:** the ONLY sanctioned use of `test.skip()` is a product regression that passes all three gates in `## Product-Bug Escalation` and has a filed/linked ticket — there you skip with the mandatory `// Skipped due to bug #<number>: <url>` annotation and open one skip PR. For flakiness, can't-determine, or any other reason, `test.skip()` / `test.fixme()` / `test.only` remain **absolutely forbidden**. A bare `{"prs":[]}` is sanctioned ONLY for the Gate B manual-intervention case (an unpinnable green→red flip on a test that is already hardened) and must carry a `manual_intervention` note; never leave `{"prs":[]}` with no note and no issue filed for any other reason.
 - **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npm run responses:regenerate` and commit the result. Manual edits will be overwritten and produce misleading diffs.
+- **Never fix a responsive-layout failure by pinning or widening the viewport.** `test.use({viewport: ...})` and `page.setViewportSize(...)` are not fixes for a UI that reflows, collapses a toolbar into a menu, or hides a column at the suite's default width — they force the test to stop exercising the layout most users actually see, and a per-file `test.use` silently changes every other test in that file too. Interact with whatever the narrow-width UI actually offers (open the menu, click the item by its accessible name, scroll to reveal on-screen content) or, when the same information is genuinely rendered nowhere at that width, verify it through a different always-visible surface (a different tab, filter, or list column) instead. Confirm which case you're in by reading the component source — is the element conditionally never rendered (e.g. a JSX branch that returns `null` / omits the column) or only `display:none`-hidden by CSS? Only the former genuinely has no on-screen alternative. If a live/local environment is available to you in the session (it is not part of the automated dispatch's tool set — see Forbidden tools above), confirm by inspecting the rendered app instead of guessing from source alone. If no non-viewport fix exists at all, say so explicitly in the PR body rather than defaulting to a silent viewport pin.
 - **Minimal diff:** no refactoring, no dependency bumps, no unrelated edits, no formatting sweeps on untouched files.
 - **PR title type must be `test:`** — commitlint rejects `fix:` for test-only changes (see Commit / PR Conventions above).
 - **One PR per version** — a single PR may fix multiple tests on the same `stable/<version>` branch, including a mix of API and E2E failures, but never crosses branch boundaries.


### PR DESCRIPTION
## Summary

PR #59921 (the "add suspend and resume controls to Operate" nightly fix) fixed
six failing specs by pinning `test.use({viewport: {width: 1920, height: 1080}})`
to route around a new Carbon `xlg` breakpoint that collapses the
process-instance header's operation buttons into an "Actions" menu below
1312px — which is Playwright's default viewport width for this suite. That
masks the layout most users actually see and, since `test.use` is file-scoped,
silently changed the viewport for every other test in those files too.

While fixing the follow-up failures on that PR, I confirmed (against the live
app at the suite's actual default viewport) that the collapsed state renders a
real, accessible `menu "Actions"` with items ("Suspend"/"Cancel"/"Modify"/"Migrate")
— a genuine interaction path, not a UI limitation. The correct fix is to open
that menu and click the item, not to force a wider screen.

This adds explicit guidance to `qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md`
so the nightly fix agent recognizes this failure pattern and knows the
non-viewport fix:

- **Diagnosis steps**: a new pattern entry — "Header/toolbar collapses into a
  menu, or a column disappears, at the suite's default viewport" — framing it
  as a UI change to adapt to, not a regression, with the fix (open the menu and
  click by accessible name, scroll to reveal on-screen content, or use a
  different always-visible surface for the same information).
- **Constraints**: a hard rule against `test.use({viewport})` /
  `page.setViewportSize()` as a fix for this failure class, plus the one
  genuine exception — an element that is conditionally never rendered (not
  just CSS-hidden) at the default width has no on-screen alternative — and how
  to tell the two cases apart (read the component source, or inspect the live
  app if a session has one available; the automated dispatch does not, per the
  existing Forbidden-tools list).

## Why now

Both `#59921`'s own follow-up fixes (unrelated `test:` commits, not part of
this PR) hit exactly this: three tests still needed the viewport pin removed
and replaced with real interaction/an alternative always-visible surface, and
one test genuinely had no alternative (a table column unmounted, not hidden,
below the breakpoint) — verified via the local docker-compose environment and
a live browser check at 1280px, per `qa/c8-orchestration-cluster-e2e-test-suite/README.md`.

## Test plan

Documentation-only change (`AGENTS.md`), no code touched. N/A for CI; reviewed
for consistency with the existing "Never mask a failure..." language in
`## Product-Bug Escalation` (which covers masking a *regression* — a
narrower case than this general responsive-UI-fix guidance).