### PR TITLE
fix: use per physical tenant exporter config for static initialization

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -54,7 +54,9 @@ public final class StaticConfigurationGenerator {
                 Collectors.toMap(
                     Entry::getKey, e -> e.getValue().getCluster().getPartitionsCount()));
     final var partitionIds = getSortedPartitionIds(partitionCountPerTenant);
-    final var partitionConfig = generatePartitionConfig(brokerCfg);
+    final var partitionConfig =
+        physicalTenantConfigs.entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> generatePartitionConfig(e.getValue())));
     final var clusterId = clusterCfg.getClusterId();
 
     return new StaticConfiguration(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -58,6 +58,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -231,7 +232,12 @@ public final class ClusterConfigurationManagerService
                 ClusterConfiguration.uninitialized()))
         .andThen(
             new ExporterStateInitializer(
-                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
+                staticConfiguration
+                    .partitionConfigPerPhysicalTenant()
+                    .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                    .exporting()
+                    .exporters()
+                    .keySet(),
                 staticConfiguration.localMemberId(),
                 managerActor,
                 false))
@@ -265,7 +271,12 @@ public final class ClusterConfigurationManagerService
         .orThen(new StaticInitializer<>(staticConfiguration::generateTopology))
         .andThen(
             new ExporterStateInitializer(
-                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
+                staticConfiguration
+                    .partitionConfigPerPhysicalTenant()
+                    .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                    .exporting()
+                    .exporters()
+                    .keySet(),
                 staticConfiguration.localMemberId(),
                 managerActor,
                 true))
@@ -307,11 +318,7 @@ public final class ClusterConfigurationManagerService
                 clusterConfigurationGossiper::updateCurrentClusterConfiguration,
                 managerActor,
                 CurrentClusterConfiguration.uninitialized()))
-        .andThen(
-            new PartitionGroupExporterStateInitializer(
-                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
-                staticConfiguration.localMemberId(),
-                false))
+        .andThen(exporterStateModifier(staticConfiguration, false))
         .andThen(
             PartitionDistributorInitializer
                 .currentClusterConfigurationPartitionDistributorInitializer(staticConfiguration))
@@ -342,11 +349,7 @@ public final class ClusterConfigurationManagerService
                 gossiperConfig.bootstrapTimeout(),
                 CurrentClusterConfiguration.uninitialized()))
         .orThen(new StaticInitializer<>(staticConfiguration::generateCurrentClusterConfiguration))
-        .andThen(
-            new PartitionGroupExporterStateInitializer(
-                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
-                staticConfiguration.localMemberId(),
-                true))
+        .andThen(exporterStateModifier(staticConfiguration, true))
         .andThen(
             PartitionDistributorInitializer
                 .currentClusterConfigurationPartitionDistributorInitializer(staticConfiguration))
@@ -354,6 +357,17 @@ public final class ClusterConfigurationManagerService
             new PartitionGroupExportingStateInitializer(
                 legacyExportingStates, staticConfiguration.localMemberId()))
         .andThen(new PhysicalTenantProvisioningInitializer(staticConfiguration));
