### PR TITLE
fix: prevent a compensate-all throw event from waiting forever after an aborted compensation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -459,6 +459,20 @@ public class BpmnCompensationSubscriptionBehaviour {
     deleteSubscriptionsTopToBottom(subscriptions, context.getElementInstanceKey());
   }
 
+  /**
+   * Deletes the compensation subscriptions that were triggered by the given compensation throw
+   * event. Called when the throw event is terminated, for example by a terminate end event or an
+   * interrupting event subprocess in its flow scope. The compensation is aborted together with the
+   * throw event; leaving the subscriptions behind would block the completion of their flow scope
+   * and of any later compensation that sweeps that scope.
+   */
+  public void deleteSubscriptionsOfCompensationThrowEvent(final BpmnElementContext context) {
+    compensationSubscriptionState
+        .findSubscriptionsByThrowEventInstanceKey(
+            context.getTenantId(), context.getProcessInstanceKey(), context.getElementInstanceKey())
+        .forEach(this::appendCompensationSubscriptionDeleteEvent);
+  }
+
   private void deleteSubscriptionsTopToBottom(
       final Collection<CompensationSubscription> subscriptions, final long scopeKey) {
     subscriptions.stream()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -465,6 +465,12 @@ public class BpmnCompensationSubscriptionBehaviour {
    * interrupting event subprocess in its flow scope. The compensation is aborted together with the
    * throw event; leaving the subscriptions behind would block the completion of their flow scope
    * and of any later compensation that sweeps that scope.
+   *
+   * <p>Deleting unconditionally is safe only because a compensation throw event cannot be
+   * terminated on its own today: it always goes down together with its flow scope, taking any
+   * activated compensation handlers with it. If a future change allowed a compensation throw event
+   * to be interrupted by itself (e.g. a boundary event on it), a still-running handler's completion
+   * would be silently stranded instead of blocked, since its subscription would already be gone.
    */
   public void deleteSubscriptionsOfCompensationThrowEvent(final BpmnElementContext context) {
     compensationSubscriptionState

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -462,5 +462,11 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
                               stateTransitionBehavior.takeOutgoingSequenceFlows(
                                   element, completed)));
     }
+
+    @Override
+    public void onTerminate(
+        final ExecutableEndEvent element, final BpmnElementContext terminating) {
+      compensationSubscriptionBehaviour.deleteSubscriptionsOfCompensationThrowEvent(terminating);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -442,5 +442,11 @@ public class IntermediateThrowEventProcessor
                               stateTransitionBehavior.takeOutgoingSequenceFlows(
                                   element, completed)));
     }
