### PR TITLE
fix: prevent unparseable test reports from hiding flaky-test data

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -23,6 +23,11 @@ runs:
   - name: Test Summary
     uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
     if: ${{ inputs.skipSummary == 'false' }}
+    # The summary is presentational: it renders test counts into the job summary and feeds
+    # nothing downstream. A single unparseable TEST-*.xml used to fail this step and abort the
+    # whole composite action, skipping "Find flaky tests" and leaving the flakyTests output
+    # empty -- indistinguishable from a clean run, so flakes went unreported to CI health.
+    continue-on-error: true
     with:
       paths: |
         **/target/failsafe-reports/TEST-*.xml


### PR DESCRIPTION
## Description

`General / Unit - Back End` failed on `main` ([run 31587848428](https://github.com/camunda/camunda/actions/runs/31587848428/job/94085826851), tied to INC-7122) even though the Maven build and all 628 tests passed. The `Test Summary` step in `analyze-test-runs` hit a malformed `<property .../>` element in a Surefire report and failed, which aborted the whole composite action before `Find flaky tests` ran.

Because the action aborted early, its `flakyTests` output came back empty — indistinguishable from a run with no flakes. Any flaky tests in that run went unreported to CI health.

`Test Summary` is purely presentational (job summary table, no outputs consumed downstream), so it shouldn't be able to gate the job or block the steps that do carry signal. This marks only that step `continue-on-error: true`: a malformed report now degrades to a warning instead of skipping flaky-test detection. The other two steps (`Find flaky tests`, `Unfinished tests`) keep their current fail-fast behavior.

Considered and rejected:
- `skipSummary: "true"` — disables the summary on every run, not just runs with a bad file.
- `continue-on-error` on the whole composite action — would also mask genuine failures in flaky-test/unfinished-test detection.

Applies to all six call sites of `analyze-test-runs` in `ci.yml` and other workflows, not just the job that triggered this.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related to INC-7122