+  }
+
+  private static PartitionGroupExporterStateInitializer exporterStateModifier(
+      final StaticConfiguration staticConfiguration, final boolean isCoordinator) {
+    return new PartitionGroupExporterStateInitializer(
+        staticConfiguration.partitionConfigPerPhysicalTenant().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey, e -> e.getValue().exporting().exporters().keySet())),
+        staticConfiguration.localMemberId(),
+        isCoordinator);
   }
 
   private Supplier<List<MemberId>> initializationMembers(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -31,12 +32,12 @@ import java.util.Set;
 public class PartitionGroupExporterStateInitializer
     implements ClusterConfigurationModifier<CurrentClusterConfiguration> {
 
-  private final Set<String> configuredExporters;
+  private final Map<String, Set<String>> configuredExporters;
   private final MemberId localMemberId;
   private final boolean isCoordinator;
 
   public PartitionGroupExporterStateInitializer(
-      final Set<String> configuredExporters,
+      final Map<String, Set<String>> configuredExporters,
       final MemberId localMemberId,
       final boolean isCoordinator) {
     this.configuredExporters = configuredExporters;
@@ -63,7 +64,12 @@ public class PartitionGroupExporterStateInitializer
       if (updated.partitionGroup(groupId).hasMember(localMemberId)) {
         updated =
             updated.updatePartitionGroupConfig(
-                groupId, group -> group.updateMember(localMemberId, this::updateExporterState));
+                groupId,
+                group ->
+                    group.updateMember(
+                        localMemberId,
+                        brokerPartitionState ->
+                            updateExporterState(groupId, brokerPartitionState)));
       }
     }
     return updated;
@@ -76,20 +82,33 @@ public class PartitionGroupExporterStateInitializer
       for (final var memberId : updated.partitionGroup(groupId).members().keySet()) {
         updated =
             updated.updatePartitionGroupConfig(
-                groupId, group -> group.updateMember(memberId, this::updateExporterState));
+                groupId,
+                group ->
+                    group.updateMember(
+                        memberId,
+                        brokerPartitionState ->
+                            updateExporterState(groupId, brokerPartitionState)));
       }
     }
     return updated;
   }
 
   private BrokerPartitionState updateExporterState(
-      final BrokerPartitionState brokerPartitionState) {
+      final String groupId, final BrokerPartitionState brokerPartitionState) {
     BrokerPartitionState updated = brokerPartitionState;
+    if (!configuredExporters.containsKey(groupId)) {
+      // All partition groups should have a configuration. When we support disabling physical
+      // tenants, those groups must be filtered out before this call.
+      throw new IllegalStateException(
+          "No configuration found for partition group '%s'".formatted(groupId));
+    }
+
+    final Set<String> configuredExportersForGroup = configuredExporters.get(groupId);
     for (final var p : brokerPartitionState.partitions().keySet()) {
       final PartitionState currentPartitionState = brokerPartitionState.partitions().get(p);
       final var updatedPartitionState =
           ExporterStateInitializer.updateExporterStateInPartition(
-              currentPartitionState, configuredExporters);
+              currentPartitionState, configuredExportersForGroup);
       // Do not update the partition state if it is unchanged, otherwise the version would be
       // bumped during every restart and could interfere with other concurrent configuration
       // changes.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -13,7 +13,6 @@ import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
@@ -130,14 +129,11 @@ public class PhysicalTenantProvisioningInitializer
     final var targetDistribution =
         getTargetDistribution(configuration, targetMembers, targetPartitionIds);
 
-    final Map<String, DynamicPartitionConfig> partitionConfigByNewGroup =
-        newTenantIds.stream()
-            .collect(
-                Collectors.toMap(
-                    tenantId -> tenantId, ignored -> staticConfiguration.partitionConfig()));
     final var operationsByGroup =
         PartitionReassignmentOperationsGenerator.generateOperations(
-            configuration, targetDistribution, partitionConfigByNewGroup);
+            configuration,
+            targetDistribution,
+            staticConfiguration.partitionConfigPerPhysicalTenant());
 
     var result = configuration;
     for (final var newTenantId : newTenantIds) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
