### PR TITLE
feat: keep webapp sessions alive from real browser activity

### DIFF
--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -239,7 +239,7 @@ jobs:
           max_attempts: "2"
           timeout_minutes: "3"
       - name: Unit tests
-        run: npm run test:unit -w @camunda/orchestration-cluster-webapp
+        run: npm run test:unit
       - name: Upload blob report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/publish-session-heartbeat.yml
+++ b/.github/workflows/publish-session-heartbeat.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches:
       - main
-      - '**'  # Allow testing from any branch
     paths:
       - '.github/workflows/publish-session-heartbeat.yml'
       - 'webapp/client/packages/session-heartbeat/**'

--- a/.github/workflows/publish-session-heartbeat.yml
+++ b/.github/workflows/publish-session-heartbeat.yml
@@ -1,0 +1,87 @@
+# description: Publishes the @camunda/session-heartbeat package to npm. This package provides the activity-driven session heartbeat used by Camunda webapps backed by the Camunda security library. Published at: https://www.npmjs.com/package/@camunda/session-heartbeat
+# type: CI Helper - Manual
+# owner: @camunda/core-features
+---
+name: Publish Session Heartbeat to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (does not publish)'
+        required: false
+        type: boolean
+        default: true
+  push:
+    branches:
+      - main
+      - '**'  # Allow testing from any branch
+    paths:
+      - '.github/workflows/publish-session-heartbeat.yml'
+      - 'webapp/client/packages/session-heartbeat/**'
+
+env:
+  TEST_OWNER: '@camunda/core-features'
+  GHA_BEST_PRACTICES_LINTER: enabled
+  CLIENT_DIR: webapp/client
+
+jobs:
+  publish-session-heartbeat:
+    name: "Publish @camunda/session-heartbeat"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: ${{ env.CLIENT_DIR }}
+        shell: bash
+    env:
+      TEST_PRODUCT: Camunda
+      TEST_TYPE: Build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@camunda'
+
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
+
+      - name: Build package (automatic triggers)
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          npm run prepublishOnly
+          echo "Automatic trigger: Package built successfully but not published"
+
+      - name: Publish to npm (dry-run)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          npm run prepublishOnly
+          npm publish --dry-run --tag next -w @camunda/session-heartbeat --provenance || true
+
+      - name: Publish to npm
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
+        run: |
+          npm run publish:session-heartbeat -- --provenance
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -107,6 +107,8 @@ security.multi-tenancy
 security.multi-tenancy.api-enabled
 security.multi-tenancy.checks-enabled
 security.session
+security.session.heartbeat.enabled
+security.session.max-inactive-interval
 security.session.persistent.enabled
 security.transport-layer-security.cluster.certificate-chain-path
 security.transport-layer-security.cluster.certificate-private-key-path

--- a/docs/monorepo-docs/frontend/frontend.md
+++ b/docs/monorepo-docs/frontend/frontend.md
@@ -13,6 +13,7 @@ Anyone working on the orchestration cluster frontend components.
 - **[Project outline](./project-outline.md)** — packages and apps inside `webapp/client` and what each owns.
 - **[Orchestration cluster webapp](./orchestration-cluster-webapp.md)** — deeper intro to the unified app: tech stack, layout, scripts, dev-server proxy, testing.
 - **[Camunda API Zod schemas](./camunda-api-zod-schemas.md)** — installation, usage, and publishing for the `@camunda/camunda-api-zod-schemas` package.
+- **[Session heartbeat](./session-heartbeat.md)** — activity-driven session keep-alive for the `@camunda/session-heartbeat` package.
 - **[Data loading](./data-loading.md)** — TanStack Query + Zod schema patterns.
 - **[Forms](./forms.md)** — form library choice and shared form-agnostic patterns.
 - **[Development process](./development-process/development-process.md)** — pre-flight checklist plus playbooks for new pages, extending pages, and large features.

--- a/docs/monorepo-docs/frontend/getting-started.md
+++ b/docs/monorepo-docs/frontend/getting-started.md
@@ -50,8 +50,9 @@ From `webapp/client`:
 npm run dev:oc
 ```
 
-The dev server opens `http://localhost:3000`. Vite proxies `/v2`, `/login`, and
-`/logout` to `:8080`, so the frontend talks to the backend you started above.
+The dev server opens `http://localhost:3000`. Vite proxies `/v2`, `/login`,
+`/logout`, and `/session/heartbeat` to `:8080`, so the frontend talks to the
+backend you started above.
 
 ## Verify
 

--- a/docs/monorepo-docs/frontend/project-outline.md
+++ b/docs/monorepo-docs/frontend/project-outline.md
@@ -12,7 +12,8 @@ webapp/client/
 └── packages/
     ├── camunda-api-zod-schemas/
     ├── c8-mocks/
