### PR TITLE
feat: purge a single physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -485,7 +485,7 @@ public class ClusterEndpoint {
       @RequestParam(defaultValue = "false") final boolean dryRun) {
     try {
       return requestSender
-          .purge(new PurgeRequest(dryRun))
+          .purge(new PurgeRequest(Optional.empty(), dryRun))
           .thenApply(ClusterApiUtils::mapOperationResponse)
           .exceptionally(ClusterApiUtils::mapError);
     } catch (final Exception error) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -480,12 +480,18 @@ public class ClusterEndpoint {
     };
   }
 
+  /**
+   * Purges the cluster. Without a {@code physicalTenant} query parameter, every physical tenant is
+   * purged, keeping the whole-cluster meaning of a purge. With the parameter, only the given
+   * physical tenant's partitions and exported history are purged.
+   */
   @PostMapping(path = "/purge", produces = "application/json")
   public CompletableFuture<ResponseEntity<?>> purge(
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
     try {
       return requestSender
-          .purge(new PurgeRequest(Optional.empty(), dryRun))
+          .purge(new PurgeRequest(nonBlank(physicalTenant), dryRun))
           .thenApply(ClusterApiUtils::mapOperationResponse)
           .exceptionally(ClusterApiUtils::mapError);
     } catch (final Exception error) {
@@ -653,6 +659,11 @@ public class ClusterEndpoint {
       return invalidRequest(String.join("; ", errors));
     }
     return action.apply(parsed);
+  }
+
+  /** Treats an absent and a blank query parameter alike, as "not given". */
+  private static Optional<String> nonBlank(final @Nullable String value) {
+    return Optional.ofNullable(value).filter(v -> !v.isBlank());
   }
 
   public record PartitionAddRequest(int priority) {}

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -401,7 +401,7 @@ components:
       style: form
       required: false
       schema:
-        type: string
+        $ref: 'components.yaml#/schemas/PhysicalTenantId'
     ForceParameter:
       name: force
       description: If true, the operation is a force operation. This is typically used to force remove a set of brokers when they are not available.
@@ -420,14 +420,6 @@ components:
       schema:
         type: integer
         format: int32
-    PhysicalTenantParameter:
-      name: physicalTenant
-      description: Scopes the response to one physical tenant.
-      in: query
-      style: form
-      required: false
-      schema:
-        $ref: 'components.yaml#/schemas/PhysicalTenantId'
   responses:
     AddBrokersResponse:
       description: Request to add a new broker is accepted.

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -97,8 +97,11 @@ paths:
         During this operation all brokers will leave their partitions, data will be deleted,
         and then the brokers will rejoin their partition with empty state, restoring the
         original topology.
+        Without the physicalTenant parameter every physical tenant is purged; with it, only
+        the given physical tenant is purged and the others are left untouched.
       parameters:
         - $ref: '#/components/parameters/DryRunParameter'
+        - $ref: '#/components/parameters/PhysicalTenantParameter'
       responses:
         '202':
           $ref: "#/components/responses/ClusterConfigPurgeResponse"
@@ -391,6 +394,14 @@ components:
       schema:
         type: boolean
         default: false
+    PhysicalTenantParameter:
+      name: physicalTenant
+      description: Id of the physical tenant to target. If not specified, the operation applies to all physical tenants.
+      in: query
+      style: form
+      required: false
+      schema:
+        type: string
     ForceParameter:
       name: force
       description: If true, the operation is a force operation. This is typically used to force remove a set of brokers when they are not available.

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.shared.management;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -17,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
@@ -37,6 +39,7 @@ import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -168,6 +171,63 @@ final class ClusterEndpointTest {
       final var body = (GetTopologyResponse) response.getBody();
       assertThat(body).isNotNull();
       assertThat(body.getVersion()).isEqualTo(-1);
+    }
+  }
+
+  @Nested
+  class PurgeEndpoint {
+
+    @Test
+    void shouldPurgeEveryPhysicalTenantWhenParameterIsAbsent() {
+      // given
+      final var sender = senderAcceptingPurge();
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      endpoint.purge(false, null).join();
+
+      // then
+      verify(sender).purge(new PurgeRequest(Optional.empty(), false));
+    }
+
+    @Test
+    void shouldPurgeOnlyTheGivenPhysicalTenant() {
+      // given
+      final var sender = senderAcceptingPurge();
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      endpoint.purge(true, "tenant-a").join();
+
+      // then
+      verify(sender).purge(new PurgeRequest(Optional.of("tenant-a"), true));
+    }
+
+    @Test
+    void shouldTreatABlankPhysicalTenantAsAbsent() {
+      // given
+      final var sender = senderAcceptingPurge();
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      endpoint.purge(false, "  ").join();
+
+      // then
+      verify(sender).purge(new PurgeRequest(Optional.empty(), false));
+    }
+
+    private ClusterConfigurationManagementRequestSender senderAcceptingPurge() {
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      when(sender.purge(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  Either.right(
+                      new ClusterConfigurationChangeResponse(
+                          1L,
+                          new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                              Map.of(), Map.of(), List.of()),
+                          null))));
+      return sender;
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -47,7 +47,12 @@ public sealed interface ClusterConfigurationManagementRequest {
   record ReassignPartitionsRequest(Set<MemberId> members, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record PurgeRequest(boolean dryRun) implements ClusterConfigurationManagementRequest {}
+  /**
+   * Purge the partitions and the exported history of the given physical tenant. If no
+   * physicalTenantId is provided, it applies to all tenants.
+   */
+  record PurgeRequest(Optional<String> physicalTenantId, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
 
   record BrokerScaleRequest(
       Set<MemberId> members, Optional<Integer> newReplicationFactor, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -194,7 +194,8 @@ public final class ClusterConfigurationManagementRequestsHandler
 
   @Override
   public ActorFuture<ClusterConfigurationChangeResponse> purge(final PurgeRequest purgeRequest) {
-    return handleRequest(purgeRequest.dryRun(), new PurgeRequestTransformer());
+    return handleRequest(
+        purgeRequest.dryRun(), new PurgeRequestTransformer(purgeRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -8,45 +8,114 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
 
+/**
+ * Purges a cluster: every broker leaves its partitions, the exported history is deleted, and the
+ * partitions are bootstrapped again with empty state, restoring the original topology.
+ *
+ * <p>Purging is per physical tenant: each tenant has its own partitions and its own exporters, so
+ * purging one tenant must not touch another's data. When a physical tenant is given, only that
+ * tenant's partition group is purged; without one, every tenant is purged, each within its own
+ * group and in parallel with the others.
+ */
 public final class PurgeRequestTransformer implements ConfigurationChangeRequest {
+
+  private final Optional<String> physicalTenantId;
+
+  public PurgeRequestTransformer() {
+    this(Optional.empty());
+  }
+
+  public PurgeRequestTransformer(final Optional<String> physicalTenantId) {
+    this.physicalTenantId = physicalTenantId;
+  }
 
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
+    throw new UnsupportedOperationException(
+        "PurgeRequestTransformer builds its change plan via phases(CurrentClusterConfiguration); "
+            + "the new-model coordinator path never calls operations(ClusterConfiguration)");
+  }
 
-    final var firstMember = clusterConfiguration.members().keySet().stream().findFirst();
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to purge physical tenant '%s', but the physical tenant does not exist"
+                  .formatted(physicalTenantId.get())));
+    }
+
+    final List<String> groupIds =
+        physicalTenantId
+            .<List<String>>map(List::of)
+            .orElseGet(() -> List.copyOf(clusterConfiguration.partitionGroups().keySet()));
+
+    final Map<String, List<PartitionGroupOperation>> groupOperations = new LinkedHashMap<>();
+    for (final var groupId : groupIds) {
+      final var operations =
+          purgeOperationsFor(Objects.requireNonNull(clusterConfiguration.partitionGroup(groupId)));
+      if (!operations.isEmpty()) {
+        groupOperations.put(groupId, operations);
+      }
+    }
+
+    if (groupOperations.isEmpty()) {
+      return Either.right(List.of());
+    }
+    return Either.right(List.of(new PartitionGroupParallelPhase(groupOperations)));
+  }
+
+  /**
+   * Builds the purge plan of a single partition group: all members leave their partitions, the
+   * history exported by this group is deleted, the group's incarnation number is bumped, and the
+   * partitions are bootstrapped and joined again with their original priorities and configuration.
+   */
+  private List<PartitionGroupOperation> purgeOperationsFor(
+      final PartitionGroupConfiguration group) {
+    final var firstMember = group.members().keySet().stream().findFirst();
     if (firstMember.isEmpty()) {
-      return Either.right(new ArrayList<>());
+      return List.of();
     }
 
     final SortedMap<Integer, PartitionBootstrapOperation> primaries =
-        createBootstrapOperations(clusterConfiguration.members());
+        createBootstrapOperations(group.members());
 
     final Map<Integer, List<PartitionJoinOperation>> followers =
         new TreeMap<>(Comparator.naturalOrder());
 
-    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
-    for (final var member : clusterConfiguration.members().entrySet()) {
+    final List<PartitionGroupOperation> operations = new ArrayList<>();
+    for (final var member : group.members().entrySet()) {
       final var memberId = member.getKey();
       for (final var partitions : member.getValue().partitions().entrySet()) {
         final var partitionId = partitions.getKey();
@@ -67,22 +136,15 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
     operations.add(new DeleteHistoryOperation(firstMember.get()));
     operations.add(new UpdateIncarnationNumberOperation(firstMember.get()));
 
-    primaries.forEach(
-        (partitionId, bootstrapOperation) -> {
-          operations.add(bootstrapOperation);
-        });
+    operations.addAll(primaries.values());
+    followers.values().forEach(operations::addAll);
 
-    followers.forEach(
-        (partitionId, joinOperations) -> {
-          operations.addAll(joinOperations);
-        });
-
-    return Either.right(operations);
+    return operations;
   }
 
   /** This method creates the BootstrapOperations for all leaders for each partition. */
   private SortedMap<Integer, PartitionBootstrapOperation> createBootstrapOperations(
-      final Map<MemberId, MemberState> members) {
+      final Map<MemberId, BrokerPartitionState> members) {
 
     final SortedMap<Integer, PartitionBootstrapOperation> primaries =
         new TreeMap<>(Comparator.naturalOrder());

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1055,7 +1055,9 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodePurgeRequest(final PurgeRequest req) {
-    return Requests.PurgeRequest.newBuilder().setDryRun(req.dryRun()).build().toByteArray();
+    final var builder = Requests.PurgeRequest.newBuilder().setDryRun(req.dryRun());
+    req.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+    return builder.build().toByteArray();
   }
 
   @Override
@@ -1437,7 +1439,11 @@ public class ProtoBufSerializer
   public PurgeRequest decodePurgeRequest(final byte[] encodedRequest) {
     try {
       final var purgeRequest = Requests.PurgeRequest.parseFrom(encodedRequest);
-      return new PurgeRequest(purgeRequest.getDryRun());
+      final Optional<String> physicalTenantId =
+          purgeRequest.hasPhysicalTenantId()
+              ? Optional.of(purgeRequest.getPhysicalTenantId())
+              : Optional.empty();
+      return new PurgeRequest(physicalTenantId, purgeRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -24,6 +24,9 @@ message JoinPartitionRequest {
 
 message PurgeRequest {
   bool dryRun = 1;
+  // When physicalTenantId is set, only that tenant is purged.
+  // If not set, all tenants are purged.
+  optional string physicalTenantId = 2;
 }
 
 message LeavePartitionRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -484,7 +484,7 @@ final class NewModelManagementApiEndpointsTest {
             .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
 
     // when
-    final var response = handler.purge(new PurgeRequest(false)).join();
+    final var response = handler.purge(new PurgeRequest(Optional.empty(), false)).join();
 
     // then — purge produces a plan and preserves the partition assignment of every member
     assertThat(response.legacyResponse().plannedChanges()).isNotEmpty();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
@@ -907,7 +907,7 @@ abstract class ClusterConfigurationManagementApiTestBase {
             .updateMember(
                 memberFactory.apply(2),
                 m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
-    final var request = new PurgeRequest(false);
+    final var request = new PurgeRequest(Optional.empty(), false);
 
     // when
     final var changeStatus = clientApi.purge(request).join().get();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -7,195 +7,249 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
-import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 final class ClusterPurgeRequestTransformerTest {
+
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
 
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @Test
-  void shouldPurgeCluster() {
+  void shouldPurgePhysicalTenant() {
     // given
     final var transformer = new PurgeRequestTransformer();
-
-    final ClusterConfiguration currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(0, PartitionState.active(2, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(0, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)));
-
-    // when
-    final var result = transformer.operations(currentTopology);
-
-    // then
-    assertThat(result)
-        .isRight()
-        .right()
-        .satisfies(
-            operations -> {
-              assertThat(operations)
-                  .containsExactly(
-                      new PartitionLeaveOperation(id0, 0, 0),
-                      new PartitionLeaveOperation(id0, 1, 0),
-                      new PartitionLeaveOperation(id1, 0, 0),
-                      new PartitionLeaveOperation(id1, 1, 0),
-                      new DeleteHistoryOperation(id0),
-                      new UpdateIncarnationNumberOperation(id0),
-                      new PartitionBootstrapOperation(
-                          id0, 0, 2, Optional.of(partitionConfig), false),
-                      new PartitionBootstrapOperation(
-                          id1, 1, 2, Optional.of(partitionConfig), false),
-                      new PartitionJoinOperation(id1, 0, 1),
-                      new PartitionJoinOperation(id0, 1, 1));
-            });
-  }
-
-  @Test
-  void purgeClusterShouldBootstrapPartitionsInOrder() {
-    // given
-    final var transformer = new PurgeRequestTransformer();
-
-    final ClusterConfiguration currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(0, PartitionState.active(2, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(0, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-
-    // when
-    final var result = transformer.operations(currentTopology);
-
-    // then
-    assertThat(result)
-        .isRight()
-        .right()
-        .satisfies(
-            operations -> {
-              assertThat(operations)
-                  .containsExactly(
-                      new PartitionLeaveOperation(id0, 0, 0),
-                      new PartitionLeaveOperation(id0, 1, 0),
-                      new PartitionLeaveOperation(id0, 2, 0),
-                      new PartitionLeaveOperation(id1, 0, 0),
-                      new PartitionLeaveOperation(id1, 1, 0),
-                      new PartitionLeaveOperation(id1, 2, 0),
-                      new DeleteHistoryOperation(id0),
-                      new UpdateIncarnationNumberOperation(id0),
-                      new PartitionBootstrapOperation(
-                          id0, 0, 2, Optional.of(partitionConfig), false),
-                      new PartitionBootstrapOperation(
-                          id1, 1, 2, Optional.of(partitionConfig), false),
-                      new PartitionBootstrapOperation(
-                          id0, 2, 2, Optional.of(partitionConfig), false),
-                      new PartitionJoinOperation(id1, 0, 1),
-                      new PartitionJoinOperation(id0, 1, 1),
-                      new PartitionJoinOperation(id1, 2, 1));
-            });
-  }
-
-  @Test
-  void shouldCreateBootstrapOperationWithExporterConfig() {
-    // given
-    final var transformer = new PurgeRequestTransformer();
-    final ExportingConfig exportingConfig =
-        new ExportingConfig(
-            ExportingState.EXPORTING,
+    final var clusterConfiguration =
+        withPartitionGroups(
             Map.of(
-                "exporter",
-                new ExporterState(1, ExporterState.State.ENABLED, Optional.of("config"))));
-    final var partitionConfigWithExporter =
-        DynamicPartitionConfig.init().updateExporting(exportingConfig);
-
-    final ClusterConfiguration currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .updateMember(
-                id0, m -> m.addPartition(0, PartitionState.active(2, partitionConfigWithExporter)));
+                TENANT_A,
+                group()
+                    .addMember(id0, member(Map.of(0, active(2), 1, active(1))))
+                    .addMember(id1, member(Map.of(0, active(1), 1, active(2))))));
 
     // when
-    final var result = transformer.operations(currentTopology);
+    final var result = transformer.phases(clusterConfiguration);
 
     // then
-    assertThat(result)
-        .isRight()
-        .right()
-        .satisfies(
-            operations -> {
-              assertThat(operations)
-                  .contains(
-                      new PartitionBootstrapOperation(
-                          id0, 0, 2, Optional.of(partitionConfigWithExporter), false));
-            });
+    assertThat(operationsOf(result, TENANT_A))
+        .containsExactly(
+            new PartitionLeaveOperation(id0, 0, 0),
+            new PartitionLeaveOperation(id0, 1, 0),
+            new PartitionLeaveOperation(id1, 0, 0),
+            new PartitionLeaveOperation(id1, 1, 0),
+            new DeleteHistoryOperation(id0),
+            new UpdateIncarnationNumberOperation(id0),
+            new PartitionBootstrapOperation(id0, 0, 2, Optional.of(partitionConfig), false),
+            new PartitionBootstrapOperation(id1, 1, 2, Optional.of(partitionConfig), false),
+            new PartitionJoinOperation(id1, 0, 1),
+            new PartitionJoinOperation(id0, 1, 1));
   }
 
   @Test
-  void shouldRecreatePartitionsWithDifferentConfig() {
+  void purgeShouldBootstrapPartitionsInOrder() {
     // given
     final var transformer = new PurgeRequestTransformer();
-    final DynamicPartitionConfig config0 =
-        DynamicPartitionConfig.init()
-            .updateExporting(
-                new ExportingConfig(
-                    ExportingState.EXPORTING,
-                    Map.of(
-                        "exporter",
-                        new ExporterState(1, ExporterState.State.ENABLED, Optional.of("config")))));
-    final DynamicPartitionConfig config1 =
-        DynamicPartitionConfig.init()
-            .updateExporting(
-                new ExportingConfig(
-                    ExportingState.EXPORTING,
-                    Map.of(
-                        "exporter", new ExporterState(1, State.DISABLED, Optional.of("config")))));
-
-    final ClusterConfiguration currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(0, PartitionState.active(2, config0)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, config1)));
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A,
+                group()
+                    .addMember(id0, member(Map.of(0, active(2), 1, active(1), 2, active(2))))
+                    .addMember(id1, member(Map.of(0, active(1), 1, active(2), 2, active(1))))));
 
     // when
-    final var result = transformer.operations(currentTopology);
+    final var result = transformer.phases(clusterConfiguration);
 
     // then
-    assertThat(result)
-        .isRight()
-        .right()
-        .satisfies(
-            operations -> {
-              assertThat(operations)
-                  .contains(new PartitionBootstrapOperation(id0, 0, 2, Optional.of(config0), false))
-                  .contains(
-                      new PartitionBootstrapOperation(id1, 1, 2, Optional.of(config1), false));
-            });
+    assertThat(operationsOf(result, TENANT_A))
+        .containsExactly(
+            new PartitionLeaveOperation(id0, 0, 0),
+            new PartitionLeaveOperation(id0, 1, 0),
+            new PartitionLeaveOperation(id0, 2, 0),
+            new PartitionLeaveOperation(id1, 0, 0),
+            new PartitionLeaveOperation(id1, 1, 0),
+            new PartitionLeaveOperation(id1, 2, 0),
+            new DeleteHistoryOperation(id0),
+            new UpdateIncarnationNumberOperation(id0),
+            new PartitionBootstrapOperation(id0, 0, 2, Optional.of(partitionConfig), false),
+            new PartitionBootstrapOperation(id1, 1, 2, Optional.of(partitionConfig), false),
+            new PartitionBootstrapOperation(id0, 2, 2, Optional.of(partitionConfig), false),
+            new PartitionJoinOperation(id1, 0, 1),
+            new PartitionJoinOperation(id0, 1, 1),
+            new PartitionJoinOperation(id1, 2, 1));
+  }
+
+  @Test
+  void shouldPurgeEveryPhysicalTenantWhenNoneIsGiven() {
+    // given
+    final var transformer = new PurgeRequestTransformer();
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, group().addMember(id0, member(Map.of(0, active(1)))),
+                TENANT_B, group().addMember(id1, member(Map.of(0, active(1))))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — both tenants are purged, each within its own group
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A, TENANT_B);
+    assertThat(phase.groupOperations().get(TENANT_A))
+        .containsExactly(
+            new PartitionLeaveOperation(id0, 0, 0),
+            new DeleteHistoryOperation(id0),
+            new UpdateIncarnationNumberOperation(id0),
+            new PartitionBootstrapOperation(id0, 0, 1, Optional.of(partitionConfig), false));
+    assertThat(phase.groupOperations().get(TENANT_B))
+        .containsExactly(
+            new PartitionLeaveOperation(id1, 0, 0),
+            new DeleteHistoryOperation(id1),
+            new UpdateIncarnationNumberOperation(id1),
+            new PartitionBootstrapOperation(id1, 0, 1, Optional.of(partitionConfig), false));
+  }
+
+  @Test
+  void shouldPurgeOnlyTheGivenPhysicalTenant() {
+    // given
+    final var transformer = new PurgeRequestTransformer(Optional.of(TENANT_A));
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, group().addMember(id0, member(Map.of(0, active(1)))),
+                TENANT_B, group().addMember(id1, member(Map.of(0, active(1))))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — tenant B keeps its partitions and its history
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenantId() {
+    // given
+    final var transformer = new PurgeRequestTransformer(Optional.of("unknown-tenant"));
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, group().addMember(id0, member(Map.of(0, active(1))))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown-tenant");
+  }
+
+  @Test
+  void shouldNotPlanAnythingWhenThePhysicalTenantHasNoMembers() {
+    // given
+    final var transformer = new PurgeRequestTransformer(Optional.of(TENANT_A));
+    final var clusterConfiguration = withPartitionGroups(Map.of(TENANT_A, group()));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get()).isEmpty();
+  }
+
+  @Test
+  void shouldBootstrapPartitionsWithTheirExporterConfig() {
+    // given — the two partitions of the tenant have a different exporter configuration
+    final var transformer = new PurgeRequestTransformer();
+    final var enabledExporter =
+        configWithExporter(new ExporterState(1, State.ENABLED, Optional.of("config")));
+    final var disabledExporter =
+        configWithExporter(new ExporterState(1, State.DISABLED, Optional.of("config")));
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A,
+                group()
+                    .addMember(id0, member(Map.of(0, PartitionState.active(2, enabledExporter))))
+                    .addMember(
+                        id1, member(Map.of(1, PartitionState.active(2, disabledExporter))))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — each partition is recreated with the configuration it had
+    assertThat(operationsOf(result, TENANT_A))
+        .contains(
+            new PartitionBootstrapOperation(id0, 0, 2, Optional.of(enabledExporter), false),
+            new PartitionBootstrapOperation(id1, 1, 2, Optional.of(disabledExporter), false));
+  }
+
+  private List<PartitionGroupOperation> operationsOf(
+      final Either<Exception, List<Phase>> result, final String groupId) {
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    return phase.groupOperations().get(groupId);
+  }
+
+  private DynamicPartitionConfig configWithExporter(final ExporterState exporterState) {
+    return DynamicPartitionConfig.init()
+        .updateExporting(
+            new ExportingConfig(ExportingState.EXPORTING, Map.of("exporter", exporterState)));
+  }
+
+  private PartitionState active(final int priority) {
+    return PartitionState.active(priority, partitionConfig);
+  }
+
+  private BrokerPartitionState member(final Map<Integer, PartitionState> partitions) {
+    return BrokerPartitionState.initialize(partitions);
+  }
+
+  private PartitionGroupConfiguration group() {
+    return PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION);
+  }
+
+  private CurrentClusterConfiguration withPartitionGroups(
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        partitionGroups,
+        PhasedChangeState.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -39,8 +39,8 @@ import org.junit.jupiter.api.Test;
 
 final class ClusterPurgeRequestTransformerTest {
 
-  private static final String TENANT_A = "tenant-a";
-  private static final String TENANT_B = "tenant-b";
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
 
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
@@ -164,7 +164,7 @@ final class ClusterPurgeRequestTransformerTest {
   @Test
   void shouldRejectAnUnknownPhysicalTenantId() {
     // given
-    final var transformer = new PurgeRequestTransformer(Optional.of("unknown-tenant"));
+    final var transformer = new PurgeRequestTransformer(Optional.of("unknowntenant"));
     final var clusterConfiguration =
         withPartitionGroups(Map.of(TENANT_A, group().addMember(id0, member(Map.of(0, active(1))))));
 
@@ -173,9 +173,7 @@ final class ClusterPurgeRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isLeft();
-    assertThat(result.getLeft())
-        .isInstanceOf(NotFound.class)
-        .hasMessageContaining("unknown-tenant");
+    assertThat(result.getLeft()).isInstanceOf(NotFound.class).hasMessageContaining("unknowntenant");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -364,7 +364,20 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodePurgeRequest() {
     // given
-    final var purgeRequest = new PurgeRequest(true);
+    final var purgeRequest = new PurgeRequest(Optional.empty(), true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodePurgeRequest(purgeRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodePurgeRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(purgeRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodePurgeRequestWithPhysicalTenantId() {
+    // given
+    final var purgeRequest = new PurgeRequest(Optional.of("tenant-a"), true);
 
     // when
     final var encodedRequest = protoBufSerializer.encodePurgeRequest(purgeRequest);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -377,7 +377,7 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodePurgeRequestWithPhysicalTenantId() {
     // given
-    final var purgeRequest = new PurgeRequest(Optional.of("tenant-a"), true);
+    final var purgeRequest = new PurgeRequest(Optional.of("tenanta"), true);
 
     // when
     final var encodedRequest = protoBufSerializer.encodePurgeRequest(purgeRequest);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPurgeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPurgeIT.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.grpc.Status.Code;
 import java.time.Duration;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,15 +72,10 @@ final class PhysicalTenantPurgeIT {
     // when - purging tenant A only
     ClusterActuator.of(broker).purge(false, TENANT_A);
 
-    // then - tenant A loses its process. NOT_FOUND, rather than any failure, is asserted so that
-    // a partition that is merely unavailable mid-purge does not end the wait early.
+    // then - tenant A loses its process
     await("tenant A no longer knows its process")
         .atMost(Duration.ofMinutes(2))
-        .untilAsserted(
-            () ->
-                assertThatThrownBy(() -> createInstance(tenantAClient))
-                    .isInstanceOf(ClientStatusException.class)
-                    .hasMessageContaining("NOT_FOUND"));
+        .untilAsserted(() -> assertProcessNotFound(tenantAClient));
 
     // and - tenant A serves commands again on empty state
     deploy(tenantAClient);
@@ -105,13 +101,21 @@ final class PhysicalTenantPurgeIT {
         .atMost(Duration.ofMinutes(2))
         .untilAsserted(
             () -> {
-              assertThatThrownBy(() -> createInstance(tenantAClient))
-                  .isInstanceOf(ClientStatusException.class)
-                  .hasMessageContaining("NOT_FOUND");
-              assertThatThrownBy(() -> createInstance(defaultClient))
-                  .isInstanceOf(ClientStatusException.class)
-                  .hasMessageContaining("NOT_FOUND");
+              assertProcessNotFound(tenantAClient);
+              assertProcessNotFound(defaultClient);
             });
+  }
+
+  /**
+   * Asserts that the tenant this client targets no longer has the process. NOT_FOUND, rather than
+   * any failure, is asserted so that a partition that is merely unavailable mid-purge does not end
+   * the wait early.
+   */
+  private void assertProcessNotFound(final CamundaClient client) {
+    assertThatThrownBy(() -> createInstance(client))
+        .isInstanceOf(ClientStatusException.class)
+        .satisfies(
+            t -> assertThat(((ClientStatusException) t).getStatusCode()).isEqualTo(Code.NOT_FOUND));
   }
 
   /**

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPurgeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPurgeIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the {@code cluster/purge} actuator's {@code physicalTenant} query parameter tears
+ * down and re-bootstraps only the named tenant's partitions: after purging one tenant, its
+ * processes are gone and it serves commands again on empty state, while another tenant keeps
+ * everything it had.
+ */
+@ZeebeIntegration
+final class PhysicalTenantPurgeIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String PROCESS_ID = "purge-process";
+
+  // both tenants run broker-only (no secondary storage); declaring tenant A starts a second,
+  // fully isolated partition group for it
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  @AutoClose private CamundaClient defaultClient;
+  @AutoClose private CamundaClient tenantAClient;
+
+  @BeforeEach
+  void beforeEach() {
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+  }
+
+  @Test
+  void shouldPurgeOnlyTheTargetedPhysicalTenant() {
+    // given - the same process deployed to, and runnable in, both physical tenants
+    deploy(defaultClient);
+    deploy(tenantAClient);
+    assertThat(createInstance(defaultClient)).isPositive();
+    assertThat(createInstance(tenantAClient)).isPositive();
+
+    // when - purging tenant A only
+    ClusterActuator.of(broker).purge(false, TENANT_A);
+
+    // then - tenant A loses its process. NOT_FOUND, rather than any failure, is asserted so that
+    // a partition that is merely unavailable mid-purge does not end the wait early.
+    await("tenant A no longer knows its process")
+        .atMost(Duration.ofMinutes(2))
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(() -> createInstance(tenantAClient))
+                    .isInstanceOf(ClientStatusException.class)
+                    .hasMessageContaining("NOT_FOUND"));
+
+    // and - tenant A serves commands again on empty state
+    deploy(tenantAClient);
+    assertThat(createInstance(tenantAClient)).isPositive();
+
+    // and - the default tenant kept its own process throughout
+    assertThat(createInstance(defaultClient)).isPositive();
+  }
+
+  @Test
+  void shouldPurgeEveryPhysicalTenantWhenNoneIsGiven() {
+    // given - the same process deployed to, and runnable in, both physical tenants
+    deploy(defaultClient);
+    deploy(tenantAClient);
+    assertThat(createInstance(defaultClient)).isPositive();
+    assertThat(createInstance(tenantAClient)).isPositive();
+
+    // when - purging without naming a physical tenant
+    ClusterActuator.of(broker).purge(false);
+
+    // then - every tenant loses its process, keeping the whole-cluster meaning of a purge
+    await("no physical tenant knows its process anymore")
+        .atMost(Duration.ofMinutes(2))
+        .untilAsserted(
+            () -> {
+              assertThatThrownBy(() -> createInstance(tenantAClient))
+                  .isInstanceOf(ClientStatusException.class)
+                  .hasMessageContaining("NOT_FOUND");
+              assertThatThrownBy(() -> createInstance(defaultClient))
+                  .isInstanceOf(ClientStatusException.class)
+                  .hasMessageContaining("NOT_FOUND");
+            });
+  }
+
+  /**
+   * Deploys the process to the given tenant, retrying until it lands: a tenant's partition group
+   * may need a moment to elect a leader, both after startup and after a purge.
+   */
+  private void deploy(final CamundaClient client) {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done();
+
+    await("deployment succeeds")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, PROCESS_ID + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+  }
+
+  private long createInstance(final CamundaClient client) {
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId(PROCESS_ID)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -359,6 +359,11 @@ public interface ClusterActuator {
   @Headers({"Content-Type: application/json"})
   PlannedOperationsResponse purge(@Param boolean dryRun);
 
+  /** Purges only the given physical tenant, leaving the other physical tenants untouched. */
+  @RequestLine("POST /purge?dryRun={dryRun}&physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json"})
+  PlannedOperationsResponse purge(@Param boolean dryRun, @Param String physicalTenant);
+
   @RequestLine("PATCH /routing-state?dryRun={dryRun}&force={force}")
   @Headers({"Content-Type: application/json", "accept: application/json"})
   void patchRoutingState(@RequestBody final RoutingState routingState, @Param boolean dryRun);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Description

Purging tears down and re-bootstraps partitions and deletes the exported history.
Both are per physical tenant: each tenant owns its partitions and its own exporter repository. The purge transformer, however, planned a single flat operation list over the legacy default-group view of the configuration, so with more than one physical tenant a purge left every non-default tenant untouched — and there was no way to ask for one.

`PurgeRequestTransformer` now plans on the multi-partition-group model, emitting one `PartitionGroupParallelPhase` with operations grouped per partition group: the tenant named in the request, or every tenant when none is given (each purged within its own group, in parallel). `PurgeRequest` carries an optional `physicalTenantId`, and `POST /actuator/cluster/purge` accepts a matching `physicalTenant` query parameter.
Omitting it keeps the actuator's established whole-cluster meaning, as decided in ADR management/003 D3.

The per-tenant history deletion this depends on already landed in #59893 — the appliers are registered per partition group, so each group's deletion runs through its own exporter repository.

`operations(ClusterConfiguration)` on the transformer now throws `UnsupportedOperationException`, following `ExporterDisableRequestTransformer`: it cannot express a non-default group, and the new-model coordinator never calls it.

## Related issues

closes #57017 
