### PR TITLE
test: surface a missing buildUrl path param at the call site, not as a 404

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
@@ -143,7 +143,7 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
   test('Activate AdHoc Activities FailsWithMissingElements', async ({
     request,
   }) => {
-    const adHocKey = state.adHocSubProcessInstanceKey as string;
+    const adHocKey = state.adHocSubProcessInstanceKeySimple as string;
 
     const invalidBody = {
       cancelRemainingInstances: false,
@@ -171,7 +171,7 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
   test('Activate AdHoc Activities ReturnsUnauthorizedWithoutAuth', async ({
     request,
   }) => {
-    const adHocKey = state.adHocSubProcessInstanceKey as string;
+    const adHocKey = state.adHocSubProcessInstanceKeySimple as string;
 
     const body = {
       elements: [

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
@@ -639,7 +639,7 @@ test.describe.parallel('Mapping Rules API Tests', () => {
   });
 
   test('Delete Mapping Rule Unauthorized', async ({request}) => {
-    const p = {mappingRuleId: state['mappingRuleId1'] as string};
+    const p = {mappingRuleId: mappingRule2.mappingRuleId as string};
     const res = await request.delete(
       buildUrl('/mapping-rules/{mappingRuleId}', p),
       {headers: {}},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
@@ -42,6 +42,12 @@ test.describe.parallel('Role Mapping Rules API Tests', () => {
     await createRoleAndStoreResponseFields(request, 3, state);
     await assignRolesToMappingRules(
       request,
+      1,
+      state['roleId1'] as string,
+      state,
+    );
+    await assignRolesToMappingRules(
+      request,
       2,
       state['roleId2'] as string,
       state,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
@@ -172,7 +172,7 @@ test.describe.parallel('Role Users API Tests', () => {
 
   test('Search Role Users Unauthorized', async ({request}) => {
     const roleId: string = state['roleId1'] as string;
-    const p = {userId: userFromState(roleId, state) as string};
+    const p = {roleId};
     const res = await request.post(
       buildUrl('/roles/{roleId}/users/search', p),
       {headers: {}, data: {}},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-users-api-tests.spec.ts
@@ -171,7 +171,7 @@ test.describe.parallel('Tenant Users API Tests', () => {
 
   test('Search Tenant Users Unauthorized', async ({request}) => {
     const tenantId: string = state['tenantId1'] as string;
-    const p = {userName: userFromState(tenantId, state) as string};
+    const p = {tenantId};
     const res = await request.post(
       buildUrl('/tenants/{tenantId}/users/search', p),
       {headers: {}, data: {}},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -258,14 +258,23 @@ export function octetStreamHeaders(token?: string): Record<string, string> {
 
 export function buildUrl(
   pathTemplate: string, // e.g., "/tenants/{tenantId}"
-  params?: Record<string, string | number | undefined>,
+  params?: Record<string, string | number>,
   query?: Record<string, string | number | undefined>,
 ): string {
   const version: string = 'v2';
   const base = credentials.baseUrl;
   let url = `${base}/${version}${pathTemplate}`.replace(/\{(\w+)}/g, (_, k) => {
     const v = params?.[k];
-    return v == null ? '__MISSING_PARAM__' : String(v);
+    // A substituted placeholder would build a request to a nonsense path that the
+    // gateway answers with a plausible 404, so a test asserting 404 would pass
+    // without exercising anything. Failing here points at the call site instead.
+    if (v == null) {
+      throw new Error(
+        `buildUrl: missing path parameter "${k}" for path template "${pathTemplate}". ` +
+          `Received params: ${JSON.stringify(params ?? {})}`,
+      );
+    }
+    return String(v);
   });
   if (query) {
     const q = Object.entries(query)


### PR DESCRIPTION
## Why

`buildUrl` in `qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts` substituted the literal string `__MISSING_PARAM__` whenever a `{placeholder}` had no matching entry in `params`:

```ts
return v == null ? '__MISSING_PARAM__' : String(v);
```

A misspelled or forgotten key therefore built a syntactically valid request to a nonsense path — `/v2/resources/__MISSING_PARAM__/content` — which the gateway answers with a plausible-looking `404`. A test asserting `404` passes having verified nothing, and a test asserting `200` fails with a message that points at the API rather than at the typo.

## What changed

- `buildUrl` now throws an `Error` naming both the path template and the missing key, at URL-construction time, before any request is sent.
- `params` values are typed `string | number` instead of `string | number | undefined`. A template's placeholders are all required by construction, so a statically-undefined value is always a bug. `query` keeps `undefined`, where it legitimately means "omit this parameter".

Nothing depended on the sentinel: `__MISSING_PARAM__` appeared exactly once in the suite, in its own definition, and no spec referenced the string.

## Call-site impact

The type tightening costs **zero call-site churn** — `tsc` is clean across the ~2600 `buildUrl` call sites, because no call site passes a value TypeScript already knows may be `undefined`. Verified by temporarily injecting a deliberate `{k: someUndefinedVar}` call and confirming `tsc` rejects it, so the check is real and not vacuous.

What remains is the runtime class: values typed as defined that happen to be `undefined` at runtime — most commonly the `as string` reads out of the shared test-state map in `utils/requestHelpers/get-value-from-state-requestHelpers.ts`. Those previously produced a quiet `404` and may have been masking latent test bugs; they now throw. That is the fix working, not a regression. <!-- LATENT_BUGS -->

## Verification

PR CI only lints this suite, so a green lint proves little for a change touching 1519 placeholder-form call sites. Gate is a full on-demand run of `c8-orchestration-cluster-e2e-tests-on-demand.yml` against this branch — result posted as a comment below.

Local: `npm run lint` green (0 errors; the 199 warnings are pre-existing), `npx prettier --check` clean.

## Scope

Relates to #59880. The ticket also calls for standardising the `utils/requestHelpers/` on the placeholder form — 265 template-literal call sites across 64 files that bypass the guard entirely. That is #60010, a separate purely mechanical PR stacked on this one, and it carries the `Closes`.

Out of scope: #59888 (generated path union), #59879, #59889.