### PR TITLE
ci: add daily max-throughput leg for no-secondary-storage load test

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -1,12 +1,17 @@
-# description: Runs a daily max-load stress test against main, currently in two variants: gRPC
-#              and REST (both against Elasticsearch). After a 15-minute warmup, profiles the next
-#              30 minutes of each variant via async-profiler. After a 3-hour soak: snapshots
-#              metrics as a GitHub artifact, posts a side-by-side summary table (with flamegraph
-#              links) to Slack, then immediately deletes the namespaces to reduce cost.
+# description: Runs a daily max-load stress test against main, currently in three variants: gRPC
+#              and REST (both against Elasticsearch), and no-secondary-storage (exporters
+#              disabled). After a 15-minute warmup, profiles the next 30 minutes of each variant
+#              via async-profiler. After a 3-hour soak: snapshots metrics as a GitHub artifact,
+#              posts a side-by-side summary table (with flamegraph links) to Slack, then
+#              immediately deletes the namespaces to reduce cost.
 #              Naming pattern: medic-daily-YYYY-MM-DD-<sha>
 #              Each variant's full lifecycle (setup, warmup, profile, soak, collect-metrics,
 #              cleanup) is delegated to the reusable stress-load-test.yml workflow via a
 #              matrix — adding a variant is a one-line matrix entry, not a 6-job copy-paste.
+#              The no-secondary-storage variant only runs this daily `max` leg; it deliberately
+#              does not get its own multi-week weekly endurance rotation, since that long-horizon
+#              engine coverage is not storage-specific and is already provided by the ES/OS/RDBMS
+#              weekly runs.
 # calls: stress-load-test.yml (per variant)
 # type: CI
 # owner: @camunda/reliability-testing
@@ -90,10 +95,17 @@ jobs:
             label: gRPC
             load-test-load: ''
             load-test-setup-helm-values: '--set elasticsearch.storage.requests=64Gi'
+            secondary-storage-type: elasticsearch
           - key: rest
             label: REST
             load-test-load: '--set global.preferRest.enabled=true'
             load-test-setup-helm-values: '--set elasticsearch.storage.requests=64Gi'
+            secondary-storage-type: elasticsearch
+          - key: none
+            label: None
+            load-test-load: ''
+            load-test-setup-helm-values: ''
+            secondary-storage-type: none
     uses: ./.github/workflows/stress-load-test.yml
     secrets: inherit
     with:
@@ -101,6 +113,7 @@ jobs:
       build-frontend: true
       load-test-load: ${{ matrix.variant.load-test-load }}
       load-test-setup-helm-values: ${{ matrix.variant.load-test-setup-helm-values }}
+      secondary-storage-type: ${{ matrix.variant.secondary-storage-type }}
 
   # Aggregates every variant's metrics artifact into one place.
   aggregate-metrics:
@@ -130,7 +143,7 @@ jobs:
           # Keep in sync with the `run-variant` matrix above (key:label pairs) — this determines
           # the Slack summary table's column order, which is not guaranteed by artifact download
           # order. key here must match the -<key> suffix used to build the run-variant name above.
-          VARIANT_ORDER: 'grpc:gRPC rest:REST'
+          VARIANT_ORDER: 'grpc:gRPC rest:REST none:None'
         run: |
           manifest='[]'
           for entry in $VARIANT_ORDER; do

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -103,7 +103,7 @@ jobs:
             secondary-storage-type: elasticsearch
           - key: none
             label: None