@@ -28,7 +29,7 @@ public record StaticConfiguration(
     MemberId localMemberId,
     List<PartitionId> partitionIds,
     int replicationFactor,
-    DynamicPartitionConfig partitionConfig,
+    Map<String, DynamicPartitionConfig> partitionConfigPerPhysicalTenant,
     @Nullable String clusterId) {
 
   public int partitionCount() {
@@ -42,7 +43,10 @@ public record StaticConfiguration(
         partitionDistribution.stream()
             .filter(p -> p.id().group().equals(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
             .collect(Collectors.toSet());
-    return ConfigurationUtil.getClusterConfigFrom(defaultPartitions, partitionConfig, clusterId);
+    return ConfigurationUtil.getClusterConfigFrom(
+        defaultPartitions,
+        partitionConfigPerPhysicalTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID),
+        clusterId);
   }
 
   /**
@@ -55,7 +59,7 @@ public record StaticConfiguration(
   public CurrentClusterConfiguration generateCurrentClusterConfiguration() {
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
     return ConfigurationUtil.getCurrentClusterConfigurationFrom(
-        clusterMembers, partitionDistribution, partitionConfig, clusterId);
+        clusterMembers, partitionDistribution, partitionConfigPerPhysicalTenant, clusterId);
   }
 
   public Set<PartitionMetadata> generatePartitionDistribution() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -75,14 +75,11 @@ public final class ConfigurationUtil {
    * per distinct {@link PartitionId#group()} found in it, each with its own {@link RoutingState}
    * initialized from that group's own partition count; only members that replicate at least one
    * partition of a group appear in that group.
-   *
-   * <p>{@code partitionConfig} (exporter state) is applied uniformly to every partition regardless
-   * of group, since {@code StaticConfiguration} has no per-group exporter configuration yet.
    */
   public static CurrentClusterConfiguration getCurrentClusterConfigurationFrom(
       final Set<MemberId> clusterMembers,
       final Set<PartitionMetadata> partitionDistribution,
-      final DynamicPartitionConfig partitionConfig,
+      final Map<String, DynamicPartitionConfig> partitionConfig,
       @Nullable final String clusterId) {
     final Map<MemberId, BrokerState> brokerStates = new HashMap<>();
     for (final var member : clusterMembers) {
@@ -107,7 +104,7 @@ public final class ConfigurationUtil {
         partitionStatesByGroupAndMember
             .computeIfAbsent(groupId, ignored -> new HashMap<>())
             .computeIfAbsent(member, ignored -> new HashMap<>())
-            .put(partitionId, PartitionState.active(memberPriority, partitionConfig));
+            .put(partitionId, PartitionState.active(memberPriority, partitionConfig.get(groupId)));
       }
     }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -471,7 +471,7 @@ final class ClusterConfigurationInitializerTest {
         member,
         List.of(partitionId),
         1,
-        DynamicPartitionConfig.init(),
+        Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, DynamicPartitionConfig.init()),
         null);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -397,7 +397,8 @@ class ClusterConfigurationManagementIntegrationTest {
                   cluster.getMembershipService().getLocalMember().id(),
                   List.of(),
                   3,
-                  DynamicPartitionConfig.init(),
+                  Map.of(
+                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, DynamicPartitionConfig.init()),
                   "clusterId"),
               Map.of());
       startFuture.onComplete(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
@@ -739,9 +740,9 @@ final class ClusterConfigurationManagerImplNewConfigTest {
             new ControllablePartitionDistributor().withPartitions(Set.of(partition)),
             Set.of(MEMBER_0, MEMBER_1),
             MEMBER_0,
-            List.of(new PartitionId(CurrentClusterConfiguration.DEFAULT_GROUP, 1)),
+            List.of(new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1)),
             1,
-            partitionConfig,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, partitionConfig),
             "cluster-x");
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializerTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,7 @@ final class PartitionDistributorInitializerTest {
         MemberId.from("0"),
         List.of(new PartitionId("test", 1)),
         1,
-        DynamicPartitionConfig.init(),
+        Map.of("test", DynamicPartitionConfig.init()),
         null);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
@@ -49,8 +49,9 @@ final class PartitionGroupExporterStateInitializerTest {
             PhasedChangeState.empty());
 
     // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"), "tenant-b", Set.of("expA"));
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 
@@ -78,8 +79,9 @@ final class PartitionGroupExporterStateInitializerTest {
             PhasedChangeState.empty());
 
     // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"));
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 
@@ -118,8 +120,9 @@ final class PartitionGroupExporterStateInitializerTest {
             PhasedChangeState.empty());
 
     // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"));
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 
@@ -143,13 +146,100 @@ final class PartitionGroupExporterStateInitializerTest {
             PhasedChangeState.empty());
 
     // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"));
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 
     // then
     assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldOnlyUpdateTenantWhoseExportersAdded() {
+    // given — local member replicates a partition in two different groups, but only one has
+    // exporter changes
+    final var configA = DynamicPartitionConfig.init();
+    final var configB =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of("expA", new ExporterState(0, State.ENABLED, Optional.empty()))));
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(
+                "tenant-a", groupWithMember(LOCAL_MEMBER_ID, configA),
+                "tenant-b", groupWithMember(LOCAL_MEMBER_ID, configB)),
+            PhasedChangeState.empty());
+
+    // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"), "tenant-b", Set.of("expA"));
+    final var result =
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
+            .modify(configuration)
+            .join();
+
+    // then — only tenant-a is updated; tenant-b is unchanged
+    assertThat(
+            result
+                .partitionGroup("tenant-a")
+                .getMember(LOCAL_MEMBER_ID)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .containsKey("expA");
+    assertThat(result.partitionGroup("tenant-b"))
+        .isEqualTo(configuration.partitionGroup("tenant-b"));
+  }
+
+  @Test
+  void shouldOnlyUpdateTenantWhoseExporterRemoved() {
+    // given — local member replicates a partition in two different groups, but only one has
+    // exporter changes
+    final var configA =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of("expA", new ExporterState(0, State.ENABLED, Optional.empty()))));
+    final var configB =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of("expA", new ExporterState(0, State.ENABLED, Optional.empty()))));
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(
+                "tenant-a", groupWithMember(LOCAL_MEMBER_ID, configA),
+                "tenant-b", groupWithMember(LOCAL_MEMBER_ID, configB)),
+            PhasedChangeState.empty());
+
+    // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"), "tenant-b", Set.<String>of());
+    final var result =
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
+            .modify(configuration)
+            .join();
+
+    // then — only tenant-b is updated; tenant-a is unchanged
+    assertThat(result.partitionGroup("tenant-a"))
+        .isEqualTo(configuration.partitionGroup("tenant-a"));
+    assertThat(
+            result
+                .partitionGroup("tenant-b")
+                .getMember(LOCAL_MEMBER_ID)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters()
+                .get("expA")
+                .state())
+        .isEqualTo(State.CONFIG_NOT_FOUND);
   }
 
   @Test
