### PR TITLE
test: fix flakiness with BatchOperationIT.shouldFindBatchOperationByState

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -742,7 +742,10 @@ public class BatchOperationIT {
                         .states(BatchOperationState.ACTIVE.name())
                         .build(),
                     BatchOperationSort.of(b -> b),
-                    SearchQueryPage.of(b -> b.from(0).size(10))));
+                    // need to make sure we request a large enough page size otherwise we might not
+                    // get the batch operation we just created if there are many other batch
+                    // operations in the database (created by the other tests)
+                    SearchQueryPage.of(b -> b.from(0).size(1000))));
 
     assertThat(searchResult).isNotNull();
     assertThat(searchResult.items()).isNotEmpty();


### PR DESCRIPTION
the other tests are potentially creating multiple ACTIVE batch operations, so we need to ensure we request a large enough batch to guarantee we get the record we are after.