-            load-test-load: ''
+            load-test-load: '--set load-tester.starter.rate=500'
             load-test-setup-helm-values: ''
             secondary-storage-type: none
     uses: ./.github/workflows/stress-load-test.yml

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -364,9 +364,9 @@ Example running tests (naming pattern: `medic-y-<year>-cw-<week>-<sha>-<variant>
 
 ### Daily load tests
 
-Daily stress tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml).
+Daily stress tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml), in three variants: gRPC and REST (both against Elasticsearch), and no-secondary-storage (exporters disabled).
 
-**Goal:** Validating the reliability of the current main under stress, and detecting newly introduced instabilities with a short feedback loop.
+**Goal:** Validating the reliability of the current main under stress, and detecting newly introduced instabilities with a short feedback loop. The no-secondary-storage variant only runs this daily `max` leg — it does not get its own multi-week weekly endurance rotation, since that long-horizon engine coverage is not storage-specific and is already provided by the ES/OS/RDBMS weekly runs (see [Weekly load tests](#weekly-load-tests) above).
 
 **Benefits:**
 
@@ -376,7 +376,7 @@ Daily stress tests run against the state of the **main** branch via the [Camunda
 
 **Validation:** TBD — explicit dashboard with KPIs is tracked in [#42274](https://github.com/camunda/camunda/issues/42274).
 
-**Profiling:** unlike the PR-label flow, profiling here is unconditional — after each run's setup job succeeds, the reusable [`profile-load-test.yml`](../.github/workflows/profile-load-test.yml) workflow waits out the same 15-minute warmup as the metrics path, then captures a 30-minute async-profiler flamegraph for both the gRPC and REST runs, in parallel with the 3-hour soak. Flamegraph artifacts upload the same way as the PR path.
+**Profiling:** unlike the PR-label flow, profiling here is unconditional — after each run's setup job succeeds, the reusable [`profile-load-test.yml`](../.github/workflows/profile-load-test.yml) workflow waits out the same 15-minute warmup as the metrics path, then captures a 30-minute async-profiler flamegraph for each of the gRPC, REST, and no-secondary-storage runs, in parallel with the 3-hour soak. Flamegraph artifacts upload the same way as the PR path.
 
 ### Ad-hoc load tests
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -364,7 +364,7 @@ Example running tests (naming pattern: `medic-y-<year>-cw-<week>-<sha>-<variant>
 
 ### Daily load tests
 
-Daily stress tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml), in three variants: gRPC and REST (both against Elasticsearch), and no-secondary-storage (exporters disabled).
+Daily stress tests run against the state of the **main** branch via the [Daily load tests GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-daily-load-tests.yml), in three variants: gRPC and REST (both against Elasticsearch), and no-secondary-storage (exporters disabled).
 
 **Goal:** Validating the reliability of the current main under stress, and detecting newly introduced instabilities with a short feedback loop. The no-secondary-storage variant only runs this daily `max` leg — it does not get its own multi-week weekly endurance rotation, since that long-horizon engine coverage is not storage-specific and is already provided by the ES/OS/RDBMS weekly runs (see [Weekly load tests](#weekly-load-tests) above).
 


### PR DESCRIPTION
## Description

Adds a third `none` (no-secondary-storage) variant to the daily load test workflow (`camunda-daily-load-tests.yml`), running the `max` scenario with the same 15-minute warmup / 3-hour soak timing as the existing gRPC and REST legs, and extends the daily Slack summary script to report it alongside them.

This closes out the two acceptance criteria left open when #56506 (which fixed the `benchmark-none` deploy crash by bumping the `camunda-platform-helm` chart to `15.0.0-alpha4`) was closed: a recurring scheduled run, and Grafana visibility for the no-secondary-storage configuration.

The `none` variant deliberately does **not** join the multi-week weekly endurance rotation - that long-horizon engine-stability coverage isn't storage-specific and is already provided by the ES/OS/RDBMS weekly runs.

**Verification so far:** `actionlint` passes clean on the modified workflow, the YAML parses, and the updated Slack script's table-rendering logic was dry-run locally with sample data (confirmed correct column widths/alignment and the "None" Grafana deep-link construction) without hitting the network. A manual `workflow_dispatch` run (or the next scheduled 02:00 UTC run) is still recommended after merge to confirm the `none` leg completes end-to-end in production and posts correctly to Slack.

## Checklist

<!-- Neither checklist item applies: this workflow only runs on `main` (no stable-branch wrapper to backport), and this PR doesn't touch the C8 Orchestration Cluster E2E Test Suite. -->

## Related issues

Closes #59964