@@ -171,8 +261,9 @@ final class PartitionGroupExporterStateInitializerTest {
             postRestorePendingState());
 
     // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"), "tenant-b", Set.of("expA"));
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, true)
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, true)
             .modify(configuration)
             .join();
 
@@ -216,10 +307,11 @@ final class PartitionGroupExporterStateInitializerTest {
             GlobalConfiguration.init(),
             Map.of("tenant-a", groupWithMember(LOCAL_MEMBER_ID, config)),
             postRestorePendingState());
+    final var exporters = Map.of("tenant-a", Set.of("expA"));
 
     // when
     final var result =
-        new PartitionGroupExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, false)
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
             .modify(configuration)
             .join();
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -210,7 +211,7 @@ final class PhysicalTenantProvisioningInitializerTest {
             LOCAL_MEMBER_ID,
             List.of(new PartitionId("tenantA", 1), new PartitionId("tenantA", 2)),
             5,
-            partitionConfig,
+            Map.of("tenantA", partitionConfig),
             "clusterId");
     final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
 
@@ -231,13 +232,17 @@ final class PhysicalTenantProvisioningInitializerTest {
       final List<List<PartitionId>> tenantPartitionIds, final int replicationFactor) {
     final List<PartitionId> allPartitionIds =
         tenantPartitionIds.stream().flatMap(List::stream).toList();
+    final var tenantConfigs =
+        tenantPartitionIds.stream()
+            .map(list -> list.get(0).group())
+            .collect(Collectors.toMap(Function.identity(), list -> partitionConfig));
     return new StaticConfiguration(
         new RoundRobinPartitionDistributor(),
         Set.of(member(0), member(1), member(2)),
         LOCAL_MEMBER_ID,
         allPartitionIds,
         replicationFactor,
-        partitionConfig,
+        tenantConfigs,
         "clusterId");
   }
 
