### PR TITLE
fix: only run protobuf backwards-compatibility check on PRs and merge queues

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -174,11 +174,14 @@ outputs:
         steps.filter-zeebe.outputs.zeebe-change == 'true'
       }}
   protobuf-changes:
-    description: Output whether any Protobuf files have changed
+    description: >-
+      Output whether the Protobuf backwards-compatibility check should be run based on GitHub event and files changed.
+      Restricted to pull requests and merge queues: the check's breaking-change comparison relies on PR/merge-group
+      context (e.g. a "BREAKING CHANGE:" acknowledgment) that isn't available on a plain push to main/stable.
     value: >-
       ${{
-        github.event_name == 'push' ||
-        (steps.filter-common.outputs.protobuf-change == 'true' && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch')
+        (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
+        steps.filter-common.outputs.protobuf-change == 'true'
       }}
   openapi-changes:
     description: Output whether any C8 OpenAPI code has changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2309,8 +2309,7 @@ jobs:
       # set the comparison based on the type of workflow trigger:
       #   - for PRs, we use the last commit of the base
       #   - for merge queues, we use the last commit of the target merge queue
-      #   - for a push, we use the last commit before the push
-      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
     if: needs.detect-changes.outputs.protobuf-changes == 'true'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
@@ -2329,13 +2328,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
-        # by the default the action will compare against the base branch, or if on push, against the
-        # previous commit
       - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0
         if: |
           !(contains(steps.pr-body.outputs.result, 'BREAKING CHANGE:') ||
-            contains(github.event.merge_group.head_commit.message, 'BREAKING CHANGE:') ||
-            contains(github.event.push.commits.*.message, 'BREAKING CHANGE:'))
+            contains(github.event.merge_group.head_commit.message, 'BREAKING CHANGE:'))
         with:
           format: false
           lint: false


### PR DESCRIPTION
## Summary

`CI: protobuf-checks` was forced to run on every push to main/stable via the `protobuf-changes` filter, regardless of whether protobuf files had actually changed. buf's breaking-change detection relies on PR/merge-group context (a `BREAKING CHANGE:` acknowledgment from the PR body or merge-group commit message) to allow intentional breaking changes through — that context doesn't exist on a plain push. A PR merged with a `BREAKING CHANGE:` note (adding a net-new proto module, #59843) passed on the PR but then failed once the merge commit landed on `main`.

The PR/merge-group check already covers every commit before it reaches main, so re-running it on push adds no coverage — it can only fail there once a change has already been let through.

## Changes

- Restrict the `protobuf-changes` filter output to `pull_request` and `merge_group` triggers. Keeping the decision in the paths-filter action leaves all trigger-and-path gating in one place; the two-trigger allowlist also subsumes the previous explicit `schedule`/`workflow_dispatch` exclusions.
- Expand the output's description to explain why this filter is trigger-restricted, since it now diverges from the "did these files change" shape of its neighbours.
- Drop the now-dead push-only `BASE_SHA` fallback and `BREAKING CHANGE:` branch from the job.

INC-7128