### PR TITLE
ci: retry on TLS certificate verification errors in E2E workflow monitoring

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -844,7 +844,7 @@ jobs:
                 return 0
               fi
 
-              if echo "$out" | grep -Eq 'HTTP 502|HTTP 503|HTTP 504|TLS handshake timeout|timeout|temporarily unavailable|connection reset by peer|EOF'; then
+              if echo "$out" | grep -Eq 'HTTP 502|HTTP 503|HTTP 504|TLS handshake timeout|timeout|temporarily unavailable|connection reset by peer|EOF|tls:|certificate'; then
                 if (( attempt >= max_attempts )); then
                   echo "gh api failed after ${attempt}/${max_attempts} attempts for $endpoint" >&2
                   echo "$out" >&2

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -844,7 +844,7 @@ jobs:
                 return 0
               fi
 
-              if echo "$out" | grep -Eq 'HTTP 502|HTTP 503|HTTP 504|TLS handshake timeout|timeout|temporarily unavailable|connection reset by peer|EOF|tls:|certificate'; then
+              if echo "$out" | grep -Eq 'HTTP 502|HTTP 503|HTTP 504|TLS handshake timeout|timeout|temporarily unavailable|connection reset by peer|EOF|tls: failed to verify certificate|x509: certificate'; then
                 if (( attempt >= max_attempts )); then
                   echo "gh api failed after ${attempt}/${max_attempts} attempts for $endpoint" >&2
                   echo "$out" >&2


### PR DESCRIPTION
## Description

The E2E workflow monitor's `gh API` retry function was not catching TLS certificate verification errors, causing the workflow to fail immediately instead of retrying. When GitHub API calls are routed through a proxy with certificate validation issues, the error `tls: failed to verify certificate: x509: certificate is not valid for any names` would trigger an immediate failure.

### Root Cause
The transient error detection regex in `gh_api_with_retry()` only checked for specific patterns like `HTTP 502`, `TLS handshake timeout`, `timeout`, etc., but did not include TLS certificate validation errors. This caused the function to treat certificate errors as non-retryable and fail immediately.

### Solution
Added `tls:` and `certificate` patterns to the transient error detection regex so these errors trigger a retry with exponential backoff (up to 6 attempts, with delays of 2s, 4s, 8s, 16s, 32s, 64s) before treating them as fatal.

### Testing
This is a defensive fix for intermittent infrastructure/proxy issues. The change allows the workflow to automatically recover from transient TLS certificate validation failures without intervention, reducing false negatives in CI.

## Checklist

- [ ] Enable backports when necessary
- [ ] Related tests have been run (N/A - CI workflow change only)

## Related issues

Fixes intermittent failures in `docker-build-helm-integration.yml` E2E test monitoring due to TLS certificate verification errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Csu7VmeUpWoKSsKTJtaYnW)_