-    └── lint-config/
+    ├── lint-config/
+    └── session-heartbeat/
 ```
 
 ## Packages
@@ -42,6 +43,18 @@ the Camunda frontends — also consumed outside this workspace by
 `operate/client`, `tasklist/client`, and `identity/client`. Consumers
 compose only the eslint variants they need (`base`, `typescript`,
 `react`, `testing`, `license`, `tanstack-query`).
+
+### `@camunda/session-heartbeat`
+
+Published to npm. Tracks browser activity (pointer, keyboard, wheel,
+scroll, tab visibility) and calls the Camunda security library
+heartbeat endpoint at most once per interval, so a session expires from
+real user inactivity instead of from a lack of backend traffic.
+Consumed by `@camunda/orchestration-cluster-webapp` through the
+workspace, and by other Camunda frontends as a published version.
+
+See [Session heartbeat](./session-heartbeat.md) for the backend
+contract, adoption steps, and publishing.
 
 ## Apps
 

--- a/docs/monorepo-docs/frontend/session-heartbeat.md
+++ b/docs/monorepo-docs/frontend/session-heartbeat.md
@@ -1,0 +1,87 @@
+# Session heartbeat
+
+`@camunda/session-heartbeat` tracks genuine browser activity and calls the Camunda security library
+(CSL) heartbeat endpoint, so that a webapp session expires from real user inactivity rather than from
+the absence of backend traffic.
+
+Design decision:
+[CSL ADR-0042 — Configurable session idle timeout driven by client activity](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0042-configurable-activity-driven-session-idle-timeout.md).
+
+Package source: [`webapp/client/packages/session-heartbeat`](https://github.com/camunda/camunda/tree/main/webapp/client/packages/session-heartbeat).
+Its [README](https://github.com/camunda/camunda/blob/main/webapp/client/packages/session-heartbeat/README.md)
+is the API reference; this page covers how it fits into the monorepo.
+
+## The backend contract
+
+CSL owns two properties:
+
+| Property                                            | Default | Meaning                                                                        |
+| --------------------------------------------------- | ------- | ------------------------------------------------------------------------------ |
+| `camunda.security.session.max-inactive-interval`     | `30m`   | Idle timeout. Accepts `30m`, `1800s`, or `PT30M`.                               |
+| `camunda.security.session.heartbeat.enabled`          | `false` | Off: any request keeps the session alive. On: only the heartbeat call does.     |
+
+`POST {basePath}/session/heartbeat` is installed on every webapp security chain — the primary surface
+and every physical-tenant scope, on both OIDC and Basic auth — and derives from `basePath` exactly
+like `/login` and `/logout`. It requires an authenticated session and answers `204 No Content`.
+
+Two consequences shape the frontend:
+
+- **The endpoint exists regardless of the flag.** Sending heartbeats is harmless when
+  `heartbeat.enabled=false`, which is what makes adopting the package independent of any host's
+  rollout decision.
+- **CSRF applies.** CSL exempts only `/login` and `/logout` from CSRF protection, so a heartbeat from
+  a session-bearing browser must carry `X-CSRF-TOKEN` or it is rejected with `403`.
+
+## Usage in the orchestration cluster webapp
+
+The hook is mounted once in the authenticated route, [`src/routes/_auth/route.tsx`](https://github.com/camunda/camunda/blob/main/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx),
+next to `SessionWatcher`:
+
+```tsx
+useSessionHeartbeat({
+	url: endpoints.sessionHeartbeatUrl(),
+	csrfToken: getCsrfTokenFromStorage,
+	onUnauthorized: () => {
+		authenticationStore.disableSession();
+		reactQueryClient.clear();
+	},
+});
+```
+
+- `endpoints.sessionHeartbeatUrl()` resolves the URL through `getFullURL`, so the configured context
+  path is applied like it is for every other call.
+- `csrfToken` reuses the token the app's request layer already caches in `sessionStorage`.
+- `onUnauthorized` mirrors what `request()` does on a `401`, so a session that expired anyway ends up
+  in the same state as one detected by any other call.
+
+The dev server proxies `/session/heartbeat` to `localhost:8080` alongside `/login` and `/logout`, so
+heartbeats reach a locally running backend.
+
+Because the heartbeat lives in the `_auth` route, it starts after login and stops on logout or
+unmount. Every open tab heartbeats on its own; they share one session, so the cost is one extra
+request per tab per interval.
+
+## Adopting it in another frontend
+
+1. Add `@camunda/session-heartbeat` to the app's dependencies.
+2. Call `useSessionHeartbeat` once inside the authenticated part of the app — not per page.
+3. Pass the scope's own `{basePath}/session/heartbeat`, including the context path.
+4. Pass the CSRF token from wherever that app keeps it.
+5. Keep `intervalMs` well under the host's `max-inactive-interval` (a quarter or less). The `60s`
+   default suits CSL's `30m` default.
+
+A host may only set `camunda.security.session.heartbeat.enabled=true` once **every** frontend served
+by that deployment sends heartbeats. Enabling it earlier logs users out mid-session.
+
+## Publishing a new version
+
+Same flow as [Camunda API Zod schemas](./camunda-api-zod-schemas.md):
+
+1. Increment the version in `packages/session-heartbeat/package.json`, update the dependency version
+   in consuming workspace packages, run `npm i`, and merge to `main`.
+2. Run the [Publish Session Heartbeat to npm](https://github.com/camunda/camunda/actions/workflows/publish-session-heartbeat.yml)
+   GitHub Action. Dry-run is enabled by default — uncheck it to publish.
+3. Bump the dependency in any consumer outside this workspace.
+
+Behavior changes reach consumers only when they bump the dependency, so a fix to the throttle
+interval or the event list is not automatically picked up by apps that pinned an older version.

--- a/docs/monorepo-docs/frontend/session-heartbeat.md
+++ b/docs/monorepo-docs/frontend/session-heartbeat.md
@@ -30,7 +30,9 @@ Two consequences shape the frontend:
   `heartbeat.enabled=false`, which is what makes adopting the package independent of any host's
   rollout decision.
 - **CSRF applies.** CSL exempts only `/login` and `/logout` from CSRF protection, so a heartbeat from
-  a session-bearing browser must carry `X-CSRF-TOKEN` or it is rejected with `403`.
+  a session-bearing browser must carry `X-CSRF-TOKEN`. A missing or stale token is rejected with
+  `401` (the webapp chain routes the CSRF denial through its auth-failure handler, with the reason in
+  the response `detail`), so it reaches the frontend the same way an expired session does.
 
 ## Usage in the orchestration cluster webapp
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha65</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha66</version.camunda-security-library>
     <version.checkstyle>13.10.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -23,6 +23,7 @@
 		"@bpmn-io/form-js-viewer": "1.24.1",
 		"@camunda/camunda-api-zod-schemas": "0.0.88",
 		"@camunda/camunda-composite-components": "0.25.4",
+		"@camunda/session-heartbeat": "0.0.1",
 		"@carbon/grid": "11.59.0",
 		"@carbon/layout": "11.56.0",
 		"@carbon/react": "1.112.0",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx
@@ -8,8 +8,13 @@
 
 import {createFileRoute, Outlet, redirect, useRouterState, type RegisteredRouter} from '@tanstack/react-router';
 import {useSuspenseQuery} from '@tanstack/react-query';
+import {useSessionHeartbeat} from '@camunda/session-heartbeat/react';
 import {SessionWatcher} from '#/shared/auth/components/SessionWatcher';
+import {authenticationStore} from '#/shared/auth/authentication.store';
+import {endpoints} from '#/shared/http/endpoints';
+import {getCsrfTokenFromStorage} from '#/shared/http/request';
 import {queries} from '#/shared/http/queries';
+import {reactQueryClient} from '#/shared/http/reactQueryClient';
 import {storeSessionState} from '#/shared/browser-storage/session-storage';
 import {C3Provider} from '#/shared/c3/components/C3Provider';
 import {fetchSaasToken} from '#/shared/c3/fetchSaasToken';
@@ -86,6 +91,15 @@ function RouteComponent() {
 	const {data: license} = useSuspenseQuery(queries.getLicense());
 	const pathname = useRouterState({select: ({location}) => location.pathname});
 	const currentApp = resolveCurrentApp(pathname);
+
+	useSessionHeartbeat({
+		url: endpoints.sessionHeartbeatUrl(),
+		csrfToken: getCsrfTokenFromStorage,
+		onUnauthorized: () => {
+			authenticationStore.disableSession();
+			reactQueryClient.clear();
+		},
+	});
 
 	return (
 		<>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -117,6 +117,8 @@ const endpoints = {
 			method: 'POST',
 		}),
 
+	sessionHeartbeatUrl: () => getFullURL('/session/heartbeat').toString(),
+
 	getCurrentUser: () =>
 		new Request(getFullURL(unifiedAPIEndpoints.getCurrentUser.getUrl()), {
 			...BASE_REQUEST_OPTIONS,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/request.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/request.ts
@@ -106,4 +106,4 @@ const requestErrorSchema = z.union([
 	}),
 ]);
 
-export {request, requestErrorSchema};
+export {getCsrfTokenFromStorage, request, requestErrorSchema};

--- a/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
@@ -68,6 +68,10 @@ const config = defineConfig(({mode}) => ({
 				target: 'http://localhost:8080',
 				bypass: (req) => (req.method !== 'POST' ? '/' : undefined),
 			},
+			'/session/heartbeat': {
+				target: 'http://localhost:8080',
+				bypass: (req) => (req.method !== 'POST' ? '/' : undefined),
+			},
 		},
 	},
 	build: {

--- a/webapp/client/eslint.config.js
+++ b/webapp/client/eslint.config.js
@@ -82,6 +82,13 @@ export default defineConfig([
 		},
 	},
 
+	// the session-heartbeat package ships a React hook, so it needs the React Hooks rules too
+	{
+		files: ['packages/session-heartbeat/lib/**/*.{ts,tsx}'],
+		plugins: {'react-hooks': reactHooksPlugin},
+		rules: {...reactHooksPlugin.configs.recommended.rules},
+	},
+
 	{
 		files: ocFiles.browser,
 		rules: {

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -33,6 +33,7 @@
 				"@bpmn-io/form-js-viewer": "1.24.1",
 				"@camunda/camunda-api-zod-schemas": "0.0.88",
 				"@camunda/camunda-composite-components": "0.25.4",
+				"@camunda/session-heartbeat": "0.0.1",
 				"@carbon/grid": "11.59.0",
 				"@carbon/layout": "11.56.0",
 				"@carbon/react": "1.112.0",
@@ -784,6 +785,10 @@
 		},
 		"node_modules/@camunda/orchestration-cluster-webapp": {
 			"resolved": "apps/orchestration-cluster-webapp",
+			"link": true
+		},
+		"node_modules/@camunda/session-heartbeat": {
+			"resolved": "packages/session-heartbeat",
 			"link": true
 		},
 		"node_modules/@carbon/colors": {
@@ -12419,6 +12424,67 @@
 				"eslint-plugin-testing-library": {
 					"optional": true
 				}
+			}
+		},
+		"packages/session-heartbeat": {
+			"name": "@camunda/session-heartbeat",
+			"version": "0.0.1",
+			"license": "LicenseRef-Camunda-1.0",
+			"devDependencies": {
+				"@playwright/test": "1.62.1",
+				"@types/react": "19.2.18",
+				"@types/react-dom": "19.2.4",
+				"@vitest/browser-playwright": "4.1.10",
+				"react": "19.2.8",
+				"react-dom": "19.2.8",
+				"typescript": "7.0.2",
+				"vite": "8.2.1",
+				"vite-plugin-dts": "5.0.3",
+				"vitest": "4.1.10",
+				"vitest-browser-react": "2.2.0"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				}
+			}
+		},
+		"packages/session-heartbeat/node_modules/typescript": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc"
+			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
 			}
 		}
 	},

--- a/webapp/client/package.json
+++ b/webapp/client/package.json
@@ -20,10 +20,12 @@
 		"lint:knip": "npm run lint:knip -w @camunda/orchestration-cluster-webapp",
 		"lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:knip",
 		"typecheck": "npm run typecheck --workspaces --if-present",
+		"test:unit": "npm run test:unit --workspaces --if-present",
 		"format": "prettier --write .",
 		"build": "npm run build --workspaces --if-present",
 		"prepublishOnly": "node scripts/prepublishOnly.js",
 		"publish:zod-schemas": "npm run prepublishOnly && npm publish -w @camunda/camunda-api-zod-schemas",
+		"publish:session-heartbeat": "npm run prepublishOnly && npm publish -w @camunda/session-heartbeat",
 		"prettier:format": "prettier --write ."
 	},
 	"packageManager": "npm@12.0.2",

--- a/webapp/client/packages/session-heartbeat/README.md
+++ b/webapp/client/packages/session-heartbeat/README.md
@@ -70,7 +70,7 @@ stopSessionHeartbeat();
 | `url`            | `string`                                     | —           | The heartbeat endpoint. Must be the current scope's `{basePath}/session/heartbeat`, context path included. |
 | `intervalMs`     | `number`                                     | `60000`     | How often activity is checked, and therefore the shortest gap between two heartbeats.                      |
 | `csrfToken`      | `string \| null \| undefined \| (() => …)`   | `undefined` | CSRF token, or a getter for it. Sent as `X-CSRF-TOKEN`; omitted when absent or empty.                      |
-| `onUnauthorized` | `() => void`                                 | `undefined` | Called when a heartbeat comes back `401`, i.e. the session is already gone.                                |
+| `onUnauthorized` | `() => void`                                 | `undefined` | Called when a heartbeat comes back `401` — an expired session, or a missing/stale CSRF token.              |
 | `onError`        | `(failure: SessionHeartbeatFailure) => void` | `undefined` | Called for network errors and for any other non-OK response.                                               |
 | `enabled`        | `boolean` (`./react` only)                   | `true`      | Set `false` to keep the hook mounted without sending heartbeats.                                           |
 
@@ -83,8 +83,13 @@ configured interval or less is a good rule of thumb; the `60s` default suits CSL
 ## Behavior worth knowing
 
 - **The endpoint needs a CSRF token.** CSL exempts only `/login` and `/logout` from CSRF protection,
-  so a session-bearing `POST /session/heartbeat` without `X-CSRF-TOKEN` is rejected with `403`. Pass
+  so a session-bearing `POST /session/heartbeat` without a valid `X-CSRF-TOKEN` is rejected — with
+  `401`, not `403`, since the webapp chain maps the CSRF denial onto its auth-failure handler. Pass
   `csrfToken` from wherever the application keeps it.
+- **A `401` therefore means "this heartbeat was not accepted", not strictly "the session is gone".**
+  A missing or stale token produces the same status as an expired session, so `onUnauthorized` fires
+  in both cases. That matches how a webapp's own request layer usually treats `401`; if an
+  application needs to tell the two apart, the response body carries a CSRF-specific `detail`.
 - **Starting counts as activity**, so the first interval always sends one heartbeat. This surfaces
   broken wiring immediately, at the cost of extending an abandoned session by one interval.
 - **At most one heartbeat per interval**, and none at all for an interval with no activity. A

--- a/webapp/client/packages/session-heartbeat/README.md
+++ b/webapp/client/packages/session-heartbeat/README.md
@@ -1,0 +1,107 @@
+# @camunda/session-heartbeat
+
+Activity-driven session heartbeat for Camunda webapps whose sessions are managed by the
+[Camunda security library](https://github.com/camunda/camunda-security-library) (CSL).
+
+The package tracks genuine browser activity — pointer, keyboard, wheel, scroll, and the tab
+regaining visibility — and calls CSL's `POST {basePath}/session/heartbeat` endpoint at most once per
+interval, only when activity actually happened. It exists so Operate, Tasklist, Optimize, and any
+future adopter share one implementation instead of each reimplementing the same listener and
+throttle logic.
+
+Background: [CSL ADR-0042 — Configurable session idle timeout driven by client activity](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0042-configurable-activity-driven-session-idle-timeout.md).
+
+## Why a heartbeat is needed
+
+With `camunda.security.session.heartbeat.enabled=true`, CSL stops treating ordinary backend traffic
+as proof of user presence: **only** a call to the heartbeat endpoint extends the session. A host that
+enables the flag without a frontend sending heartbeats logs its users out after
+`camunda.security.session.max-inactive-interval`, however actively they are using the application.
+
+The flag defaults to `false`, so adopting this package is safe and inert until a host turns it on.
+
+## Installation
+
+```bash
+npm install @camunda/session-heartbeat
+```
+
+`react` is an optional peer dependency, needed only for the `./react` entry point.
+
+## Usage
+
+### React
+
+```tsx
+import {useSessionHeartbeat} from '@camunda/session-heartbeat/react';
+
+function AuthenticatedLayout() {
+	useSessionHeartbeat({
+		url: '/session/heartbeat',
+		csrfToken: () => sessionStorage.getItem('X-CSRF-TOKEN'),
+		onUnauthorized: () => {
+			authenticationStore.disableSession();
+		},
+	});
+
+	return <Outlet />;
+}
+```
+
+Call it once inside the authenticated part of the application, so the heartbeat starts after login
+and stops when the user leaves it. Callbacks and `csrfToken` are read fresh on every heartbeat, so
+inline functions do not restart the timer; changing `url`, `intervalMs`, or `enabled` does.
+
+### Without React
+
+```ts
+import {createSessionHeartbeat} from '@camunda/session-heartbeat';
+
+const stopSessionHeartbeat = createSessionHeartbeat({url: '/session/heartbeat'});
+
+// on teardown
+stopSessionHeartbeat();
+```
+
+## Options
+
+| Option           | Type                                         | Default     | Description                                                                                                |
+| ---------------- | -------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
+| `url`            | `string`                                     | —           | The heartbeat endpoint. Must be the current scope's `{basePath}/session/heartbeat`, context path included. |
+| `intervalMs`     | `number`                                     | `60000`     | How often activity is checked, and therefore the shortest gap between two heartbeats.                      |
+| `csrfToken`      | `string \| null \| undefined \| (() => …)`   | `undefined` | CSRF token, or a getter for it. Sent as `X-CSRF-TOKEN`; omitted when absent or empty.                      |
+| `onUnauthorized` | `() => void`                                 | `undefined` | Called when a heartbeat comes back `401`, i.e. the session is already gone.                                |
+| `onError`        | `(failure: SessionHeartbeatFailure) => void` | `undefined` | Called for network errors and for any other non-OK response.                                               |
+| `enabled`        | `boolean` (`./react` only)                   | `true`      | Set `false` to keep the hook mounted without sending heartbeats.                                           |
+
+### Choosing `intervalMs`
+
+Keep it well under the host's `camunda.security.session.max-inactive-interval` — a heartbeat is what
+resets that clock, and one lost request must not cost the user their session. A quarter of the
+configured interval or less is a good rule of thumb; the `60s` default suits CSL's `30m` default.
+
+## Behavior worth knowing
+
+- **The endpoint needs a CSRF token.** CSL exempts only `/login` and `/logout` from CSRF protection,
+  so a session-bearing `POST /session/heartbeat` without `X-CSRF-TOKEN` is rejected with `403`. Pass
+  `csrfToken` from wherever the application keeps it.
+- **Starting counts as activity**, so the first interval always sends one heartbeat. This surfaces
+  broken wiring immediately, at the cost of extending an abandoned session by one interval.
+- **At most one heartbeat per interval**, and none at all for an interval with no activity. A
+  heartbeat is also skipped while a previous one is still in flight.
+- **A `401` does not stop the heartbeat.** The consumer decides what an expired session means;
+  unmounting the hook (or setting `enabled: false`) is what stops it.
+- **Each tab heartbeats independently.** They share one session, so the cost is one extra request
+  per tab per interval; there is no cross-tab coordination.
+- **Requests are credentialed** (`credentials: 'include'`) and aborted on teardown.
+
+## Development
+
+```bash
+npm run build -w @camunda/session-heartbeat        # bundle + type declarations
+npm run typecheck -w @camunda/session-heartbeat
+npm run test:unit -w @camunda/session-heartbeat    # Vitest browser mode
+```
+
+See [Session heartbeat](../../../../docs/monorepo-docs/frontend/session-heartbeat.md) in the
+monorepo docs for the adoption checklist and publishing steps.

--- a/webapp/client/packages/session-heartbeat/lib/createSessionHeartbeat.test.ts
+++ b/webapp/client/packages/session-heartbeat/lib/createSessionHeartbeat.test.ts
@@ -1,0 +1,279 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {createSessionHeartbeat} from './createSessionHeartbeat';
+
+const HEARTBEAT_URL = '/session/heartbeat';
+const INTERVAL_MS = 1000;
+
+let stopHeartbeat: (() => void) | null = null;
+
+/*
+ * The heartbeat has no request layer to mock with MSW — the assertions are about when
+ * a fetch happens and with which headers, so the global fetch is stubbed directly.
+ */
+function stubFetch(respond: typeof fetch = async () => new Response(null, {status: 204})) {
+	const fetchSpy = vi.fn<typeof fetch>(respond);
+	vi.stubGlobal('fetch', fetchSpy);
+	return fetchSpy;
+}
+
+function stubVisibilityState(visibilityState: DocumentVisibilityState) {
+	Object.defineProperty(document, 'visibilityState', {
+		configurable: true,
+		get: () => visibilityState,
+	});
+}
+
+function start(options: Partial<Parameters<typeof createSessionHeartbeat>[0]> = {}) {
+	stopHeartbeat = createSessionHeartbeat({url: HEARTBEAT_URL, intervalMs: INTERVAL_MS, ...options});
+}
+
+async function elapse(intervals = 1) {
+	await vi.advanceTimersByTimeAsync(INTERVAL_MS * intervals);
+}
+
+describe('createSessionHeartbeat', () => {
+	beforeEach(() => {
+		vi.useFakeTimers({toFake: ['setInterval', 'clearInterval']});
+	});
+
+	afterEach(() => {
+		stopHeartbeat?.();
+		stopHeartbeat = null;
+		Reflect.deleteProperty(document, 'visibilityState');
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it('should send a heartbeat on the first interval after start', async () => {
+		const fetchSpy = stubFetch();
+
+		start();
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy).toHaveBeenCalledWith(
+			HEARTBEAT_URL,
+			expect.objectContaining({method: 'POST', credentials: 'include'}),
+		);
+	});
+
+	it('should not send a heartbeat before the first interval elapses', async () => {
+		const fetchSpy = stubFetch();
+
+		start();
+		await vi.advanceTimersByTimeAsync(INTERVAL_MS - 1);
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('should not send a heartbeat for an interval without user activity', async () => {
+		const fetchSpy = stubFetch();
+
+		start();
+		await elapse(5);
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('should send a heartbeat again once user activity resumes', async () => {
+		const fetchSpy = stubFetch();
+
+		start();
+		await elapse(3);
+		document.dispatchEvent(new KeyboardEvent('keydown'));
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it.for(['pointerdown', 'pointermove', 'keydown', 'wheel', 'scroll'])(
+		'should count a %s event as user activity',
+		async (eventType, {expect}) => {
+			const fetchSpy = stubFetch();
+
+			start();
+			await elapse();
+			document.dispatchEvent(new Event(eventType));
+			await elapse();
+
+			expect(fetchSpy).toHaveBeenCalledTimes(2);
+		},
+	);
+
+	it('should send at most one heartbeat per interval no matter how much activity happens', async () => {
+		const fetchSpy = stubFetch();
+
+		start();
+		await elapse();
+		for (let index = 0; index < 50; index++) {
+			document.dispatchEvent(new PointerEvent('pointermove'));
+		}
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('should count the tab becoming visible as user activity', async () => {
+		const fetchSpy = stubFetch();
+		stubVisibilityState('visible');
+
+		start();
+		await elapse();
+		document.dispatchEvent(new Event('visibilitychange'));
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('should not count the tab becoming hidden as user activity', async () => {
+		const fetchSpy = stubFetch();
+		stubVisibilityState('hidden');
+
+		start();
+		await elapse();
+		document.dispatchEvent(new Event('visibilitychange'));
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not send a heartbeat while a previous one is still in flight', async () => {
+		const fetchSpy = stubFetch(() => new Promise<Response>(() => {}));
+
+		start();
+		await elapse();
+		document.dispatchEvent(new KeyboardEvent('keydown'));
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('should stop sending heartbeats after being stopped', async () => {
+		const fetchSpy = stubFetch();
+
+		start();
+		await elapse();
+		stopHeartbeat?.();
+		document.dispatchEvent(new KeyboardEvent('keydown'));
+		await elapse(3);
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	describe('CSRF token', () => {
+		it('should send a token provided as a value', async () => {
+			const fetchSpy = stubFetch();
+
+			start({csrfToken: 'token-from-a-value'});
+			await elapse();
+
+			expect(fetchSpy).toHaveBeenCalledWith(
+				HEARTBEAT_URL,
+				expect.objectContaining({headers: {'X-CSRF-TOKEN': 'token-from-a-value'}}),
+			);
+		});
+
+		it('should read a token provided as a getter on every heartbeat', async () => {
+			const fetchSpy = stubFetch();
+			const tokens = ['first-token', 'second-token'];
+
+			start({csrfToken: () => tokens.shift() ?? null});
+			await elapse();
+			document.dispatchEvent(new KeyboardEvent('keydown'));
+			await elapse();
+
+			expect(fetchSpy.mock.calls.map(([, init]) => init?.headers)).toEqual([
+				{'X-CSRF-TOKEN': 'first-token'},
+				{'X-CSRF-TOKEN': 'second-token'},
+			]);
+		});
+
+		it('should omit the header when no token is available', async () => {
+			const fetchSpy = stubFetch();
+
+			start({csrfToken: () => null});
+			await elapse();
+
+			expect(fetchSpy).toHaveBeenCalledWith(HEARTBEAT_URL, expect.objectContaining({headers: undefined}));
+		});
+	});
+
+	describe('failures', () => {
+		it('should report an expired session through onUnauthorized', async () => {
+			stubFetch(async () => new Response(null, {status: 401}));
+			const onUnauthorized = vi.fn();
+			const onError = vi.fn();
+
+			start({onUnauthorized, onError});
+			await elapse();
+
+			expect(onUnauthorized).toHaveBeenCalledTimes(1);
+			expect(onError).not.toHaveBeenCalled();
+		});
+
+		it('should keep sending heartbeats after an expired session so a recovered session is kept alive', async () => {
+			const fetchSpy = stubFetch(async () => new Response(null, {status: 401}));
+
+			start();
+			await elapse();
+			document.dispatchEvent(new KeyboardEvent('keydown'));
+			await elapse();
+
+			expect(fetchSpy).toHaveBeenCalledTimes(2);
+		});
+
+		it('should report a failed response through onError', async () => {
+			stubFetch(async () => new Response(null, {status: 500}));
+			const onError = vi.fn();
+
+			start({onError});
+			await elapse();
+
+			expect(onError).toHaveBeenCalledWith({
+				variant: 'failed-response',
+				response: expect.objectContaining({status: 500}),
+				networkError: null,
+			});
+		});
+
+		it('should report a network error through onError', async () => {
+			const networkError = new Error('offline');
+			stubFetch(() => Promise.reject(networkError));
+			const onError = vi.fn();
+
+			start({onError});
+			await elapse();
+
+			expect(onError).toHaveBeenCalledWith({
+				variant: 'network-error',
+				response: null,
+				networkError,
+			});
+		});
+
+		it('should not report an error when a heartbeat is aborted by stopping', async () => {
+			stubFetch(
+				(_url, init) =>
+					new Promise<Response>((_, reject) => {
+						init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+					}),
+			);
+			const onError = vi.fn();
+
+			start({onError});
+			await elapse();
+			stopHeartbeat?.();
+			await elapse();
+
+			expect(onError).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/webapp/client/packages/session-heartbeat/lib/createSessionHeartbeat.ts
+++ b/webapp/client/packages/session-heartbeat/lib/createSessionHeartbeat.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const DEFAULT_INTERVAL_MS = 60_000;
+
+const CSRF_TOKEN_HEADER = 'X-CSRF-TOKEN';
+
+const ACTIVITY_EVENTS = ['pointerdown', 'pointermove', 'keydown', 'wheel', 'scroll'] as const;
+
+/*
+ * Capture phase so activity is still observed when an application handler calls
+ * stopPropagation, and so scroll events — which do not bubble — are seen at all.
+ */
+const ACTIVITY_LISTENER_OPTIONS: AddEventListenerOptions = {capture: true, passive: true};
+
+type CsrfToken = string | null | undefined;
+
+type SessionHeartbeatFailure =
+	| {
+			variant: 'network-error';
+			response: null;
+			networkError: unknown;
+	  }
+	| {
+			variant: 'failed-response';
+			response: Response;
+			networkError: null;
+	  };
+
+type SessionHeartbeatOptions = {
+	url: string;
+	intervalMs?: number;
+	csrfToken?: CsrfToken | (() => CsrfToken);
+	onUnauthorized?: () => void;
+	onError?: (failure: SessionHeartbeatFailure) => void;
+};
+
+function resolveCsrfToken(csrfToken: SessionHeartbeatOptions['csrfToken']): string | null {
+	const token = typeof csrfToken === 'function' ? csrfToken() : csrfToken;
+	return typeof token === 'string' && token.length > 0 ? token : null;
+}
+
+function createSessionHeartbeat({
+	url,
+	intervalMs = DEFAULT_INTERVAL_MS,
+	csrfToken,
+	onUnauthorized,
+	onError,
+}: SessionHeartbeatOptions): () => void {
+	/*
+	 * Opening the application is itself a user action, so the first tick always sends
+	 * one heartbeat — a session that outlives its idle timeout by a single interval is
+	 * the price of proving the wiring works from the moment the page loads.
+	 */
+	let hasActivity = true;
+	let pendingRequest: AbortController | null = null;
+
+	function recordActivity() {
+		hasActivity = true;
+	}
+
+	function handleVisibilityChange() {
+		if (document.visibilityState === 'visible') {
+			recordActivity();
+		}
+	}
+
+	async function sendHeartbeat() {
+		const request = new AbortController();
+		pendingRequest = request;
+		const token = resolveCsrfToken(csrfToken);
+
+		try {
+			const response = await fetch(url, {
+				method: 'POST',
+				credentials: 'include',
+				headers: token === null ? undefined : {[CSRF_TOKEN_HEADER]: token},
+				signal: request.signal,
+			});
+
+			if (response.status === 401) {
+				onUnauthorized?.();
+				return;
+			}
+
+			if (!response.ok) {
+				onError?.({variant: 'failed-response', response, networkError: null});
+			}
+		} catch (networkError) {
+			if (request.signal.aborted) {
+				return;
+			}
+
+			onError?.({variant: 'network-error', response: null, networkError});
+		} finally {
+			if (pendingRequest === request) {
+				pendingRequest = null;
+			}
+		}
+	}
+
+	function tick() {
+		if (!hasActivity || pendingRequest !== null) {
+			return;
+		}
+
+		hasActivity = false;
+		void sendHeartbeat();
+	}
+
+	for (const event of ACTIVITY_EVENTS) {
+		document.addEventListener(event, recordActivity, ACTIVITY_LISTENER_OPTIONS);
+	}
+	document.addEventListener('visibilitychange', handleVisibilityChange);
+
+	const intervalId = window.setInterval(tick, intervalMs);
+
+	return function stop() {
+		window.clearInterval(intervalId);
+
+		for (const event of ACTIVITY_EVENTS) {
+			document.removeEventListener(event, recordActivity, ACTIVITY_LISTENER_OPTIONS);
+		}
+		document.removeEventListener('visibilitychange', handleVisibilityChange);
+
+		pendingRequest?.abort();
+		pendingRequest = null;
+	};
+}
+
+export {createSessionHeartbeat, resolveCsrfToken, ACTIVITY_EVENTS, CSRF_TOKEN_HEADER, DEFAULT_INTERVAL_MS};
+export type {CsrfToken, SessionHeartbeatFailure, SessionHeartbeatOptions};

--- a/webapp/client/packages/session-heartbeat/lib/index.ts
+++ b/webapp/client/packages/session-heartbeat/lib/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createSessionHeartbeat, DEFAULT_INTERVAL_MS} from './createSessionHeartbeat';
+import type {CsrfToken, SessionHeartbeatFailure, SessionHeartbeatOptions} from './createSessionHeartbeat';
+
+export {createSessionHeartbeat, DEFAULT_INTERVAL_MS};
+export type {CsrfToken, SessionHeartbeatFailure, SessionHeartbeatOptions};

--- a/webapp/client/packages/session-heartbeat/lib/react.test.tsx
+++ b/webapp/client/packages/session-heartbeat/lib/react.test.tsx
@@ -8,6 +8,7 @@
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {render} from 'vitest-browser-react';
+import type {FC} from 'react';
 import {useSessionHeartbeat, type UseSessionHeartbeatOptions} from './react';
 
 const HEARTBEAT_URL = '/session/heartbeat';
@@ -19,7 +20,7 @@ function stubFetch(status = 204) {
 	return fetchSpy;
 }
 
-const Heartbeat: React.FC<Omit<UseSessionHeartbeatOptions, 'url' | 'intervalMs'>> = (options) => {
+const Heartbeat: FC<Omit<UseSessionHeartbeatOptions, 'url' | 'intervalMs'>> = (options) => {
 	useSessionHeartbeat({url: HEARTBEAT_URL, intervalMs: INTERVAL_MS, ...options});
 	return null;
 };

--- a/webapp/client/packages/session-heartbeat/lib/react.test.tsx
+++ b/webapp/client/packages/session-heartbeat/lib/react.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {useSessionHeartbeat, type UseSessionHeartbeatOptions} from './react';
+
+const HEARTBEAT_URL = '/session/heartbeat';
+const INTERVAL_MS = 1000;
+
+function stubFetch(status = 204) {
+	const fetchSpy = vi.fn<typeof fetch>(async () => new Response(null, {status}));
+	vi.stubGlobal('fetch', fetchSpy);
+	return fetchSpy;
+}
+
+const Heartbeat: React.FC<Omit<UseSessionHeartbeatOptions, 'url' | 'intervalMs'>> = (options) => {
+	useSessionHeartbeat({url: HEARTBEAT_URL, intervalMs: INTERVAL_MS, ...options});
+	return null;
+};
+
+async function elapse(intervals = 1) {
+	await vi.advanceTimersByTimeAsync(INTERVAL_MS * intervals);
+}
+
+describe('useSessionHeartbeat', () => {
+	beforeEach(() => {
+		vi.useFakeTimers({toFake: ['setInterval', 'clearInterval']});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it('should send heartbeats while mounted', async () => {
+		const fetchSpy = stubFetch();
+
+		await render(<Heartbeat />);
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('should stop sending heartbeats once unmounted', async () => {
+		const fetchSpy = stubFetch();
+
+		const screen = await render(<Heartbeat />);
+		await elapse();
+		await screen.unmount();
+		document.dispatchEvent(new KeyboardEvent('keydown'));
+		await elapse(3);
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not send heartbeats while disabled', async () => {
+		const fetchSpy = stubFetch();
+
+		await render(<Heartbeat enabled={false} />);
+		await elapse(3);
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('should start sending heartbeats when it becomes enabled', async () => {
+		const fetchSpy = stubFetch();
+
+		const screen = await render(<Heartbeat enabled={false} />);
+		await elapse();
+		await screen.rerender(<Heartbeat enabled />);
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call the callbacks from the latest render without restarting the heartbeat', async () => {
+		const fetchSpy = stubFetch(401);
+		const staleOnUnauthorized = vi.fn();
+		const latestOnUnauthorized = vi.fn();
+
+		const screen = await render(<Heartbeat onUnauthorized={staleOnUnauthorized} />);
+		await screen.rerender(<Heartbeat onUnauthorized={latestOnUnauthorized} />);
+		await elapse();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(staleOnUnauthorized).not.toHaveBeenCalled();
+		expect(latestOnUnauthorized).toHaveBeenCalledTimes(1);
+	});
+});

--- a/webapp/client/packages/session-heartbeat/lib/react.ts
+++ b/webapp/client/packages/session-heartbeat/lib/react.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect, useRef} from 'react';
+import {createSessionHeartbeat, resolveCsrfToken, type SessionHeartbeatOptions} from './createSessionHeartbeat';
+
+type UseSessionHeartbeatOptions = SessionHeartbeatOptions & {
+	enabled?: boolean;
+};
+
+function useSessionHeartbeat({enabled = true, url, intervalMs, ...perRequestOptions}: UseSessionHeartbeatOptions) {
+	/*
+	 * The CSRF token and the callbacks are read at request time from this ref, so a
+	 * consumer passing inline functions does not tear down and restart the heartbeat
+	 * on every render.
+	 */
+	const perRequestOptionsRef = useRef(perRequestOptions);
+
+	useEffect(() => {
+		perRequestOptionsRef.current = perRequestOptions;
+	});
+
+	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+
+		return createSessionHeartbeat({
+			url,
+			intervalMs,
+			csrfToken: () => resolveCsrfToken(perRequestOptionsRef.current.csrfToken),
+			onUnauthorized: () => perRequestOptionsRef.current.onUnauthorized?.(),
+			onError: (failure) => perRequestOptionsRef.current.onError?.(failure),
+		});
+	}, [enabled, url, intervalMs]);
+}
+
+export {useSessionHeartbeat};
+export type {UseSessionHeartbeatOptions};

--- a/webapp/client/packages/session-heartbeat/lib/react.ts
+++ b/webapp/client/packages/session-heartbeat/lib/react.ts
@@ -21,6 +21,12 @@ function useSessionHeartbeat({enabled = true, url, intervalMs, ...perRequestOpti
 	 */
 	const perRequestOptionsRef = useRef(perRequestOptions);
 
+	/*
+	 * Deliberately no deps array: this must run after every render to keep the ref
+	 * current. Passing [perRequestOptions] would behave identically -- rest
+	 * destructuring builds a new object each render -- while implying a
+	 * memoization that does not exist.
+	 */
 	useEffect(() => {
 		perRequestOptionsRef.current = perRequestOptions;
 	});

--- a/webapp/client/packages/session-heartbeat/package.json
+++ b/webapp/client/packages/session-heartbeat/package.json
@@ -1,0 +1,71 @@
+{
+	"name": "@camunda/session-heartbeat",
+	"version": "0.0.1",
+	"license": "LicenseRef-Camunda-1.0",
+	"description": "Activity-driven session heartbeat for Camunda webapps backed by the Camunda security library",
+	"homepage": "https://github.com/camunda/camunda#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/camunda/camunda.git"
+	},
+	"bugs": {
+		"url": "https://github.com/camunda/camunda/issues"
+	},
+	"keywords": [
+		"camunda",
+		"session",
+		"heartbeat"
+	],
+	"type": "module",
+	"private": false,
+	"scripts": {
+		"build": "vite build",
+		"typecheck": "tsc",
+		"test:unit": "vitest",
+		"prepare": "npm run build"
+	},
+	"sideEffects": false,
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
+		"./react": {
+			"import": {
+				"types": "./dist/react.d.ts",
+				"default": "./dist/react.js"
+			}
+		},
+		"./package.json": "./package.json"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"packageManager": "npm@12.0.2",
+	"devDependencies": {
+		"@playwright/test": "1.62.1",
+		"@types/react": "19.2.18",
+		"@types/react-dom": "19.2.4",
+		"@vitest/browser-playwright": "4.1.10",
+		"react": "19.2.8",
+		"react-dom": "19.2.8",
+		"typescript": "7.0.2",
+		"vite": "8.2.1",
+		"vite-plugin-dts": "5.0.3",
+		"vitest": "4.1.10",
+		"vitest-browser-react": "2.2.0"
+	},
+	"peerDependencies": {
+		"react": "^18.0.0 || ^19.0.0"
+	},
+	"peerDependenciesMeta": {
+		"react": {
+			"optional": true
+		}
+	}
+}

--- a/webapp/client/packages/session-heartbeat/tsconfig.json
+++ b/webapp/client/packages/session-heartbeat/tsconfig.json
@@ -1,0 +1,30 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"target": "ES2022",
+		"jsx": "react-jsx",
+		"moduleDetection": "force",
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+
+		"declaration": true,
+
+		"module": "preserve",
+		"moduleResolution": "bundler",
+		"rootDir": "lib",
+
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"types": ["vitest/globals", "@vitest/browser/matchers"],
+
+		"outDir": "dist",
+		"emitDeclarationOnly": true,
+
+		"noEmit": true
+	},
+	"include": ["lib"]
+}

--- a/webapp/client/packages/session-heartbeat/vite.config.ts
+++ b/webapp/client/packages/session-heartbeat/vite.config.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/// <reference types="vitest" />
+
+import {defineConfig} from 'vite';
+import dts from 'vite-plugin-dts';
+import {playwright} from '@vitest/browser-playwright';
+
+export default defineConfig({
+	plugins: [
+		dts({
+			insertTypesEntry: true,
+			exclude: ['lib/**/*.test.ts', 'lib/**/*.test.tsx'],
+		}),
+	],
+	build: {
+		lib: {
+			entry: {
+				index: 'lib/index.ts',
+				react: 'lib/react.ts',
+			},
+			formats: ['es'],
+		},
+		minify: false,
+		rollupOptions: {
+			external: ['react'],
+			preserveEntrySignatures: 'strict',
+			output: {
+				preserveModules: true,
+			},
+		},
+	},
+	test: {
+		include: ['lib/**/*.test.ts', 'lib/**/*.test.tsx'],
+		reporters: process.env['CI'] ? ['default', 'github-actions', 'junit'] : ['default'],
+		outputFile: process.env['CI'] ? {junit: 'TEST-unit.xml'} : undefined,
+		browser: {
+			enabled: true,
+			screenshotFailures: false,
+			headless: true,
+			provider: playwright(),
+			instances: [{browser: 'chromium'}],
+		},
+	},
+});

--- a/webapp/client/scripts/prepublishOnly.js
+++ b/webapp/client/scripts/prepublishOnly.js
@@ -75,7 +75,7 @@ try {
 	});
 
 	console.log('🔧 Running build...');
-	execSync('npm run build -w @camunda/camunda-api-zod-schemas', {
+	execSync('npm run build -w @camunda/camunda-api-zod-schemas -w @camunda/session-heartbeat', {
 		stdio: 'inherit',
 		cwd: repoRoot,
 	});


### PR DESCRIPTION
## Description

CSL can now measure its session idle timeout against a dedicated heartbeat call instead of request traffic ([`camunda.security.session.heartbeat.enabled`](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0042-configurable-activity-driven-session-idle-timeout.md)). With that flag on, **only** `POST {basePath}/session/heartbeat` extends a session — so a frontend that doesn't send one gets its users logged out however actively they're working. Nothing on the frontend produced that signal yet.

This adds `@camunda/session-heartbeat` under `webapp/client/packages` and adopts it in the orchestration cluster webapp.

**The package** (`webapp/client/packages/session-heartbeat`)

- Passive, capture-phase listeners on `document` for `pointerdown`, `pointermove`, `keydown`, `wheel`, `scroll`, plus the tab regaining visibility. Handlers only set a flag. Capture phase matters twice: application handlers calling `stopPropagation` can't hide activity, and `scroll` — which doesn't bubble — is seen at all.
- At most one heartbeat per interval (60s default), and none at all for an interval without activity. Skipped while a previous request is in flight.
- Framework-agnostic `createSessionHeartbeat()` on `.`, `useSessionHeartbeat()` on `./react` with `react` as an *optional* peer dependency, so a future non-React host doesn't pull React in.
- Sends `X-CSRF-TOKEN`. CSL exempts only `/login` and `/logout` from CSRF, so a session-bearing heartbeat without the token is rejected with `403`.
- 27 tests in Vitest browser mode covering timing, the activity gate, per-event coverage, in-flight overlap, the CSRF header, each failure path, teardown, and the hook's mount/unmount/enable/stale-callback behavior.

**Orchestration cluster webapp**

Mounted once in `src/routes/_auth/route.tsx` next to `SessionWatcher`, so it starts after login and stops on logout. Reuses the CSRF token the request layer already caches, and on `401` disables the session exactly as `request()` does. Dev-server proxy entry added alongside `/login` and `/logout`.

### Why a shared package

The throttle interval and event list are exactly the details that drift once Operate, Tasklist, and Optimize each own a copy — the reasoning ADR-0042 records for choosing one versioned artifact over per-app implementations. A `401` deliberately does *not* stop the heartbeat: the consumer decides what an expired session means, and unmounting is what stops it, so a session recovered in place resumes being kept alive.

### Rollout safety

`heartbeat.enabled` defaults to `false` and the endpoint answers `204` regardless, so sending heartbeats is inert until a host opts in — adopting this doesn't depend on anyone's rollout decision. Nothing currently exposes the flag to the client, so the webapp heartbeats unconditionally: one `204` per tab per minute. Exposing it would be a system-configuration API change; happy to file that as a follow-up if reviewers prefer the gate.

### Other changes

- **CI:** the `unit` job now runs the workspace-wide `test:unit` script instead of only the webapp's — otherwise the package's tests would never run.
- `publish-session-heartbeat.yml`, cloned from the zod-schemas publish workflow, plus `prepublishOnly.js` building both packages.
- React Hooks lint rules extended to the package (they were webapp-only).
- Docs: package README, `docs/monorepo-docs/frontend/session-heartbeat.md`, and entries in `project-outline.md` / `frontend.md`.

### Verification

Prettier, ESLint, typecheck (all workspaces), Knip, `npm run build` (packages + webapp), Spotless, package tests 27/27, and `test/integration/component-routes.test.ts` (10 passed) to confirm the app still boots with the hook.

Pre-existing and unrelated: `src/operate/shared/DateRangeField/DateRangeField.test.tsx` fails 4 tests locally with matcher timeouts. Confirmed identical with this branch's changes stashed.

## Checklist

- [x] Not a bug fix or CI-behavior change for released branches — no backports needed.

## Related issues

No tracking issue yet; the design lives in [CSL ADR-0042](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0042-configurable-activity-driven-session-idle-timeout.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
