### PR TITLE
fix: bridge Helm chart's Identity config in Optimize's CSL compatibility bridge

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -158,7 +158,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     // all-or-nothing on the issuer-uri: withhold both credentials rather than trade a login problem
     // for a boot failure. Mirrors bridgeAuth0SaasOrgAndCluster's all-or-nothing precedent below.
     if (!derived.containsKey(OIDC_PREFIX + "issuer-uri")
-        && env.getProperty(OIDC_PREFIX + "issuer-uri") == null) {
+        && isBlank(env.getProperty(OIDC_PREFIX + "issuer-uri"))) {
       final String clientId = env.getProperty("camunda.identity.clientId");
       final String clientSecret = env.getProperty("CAMUNDA_IDENTITY_CLIENT_SECRET");
       if (!isBlank(clientId) || !isBlank(clientSecret)) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -38,7 +38,10 @@ import org.springframework.core.env.MapPropertySource;
  * <p>Bridges the CCSM (Identity) and CCSaaS (Auth0) OIDC registrations from their {@code
  * CAMUNDA_OPTIMIZE_IDENTITY_*} / {@code CAMUNDA_OPTIMIZE_AUTH0_*} / {@code
  * CAMUNDA_OPTIMIZE_CLIENT_*} env-var interface (the {@code ${...}} placeholders in {@code
- * service-config.yaml}).
+ * service-config.yaml}), or from the {@code camunda.identity.issuer} / {@code
+ * camunda.identity.clientId} / {@code camunda.identity.audience} / {@code
+ * CAMUNDA_IDENTITY_CLIENT_SECRET} config surface the official {@code camunda-platform} Helm chart's
+ * Optimize ConfigMap renders instead.
  *
  * <p>Every recognised legacy key logs a deprecation warning naming its {@code camunda.security.*}
  * replacement (or, for obsolete keys, stating that it no longer has any effect). Legacy keys stay
@@ -120,8 +123,19 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     }
   }
 
-  // OIDC / Identity (CCSM), from the CAMUNDA_OPTIMIZE_IDENTITY_* env vars. Skipped when Auth0 is
+  // OIDC / Identity (CCSM), from the CAMUNDA_OPTIMIZE_IDENTITY_* env vars, or — when those are
+  // unset, as with the official camunda-platform Helm chart's Optimize ConfigMap — from the
+  // camunda.identity.* structured config it renders instead (application-ccsm.yaml) plus the
+  // CAMUNDA_IDENTITY_CLIENT_SECRET env var it uses for the secret. Skipped when Auth0 is
   // configured (the two modes are mutually exclusive, cloud wins) to avoid a mixed registration.
+  //
+  // Deliberately NOT bridged: camunda.identity.issuerBackendUrl. CSL has a single issuer-uri, used
+  // for OIDC discovery AND for validating each token's iss claim against the discovery document's
+  // issuer field. Keycloak reports the same externally-configured issuer regardless of which URL
+  // was dialed to reach it, so pointing issuer-uri at the backend-reachable URL would make
+  // discovery fail (issuer mismatch) instead of fixing reachability. camunda.identity.issuer (the
+  // browser-facing one) is the correct, and only, source for issuer-uri — mirroring the existing
+  // CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL precedent, which never bridged _ISSUER_BACKEND_URL either.
   private void bridgeIdentityOidc(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
     if (isAuth0Configured(env)) {
@@ -131,6 +145,10 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", OIDC_PREFIX + "client-secret");
+    mapIfAbsentAndPresent(env, derived, "camunda.identity.issuer", OIDC_PREFIX + "issuer-uri");
+    mapIfAbsentAndPresent(env, derived, "camunda.identity.clientId", OIDC_PREFIX + "client-id");
+    mapIfAbsentAndPresent(
+        env, derived, "CAMUNDA_IDENTITY_CLIENT_SECRET", OIDC_PREFIX + "client-secret");
   }
 
   // OIDC / Auth0 (CCSaaS cloud), from the CAMUNDA_OPTIMIZE_AUTH0_* / CAMUNDA_OPTIMIZE_CLIENT_* env
@@ -348,6 +366,22 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
       derived.putIfAbsent(cslKey, value);
       warnDeprecated(legacyKey, cslKey);
     }
