### PR TITLE
refactor: put every buildUrl call site behind the missing-param guard

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-get-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-get-api-tests.spec.ts
@@ -54,9 +54,12 @@ test.describe.parallel('Get Audit Logs API Tests', () => {
     await test.step('Get Audit Logs', async () => {
       const auditLogKey = expectedAuditLog.auditLogKey;
       await expect(async () => {
-        const res = await request.get(buildUrl(`/audit-logs/${auditLogKey}`), {
-          headers: jsonHeaders(),
-        });
+        const res = await request.get(
+          buildUrl('/audit-logs/{auditLogKey}', {auditLogKey}),
+          {
+            headers: jsonHeaders(),
+          },
+        );
 
         await assertStatusCode(res, 200);
         await validateResponse(
@@ -76,7 +79,7 @@ test.describe.parallel('Get Audit Logs API Tests', () => {
   test('Get Audit Logs - Not Found', async ({request}) => {
     const invalidAuditLogKey = 'meowmeowInvalidAuditLogKey';
     const res = await request.get(
-      buildUrl(`/audit-logs/${invalidAuditLogKey}`),
+      buildUrl('/audit-logs/{auditLogKey}', {auditLogKey: invalidAuditLogKey}),
       {
         headers: jsonHeaders(),
       },
@@ -146,10 +149,13 @@ test.describe.parallel('Get Audit Logs API Tests', () => {
     await test.step('Get Audit Logs with user having only Resource Authorization - Expect Forbidden', async () => {
       const auditLogKey = expectedAuditLog.auditLogKey;
       await expect(async () => {
-        const res = await request.get(buildUrl(`/audit-logs/${auditLogKey}`), {
-          headers: jsonHeaders(token), // overrides default demo:demo
-          data: {},
-        });
+        const res = await request.get(
+          buildUrl('/audit-logs/{auditLogKey}', {auditLogKey}),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: {},
+          },
+        );
         await assertForbiddenRequest(res, 'Unauthorized to perform');
       }).toPass(defaultAssertionOptions);
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/delete-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/delete-authorization-api.spec.ts
@@ -78,7 +78,9 @@ test.describe.parallel('Delete Authorization API', () => {
 
     await test.step('Delete authorization', async () => {
       const deleteRes = await request.delete(
-        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: userAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -144,7 +146,9 @@ test.describe.parallel('Delete Authorization API', () => {
 
     await test.step('Delete authorization', async () => {
       const deleteRes = await request.delete(
-        buildUrl(`/authorizations/${roleAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: roleAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -209,7 +213,9 @@ test.describe.parallel('Delete Authorization API', () => {
 
     await test.step('Delete authorization', async () => {
       const deleteRes = await request.delete(
-        buildUrl(`/authorizations/${mappingRuleAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: mappingRuleAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -263,7 +269,9 @@ test.describe.parallel('Delete Authorization API', () => {
 
     await test.step('Delete authorization', async () => {
       const deleteRes = await request.delete(
-        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: userAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -277,7 +285,9 @@ test.describe.parallel('Delete Authorization API', () => {
 
     await test.step('Attempt to delete already deleted authorization', async () => {
       const deleteRes = await request.delete(
-        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: userAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -293,7 +303,9 @@ test.describe.parallel('Delete Authorization API', () => {
     request,
   }) => {
     const deleteRes = await request.delete(
-      buildUrl(`/authorizations/anyAuthorizationKey`),
+      buildUrl('/authorizations/{authorizationKey}', {
+        authorizationKey: 'anyAuthorizationKey',
+      }),
       {
         headers: {
           'Content-Type': 'application/json',
@@ -308,7 +320,9 @@ test.describe.parallel('Delete Authorization API', () => {
   }) => {
     const invalidAuthorizationKey = 'meow';
     const deleteRes = await request.delete(
-      buildUrl(`/authorizations/${invalidAuthorizationKey}`),
+      buildUrl('/authorizations/{authorizationKey}', {
+        authorizationKey: invalidAuthorizationKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -378,7 +392,9 @@ test.describe.parallel('Delete Authorization API', () => {
 
       await expect(async () => {
         const deleteRes = await request.delete(
-          buildUrl(`/authorizations/${userAuthorizationKey}`),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: userAuthorizationKey,
+          }),
           {
             headers: jsonHeaders(token), // overrides default demo:demo
           },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/get-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/get-authorization-api.spec.ts
@@ -77,7 +77,9 @@ test.describe.parallel('Get Authorization API', () => {
     await test.step('Get Authorization and assert results', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/authorizations/${userAuthorizationKey}`),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: userAuthorizationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -103,7 +105,9 @@ test.describe.parallel('Get Authorization API', () => {
     await test.step('Get Authorization and assert results', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/authorizations/${nonExistentAuthorizationKey}`),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: nonExistentAuthorizationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -149,7 +153,9 @@ test.describe.parallel('Get Authorization API', () => {
     await test.step('Get Authorization without authorization header', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/authorizations/${userAuthorizationKey}`),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: userAuthorizationKey,
+          }),
           {
             headers: {
               'Content-Type': 'application/json',
@@ -220,7 +226,9 @@ test.describe.parallel('Get Authorization API', () => {
 
       await expect(async () => {
         const authRes = await request.get(
-          buildUrl(`/authorizations/${userAuthorizationKey}`),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: userAuthorizationKey,
+          }),
           {
             headers: jsonHeaders(token), // overrides default demo:demo
           },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/update-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/update-authorization-api.spec.ts
@@ -88,7 +88,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update user authorization to add UPDATE permission', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: userAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -111,9 +113,9 @@ test.describe.parallel('Update Authorization API', () => {
 
       await expect(async () => {
         const getAuthRes = await request.get(
-          buildUrl(
-            `/authorizations/${expectedUserAuthorization.authorizationKey}`,
-          ),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: expectedUserAuthorization.authorizationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -192,7 +194,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update role authorization with changed resourceId', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${roleAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: roleAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -214,9 +218,9 @@ test.describe.parallel('Update Authorization API', () => {
       };
       await expect(async () => {
         const getAuthRes = await request.get(
-          buildUrl(
-            `/authorizations/${expectedRoleAuthorization.authorizationKey}`,
-          ),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: expectedRoleAuthorization.authorizationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -287,7 +291,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update group authorization to new group ownerId', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${groupAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: groupAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -310,9 +316,9 @@ test.describe.parallel('Update Authorization API', () => {
       await waitForAssertion({
         assertion: async () => {
           const getAuthRes = await request.get(
-            buildUrl(
-              `/authorizations/${expectedGroupAuthorization.authorizationKey}`,
-            ),
+            buildUrl('/authorizations/{authorizationKey}', {
+              authorizationKey: expectedGroupAuthorization.authorizationKey,
+            }),
             {
               headers: jsonHeaders(),
             },
@@ -415,7 +421,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update mapping rule authorization with new ownerId, resourceId and permissionTypes', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${mappingRuleAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: mappingRuleAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -437,9 +445,9 @@ test.describe.parallel('Update Authorization API', () => {
       };
       await expect(async () => {
         const getAuthRes = await request.get(
-          buildUrl(
-            `/authorizations/${expectedMappingRuleAuthorization.authorizationKey}`,
-          ),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: expectedMappingRuleAuthorization.authorizationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -513,7 +521,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update role authorization with the same authorization', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${roleAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: roleAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -535,9 +545,9 @@ test.describe.parallel('Update Authorization API', () => {
       };
       await expect(async () => {
         const getAuthRes = await request.get(
-          buildUrl(
-            `/authorizations/${expectedRoleAuthorization.authorizationKey}`,
-          ),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: expectedRoleAuthorization.authorizationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -595,7 +605,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update user authorization with empty request body', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: userAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -621,9 +633,9 @@ test.describe.parallel('Update Authorization API', () => {
 
       await expect(async () => {
         const getAuthRes = await request.get(
-          buildUrl(
-            `/authorizations/${expectedUserAuthorization.authorizationKey}`,
-          ),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: expectedUserAuthorization.authorizationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -684,7 +696,9 @@ test.describe.parallel('Update Authorization API', () => {
     await test.step('Update user authorization to add UPDATE permission', async () => {
       await expect(async () => {
         const authRes = await request.put(
-          buildUrl(`/authorizations/${userAuthorizationKey}`),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: userAuthorizationKey,
+          }),
           {
             headers: {
               'Content-Type': 'application/json',
@@ -738,7 +752,9 @@ test.describe.parallel('Update Authorization API', () => {
     await test.step('Attempt to update non-existent authorization', async () => {
       await expect(async () => {
         const authRes = await request.put(
-          buildUrl(`/authorizations/${notExistingUserAuthorizationKey}`),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: notExistingUserAuthorizationKey,
+          }),
           {
             headers: jsonHeaders(),
             data: {
@@ -812,7 +828,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update role authorization with changed resourceId', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${roleAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: roleAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -837,9 +855,9 @@ test.describe.parallel('Update Authorization API', () => {
       };
       await expect(async () => {
         const getAuthRes = await request.get(
-          buildUrl(
-            `/authorizations/${expectedRoleAuthorization.authorizationKey}`,
-          ),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: expectedRoleAuthorization.authorizationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -893,7 +911,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update user authorization with invalid resourceType', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: userAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -949,7 +969,9 @@ test.describe.parallel('Update Authorization API', () => {
 
     await test.step('Update user authorization with empty permissionTypes', async () => {
       const authRes = await request.put(
-        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        buildUrl('/authorizations/{authorizationKey}', {
+          authorizationKey: userAuthorizationKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -1031,7 +1053,9 @@ test.describe.parallel('Update Authorization API', () => {
     await test.step('Update user authorization to add UPDATE permission', async () => {
       await expect(async () => {
         const authRes = await request.put(
-          buildUrl(`/authorizations/${userAuthorizationKey}`),
+          buildUrl('/authorizations/{authorizationKey}', {
+            authorizationKey: userAuthorizationKey,
+          }),
           {
             headers: jsonHeaders(token), // overrides default demo:demo
             data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts
@@ -36,7 +36,9 @@ test.describe('Get Batch Operation Tests', () => {
       await expect(async () => {
         const batchOperationKey = localState['batchOperationKey'] as string;
         const res = await request.get(
-          buildUrl(`/batch-operations/${batchOperationKey}`),
+          buildUrl('/batch-operations/{batchOperationKey}', {
+            batchOperationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -72,7 +74,9 @@ test.describe('Get Batch Operation Tests', () => {
   test('Get Batch Operation - Not Found', async ({request}) => {
     const unknownBatchOperationKey = '2251799813999999';
     const res = await request.get(
-      buildUrl(`/batch-operations/${unknownBatchOperationKey}`),
+      buildUrl('/batch-operations/{batchOperationKey}', {
+        batchOperationKey: unknownBatchOperationKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -93,7 +97,9 @@ test.describe('Get Batch Operation Tests', () => {
 
     await test.step('Get Batch Operation without auth', async () => {
       const authRes = await request.get(
-        buildUrl(`/batch-operations/${localState['batchOperationKey']}`),
+        buildUrl('/batch-operations/{batchOperationKey}', {
+          batchOperationKey: localState['batchOperationKey'] as string,
+        }),
         {
           // No Authorization header on purpose
           headers: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -135,7 +135,9 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
 
     await test.step('Send cancel request without auth', async () => {
       const res = await request.post(
-        buildUrl(`/batch-operations/${key}/cancellation`),
+        buildUrl('/batch-operations/{batchOperationKey}/cancellation', {
+          batchOperationKey: key,
+        }),
         {
           data: {},
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -126,7 +126,9 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
       });
 
     const res = await request.post(
-      buildUrl(`/batch-operations/${key}/suspension`),
+      buildUrl('/batch-operations/{batchOperationKey}/suspension', {
+        batchOperationKey: key,
+      }),
       {
         data: {},
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
@@ -81,7 +81,7 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
     await test.step('Delete Decision Instance', async () => {
       await expect(async () => {
         const res = await request.post(
-          buildUrl(`/decision-instances/deletion`),
+          buildUrl('/decision-instances/deletion'),
           {
             headers: jsonHeaders(),
             data: {
@@ -115,7 +115,9 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
     await test.step('Verify batch operation has two operations', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/batch-operations/${createdBatchOperationKey}`),
+          buildUrl('/batch-operations/{batchOperationKey}', {
+            batchOperationKey: createdBatchOperationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -141,7 +143,9 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
     await test.step('Verify Decision Instance is Deleted', async () => {
       await expect(async () => {
         const res1 = await request.get(
-          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete1}`),
+          buildUrl('/decision-instances/{decisionEvaluationInstanceKey}', {
+            decisionEvaluationInstanceKey: decisionEvaluationKeyToDelete1,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -157,7 +161,9 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
     await test.step('Verify Decision Instance is Deleted', async () => {
       await expect(async () => {
         const res2 = await request.get(
-          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete2}`),
+          buildUrl('/decision-instances/{decisionEvaluationInstanceKey}', {
+            decisionEvaluationInstanceKey: decisionEvaluationKeyToDelete2,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -235,7 +241,9 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
     await test.step('Verify No Operations are done in Batch Operation', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/batch-operations/${createdBatchOperationKey}`),
+          buildUrl('/batch-operations/{batchOperationKey}', {
+            batchOperationKey: createdBatchOperationKey,
+          }),
           {
             headers: jsonHeaders(),
           },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
@@ -71,9 +71,9 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
       );
 
       const res = await request.post(
-        buildUrl(
-          `/decision-instances/${decisionEvaluationKeyToDelete}/deletion`,
-        ),
+        buildUrl('/decision-instances/{decisionEvaluationKey}/deletion', {
+          decisionEvaluationKey: decisionEvaluationKeyToDelete,
+        }),
         {
           headers: jsonHeaders(token), // overrides default demo:demo
         },
@@ -94,9 +94,9 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
     await test.step('Delete Decision Instance', async () => {
       await expect(async () => {
         const res = await request.post(
-          buildUrl(
-            `/decision-instances/${decisionEvaluationKeyToDelete}/deletion`,
-          ),
+          buildUrl('/decision-instances/{decisionEvaluationKey}/deletion', {
+            decisionEvaluationKey: decisionEvaluationKeyToDelete,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -111,7 +111,9 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
         decisionInstanceToDelete.decisionEvaluationInstanceKey;
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet}`),
+          buildUrl('/decision-instances/{decisionEvaluationInstanceKey}', {
+            decisionEvaluationInstanceKey: decisionEvaluationInstanceKeyToGet,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -131,7 +133,9 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
       decisionInstanceToDelete.decisionEvaluationKey;
 
     const res = await request.post(
-      buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete}/deletion`),
+      buildUrl('/decision-instances/{decisionEvaluationKey}/deletion', {
+        decisionEvaluationKey: decisionEvaluationKeyToDelete,
+      }),
       {
         headers: {
           'Content-Type': 'application/json',
@@ -145,9 +149,9 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
     const notExistingDecisionEvaluationKeyToDelete = '9999999999999';
 
     const res = await request.post(
-      buildUrl(
-        `/decision-instances/${notExistingDecisionEvaluationKeyToDelete}/deletion`,
-      ),
+      buildUrl('/decision-instances/{decisionEvaluationKey}/deletion', {
+        decisionEvaluationKey: notExistingDecisionEvaluationKeyToDelete,
+      }),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
@@ -42,7 +42,9 @@ test.describe.parallel('Get Decision Instances API Tests', () => {
 
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet}`),
+        buildUrl('/decision-instances/{decisionEvaluationInstanceKey}', {
+          decisionEvaluationInstanceKey: decisionEvaluationInstanceKeyToGet,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -74,7 +76,9 @@ test.describe.parallel('Get Decision Instances API Tests', () => {
     const someRandomNotExistingKey = '9999999999999999-1';
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-instances/${someRandomNotExistingKey}`),
+        buildUrl('/decision-instances/{decisionEvaluationInstanceKey}', {
+          decisionEvaluationInstanceKey: someRandomNotExistingKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -93,7 +97,9 @@ test.describe.parallel('Get Decision Instances API Tests', () => {
       decisionInstanceToGet.decisionEvaluationInstanceKey;
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet}`),
+        buildUrl('/decision-instances/{decisionEvaluationInstanceKey}', {
+          decisionEvaluationInstanceKey: decisionEvaluationInstanceKeyToGet,
+        }),
         {
           headers: {
             'Content-Type': 'application/json',
@@ -109,7 +115,9 @@ test.describe.parallel('Get Decision Instances API Tests', () => {
   test('Get Decision Instance - Bad Request', async ({request}) => {
     const invalidDecisionEvaluationInstanceKey = '+++';
     const res = await request.get(
-      buildUrl(`/decision-instances/${invalidDecisionEvaluationInstanceKey}`),
+      buildUrl('/decision-instances/{decisionEvaluationInstanceKey}', {
+        decisionEvaluationInstanceKey: invalidDecisionEvaluationInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-get-json-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-get-json-api.spec.ts
@@ -39,7 +39,9 @@ test.describe.parallel('Get JSON Decision Requirements API Tests', () => {
       decisionRequirementToGet.decisionRequirementsKey;
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-requirements/${decisionRequirementsToGetKey}`),
+        buildUrl('/decision-requirements/{decisionRequirementsKey}', {
+          decisionRequirementsKey: decisionRequirementsToGetKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -67,7 +69,9 @@ test.describe.parallel('Get JSON Decision Requirements API Tests', () => {
     const someRandomNotExistingKey = '9999999999999999';
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-requirements/${someRandomNotExistingKey}`),
+        buildUrl('/decision-requirements/{decisionRequirementsKey}', {
+          decisionRequirementsKey: someRandomNotExistingKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -84,7 +88,9 @@ test.describe.parallel('Get JSON Decision Requirements API Tests', () => {
     await expect(async () => {
       const someInvalidValue = 'meow';
       const res = await request.get(
-        buildUrl(`/decision-requirements/${someInvalidValue}`),
+        buildUrl('/decision-requirements/{decisionRequirementsKey}', {
+          decisionRequirementsKey: someInvalidValue,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -103,7 +109,9 @@ test.describe.parallel('Get JSON Decision Requirements API Tests', () => {
       decisionRequirementToGet.decisionRequirementsKey;
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-requirements/${decisionRequirementsToGetKey}`),
+        buildUrl('/decision-requirements/{decisionRequirementsKey}', {
+          decisionRequirementsKey: decisionRequirementsToGetKey,
+        }),
         {
           headers: {
             'Content-Type': 'application/json',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-get-xml-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-get-xml-api.spec.ts
@@ -36,7 +36,9 @@ test.describe.parallel('Get XML Decision Requirements API Tests', () => {
       decisionRequirementToGet.decisionRequirementsKey;
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-requirements/${decisionRequirementsToGetKey}/xml`),
+        buildUrl('/decision-requirements/{decisionRequirementsKey}/xml', {
+          decisionRequirementsKey: decisionRequirementsToGetKey,
+        }),
         {
           headers: textXMLHeaders(),
         },
@@ -51,7 +53,9 @@ test.describe.parallel('Get XML Decision Requirements API Tests', () => {
     const someRandomNotExistingKey = '9999999999999999';
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-requirements/${someRandomNotExistingKey}/xml`),
+        buildUrl('/decision-requirements/{decisionRequirementsKey}/xml', {
+          decisionRequirementsKey: someRandomNotExistingKey,
+        }),
         {
           headers: textXMLHeaders(),
         },
@@ -68,7 +72,9 @@ test.describe.parallel('Get XML Decision Requirements API Tests', () => {
     await expect(async () => {
       const someInvalidValue = 'meow';
       const res = await request.get(
-        buildUrl(`/decision-requirements/${someInvalidValue}/xml`),
+        buildUrl('/decision-requirements/{decisionRequirementsKey}/xml', {
+          decisionRequirementsKey: someInvalidValue,
+        }),
         {
           headers: textXMLHeaders(),
         },
@@ -87,7 +93,9 @@ test.describe.parallel('Get XML Decision Requirements API Tests', () => {
       decisionRequirementToGet.decisionRequirementsKey;
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/decision-requirements/${decisionRequirementsToGetKey}/xml`),
+        buildUrl('/decision-requirements/{decisionRequirementsKey}/xml', {
+          decisionRequirementsKey: decisionRequirementsToGetKey,
+        }),
         {
           headers: {
             'Content-Type': 'application/json',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-get-api.spec.ts
@@ -24,23 +24,22 @@ import {EXPECTED_ELEMENT_INSTANCE_GET_SUCCESS} from '../../../../utils/beans/ele
 test.describe.parallel('Get Element Instance API', () => {
   const state: Record<string, string> = {};
 
-  test.beforeAll(async () => {
+  test.beforeAll(async ({request}) => {
     await deploy(['./resources/element_instance_get_update_tests.bpmn']);
     await createInstances('element_instance_get_update_tests', 1, 1).then(
       (instances) => {
         state.processInstanceKey = instances[0].processInstanceKey;
       },
     );
+    // The tests in this describe run in parallel, so resolving the element
+    // instance key inside one of them leaves the others racing it.
+    state.elementInstanceKey = await searchActiveElementInstance(
+      request,
+      state.processInstanceKey,
+    );
   });
 
   test('Get Element Instance - Success', async ({request}) => {
-    await test.step('Find element instance key of active element', async () => {
-      state.elementInstanceKey = await searchActiveElementInstance(
-        request,
-        state.processInstanceKey,
-      );
-    });
-
     await test.step('Get element instance', async () => {
       await expect(async () => {
         const res = await request.get(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-get-api.spec.ts
@@ -44,7 +44,9 @@ test.describe.parallel('Get Element Instance API', () => {
     await test.step('Get element instance', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/element-instances/${state.elementInstanceKey}`),
+          buildUrl('/element-instances/{elementInstanceKey}', {
+            elementInstanceKey: state.elementInstanceKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -72,7 +74,9 @@ test.describe.parallel('Get Element Instance API', () => {
 
   test('Get Element Instance - Unauthorized', async ({request}) => {
     const res = await request.get(
-      buildUrl(`/element-instances/${state.elementInstanceKey}`),
+      buildUrl('/element-instances/{elementInstanceKey}', {
+        elementInstanceKey: state.elementInstanceKey,
+      }),
       {
         // No auth headers
       },
@@ -81,9 +85,14 @@ test.describe.parallel('Get Element Instance API', () => {
   });
 
   test('Get Element Instance - Not Found', async ({request}) => {
-    const res = await request.get(buildUrl(`/element-instances/999999999999`), {
-      headers: jsonHeaders(),
-    });
+    const res = await request.get(
+      buildUrl('/element-instances/{elementInstanceKey}', {
+        elementInstanceKey: '999999999999',
+      }),
+      {
+        headers: jsonHeaders(),
+      },
+    );
     await assertNotFoundRequest(
       res,
       "Element Instance with key '999999999999' not found",
@@ -91,9 +100,14 @@ test.describe.parallel('Get Element Instance API', () => {
   });
 
   test('Get Element Instance - Invalid Key Format', async ({request}) => {
-    const res = await request.get(buildUrl(`/element-instances/invalidKey`), {
-      headers: jsonHeaders(),
-    });
+    const res = await request.get(
+      buildUrl('/element-instances/{elementInstanceKey}', {
+        elementInstanceKey: 'invalidKey',
+      }),
+      {
+        headers: jsonHeaders(),
+      },
+    );
     await assertBadRequest(
       res,
       "Failed to convert 'elementInstanceKey' with value: 'invalidKey'",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -94,13 +94,16 @@ test.describe('Element Instance Incident Search API', () => {
 
     await test.step('Fail job on called process', async () => {
       const jobKey = await activateJobToObtainAValidJobKey(request, 'meow');
-      const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
-        headers: jsonHeaders(),
-        data: {
-          retries: 0,
-          errorMessage: 'Simulated failure',
+      const failRes = await request.post(
+        buildUrl('/jobs/{jobKey}/failure', {jobKey}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            retries: 0,
+            errorMessage: 'Simulated failure',
+          },
         },
-      });
+      );
 
       await assertStatusCode(failRes, 204);
     });
@@ -117,9 +120,9 @@ test.describe('Element Instance Incident Search API', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {},
@@ -147,9 +150,9 @@ test.describe('Element Instance Incident Search API', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -182,9 +185,9 @@ test.describe('Element Instance Incident Search API', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -224,9 +227,9 @@ test.describe('Element Instance Incident Search API', () => {
     const errorMessage2 = 'Simulated failure';
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -269,9 +272,9 @@ test.describe('Element Instance Incident Search API', () => {
     const notExistingProcessInstanceKey = '9999999999999';
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -300,9 +303,9 @@ test.describe('Element Instance Incident Search API', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -325,9 +328,9 @@ test.describe('Element Instance Incident Search API', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -350,9 +353,9 @@ test.describe('Element Instance Incident Search API', () => {
     const notExistingElementInstanceKey = '9999999999999';
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${notExistingElementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: notExistingElementInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {},
@@ -370,9 +373,9 @@ test.describe('Element Instance Incident Search API', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: {},
           data: {},
@@ -412,9 +415,9 @@ test.describe('Element Instance Incident Search API', () => {
     await test.step('Attempt to search element instance incidents without proper authorization', async () => {
       await expect(async () => {
         const res = await request.post(
-          buildUrl(
-            `/element-instances/${state.elementInstanceKey}/incidents/search`,
-          ),
+          buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+            elementInstanceKey: state.elementInstanceKey as string,
+          }),
           {
             headers: jsonHeaders(token), // overrides default demo:demo
             data: {},
@@ -439,9 +442,9 @@ test.describe('Element Instance Incident Search API', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(
-          `/element-instances/${state.elementInstanceKey}/incidents/search`,
-        ),
+        buildUrl('/element-instances/{elementInstanceKey}/incidents/search', {
+          elementInstanceKey: state.elementInstanceKey as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-definition-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-definition-api-tests.spec.ts
@@ -117,7 +117,7 @@ test.describe
     await test.step('Get process instance statistics by error to get errorHashCode', async () => {
       await expect(async () => {
         const res = await request.post(
-          buildUrl(`/incidents/statistics/process-instances-by-error`),
+          buildUrl('/incidents/statistics/process-instances-by-error'),
           {
             headers: jsonHeaders(),
           },
@@ -146,7 +146,7 @@ test.describe
     await test.step('Get process instance statistics by definition with errorHashCode filter', async () => {
       await expect(async () => {
         const res = await request.post(
-          buildUrl(`/incidents/statistics/process-instances-by-definition`),
+          buildUrl('/incidents/statistics/process-instances-by-definition'),
           {
             headers: jsonHeaders(),
             data: {
@@ -186,7 +186,7 @@ test.describe
 
     await test.step('Get process instance statistics by definition without authorization', async () => {
       const res = await request.post(
-        buildUrl(`/incidents/statistics/process-instances-by-definition`),
+        buildUrl('/incidents/statistics/process-instances-by-definition'),
         {
           headers: {},
           data: {
@@ -205,7 +205,7 @@ test.describe
   }) => {
     const errorHashCode = 'meow';
     const res = await request.post(
-      buildUrl(`/incidents/statistics/process-instances-by-definition`),
+      buildUrl('/incidents/statistics/process-instances-by-definition'),
       {
         headers: jsonHeaders(),
         data: {
@@ -230,7 +230,7 @@ test.describe
       );
       const errorHashCode = 123456789;
       const res = await request.post(
-        buildUrl(`/incidents/statistics/process-instances-by-definition`),
+        buildUrl('/incidents/statistics/process-instances-by-definition'),
         {
           headers: jsonHeaders(token),
           data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-error-api-tests.spec.ts
@@ -106,7 +106,7 @@ test.describe('Get Process Instance Statistics By Error API Tests', () => {
     await test.step('Get process instance statistics by error', async () => {
       await expect(async () => {
         const res = await request.post(
-          buildUrl(`/incidents/statistics/process-instances-by-error`),
+          buildUrl('/incidents/statistics/process-instances-by-error'),
           {
             headers: jsonHeaders(),
           },
@@ -161,7 +161,7 @@ test.describe('Get Process Instance Statistics By Error API Tests', () => {
 
     await test.step('Get process instance statistics by error sorted ASC by activeInstancesWithErrorCount', async () => {
       const res = await request.post(
-        buildUrl(`/incidents/statistics/process-instances-by-error`),
+        buildUrl('/incidents/statistics/process-instances-by-error'),
         {
           headers: jsonHeaders(),
           data: {
@@ -198,7 +198,7 @@ test.describe('Get Process Instance Statistics By Error API Tests', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/incidents/statistics/process-instances-by-error`),
+        buildUrl('/incidents/statistics/process-instances-by-error'),
         {
           headers: jsonHeaders(),
           data: {
@@ -222,7 +222,7 @@ test.describe('Get Process Instance Statistics By Error API Tests', () => {
   }) => {
     const invalidSortField = 'invalid';
     const res = await request.post(
-      buildUrl(`/incidents/statistics/process-instances-by-error`),
+      buildUrl('/incidents/statistics/process-instances-by-error'),
       {
         headers: jsonHeaders(),
         data: {
@@ -245,7 +245,7 @@ test.describe('Get Process Instance Statistics By Error API Tests', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/incidents/statistics/process-instances-by-error`),
+      buildUrl('/incidents/statistics/process-instances-by-error'),
       {
         headers: {},
         data: {},
@@ -263,7 +263,7 @@ test.describe('Get Process Instance Statistics By Error API Tests', () => {
         `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
       );
       const res = await request.post(
-        buildUrl(`/incidents/statistics/process-instances-by-error`),
+        buildUrl('/incidents/statistics/process-instances-by-error'),
         {
           headers: jsonHeaders(token),
           data: {},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-get-api.spec.ts
@@ -47,9 +47,12 @@ test.describe.parallel('Search Incidents API Tests', () => {
 
     for (const incidentKey of localState['incidentKeys'] as string[]) {
       await expect(async () => {
-        const res = await request.get(buildUrl(`/incidents/${incidentKey}`), {
-          headers: jsonHeaders(),
-        });
+        const res = await request.get(
+          buildUrl('/incidents/{incidentKey}', {incidentKey}),
+          {
+            headers: jsonHeaders(),
+          },
+        );
 
         await assertStatusCode(res, 200);
         await validateResponse(
@@ -81,7 +84,7 @@ test.describe.parallel('Search Incidents API Tests', () => {
 
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/incidents/${firstIncidentKey}`),
+        buildUrl('/incidents/{incidentKey}', {incidentKey: firstIncidentKey}),
         {
           headers: {
             'Content-Type': 'application/json',
@@ -97,9 +100,12 @@ test.describe.parallel('Search Incidents API Tests', () => {
   test('Get Incidents Not Found', async ({request}) => {
     await expect(async () => {
       const someWrongValue = '9675540027';
-      const res = await request.get(buildUrl(`/incidents/${someWrongValue}`), {
-        headers: jsonHeaders(),
-      });
+      const res = await request.get(
+        buildUrl('/incidents/{incidentKey}', {incidentKey: someWrongValue}),
+        {
+          headers: jsonHeaders(),
+        },
+      );
 
       await assertNotFoundRequest(
         res,
@@ -112,7 +118,7 @@ test.describe.parallel('Search Incidents API Tests', () => {
     await expect(async () => {
       const someInvalidValue = 'meow';
       const res = await request.get(
-        buildUrl(`/incidents/${someInvalidValue}`),
+        buildUrl('/incidents/{incidentKey}', {incidentKey: someInvalidValue}),
         {
           headers: jsonHeaders(),
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-resolve-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-resolve-api.spec.ts
@@ -85,7 +85,9 @@ test.describe.parallel('Resolve Incidents API Tests', () => {
 
     await test.step('Update element instance variables', async () => {
       const updateRes = await request.put(
-        buildUrl(`/element-instances/${elementInstanceKey['key']}/variables`),
+        buildUrl('/element-instances/{elementInstanceKey}/variables', {
+          elementInstanceKey: elementInstanceKey['key'],
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -100,7 +102,7 @@ test.describe.parallel('Resolve Incidents API Tests', () => {
 
     await test.step('Resolve Incident', async () => {
       const resolveRes = await request.post(
-        buildUrl(`/incidents/${incidentKey}/resolution`),
+        buildUrl('/incidents/{incidentKey}/resolution', {incidentKey}),
         {
           headers: jsonHeaders(),
         },
@@ -145,7 +147,9 @@ test.describe.parallel('Resolve Incidents API Tests', () => {
     await expect(async () => {
       const someWrongValue = '9675540027';
       const res = await request.post(
-        buildUrl(`/incidents/${someWrongValue}/resolution`),
+        buildUrl('/incidents/{incidentKey}/resolution', {
+          incidentKey: someWrongValue,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -162,7 +166,9 @@ test.describe.parallel('Resolve Incidents API Tests', () => {
     await expect(async () => {
       const someInvalidValue = 'meow';
       const res = await request.post(
-        buildUrl(`/incidents/${someInvalidValue}/resolution`),
+        buildUrl('/incidents/{incidentKey}/resolution', {
+          incidentKey: someInvalidValue,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -179,7 +185,9 @@ test.describe.parallel('Resolve Incidents API Tests', () => {
     const someNotExistingValue = '9999999999999999';
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/incidents/${someNotExistingValue}/resolution`),
+        buildUrl('/incidents/{incidentKey}/resolution', {
+          incidentKey: someNotExistingValue,
+        }),
         {
           headers: {
             'Content-Type': 'application/json',
@@ -201,13 +209,16 @@ test.describe.parallel('Resolve Incidents API Tests', () => {
     const jobKey = await activateJobToObtainAValidJobKey(request, 'test-fail');
 
     await test.step('Fail job to create incident', async () => {
-      const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
-        headers: jsonHeaders(),
-        data: {
-          retries: 0,
-          errorMessage: 'Simulated failure',
+      const failRes = await request.post(
+        buildUrl('/jobs/{jobKey}/failure', {jobKey}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            retries: 0,
+            errorMessage: 'Simulated failure',
+          },
         },
-      });
+      );
       await assertStatusCode(failRes, 204);
     });
 
@@ -254,18 +265,23 @@ test.describe.parallel('Resolve Incidents API Tests', () => {
     const incidentKeyValue = incidentKey['key'];
 
     await test.step('Update job to create additional retry', async () => {
-      const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-        headers: jsonHeaders(),
-        data: {
-          changeset: {retries: 1},
+      const updateRes = await request.patch(
+        buildUrl('/jobs/{jobKey}', {jobKey}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            changeset: {retries: 1},
+          },
         },
-      });
+      );
       await assertStatusCode(updateRes, 204);
     });
 
     await test.step('Resolve Incident', async () => {
       const resolveRes = await request.post(
-        buildUrl(`/incidents/${incidentKeyValue}/resolution`),
+        buildUrl('/incidents/{incidentKey}/resolution', {
+          incidentKey: incidentKeyValue,
+        }),
         {
           headers: jsonHeaders(),
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-cancel-process-instance-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-cancel-process-instance-tests.spec.ts
@@ -211,7 +211,7 @@ test.describe.parallel('Cancel Process Instance Execution Listener', () => {
           cancelListenerType,
         );
         const failRes = await request.post(
-          buildUrl(`/jobs/${jobKey}/failure`),
+          buildUrl('/jobs/{jobKey}/failure', {jobKey}),
           {
             headers: jsonHeaders(),
             data: {
@@ -249,14 +249,19 @@ test.describe.parallel('Cancel Process Instance Execution Listener', () => {
           extendedAssertionOptions,
         );
 
-        const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-          headers: jsonHeaders(),
-          data: {changeset: {retries: 1}},
-        });
+        const updateRes = await request.patch(
+          buildUrl('/jobs/{jobKey}', {jobKey}),
+          {
+            headers: jsonHeaders(),
+            data: {changeset: {retries: 1}},
+          },
+        );
         await assertStatusCode(updateRes, 204);
 
         const resolveRes = await request.post(
-          buildUrl(`/incidents/${incidents[0].incidentKey}/resolution`),
+          buildUrl('/incidents/{incidentKey}/resolution', {
+            incidentKey: incidents[0].incidentKey,
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(resolveRes, 204);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
@@ -53,7 +53,7 @@ test.describe('Job Completion API Tests', () => {
     const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
 
     const completeRes = await request.post(
-      buildUrl(`/jobs/${jobKey}/completion`),
+      buildUrl('/jobs/{jobKey}/completion', {jobKey}),
       {
         headers: jsonHeaders(),
         data: {},
@@ -68,7 +68,7 @@ test.describe('Job Completion API Tests', () => {
 
     await test.step('Send complete request for non-existing job', async () => {
       const completeRes = await request.post(
-        buildUrl(`/jobs/${jobKey}/completion`),
+        buildUrl('/jobs/{jobKey}/completion', {jobKey}),
         {
           headers: jsonHeaders(),
           data: {},
@@ -86,7 +86,7 @@ test.describe('Job Completion API Tests', () => {
 
     await test.step('Send invalid payload to provoke a bad request', async () => {
       const completeRes = await request.post(
-        buildUrl(`/jobs/${jobKey}/completion`),
+        buildUrl('/jobs/{jobKey}/completion', {jobKey}),
         {
           headers: jsonHeaders(),
           data: {
@@ -110,7 +110,9 @@ test.describe('Job Completion API Tests', () => {
 
     await test.step('First completion (should succeed)', async () => {
       const completeRes = await request.post(
-        buildUrl(`/jobs/${localState['jobKey']}/failure`),
+        buildUrl('/jobs/{jobKey}/failure', {
+          jobKey: localState['jobKey'] as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -124,7 +126,9 @@ test.describe('Job Completion API Tests', () => {
 
     await test.step('Second completion (should conflict)', async () => {
       const completeAgainRes = await request.post(
-        buildUrl(`/jobs/${localState['jobKey']}/completion`),
+        buildUrl('/jobs/{jobKey}/completion', {
+          jobKey: localState['jobKey'] as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
@@ -45,13 +45,16 @@ test.describe('Job Error API Tests', () => {
   test('Throw Error for Job - success', async ({request}) => {
     const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
     await expect(async () => {
-      const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
-        headers: jsonHeaders(),
-        data: {
-          errorCode: 'ERROR_CODE_1',
-          errorMessage: 'Simulated Error',
+      const errorRes = await request.post(
+        buildUrl('/jobs/{jobKey}/error', {jobKey}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            errorCode: 'ERROR_CODE_1',
+            errorMessage: 'Simulated Error',
+          },
         },
-      });
+      );
 
       await assertStatusCode(errorRes, 204);
     }).toPass(defaultAssertionOptions);
@@ -60,13 +63,16 @@ test.describe('Job Error API Tests', () => {
   test('Throw Error for Job - not found', async ({request}) => {
     const jobKey = 2251799813738612;
 
-    const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
-      headers: jsonHeaders(),
-      data: {
-        errorCode: 'ERROR_CODE_NOT_FOUND',
-        errorMessage: 'Simulated error',
+    const errorRes = await request.post(
+      buildUrl('/jobs/{jobKey}/error', {jobKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          errorCode: 'ERROR_CODE_NOT_FOUND',
+          errorMessage: 'Simulated error',
+        },
       },
-    });
+    );
     await assertNotFoundRequest(
       errorRes,
       `Command 'THROW_ERROR' rejected with code 'NOT_FOUND': Expected to throw an error for job with key '2251799813738612', but no such job was found`,
@@ -76,13 +82,16 @@ test.describe('Job Error API Tests', () => {
   test('Throw Error for Job - invalid request', async ({request}) => {
     const jobKey = 2251799813738612;
 
-    const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
-      headers: jsonHeaders(),
-      data: {
-        errorCode: 2, // Wrong type
-        errorMessage: 2, // wrong type
+    const errorRes = await request.post(
+      buildUrl('/jobs/{jobKey}/error', {jobKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          errorCode: 2, // Wrong type
+          errorMessage: 2, // wrong type
+        },
       },
-    });
+    );
     await assertBadRequest(errorRes, '');
   });
 
@@ -99,13 +108,16 @@ test.describe('Job Error API Tests', () => {
     await test.step('Throw error for the job (first time) and expect 204', async () => {
       const jobKey = localState['jobKey'] as number;
       await expect(async () => {
-        const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
-          headers: jsonHeaders(),
-          data: {
-            errorCode: 'SIMULATED',
-            errorMessage: 'Simulated failure',
+        const errorRes = await request.post(
+          buildUrl('/jobs/{jobKey}/error', {jobKey}),
+          {
+            headers: jsonHeaders(),
+            data: {
+              errorCode: 'SIMULATED',
+              errorMessage: 'Simulated failure',
+            },
           },
-        });
+        );
         await assertStatusCode(errorRes, 204);
       }).toPass(defaultAssertionOptions);
     });
@@ -114,7 +126,7 @@ test.describe('Job Error API Tests', () => {
       const jobKey = localState['jobKey'] as number;
       await expect(async () => {
         const errorAgainRes = await request.post(
-          buildUrl(`/jobs/${jobKey}/error`),
+          buildUrl('/jobs/{jobKey}/error', {jobKey}),
           {
             headers: jsonHeaders(),
             data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
@@ -46,13 +46,16 @@ test.describe('Job Fail API Tests', () => {
 
     // Now fail the job
     await expect(async () => {
-      const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
-        headers: jsonHeaders(),
-        data: {
-          retries: 0,
-          errorMessage: 'Simulated failure',
+      const failRes = await request.post(
+        buildUrl('/jobs/{jobKey}/failure', {jobKey}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            retries: 0,
+            errorMessage: 'Simulated failure',
+          },
         },
-      });
+      );
 
       await assertStatusCode(failRes, 204);
     }).toPass(defaultAssertionOptions);
@@ -61,13 +64,16 @@ test.describe('Job Fail API Tests', () => {
   test('Fail Job - Job not found', async ({request}) => {
     const jobKey = 2251799813738612;
 
-    const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
-      headers: jsonHeaders(),
-      data: {
-        retries: 2,
-        errorMessage: 'Simulated failure',
+    const failRes = await request.post(
+      buildUrl('/jobs/{jobKey}/failure', {jobKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          retries: 2,
+          errorMessage: 'Simulated failure',
+        },
       },
-    });
+    );
     await assertNotFoundRequest(
       failRes,
       `Command 'FAIL' rejected with code 'NOT_FOUND': Expected to fail job with key '${jobKey}', but no such job was found`,
@@ -77,13 +83,16 @@ test.describe('Job Fail API Tests', () => {
   test('Fail Job - invalid request', async ({request}) => {
     const jobKey = 2251799813738612;
 
-    const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
-      headers: jsonHeaders(),
-      data: {
-        retries: '2', // Wrong type
-        errorMessage: 2, // wrong type
+    const failRes = await request.post(
+      buildUrl('/jobs/{jobKey}/failure', {jobKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          retries: '2', // Wrong type
+          errorMessage: 2, // wrong type
+        },
       },
-    });
+    );
     await assertBadRequest(failRes, '');
   });
 
@@ -100,7 +109,9 @@ test.describe('Job Fail API Tests', () => {
     await test.step('fail the job for the first time', async () => {
       await expect(async () => {
         const failRes = await request.post(
-          buildUrl(`/jobs/${localState['jobKey']}/failure`),
+          buildUrl('/jobs/{jobKey}/failure', {
+            jobKey: localState['jobKey'] as string,
+          }),
           {
             headers: jsonHeaders(),
             data: {
@@ -115,7 +126,9 @@ test.describe('Job Fail API Tests', () => {
 
     await test.step('fail the job for the second time', async () => {
       const failAgainRes = await request.post(
-        buildUrl(`/jobs/${localState['jobKey']}/failure`),
+        buildUrl('/jobs/{jobKey}/failure', {
+          jobKey: localState['jobKey'] as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
@@ -46,12 +46,15 @@ test.describe('Job Update API Tests', () => {
 
     await test.step('PATCH update the job', async () => {
       await expect(async () => {
-        const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-          headers: jsonHeaders(),
-          data: {
-            changeset: {retries: 1, timeout: 9000},
+        const updateRes = await request.patch(
+          buildUrl('/jobs/{jobKey}', {jobKey}),
+          {
+            headers: jsonHeaders(),
+            data: {
+              changeset: {retries: 1, timeout: 9000},
+            },
           },
-        });
+        );
         await assertStatusCode(updateRes, 204);
       }).toPass(defaultAssertionOptions);
     });
@@ -61,13 +64,16 @@ test.describe('Job Update API Tests', () => {
     const jobKey = 2251799813738612; // non-existing
 
     await test.step('Send update for non-existing job', async () => {
-      const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-        headers: jsonHeaders(),
-        data: {
-          changeset: {retries: 0, timeout: 0},
-          operationReference: 0,
+      const updateRes = await request.patch(
+        buildUrl('/jobs/{jobKey}', {jobKey}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            changeset: {retries: 0, timeout: 0},
+            operationReference: 0,
+          },
         },
-      });
+      );
 
       await assertNotFoundRequest(
         updateRes,
@@ -80,13 +86,16 @@ test.describe('Job Update API Tests', () => {
     const jobKey = 2251799813738612; // non-existing
 
     await test.step('Send invalid payload to provoke a bad request', async () => {
-      const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-        headers: jsonHeaders(),
-        data: {
-          changeset: {retries: 'zero', timeout: 'zero'},
-          operationReference: 'invalid',
+      const updateRes = await request.patch(
+        buildUrl('/jobs/{jobKey}', {jobKey}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            changeset: {retries: 'zero', timeout: 'zero'},
+            operationReference: 'invalid',
+          },
         },
-      });
+      );
       await assertBadRequest(updateRes, '');
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-before-all-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-before-all-tests.spec.ts
@@ -193,7 +193,7 @@ test.describe.parallel('Multi-Instance Execution Listeners — beforeAll', () =>
         );
 
         const failRes = await request.post(
-          buildUrl(`/jobs/${jobKey}/failure`),
+          buildUrl('/jobs/{jobKey}/failure', {jobKey}),
           {
             headers: jsonHeaders(),
             data: {retries: 0, errorMessage: 'Simulated failure NEG-02'},
@@ -234,14 +234,19 @@ test.describe.parallel('Multi-Instance Execution Listeners — beforeAll', () =>
         );
 
         // ── Recovery: update retries + resolve incident ──────────────────────
-        const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-          headers: jsonHeaders(),
-          data: {changeset: {retries: 1}},
-        });
+        const updateRes = await request.patch(
+          buildUrl('/jobs/{jobKey}', {jobKey}),
+          {
+            headers: jsonHeaders(),
+            data: {changeset: {retries: 1}},
+          },
+        );
         await assertStatusCode(updateRes, 204);
 
         const resolveRes = await request.post(
-          buildUrl(`/incidents/${incidents[0].incidentKey}/resolution`),
+          buildUrl('/incidents/{incidentKey}/resolution', {
+            incidentKey: incidents[0].incidentKey,
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(resolveRes, 204);
@@ -652,7 +657,7 @@ test.describe.parallel('Multi-Instance Execution Listeners — beforeAll', () =>
 
           // Fail one job with retries=1 (FAILED state, no incident, re-activatable immediately)
           const failRes = await request.post(
-            buildUrl(`/jobs/${startJobs[0].jobKey}/failure`),
+            buildUrl('/jobs/{jobKey}/failure', {jobKey: startJobs[0].jobKey}),
             {
               headers: jsonHeaders(),
               data: {retries: 1, errorMessage: 'Simulated start EL failure'},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
@@ -159,7 +159,7 @@ test.describe
         );
 
         const failRes = await request.post(
-          buildUrl(`/jobs/${jobKey}/failure`),
+          buildUrl('/jobs/{jobKey}/failure', {jobKey}),
           {
             headers: jsonHeaders(),
             data: {retries: 0, errorMessage: 'Simulated start EL failure'},
@@ -220,10 +220,13 @@ test.describe
           extendedAssertionOptions,
         );
 
-        const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-          headers: jsonHeaders(),
-          data: {changeset: {retries: 1}},
-        });
+        const updateRes = await request.patch(
+          buildUrl('/jobs/{jobKey}', {jobKey}),
+          {
+            headers: jsonHeaders(),
+            data: {changeset: {retries: 1}},
+          },
+        );
         await assertStatusCode(updateRes, 204);
 
         // Regression check #2 (#54238 fixed): /jobs/search must return HTTP 200
@@ -244,7 +247,9 @@ test.describe
         }).toPass(extendedAssertionOptions);
 
         const resolveRes = await request.post(
-          buildUrl(`/incidents/${incidents[0].incidentKey}/resolution`),
+          buildUrl('/incidents/{incidentKey}/resolution', {
+            incidentKey: incidents[0].incidentKey,
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(resolveRes, 204);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-message-subscription-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-message-subscription-api-tests.spec.ts
@@ -55,7 +55,7 @@ test.describe('Search Message Subscription API Tests', () => {
   });
 
   test('Search Subscriptions Unauthorized', async ({request}) => {
-    const res = await request.post(buildUrl(`/message-subscriptions/search`), {
+    const res = await request.post(buildUrl('/message-subscriptions/search'), {
       headers: {},
       data: {filter: {name: state.name}},
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
@@ -192,7 +192,9 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
 
     await test.step('Get definitionKEy of process instance', async () => {
       const res = await request.get(
-        buildUrl(`/process-instances/${processInstanceKey}`),
+        buildUrl('/process-instances/{processInstanceKey}', {
+          processInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -84,7 +84,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
 
   test('Get process instance statistics - Success', async ({request}) => {
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances`),
+      buildUrl('/process-definitions/statistics/process-instances'),
       {
         headers: jsonHeaders(),
       },
@@ -106,7 +106,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances`),
+      buildUrl('/process-definitions/statistics/process-instances'),
       {
         headers: jsonHeaders(),
         data: {
@@ -148,7 +148,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances`),
+      buildUrl('/process-definitions/statistics/process-instances'),
       {
         headers: jsonHeaders(),
         data: {
@@ -197,7 +197,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     // reverse relationship exact regardless of collation.
     const fetchProcessDefinitionIds = async (order: 'ASC' | 'DESC') => {
       const res = await request.post(
-        buildUrl(`/process-definitions/statistics/process-instances`),
+        buildUrl('/process-definitions/statistics/process-instances'),
         {
           headers: jsonHeaders(),
           data: {
@@ -252,7 +252,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
   }) => {
     const notExistingField = 'meow';
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances`),
+      buildUrl('/process-definitions/statistics/process-instances'),
       {
         headers: jsonHeaders(),
         data: {
@@ -276,7 +276,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
   }) => {
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/process-definitions/statistics/process-instances`),
+        buildUrl('/process-definitions/statistics/process-instances'),
         {
           headers: jsonHeaders(),
           data: {
@@ -306,7 +306,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances`),
+      buildUrl('/process-definitions/statistics/process-instances'),
       {
         headers: jsonHeaders(),
         data: {
@@ -326,7 +326,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
 
   test('Get process instance statistics - Unauthorized', async ({request}) => {
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances`),
+      buildUrl('/process-definitions/statistics/process-instances'),
       {
         headers: {},
       },
@@ -341,7 +341,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
     );
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances`),
+      buildUrl('/process-definitions/statistics/process-instances'),
       {
         headers: jsonHeaders(token), // overrides default demo:demo
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -105,7 +105,7 @@ test.describe.parallel('Process instance statistics by version', () => {
     await expect(async () => {
       const res = await request.post(
         buildUrl(
-          `/process-definitions/statistics/process-instances-by-version`,
+          '/process-definitions/statistics/process-instances-by-version',
         ),
         {
           headers: jsonHeaders(),
@@ -153,7 +153,7 @@ test.describe.parallel('Process instance statistics by version', () => {
       for (const sortOption of sort) {
         const res = await request.post(
           buildUrl(
-            `/process-definitions/statistics/process-instances-by-version`,
+            '/process-definitions/statistics/process-instances-by-version',
           ),
           {
             headers: jsonHeaders(),
@@ -220,7 +220,7 @@ test.describe.parallel('Process instance statistics by version', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      buildUrl('/process-definitions/statistics/process-instances-by-version'),
       {
         headers: jsonHeaders(),
         data: {},
@@ -234,7 +234,7 @@ test.describe.parallel('Process instance statistics by version', () => {
   }) => {
     const notExistingField = {meow: 'meow'};
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      buildUrl('/process-definitions/statistics/process-instances-by-version'),
       {
         headers: jsonHeaders(),
         data: {
@@ -256,7 +256,7 @@ test.describe.parallel('Process instance statistics by version', () => {
   }) => {
     const nonExistingProcessDefinitionId = 'nonExistingProcessDefinitionId';
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      buildUrl('/process-definitions/statistics/process-instances-by-version'),
       {
         headers: jsonHeaders(),
         data: {
@@ -284,7 +284,7 @@ test.describe.parallel('Process instance statistics by version', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      buildUrl('/process-definitions/statistics/process-instances-by-version'),
       {
         headers: {},
         data: {
@@ -304,7 +304,7 @@ test.describe.parallel('Process instance statistics by version', () => {
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
     );
     const res = await request.post(
-      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      buildUrl('/process-definitions/statistics/process-instances-by-version'),
       {
         headers: jsonHeaders(token), // overrides default demo:demo
         data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-api.spec.ts
@@ -37,7 +37,9 @@ test.describe.parallel('Process Definition Get API', () => {
   test('Get Process Definition - Success', async ({request}) => {
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/process-definitions/${state.processDefinitionKey}`),
+        buildUrl('/process-definitions/{processDefinitionKey}', {
+          processDefinitionKey: state.processDefinitionKey as string,
+        }),
         {headers: jsonHeaders()},
       );
       await assertStatusCode(res, 200);
@@ -61,9 +63,14 @@ test.describe.parallel('Process Definition Get API', () => {
   });
 
   test('Get Process Definition - Not Found', async ({request}) => {
-    const res = await request.get(buildUrl(`/process-definitions/123456`), {
-      headers: jsonHeaders(),
-    });
+    const res = await request.get(
+      buildUrl('/process-definitions/{processDefinitionKey}', {
+        processDefinitionKey: '123456',
+      }),
+      {
+        headers: jsonHeaders(),
+      },
+    );
     await assertNotFoundRequest(
       res,
       "Process Definition with key '123456' not found",
@@ -72,15 +79,22 @@ test.describe.parallel('Process Definition Get API', () => {
 
   test('Get Process Definition - Unauthorized', async ({request}) => {
     const res = await request.get(
-      buildUrl(`/process-definitions/${state.processDefinitionKey}`),
+      buildUrl('/process-definitions/{processDefinitionKey}', {
+        processDefinitionKey: state.processDefinitionKey as string,
+      }),
     );
     await assertUnauthorizedRequest(res);
   });
 
   test('Get Process Definition - Invalid Key', async ({request}) => {
-    const res = await request.get(buildUrl(`/process-definitions/invalidKey`), {
-      headers: {...jsonHeaders()},
-    });
+    const res = await request.get(
+      buildUrl('/process-definitions/{processDefinitionKey}', {
+        processDefinitionKey: 'invalidKey',
+      }),
+      {
+        headers: {...jsonHeaders()},
+      },
+    );
     await assertBadRequest(
       res,
       "Failed to convert 'processDefinitionKey' with value: 'invalidKey'",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
@@ -57,9 +57,10 @@ test.describe.parallel('Process Definition Get Start Form API', () => {
   test('Get Process Definition Start Form - Success 200', async ({request}) => {
     await expect(async () => {
       const res = await request.get(
-        buildUrl(
-          `/process-definitions/${state.processDefinitionKey_withLinkedForm}/form`,
-        ),
+        buildUrl('/process-definitions/{processDefinitionKey}/form', {
+          processDefinitionKey:
+            state.processDefinitionKey_withLinkedForm as string,
+        }),
         {headers: jsonHeaders()},
       );
       await assertStatusCode(res, 200);
@@ -85,9 +86,10 @@ test.describe.parallel('Process Definition Get Start Form API', () => {
   }) => {
     await expect(async () => {
       const res = await request.get(
-        buildUrl(
-          `/process-definitions/${state.processDefinitionKey_withEmbeddedForm}/form`,
-        ),
+        buildUrl('/process-definitions/{processDefinitionKey}/form', {
+          processDefinitionKey:
+            state.processDefinitionKey_withEmbeddedForm as string,
+        }),
         {headers: jsonHeaders()},
       );
       await assertStatusCode(res, 204);
@@ -96,7 +98,9 @@ test.describe.parallel('Process Definition Get Start Form API', () => {
 
   test('Get Process Definition Start Form - Not Found', async ({request}) => {
     const res = await request.get(
-      buildUrl(`/process-definitions/123456/form`),
+      buildUrl('/process-definitions/{processDefinitionKey}/form', {
+        processDefinitionKey: '123456',
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -111,14 +115,18 @@ test.describe.parallel('Process Definition Get Start Form API', () => {
     request,
   }) => {
     const res = await request.get(
-      buildUrl(`/process-definitions/${state.processDefinitionKey}/form`),
+      buildUrl('/process-definitions/{processDefinitionKey}/form', {
+        processDefinitionKey: state.processDefinitionKey as string,
+      }),
     );
     await assertUnauthorizedRequest(res);
   });
 
   test('Get Process Definition Start Form - Invalid Key', async ({request}) => {
     const res = await request.get(
-      buildUrl(`/process-definitions/invalidKey/form`),
+      buildUrl('/process-definitions/{processDefinitionKey}/form', {
+        processDefinitionKey: 'invalidKey',
+      }),
       {
         headers: {...jsonHeaders()},
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
@@ -116,7 +116,8 @@ test.describe.parallel('Process Definition Get Start Form API', () => {
   }) => {
     const res = await request.get(
       buildUrl('/process-definitions/{processDefinitionKey}/form', {
-        processDefinitionKey: state.processDefinitionKey as string,
+        processDefinitionKey:
+          state.processDefinitionKey_withLinkedForm as string,
       }),
     );
     await assertUnauthorizedRequest(res);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-statistics-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-statistics-api-tests.spec.ts
@@ -36,7 +36,8 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
     await expect(async () => {
       const res = await request.post(
         buildUrl(
-          `/process-definitions/${state.processDefinitionKey}/statistics/element-instances`,
+          '/process-definitions/{processDefinitionKey}/statistics/element-instances',
+          {processDefinitionKey: state.processDefinitionKey},
         ),
         {
           headers: jsonHeaders(),
@@ -76,7 +77,8 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
   }) => {
     const res = await request.post(
       buildUrl(
-        `/process-definitions/${state.processDefinitionKey}/statistics/element-instances`,
+        '/process-definitions/{processDefinitionKey}/statistics/element-instances',
+        {processDefinitionKey: state.processDefinitionKey},
       ),
       {
         headers: {},
@@ -91,7 +93,10 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-definitions/invalidKey/statistics/element-instances`),
+      buildUrl(
+        '/process-definitions/{processDefinitionKey}/statistics/element-instances',
+        {processDefinitionKey: 'invalidKey'},
+      ),
       {
         headers: jsonHeaders(),
         data: {}, // empty body for basic search
@@ -109,7 +114,8 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
     await expect(async () => {
       const res = await request.post(
         buildUrl(
-          `/process-definitions/${state.processDefinitionKey}/statistics/element-instances`,
+          '/process-definitions/{processDefinitionKey}/statistics/element-instances',
+          {processDefinitionKey: state.processDefinitionKey},
         ),
         {
           headers: jsonHeaders(),
@@ -140,7 +146,8 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
   }) => {
     const res = await request.post(
       buildUrl(
-        `/process-definitions/${state.processDefinitionKey}/statistics/element-instances`,
+        '/process-definitions/{processDefinitionKey}/statistics/element-instances',
+        {processDefinitionKey: state.processDefinitionKey},
       ),
       {
         headers: jsonHeaders(),
@@ -168,7 +175,8 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
     await expect(async () => {
       const res = await request.post(
         buildUrl(
-          `/process-definitions/${state.processDefinitionKey}/statistics/element-instances`,
+          '/process-definitions/{processDefinitionKey}/statistics/element-instances',
+          {processDefinitionKey: state.processDefinitionKey},
         ),
         {
           headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-xml-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-xml-api.spec.ts
@@ -39,7 +39,9 @@ test.describe.parallel('Process Definition Get XML API', () => {
   test('Get Process Definition XML - Success', async ({request}) => {
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/process-definitions/${state.processDefinitionKey}/xml`),
+        buildUrl('/process-definitions/{processDefinitionKey}/xml', {
+          processDefinitionKey: state.processDefinitionKey as string,
+        }),
         {headers: textXMLHeaders()},
       );
 
@@ -50,9 +52,14 @@ test.describe.parallel('Process Definition Get XML API', () => {
   });
 
   test('Get Process Definition XML - Not Found', async ({request}) => {
-    const res = await request.get(buildUrl(`/process-definitions/123456/xml`), {
-      headers: jsonHeaders(),
-    });
+    const res = await request.get(
+      buildUrl('/process-definitions/{processDefinitionKey}/xml', {
+        processDefinitionKey: '123456',
+      }),
+      {
+        headers: jsonHeaders(),
+      },
+    );
     await assertNotFoundRequest(
       res,
       "Process Definition with key '123456' not found",
@@ -61,14 +68,18 @@ test.describe.parallel('Process Definition Get XML API', () => {
 
   test('Get Process Definition XML - Unauthorized', async ({request}) => {
     const res = await request.get(
-      buildUrl(`/process-definitions/${state.processDefinitionKey}/xml`),
+      buildUrl('/process-definitions/{processDefinitionKey}/xml', {
+        processDefinitionKey: state.processDefinitionKey as string,
+      }),
     );
     await assertUnauthorizedRequest(res);
   });
 
   test('Get Process Definition XML - Invalid Key', async ({request}) => {
     const res = await request.get(
-      buildUrl(`/process-definitions/invalidKey/xml`),
+      buildUrl('/process-definitions/{processDefinitionKey}/xml', {
+        processDefinitionKey: 'invalidKey',
+      }),
       {
         headers: {...jsonHeaders()},
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-business-id-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-business-id-api.spec.ts
@@ -271,7 +271,9 @@ test.describe.parallel('Business ID - Uniqueness Enforcement', () => {
     await test.step('Confirm the existing instance is ACTIVE', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/process-instances/${localState['processInstanceKey']}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: localState['processInstanceKey'] as string,
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(res, 200);
@@ -329,9 +331,9 @@ test.describe.parallel('Business ID - Uniqueness Enforcement', () => {
 
     await test.step('Migrate process instance to v2', async () => {
       const res = await request.post(
-        buildUrl(
-          `/process-instances/${localState['processInstanceKey']}/migration`,
-        ),
+        buildUrl('/process-instances/{processInstanceKey}/migration', {
+          processInstanceKey: localState['processInstanceKey'],
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -352,7 +354,9 @@ test.describe.parallel('Business ID - Uniqueness Enforcement', () => {
     await test.step('GET migrated instance — businessId must be retained', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/process-instances/${localState['processInstanceKey']}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: localState['processInstanceKey'],
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(res, 200);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-business-id-api2.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-business-id-api2.spec.ts
@@ -43,9 +43,9 @@ test.describe.parallel('Business ID - GET Response', () => {
     await test.step('GET process instance and verify businessId is returned', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(
-            `${PROCESS_INSTANCE_ENDPOINT}/${localState['processInstanceKey']}`,
-          ),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: localState['processInstanceKey'] as string,
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(res, 200);
@@ -84,9 +84,9 @@ test.describe.parallel('Business ID - GET Response', () => {
     await test.step('GET process instance and verify businessId is null', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(
-            `${PROCESS_INSTANCE_ENDPOINT}/${localState['processInstanceKey']}`,
-          ),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: localState['processInstanceKey'] as string,
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(res, 200);
@@ -130,15 +130,12 @@ test.describe.parallel('Business ID - Search API', () => {
 
     await test.step('Search with businessId filter and verify exactly one result', async () => {
       await expect(async () => {
-        const res = await request.post(
-          buildUrl(`${PROCESS_INSTANCE_ENDPOINT}/search`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {businessId},
-            },
+        const res = await request.post(buildUrl('/process-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {businessId},
           },
-        );
+        });
         await assertStatusCode(res, 200);
         await validateResponse(
           {
@@ -178,17 +175,14 @@ test.describe.parallel('Business ID - Search API', () => {
 
     await test.step('Search and verify businessId field is present in search items', async () => {
       await expect(async () => {
-        const res = await request.post(
-          buildUrl(`${PROCESS_INSTANCE_ENDPOINT}/search`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                processInstanceKey: localState['processInstanceKey'],
-              },
+        const res = await request.post(buildUrl('/process-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: localState['processInstanceKey'],
             },
           },
-        );
+        });
         await assertStatusCode(res, 200);
         await validateResponse(
           {
@@ -215,15 +209,12 @@ test.describe.parallel('Business ID - Search API', () => {
   }) => {
     const nonExistentBusinessId = uniqueBusinessId('no-match');
 
-    const res = await request.post(
-      buildUrl(`${PROCESS_INSTANCE_ENDPOINT}/search`),
-      {
-        headers: jsonHeaders(),
-        data: {
-          filter: {businessId: nonExistentBusinessId},
-        },
+    const res = await request.post(buildUrl('/process-instances/search'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {businessId: nonExistentBusinessId},
       },
-    );
+    });
     await assertStatusCode(res, 200);
     await validateResponse(
       {
@@ -267,20 +258,17 @@ test.describe.parallel('Business ID - Search API', () => {
 
     await test.step('Search sorted by businessId ascending and verify order', async () => {
       await expect(async () => {
-        const res = await request.post(
-          buildUrl(`${PROCESS_INSTANCE_ENDPOINT}/search`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                processInstanceKey: {
-                  $in: [localState['key1'], localState['key2']],
-                },
+        const res = await request.post(buildUrl('/process-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: {
+                $in: [localState['key1'], localState['key2']],
               },
-              sort: [{field: 'businessId', order: 'asc'}],
             },
+            sort: [{field: 'businessId', order: 'asc'}],
           },
-        );
+        });
         await assertStatusCode(res, 200);
         await validateResponse(
           {
@@ -332,18 +320,14 @@ test.describe.parallel('Business ID - Call Activity Propagation', () => {
 
     await test.step('Search for child process instance by parent key', async () => {
       await expect(async () => {
-        const res = await request.post(
-          buildUrl(`${PROCESS_INSTANCE_ENDPOINT}/search`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                parentProcessInstanceKey:
-                  localState['parentProcessInstanceKey'],
-              },
+        const res = await request.post(buildUrl('/process-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              parentProcessInstanceKey: localState['parentProcessInstanceKey'],
             },
           },
-        );
+        });
         await assertStatusCode(res, 200);
         const json = await res.json();
         expect(json.page.totalItems).toBe(1);
@@ -355,9 +339,9 @@ test.describe.parallel('Business ID - Call Activity Propagation', () => {
     await test.step('GET child process instance and verify it inherits businessId', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(
-            `${PROCESS_INSTANCE_ENDPOINT}/${localState['childProcessInstanceKey']}`,
-          ),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: localState['childProcessInstanceKey'] as string,
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(res, 200);
@@ -397,18 +381,14 @@ test.describe.parallel('Business ID - Call Activity Propagation', () => {
 
     await test.step('Search for child process instance by parent key', async () => {
       await expect(async () => {
-        const res = await request.post(
-          buildUrl(`${PROCESS_INSTANCE_ENDPOINT}/search`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                parentProcessInstanceKey:
-                  localState['parentProcessInstanceKey'],
-              },
+        const res = await request.post(buildUrl('/process-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              parentProcessInstanceKey: localState['parentProcessInstanceKey'],
             },
           },
-        );
+        });
         await assertStatusCode(res, 200);
         const json = await res.json();
         expect(json.page.totalItems).toBe(1);
@@ -420,9 +400,9 @@ test.describe.parallel('Business ID - Call Activity Propagation', () => {
     await test.step('GET child process instance and verify businessId is null', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(
-            `${PROCESS_INSTANCE_ENDPOINT}/${localState['childProcessInstanceKey']}`,
-          ),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: localState['childProcessInstanceKey'] as string,
+          }),
           {headers: jsonHeaders()},
         );
         await assertStatusCode(res, 200);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-cancel-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-cancel-api.spec.ts
@@ -44,9 +44,11 @@ test.describe.parallel('Cancel Process instance Tests', () => {
     });
 
     await test.step('Cancel Process Instance', async () => {
-      const processInstanceKey = localState['processInstanceKey'];
+      const processInstanceKey = localState['processInstanceKey'] as string;
       const res = await request.post(
-        buildUrl(`/process-instances/${processInstanceKey}/cancellation`),
+        buildUrl('/process-instances/{processInstanceKey}/cancellation', {
+          processInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -59,7 +61,9 @@ test.describe.parallel('Cancel Process instance Tests', () => {
   test('Cancel Process Instance - Not Found', async ({request}) => {
     const fakeProcessInstanceKey = '2251799813704885';
     const res = await request.post(
-      buildUrl(`/process-instances/${fakeProcessInstanceKey}/cancellation`),
+      buildUrl('/process-instances/{processInstanceKey}/cancellation', {
+        processInstanceKey: fakeProcessInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -76,7 +80,9 @@ test.describe.parallel('Cancel Process instance Tests', () => {
   }) => {
     const invalidProcessInstanceKey = 'invalidKey';
     const res = await request.post(
-      buildUrl(`/process-instances/${invalidProcessInstanceKey}/cancellation`),
+      buildUrl('/process-instances/{processInstanceKey}/cancellation', {
+        processInstanceKey: invalidProcessInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -90,7 +96,9 @@ test.describe.parallel('Cancel Process instance Tests', () => {
 
   test('Cancel Process Instance - Unauthorized', async ({request}) => {
     const res = await request.post(
-      buildUrl(`/process-instances/2251799813704885/cancellation`),
+      buildUrl('/process-instances/{processInstanceKey}/cancellation', {
+        processInstanceKey: '2251799813704885',
+      }),
       {
         // No auth headers
         headers: {
@@ -127,9 +135,11 @@ test.describe.parallel('Cancel Process instance Tests', () => {
     });
 
     await test.step('Then cancel it', async () => {
-      const processInstanceKey = localState['processInstanceKey'];
+      const processInstanceKey = localState['processInstanceKey'] as string;
       const res = await request.post(
-        buildUrl(`/process-instances/${processInstanceKey}/cancellation`),
+        buildUrl('/process-instances/{processInstanceKey}/cancellation', {
+          processInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -139,9 +149,11 @@ test.describe.parallel('Cancel Process instance Tests', () => {
     });
 
     await test.step('Then try to cancel it again', async () => {
-      const processInstanceKey = localState['processInstanceKey'];
+      const processInstanceKey = localState['processInstanceKey'] as string;
       const res = await request.post(
-        buildUrl(`/process-instances/${processInstanceKey}/cancellation`),
+        buildUrl('/process-instances/{processInstanceKey}/cancellation', {
+          processInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
@@ -107,7 +107,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
     await test.step('Verify Process Instance Key to Delete has state COMPLETED', async () => {
       await expect(async () => {
         const response = await request.get(
-          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: processInstanceKeyToDelete,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -156,7 +158,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
     await test.step('Verify process instance is deleted', async () => {
       await expect(async () => {
         const response = await request.get(
-          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: processInstanceKeyToDelete,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -179,7 +183,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
       for (const processInstanceKey of processInstancesToDelete) {
         await expect(async () => {
           const response = await request.get(
-            buildUrl(`/process-instances/${processInstanceKey}`),
+            buildUrl('/process-instances/{processInstanceKey}', {
+              processInstanceKey,
+            }),
             {
               headers: jsonHeaders(),
             },
@@ -230,7 +236,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
       for (const processInstanceKey of processInstancesToDelete) {
         await expect(async () => {
           const response = await request.get(
-            buildUrl(`/process-instances/${processInstanceKey}`),
+            buildUrl('/process-instances/{processInstanceKey}', {
+              processInstanceKey,
+            }),
             {
               headers: jsonHeaders(),
             },
@@ -253,7 +261,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
     await test.step('Verify Process Instance Key to Delete has state ACTIVE', async () => {
       await expect(async () => {
         const response = await request.get(
-          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: processInstanceKeyToDelete,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -298,7 +308,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
     await test.step('Verify the batch operation is completed', async () => {
       await expect(async () => {
         const statusRes = await request.get(
-          buildUrl(`/batch-operations/${batchOperationKey}`),
+          buildUrl('/batch-operations/{batchOperationKey}', {
+            batchOperationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -324,7 +336,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
     await test.step('Verify process instance is still active', async () => {
       await expect(async () => {
         const response = await request.get(
-          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: processInstanceKeyToDelete,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -354,7 +368,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
       for (const processInstanceKey of processInstancesToDelete) {
         await expect(async () => {
           const response = await request.get(
-            buildUrl(`/process-instances/${processInstanceKey}`),
+            buildUrl('/process-instances/{processInstanceKey}', {
+              processInstanceKey,
+            }),
             {
               headers: jsonHeaders(),
             },
@@ -400,7 +416,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
     await test.step('Verify the batch operation is completed', async () => {
       await expect(async () => {
         const statusRes = await request.get(
-          buildUrl(`/batch-operations/${batchOperationKey}`),
+          buildUrl('/batch-operations/{batchOperationKey}', {
+            batchOperationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -427,7 +445,9 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
       for (const processInstanceKey of processInstancesToDelete) {
         await expect(async () => {
           const response = await request.get(
-            buildUrl(`/process-instances/${processInstanceKey}`),
+            buildUrl('/process-instances/{processInstanceKey}', {
+              processInstanceKey,
+            }),
             {
               headers: jsonHeaders(),
             },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
@@ -97,7 +97,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
     await test.step('Verify process instance is listed and complete', async () => {
       await expect(async () => {
         const response = await request.get(
-          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: processInstanceKeyToDelete,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -118,7 +120,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
 
     await test.step('Delete the process instance', async () => {
       const response = await request.post(
-        buildUrl(`/process-instances/${processInstanceKeyToDelete}/deletion`),
+        buildUrl('/process-instances/{processInstanceKey}/deletion', {
+          processInstanceKey: processInstanceKeyToDelete,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -129,7 +133,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
     await test.step('Verify process instance is deleted', async () => {
       await expect(async () => {
         const response = await request.get(
-          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: processInstanceKeyToDelete,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -145,7 +151,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
   test('Delete Single Process Instance - Unauthorized', async ({request}) => {
     const someInstanceKey = '999999999999999';
     const response = await request.post(
-      buildUrl(`/process-instances/${someInstanceKey}/deletion`),
+      buildUrl('/process-instances/{processInstanceKey}/deletion', {
+        processInstanceKey: someInstanceKey,
+      }),
       {
         headers: {},
       },
@@ -159,7 +167,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
     );
     const response = await request.post(
-      buildUrl(`/process-instances/${someInstanceKey}/deletion`),
+      buildUrl('/process-instances/{processInstanceKey}/deletion', {
+        processInstanceKey: someInstanceKey,
+      }),
       {
         headers: jsonHeaders(token), // overrides default demo:demo
       },
@@ -175,7 +185,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
 
     await test.step('Delete the process instance', async () => {
       const response = await request.post(
-        buildUrl(`/process-instances/${someNotExistingInstanceKey}/deletion`),
+        buildUrl('/process-instances/{processInstanceKey}/deletion', {
+          processInstanceKey: someNotExistingInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
         },
@@ -191,7 +203,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
     await test.step('Verify process instance is listed and active', async () => {
       await expect(async () => {
         const response = await request.get(
-          buildUrl(`/process-instances/${activeProcessInstanceKeyToDelete}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey: activeProcessInstanceKeyToDelete,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -212,9 +226,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
 
     await test.step('Try to delete active process instance', async () => {
       const response = await request.post(
-        buildUrl(
-          `/process-instances/${activeProcessInstanceKeyToDelete}/deletion`,
-        ),
+        buildUrl('/process-instances/{processInstanceKey}/deletion', {
+          processInstanceKey: activeProcessInstanceKeyToDelete,
+        }),
         {
           headers: jsonHeaders(),
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-api.spec.ts
@@ -51,9 +51,11 @@ test.describe.parallel('Get Process instance Tests', () => {
 
     await test.step('Get Process Instance', async () => {
       await expect(async () => {
-        const processInstanceKey = localState['processInstanceKey'];
+        const processInstanceKey = localState['processInstanceKey'] as string;
         const res = await request.get(
-          buildUrl(`/process-instances/${processInstanceKey}`),
+          buildUrl('/process-instances/{processInstanceKey}', {
+            processInstanceKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -87,7 +89,9 @@ test.describe.parallel('Get Process instance Tests', () => {
   test('Get Process Instance - Not Found', async ({request}) => {
     const unknownProcessInstanceKey = '9999999999999999';
     const res = await request.get(
-      buildUrl(`/process-instances/${unknownProcessInstanceKey}`),
+      buildUrl('/process-instances/{processInstanceKey}', {
+        processInstanceKey: unknownProcessInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -101,7 +105,9 @@ test.describe.parallel('Get Process instance Tests', () => {
   test('Get Process Instance - Invalid Key', async ({request}) => {
     const invalidProcessInstanceKey = 'invalidKey123';
     const res = await request.get(
-      buildUrl(`/process-instances/${invalidProcessInstanceKey}`),
+      buildUrl('/process-instances/{processInstanceKey}', {
+        processInstanceKey: invalidProcessInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -134,7 +140,9 @@ test.describe.parallel('Get Process instance Tests', () => {
 
     await test.step('Get Process Instance without auth', async () => {
       const authRes = await request.get(
-        buildUrl(`/process-instances/${localState['processInstanceKey']}`),
+        buildUrl('/process-instances/{processInstanceKey}', {
+          processInstanceKey: localState['processInstanceKey'] as string,
+        }),
         {
           // No auth headers
           headers: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-call-hierachy-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-call-hierachy-api.spec.ts
@@ -78,9 +78,9 @@ test.describe.parallel('Get Process Instance Call Hierarchy Tests', () => {
     await test.step('Get Process Instance Call Hierarchy', async () => {
       await expect(async () => {
         const res = await request.get(
-          buildUrl(
-            `/process-instances/${localState['childProcessInstanceKey']}/call-hierarchy`,
-          ),
+          buildUrl('/process-instances/{processInstanceKey}/call-hierarchy', {
+            processInstanceKey: localState['childProcessInstanceKey'] as string,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -118,7 +118,9 @@ test.describe.parallel('Get Process Instance Call Hierarchy Tests', () => {
     request,
   }) => {
     const res = await request.get(
-      buildUrl(`/process-instances/2251799813685249/call-hierarchy`),
+      buildUrl('/process-instances/{processInstanceKey}/call-hierarchy', {
+        processInstanceKey: '2251799813685249',
+      }),
       {
         // No auth headers
         headers: {},
@@ -131,7 +133,9 @@ test.describe.parallel('Get Process Instance Call Hierarchy Tests', () => {
     request,
   }) => {
     const res = await request.get(
-      buildUrl(`/process-instances/2251799813685249/call-hierarchy`),
+      buildUrl('/process-instances/{processInstanceKey}/call-hierarchy', {
+        processInstanceKey: '2251799813685249',
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -146,7 +150,9 @@ test.describe.parallel('Get Process Instance Call Hierarchy Tests', () => {
     request,
   }) => {
     const res = await request.get(
-      buildUrl(`/process-instances/invalid-key/call-hierarchy`),
+      buildUrl('/process-instances/{processInstanceKey}/call-hierarchy', {
+        processInstanceKey: 'invalid-key',
+      }),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-sequenceflows-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-sequenceflows-api.spec.ts
@@ -51,9 +51,9 @@ test.describe.parallel('Get Process instance Sequence Flows Tests', () => {
     await test.step('Get Process Instance Sequence Flows', async () => {
       await expect(async () => {
         const getResponse = await request.get(
-          buildUrl(
-            `/process-instances/${localState['processInstanceKey']}/sequence-flows`,
-          ),
+          buildUrl('/process-instances/{processInstanceKey}/sequence-flows', {
+            processInstanceKey: localState['processInstanceKey'] as string,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -88,7 +88,9 @@ test.describe.parallel('Get Process instance Sequence Flows Tests', () => {
     request,
   }) => {
     const res = await request.get(
-      buildUrl(`/process-instances/2251799813685249/sequence-flows`),
+      buildUrl('/process-instances/{processInstanceKey}/sequence-flows', {
+        processInstanceKey: '2251799813685249',
+      }),
       {
         // No auth headers
       },
@@ -98,7 +100,9 @@ test.describe.parallel('Get Process instance Sequence Flows Tests', () => {
 
   test('Get Process Instance Sequence Flows - No Items', async ({request}) => {
     const res = await request.get(
-      buildUrl(`/process-instances/1111799813685211/sequence-flows`),
+      buildUrl('/process-instances/{processInstanceKey}/sequence-flows', {
+        processInstanceKey: '1111799813685211',
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -120,7 +124,9 @@ test.describe.parallel('Get Process instance Sequence Flows Tests', () => {
     request,
   }) => {
     const res = await request.get(
-      buildUrl(`/process-instances/invalid-key/sequence-flows`),
+      buildUrl('/process-instances/{processInstanceKey}/sequence-flows', {
+        processInstanceKey: 'invalid-key',
+      }),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-statistics-api.spec.ts
@@ -52,7 +52,8 @@ test.describe.parallel('Get Process Instance Statistics Tests', () => {
       await expect(async () => {
         const res = await request.get(
           buildUrl(
-            `/process-instances/${localState['processInstanceKey']}/statistics/element-instances`,
+            '/process-instances/{processInstanceKey}/statistics/element-instances',
+            {processInstanceKey: localState['processInstanceKey'] as string},
           ),
           {
             headers: jsonHeaders(),
@@ -99,7 +100,8 @@ test.describe.parallel('Get Process Instance Statistics Tests', () => {
   test('Get Process Instance Statistics - Unauthorized', async ({request}) => {
     const res = await request.get(
       buildUrl(
-        `/process-instances/2251799813685249/statistics/element-instances`,
+        '/process-instances/{processInstanceKey}/statistics/element-instances',
+        {processInstanceKey: '2251799813685249'},
       ),
       {
         // No auth headers
@@ -114,7 +116,8 @@ test.describe.parallel('Get Process Instance Statistics Tests', () => {
   }) => {
     const res = await request.get(
       buildUrl(
-        `/process-instances/2251799813685249/statistics/element-instances`,
+        '/process-instances/{processInstanceKey}/statistics/element-instances',
+        {processInstanceKey: '2251799813685249'},
       ),
       {
         headers: jsonHeaders(),
@@ -135,7 +138,10 @@ test.describe.parallel('Get Process Instance Statistics Tests', () => {
 
   test('Get Process Instance Statistics - Bad Request', async ({request}) => {
     const res = await request.get(
-      buildUrl(`/process-instances/invalid-key/statistics/element-instances`),
+      buildUrl(
+        '/process-instances/{processInstanceKey}/statistics/element-instances',
+        {processInstanceKey: 'invalid-key'},
+      ),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-migrate-api.spec.ts
@@ -68,9 +68,9 @@ test.describe.serial('Test process instance migrate API', () => {
 
     await test.step('Migrate process instance to version 2', async () => {
       const res = await request.post(
-        buildUrl(
-          `/process-instances/${localState.processInstanceKey}/migration`,
-        ),
+        buildUrl('/process-instances/{processInstanceKey}/migration', {
+          processInstanceKey: localState.processInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -139,9 +139,9 @@ test.describe.serial('Test process instance migrate API', () => {
 
     await test.step('Migrate process instance to version 2 to wrong task type', async () => {
       const res = await request.post(
-        buildUrl(
-          `/process-instances/${localState.processInstanceKey}/migration`,
-        ),
+        buildUrl('/process-instances/{processInstanceKey}/migration', {
+          processInstanceKey: localState.processInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -164,7 +164,9 @@ test.describe.serial('Test process instance migrate API', () => {
   }) => {
     const invalidProcessInstanceKey = 'invalidKey';
     const res = await request.post(
-      buildUrl(`/process-instances/${invalidProcessInstanceKey}/migration`),
+      buildUrl('/process-instances/{processInstanceKey}/migration', {
+        processInstanceKey: invalidProcessInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {},
@@ -181,7 +183,9 @@ test.describe.serial('Test process instance migrate API', () => {
   }) => {
     const processInstanceKey = 2251799813738499;
     const res = await request.post(
-      buildUrl(`/process-instances/${processInstanceKey}/migration`),
+      buildUrl('/process-instances/{processInstanceKey}/migration', {
+        processInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {
@@ -207,7 +211,9 @@ test.describe.serial('Test process instance migrate API', () => {
   }) => {
     const processInstanceKey = 2251799813738499;
     const res = await request.post(
-      buildUrl(`/process-instances/${processInstanceKey}/migration`),
+      buildUrl('/process-instances/{processInstanceKey}/migration', {
+        processInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {
@@ -225,7 +231,9 @@ test.describe.serial('Test process instance migrate API', () => {
   test('Process instance migrate - Unauthorized', async ({request}) => {
     const processInstanceKey = 2251799813704885;
     const res = await request.post(
-      buildUrl(`/process-instances/${processInstanceKey}/migration`),
+      buildUrl('/process-instances/{processInstanceKey}/migration', {
+        processInstanceKey,
+      }),
       {
         // No auth headers
         headers: {
@@ -250,7 +258,9 @@ test.describe.serial('Test process instance migrate API', () => {
   }) => {
     const nonExistingProcessInstanceKey = 2251799813738499;
     const res = await request.post(
-      buildUrl(`/process-instances/${nonExistingProcessInstanceKey}/migration`),
+      buildUrl('/process-instances/{processInstanceKey}/migration', {
+        processInstanceKey: nonExistingProcessInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-modify-process-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-modify-process-api.spec.ts
@@ -81,9 +81,9 @@ test.describe.parallel('Process Instance Modify Process API', () => {
 
     await test.step('Modify process instance', async () => {
       const res = await request.post(
-        buildUrl(
-          `/process-instances/${localStorage['processInstanceKey']}/modification`,
-        ),
+        buildUrl('/process-instances/{processInstanceKey}/modification', {
+          processInstanceKey: localStorage['processInstanceKey'] as string,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -162,9 +162,9 @@ test.describe.parallel('Process Instance Modify Process API', () => {
     });
 
     const res = await request.post(
-      buildUrl(
-        `/process-instances/${localStorage['processInstanceKey']}/modification`,
-      ),
+      buildUrl('/process-instances/{processInstanceKey}/modification', {
+        processInstanceKey: localStorage['processInstanceKey'] as string,
+      }),
       {
         headers: jsonHeaders(),
         data: {
@@ -186,7 +186,9 @@ test.describe.parallel('Process Instance Modify Process API', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-instances/invalidKey/modification`),
+      buildUrl('/process-instances/{processInstanceKey}/modification', {
+        processInstanceKey: 'invalidKey',
+      }),
       {
         headers: jsonHeaders(),
         data: {
@@ -207,7 +209,9 @@ test.describe.parallel('Process Instance Modify Process API', () => {
 
   test('Modify process instance - Unauthorized', async ({request}) => {
     const res = await request.post(
-      buildUrl(`/process-instances/2251799813704885/modification`),
+      buildUrl('/process-instances/{processInstanceKey}/modification', {
+        processInstanceKey: '2251799813704885',
+      }),
       {
         // No auth headers
         headers: {
@@ -228,7 +232,9 @@ test.describe.parallel('Process Instance Modify Process API', () => {
 
   test('Modify process instance - Not Found', async ({request}) => {
     const res = await request.post(
-      buildUrl(`/process-instances/2251799813704885/modification`),
+      buildUrl('/process-instances/{processInstanceKey}/modification', {
+        processInstanceKey: '2251799813704885',
+      }),
       {
         headers: jsonHeaders(),
         data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts
@@ -91,9 +91,9 @@ test.describe.serial('Resolve related incidents API Tests', () => {
         incidentKeys = [];
         elementInstanceKey = '';
         const incidents = await request.post(
-          buildUrl(
-            `/process-instances/${processInstanceKeyWithIncidentToResolve}/incidents/search`,
-          ),
+          buildUrl('/process-instances/{processInstanceKey}/incidents/search', {
+            processInstanceKey: processInstanceKeyWithIncidentToResolve,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -124,7 +124,9 @@ test.describe.serial('Resolve related incidents API Tests', () => {
 
     await test.step('Update element instance variables', async () => {
       const updateRes = await request.put(
-        buildUrl(`/element-instances/${elementInstanceKey}/variables`),
+        buildUrl('/element-instances/{elementInstanceKey}/variables', {
+          elementInstanceKey,
+        }),
         {
           headers: jsonHeaders(),
           data: {
@@ -140,7 +142,8 @@ test.describe.serial('Resolve related incidents API Tests', () => {
     await test.step('Resolve incidents', async () => {
       const resolveRes = await request.post(
         buildUrl(
-          `/process-instances/${processInstanceKeyWithIncidentToResolve}/incident-resolution`,
+          '/process-instances/{processInstanceKey}/incident-resolution',
+          {processInstanceKey: processInstanceKeyWithIncidentToResolve},
         ),
         {
           headers: jsonHeaders(),
@@ -163,7 +166,9 @@ test.describe.serial('Resolve related incidents API Tests', () => {
     await test.step('Poll batch operation until completion', async () => {
       await expect(async () => {
         const statusRes = await request.get(
-          buildUrl(`/batch-operations/${batchOperationKey}`),
+          buildUrl('/batch-operations/{batchOperationKey}', {
+            batchOperationKey,
+          }),
           {
             headers: jsonHeaders(),
           },
@@ -226,9 +231,9 @@ test.describe.serial('Resolve related incidents API Tests', () => {
   }) => {
     const invalidProcessInstanceKey = 'meow';
     const resolveRes = await request.post(
-      buildUrl(
-        `/process-instances/${invalidProcessInstanceKey}/incident-resolution`,
-      ),
+      buildUrl('/process-instances/{processInstanceKey}/incident-resolution', {
+        processInstanceKey: invalidProcessInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -244,9 +249,9 @@ test.describe.serial('Resolve related incidents API Tests', () => {
   }) => {
     const someNotExistingProcessInstanceKey = '123456789';
     const resolveRes = await request.post(
-      buildUrl(
-        `/process-instances/${someNotExistingProcessInstanceKey}/incident-resolution`,
-      ),
+      buildUrl('/process-instances/{processInstanceKey}/incident-resolution', {
+        processInstanceKey: someNotExistingProcessInstanceKey,
+      }),
       {
         headers: {},
       },
@@ -259,9 +264,9 @@ test.describe.serial('Resolve related incidents API Tests', () => {
   }) => {
     const someNotExistingProcessInstanceKey = '123456789';
     const resolveRes = await request.post(
-      buildUrl(
-        `/process-instances/${someNotExistingProcessInstanceKey}/incident-resolution`,
-      ),
+      buildUrl('/process-instances/{processInstanceKey}/incident-resolution', {
+        processInstanceKey: someNotExistingProcessInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -279,9 +284,9 @@ test.describe.serial('Resolve related incidents API Tests', () => {
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
     );
     const resolveRes = await request.post(
-      buildUrl(
-        `/process-instances/${processInstanceKeyWithIncidentToResolve}/incident-resolution`,
-      ),
+      buildUrl('/process-instances/{processInstanceKey}/incident-resolution', {
+        processInstanceKey: processInstanceKeyWithIncidentToResolve,
+      }),
       {
         headers: jsonHeaders(token), // overrides default demo:demo
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-search-incidents-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-search-incidents-api.spec.ts
@@ -63,7 +63,8 @@ test.describe.parallel('Process Instance Search Incidents Tests', () => {
         .expect(async () => {
           const searchResult = await request.post(
             buildUrl(
-              `/process-instances/${processInstanceKey}/incidents/search`,
+              '/process-instances/{processInstanceKey}/incidents/search',
+              {processInstanceKey},
             ),
             {
               headers: jsonHeaders(),
@@ -97,7 +98,9 @@ test.describe.parallel('Process Instance Search Incidents Tests', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-instances/2251799813685249/incidents/search`),
+      buildUrl('/process-instances/{processInstanceKey}/incidents/search', {
+        processInstanceKey: '2251799813685249',
+      }),
       {
         data: {},
       },
@@ -109,7 +112,9 @@ test.describe.parallel('Process Instance Search Incidents Tests', () => {
     request,
   }) => {
     const res = await request.post(
-      buildUrl(`/process-instances/9999999999999/incidents/search`),
+      buildUrl('/process-instances/{processInstanceKey}/incidents/search', {
+        processInstanceKey: '9999999999999',
+      }),
       {
         headers: jsonHeaders(),
         data: {},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -128,7 +128,9 @@ async function createCompletedProcessInstance(request: APIRequestContext) {
   let completedInstance: Record<string, unknown> | undefined;
   await expect(async () => {
     const getRes = await request.get(
-      buildUrl(`/process-instances/${createdInstance.processInstanceKey}`),
+      buildUrl('/process-instances/{processInstanceKey}', {
+        processInstanceKey: createdInstance.processInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-assign-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-assign-api-tests.spec.ts
@@ -37,7 +37,7 @@ test.describe.parallel('Assign User Task Tests', () => {
     );
     const assignee = 'demo';
     const res = await request.post(
-      buildUrl(`/user-tasks/${userTaskKey}/assignment`),
+      buildUrl('/user-tasks/{userTaskKey}/assignment', {userTaskKey}),
       {
         headers: jsonHeaders(),
         data: {
@@ -57,7 +57,7 @@ test.describe.parallel('Assign User Task Tests', () => {
       'CREATED',
     );
     const res = await request.post(
-      buildUrl(`/user-tasks/${userTaskKey}/assignment`),
+      buildUrl('/user-tasks/{userTaskKey}/assignment', {userTaskKey}),
       {
         headers: jsonHeaders(),
         data: {}, // Missing assignee
@@ -73,7 +73,7 @@ test.describe.parallel('Assign User Task Tests', () => {
       'CREATED',
     );
     const res = await request.post(
-      buildUrl(`/user-tasks/${userTaskKey}/assignment`),
+      buildUrl('/user-tasks/{userTaskKey}/assignment', {userTaskKey}),
       {
         // No auth headers
         headers: {
@@ -92,7 +92,9 @@ test.describe.parallel('Assign User Task Tests', () => {
     // so the command reaches the engine and is rejected with NOT_FOUND (404).
     const unknownUserTaskKey = '4503599627370495';
     const res = await request.post(
-      buildUrl(`/user-tasks/${unknownUserTaskKey}/assignment`),
+      buildUrl('/user-tasks/{userTaskKey}/assignment', {
+        userTaskKey: unknownUserTaskKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {
@@ -115,7 +117,9 @@ test.describe.parallel('Assign User Task Tests', () => {
     // of a permanent 404.
     const outOfRangeUserTaskKey = '9999999999999999';
     const res = await request.post(
-      buildUrl(`/user-tasks/${outOfRangeUserTaskKey}/assignment`),
+      buildUrl('/user-tasks/{userTaskKey}/assignment', {
+        userTaskKey: outOfRangeUserTaskKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {
@@ -138,7 +142,7 @@ test.describe.parallel('Assign User Task Tests', () => {
 
     await test.step('First assignment', async () => {
       const res1 = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/assignment`),
+        buildUrl('/user-tasks/{userTaskKey}/assignment', {userTaskKey}),
         {
           headers: jsonHeaders(),
           data: {
@@ -151,7 +155,7 @@ test.describe.parallel('Assign User Task Tests', () => {
 
     await test.step('Second assignment with the same assignee', async () => {
       const res2 = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/assignment`),
+        buildUrl('/user-tasks/{userTaskKey}/assignment', {userTaskKey}),
         {
           headers: jsonHeaders(),
           data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-complete-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-complete-api-tests.spec.ts
@@ -125,7 +125,7 @@ test.describe.parallel('Complete User Task Tests', () => {
       'CREATED',
     );
     const res = await request.post(
-      buildUrl(`/user-tasks/${userTaskKey}/completion`),
+      buildUrl('/user-tasks/{userTaskKey}/completion', {userTaskKey}),
       {
         // No auth headers
         headers: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-get-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-get-api-tests.spec.ts
@@ -34,9 +34,12 @@ test.describe.parallel('Get User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.get(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-    });
+    const res = await request.get(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+      },
+    );
     const responseBody = await res.json();
     validateResponseShape(
       {
@@ -51,7 +54,7 @@ test.describe.parallel('Get User Task Tests', () => {
   test('Get user task - not found', async ({request}) => {
     const unknownUserTaskKey = '9999999999999999';
     const res = await request.get(
-      buildUrl(`/user-tasks/${unknownUserTaskKey}`),
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey: unknownUserTaskKey}),
       {
         headers: jsonHeaders(),
       },
@@ -68,12 +71,15 @@ test.describe.parallel('Get User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.get(buildUrl(`/user-tasks/${userTaskKey}`), {
-      // No auth headers
-      headers: {
-        'Content-Type': 'application/json',
+    const res = await request.get(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        // No auth headers
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
-    });
+    );
     await assertUnauthorizedRequest(res);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-get-form-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-get-form-api-tests.spec.ts
@@ -92,7 +92,7 @@ test.describe.parallel('Get User Task Form Tests', () => {
 
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/user-tasks/${userTaskKey}/form`),
+        buildUrl('/user-tasks/{userTaskKey}/form', {userTaskKey}),
         {
           headers: jsonHeaders(),
         },
@@ -129,7 +129,7 @@ test.describe.parallel('Get User Task Form Tests', () => {
 
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/user-tasks/${userTaskKey}/form`),
+        buildUrl('/user-tasks/{userTaskKey}/form', {userTaskKey}),
         {
           headers: jsonHeaders(),
         },
@@ -147,12 +147,15 @@ test.describe.parallel('Get User Task Form Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.get(buildUrl(`/user-tasks/${userTaskKey}/form`), {
-      // No auth headers
-      headers: {
-        'Content-Type': 'application/json',
+    const res = await request.get(
+      buildUrl('/user-tasks/{userTaskKey}/form', {userTaskKey}),
+      {
+        // No auth headers
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
-    });
+    );
     await assertUnauthorizedRequest(res);
   });
 
@@ -161,7 +164,9 @@ test.describe.parallel('Get User Task Form Tests', () => {
   }) => {
     const invalidUserTaskKey = 'invalidKey';
     const res = await request.get(
-      buildUrl(`/user-tasks/${invalidUserTaskKey}/form`),
+      buildUrl('/user-tasks/{userTaskKey}/form', {
+        userTaskKey: invalidUserTaskKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -178,7 +183,9 @@ test.describe.parallel('Get User Task Form Tests', () => {
     const nonExistingUserTaskKey = '2251799813711183';
     await expect(async () => {
       const res = await request.get(
-        buildUrl(`/user-tasks/${nonExistingUserTaskKey}/form`),
+        buildUrl('/user-tasks/{userTaskKey}/form', {
+          userTaskKey: nonExistingUserTaskKey,
+        }),
         {
           headers: jsonHeaders(),
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-permission-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-permission-api-tests.spec.ts
@@ -67,9 +67,12 @@ test.describe.serial('User Task Permission API - Forbidden', () => {
     );
 
     await expect(async () => {
-      const res = await request.get(buildUrl(`/user-tasks/${userTaskKey}`), {
-        headers: jsonHeaders(userWithoutPermissionsToken),
-      });
+      const res = await request.get(
+        buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+        {
+          headers: jsonHeaders(userWithoutPermissionsToken),
+        },
+      );
       await assertForbiddenRequest(res, READ_FORBIDDEN_DETAIL);
     }).toPass(defaultAssertionOptions);
   });
@@ -85,7 +88,7 @@ test.describe.serial('User Task Permission API - Forbidden', () => {
 
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/assignment`),
+        buildUrl('/user-tasks/{userTaskKey}/assignment', {userTaskKey}),
         {
           headers: jsonHeaders(userWithoutPermissionsToken),
           data: {assignee: userWithoutPermissions.username},
@@ -106,7 +109,7 @@ test.describe.serial('User Task Permission API - Forbidden', () => {
 
     await expect(async () => {
       const res = await request.delete(
-        buildUrl(`/user-tasks/${userTaskKey}/assignee`),
+        buildUrl('/user-tasks/{userTaskKey}/assignee', {userTaskKey}),
         {
           headers: jsonHeaders(userWithoutPermissionsToken),
         },
@@ -125,13 +128,16 @@ test.describe.serial('User Task Permission API - Forbidden', () => {
     );
 
     await expect(async () => {
-      const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-        headers: jsonHeaders(userWithoutPermissionsToken),
-        data: {
-          changeset: {priority: 80},
-          action: 'customUpdate',
+      const res = await request.patch(
+        buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+        {
+          headers: jsonHeaders(userWithoutPermissionsToken),
+          data: {
+            changeset: {priority: 80},
+            action: 'customUpdate',
+          },
         },
-      });
+      );
       await assertForbiddenRequest(res, UPDATE_USER_TASK_FORBIDDEN_DETAIL);
     }).toPass(defaultAssertionOptions);
   });
@@ -147,7 +153,7 @@ test.describe.serial('User Task Permission API - Forbidden', () => {
 
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/completion`),
+        buildUrl('/user-tasks/{userTaskKey}/completion', {userTaskKey}),
         {
           headers: jsonHeaders(userWithoutPermissionsToken),
           data: {},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
@@ -41,7 +41,7 @@ test.describe.parallel('Search User Task Variables Tests', () => {
 
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/variables/search`),
+        buildUrl('/user-tasks/{userTaskKey}/variables/search', {userTaskKey}),
         {
           headers: jsonHeaders(),
           data: {},
@@ -70,7 +70,7 @@ test.describe.parallel('Search User Task Variables Tests', () => {
 
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/variables/search`),
+        buildUrl('/user-tasks/{userTaskKey}/variables/search', {userTaskKey}),
         {
           headers: jsonHeaders(),
           data: {
@@ -105,7 +105,7 @@ test.describe.parallel('Search User Task Variables Tests', () => {
       'CREATED',
     );
     const res = await request.post(
-      buildUrl(`/user-tasks/${userTaskKey}/variables/search`),
+      buildUrl('/user-tasks/{userTaskKey}/variables/search', {userTaskKey}),
       {
         // No auth headers
         headers: {
@@ -125,7 +125,7 @@ test.describe.parallel('Search User Task Variables Tests', () => {
       'CREATED',
     );
     const res = await request.post(
-      buildUrl(`/user-tasks/${userTaskKey}/variables/search`),
+      buildUrl('/user-tasks/{userTaskKey}/variables/search', {userTaskKey}),
       {
         headers: jsonHeaders(),
         data: {
@@ -145,7 +145,9 @@ test.describe.parallel('Search User Task Variables Tests', () => {
   }) => {
     const invalidUserTaskKey = 'invalidKey';
     const res = await request.post(
-      buildUrl(`/user-tasks/${invalidUserTaskKey}/variables/search`),
+      buildUrl('/user-tasks/{userTaskKey}/variables/search', {
+        userTaskKey: invalidUserTaskKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {},
@@ -167,7 +169,7 @@ test.describe.parallel('Search User Task Variables Tests', () => {
     );
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/variables/search`),
+        buildUrl('/user-tasks/{userTaskKey}/variables/search', {userTaskKey}),
         {
           headers: jsonHeaders(),
           data: {
@@ -203,7 +205,7 @@ test.describe.parallel('Search User Task Variables Tests', () => {
     );
     await expect(async () => {
       const res = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/variables/search`),
+        buildUrl('/user-tasks/{userTaskKey}/variables/search', {userTaskKey}),
         {
           headers: jsonHeaders(),
           data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
@@ -39,7 +39,7 @@ test.describe.parallel('Unassign User Task Tests', () => {
 
     await test.step('First assignment', async () => {
       const res1 = await request.post(
-        buildUrl(`/user-tasks/${userTaskKey}/assignment`),
+        buildUrl('/user-tasks/{userTaskKey}/assignment', {userTaskKey}),
         {
           headers: jsonHeaders(),
           data: {
@@ -52,7 +52,7 @@ test.describe.parallel('Unassign User Task Tests', () => {
 
     await test.step('Then unassignment', async () => {
       const res2 = await request.delete(
-        buildUrl(`/user-tasks/${userTaskKey}/assignee`),
+        buildUrl('/user-tasks/{userTaskKey}/assignee', {userTaskKey}),
         {
           headers: jsonHeaders(),
         },
@@ -68,7 +68,7 @@ test.describe.parallel('Unassign User Task Tests', () => {
       'CREATED',
     );
     const res = await request.delete(
-      buildUrl(`/user-tasks/${userTaskKey}/assignee`),
+      buildUrl('/user-tasks/{userTaskKey}/assignee', {userTaskKey}),
       {
         // No auth headers
         headers: {
@@ -84,7 +84,9 @@ test.describe.parallel('Unassign User Task Tests', () => {
     // so the command reaches the engine and is rejected with NOT_FOUND (404).
     const unknownUserTaskKey = '4503599627370495';
     const res = await request.delete(
-      buildUrl(`/user-tasks/${unknownUserTaskKey}/assignee`),
+      buildUrl('/user-tasks/{userTaskKey}/assignee', {
+        userTaskKey: unknownUserTaskKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -107,7 +109,9 @@ test.describe.parallel('Unassign User Task Tests', () => {
     // of a permanent 404.
     const outOfRangeUserTaskKey = '9999999999999999';
     const res = await request.delete(
-      buildUrl(`/user-tasks/${outOfRangeUserTaskKey}/assignee`),
+      buildUrl('/user-tasks/{userTaskKey}/assignee', {
+        userTaskKey: outOfRangeUserTaskKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -122,7 +126,9 @@ test.describe.parallel('Unassign User Task Tests', () => {
   }) => {
     const invalidUserTaskKey = 'invalidKey';
     const res = await request.delete(
-      buildUrl(`/user-tasks/${invalidUserTaskKey}/assignee`),
+      buildUrl('/user-tasks/{userTaskKey}/assignee', {
+        userTaskKey: invalidUserTaskKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -142,7 +148,7 @@ test.describe.parallel('Unassign User Task Tests', () => {
 
     await test.step('First unassignment', async () => {
       const res1 = await request.delete(
-        buildUrl(`/user-tasks/${userTaskKey}/assignee`),
+        buildUrl('/user-tasks/{userTaskKey}/assignee', {userTaskKey}),
         {
           headers: jsonHeaders(),
         },
@@ -152,7 +158,7 @@ test.describe.parallel('Unassign User Task Tests', () => {
 
     await test.step('Second unassignment', async () => {
       const res2 = await request.delete(
-        buildUrl(`/user-tasks/${userTaskKey}/assignee`),
+        buildUrl('/user-tasks/{userTaskKey}/assignee', {userTaskKey}),
         {
           headers: jsonHeaders(),
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-update-api-tests.spec.ts
@@ -64,19 +64,22 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          dueDate: generateFutureDates().dueDate,
-          followUpDate: generateFutureDates().followUpDate,
-          candidateUsers: ['user1', 'user2'],
-          candidateGroups: ['group1', 'group2'],
-          priority: 80,
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            dueDate: generateFutureDates().dueDate,
+            followUpDate: generateFutureDates().followUpDate,
+            candidateUsers: ['user1', 'user2'],
+            candidateGroups: ['group1', 'group2'],
+            priority: 80,
+          },
+          action: 'customUpdate',
         },
-        action: 'customUpdate',
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -88,14 +91,17 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          dueDate: generateFutureDates().dueDate,
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            dueDate: generateFutureDates().dueDate,
+          },
         },
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -107,14 +113,17 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          followUpDate: generateFutureDates().followUpDate,
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            followUpDate: generateFutureDates().followUpDate,
+          },
         },
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -126,14 +135,17 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          candidateUsers: ['user1', 'user2'],
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            candidateUsers: ['user1', 'user2'],
+          },
         },
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -145,14 +157,17 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          candidateGroups: ['group1'],
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            candidateGroups: ['group1'],
+          },
         },
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -164,14 +179,17 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          priority: 10,
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            priority: 10,
+          },
         },
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -183,15 +201,18 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          dueDate: '',
-          followUpDate: '',
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            dueDate: '',
+            followUpDate: '',
+          },
         },
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -203,15 +224,18 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          candidateUsers: [],
-          candidateGroups: [],
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            candidateUsers: [],
+            candidateGroups: [],
+          },
         },
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -223,12 +247,15 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {},
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {},
+        },
       },
-    });
+    );
     await assertInvalidArgument(res, 400, 'changeset');
   });
 
@@ -238,15 +265,18 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          priority: 75,
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            priority: 75,
+          },
+          action: 'myCustomAction',
         },
-        action: 'myCustomAction',
       },
-    });
+    );
     await assertStatusCode(res, 204);
   });
 
@@ -263,7 +293,7 @@ test.describe.parallel('Update User Task Tests', () => {
 
     await test.step('Update the user task', async () => {
       const updateRes = await request.patch(
-        buildUrl(`/user-tasks/${userTaskKey}`),
+        buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
         {
           headers: jsonHeaders(),
           data: {
@@ -281,7 +311,7 @@ test.describe.parallel('Update User Task Tests', () => {
     await test.step('Verify the updated fields via GET', async () => {
       await expect(async () => {
         const getRes = await request.get(
-          buildUrl(`/user-tasks/${userTaskKey}`),
+          buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
           {
             headers: jsonHeaders(),
           },
@@ -303,14 +333,17 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          priority: 101,
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            priority: 101,
+          },
         },
       },
-    });
+    );
     await assertInvalidArgument(res, 400, 'priority');
   });
 
@@ -322,14 +355,17 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      headers: jsonHeaders(),
-      data: {
-        changeset: {
-          priority: -1,
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          changeset: {
+            priority: -1,
+          },
         },
       },
-    });
+    );
     await assertInvalidArgument(res, 400, 'priority');
   });
 
@@ -339,17 +375,20 @@ test.describe.parallel('Update User Task Tests', () => {
       state['processInstanceKey'] as string,
       'CREATED',
     );
-    const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
-      // No auth headers
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: {
-        changeset: {
-          priority: 50,
+    const res = await request.patch(
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
+      {
+        // No auth headers
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {
+          changeset: {
+            priority: 50,
+          },
         },
       },
-    });
+    );
     await assertUnauthorizedRequest(res);
   });
 
@@ -358,7 +397,7 @@ test.describe.parallel('Update User Task Tests', () => {
     // so the command reaches the engine and is rejected with NOT_FOUND (404).
     const unknownUserTaskKey = '4503599627370495';
     const res = await request.patch(
-      buildUrl(`/user-tasks/${unknownUserTaskKey}`),
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey: unknownUserTaskKey}),
       {
         headers: jsonHeaders(),
         data: {
@@ -383,7 +422,9 @@ test.describe.parallel('Update User Task Tests', () => {
     // of a permanent 404.
     const outOfRangeUserTaskKey = '9999999999999999';
     const res = await request.patch(
-      buildUrl(`/user-tasks/${outOfRangeUserTaskKey}`),
+      buildUrl('/user-tasks/{userTaskKey}', {
+        userTaskKey: outOfRangeUserTaskKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {
@@ -414,7 +455,7 @@ test.describe.parallel('Update User Task Tests', () => {
     await test.step('Attempt to update the completed user task', async () => {
       await expect(async () => {
         const updateRes = await request.patch(
-          buildUrl(`/user-tasks/${userTaskKey}`),
+          buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
           {
             headers: jsonHeaders(),
             data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-get-api.spec.ts
@@ -34,9 +34,12 @@ test.describe.parallel('Get Variable API Tests', () => {
     await test.step('Get Variable by key', async () => {
       await expect(async () => {
         const variableKey = localState['variableKey'] as string;
-        const res = await request.get(buildUrl(`/variables/${variableKey}`), {
-          headers: jsonHeaders(),
-        });
+        const res = await request.get(
+          buildUrl('/variables/{variableKey}', {variableKey}),
+          {
+            headers: jsonHeaders(),
+          },
+        );
 
         await assertStatusCode(res, 200);
         await validateResponse(
@@ -63,7 +66,7 @@ test.describe.parallel('Get Variable API Tests', () => {
   test('Get Variable Not Found', async ({request}) => {
     const unknownVariableKey = '9999999999999999';
     const res = await request.get(
-      buildUrl(`/variables/${unknownVariableKey}`),
+      buildUrl('/variables/{variableKey}', {variableKey: unknownVariableKey}),
       {
         headers: jsonHeaders(),
       },
@@ -78,7 +81,7 @@ test.describe.parallel('Get Variable API Tests', () => {
   test('Get Variable Invalid Key', async ({request}) => {
     const invalidVariableKey = 'invalidKey123';
     const res = await request.get(
-      buildUrl(`/variables/${invalidVariableKey}`),
+      buildUrl('/variables/{variableKey}', {variableKey: invalidVariableKey}),
       {
         headers: jsonHeaders(),
       },
@@ -94,7 +97,9 @@ test.describe.parallel('Get Variable API Tests', () => {
 
     await test.step('Get Variable without auth', async () => {
       const res = await request.get(
-        buildUrl(`/variables/${localState['variableKey']}`),
+        buildUrl('/variables/{variableKey}', {
+          variableKey: localState['variableKey'] as string,
+        }),
         {
           headers: {
             'Content-Type': 'application/json',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -654,7 +654,7 @@ test.describe('task details page', () => {
     );
 
     const userTaskRes = await request.get(
-      buildUrl(`/user-tasks/${userTaskKey}`),
+      buildUrl('/user-tasks/{userTaskKey}', {userTaskKey}),
       {headers: jsonHeaders()},
     );
     expect((await userTaskRes.json()).customHeaders).toEqual({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
@@ -25,7 +25,8 @@ export async function createDemoOperations(
     [...new Array(count)].map(async (_, index) => {
       const response = await request.post(
         buildUrl(
-          `/process-instances/${processInstanceKey}/incident-resolution`,
+          '/process-instances/{processInstanceKey}/incident-resolution',
+          {processInstanceKey},
         ),
         {
           ...requestHeaders,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
@@ -84,7 +84,9 @@ export async function grantUserResourceAuthorization(
 
   await expect(async () => {
     const statusRes = await request.get(
-      buildUrl(`/authorizations/${authBody.authorizationKey}`),
+      buildUrl('/authorizations/{authorizationKey}', {
+        authorizationKey: authBody.authorizationKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -147,7 +149,7 @@ export async function expectAuthorizationCanBeFound(
 ) {
   await expect(async () => {
     const statusRes = await request.get(
-      buildUrl(`/authorizations/${authorizationKey}`),
+      buildUrl('/authorizations/{authorizationKey}', {authorizationKey}),
       {
         headers: jsonHeaders(),
       },
@@ -200,7 +202,7 @@ export async function expectAuthorizationCanNotBeFound(
 ) {
   await expect(async () => {
     const statusRes = await request.get(
-      buildUrl(`/authorizations/${authorizationKey}`),
+      buildUrl('/authorizations/{authorizationKey}', {authorizationKey}),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -20,7 +20,9 @@ export async function cancelBatchOperation(
   const result: Record<string, APIResponse> = {};
   await expect(async () => {
     const res = await request.post(
-      buildUrl(`/batch-operations/${batchOperationKey}/cancellation`),
+      buildUrl('/batch-operations/{batchOperationKey}/cancellation', {
+        batchOperationKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -50,7 +52,9 @@ export async function suspendBatchOperation(
   const result: Record<string, unknown> = {};
   await expect(async () => {
     const res = await request.post(
-      buildUrl(`/batch-operations/${batchOperationKey}/suspension`),
+      buildUrl('/batch-operations/{batchOperationKey}/suspension', {
+        batchOperationKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -69,7 +73,9 @@ export async function resumeBatchOperation(
   const result: Record<string, unknown> = {};
   await expect(async () => {
     const res = await request.post(
-      buildUrl(`/batch-operations/${batchOperationKey}/resumption`),
+      buildUrl('/batch-operations/{batchOperationKey}/resumption', {
+        batchOperationKey,
+      }),
       {
         headers: jsonHeaders(),
       },
@@ -86,9 +92,14 @@ export async function createCompletedBatchOperation(
   const key = await createCancellationBatch(request);
 
   await expect(async () => {
-    const res = await request.get(buildUrl(`/batch-operations/${key}`), {
-      headers: jsonHeaders(),
-    });
+    const res = await request.get(
+      buildUrl('/batch-operations/{batchOperationKey}', {
+        batchOperationKey: key,
+      }),
+      {
+        headers: jsonHeaders(),
+      },
+    );
     await assertStatusCode(res, 200);
     await validateResponse(
       {
@@ -115,7 +126,7 @@ export async function expectBatchState(
 ) {
   await expect(async () => {
     const statusRes = await request.get(
-      buildUrl(`/batch-operations/${batchOperationKey}`),
+      buildUrl('/batch-operations/{batchOperationKey}', {batchOperationKey}),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/clock-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/clock-requestHelpers.ts
@@ -24,7 +24,9 @@ export async function createProcessInstanceAndRetrieveTimeStamp(
 
   await expect(async () => {
     const res = await request.get(
-      buildUrl(`/process-instances/${processInstanceKeyToGet}`),
+      buildUrl('/process-instances/{processInstanceKey}', {
+        processInstanceKey: processInstanceKeyToGet,
+      }),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-version-tag-requestHelpers.ts
@@ -190,7 +190,7 @@ export async function resolveIncident(
   incidentKey: string,
 ): Promise<void> {
   const res = await request.post(
-    buildUrl(`/incidents/${incidentKey}/resolution`),
+    buildUrl('/incidents/{incidentKey}/resolution', {incidentKey}),
     {headers: jsonHeaders()},
   );
   await assertStatusCode(res, 204);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -119,7 +119,7 @@ export async function completeJob(
   variables?: Record<string, unknown>,
 ): Promise<void> {
   const completeRes = await request.post(
-    buildUrl(`/jobs/${jobKey}/completion`),
+    buildUrl('/jobs/{jobKey}/completion', {jobKey}),
     {
       headers: jsonHeaders(),
       ...(variables !== undefined && {data: {variables}}),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -206,13 +206,16 @@ export async function failJob(
   retries = 0,
   errorMessage = 'Simulated failure',
 ) {
-  const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
-    headers: jsonHeaders(),
-    data: {
-      retries: retries,
-      errorMessage: errorMessage,
+  const failRes = await request.post(
+    buildUrl('/jobs/{jobKey}/failure', {jobKey}),
+    {
+      headers: jsonHeaders(),
+      data: {
+        retries: retries,
+        errorMessage: errorMessage,
+      },
     },
-  });
+  );
   await assertStatusCode(failRes, 204);
 }
 
@@ -222,13 +225,16 @@ export async function throwErrorForJob(
   errorCode: string,
   errorMessage = 'Simulated error',
 ) {
-  const throwRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
-    headers: jsonHeaders(),
-    data: {
-      errorCode: errorCode,
-      errorMessage: errorMessage,
+  const throwRes = await request.post(
+    buildUrl('/jobs/{jobKey}/error', {jobKey}),
+    {
+      headers: jsonHeaders(),
+      data: {
+        errorCode: errorCode,
+        errorMessage: errorMessage,
+      },
     },
-  });
+  );
   await assertStatusCode(throwRes, 204);
 }
 
@@ -239,7 +245,9 @@ export async function verifyIncidentsForProcessInstance(
 ) {
   return await expect(async () => {
     const res = await request.post(
-      buildUrl(`/process-instances/${processInstanceKey}/incidents/search`),
+      buildUrl('/process-instances/{processInstanceKey}/incidents/search', {
+        processInstanceKey,
+      }),
       {
         headers: jsonHeaders(),
         data: {
@@ -272,7 +280,7 @@ export async function expectProcessInstanceCanBeFound(
 ) {
   await expect(async () => {
     const statusRes = await request.get(
-      buildUrl(`/process-instances/${processInstanceKey}`),
+      buildUrl('/process-instances/{processInstanceKey}', {processInstanceKey}),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-task-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-task-requestHelpers.ts
@@ -71,9 +71,12 @@ export async function completeUserTask(
   userTaskKey: string,
   payload: unknown = {},
 ) {
-  return await request.post(buildUrl(`/user-tasks/${userTaskKey}/completion`), {
-    headers: jsonHeaders(),
-    data: payload,
-    timeout: 60_000,
-  });
+  return await request.post(
+    buildUrl('/user-tasks/{userTaskKey}/completion', {userTaskKey}),
+    {
+      headers: jsonHeaders(),
+      data: payload,
+      timeout: 60_000,
+    },
+  );
 }


### PR DESCRIPTION
Stacked on #60009 — base is that PR's branch, so this diff shows only the migration. GitHub retargets to `main` once #60009 merges.

Closes #59880

## Why

`buildUrl` only validates path parameters it substitutes itself. The guard added in #60009 therefore covers the `{param}` placeholder form and nothing else — call sites that interpolate the value into a template literal bypass it entirely, and an interpolated `undefined` silently yields the literal string `"undefined"` in the path. Same silent-404 failure mode as the old sentinel, just spelled differently.

```ts
buildUrl(`/jobs/${jobKey}/completion`)   ->   buildUrl('/jobs/{jobKey}/completion', {jobKey})
```

This is also the prerequisite for #59888 (typing `buildUrl`'s first argument against a generated union of paths), which needs every first argument to be a literal path template.

## What changed

318 call sites across 58 files. `grep -rn 'buildUrl(\`' utils/ tests/ v2-stateless-tests/ pages/` now returns nothing.

Beyond the plain `${var}` case:

- **Placeholder names come from the OpenAPI path templates** in `zeebe/gateway-protocol/.../v2/rest-api.yaml`, not from the local variable name — so `${processInstanceKeyToDelete}` becomes `'/process-instances/{processInstanceKey}', {processInstanceKey: processInstanceKeyToDelete}`. Every call site for an endpoint now spells the template identically, which is what #59888 needs.
- **Hardcoded key segments move into the params object** too: `/process-instances/2251799813685249/sequence-flows` becomes the template plus `{processInstanceKey: '2251799813685249'}`.
- **`PROCESS_INSTANCE_ENDPOINT` is inlined** at its interpolating call sites in `process-instance-business-id-api2.spec.ts`; a path assembled from a variable cannot carry placeholders. The plain `buildUrl(PROCESS_INSTANCE_ENDPOINT)` uses are untouched.
- **34 `as string` casts added** where the value is read out of a `Record<string, unknown>` test-state map. #60009 narrowed the `params` value type to `string | number`, so these reads no longer type-check implicitly. The interpolation they replace did the same coercion via `String()`, so behaviour is unchanged — but they mark exactly the places where a runtime `undefined` can still reach the guard.

## Verification

Purely mechanical; **no behaviour change intended**. To make that claim checkable rather than asserted, both forms of all 318 migrated call sites were rendered down to a normalised URL skeleton and compared pairwise: **0 differences**. Reformatting in the diff is prettier re-wrapping calls that the longer first argument pushed past 80 columns — every one of the 58 files was already prettier-clean at the base commit, so nothing unrelated got swept in.

Local: `tsc` clean, `npm run lint` green (0 errors; the 199 warnings are pre-existing).

PR CI only lints this suite, so an on-demand run of `c8-orchestration-cluster-e2e-tests-on-demand.yml` is the real gate — result posted as a comment below.

Commits are split by area (helpers, then per resource group) for review.

## Out of scope

#59888 (the codegen itself), #59879, #59889.