+
+    @Override
+    public void onTerminate(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext terminating) {
+      compensationSubscriptionBehaviour.deleteSubscriptionsOfCompensationThrowEvent(terminating);
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.BoundaryEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
@@ -3443,6 +3444,253 @@ public class CompensationEventExecutionTest {
             "adhoc-subprocess#innerInstance",
             "adhoc-subprocess",
             PROCESS_ID);
+  }
+
+  @Test
+  public void shouldCompleteCompensateAllAfterCompensationWasTerminatedByTerminateEndEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("subprocess")
+            .embeddedSubProcess()
+            .startEvent()
+            .parallelGateway("inner-fork")
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .intermediateThrowEvent(
+                "inner-compensation-throw-event",
+                i -> i.compensateEventDefinition().compensateEventDefinitionDone())
+            .endEvent("inner-end")
+            .moveToNode("inner-fork")
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .endEvent("terminate-end", EndEventBuilder::terminate)
+            .subProcessDone()
+            .serviceTask(
+                "C",
+                task ->
+                    task.zeebeJobType("C")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-C").zeebeJobType("Undo-C")))
+            .intermediateThrowEvent(
+                "compensation-throw-event",
+                i -> i.compensateEventDefinition().compensateEventDefinitionDone())
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    // A completes and the inner throw event starts compensating it; Undo-A is left pending
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType("Undo-A")
+        .getFirst();
+
+    // the parallel branch reaches the terminate end event and terminates the pending compensation
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("C").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-C").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(6))
+        .extracting(Record::getIntent, r -> r.getValue().getCompensationHandlerId())
+        .contains(tuple(CompensationSubscriptionIntent.DELETED, "Undo-A"));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("Undo-C", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void
+      shouldCompleteCompensateAllAfterCompensationEndEventWasTerminatedByTerminateEndEvent() {
+    // given a subprocess whose compensation is driven by a compensation *end* event (exercising
+    // EndEventProcessor), left pending when a parallel branch hits a terminate end event
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("subprocess")
+            .embeddedSubProcess()
+            .startEvent()
+            .parallelGateway("inner-fork")
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .endEvent(
+                "inner-compensation-end",
+                e -> e.compensateEventDefinition().compensateEventDefinitionDone())
+            .moveToNode("inner-fork")
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .endEvent("terminate-end", EndEventBuilder::terminate)
+            .subProcessDone()
+            .serviceTask(
+                "C",
+                task ->
+                    task.zeebeJobType("C")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-C").zeebeJobType("Undo-C")))
+            .intermediateThrowEvent(
+                "compensation-throw-event",
+                i -> i.compensateEventDefinition().compensateEventDefinitionDone())
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    // A completes and the compensation end event starts compensating it; Undo-A is left pending
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType("Undo-A")
+        .getFirst();
+
+    // the parallel branch reaches the terminate end event and terminates the pending compensation
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("C").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-C").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(6))
+        .extracting(Record::getIntent, r -> r.getValue().getCompensationHandlerId())
+        .contains(tuple(CompensationSubscriptionIntent.DELETED, "Undo-A"));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("Undo-C", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldCompleteCompensateAllAfterCompensationWasInterruptedByEventSubprocess() {
+    // given an interrupting event subprocess *inside* the subprocess: interrupting it terminates
+    // the
+    // pending compensation throw event while the subprocess completes (rather than terminates), so
+    // the orphaned subscription would strand the later root-level compensate-all
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("subprocess")
+            .embeddedSubProcess()
+            .eventSubProcess(
+                "inner-event-subprocess",
+                eventSubProcess ->
+                    eventSubProcess
+                        .startEvent("interrupting-start")
+                        .message(m -> m.name("interrupt").zeebeCorrelationKeyExpression("\"key\""))
+                        .interrupting(true)
+                        .endEvent())
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .intermediateThrowEvent(
+                "inner-compensation-throw-event",
+                i -> i.compensateEventDefinition().compensateEventDefinitionDone())
+            .endEvent("inner-end")
+            .subProcessDone()
+            .serviceTask(
+                "C",
+                task ->
+                    task.zeebeJobType("C")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-C").zeebeJobType("Undo-C")))
+            .intermediateThrowEvent(
+                "compensation-throw-event",
+                i -> i.compensateEventDefinition().compensateEventDefinitionDone())
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    // A completes and the inner throw event starts compensating it; Undo-A is left pending
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType("Undo-A")
+        .getFirst();
+
+    // the interrupting event subprocess terminates the pending compensation throw event
+    ENGINE
+        .message()
+        .withName("interrupt")
+        .withCorrelationKey("key")
+        .withVariables(Map.of())
+        .publish();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("C").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-C").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(6))
+        .extracting(Record::getIntent, r -> r.getValue().getCompensationHandlerId())
+        .contains(tuple(CompensationSubscriptionIntent.DELETED, "Undo-A"));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("Undo-C", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -3508,7 +3508,10 @@ public class CompensationEventExecutionTest {
     assertThat(
             RecordingExporter.compensationSubscriptionRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(6))
+                .limit(
+                    r ->
+                        r.getIntent() == CompensationSubscriptionIntent.DELETED
+                            && r.getValue().getCompensationHandlerId().equals("Undo-A")))
         .extracting(Record::getIntent, r -> r.getValue().getCompensationHandlerId())
         .contains(tuple(CompensationSubscriptionIntent.DELETED, "Undo-A"));
 
@@ -3587,7 +3590,10 @@ public class CompensationEventExecutionTest {
     assertThat(
             RecordingExporter.compensationSubscriptionRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(6))
+                .limit(
+                    r ->
+                        r.getIntent() == CompensationSubscriptionIntent.DELETED
+                            && r.getValue().getCompensationHandlerId().equals("Undo-A")))
         .extracting(Record::getIntent, r -> r.getValue().getCompensationHandlerId())
         .contains(tuple(CompensationSubscriptionIntent.DELETED, "Undo-A"));
 
@@ -3677,7 +3683,10 @@ public class CompensationEventExecutionTest {
     assertThat(
             RecordingExporter.compensationSubscriptionRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(6))
+                .limit(
+                    r ->
+                        r.getIntent() == CompensationSubscriptionIntent.DELETED
+                            && r.getValue().getCompensationHandlerId().equals("Undo-A")))
         .extracting(Record::getIntent, r -> r.getValue().getCompensationHandlerId())
         .contains(tuple(CompensationSubscriptionIntent.DELETED, "Undo-A"));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -3702,6 +3702,98 @@ public class CompensationEventExecutionTest {
             tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Test
+  public void shouldDeleteNestedCompensationSubscriptionsWhenThrowEventIsTerminated() {
+    // given a throw event whose compensation reaches into a deeper, already-completed subprocess:
+    // triggering it stamps the same throw-event key onto both the inner flow-scope marker and the
+    // deeper Undo-A handler. A parallel terminate end event then terminates the throw event while
+    // Undo-A is still pending. The cleanup must delete *all* subscriptions carrying that key, not
+    // just the first one, or the surviving one strands the later root-level compensate-all.
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("outer")
+            .embeddedSubProcess()
+            .startEvent()
+            .parallelGateway("outer-fork")
+            .subProcess("inner")
+            .embeddedSubProcess()
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .endEvent()
+            .subProcessDone()
+            .intermediateThrowEvent(
+                "inner-compensation-throw-event",
+                i -> i.compensateEventDefinition().compensateEventDefinitionDone())
+            .endEvent("inner-branch-end")
+            .moveToNode("outer-fork")
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .endEvent("terminate-end", EndEventBuilder::terminate)
+            .subProcessDone()
+            .serviceTask(
+                "C",
+                task ->
+                    task.zeebeJobType("C")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-C").zeebeJobType("Undo-C")))
+            .intermediateThrowEvent(
+                "compensation-throw-event",
+                i -> i.compensateEventDefinition().compensateEventDefinitionDone())
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    // A completes, the inner subprocess completes, and the inner throw event compensates across the
+    // subprocess boundary; Undo-A is left pending
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType("Undo-A")
+        .getFirst();
+
+    // the parallel branch reaches the terminate end event and terminates the pending compensation
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("C").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-C").complete();
+
+    // then the deeper subscription was deleted (not just the inner flow-scope marker) ...
+    assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(
+                    r ->
+                        r.getIntent() == CompensationSubscriptionIntent.DELETED
+                            && r.getValue().getCompensationHandlerId().equals("Undo-A")))
+        .extracting(Record::getIntent, r -> r.getValue().getCompensationHandlerId())
+        .contains(tuple(CompensationSubscriptionIntent.DELETED, "Undo-A"));
+
+    // ... and no orphan stranded the root-level compensate-all, so the instance completes
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("outer", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("Undo-C", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {
     final var resourceAsStream = getClass().getResourceAsStream(classpath);
     return Bpmn.readModelFromStream(resourceAsStream);


### PR DESCRIPTION
## Description

Fixes a process instance that can hang forever: a "compensate all" throw event stays active, so a downstream parallel join never gets its token and the root `PROCESS` element never reaches `ELEMENT_COMPLETED`.

**Root cause** (differs from the issue's original write-up, which described the symptom): when a compensation throw event is terminated while its flow scope survives it — a terminate end event, or an interrupting event subprocess, in the same scope — the compensation subscriptions it had triggered were never removed from state. Subscriptions were only deleted on *scope* termination (`deleteSubscriptionsOfSubprocess`, `deleteSubscriptionsOfProcessInstance`); here the scope *completes* instead. The orphaned, permanently-`TRIGGERED` subscription made the completing scope look compensable, so it received a handler-less flow-scope marker. A later "compensate all" swept up that marker, and `completeFlowScopeSubscriptionFromBottomToTop` could never clear it because the orphan still sat in the marker's own scope — so the throw event's subscription set never emptied.

**Fix:** terminating a compensation throw event now deletes every subscription that references it (`BpmnCompensationSubscriptionBehaviour#deleteSubscriptionsOfCompensationThrowEvent`, wired into the `onTerminate` hook of both the compensation intermediate throw event and the compensation end event). No protocol or state-schema change.

The issue's two proposed solution ideas were considered and rejected:
- Excluding handler-less flow-scope markers of already-completed scopes from a compensation sweep — rejected: those markers are how compensation reaches into already-completed subprocesses; excluding them breaks nested compensation.
- Clearing markers eagerly when their owning scope completes — rejected: markers are *created* at scope completion, so "eagerly" doesn't apply; the actual defect is the orphaned subscription that gets swept up alongside them.

Reproduced locally against the four seed pairs from the issue (`processSeed=8531052556787608471` with each of the reported `executionPathSeed`s) via `ProcessExecutionRandomizedPropertyTest#shouldExecuteProcessToEnd` — all four hung on `main` and all four pass with this fix.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59962