@@ -263,8 +268,13 @@ final class PhysicalTenantProvisioningInitializerTest {
     for (int i = 0; i < 3; i++) {
       members.add(member(i));
     }
+    final var tenantConfigs =
+        existing.stream()
+            .map(p -> p.id().group())
+            .distinct()
+            .collect(Collectors.toMap(Function.identity(), group -> partitionConfig));
     return ConfigurationUtil.getCurrentClusterConfigurationFrom(
-        members, existing, partitionConfig, "clusterId");
+        members, existing, tenantConfigs, "clusterId");
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerPropertyTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import net.jqwik.api.ForAll;
@@ -81,8 +82,13 @@ final class AdditivePartitionReassignerPropertyTest {
 
   private CurrentClusterConfiguration configurationWith(
       final Set<MemberId> targetMembers, final Set<PartitionMetadata> distribution) {
+    final var tenantConfigs =
+        distribution.stream()
+            .map(p -> p.id().group())
+            .distinct()
+            .collect(Collectors.toMap(Function.identity(), p -> partitionConfig));
     return ConfigurationUtil.getCurrentClusterConfigurationFrom(
-        targetMembers, distribution, partitionConfig, "clusterId");
+        targetMembers, distribution, tenantConfigs, "clusterId");
   }
 
   private Set<MemberId> members(final int count) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -367,8 +368,12 @@ final class AdditivePartitionReassignerTest {
     for (int i = 0; i < 5; i++) {
       members.add(member(i));
     }
+
+    final var tenantConfig =
+        existingGroups.keySet().stream()
+            .collect(Collectors.toMap(group -> group, group -> partitionConfig));
     return ConfigurationUtil.getCurrentClusterConfigurationFrom(
-        members, allExisting, partitionConfig, "clusterId");
+        members, allExisting, tenantConfig, "clusterId");
   }
 
   private Set<MemberId> members(final int count) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -300,9 +300,13 @@ class ConfigurationUtilTest {
     final var clusterMembers = Set.of(member(0), member(1), member(2));
 
     // when
+    final var tenantConfigs =
+        Map.of(
+            "default", partitionConfig,
+            "tenantA", partitionConfig);
     final var configuration =
         ConfigurationUtil.getCurrentClusterConfigurationFrom(
-            clusterMembers, partitionDistribution, partitionConfig, "clusterId");
+            clusterMembers, partitionDistribution, tenantConfigs, "clusterId");
 
     // then — every cluster member is ACTIVE in the global configuration, regardless of partitions
     assertThat(configuration.globalConfiguration().members().keySet())
@@ -336,7 +340,7 @@ class ConfigurationUtilTest {
     // when
     final var configuration =
         ConfigurationUtil.getCurrentClusterConfigurationFrom(
-            Set.of(member(0)), Set.of(partitionOne), partitionConfig, null);
+            Set.of(member(0)), Set.of(partitionOne), Map.of(GROUP_NAME, partitionConfig), null);
 
     // then
     assertThat(configuration.globalConfiguration().clusterId()).isEmpty();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGeneratorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGeneratorTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 final class PartitionReassignmentOperationsGeneratorTest {
@@ -261,8 +262,16 @@ final class PartitionReassignmentOperationsGeneratorTest {
     for (int i = 0; i < 4; i++) {
       members.add(member(i));
     }
+
+    final var tenantConfig =
+        new HashSet<>(existing)
+            .stream()
+                .map(PartitionMetadata::id)
+                .map(PartitionId::group)
+                .distinct()
+                .collect(Collectors.toMap(group -> group, group -> partitionConfig));
     return ConfigurationUtil.getCurrentClusterConfigurationFrom(
-        members, existing, partitionConfig, "clusterId");
+        members, existing, tenantConfig, "clusterId");
   }
 
   private MemberId member(final int id) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
@@ -94,20 +94,18 @@ final class PhysicalTenantExporterConfigIT {
       TestSearchContainers.createDefaultElasticsearchContainer();
 
   private static final String ES_URL;
-
-  static {
-    ES.start();
-    ES_URL = "http://" + ES.getHttpHostAddress();
-  }
-
   private static final HttpClient HTTP = HttpClient.newHttpClient();
   private static final ObjectMapper MAPPER = new ObjectMapper();
-
   private static final PhysicalTenantsITHelper TENANTS =
       PhysicalTenantsITHelper.builder()
           .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
           .withTenant(TENANT_A, Storage.none())
           .build();
+
+  static {
+    ES.start();
+    ES_URL = "http://" + ES.getHttpHostAddress();
+  }
 
   // The exporters are declared in the ROOT config (so they are enabled on every partition group).
   // tenantA redeclares the location exporter fully with a different "target" arg (the
@@ -225,11 +223,6 @@ final class PhysicalTenantExporterConfigIT {
    * present in the tenant's ExporterRepository. To be re-enabled once the cluster-configuration
    * layer supports per-physical-tenant exporters.
    */
-  @Disabled(
-      "Tenant-only exporters require per-physical-tenant exporter support in the"
-          + " cluster-configuration layer (initial DynamicPartitionConfig is generated from the"
-          + " root BrokerCfg only); tracked in"
-          + " https://github.com/camunda/camunda/issues/56652")
   @Test
   void shouldApplyExporterConfiguredOnlyForPhysicalTenant() {
     // given — records flow through tenantA's partition group


### PR DESCRIPTION
## Description

The fix ensures that dynamic cluster configuration uses the exporters configured per physical tenant instead of the default one. 

## Related issues

related #56652 
