### PR TITLE
Add agent-definition search domain + ES/OS reader

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read;
 
+import io.camunda.db.rdbms.read.service.AgentDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.AgentHistoryDbReader;
 import io.camunda.db.rdbms.read.service.AgentInstanceDbReader;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
@@ -59,6 +60,7 @@ import io.camunda.search.clients.reader.SearchClientReaders;
  * datasource. Built from the tenant's {@link RdbmsMapperBundle} via {@link #create}.
  */
 public record RdbmsTenantReaders(
+    AgentDefinitionDbReader agentDefinitionReader,
     AgentInstanceDbReader agentInstanceReader,
     AgentHistoryDbReader agentHistoryReader,
     AuditLogDbReader auditLogReader,
@@ -110,6 +112,7 @@ public record RdbmsTenantReaders(
   public static RdbmsTenantReaders create(
       final RdbmsMapperBundle mappers, final RdbmsReaderConfig readerConfig) {
     return new RdbmsTenantReaders(
+        new AgentDefinitionDbReader(),
         new AgentInstanceDbReader(mappers.agentInstanceMapper(), readerConfig),
         new AgentHistoryDbReader(mappers.agentHistoryMapper(), readerConfig),
         new AuditLogDbReader(mappers.auditLogMapper(), readerConfig),
@@ -164,6 +167,7 @@ public record RdbmsTenantReaders(
 
   public SearchClientReaders toSearchClientReaders() {
     return new SearchClientReaders(
+        agentDefinitionReader,
         agentInstanceReader,
         agentHistoryReader,
         authorizationReader,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReader.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.search.clients.reader.AgentDefinitionReader;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+
+public class AgentDefinitionDbReader implements AgentDefinitionReader {
+
+  @Override
+  public SearchQueryResult<AgentDefinitionEntity> search(
+      final AgentDefinitionQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException(
+        "AgentDefinitionReader#search() not supported for RDBMS, see"
+            + " https://github.com/camunda/camunda/issues/59079");
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.search;
 
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.clients.cache.ProcessCache;
+import io.camunda.search.clients.reader.AgentDefinitionDocumentReader;
 import io.camunda.search.clients.reader.AgentHistoryDocumentReader;
 import io.camunda.search.clients.reader.AgentInstanceDocumentReader;
 import io.camunda.search.clients.reader.AuditLogDocumentReader;
@@ -55,6 +56,7 @@ import io.camunda.search.clients.reader.WaitStateDocumentReader;
 import io.camunda.search.clients.reader.WaitStateStatisticsDocumentReader;
 import io.camunda.search.clients.reader.utils.IncidentErrorHashCodeNormalizer;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
@@ -100,6 +102,8 @@ public final class SearchClientReadersFactory {
       final ProcessCache.Configuration processCacheConfig) {
 
     // --- Phase 1: Simple readers (no cross-reader dependencies) ---
+    final var agentDefinitionReader =
+        new AgentDefinitionDocumentReader(executor, descriptors.get(AgentDefinitionIndex.class));
     final var agentInstanceReader =
         new AgentInstanceDocumentReader(executor, descriptors.get(AgentInstanceTemplate.class));
     final var agentHistoryReader =
@@ -220,6 +224,7 @@ public final class SearchClientReadersFactory {
 
     // --- Assemble ---
     return new SearchClientReaders(
+        agentDefinitionReader,
         agentInstanceReader,
         agentHistoryReader,
         authorizationReader,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentDefinitionDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentDefinitionDocumentReader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class AgentDefinitionDocumentReader extends DocumentBasedReader
+    implements AgentDefinitionReader {
+
+  public AgentDefinitionDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public AgentDefinitionEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getById(
+            String.valueOf(key),
+            io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity.class,
+            indexDescriptor.getFullQualifiedName());
+  }
+
+  @Override
+  public SearchQueryResult<AgentDefinitionEntity> search(
+      final AgentDefinitionQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity.class,
+            resourceAccessChecks);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -87,6 +87,7 @@ import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsAgg
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsTUAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.VariableNameAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.WaitStateStatisticsAggregationResultTransformer;
+import io.camunda.search.clients.transformers.entity.AgentDefinitionEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AgentHistoryEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AgentInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AuditLogEntityTransformer;
@@ -119,6 +120,7 @@ import io.camunda.search.clients.transformers.entity.UserEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
 import io.camunda.search.clients.transformers.entity.WaitStateEntityTransformer;
+import io.camunda.search.clients.transformers.filter.AgentDefinitionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AgentHistoryFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AgentInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AuditLogFilterTransformer;
@@ -171,6 +173,7 @@ import io.camunda.search.clients.transformers.result.DecisionRequirementsResultC
 import io.camunda.search.clients.transformers.result.DeployedResourceResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessDefinitionResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfigTransformer;
+import io.camunda.search.clients.transformers.sort.AgentDefinitionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.AgentHistoryFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.AgentInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.AuditLogSortTransformer;
@@ -204,6 +207,7 @@ import io.camunda.search.clients.transformers.sort.UserFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.UserTaskFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.WaitStateFieldSortingTransformer;
+import io.camunda.search.filter.AgentDefinitionFilter;
 import io.camunda.search.filter.AgentInstanceFilter;
 import io.camunda.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.search.filter.AuditLogFilter;
@@ -250,6 +254,7 @@ import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.search.filter.WaitStateStatisticsFilter;
+import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
@@ -304,6 +309,7 @@ import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.search.result.DeployedResourceQueryResultConfig;
 import io.camunda.search.result.ProcessDefinitionQueryResultConfig;
 import io.camunda.search.result.ProcessInstanceQueryResultConfig;
+import io.camunda.search.sort.AgentDefinitionSort;
 import io.camunda.search.sort.AgentInstanceHistorySort;
 import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.search.sort.AuditLogSort;
@@ -339,6 +345,7 @@ import io.camunda.search.sort.UserTaskSort;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.search.sort.WaitStateSort;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
@@ -376,6 +383,7 @@ import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
 import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
@@ -468,6 +476,7 @@ public final class ServiceTransformers {
         new TypedSearchQueryTransformer<>(mappers);
     // query -> request
     Stream.of(
+            AgentDefinitionQuery.class,
             AgentInstanceHistoryQuery.class,
             AgentInstanceQuery.class,
             AuthorizationQuery.class,
@@ -519,6 +528,7 @@ public final class ServiceTransformers {
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
+    mappers.put(AgentDefinitionEntity.class, new AgentDefinitionEntityTransformer());
     mappers.put(AgentHistoryEntity.class, new AgentHistoryEntityTransformer());
     mappers.put(AgentInstanceEntity.class, new AgentInstanceEntityTransformer());
     mappers.put(AuthorizationEntity.class, new AuthorizationEntityTransformer());
@@ -557,6 +567,7 @@ public final class ServiceTransformers {
     mappers.put(DeployedResourceEntity.class, new DeployedResourceEntityTransformer());
 
     // domain field sorting -> database field sorting
+    mappers.put(AgentDefinitionSort.class, new AgentDefinitionFieldSortingTransformer());
     mappers.put(AgentInstanceHistorySort.class, new AgentHistoryFieldSortingTransformer());
     mappers.put(AgentInstanceSort.class, new AgentInstanceFieldSortingTransformer());
     mappers.put(AuthorizationSort.class, new AuthorizationFieldSortingTransformer());
@@ -597,6 +608,9 @@ public final class ServiceTransformers {
     mappers.put(WaitStateSort.class, new WaitStateFieldSortingTransformer());
 
     // filters -> search query
+    mappers.put(
+        AgentDefinitionFilter.class,
+        new AgentDefinitionFilterTransformer(indexDescriptors.get(AgentDefinitionIndex.class)));
     mappers.put(
         AgentInstanceHistoryFilter.class,
         new AgentHistoryFilterTransformer(indexDescriptors.get(AgentHistoryTemplate.class)));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentDefinitionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentDefinitionEntityTransformer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+
+public class AgentDefinitionEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity,
+        AgentDefinitionEntity> {
+
+  @Override
+  public AgentDefinitionEntity apply(
+      final io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity source) {
+    return new AgentDefinitionEntity(
+        source.getKey(),
+        toAgentType(source.getAgentType()),
+        source.getName(),
+        source.getElementId(),
+        source.getBpmnProcessId(),
+        source.getProcessDefinitionKey(),
+        source.getProcessDefinitionVersion(),
+        source.getProcessDefinitionVersionTag(),
+        source.getTenantId());
+  }
+
+  private static AgentType toAgentType(
+      final io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionType source) {
+    return switch (source) {
+      case AI_AGENT_SUB_PROCESS -> AgentType.AI_AGENT_SUB_PROCESS;
+      case AI_AGENT_TASK -> AgentType.AI_AGENT_TASK;
+      case EXTERNAL_AGENT -> AgentType.EXTERNAL_AGENT;
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentDefinitionFilterTransformer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.AGENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.ELEMENT_ID;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.KEY;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.NAME;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.PROCESS_DEFINITION_VERSION;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.PROCESS_DEFINITION_VERSION_TAG;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.TENANT_ID;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.AgentDefinitionFilter;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+
+public class AgentDefinitionFilterTransformer
+    extends IndexFilterTransformer<AgentDefinitionFilter> {
+
+  public AgentDefinitionFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final AgentDefinitionFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    queries.addAll(longOperations(KEY, filter.agentDefinitionKeyOperations()));
+    queries.addAll(stringOperations(AGENT_TYPE, filter.agentTypeOperations()));
+    queries.addAll(stringOperations(NAME, filter.nameOperations()));
+    queries.addAll(stringOperations(ELEMENT_ID, filter.elementIdOperations()));
+    queries.addAll(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()));
+    queries.addAll(longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()));
+    queries.addAll(
+        intOperations(PROCESS_DEFINITION_VERSION, filter.processDefinitionVersionOperations()));
+    queries.addAll(
+        stringOperations(
+            PROCESS_DEFINITION_VERSION_TAG, filter.processDefinitionVersionTagOperations()));
+    queries.addAll(stringOperations(TENANT_ID, filter.tenantIdOperations()));
+    return and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(
+      final RequiredAuthorization<?> authorization) {
+    return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentDefinitionFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentDefinitionFieldSortingTransformer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.AGENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.ELEMENT_ID;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.KEY;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.NAME;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.PROCESS_DEFINITION_VERSION;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.PROCESS_DEFINITION_VERSION_TAG;
+import static io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex.TENANT_ID;
+
+public class AgentDefinitionFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "agentDefinitionKey" -> KEY; // ES/OS stores the key as "key", not "agentDefinitionKey"
+      case "agentType" -> AGENT_TYPE;
+      case "name" -> NAME;
+      case "elementId" -> ELEMENT_ID;
+      case "processDefinitionId" -> BPMN_PROCESS_ID;
+      case "processDefinitionKey" -> PROCESS_DEFINITION_KEY;
+      case "processDefinitionVersion" -> PROCESS_DEFINITION_VERSION;
+      case "processDefinitionVersionTag" -> PROCESS_DEFINITION_VERSION_TAG;
+      case "tenantId" -> TENANT_ID;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/AgentDefinitionDocumentReaderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/AgentDefinitionDocumentReaderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import org.junit.jupiter.api.Test;
+
+class AgentDefinitionDocumentReaderTest {
+
+  @Test
+  void shouldGetByKey() {
+    // given
+    final var executor = mock(SearchClientBasedQueryExecutor.class);
+    final var indexDescriptor = mock(IndexDescriptor.class);
+    final var reader = new AgentDefinitionDocumentReader(executor, indexDescriptor);
+
+    final var entity =
+        new AgentDefinitionEntity(
+            1L,
+            AgentType.AI_AGENT_TASK,
+            "name",
+            "elementId",
+            "processDefinitionId",
+            2L,
+            3,
+            "versionTag",
+            "tenantId");
+
+    when(indexDescriptor.getFullQualifiedName()).thenReturn("agent-definition-index");
+    when(executor.getById(
+            eq("1"),
+            eq(io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity.class),
+            eq("agent-definition-index")))
+        .thenReturn(entity);
+
+    // when
+    final var result = reader.getByKey(1L, ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(result).isEqualTo(entity);
+    verify(executor)
+        .getById(
+            "1",
+            io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity.class,
+            "agent-definition-index");
+  }
+
+  @Test
+  void shouldSearch() {
+    // given
+    final var executor = mock(SearchClientBasedQueryExecutor.class);
+    final var indexDescriptor = mock(IndexDescriptor.class);
+    final var reader = new AgentDefinitionDocumentReader(executor, indexDescriptor);
+
+    final var entity =
+        new AgentDefinitionEntity(
+            1L,
+            AgentType.AI_AGENT_TASK,
+            "name",
+            "elementId",
+            "processDefinitionId",
+            2L,
+            3,
+            "versionTag",
+            "tenantId");
+
+    final var query = AgentDefinitionQuery.of(b -> b);
+    when(executor.search(
+            eq(query),
+            eq(io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity.class),
+            any(ResourceAccessChecks.class)))
+        .thenReturn(SearchQueryResult.of(entity));
+
+    // when
+    final var result = reader.search(query, ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(result.items()).containsExactly(entity);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentDefinitionEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentDefinitionEntityTransformerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class AgentDefinitionEntityTransformerTest {
+
+  private final AgentDefinitionEntityTransformer transformer =
+      new AgentDefinitionEntityTransformer();
+
+  private io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity buildSource() {
+    return new io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionEntity()
+        .setKey(100L)
+        .setAgentType(
+            io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionType.AI_AGENT_TASK)
+        .setName("myAgent")
+        .setElementId("Task_1")
+        .setBpmnProcessId("myProcess")
+        .setProcessDefinitionKey(400L)
+        .setProcessDefinitionVersion(2)
+        .setProcessDefinitionVersionTag("v2")
+        .setTenantId("<default>");
+  }
+
+  @Test
+  void shouldMapAllFields() {
+    final var result = transformer.apply(buildSource());
+
+    assertThat(result.agentDefinitionKey()).isEqualTo(100L);
+    assertThat(result.agentType()).isEqualTo(AgentType.AI_AGENT_TASK);
+    assertThat(result.name()).isEqualTo("myAgent");
+    assertThat(result.elementId()).isEqualTo("Task_1");
+    assertThat(result.processDefinitionId()).isEqualTo("myProcess");
+    assertThat(result.processDefinitionKey()).isEqualTo(400L);
+    assertThat(result.processDefinitionVersion()).isEqualTo(2);
+    assertThat(result.processDefinitionVersionTag()).isEqualTo("v2");
+    assertThat(result.tenantId()).isEqualTo("<default>");
+  }
+
+  @ParameterizedTest
+  @EnumSource(io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionType.class)
+  void shouldMapEveryAgentType(
+      final io.camunda.webapps.schema.entities.agentdefinition.AgentDefinitionType webappsType) {
+    final var source = buildSource().setAgentType(webappsType);
+
+    final var result = transformer.apply(source);
+
+    assertThat(result.agentType()).isNotNull();
+    assertThat(result.agentType().name()).isEqualTo(webappsType.name());
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentDefinitionFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentDefinitionFilterTransformerTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchMatchNoneQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.query.SearchTermsQuery;
+import io.camunda.search.clients.types.TypedValue;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.security.core.authz.AuthorizationCheck;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.security.core.authz.TenantCheck;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentDefinitionFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByAgentDefinitionKey() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.agentDefinitionKeys(100L));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("key");
+              assertThat(t.value().longValue()).isEqualTo(100L);
+            });
+  }
+
+  @Test
+  void shouldQueryByAgentType() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.agentTypes("AI_AGENT_TASK"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("agentType");
+              assertThat(t.value().stringValue()).isEqualTo("AI_AGENT_TASK");
+            });
+  }
+
+  @Test
+  void shouldQueryByName() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.names("myAgent"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("name");
+              assertThat(t.value().stringValue()).isEqualTo("myAgent");
+            });
+  }
+
+  @Test
+  void shouldQueryByElementId() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.elementIds("Task_1"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("elementId");
+              assertThat(t.value().stringValue()).isEqualTo("Task_1");
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessDefinitionId() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.processDefinitionIds("myProcess"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("bpmnProcessId");
+              assertThat(t.value().stringValue()).isEqualTo("myProcess");
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessDefinitionKey() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.processDefinitionKeys(400L));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processDefinitionKey");
+              assertThat(t.value().longValue()).isEqualTo(400L);
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessDefinitionVersion() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.processDefinitionVersions(2));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processDefinitionVersion");
+              assertThat(t.value().intValue()).isEqualTo(2);
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessDefinitionVersionTag() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.processDefinitionVersionTags("v1"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processDefinitionVersionTag");
+              assertThat(t.value().stringValue()).isEqualTo("v1");
+            });
+  }
+
+  @Test
+  void shouldQueryByTenantId() {
+    final var filter = FilterBuilders.agentDefinition(f -> f.tenantIds("<default>"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("tenantId");
+              assertThat(t.value().stringValue()).isEqualTo("<default>");
+            });
+  }
+
+  @Test
+  void shouldQueryByAllFields() {
+    final var filter =
+        FilterBuilders.agentDefinition(
+            f ->
+                f.agentDefinitionKeys(100L)
+                    .agentTypes("AI_AGENT_TASK")
+                    .names("myAgent")
+                    .elementIds("Task_1")
+                    .processDefinitionIds("myProcess")
+                    .processDefinitionKeys(400L)
+                    .processDefinitionVersions(2)
+                    .processDefinitionVersionTags("v1")
+                    .tenantIds("<default>"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption()).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) searchRequest.queryOption()).must()).hasSize(9);
+  }
+
+  @Test
+  void shouldApplyAuthorizationCheck() {
+    // given
+    final var authorization =
+        RequiredAuthorization.of(
+            a -> a.processDefinition().readProcessDefinition().resourceIds(List.of("1", "2")));
+    final var authorizationCheck = AuthorizationCheck.enabled(authorization);
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, TenantCheck.disabled());
+
+    // when
+    final var searchQuery =
+        transformQuery(FilterBuilders.agentDefinition(b -> b), resourceAccessChecks);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermsQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo(AgentDefinitionIndex.BPMN_PROCESS_ID);
+              assertThat(t.values().stream().map(TypedValue::stringValue).toList())
+                  .containsExactlyInAnyOrder("1", "2");
+            });
+  }
+
+  @Test
+  void shouldReturnNonMatchWhenNoResourceIdsProvided() {
+    // given
+    final var authorization =
+        RequiredAuthorization.of(a -> a.processDefinition().readProcessDefinition());
+    final var authorizationCheck = AuthorizationCheck.enabled(authorization);
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, TenantCheck.disabled());
+
+    // when
+    final var searchQuery =
+        transformQuery(FilterBuilders.agentDefinition(b -> b), resourceAccessChecks);
+
+    // then
+    assertThat(searchQuery.queryOption()).isInstanceOf(SearchMatchNoneQuery.class);
+  }
+
+  @Test
+  void shouldApplyTenantCheck() {
+    // given
+    final var tenantCheck = TenantCheck.enabled(List.of("a", "b"));
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), tenantCheck);
+
+    // when
+    final var searchQuery =
+        transformQuery(FilterBuilders.agentDefinition(b -> b), resourceAccessChecks);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermsQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo(AgentDefinitionIndex.TENANT_ID);
+              assertThat(t.values().stream().map(TypedValue::stringValue).toList())
+                  .containsExactlyInAnyOrder("a", "b");
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentDefinitionFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentDefinitionFieldSortingTransformerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.AgentDefinitionSort;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AgentDefinitionFieldSortingTransformerTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments(
+            AgentDefinitionIndex.KEY, SortOrder.DESC, s -> s.agentDefinitionKey().desc()),
+        new TestArguments(AgentDefinitionIndex.AGENT_TYPE, SortOrder.ASC, s -> s.agentType().asc()),
+        new TestArguments(AgentDefinitionIndex.NAME, SortOrder.ASC, s -> s.name().asc()),
+        new TestArguments(
+            AgentDefinitionIndex.ELEMENT_ID, SortOrder.DESC, s -> s.elementId().desc()),
+        new TestArguments(
+            AgentDefinitionIndex.BPMN_PROCESS_ID,
+            SortOrder.ASC,
+            s -> s.processDefinitionId().asc()),
+        new TestArguments(
+            AgentDefinitionIndex.PROCESS_DEFINITION_KEY,
+            SortOrder.DESC,
+            s -> s.processDefinitionKey().desc()),
+        new TestArguments(
+            AgentDefinitionIndex.PROCESS_DEFINITION_VERSION,
+            SortOrder.ASC,
+            s -> s.processDefinitionVersion().asc()),
+        new TestArguments(
+            AgentDefinitionIndex.PROCESS_DEFINITION_VERSION_TAG,
+            SortOrder.DESC,
+            s -> s.processDefinitionVersionTag().desc()),
+        new TestArguments(AgentDefinitionIndex.TENANT_ID, SortOrder.ASC, s -> s.tenantId().asc()));
+  }
+
+  @ParameterizedTest(name = "should sort by {0} in ''{1}'' direction")
+  @MethodSource("provideSortParameters")
+  void shouldSortByField(
+      final String expectedField,
+      final SortOrder sortOrder,
+      final Function<AgentDefinitionSort.Builder, ObjectBuilder<AgentDefinitionSort>> fn) {
+    final var request = SearchQueryBuilders.agentDefinitionSearchQuery(q -> q.sort(fn));
+    final var sort = transformRequest(request);
+
+    assertThat(sort).hasSize(2);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(expectedField);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(AgentDefinitionIndex.KEY);
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  @Test
+  void shouldUseAgentDefinitionKeyAsDefaultTiebreakerWhenNoSortSpecified() {
+    // given — query with no explicit sort
+    final var request = SearchQueryBuilders.agentDefinitionSearchQuery(q -> q);
+    // when
+    final var sort = transformRequest(request);
+    // then — only the implicit default tiebreaker is appended
+    assertThat(sort).hasSize(1);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(AgentDefinitionIndex.KEY);
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  @Test
+  void shouldThrowForUnknownSortField() {
+    final var transformer = new AgentDefinitionFieldSortingTransformer();
+
+    assertThatThrownBy(() -> transformer.apply("unknownField"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknownField");
+  }
+
+  private record TestArguments(
+      String expectedField,
+      SortOrder sortOrder,
+      Function<AgentDefinitionSort.Builder, ObjectBuilder<AgentDefinitionSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {expectedField, sortOrder, fn};
+    }
+
+    @Override
+    public String toString() {
+      return expectedField + " " + sortOrder;
+    }
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/AgentDefinitionReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/AgentDefinitionReader.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.query.AgentDefinitionQuery;
+
+public interface AgentDefinitionReader
+    extends SearchEntityReader<AgentDefinitionEntity, AgentDefinitionQuery> {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.reader;
 
 public record SearchClientReaders(
+    AgentDefinitionReader agentDefinitionReader,
     AgentInstanceReader agentInstanceReader,
     AgentHistoryReader agentHistoryReader,
     AuthorizationReader authorizationReader,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentDefinitionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentDefinitionEntity.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.security.core.authz.TenantOwnedEntity;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AgentDefinitionEntity(
+    Long agentDefinitionKey,
+    AgentType agentType,
+    String name,
+    String elementId,
+    String processDefinitionId,
+    Long processDefinitionKey,
+    Integer processDefinitionVersion,
+    @Nullable String processDefinitionVersionTag,
+    String tenantId)
+    implements TenantOwnedEntity {
+
+  public AgentDefinitionEntity {
+    Objects.requireNonNull(agentDefinitionKey, "agentDefinitionKey");
+    Objects.requireNonNull(agentType, "agentType");
+    Objects.requireNonNull(name, "name");
+    Objects.requireNonNull(elementId, "elementId");
+    Objects.requireNonNull(processDefinitionId, "processDefinitionId");
+    Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
+    Objects.requireNonNull(processDefinitionVersion, "processDefinitionVersion");
+    Objects.requireNonNull(tenantId, "tenantId");
+  }
+
+  public enum AgentType {
+    AI_AGENT_SUB_PROCESS,
+    AI_AGENT_TASK,
+    EXTERNAL_AGENT
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentDefinitionFilter.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.FilterUtil;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record AgentDefinitionFilter(
+    List<Operation<Long>> agentDefinitionKeyOperations,
+    List<Operation<String>> agentTypeOperations,
+    List<Operation<String>> nameOperations,
+    List<Operation<String>> elementIdOperations,
+    List<Operation<String>> processDefinitionIdOperations,
+    List<Operation<Long>> processDefinitionKeyOperations,
+    List<Operation<Integer>> processDefinitionVersionOperations,
+    List<Operation<String>> processDefinitionVersionTagOperations,
+    List<Operation<String>> tenantIdOperations)
+    implements FilterBase {
+
+  public static AgentDefinitionFilter of(
+      final Function<AgentDefinitionFilter.Builder, ObjectBuilder<AgentDefinitionFilter>> fn) {
+    return FilterBuilders.agentDefinition(fn);
+  }
+
+  public static final class Builder implements ObjectBuilder<AgentDefinitionFilter> {
+
+    private List<Operation<Long>> agentDefinitionKeyOperations;
+    private List<Operation<String>> agentTypeOperations;
+    private List<Operation<String>> nameOperations;
+    private List<Operation<String>> elementIdOperations;
+    private List<Operation<String>> processDefinitionIdOperations;
+    private List<Operation<Long>> processDefinitionKeyOperations;
+    private List<Operation<Integer>> processDefinitionVersionOperations;
+    private List<Operation<String>> processDefinitionVersionTagOperations;
+    private List<Operation<String>> tenantIdOperations;
+
+    public Builder agentDefinitionKeyOperations(final List<Operation<Long>> operations) {
+      agentDefinitionKeyOperations = addValuesToList(agentDefinitionKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder agentDefinitionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return agentDefinitionKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder agentDefinitionKeys(final Long value, final Long... values) {
+      return agentDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder agentTypeOperations(final List<Operation<String>> operations) {
+      agentTypeOperations = addValuesToList(agentTypeOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder agentTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return agentTypeOperations(collectValues(operation, operations));
+    }
+
+    public Builder agentTypes(final String value, final String... values) {
+      return agentTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder nameOperations(final List<Operation<String>> operations) {
+      nameOperations = addValuesToList(nameOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder nameOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return nameOperations(collectValues(operation, operations));
+    }
+
+    public Builder names(final String value, final String... values) {
+      return nameOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder elementIdOperations(final List<Operation<String>> operations) {
+      elementIdOperations = addValuesToList(elementIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder elementIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return elementIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder elementIds(final String value, final String... values) {
+      return elementIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
+      processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionIds(final String value, final String... values) {
+      return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionKeyOperations(final List<Operation<Long>> operations) {
+      processDefinitionKeyOperations = addValuesToList(processDefinitionKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processDefinitionKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionKeys(final Long value, final Long... values) {
+      return processDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionVersionOperations(final List<Operation<Integer>> operations) {
+      processDefinitionVersionOperations =
+          addValuesToList(processDefinitionVersionOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionVersionOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return processDefinitionVersionOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionVersions(final Integer value, final Integer... values) {
+      return processDefinitionVersionOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionVersionTagOperations(final List<Operation<String>> operations) {
+      processDefinitionVersionTagOperations =
+          addValuesToList(processDefinitionVersionTagOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionVersionTagOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionVersionTagOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionVersionTags(final String value, final String... values) {
+      return processDefinitionVersionTagOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder tenantIdOperations(final List<Operation<String>> operations) {
+      tenantIdOperations = addValuesToList(tenantIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder tenantIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return tenantIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder tenantIds(final String value, final String... values) {
+      return tenantIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @Override
+    public AgentDefinitionFilter build() {
+      return new AgentDefinitionFilter(
+          Objects.requireNonNullElse(agentDefinitionKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(agentTypeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(nameOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(elementIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionVersionOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(
+              processDefinitionVersionTagOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -14,6 +14,15 @@ public final class FilterBuilders {
 
   private FilterBuilders() {}
 
+  public static AgentDefinitionFilter.Builder agentDefinition() {
+    return new AgentDefinitionFilter.Builder();
+  }
+
+  public static AgentDefinitionFilter agentDefinition(
+      final Function<AgentDefinitionFilter.Builder, ObjectBuilder<AgentDefinitionFilter>> fn) {
+    return fn.apply(agentDefinition()).build();
+  }
+
   public static AgentInstanceFilter.Builder agentInstance() {
     return new AgentInstanceFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/query/AgentDefinitionQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AgentDefinitionQuery.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.AgentDefinitionFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.AgentDefinitionSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record AgentDefinitionQuery(
+    AgentDefinitionFilter filter, AgentDefinitionSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<AgentDefinitionFilter, AgentDefinitionSort> {
+
+  public static AgentDefinitionQuery of(
+      final Function<Builder, ObjectBuilder<AgentDefinitionQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<
+          AgentDefinitionQuery, Builder, AgentDefinitionFilter, AgentDefinitionSort> {
+
+    private static final AgentDefinitionFilter EMPTY_FILTER =
+        FilterBuilders.agentDefinition().build();
+    private static final AgentDefinitionSort EMPTY_SORT =
+        SortOptionBuilders.agentDefinition().build();
+
+    private AgentDefinitionFilter filter;
+    private AgentDefinitionSort sort;
+
+    @Override
+    public Builder filter(final AgentDefinitionFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final AgentDefinitionSort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<AgentDefinitionFilter.Builder, ObjectBuilder<AgentDefinitionFilter>> fn) {
+      return filter(FilterBuilders.agentDefinition(fn));
+    }
+
+    public Builder sort(
+        final Function<AgentDefinitionSort.Builder, ObjectBuilder<AgentDefinitionSort>> fn) {
+      return sort(SortOptionBuilders.agentDefinition(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public AgentDefinitionQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new AgentDefinitionQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -14,6 +14,15 @@ public final class SearchQueryBuilders {
 
   private SearchQueryBuilders() {}
 
+  public static AgentDefinitionQuery.Builder agentDefinitionSearchQuery() {
+    return new AgentDefinitionQuery.Builder();
+  }
+
+  public static AgentDefinitionQuery agentDefinitionSearchQuery(
+      final Function<AgentDefinitionQuery.Builder, ObjectBuilder<AgentDefinitionQuery>> fn) {
+    return fn.apply(agentDefinitionSearchQuery()).build();
+  }
+
   public static AgentInstanceQuery.Builder agentInstanceSearchQuery() {
     return new AgentInstanceQuery.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/AgentDefinitionSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/AgentDefinitionSort.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record AgentDefinitionSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static AgentDefinitionSort of(
+      final Function<Builder, ObjectBuilder<AgentDefinitionSort>> fn) {
+    return SortOptionBuilders.agentDefinition(fn);
+  }
+
+  public static final class Builder extends SortOption.AbstractBuilder<Builder>
+      implements ObjectBuilder<AgentDefinitionSort> {
+
+    public Builder agentDefinitionKey() {
+      currentOrdering = new FieldSorting("agentDefinitionKey", null);
+      return this;
+    }
+
+    public Builder agentType() {
+      currentOrdering = new FieldSorting("agentType", null);
+      return this;
+    }
+
+    public Builder name() {
+      currentOrdering = new FieldSorting("name", null);
+      return this;
+    }
+
+    public Builder elementId() {
+      currentOrdering = new FieldSorting("elementId", null);
+      return this;
+    }
+
+    public Builder processDefinitionId() {
+      currentOrdering = new FieldSorting("processDefinitionId", null);
+      return this;
+    }
+
+    public Builder processDefinitionKey() {
+      currentOrdering = new FieldSorting("processDefinitionKey", null);
+      return this;
+    }
+
+    public Builder processDefinitionVersion() {
+      currentOrdering = new FieldSorting("processDefinitionVersion", null);
+      return this;
+    }
+
+    public Builder processDefinitionVersionTag() {
+      currentOrdering = new FieldSorting("processDefinitionVersionTag", null);
+      return this;
+    }
+
+    public Builder tenantId() {
+      currentOrdering = new FieldSorting("tenantId", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public AgentDefinitionSort build() {
+      return new AgentDefinitionSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -14,6 +14,15 @@ public final class SortOptionBuilders {
 
   private SortOptionBuilders() {}
 
+  public static AgentDefinitionSort.Builder agentDefinition() {
+    return new AgentDefinitionSort.Builder();
+  }
+
+  public static AgentDefinitionSort agentDefinition(
+      final Function<AgentDefinitionSort.Builder, ObjectBuilder<AgentDefinitionSort>> fn) {
+    return fn.apply(agentDefinition()).build();
+  }
+
   public static AgentInstanceSort.Builder agentInstance() {
     return new AgentInstanceSort.Builder();
   }


### PR DESCRIPTION
## Description

Adds the agent-definition search domain and its Elasticsearch/OpenSearch reader, so `AgentDefinition` documents exported by `AgentDefinitionHandler` (introduced in #59904) become queryable through the standard `search` module abstractions (filter/sort/query, transformers, and reader).

This is the foundational search-layer piece behind the "Real-Time Agent Visibility" epic (camunda/product-hub#3462) and directly implements #59078. Without it, the `AgentDefinitionIndex` documents that #59904 writes to ES/OS have no way of being read back — this PR closes that gap for the ES/OS backend so the upcoming agent-definition search REST endpoint can query them.

### What's introduced

- **`search-domain`**: `AgentDefinitionFilter`, `AgentDefinitionSort`, `AgentDefinitionQuery`, `AgentDefinitionEntity` (with nested `AgentType`), plus the corresponding `FilterBuilders`/`SortOptionBuilders`/`SearchQueryBuilders` factories — the domain-level, backend-agnostic objects other search consumers depend on.
- **`search-client-query-transformer`**: `AgentDefinitionFilterTransformer` (translates filter operations to ES/OS queries, including the `toAuthorizationCheckSearchQuery` authorization check on `processDefinitionId`/`BPMN_PROCESS_ID`, matching the OpenAPI's `PROCESS_DEFINITION` resource-scoped permission enforcement), `AgentDefinitionFieldSortingTransformer`, and `AgentDefinitionEntityTransformer` (webapps-schema entity → search-domain entity), all registered in `ServiceTransformers`.
- **`search-client-reader`/`search-client-query-transformer`**: `AgentDefinitionReader` interface and its ES/OS-backed `AgentDefinitionDocumentReader` implementation. `getByKey()` resolves directly via `getById()` since the agent-definition key is the document `_id` (agent definitions are immutable, deploy-time data written once — analogous to `DecisionDefinitionDocumentReader`, not `AgentInstanceDocumentReader`).
- **Registry wiring**: `agentDefinitionReader` added to the shared `SearchClientReaders` record, wired to the real ES/OS reader in `SearchClientReadersFactory` (dist). Since agent definitions are only exported via ES/OS today (no RDBMS mapper/table), `AgentDefinitionDbReader` is added as a stub in `db/rdbms` whose `search()` throws `UnsupportedOperationException`, keeping the RDBMS reader-composition contract satisfied without silently returning wrong results.

### Field naming

Follows the conventions established in #59904 and the REST/OpenAPI contract: `agentDefinitionKey` maps to the entity's `key` field, `bpmnProcessId`/`processDefinitionId` follow the existing definition-entity convention, and `processDefinitionVersionTag` uses its full, unambiguous name.

## Out of scope

- **RDBMS-backed reader implementation** — tracked separately in #59079; `AgentDefinitionDbReader` intentionally throws `UnsupportedOperationException` for `search()` until that's implemented.
- **REST API endpoint(s)** for agent-definition search (e.g. `POST /agent-definitions/search`) — this PR only provides the search-domain/reader plumbing; the REST controller, service-layer wiring, and OpenAPI-generated request/response DTOs are separate follow-up work.
- **Authorization/permission checks beyond the transformer-level `toAuthorizationCheckSearchQuery`** — broader end-to-end authorization behavior is validated once the REST layer lands.
- **Documentation updates** (docs.camunda.io) for the new search capability.

## What this unblocks

- The agent-definition search REST endpoint and any service-layer consumer that needs to query `AgentDefinition` documents by filter/sort.
- Follow-up RDBMS support work (#59079) can now implement `AgentDefinitionReader` against the same interface contract established here.

## Related issues

closes #59078