+  }
+
+  // Bridges a legacy key into a CSL property, but only if no higher-priority legacy key has
+  // already supplied a value for the same CSL property. Without this, docker-compose CCSM
+  // installs that already set CAMUNDA_OPTIMIZE_IDENTITY_* would get a second, confusing
+  // deprecation warning for the identical value Optimize's own application-ccsm.yaml mirrors into
+  // camunda.identity.* automatically (an internal resource-file detail, not an operator choice).
+  private void mapIfAbsentAndPresent(
+      final ConfigurableEnvironment env,
+      final Map<String, Object> derived,
+      final String legacyKey,
+      final String cslKey) {
+    if (derived.containsKey(cslKey)) {
+      return;
+    }
+    mapIfPresent(env, derived, legacyKey, cslKey);
   }
 
   // Auth0 issuer URI is https://<domain>/ (trailing slash required for OIDC discovery). Accepts a

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -136,6 +136,10 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   // discovery fail (issuer mismatch) instead of fixing reachability. camunda.identity.issuer (the
   // browser-facing one) is the correct, and only, source for issuer-uri — mirroring the existing
   // CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL precedent, which never bridged _ISSUER_BACKEND_URL either.
+  //
+  // Also deliberately NOT bridged: camunda.identity.clientSecret, the config-file secret key that
+  // application-ccsm.yaml also declares — the official Helm chart never renders it, only the
+  // CAMUNDA_IDENTITY_CLIENT_SECRET env var, which is the only secret-carrying key bridged here.
   private void bridgeIdentityOidc(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
     if (isAuth0Configured(env)) {
@@ -145,10 +149,32 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", OIDC_PREFIX + "client-secret");
-    mapIfAbsentAndPresent(env, derived, "camunda.identity.issuer", OIDC_PREFIX + "issuer-uri");
-    mapIfAbsentAndPresent(env, derived, "camunda.identity.clientId", OIDC_PREFIX + "client-id");
-    mapIfAbsentAndPresent(
-        env, derived, "CAMUNDA_IDENTITY_CLIENT_SECRET", OIDC_PREFIX + "client-secret");
+    mapIfCslKeyUnset(env, derived, "camunda.identity.issuer", OIDC_PREFIX + "issuer-uri");
+
+    // The Helm chart's Optimize ConfigMap can legitimately render clientId/CAMUNDA_IDENTITY_
+    // CLIENT_SECRET while leaving camunda.identity.issuer blank. Bridging a client-id/secret with
+    // no issuer-uri (and no authorization-uri/token-uri/jwk-set-uri) makes CSL's
+    // ScopedClientRegistrationFactory throw IllegalStateException at startup, so this bridge is
+    // all-or-nothing on the issuer-uri: withhold both credentials rather than trade a login problem
+    // for a boot failure. Mirrors bridgeAuth0SaasOrgAndCluster's all-or-nothing precedent below.
+    if (!derived.containsKey(OIDC_PREFIX + "issuer-uri")
+        && env.getProperty(OIDC_PREFIX + "issuer-uri") == null) {
+      final String clientId = env.getProperty("camunda.identity.clientId");
+      final String clientSecret = env.getProperty("CAMUNDA_IDENTITY_CLIENT_SECRET");
+      if (!isBlank(clientId) || !isBlank(clientSecret)) {
+        LOG.warn(
+            "Optimize config 'camunda.identity.clientId'/'CAMUNDA_IDENTITY_CLIENT_SECRET' cannot"
+                + " be bridged without an OIDC issuer: 'camunda.identity.issuer' is blank and no"
+                + " 'camunda.security.authentication.oidc.issuer-uri' is set explicitly."
+                + " 'camunda.identity.issuerBackendUrl' cannot substitute for it (OIDC discovery"
+                + " would fail against it, see the Javadoc above). Leaving the OIDC client"
+                + " unconfigured rather than failing Optimize startup with a missing issuer.");
+      }
+      return;
+    }
+
+    mapIfCslKeyUnset(env, derived, "camunda.identity.clientId", OIDC_PREFIX + "client-id");
+    mapIfCslKeyUnset(env, derived, "CAMUNDA_IDENTITY_CLIENT_SECRET", OIDC_PREFIX + "client-secret");
   }
 
   // OIDC / Auth0 (CCSaaS cloud), from the CAMUNDA_OPTIMIZE_AUTH0_* / CAMUNDA_OPTIMIZE_CLIENT_* env
@@ -294,7 +320,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   private void addClientIdAsAudience(
       final ConfigurableEnvironment env, final Set<String> audiences) {
     final String clientId = env.getProperty("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID");
-    if (clientId != null && !clientId.isBlank()) {
+    if (!isBlank(clientId)) {
       audiences.add(clientId.trim());
     }
   }
@@ -302,14 +328,10 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   private void addAudience(
       final ConfigurableEnvironment env, final Set<String> audiences, final String legacyKey) {
     final String value = env.getProperty(legacyKey);
-    if (value != null && !value.isBlank()) {
+    if (!isBlank(value)) {
       audiences.add(value.trim());
       warnDeprecated(legacyKey, OIDC_PREFIX + "audiences");
     }
-  }
-
-  private static boolean isBlank(final String value) {
-    return value == null || value.isBlank();
   }
 
   // HSTS max-age: negative disables the header in CSL.
@@ -374,7 +396,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
       final String legacyKey,
       final String cslKey) {
     final String value = env.getProperty(legacyKey);
-    if (value != null && !value.isBlank()) {
+    if (!isBlank(value)) {
       derived.putIfAbsent(cslKey, value);
       warnDeprecated(legacyKey, cslKey);
     }
@@ -385,7 +407,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   // installs that already set CAMUNDA_OPTIMIZE_IDENTITY_* would get a second, confusing
   // deprecation warning for the identical value Optimize's own application-ccsm.yaml mirrors into
   // camunda.identity.* automatically (an internal resource-file detail, not an operator choice).
-  private void mapIfAbsentAndPresent(
+  private void mapIfCslKeyUnset(
       final ConfigurableEnvironment env,
       final Map<String, Object> derived,
       final String legacyKey,
@@ -394,6 +416,10 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
       return;
     }
     mapIfPresent(env, derived, legacyKey, cslKey);
+  }
+
+  private static boolean isBlank(final String value) {
+    return value == null || value.isBlank();
   }
 
   // Auth0 issuer URI is https://<domain>/ (trailing slash required for OIDC discovery). Accepts a

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -277,6 +277,14 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     } else {
       addAudience(env, audiences, "CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE");
       addAudience(env, audiences, "CAMUNDA_OPTIMIZE_API_AUDIENCE");
+      // camunda.identity.audience: the login/session-token audience the official camunda-platform
+      // Helm chart's Optimize ConfigMap renders in place of CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE.
+      // Only bridged when that legacy env var is absent: application-ccsm.yaml mirrors it into
+      // camunda.identity.audience automatically for every docker-compose CCSM install, so bridging
+      // both would double-warn for a value the operator only set once.
+      if (isBlank(env.getProperty("CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE"))) {
+        addAudience(env, audiences, "camunda.identity.audience");
+      }
     }
     if (!audiences.isEmpty()) {
       derived.putIfAbsent(OIDC_PREFIX + "audiences", String.join(",", audiences));
@@ -298,6 +306,10 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
       audiences.add(value.trim());
       warnDeprecated(legacyKey, OIDC_PREFIX + "audiences");
     }
+  }
+
+  private static boolean isBlank(final String value) {
+    return value == null || value.isBlank();
   }
 
   // HSTS max-age: negative disables the header in CSL.

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -167,6 +167,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     // not a second operator choice.
     legacy.put("camunda.identity.issuer", "http://legacy.example.com/realm");
     legacy.put("camunda.identity.clientId", "legacy-client");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
 
     final StandardEnvironment env = environmentWith(legacy);
     processor.postProcessEnvironment(env, null);
@@ -186,6 +187,38 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
             entry.getMessage().contains("camunda.identity.issuer")
                 && !entry.getMessage().contains("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL"),
         "the mirrored camunda.identity.issuer key must not get its own warning when the legacy env var already won");
+    // the secret's own warning must not fire either: the legacy secret already won
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("CAMUNDA_IDENTITY_CLIENT_SECRET"),
+        "the mirrored CAMUNDA_IDENTITY_CLIENT_SECRET key must not get its own warning when the"
+            + " legacy secret already won");
+  }
+
+  @Test
+  void shouldNotBridgeHelmChartClientCredentialsWithoutAnIssuerUri() {
+    // The official camunda-platform Helm chart's Optimize ConfigMap can legitimately render
+    // clientId/CAMUNDA_IDENTITY_CLIENT_SECRET while leaving camunda.identity.issuer blank (e.g. an
+    // OIDC-disabled or misconfigured install). Bridging the client-id/secret without an issuer-uri
+    // would let CSL's ScopedClientRegistrationFactory register a provider with no issuer,
+    // authorization-uri, token-uri, or jwk-set-uri, throwing IllegalStateException at startup.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "client-id")).isNull();
+    assertThat(env.getProperty(OIDC + "client-secret")).isNull();
+    logs.assertContains(
+        entry -> entry.getMessage().contains("camunda.identity.issuer"),
+        "expected a warning naming the missing issuer key");
+    // the secret value itself must never be logged
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("helm-secret"),
+        "client secret value must never be logged");
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -222,6 +222,32 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldTreatAnExplicitlyBlankIssuerUriAsMissingForThePartialConfigGuard() {
+    // An operator (or another property source) can set
+    // camunda.security.authentication.oidc.issuer-uri to an empty string rather than leaving it
+    // absent. The partial-config guard must treat that the same as "no issuer-uri set": otherwise
+    // it would let clientId/CAMUNDA_IDENTITY_CLIENT_SECRET bridge through with a blank issuer-uri,
+    // reintroducing the CSL startup failure the guard exists to prevent.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
+    legacy.put(OIDC + "issuer-uri", "");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "client-id")).isNull();
+    assertThat(env.getProperty(OIDC + "client-secret")).isNull();
+    logs.assertContains(
+        entry -> entry.getMessage().contains("camunda.identity.issuer"),
+        "expected a warning naming the missing issuer key");
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("helm-secret"),
+        "client secret value must never be logged");
+  }
+
+  @Test
   void shouldNotBridgeHelmChartIdentityConfigWhenAuth0IsConfigured() {
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -95,6 +95,116 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldBridgeHelmChartIdentityConfigAndLogDeprecation() {
+    // The official camunda-platform Helm chart never sets CAMUNDA_OPTIMIZE_IDENTITY_*; it renders
+    // camunda.identity.* as structured YAML (application-ccsm.yaml) plus
+    // CAMUNDA_IDENTITY_CLIENT_SECRET
+    // for the secret instead.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "http://localhost:18080/auth/realms/camunda-platform");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri"))
+        .isEqualTo("http://localhost:18080/auth/realms/camunda-platform");
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
+    assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("helm-secret");
+
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("camunda.identity.issuer")
+                && entry.getMessage().contains(OIDC + "issuer-uri"),
+        "expected deprecation warning naming the Helm-rendered issuer key");
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("camunda.identity.clientId")
+                && entry.getMessage().contains(OIDC + "client-id"),
+        "expected deprecation warning naming the Helm-rendered clientId key");
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("CAMUNDA_IDENTITY_CLIENT_SECRET")
+                && entry.getMessage().contains(OIDC + "client-secret"),
+        "expected deprecation warning naming the Helm client-secret env var");
+    // the secret value itself must never be logged
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("helm-secret"),
+        "client secret value must never be logged");
+  }
+
+  @Test
+  void shouldNotBridgeHelmChartIdentityIssuerUriKeyWhenBlank() {
+    // application-ccsm.yaml resolves camunda.identity.issuer to "" (via a Spring placeholder
+    // default) whenever CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL is unset, which is the normal state
+    // for any deployment that isn't Helm-based CCSM with CSL enabled. A blank value must never be
+    // bridged or warned about.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put("camunda.identity.clientId", "");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "client-id")).isNull();
+    assertThat(env.getProperty(OIDC + "client-secret")).isNull();
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("camunda.identity"),
+        "expected no warning for blank Helm-rendered keys");
+  }
+
+  @Test
+  void shouldPreferLegacyOptimizeIdentityEnvVarsOverHelmChartKeysAndNotDoubleWarn() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", "http://legacy.example.com/realm");
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", "legacy-client");
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", "legacy-secret");
+    // Mirrors what application-ccsm.yaml actually does in a real docker-compose CCSM deployment:
+    // the same values end up in camunda.identity.* too, purely as an internal resource-file detail,
+    // not a second operator choice.
+    legacy.put("camunda.identity.issuer", "http://legacy.example.com/realm");
+    legacy.put("camunda.identity.clientId", "legacy-client");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo("http://legacy.example.com/realm");
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("legacy-client");
+    assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("legacy-secret");
+    // exactly one warning per property, naming the legacy env var — never the mirrored
+    // camunda.identity.* key, since its value was never actually used
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL")
+                && entry.getMessage().contains(OIDC + "issuer-uri"),
+        "expected the deprecation warning to name the legacy env var");
+    logs.assertDoesNotContain(
+        entry ->
+            entry.getMessage().contains("camunda.identity.issuer")
+                && !entry.getMessage().contains("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL"),
+        "the mirrored camunda.identity.issuer key must not get its own warning when the legacy env var already won");
+  }
+
+  @Test
+  void shouldNotBridgeHelmChartIdentityConfigWhenAuth0IsConfigured() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_DOMAIN", "weblogin.example.com");
+    legacy.put("camunda.identity.issuer", "http://helm.example.com/realm");
+    legacy.put("camunda.identity.clientId", "helm-client");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("cloud-client");
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo("https://weblogin.example.com/");
+  }
+
+  @Test
   void shouldLetExplicitCamundaSecurityValueTakePrecedenceOverBridgedDefault() {
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", "http://localhost:18080/realm");

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -309,6 +309,67 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldBridgeHelmChartIdentityAudienceIntoAudiencesSet() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.audience", "optimize-api");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-api");
+  }
+
+  @Test
+  void shouldMergeHelmChartAudienceWithLegacyPublicApiAudience() {
+    // The Helm chart's camunda.identity.audience (login/session token audience) and the legacy
+    // CAMUNDA_OPTIMIZE_API_AUDIENCE (public-API bearer audience) must both survive: CSL applies one
+    // audiences set to both the login id_token decoder and the api bearer decoder.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
+    legacy.put("camunda.identity.audience", "optimize-login");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    // insertion order follows the code's call order: the pre-existing API-audience bridge call
+    // runs before the new Helm-chart identity-audience bridge call
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-public-api,optimize-login");
+  }
+
+  @Test
+  void
+      shouldNotBridgeHelmChartIdentityAudienceWhenLegacyIdentityAudienceIsAlreadySetAndNotDoubleWarn() {
+    // Mirrors what application-ccsm.yaml actually does in a real docker-compose CCSM deployment:
+    // CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE is mirrored into camunda.identity.audience automatically,
+    // with the identical value — not a second operator choice.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE", "optimize-login");
+    legacy.put("camunda.identity.audience", "optimize-login");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-login");
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("camunda.identity.audience"),
+        "the mirrored camunda.identity.audience key must not get its own warning when the legacy env var already won");
+  }
+
+  @Test
+  void shouldNotBridgeHelmChartIdentityAudienceWhenAuth0IsConfigured() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+    legacy.put("CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE", "optimize");
+    legacy.put("camunda.identity.audience", "optimize-api");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    // the CCSM-only camunda.identity.audience must not leak into the Auth0 audience set
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize,cloud-client");
+  }
+
+  @Test
   void shouldBridgeClientAudienceAndClientIdInAuth0ModeIgnoringPublicApiAudience() {
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");


### PR DESCRIPTION
## Summary

Fixes #59945. `OptimizeSecurityConfigCompatibilityPostProcessor` bridges Optimize's legacy CCSM config into CSL's `camunda.security.*` properties, but it only recognized the `CAMUNDA_OPTIMIZE_IDENTITY_*` env-var interface. The official `camunda-platform` Helm chart never sets those env vars — it renders structured `camunda.identity.issuer`/`clientId`/`audience` YAML plus a `CAMUNDA_IDENTITY_CLIENT_SECRET` env var for the secret instead. Flipping `optimize.security.csl.enabled=true` on a Helm-deployed CCSM install therefore configured no OIDC client at all.

- Bridge `camunda.identity.issuer`/`clientId` + `CAMUNDA_IDENTITY_CLIENT_SECRET` into the OIDC properties, and `camunda.identity.audience` into the audiences set — without double-warning existing docker-compose deployments (Optimize's own `application-ccsm.yaml` already mirrors the legacy env vars into these same `camunda.identity.*` keys internally, so a naive bridge would emit a second, confusing deprecation warning for a value the operator only set once).
- Guard against a partial-config startup failure: if a Helm rendering leaves `camunda.identity.issuer` blank while still setting `clientId`/secret, don't bridge the credentials either — otherwise CSL registers a client with no issuer, which throws at boot instead of the pre-existing "no OIDC client configured" symptom.

**Deliberately not bridged** (see code comments for the full rationale):
- `camunda.identity.issuerBackendUrl` — CSL's single `issuer-uri` is validated against each token's `iss` claim during OIDC discovery. Keycloak reports the same externally-configured issuer regardless of which URL was dialed to reach it, so pointing `issuer-uri` at the backend-reachable URL would break discovery/validation instead of fixing reachability.
- `api.jwtSetUri` / `api.audience` — these feed a separate resource-server chain (public API bearer tokens), not the browser login flow this issue reports broken.

**Known limitation:** if the Keycloak issuer host is only reachable via `issuerBackendUrl` and not from the Optimize pod's network path (the split-horizon scenario `issuerBackendUrl` exists for), CSL's single `issuer-uri` can't currently satisfy both browser redirects and backend-side discovery. That's a CSL/Helm-chart-level gap (see the parent epic and #58487, which migrates the chart to emit `camunda.security.*` directly), not something this bridge can resolve — flagging so it isn't read as unaddressed by this PR.

## Test plan

- [x] `OptimizeSecurityConfigCompatibilityPostProcessorTest` — 29/29 passing, including new coverage for: Helm-key bridging + deprecation warnings, blank-value no-ops, legacy-env-var precedence with no double-warning, Auth0 skip-path, audience merging/ordering, and the partial-config guard.
- [x] `./mvnw license:format spotless:apply` clean
- [x] Rebased on latest `main`, tests green