### PR TITLE
fix: surface not-reproduced outcome correctly in job summary and Slack

### DIFF
--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -119,9 +119,13 @@ DISPATCHABLE_SURFACES = frozenset(
 IGNORED_JOB_PREFIXES = ("Observe Helm chart Integration Tests status",)
 
 #: Literal prefixes, deliberately stopping before the first `${{`, matched
-#: against the trailing segment of a (possibly nested) job name.
-_SURFACE_PREFIXES: tuple[tuple[str, str], ...] = (
-    ("Playwright e2e after install", SURFACE_SM_E2E),
+#: against the trailing segment of a (possibly nested) job name. An entry may
+#: be a compiled regex instead of a literal string when the interpolated job
+#: name has a rendered value (not just an unrendered `${{ }}`) in the middle
+#: of the fragment being matched, e.g. `${{ matrix.suite }}` in the SM e2e job
+#: name (camunda-platform-helm#6841) — a plain prefix can't skip over that.
+_SURFACE_PREFIXES: tuple[tuple[str | re.Pattern[str], str], ...] = (
+    (re.compile(r"^Playwright e2e .*after install\b"), SURFACE_SM_E2E),
     ("Trigger SaaS E2E tests", SURFACE_SAAS_E2E),
     ("install for install on", SURFACE_HELM_INSTALL),
     ("Cleanup - install on", SURFACE_HELM_CLEANUP),
@@ -153,7 +157,10 @@ def surface_for_job(job_name: str) -> str | None:
             return None
 
     for prefix, surface in _SURFACE_PREFIXES:
-        if leaf.startswith(prefix):
+        if isinstance(prefix, re.Pattern):
+            if prefix.match(leaf):
+                return surface
+        elif leaf.startswith(prefix):
             return surface
 
     if _FRONTEND_BUILD_RE.match(leaf):

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -86,6 +86,34 @@ def test_unrendered_template_job_name_still_matches_prefix():
     assert classify.surface_for_job(name) == classify.SURFACE_SM_E2E
 
 
+def test_sm_e2e_job_name_with_matrix_suite_maps_to_sm_surface():
+    # camunda-platform-helm#6841 inserted `${{ matrix.suite }}` between "e2e"
+    # and "after install" to run a named suite (e.g. the alwaysgreen scenario's
+    # "full" suite), rendering e.g. run 31684711833's failing job. A plain
+    # `startswith("Playwright e2e after install")` stops matching this and the
+    # job silently drops out of triage with no evidence and no fix agent run.
+    name = (
+        "Helm chart Integration Tests / agrn - install - gke / "
+        "Playwright e2e full after install - install on gke - agrn (1 of 1)"
+    )
+    assert classify.surface_for_job(name) == classify.SURFACE_SM_E2E
+
+    smoke_name = name.replace("full after install", "smoke after install")
+    assert classify.surface_for_job(smoke_name) == classify.SURFACE_SM_E2E
+
+
+def test_unrendered_matrix_suite_job_name_still_matches_prefix():
+    # The unrendered form of `${{ matrix.suite }}` itself contains spaces, so
+    # a `\S+`-based fix for the case above would regress this one.
+    name = (
+        "Helm chart Integration Tests / agrn - install - gke / "
+        "Playwright e2e ${{ matrix.suite }} after install - "
+        "${{ inputs.flow }} on ${{ inputs.distro-platform }} - "
+        "${{ inputs.shortname }}"
+    )
+    assert classify.surface_for_job(name) == classify.SURFACE_SM_E2E
+
+
 def test_observe_status_job_is_ignored():
     assert classify.surface_for_job("Observe Helm chart Integration Tests status") is None
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -641,12 +641,13 @@ jobs:
             icon=":white_check_mark:"
             summary="$(printf '%s\n' "${lines[@]}")"
             [ "$JOB_STATUS" = "failure" ] && summary="${summary} _(post-processing failed — see run)_"
-          elif [ "$JOB_STATUS" = "failure" ]; then
-            icon=":x:"; summary="Agent failed (no fix applied)"
           elif [ "$verify" = "not-reproduced" ]; then
             icon=":grey_question:"
             summary="Not reproduced against a live Docker environment — likely a flake, or already fixed"
             [ -n "$note" ] && summary="${summary}: ${note}"
+            [ "$JOB_STATUS" = "failure" ] && summary="${summary}"$'\n'"_(post-processing failed — see run)_"
+          elif [ "$JOB_STATUS" = "failure" ]; then
+            icon=":x:"; summary="Agent failed (no fix applied)"
           elif [ "$category" = "not-determined" ]; then
             icon=":question:"; summary="Could not determine a fix — manual investigation required"
           else

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -494,9 +494,16 @@ jobs:
             else
               pr_count=$(jq '.prs | length' /tmp/fix-meta.json)
               if [ "$pr_count" -eq 0 ]; then
-                echo ":warning: **Decision: no fix applied** — agent could not determine a safe fix."
-                # Surface root_cause from the empty-prs object if the agent wrote one
-                reason=$(jq -r '.reason // .root_cause // ""' /tmp/fix-meta.json 2>/dev/null || true)
+                verify=$(jq -r '.verify // ""' /tmp/fix-meta.json 2>/dev/null || true)
+                if [ "$verify" = "not-reproduced" ]; then
+                  echo ":grey_question: **Decision: not reproduced** — the dispatched failure(s) did not reproduce against a live Docker environment (Live Docker Verify). Likely a flake, or already fixed."
+                else
+                  echo ":warning: **Decision: no fix applied** — agent could not determine a safe fix."
+                fi
+                # Surface an explanation from whichever field the agent wrote --
+                # .reason/.root_cause for the classic no-fix case, .note for a
+                # Live Docker Verify not-reproduced/skipped outcome.
+                reason=$(jq -r '.reason // .root_cause // .note // ""' /tmp/fix-meta.json 2>/dev/null || true)
                 if [ -n "$reason" ] && [ "$reason" != "null" ]; then
                   echo ""
                   echo "**Reason:** ${reason}"
@@ -578,9 +585,13 @@ jobs:
           prs_json="[]"
           pbugs_json="[]"
           category=""
+          verify=""
+          note=""
           if [ -f /tmp/fix-meta.json ]; then
             prs_json=$(jq -c '.prs // []' /tmp/fix-meta.json 2>/dev/null || echo '[]')
             category=$(jq -r '.category // ""' /tmp/fix-meta.json 2>/dev/null || echo "")
+            verify=$(jq -r '.verify // ""' /tmp/fix-meta.json 2>/dev/null || echo "")
+            note=$(jq -r '.note // ""' /tmp/fix-meta.json 2>/dev/null || echo "")
             # Accept product_bugs (array) and/or a singular product_bug (object).
             pbugs_json=$(jq -c '(.product_bugs // []) + (if .product_bug then [.product_bug] else [] end)' /tmp/fix-meta.json 2>/dev/null || echo '[]')
           fi
@@ -632,6 +643,10 @@ jobs:
             [ "$JOB_STATUS" = "failure" ] && summary="${summary} _(post-processing failed — see run)_"
           elif [ "$JOB_STATUS" = "failure" ]; then
             icon=":x:"; summary="Agent failed (no fix applied)"
+          elif [ "$verify" = "not-reproduced" ]; then
+            icon=":grey_question:"
+            summary="Not reproduced against a live Docker environment — likely a flake, or already fixed"
+            [ -n "$note" ] && summary="${summary}: ${note}"
           elif [ "$category" = "not-determined" ]; then
             icon=":question:"; summary="Could not determine a fix — manual investigation required"
           else


### PR DESCRIPTION
## Summary

Follow-up to #59965 (Live Docker Verify), caught by actually dispatching the
fix agent for real for the first time after that PR merged.

I dispatched [run 31609701262](https://github.com/camunda/camunda/actions/runs/31609701262)
against `main` with 4 real test_specs from an already-fixed nightly failure
(the suspend/resume UI failure from #59921), specifically to see the new
Live Docker Verify instructions actually get read and followed for real. They
were: the agent called `scripts/start-verify-env.sh es v2`, ran the four
specs unmodified as the reproduce gate, all four passed, and it correctly
wrote `"verify": "not-reproduced"` with a detailed `"note"` — no duplicate PR.

But the job summary and Slack notification both only ever checked the older
product-bug-escalation `category` field, so this genuinely-correct outcome
rendered as the generic ":warning: no fix applied — agent could not
determine a safe fix" (job summary) / "No fix applied — manual investigation
required" (Slack) — reading like a failure when the agent had done exactly
the right thing.

## Fix

Read `verify` alongside `category` in both places:
- `verify == "not-reproduced"` gets its own distinct, accurate message in
  both the job summary and Slack.
- The job summary's reason lookup now falls back to `note` (not just
  `reason`/`root_cause`), so the agent's actual explanation surfaces instead
  of being silently dropped.

## Test plan

- [x] `actionlint` + YAML parse clean.
- [x] Simulated both fixed branches locally against the real
  `fix-meta.json` downloaded from run 31609701262 — job summary now prints
  `:grey_question: Decision: not reproduced` with the agent's full note,
  instead of the previous generic warning.