### PR TITLE
Restore service alignments

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -58,6 +58,7 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.RuntimeBackupServices;
 import io.camunda.service.SecretServices;
 import io.camunda.service.SignalServices;
+import io.camunda.service.TenantRestoreEnvironment;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TopologyServices;
 import io.camunda.service.UsageMetricsServices;
@@ -175,6 +176,13 @@ public class CamundaServicesConfiguration {
                           tenantSecurity.getInitialization(),
                           tenantSecurity.getCompiledIdValidationPattern(),
                           tenantSecurity.getCompiledGroupIdValidationPattern()));
+
+              // -- per-tenant restore environment: which backup store this tenant runs and
+              // whether it takes continuous backups, both deployment-time choices --
+              final var restoreEnvironment =
+                  new TenantRestoreEnvironment(
+                      tenantConfig.getData().getSecondaryStorage().getType().name(),
+                      tenantConfig.getData().getPrimaryStorage().getBackup().isContinuous());
 
               // -- per-tenant process cache --
               final var processCacheConfig = tenantConfig.getApi().getRest().getProcessCache();
@@ -445,7 +453,8 @@ public class CamundaServicesConfiguration {
                           authorizationChecker,
                           tenantSecurity.getAuthorizations(),
                           executor,
-                          converter))
+                          converter,
+                          restoreEnvironment))
                   .resourceServices(
                       tenantId,
                       new ResourceServices(

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -24,7 +24,9 @@ import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryProvider;
 import io.camunda.zeebe.restore.validation.RestoreValidator;
@@ -239,11 +241,8 @@ public class RestoreApp implements ApplicationRunner {
     final var restoreRequest =
         new RestoreRequest(
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-            backupIds,
-            fromStr,
-            toStr,
-            databaseType,
-            continuousBackups,
+            new TenantRestoreArguments(
+                new RestoreParameters(backupIds, fromStr, toStr), databaseType, continuousBackups),
             false);
     final var partitionCount = camunda.getCluster().getPartitionCount();
     final RestoreValidator validator =

--- a/service/src/main/java/io/camunda/service/RecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/RecoveryServices.java
@@ -21,7 +21,9 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -45,6 +47,7 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
   private final AuthorizationChecker authorizationChecker;
   private final AuthorizationsConfiguration authorizationsConfig;
+  private final TenantRestoreEnvironment tenantRestoreEnvironment;
 
   public RecoveryServices(
       final String physicalTenantId,
@@ -54,7 +57,8 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
       final AuthorizationChecker authorizationChecker,
       final AuthorizationsConfiguration authorizationsConfig,
       final ApiServicesExecutorProvider executorProvider,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final TenantRestoreEnvironment tenantRestoreEnvironment) {
     super(
         physicalTenantId,
         brokerClient,
@@ -64,6 +68,7 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
     this.clusterConfigurationRequestSender = clusterConfigurationRequestSender;
     this.authorizationChecker = authorizationChecker;
     this.authorizationsConfig = authorizationsConfig;
+    this.tenantRestoreEnvironment = tenantRestoreEnvironment;
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> changeMode(
@@ -77,11 +82,24 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> restore(
-      final RestoreRequest restoreRequest, final CamundaAuthentication authentication) {
+      final RestoreParameters parameters,
+      final boolean dryRun,
+      final CamundaAuthentication authentication) {
     return withAnyPermission(
         RESTORE_AUTHORIZATIONS,
         authentication,
-        () -> clusterConfigurationRequestSender.restore(restoreRequest));
+        () -> clusterConfigurationRequestSender.restore(toRestoreRequest(parameters, dryRun)));
+  }
+
+  private RestoreRequest toRestoreRequest(
+      final RestoreParameters parameters, final boolean dryRun) {
+    return new RestoreRequest(
+        getPhysicalTenantId(),
+        new TenantRestoreArguments(
+            parameters,
+            tenantRestoreEnvironment.databaseType(),
+            tenantRestoreEnvironment.continuousBackups()),
+        dryRun);
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfiguration>> restoreStatus(

--- a/service/src/main/java/io/camunda/service/TenantRestoreEnvironment.java
+++ b/service/src/main/java/io/camunda/service/TenantRestoreEnvironment.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The restore inputs a physical tenant contributes from its own secondary-storage configuration
+ * rather than from the request body: which backup store it runs, so the validator can apply the
+ * right rules, and whether it takes continuous backups, so a time-range restore is accepted.
+ *
+ * <p>Backup store choice is a per-tenant deployment decision, not a per-request one, so this is
+ * resolved once per physical tenant at startup — see {@code CamundaServicesConfiguration}, which
+ * binds it from that tenant's {@code Camunda} configuration — and handed to {@link
+ * RecoveryServices} and {@link ClusterRecoveryServices} rather than read from the process-wide
+ * {@code Environment} on every request.
+ */
+@NullMarked
+public record TenantRestoreEnvironment(String databaseType, boolean continuousBackups) {}

--- a/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
@@ -30,7 +30,9 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
@@ -59,6 +61,9 @@ public class RecoveryServicesTest {
   private static final String RESTORE_FORBIDDEN_MESSAGE =
       "Unauthorized to perform operation 'RESTORE' on resource 'BACKUP'";
 
+  private static final TenantRestoreEnvironment RESTORE_ENVIRONMENT =
+      new TenantRestoreEnvironment("elasticsearch", false);
+
   private RecoveryServices services;
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender =
       mock(ClusterConfigurationManagementRequestSender.class);
@@ -79,7 +84,8 @@ public class RecoveryServicesTest {
             authorizationChecker,
             authorizationsConfig,
             mock(ApiServicesExecutorProvider.class),
-            mock(BrokerRequestAuthorizationConverter.class));
+            mock(BrokerRequestAuthorizationConverter.class),
+            RESTORE_ENVIRONMENT);
   }
 
   @ParameterizedTest
@@ -206,19 +212,25 @@ public class RecoveryServicesTest {
   }
 
   @Test
-  public void shouldForwardRestoreRequestUnchanged() {
-    // given
-    final var request =
-        new RestoreRequest(
-            PHYSICAL_TENANT_ID, List.of(100L, 101L), null, null, "elasticsearch", false, false);
+  public void shouldStampItsBoundRestoreEnvironmentIntoTheRequest() {
+    // given — the tenant's own database type and continuous-backups flag, not a global default
+    final var parameters = new RestoreParameters(List.of(100L, 101L), null, null);
     stubRestoreSuccess();
 
     // when
-    final var future = services.restore(request, authentication);
+    final var future = services.restore(parameters, false, authentication);
 
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
-    verify(clusterConfigurationRequestSender).restore(request);
+    verify(clusterConfigurationRequestSender)
+        .restore(
+            new RestoreRequest(
+                PHYSICAL_TENANT_ID,
+                new TenantRestoreArguments(
+                    parameters,
+                    RESTORE_ENVIRONMENT.databaseType(),
+                    RESTORE_ENVIRONMENT.continuousBackups()),
+                false));
   }
 
   @Test
@@ -227,7 +239,7 @@ public class RecoveryServicesTest {
     stubRestoreSuccess();
 
     // when
-    final var future = services.restore(restoreRequest(), authentication);
+    final var future = services.restore(restoreParameters(), false, authentication);
 
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
@@ -241,7 +253,7 @@ public class RecoveryServicesTest {
     stubRestoreSuccess();
 
     // when
-    final var future = services.restore(restoreRequest(), authentication);
+    final var future = services.restore(restoreParameters(), false, authentication);
 
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
@@ -256,7 +268,7 @@ public class RecoveryServicesTest {
         .thenReturn(Collections.emptySet());
 
     // when
-    final var future = services.restore(restoreRequest(), authentication);
+    final var future = services.restore(restoreParameters(), false, authentication);
 
     // then
     assertForbidden(future, RESTORE_FORBIDDEN_MESSAGE);
@@ -270,7 +282,7 @@ public class RecoveryServicesTest {
     grant(AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
 
     // when
-    final var future = services.restore(restoreRequest(), authentication);
+    final var future = services.restore(restoreParameters(), false, authentication);
 
     // then
     assertForbidden(future, RESTORE_FORBIDDEN_MESSAGE);
@@ -285,7 +297,7 @@ public class RecoveryServicesTest {
         .thenReturn(Collections.emptySet());
 
     // when
-    final var future = services.restore(restoreRequest(), authentication);
+    final var future = services.restore(restoreParameters(), false, authentication);
 
     // then
     assertThat(future)
@@ -304,7 +316,7 @@ public class RecoveryServicesTest {
         .thenReturn(CompletableFuture.completedFuture(Either.left(rejection)));
 
     // when
-    final var future = services.restore(restoreRequest(), authentication);
+    final var future = services.restore(restoreParameters(), false, authentication);
 
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
@@ -384,9 +396,8 @@ public class RecoveryServicesTest {
     assertThat(future.join().getLeft()).isEqualTo(rejection);
   }
 
-  private static RestoreRequest restoreRequest() {
-    return new RestoreRequest(
-        PHYSICAL_TENANT_ID, List.of(100L), null, null, "elasticsearch", false, false);
+  private static RestoreParameters restoreParameters() {
+    return new RestoreParameters(List.of(100L), null, null);
   }
 
   private CurrentClusterConfiguration stubTopologySuccess() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -200,14 +200,12 @@ public sealed interface ClusterConfigurationManagementRequest {
     }
   }
 
-  record RestoreRequest(
-      String physicalTenantId,
-      List<Long> backupIds,
-      @Nullable String from,
-      @Nullable String to,
-      String databaseType,
-      boolean continuousBackups,
-      boolean dryRun)
+  record RestoreParameters(List<Long> backupIds, @Nullable String from, @Nullable String to) {}
+
+  record TenantRestoreArguments(
+      RestoreParameters parameters, String databaseType, boolean continuousBackups) {}
+
+  record RestoreRequest(String physicalTenantId, TenantRestoreArguments arguments, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record RestoreResolvedRequest(Map<Integer, long[]> backups, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -30,7 +30,9 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
@@ -1641,39 +1643,63 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodeRestoreRequest(final RestoreRequest request) {
-    final var builder = Requests.RestoreRequest.newBuilder();
-    builder.setPhysicalTenantId(request.physicalTenantId());
-    builder.addAllBackupIds(request.backupIds());
-    builder.setDatabaseType(request.databaseType());
-    builder.setContinuousBackups(request.continuousBackups());
-    builder.setDryRun(request.dryRun());
-    if (request.from() != null) {
-      builder.setFrom(request.from());
-    }
-    if (request.to() != null) {
-      builder.setTo(request.to());
-    }
-
-    return builder.build().toByteArray();
+    return Requests.RestoreRequest.newBuilder()
+        .setPhysicalTenantId(request.physicalTenantId())
+        .setArguments(encodeRestoreArguments(request.arguments()))
+        .setDryRun(request.dryRun())
+        .build()
+        .toByteArray();
   }
 
   @Override
   public RestoreRequest decodeRestoreRequest(final byte[] encodedRequest) {
     try {
       final var request = Requests.RestoreRequest.parseFrom(encodedRequest);
-      final String from = request.hasFrom() ? request.getFrom() : null;
-      final String to = request.hasTo() ? request.getTo() : null;
       return new RestoreRequest(
           request.getPhysicalTenantId(),
-          request.getBackupIdsList(),
-          from,
-          to,
-          request.getDatabaseType(),
-          request.getContinuousBackups(),
+          decodeRestoreArguments(request.getArguments()),
           request.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }
+  }
+
+  private static Requests.RestoreArguments encodeRestoreArguments(
+      final TenantRestoreArguments arguments) {
+    return Requests.RestoreArguments.newBuilder()
+        .setParameters(encodeRestoreParameters(arguments.parameters()))
+        .setDatabaseType(arguments.databaseType())
+        .setContinuousBackups(arguments.continuousBackups())
+        .build();
+  }
+
+  private static TenantRestoreArguments decodeRestoreArguments(
+      final Requests.RestoreArguments arguments) {
+    return new TenantRestoreArguments(
+        decodeRestoreParameters(arguments.getParameters()),
+        arguments.getDatabaseType(),
+        arguments.getContinuousBackups());
+  }
+
+  private static Requests.RestoreParameters encodeRestoreParameters(
+      final RestoreParameters parameters) {
+    final var builder =
+        Requests.RestoreParameters.newBuilder().addAllBackupIds(parameters.backupIds());
+    if (parameters.from() != null) {
+      builder.setFrom(parameters.from());
+    }
+    if (parameters.to() != null) {
+      builder.setTo(parameters.to());
+    }
+    return builder.build();
+  }
+
+  private static RestoreParameters decodeRestoreParameters(
+      final Requests.RestoreParameters parameters) {
+    return new RestoreParameters(
+        parameters.getBackupIdsList(),
+        parameters.hasFrom() ? parameters.getFrom() : null,
+        parameters.hasTo() ? parameters.getTo() : null);
   }
 
   private static Mode toMode(final Requests.Mode mode) {

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -144,14 +144,22 @@ message CancelTopologyChangeRequest {
   int64 changeId = 1;
 }
 
-message RestoreRequest {
+message RestoreParameters {
   repeated int64 backupIds = 1;
   optional string from = 2;
   optional string to = 3;
-  string databaseType = 4;
-  bool continuousBackups = 5;
-  bool dryRun = 6;
-  string physicalTenantId = 7;
+}
+
+message RestoreArguments {
+  RestoreParameters parameters = 1;
+  string databaseType = 2;
+  bool continuousBackups = 3;
+}
+
+message RestoreRequest {
+  string physicalTenantId = 1;
+  RestoreArguments arguments = 2;
+  bool dryRun = 3;
 }
 
 message TopologyChangeResponse {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -27,8 +27,10 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestsHandler;
@@ -146,7 +148,12 @@ final class NewModelManagementApiEndpointsTest {
           public Either<Exception, RestoreResolvedRequest> validate(final RestoreRequest request) {
             return Either.right(
                 new RestoreResolvedRequest(
-                    Map.of(1, request.backupIds().stream().mapToLong(l -> l).toArray()), false));
+                    Map.of(
+                        1,
+                        request.arguments().parameters().backupIds().stream()
+                            .mapToLong(l -> l)
+                            .toArray()),
+                    false));
           }
         });
 
@@ -647,11 +654,8 @@ final class NewModelManagementApiEndpointsTest {
         handler.restore(
             new RestoreRequest(
                 PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                List.of(100L),
-                null,
-                null,
-                "elasticsearch",
-                false,
+                new TenantRestoreArguments(
+                    new RestoreParameters(List.of(100L), null, null), "elasticsearch", false),
                 true));
 
     // then — accepted, because toLegacyDefault projects the member back to RECOVERING
@@ -670,11 +674,10 @@ final class NewModelManagementApiEndpointsTest {
                     .restore(
                         new RestoreRequest(
                             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                            List.of(100L),
-                            null,
-                            null,
-                            "elasticsearch",
-                            false,
+                            new TenantRestoreArguments(
+                                new RestoreParameters(List.of(100L), null, null),
+                                "elasticsearch",
+                                false),
                             false))
                     .join())
         .hasMessageContaining("recovery mode");

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
@@ -23,8 +23,10 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -839,11 +841,8 @@ abstract class ClusterConfigurationManagementApiTestBase {
     final var request =
         new RestoreRequest(
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-            List.of(100L, 101L),
-            null,
-            null,
-            "elasticsearch",
-            false,
+            new TenantRestoreArguments(
+                new RestoreParameters(List.of(100L, 101L), null, null), "elasticsearch", false),
             false);
 
     // when
@@ -860,11 +859,8 @@ abstract class ClusterConfigurationManagementApiTestBase {
     final var request =
         new RestoreRequest(
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-            List.of(100L),
-            null,
-            null,
-            "elasticsearch",
-            false,
+            new TenantRestoreArguments(
+                new RestoreParameters(List.of(100L), null, null), "elasticsearch", false),
             false);
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandlerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandlerTest.java
@@ -15,7 +15,9 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeResult;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -41,11 +43,8 @@ final class ClusterConfigurationManagementRequestsHandlerTest {
   private static RestoreRequest restoreRequest(final boolean dryRun) {
     return new RestoreRequest(
         PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-        List.of(1L),
-        null,
-        null,
-        "elasticsearch",
-        false,
+        new TenantRestoreArguments(
+            new RestoreParameters(List.of(1L), null, null), "elasticsearch", false),
         dryRun);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
@@ -11,8 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InternalError;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
@@ -44,11 +46,8 @@ final class RestoreRequestTransformerTest {
   private static RestoreRequest restoreRequest() {
     return new RestoreRequest(
         PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-        List.of(1L),
-        null,
-        null,
-        "elasticsearch",
-        false,
+        new TenantRestoreArguments(
+            new RestoreParameters(List.of(1L), null, null), "elasticsearch", false),
         false);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RequestValidatorRegistryTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RequestValidatorRegistryTest.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.dynamic.config.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestValidator;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
@@ -25,11 +27,8 @@ final class RequestValidatorRegistryTest {
   private static RestoreRequest restoreRequest() {
     return new RestoreRequest(
         PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-        List.of(1L),
-        null,
-        null,
-        "elasticsearch",
-        false,
+        new TenantRestoreArguments(
+            new RestoreParameters(List.of(1L), null, null), "elasticsearch", false),
         false);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -14,8 +14,6 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.registry.ServiceRegistry;
-import io.camunda.spring.utils.DatabaseTypeUtils;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus.BrokerRestoreStatus;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus.PartitionRestoreStatus;
@@ -28,12 +26,10 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import java.time.Instant;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,20 +41,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 public final class RecoveryController {
 
   private static final Logger LOG = LoggerFactory.getLogger(RecoveryController.class);
-  private static final String CONTINUOUS_BACKUPS_PROPERTY =
-      "camunda.data.primary-storage.backup.continuous";
 
   private final ServiceRegistry serviceRegistry;
   private final CamundaAuthenticationProvider authenticationProvider;
-  private final Environment environment;
 
   public RecoveryController(
       final ServiceRegistry serviceRegistry,
-      final CamundaAuthenticationProvider authenticationProvider,
-      final Environment environment) {
+      final CamundaAuthenticationProvider authenticationProvider) {
     this.serviceRegistry = serviceRegistry;
     this.authenticationProvider = authenticationProvider;
-    this.environment = environment;
   }
 
   @CamundaPatchMapping(
@@ -88,12 +79,12 @@ public final class RecoveryController {
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
     LOG.info("Requested restore for physical tenant {}: {}", physicalTenantId, restoreRequest);
     final var authentication = authenticationProvider.getCamundaAuthentication();
-    final var request = toRestoreRequest(physicalTenantId, restoreRequest, dryRun);
+    final var parameters = RestoreRequestMapper.toRestoreParameters(restoreRequest);
     return RequestExecutor.executeServiceMethod(
         () ->
             serviceRegistry
                 .recoveryServices(physicalTenantId)
-                .restore(request, authentication)
+                .restore(parameters, dryRun, authentication)
                 .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
         ClusterModeChangeMapper::toClusterModeChangeResponse,
         HttpStatus.ACCEPTED);
@@ -113,29 +104,6 @@ public final class RecoveryController {
                 .thenApply(RecoveryController::restoreStatus),
         RecoveryController::mapRestoreStatus,
         HttpStatus.OK);
-  }
-
-  private RestoreRequest toRestoreRequest(
-      final String physicalTenantId,
-      final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest,
-      final boolean dryRun) {
-    final String databaseType = DatabaseTypeUtils.getDatabaseTypeOrDefault(environment);
-    final boolean continuousBackups =
-        environment.getProperty(CONTINUOUS_BACKUPS_PROPERTY, Boolean.class, false);
-    if (restoreRequest == null) {
-      return new RestoreRequest(
-          physicalTenantId, List.of(), null, null, databaseType, continuousBackups, dryRun);
-    }
-    final List<Long> backupIds =
-        restoreRequest.getBackupIds() == null ? List.of() : restoreRequest.getBackupIds();
-    return new RestoreRequest(
-        physicalTenantId,
-        backupIds,
-        restoreRequest.getFrom(),
-        restoreRequest.getTo(),
-        databaseType,
-        continuousBackups,
-        dryRun);
   }
 
   private static RestoreStatus restoreStatus(final ClusterConfiguration configuration) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RestoreRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RestoreRequestMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.protocol.model.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Maps the backup selection of a REST restore request onto the cluster configuration request,
+ * shared by the per-physical-tenant {@link RecoveryController} and the cluster-wide {@link
+ * ClusterRecoveryController}.
+ */
+@NullMarked
+final class RestoreRequestMapper {
+
+  private RestoreRequestMapper() {}
+
+  /** An absent request selects no backups, leaving the choice to the validator of the tenant. */
+  static RestoreParameters toRestoreParameters(final @Nullable RestoreRequest restoreRequest) {
+    if (restoreRequest == null) {
+      return new RestoreParameters(List.of(), null, null);
+    }
+    return new RestoreParameters(
+        restoreRequest.getBackupIds() == null ? List.of() : restoreRequest.getBackupIds(),
+        restoreRequest.getFrom(),
+        restoreRequest.getTo());
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -14,7 +14,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.gateway.protocol.model.RestoreBrokerStatus;
 import io.camunda.gateway.protocol.model.RestorePartitionStatus;
 import io.camunda.gateway.protocol.model.RestoreStatusResponse;
@@ -23,7 +22,7 @@ import io.camunda.service.RecoveryServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
@@ -49,7 +48,6 @@ import java.util.Optional;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -57,7 +55,6 @@ import org.mockito.Mockito;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 
@@ -75,8 +72,8 @@ public class RecoveryControllerTest extends RestControllerTest {
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
   }
 
-  private void stubValidationSuccess() {
-    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
+  private void stubRestoreAccepted() {
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
         .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse(0L, List.of()))));
   }
 
@@ -192,7 +189,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   @Test
   void shouldRejectRestoreWhenCallerIsNotAuthorized() {
     // given
-    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.createForbiddenException(BACKUP_RESTORE_AUTHORIZATION)));
@@ -222,7 +219,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   @Test
   void shouldMapInvalidRequestErrorFromCoordinator() {
     // given
-    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(new ErrorResponse(ErrorCode.INVALID_REQUEST, "bad params"))));
@@ -241,7 +238,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   @Test
   void shouldMapInternalErrorFromCoordinator() {
     // given
-    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(new ErrorResponse(ErrorCode.INTERNAL_ERROR, "boom"))));
@@ -260,7 +257,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   @Test
   void shouldMapConcurrentModificationFromCoordinator() {
     // given
-    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.any()))
+    Mockito.when(recoveryServices.restore(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(new ErrorResponse(ErrorCode.CONCURRENT_MODIFICATION, "boom"))));
@@ -478,202 +475,87 @@ public class RecoveryControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(configuration)));
   }
 
-  @Nested
-  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=elasticsearch"})
-  class Elasticsearch extends SecondaryStorage {
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+  void shouldForwardBackupIds(final String baseUrl) {
+    // given
+    stubRestoreAccepted();
 
-    @Override
-    String expectedDatabaseType() {
-      return "elasticsearch";
-    }
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100, 101]}")
+        .exchange()
+        .expectStatus()
+        .isAccepted()
+        .expectBody()
+        .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
+
+    Mockito.verify(recoveryServices)
+        .restore(eq(new RestoreParameters(List.of(100L, 101L), null, null)), eq(false), any());
   }
 
-  @Nested
-  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=opensearch"})
-  class OpenSearch extends SecondaryStorage {
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+  void shouldForwardNoParameters(final String baseUrl) {
+    // given
+    stubRestoreAccepted();
 
-    @Override
-    String expectedDatabaseType() {
-      return "opensearch";
-    }
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+
+    Mockito.verify(recoveryServices)
+        .restore(eq(new RestoreParameters(List.of(), null, null)), eq(false), any());
   }
 
-  @Nested
-  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=rdbms"})
-  class Rdbms extends SecondaryStorage {
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+  void shouldForwardTimeRange(final String baseUrl) {
+    // given
+    stubRestoreAccepted();
 
-    @Override
-    String expectedDatabaseType() {
-      return "rdbms";
-    }
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"from\": \"2024-01-01T10:00:00Z\", \"to\": \"2024-01-01T12:00:00Z\"}")
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+
+    Mockito.verify(recoveryServices)
+        .restore(
+            eq(new RestoreParameters(List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z")),
+            eq(false),
+            any());
   }
 
-  @Nested
-  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=none"})
-  class None extends SecondaryStorage {
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+  void shouldForwardDryRun(final String baseUrl) {
+    // given
+    stubRestoreAccepted();
 
-    @Override
-    String expectedDatabaseType() {
-      return "none";
-    }
-  }
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl + "?dryRun=true")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100]}")
+        .exchange()
+        .expectStatus()
+        .isAccepted();
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.data.secondary-storage.type=rdbms",
-        "camunda.data.primary-storage.backup.continuous=true"
-      })
-  class RdbmsWithContinuousBackups extends RdbmsSecondaryStorageWithContinuousBackups {
-
-    @Override
-    String expectedDatabaseType() {
-      return "rdbms";
-    }
-  }
-
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.data.secondary-storage.type=none",
-        "camunda.data.primary-storage.backup.continuous=true"
-      })
-  class NoneWithContinuousBackups extends RdbmsSecondaryStorageWithContinuousBackups {
-
-    @Override
-    String expectedDatabaseType() {
-      return "none";
-    }
-  }
-
-  abstract class SecondaryStorage {
-
-    abstract String expectedDatabaseType();
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardBackupIds(final String baseUrl) {
-      // given
-      stubValidationSuccess();
-
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .bodyValue("{\"backupIds\": [100, 101]}")
-          .exchange()
-          .expectStatus()
-          .isAccepted()
-          .expectBody()
-          .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
-
-      Mockito.verify(recoveryServices)
-          .restore(
-              eq(
-                  new RestoreRequest(
-                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                      List.of(100L, 101L),
-                      null,
-                      null,
-                      expectedDatabaseType(),
-                      false,
-                      false)),
-              any());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardNoParameters(final String baseUrl) {
-      // given
-      stubValidationSuccess();
-
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .exchange()
-          .expectStatus()
-          .isAccepted();
-
-      Mockito.verify(recoveryServices)
-          .restore(
-              eq(
-                  new RestoreRequest(
-                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                      List.of(),
-                      null,
-                      null,
-                      expectedDatabaseType(),
-                      false,
-                      false)),
-              any());
-    }
-  }
-
-  abstract class RdbmsSecondaryStorageWithContinuousBackups {
-
-    abstract String expectedDatabaseType();
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardContinuousFlagWithBackupIds(final String baseUrl) {
-      // given
-      stubValidationSuccess();
-
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .bodyValue("{\"backupIds\": [100, 101]}")
-          .exchange()
-          .expectStatus()
-          .isAccepted();
-
-      Mockito.verify(recoveryServices)
-          .restore(
-              eq(
-                  new RestoreRequest(
-                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                      List.of(100L, 101L),
-                      null,
-                      null,
-                      expectedDatabaseType(),
-                      true,
-                      false)),
-              any());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardContinuousFlagWithTimeRange(final String baseUrl) {
-      // given
-      stubValidationSuccess();
-
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .bodyValue("{\"from\": \"2024-01-01T10:00:00Z\", \"to\": \"2024-01-01T12:00:00Z\"}")
-          .exchange()
-          .expectStatus()
-          .isAccepted();
-
-      Mockito.verify(recoveryServices)
-          .restore(
-              eq(
-                  new RestoreRequest(
-                      PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-                      List.of(),
-                      "2024-01-01T10:00:00Z",
-                      "2024-01-01T12:00:00Z",
-                      expectedDatabaseType(),
-                      true,
-                      false)),
-              any());
-    }
+    Mockito.verify(recoveryServices)
+        .restore(eq(new RestoreParameters(List.of(100L), null, null)), eq(true), any());
   }
 }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/RestoreValidator.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/RestoreValidator.java
@@ -97,19 +97,20 @@ public final class RestoreValidator
 
   @VisibleForTesting
   void validateParameters(final RestoreRequest request) {
-    final var instantFrom = parseTimestamp(request.from(), "from");
-    final var instantTo = parseTimestamp(request.to(), "to");
+    final var parameters = request.arguments().parameters();
+    final var instantFrom = parseTimestamp(parameters.from(), "from");
+    final var instantTo = parseTimestamp(parameters.to(), "to");
     final var hasTimeRange = hasTimeRange(instantFrom, instantTo);
-    final var hasBackupIds = !request.backupIds().isEmpty();
+    final var hasBackupIds = !parameters.backupIds().isEmpty();
     Preconditions.test(
         hasBackupIds && hasTimeRange,
         "Cannot specify both backupId and from/to parameters. Choose one approach.");
 
-    final var databaseType = request.databaseType().toLowerCase();
+    final var databaseType = request.arguments().databaseType().toLowerCase();
     switch (databaseType) {
       case "rdbms", "none" -> {
         Preconditions.test(
-            hasTimeRange && !request.continuousBackups(),
+            hasTimeRange && !request.arguments().continuousBackups(),
             "Time range restore (from/to) is only supported for continuous backups.");
 
         Preconditions.test(
@@ -128,18 +129,20 @@ public final class RestoreValidator
             "Time range restore (from/to) is not supported for %s.".formatted(databaseType));
         Preconditions.test(!hasBackupIds, "No backupId specified");
         Preconditions.test(
-            request.backupIds().size() > 1,
+            parameters.backupIds().size() > 1,
             "Cannot restore from multiple backups against database type %s"
                 .formatted(databaseType));
       }
       default ->
-          throw new IllegalStateException("Invalid database type: " + request.databaseType());
+          throw new IllegalStateException(
+              "Invalid database type: " + request.arguments().databaseType());
     }
   }
 
   private Map<Integer, long[]> resolveBackups(final RestoreRequest request) {
-    if (!request.backupIds().isEmpty()) {
-      return resolveBackupsByPartition(request.backupIds());
+    final var backupIds = request.arguments().parameters().backupIds();
+    if (!backupIds.isEmpty()) {
+      return resolveBackupsByPartition(backupIds);
     }
     return resolveRdbmsRangeBackups(request);
   }
@@ -197,8 +200,8 @@ public final class RestoreValidator
   }
 
   private RestorableBackups findBackups(final RestoreRequest request) {
-    final Instant instantTo = parseTimestamp(request.to(), "to");
-    final Instant instantFrom = parseTimestamp(request.from(), "from");
+    final Instant instantTo = parseTimestamp(request.arguments().parameters().to(), "to");
+    final Instant instantFrom = parseTimestamp(request.arguments().parameters().from(), "from");
     final var exportedPositions =
         exportedPositionSupplier == null
             ? null

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreParameterValidatorTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreParameterValidatorTest.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.restore.validation;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import java.time.Instant;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
@@ -40,7 +42,10 @@ final class RestoreParameterValidatorTest {
       final String databaseType,
       final boolean continuousBackups) {
     return new RestoreRequest(
-        "default", backupIds, from, to, databaseType, continuousBackups, false);
+        "default",
+        new TenantRestoreArguments(
+            new RestoreParameters(backupIds, from, to), databaseType, continuousBackups),
+        false);
   }
 
   @Test

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
@@ -25,8 +25,10 @@ import io.camunda.zeebe.backup.common.BackupMetadata;
 import io.camunda.zeebe.backup.common.BackupMetadata.CheckpointEntry;
 import io.camunda.zeebe.backup.common.BackupMetadata.RangeEntry;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.util.Either;
 import java.time.Instant;
@@ -164,7 +166,11 @@ final class RestoreValidatorResolverTest {
   }
 
   private static RestoreRequest rdbmsRequest(final String databaseType, final boolean dryRun) {
-    return new RestoreRequest("default", List.of(), null, null, databaseType, false, dryRun);
+    return new RestoreRequest(
+        "default",
+        new TenantRestoreArguments(
+            new RestoreParameters(List.of(), null, null), databaseType, false),
+        dryRun);
   }
 
   private static BackupMetadata singleCheckpointMetadata(final int partitionId) {
@@ -232,7 +238,12 @@ final class RestoreValidatorResolverTest {
       final var validator = new RestoreValidator(1, backupStore, exportedPositionSupplier);
       final var request =
           new RestoreRequest(
-              "default", List.of(), CHECKPOINT_TIMESTAMP.toString(), null, "rdbms", true, false);
+              "default",
+              new TenantRestoreArguments(
+                  new RestoreParameters(List.of(), CHECKPOINT_TIMESTAMP.toString(), null),
+                  "rdbms",
+                  true),
+              false);
 
       // when
       final var result = validator.validate(request);
@@ -249,7 +260,12 @@ final class RestoreValidatorResolverTest {
       final var validator = new RestoreValidator(1, backupStore, exportedPositionSupplier);
       final var request =
           new RestoreRequest(
-              "default", List.of(), null, CHECKPOINT_TIMESTAMP.toString(), "rdbms", true, false);
+              "default",
+              new TenantRestoreArguments(
+                  new RestoreParameters(List.of(), null, CHECKPOINT_TIMESTAMP.toString()),
+                  "rdbms",
+                  true),
+              false);
 
       // when
       final var result = validator.validate(request);
@@ -267,11 +283,13 @@ final class RestoreValidatorResolverTest {
       final var request =
           new RestoreRequest(
               "default",
-              List.of(),
-              CHECKPOINT_TIMESTAMP.toString(),
-              CHECKPOINT_TIMESTAMP.plusSeconds(3600).toString(),
-              "rdbms",
-              true,
+              new TenantRestoreArguments(
+                  new RestoreParameters(
+                      List.of(),
+                      CHECKPOINT_TIMESTAMP.toString(),
+                      CHECKPOINT_TIMESTAMP.plusSeconds(3600).toString()),
+                  "rdbms",
+                  true),
               false);
 
       // when
@@ -414,7 +432,11 @@ final class RestoreValidatorResolverTest {
       stubBackupExists(42L);
       final var validator = new RestoreValidator(3, backupStore, null);
       final var request =
-          new RestoreRequest("default", List.of(42L), null, null, "rdbms", false, false);
+          new RestoreRequest(
+              "default",
+              new TenantRestoreArguments(
+                  new RestoreParameters(List.of(42L), null, null), "rdbms", false),
+              false);
 
       // when
       final var result = validator.validate(request);
@@ -430,7 +452,11 @@ final class RestoreValidatorResolverTest {
       stubNoBackupExists();
       final var validator = new RestoreValidator(2, backupStore, null);
       final var request =
-          new RestoreRequest("default", List.of(42L), null, null, "rdbms", false, false);
+          new RestoreRequest(
+              "default",
+              new TenantRestoreArguments(
+                  new RestoreParameters(List.of(42L), null, null), "rdbms", false),
+              false);
 
       // when / then
       final var result = validator.validate(request);
@@ -449,7 +475,11 @@ final class RestoreValidatorResolverTest {
       stubBackupExists(2, 1L);
       final var validator = new RestoreValidator(2, backupStore, null);
       final var request =
-          new RestoreRequest("default", List.of(1L), null, null, databaseType, false, false);
+          new RestoreRequest(
+              "default",
+              new TenantRestoreArguments(
+                  new RestoreParameters(List.of(1L), null, null), databaseType, false),
+              false);
 
       // when
       final var result = validator.validate(request);
@@ -464,7 +494,11 @@ final class RestoreValidatorResolverTest {
       // given
       final var validator = new RestoreValidator(2, backupStore, null);
       final var request =
-          new RestoreRequest("default", List.of(1L, 2L), null, null, databaseType, false, false);
+          new RestoreRequest(
+              "default",
+              new TenantRestoreArguments(
+                  new RestoreParameters(List.of(1L, 2L), null, null), databaseType, false),
+              false);
 
       // when
       final var result = validator.validate(request);
@@ -482,7 +516,11 @@ final class RestoreValidatorResolverTest {
       stubBackupMissing(2, 1L);
       final var validator = new RestoreValidator(2, backupStore, null);
       final var request =
-          new RestoreRequest("default", List.of(1L), null, null, "elasticsearch", false, false);
+          new RestoreRequest(
+              "default",
+              new TenantRestoreArguments(
+                  new RestoreParameters(List.of(1L), null, null), "elasticsearch", false),
+              false);
 
       // when
       final var result = validator.validate(request);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Preparation work for the ClusterAdmin restore operation. Simplified the proto operations for the RestoreRequest and it's required arguments so that it can be reused in the future by the cluster admin restore related operations.

Introduces the `TenantRestoreEnvironment`, which supplied the PT environment requirements for the restore operation to proceed.

BREAKING CHANGE: Proto request re-arrangement of the restore operations, not yet releases so accepted.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to: #59537
