### PR TITLE
feat: enable per physical tenant exporter assignment

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java
@@ -50,25 +50,6 @@ import org.springframework.core.env.Environment;
  * BrokerBasedPropertiesOverride#RDBMS_EXPORTER_NAME}) sit outside the catalog: their configuration
  * is derived downstream from the tenant's secondary-storage properties, and args-tuning declared
  * for them is taken as-is.
- *
- * <p><b>The {@code data.exporters-assigned} manifest (ADR-0008 D1/D2/D5) is implemented but not yet
- * wired into {@link PhysicalTenantResolver}, gated on <a
- * href="https://github.com/camunda/camunda/issues/56652">#56652</a>:</b> its mandatory-explicit
- * validation, the exempt/unknown/configured-but-unassigned boot errors, and the root-level
- * placement check live in {@link PhysicalTenantExporterAssignedValidation}; the narrowing of
- * unassigned catalog entries out of the tenant's resolved map lives in {@link #narrowToAssigned}.
- * Both are dormant on purpose: as long as the initial dynamic cluster configuration derives the
- * per-partition exporter <em>enable</em> state from the root {@code BrokerCfg} only, a
- * narrowed-away id would remain enabled on the tenant's partitions and be instantiated as a {@code
- * BlockingExporter}, stalling exporting and log compaction — so the interim inherit-all behavior
- * stands until #56652 flips the wire-in. To activate (from {@link PhysicalTenantResolver#of}): call
- * {@link PhysicalTenantExporterAssignedValidation#validateRootAssignedAbsent} before the tenant
- * loop, then — after the loop and once every tenant's {@link #apply} has run — {@link
- * PhysicalTenantExporterAssignedValidation#validate} for the whole resolved-by-tenant map, and only
- * then {@link #narrowToAssigned} for each tenant. Validation must precede narrowing: narrowing
- * removes ids, and validation checks assigned ids against the full pre-narrow universe. {@link
- * #apply} itself therefore changes only entry <em>contents</em>, never which ids exist for a
- * tenant.
  */
 @NullMarked
 final class PhysicalTenantExporterConfigurations {
@@ -204,9 +185,6 @@ final class PhysicalTenantExporterConfigurations {
    * here ({@link PhysicalTenantExporterAssignedValidation} already rejects it at boot whenever a
    * generic exporter could apply); an explicit empty manifest keeps only the autoconfigured
    * entries.
-   *
-   * <p><b>Dormant:</b> not yet called from {@link PhysicalTenantResolver} — wiring it in is gated
-   * on <a href="https://github.com/camunda/camunda/issues/56652">#56652</a>; see the class javadoc.
    */
   static void narrowToAssigned(
       final Camunda physicalTenant, final String tenantId, final Environment environment) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -82,6 +82,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
     PhysicalTenantRequiredOverrideValidation.validate(environment);
     PhysicalTenantAssignedProvidersValidation.validate(environment);
     PhysicalTenantDocumentAssignedValidation.validateRootAssignedAbsent(environment);
+    PhysicalTenantExporterAssignedValidation.validateRootAssignedAbsent(environment);
     final Map<String, Camunda> resolvedPhysicalTenants = new LinkedHashMap<>();
     final Binder binder = Binder.get(environment);
     for (final String physicalTenantId : physicalTenantIds) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -102,6 +102,14 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
     if (!resolvedPhysicalTenants.containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)) {
       resolvedPhysicalTenants.put(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camunda);
     }
+
+    PhysicalTenantExporterAssignedValidation.validate(
+        environment, resolvedPhysicalTenants, physicalTenantIds);
+    resolvedPhysicalTenants.forEach(
+        (physicalTenantId, physicalTenantCfg) ->
+            PhysicalTenantExporterConfigurations.narrowToAssigned(
+                physicalTenantCfg, physicalTenantId, environment));
+
     CROSS_TENANT_VALIDATIONS.forEach(v -> v.validate(resolvedPhysicalTenants));
     PhysicalTenantDocumentAssignedValidation.validate(
         environment, resolvedPhysicalTenants, physicalTenantIds);

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/ExporterArgsOverlayCharacterizationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/ExporterArgsOverlayCharacterizationTest.java
@@ -63,6 +63,7 @@ class ExporterArgsOverlayCharacterizationTest {
     properties.put("camunda.data.exporters.myexp.args.a", 1);
     properties.put("camunda.data.exporters.myexp.args.b", 2);
     properties.put("camunda.physical-tenants.tenanta.data.exporters.myexp.args.b", 99);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "myexp");
     // distinct storage location so the tenant does not collide with the synthesized 'default'
     // (cross-tenant isolation now runs inside PhysicalTenantResolver.of())
     properties.put(

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurationsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurationsTest.java
@@ -28,11 +28,12 @@ import org.springframework.mock.env.MockEnvironment;
  * Covers the step-1 rows of the ADR-0008 §2 decision table (args merge, class-divergence, and
  * autoconfigured tuning) against the test-only mergers registered via {@code
  * src/test/resources/META-INF/services} (real-merger end-to-end coverage lives in {@code
- * PhysicalTenantExporterConfigIT}), plus the dormant step-2 {@link
- * PhysicalTenantExporterConfigurations#narrowToAssigned}. The step-2 mandatory-explicit and
- * boot-error validations live in {@link PhysicalTenantExporterAssignedValidationTest}. Both step-2
- * halves are dormant (not wired into {@link PhysicalTenantResolver}) pending #56652; see {@link
- * PhysicalTenantExporterConfigurations}.
+ * PhysicalTenantExporterConfigIT}), plus the {@link
+ * PhysicalTenantExporterConfigurations#narrowToAssigned} narrowing step. The mandatory-explicit and
+ * boot-error validations live in {@link PhysicalTenantExporterAssignedValidationTest}. Both are
+ * wired into {@link PhysicalTenantResolver}, so every test that resolves via {@link
+ * #resolveTenantA()} and expects a generic exporter entry to survive must assign it explicitly; see
+ * {@link PhysicalTenantExporterConfigurations}.
  */
 class PhysicalTenantExporterConfigurationsTest {
 
@@ -73,6 +74,7 @@ class PhysicalTenantExporterConfigurationsTest {
     // given — a root catalog entry the tenant never mentions
     properties.put("camunda.data.exporters.untouched.class-name", "com.acme.CustomExporter");
     properties.put("camunda.data.exporters.untouched.args.a", 1);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "untouched");
 
     // when
     final Exporter resolved = resolveTenantA().getData().getExporters().get("untouched");
@@ -91,6 +93,7 @@ class PhysicalTenantExporterConfigurationsTest {
     properties.put("camunda.data.exporters.mergeable.args.a", 1);
     properties.put("camunda.data.exporters.mergeable.args.b", 2);
     properties.put("camunda.physical-tenants.tenanta.data.exporters.mergeable.args.b", 99);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "mergeable");
 
     // when
     final Exporter resolved = resolveTenantA().getData().getExporters().get("mergeable");
@@ -111,6 +114,7 @@ class PhysicalTenantExporterConfigurationsTest {
     properties.put("camunda.data.exporters.custom.args.a", 1);
     properties.put("camunda.data.exporters.custom.args.b", 2);
     properties.put("camunda.physical-tenants.tenanta.data.exporters.custom.args.b", 99);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "custom");
 
     // when
     final Exporter resolved = resolveTenantA().getData().getExporters().get("custom");
@@ -130,6 +134,7 @@ class PhysicalTenantExporterConfigurationsTest {
         "camunda.physical-tenants.tenanta.data.exporters.custom.class-name",
         "com.acme.CustomExporter");
     properties.put("camunda.physical-tenants.tenanta.data.exporters.custom.args.b", 5);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "custom");
 
     // when
     final Exporter resolved = resolveTenantA().getData().getExporters().get("custom");
@@ -178,6 +183,7 @@ class PhysicalTenantExporterConfigurationsTest {
         "camunda.physical-tenants.tenanta.data.exporters.private.class-name",
         "com.acme.TenantOnlyExporter");
     properties.put("camunda.physical-tenants.tenanta.data.exporters.private.args.x", "y");
+    properties.put("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "private");
 
     // when
     final Exporter resolved = resolveTenantA().getData().getExporters().get("private");
@@ -257,6 +263,7 @@ class PhysicalTenantExporterConfigurationsTest {
     properties.put(
         "camunda.data.exporters.mergeable.class-name", TestExporterConfigMergers.MERGEABLE_CLASS);
     properties.put("camunda.data.exporters.mergeable.args.a", 1);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "mergeable");
 
     // when
     final Exporter resolved = resolveTenantA().getData().getExporters().get("mergeable");

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
@@ -401,6 +401,72 @@ class PhysicalTenantResolverTest {
         .containsOnlyKeys("tenanta", "tenantb", PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }
 
+  // --- exporter assignment wiring (ADR-0008 D1/D2/D5) --------------------------------------------
+  // PhysicalTenantExporterAssignedValidation and
+  // PhysicalTenantExporterConfigurations#narrowToAssigned
+  // are unit-tested standalone elsewhere; these tests instead pin that PhysicalTenantResolver#of
+  // actually wires them in, in the right order (validate against the pre-narrow universe, then
+  // narrow) — the two lines an unrelated refactor could most easily drop or reorder.
+
+  @Test
+  void shouldRejectPhysicalTenantMissingExportersAssignedWhenGenericExporterExists() {
+    // given a root-declared generic exporter and a tenant that never declares
+    // camunda.physical-tenants.tenanta.data.exporters-assigned
+    setProperties(
+        Map.of(
+            "camunda.data.exporters.custom.class-name", "com.acme.CustomExporter",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"),
+        "tenanta");
+
+    // when / then resolution fails fast at boot — proves PhysicalTenantExporterAssignedValidation
+    // is actually invoked from the resolver, not just independently unit-testable
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(this::newResolver)
+        .withMessageContaining("tenanta")
+        .withMessageContaining("exporters-assigned");
+  }
+
+  @Test
+  void shouldNarrowAwayUnassignedGenericExporterThroughResolver() {
+    // given two root-declared generic exporters; tenantA's manifest assigns only one of them
+    setProperties(
+        Map.of(
+            "camunda.data.exporters.kept.class-name", "com.acme.KeptExporter",
+            "camunda.data.exporters.dropped.class-name", "com.acme.DroppedExporter",
+            "camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "kept",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"),
+        "tenanta");
+
+    // when — proves narrowToAssigned is actually invoked from the resolver on its resolved output
+    final Camunda tenantA = newResolver().forPhysicalTenant("tenanta");
+
+    // then only the assigned entry survives in the resolved catalog
+    assertThat(tenantA.getData().getExporters()).containsOnlyKeys("kept");
+  }
+
+  @Test
+  void shouldKeepAutoconfiguredExporterAfterNarrowingThroughResolverEvenWhenUnassigned() {
+    // given an already-materialized autoconfigured entry (simulating what secondary-storage
+    // autoconfiguration would have produced) alongside a generic exporter the tenant does assign;
+    // the autoconfigured id must never be listed in exporters-assigned (it is exempt/rejected)
+    setProperties(
+        Map.of(
+            "camunda.data.exporters.camundaexporter.args.a", 1,
+            "camunda.data.exporters.custom.class-name", "com.acme.CustomExporter",
+            "camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "custom",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"),
+        "tenanta");
+
+    // when
+    final Camunda tenantA = newResolver().forPhysicalTenant("tenanta");
+
+    // then narrowing keeps both the assigned generic entry and the unassigned autoconfigured one
+    assertThat(tenantA.getData().getExporters()).containsOnlyKeys("custom", "camundaexporter");
+  }
+
   @Test
   void shouldRejectInvalidTenantIds() {
     // tenant ids must be lowercase alphanumeric — no underscores, no uppercase, no dashes

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -582,6 +582,16 @@ public class CamundaMultiDBExtension
           }
         });
 
+    // A non-default physical tenant must explicitly declare which generic exporters run for it
+    // (PhysicalTenantExporterAssignedValidation, ADR-0008 D1/D2/D5) once any generic exporter
+    // exists in the root catalog. This harness registers recordingExporter (setupTestApplication)
+    // for every acceptance test, and physical-tenant tests assert on records exported from the
+    // tenant's own partitions (e.g. AuditLogUserTaskOperationsIT via RecordingExporter), so it is
+    // assigned here rather than narrowed away.
+    springApplication.withProperty(
+        "camunda.physical-tenants." + tenantId + ".data.exporters-assigned[0]",
+        "recordingExporter");
+
     // A non-default physical tenant must declare its assigned authentication provider when
     // running with OIDC; it does not inherit from root (PhysicalTenantAssignedProvidersValidation).
     final var authenticationMethod =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
@@ -40,7 +40,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -248,12 +247,6 @@ final class PhysicalTenantExporterConfigIT {
    * (the exporter runs on both groups). To be re-enabled once the cluster-configuration layer
    * derives per-partition exporter enable state per tenant.
    */
-  @Disabled(
-      "Narrowing a root-declared exporter out of a physical tenant requires per-physical-tenant"
-          + " exporter support in the cluster-configuration layer (initial DynamicPartitionConfig"
-          + " is generated from the root BrokerCfg only), and the assignment step is not yet wired"
-          + " into PhysicalTenantResolver; tracked in"
-          + " https://github.com/camunda/camunda/issues/56652")
   @Test
   void shouldNarrowAwayUnassignedRootExporterForTenant() {
     // given — records flow through both tenants' partition groups under distinct process ids

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterDeleteIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterDeleteIT.java
@@ -145,6 +145,10 @@ final class PhysicalTenantExporterDeleteIT {
   private void restartWithoutExporter() {
     broker.stop();
     broker.withRecordingExporter(false);
+    // tenant A's exporters-assigned[0]=recordingExporter (set by TENANTS.configure() while the
+    // exporter was still present) would otherwise go stale and trip the unknown-exporter-id check
+    // now that the exporter is gone from the root catalog
+    TENANTS.refreshExportersAssigned(broker);
     broker.start();
 
     await("every physical tenant reports the exporter as CONFIG_NOT_FOUND")

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -113,7 +113,9 @@ public final class PhysicalTenantsITHelper {
                 // here when present; callers that configure their own generic exporters and
                 // exporters-assigned afterwards (e.g. PhysicalTenantExporterConfigIT) are left
                 // untouched, since setting an empty manifest here would collide with their later
-                // indexed exporters-assigned[n] properties.
+                // indexed exporters-assigned[n] properties. A caller that later toggles {@link
+                // TestStandaloneBroker#withRecordingExporter} off (e.g. before a restart) must call
+                // {@link #refreshExportersAssigned} to keep this from going stale.
                 if (broker
                     .unifiedConfig()
                     .getData()
@@ -123,6 +125,50 @@ public final class PhysicalTenantsITHelper {
                       "camunda.physical-tenants." + tenant + ".data.exporters-assigned[0]",
                       TestStandaloneBroker.RECORDING_EXPORTER_ID);
                 }
+              }
+            });
+    return broker;
+  }
+
+  /**
+   * Re-syncs each non-default physical tenant's {@code exporters-assigned} manifest with whether
+   * {@code recordingExporter} is currently present in the broker's root catalog — including
+   * clearing a manifest {@link #configureAdminRoles} previously assigned it into. Call this after
+   * toggling {@link TestStandaloneBroker#withRecordingExporter} on an already-{@link #configure}d
+   * broker (e.g. before a restart that removes the exporter from the root configuration): the
+   * manifest {@link #configureAdminRoles} set at initial setup only reflects the catalog as it
+   * stood then, and would otherwise keep assigning an id no longer in the root catalog, tripping
+   * {@code PhysicalTenantExporterAssignedValidation}'s unknown-id check on the next restart.
+   *
+   * <p>Unlike {@link #configureAdminRoles}, this always writes something — an empty manifest when
+   * {@code recordingExporter} is absent, to actively mask a previously-assigned entry (a bare-key
+   * entry takes precedence over indexed entries under Spring's relaxed {@code List<String>}
+   * binding). Only call this on a broker that {@link #configureAdminRoles} already set up; calling
+   * it standalone on a broker managing its own exporters-assigned (e.g. {@code
+   * PhysicalTenantExporterConfigIT}) would collide with its indexed {@code exporters-assigned[n]}
+   * properties the same way an unconditional write in {@link #configureAdminRoles} would.
+   */
+  public TestStandaloneBroker refreshExportersAssigned(final TestStandaloneBroker broker) {
+    final boolean recordingExporterPresent =
+        broker
+            .unifiedConfig()
+            .getData()
+            .getExporters()
+            .containsKey(TestStandaloneBroker.RECORDING_EXPORTER_ID);
+    tenants
+        .keySet()
+        .forEach(
+            tenant -> {
+              if (DEFAULT_TENANT_ID.equals(tenant)) {
+                return;
+              }
+              final String assignedExportersKey =
+                  "camunda.physical-tenants." + tenant + ".data.exporters-assigned";
+              if (recordingExporterPresent) {
+                broker.withProperty(
+                    assignedExportersKey + "[0]", TestStandaloneBroker.RECORDING_EXPORTER_ID);
+              } else {
+                broker.withProperty(assignedExportersKey, "");
               }
             });
     return broker;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -103,6 +103,26 @@ public final class PhysicalTenantsITHelper {
                             .getInitialization()
                             .setDefaultRoles(
                                 Map.of("admin", Map.of("users", List.of(adminUsername(tenant))))));
+                // A non-default physical tenant must explicitly declare which generic exporters
+                // run for it (PhysicalTenantExporterAssignedValidation, ADR-0008 D1/D2/D5) once any
+                // generic exporter exists in the root catalog — but leaving the manifest unbound is
+                // valid too as long as the tenant's resolved catalog stays empty.
+                // TestClusterBuilder
+                // registers recordingExporter by default (and physical-tenant ITs built on it
+                // assert on records exported from the tenant's own partitions), so it is assigned
+                // here when present; callers that configure their own generic exporters and
+                // exporters-assigned afterwards (e.g. PhysicalTenantExporterConfigIT) are left
+                // untouched, since setting an empty manifest here would collide with their later
+                // indexed exporters-assigned[n] properties.
+                if (broker
+                    .unifiedConfig()
+                    .getData()
+                    .getExporters()
+                    .containsKey(TestStandaloneBroker.RECORDING_EXPORTER_ID)) {
+                  broker.withProperty(
+                      "camunda.physical-tenants." + tenant + ".data.exporters-assigned[0]",
+                      TestStandaloneBroker.RECORDING_EXPORTER_ID);
+                }
               }
             });
     return broker;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -264,14 +264,21 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
    * camunda.physical-tenants.<tenantId>.*} properties are no longer flattened at the next {@link
    * #createSpringBuilder()} — simulating a physical tenant being removed from application
    * configuration. Since those properties are refreshable (see {@link #createSpringBuilder()}),
-   * they are also cleared from any properties already registered from a previous start. Does
-   * nothing if the tenant was never declared.
+   * they are also cleared from any properties already registered from a previous start. Also strips
+   * any {@code camunda.physical-tenants.<tenantId>.*} key set directly via {@link #withProperty}
+   * (e.g. an {@code exporters-assigned} manifest, which has no {@code Camunda} POJO field to carry
+   * it and so cannot be set via {@link #withPtConfig}) — otherwise such a key would survive removal
+   * and make the tenant still look "explicitly configured" to {@link
+   * io.camunda.configuration.physicaltenants.PhysicalTenantResolver#of}. Does nothing if the tenant
+   * was never declared.
    *
    * @param tenantId the physical tenant id to remove
    * @return itself for chaining
    */
   public T removePtConfig(final String tenantId) {
     ptConfigs.remove(tenantId);
+    final String prefix = "camunda.physical-tenants." + tenantId + ".";
+    propertyOverrides.keySet().removeIf(key -> key.startsWith(prefix));
     return self();
   }
 


### PR DESCRIPTION
## Description

Wires the previously dormant per-physical-tenant exporter assignment step (ADR-0008 D1/D2/D5) into `PhysicalTenantResolver`:

- `PhysicalTenantExporterAssignedValidation` now runs at boot, requiring every physical tenant to explicitly declare `camunda.physical-tenants.<id>.data.exporters-assigned` whenever a generic exporter could apply to it (an empty list is valid and means "no generic exporters").
- `PhysicalTenantExporterConfigurations#narrowToAssigned` now runs after validation, removing unassigned catalog entries from each tenant's resolved exporter map.

This is a deliberate breaking migration: any physical-tenant setup that predates this now fails loudly at boot instead of silently inheriting every root-declared exporter. Four test harnesses/fixtures that provision physical tenants without the new mandatory key were updated accordingly:

- `CamundaMultiDBExtension` (acceptance tests) now assigns `recordingExporter` explicitly for the physical tenants it provisions, since some audit-log ITs assert on records exported from the tenant's own partitions.
- `PhysicalTenantExporterConfigurationsTest` / `ExporterArgsOverlayCharacterizationTest` (`configuration` module) now assign the specific generic exporter id(s) each test exercises.
- `PhysicalTenantsITHelper` (`zeebe/qa/util`) assigns `recordingExporter` only when it's actually present in the broker's root catalog at that point, leaving the manifest unbound otherwise (valid against an empty catalog) so it doesn't collide with tests that manage their own exporter assignment.

## Related issues

closes #56652