### PR TITLE
ci: fail a hung integration-test fork instead of the whole job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1378,6 +1378,23 @@ jobs:
       CAMUNDA_CONTAINER_VERSION: current-test
       DOCKER_IMAGE_TAG: current-test
       TEST_TYPE: Integration
+      # Bounds a hung test fork so it fails the build instead of running until the `timeout-minutes`
+      # above, which cancels the job and discards its test reports, leaving nothing to attribute the
+      # failure to -- INC-7108 sat idle for 23 of its 30 minutes and reported "no unsuccessful test
+      # cases". Failsafe instead kills the fork here and fails the build, dumping every one of the
+      # fork's threads to target/failsafe-reports/*.dump on the way out, which "Upload test artifacts"
+      # below already collects.
+      #
+      # Note this clock starts when the fork starts, not when the job does, so the usable margin is
+      # what is left of `timeout-minutes` after the checkout, distball download and image build that
+      # come first -- about 2.5 min in INC-7108. 20 min therefore fires roughly 7 min before the job
+      # deadline, against the ~30 s the reporting and upload steps below actually need. It still
+      # clears a healthy fork comfortably: the slowest of this job's shards spends under 13 min in
+      # `verify` end-to-end, of which a single fork is a fraction. Keep the two in step if either
+      # changes; a job's `timeout-minutes` cannot read the env context, and routing it through the
+      # generated matrix instead would leave the conftest rule that caps job timeouts at 30 min
+      # comparing a string against a number, flagging every run of this job as over the cap.
+      IT_FORK_TIMEOUT_SECONDS: "1200"
     services:
       registry:
         image: registry:3
@@ -1477,6 +1494,7 @@ jobs:
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=${{ env.IS_STRESS_ENABLED == 'true' && '0' || env.FLAKY_TEST_RERUN_COUNT }} -D flaky.test.reportDir=failsafe-reports
+          -D failsafe.timeout=${{ env.IT_FORK_TIMEOUT_SECONDS }}
           -Dio.camunda.process.test.camundaDockerImageName="${{ env.CAMUNDA_DOCKER_IMAGE_NAME }}"
           -Dio.camunda.process.test.camundaDockerImageVersion="${{ env.DOCKER_IMAGE_TAG }}"
           -Dio.camunda.process.test.camundaVersion="${{ env.DOCKER_IMAGE_TAG }}"


### PR DESCRIPTION
Bounds the lifetime of a forked integration-test JVM so that a single hanging test fails the build instead of running until the job timeout.

In INC-7108 `TopologyFaultToleranceTest` wedged during cluster setup, the other 106 test classes in the shard finished four minutes later, and the job then sat idle until GitHub cancelled it at the 30 minute mark. A cancelled job discards its test reports, so the alert that fired reported "Unsuccessful test cases: None captured" and gave no indication which test was involved.

With `failsafe.timeout` set, Failsafe kills the fork and fails the build with "There was a timeout in the fork", and the fork writes a dump of all its threads to `target/failsafe-reports/<timestamp>-jvmRunN.dump` before exiting. That directory is already among the paths [collected by `collect-test-artifacts`](https://github.com/camunda/camunda/blob/f30752c5b58532cb233207c45e0f518c9af40852/.github/actions/collect-test-artifacts/action.yml#L12-L18), so the stack trace of the stuck thread ships in the test-results artifact with no extra plumbing. I verified this against the Failsafe version this repo uses (3.5.6) in a throwaway project: the fork was killed on schedule, the build failed with that message, and the dump contained the sleeping test thread's stack.

The timeout is measured from when the fork starts, not from when the job does, so the margin against the job deadline is smaller than the difference between the two numbers. In INC-7108 the job started at 19:07:49, Maven at 19:10:18 and the forks at 19:10:30, so pre-fork overhead was 2 min 41 s; the steps after Maven (analyze, upload, observe) took 29 s. 20 minutes therefore fires around 19:30:30, about 7 minutes clear of the 19:37:49 deadline. It still leaves a healthy fork plenty of room: across the thirteen matrix groups in this job the slowest ("Zeebe Exporter Modules") spends under 13 minutes in `verify` end-to-end, of which a single fork is a fraction.

The trade-off worth a reviewer's attention is the interaction with `failsafe.rerunFailingTestsCount`: a fork killed part-way through a rerun now fails the build rather than getting its remaining attempts, so a genuinely slow shard on a noisy runner could go red where it previously recovered. The headroom is sized to make that unlikely, but unlike the rest of this I have reasoned that through rather than observed it.

The value sits in the job's `env`, next to the `timeout-minutes` it has to stay below, and the two have to be kept in step by hand. Deriving one from the other was tried and rejected: a job's `timeout-minutes` may only reference the github, needs, strategy, matrix, vars and inputs contexts, so the only route is through the generated matrix, and that leaves the conftest rule capping job timeouts at 30 minutes comparing a string against a number, which Rego resolves as greater-than and which would therefore report every run of this job as exceeding the cap. Reading the literal back out of the workflow file in `setup-tests` is not available either, since that job does not check out the repository.

This bounds the damage; it does not fix the hang. The stall in `RaftPartitionServer`'s journal pre-allocation that caused INC-7108 still needs a separate fix, and this change is what will produce the stack trace needed to pin it down the next time it happens.

relates to #39860