### PR TITLE
test: remove stale workarounds for closed bugs #54238 and #55864

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-before-all-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-before-all-tests.spec.ts
@@ -664,9 +664,26 @@ test.describe.parallel('Multi-Instance Execution Listeners — beforeAll', () =>
             await completeJob(request, j.jobKey);
           }
 
-          // TODO: #54238 workaround — activate the failed job before searching
-          // so it is no longer in FAILED/RETRIES_UPDATED state when /jobs/search
-          // is called (those states cause HTTP 500 in the current backend).
+          await expect(async () => {
+            const res = await request.post(buildUrl('/jobs/search'), {
+              headers: jsonHeaders(),
+              data: {filter: {processInstanceKey: piKey, type: startElJobType}},
+            });
+            await assertStatusCode(res, 200);
+            const items = (await res.json()).items as Array<{
+              jobKey: string;
+              elementId: string;
+              state: string;
+            }>;
+            expect(items).toHaveLength(3);
+            const failedJob = items.find(
+              (j) => j.jobKey === String(startJobs[0].jobKey),
+            );
+            expect(failedJob).toBeDefined();
+            expect(failedJob?.state).toBe('FAILED');
+            expect(failedJob?.elementId).toBe('miTask');
+          }).toPass(extendedAssertionOptions);
+
           let retryJobs: Awaited<ReturnType<typeof activateJobsByType>> = [];
           await expect(async () => {
             retryJobs = await activateJobsByType(
@@ -678,14 +695,6 @@ test.describe.parallel('Multi-Instance Execution Listeners — beforeAll', () =>
           }).toPass(extendedAssertionOptions);
           await completeJob(request, retryJobs[0].jobKey);
 
-          // Search after activation: all start EL jobs are now out of FAILED state.
-          await expectJobsByType(
-            request,
-            piKey,
-            startElJobType,
-            3,
-            extendedAssertionOptions,
-          );
           await expectJobsByType(request, piKey, beforeAllJobType, 1);
 
           await expectJobsByType(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -198,8 +198,7 @@ test.describe('Process Instance Variables', () => {
     });
   });
 
-  // Skipped due to bug #55864: https://github.com/camunda/camunda/issues/55864
-  test.skip('Infinite scrolling', async ({
+  test('Infinite scrolling', async ({
     page,
     operateHomePage,
     operateProcessesPage,


### PR DESCRIPTION
Two places in the e2e suite still worked around bugs that have since been fixed and closed.

**`#54238` (API test)** — `tests/api/v2/job/mi-el-before-all-tests.spec.ts` activated the failed job *before* calling `/v2/jobs/search`, solely to move it out of `FAILED` state because that state used to return HTTP 500. #54238 was fixed by #54333, so the test was tiptoeing around the exact behaviour it should assert. The workaround is gone; the spec now asserts `/jobs/search` returns 200 while the start EL job is in `FAILED` state and that the failed job carries its `elementId` (the null `elementId`/`flowNodeId` was the root cause). Mirrors the cleanup done for the sibling MI EL spec in #55017, which missed this file.

**`#55864` (Operate UI test)** — the `Infinite scrolling` test in `tests/operate/processInstanceVariables.spec.ts` was skipped for a bug closed on 2026-07-06. Unskipped; test body unchanged.

Verification: on-demand `c8-orchestration-cluster-e2e-tests-on-demand.yml` run against this branch (results posted as a comment below).

[TestRail test case suite](https://camunda.testrail.com/index.php?/suites/view/17050)

Follow-up (out of scope here): automated detection of comments that reference closed issues is now tracked in #59991. A sweep of the rest of the suite found no further stale workarounds — the remaining closed-issue references (#57579, #38880, #46405/#46407) were each checked and are legitimate context, not rot.

Closes #59887

