### PR TITLE
feat: propagate agentDefinitionKey to agent-instance storage and REST result

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstance.java
@@ -25,6 +25,9 @@ public interface AgentInstance {
   /** Returns the unique key identifying this agent instance. */
   long getAgentInstanceKey();
 
+  /** Returns the key of the agent definition this instance is linked to. */
+  long getAgentDefinitionKey();
+
   /** Returns the current execution status of the agent instance. */
   AgentInstanceStatus getStatus();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceImpl.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 public class AgentInstanceImpl implements AgentInstance {
 
   private final long agentInstanceKey;
+  private final long agentDefinitionKey;
   private final AgentInstanceStatus status;
   private final Definition definition;
   private final Metrics metrics;
@@ -49,6 +50,7 @@ public class AgentInstanceImpl implements AgentInstance {
 
   public AgentInstanceImpl(final AgentInstanceResult result) {
     agentInstanceKey = Long.parseLong(result.getAgentInstanceKey());
+    agentDefinitionKey = Long.parseLong(result.getAgentDefinitionKey());
     status = EnumUtil.convert(result.getStatus(), AgentInstanceStatus.class);
     definition = new DefinitionImpl(result.getDefinition());
     metrics = new MetricsImpl(result.getMetrics());
@@ -79,6 +81,11 @@ public class AgentInstanceImpl implements AgentInstance {
   @Override
   public long getAgentInstanceKey() {
     return agentInstanceKey;
+  }
+
+  @Override
+  public long getAgentDefinitionKey() {
+    return agentDefinitionKey;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/GetAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/GetAgentInstanceTest.java
@@ -50,6 +50,7 @@ class GetAgentInstanceTest extends ClientRestTest {
         agentInstanceKey,
         Instancio.create(AgentInstanceResult.class)
             .agentInstanceKey(String.valueOf(agentInstanceKey))
+            .agentDefinitionKey("4321")
             .status(AgentInstanceStatusEnum.IDLE)
             .processInstanceKey("9000")
             .rootProcessInstanceKey("50")
@@ -93,6 +94,10 @@ class GetAgentInstanceTest extends ClientRestTest {
               .assertThat(result.getAgentInstanceKey())
               .as("agentInstanceKey")
               .isEqualTo(agentInstanceKey);
+          softly
+              .assertThat(result.getAgentDefinitionKey())
+              .as("agentDefinitionKey")
+              .isEqualTo(4321L);
           softly.assertThat(result.getStatus()).as("status").isEqualTo(AgentInstanceStatus.IDLE);
           softly
               .assertThat(result.getProcessInstanceKey())

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
@@ -184,6 +184,7 @@ class SearchAgentInstanceTest extends ClientRestTest {
     final AgentInstanceResult provided =
         Instancio.create(AgentInstanceResult.class)
             .agentInstanceKey("42")
+            .agentDefinitionKey("84")
             .status(AgentInstanceStatusEnum.COMPLETED)
             .processInstanceKey("10")
             .rootProcessInstanceKey("5")
@@ -231,6 +232,7 @@ class SearchAgentInstanceTest extends ClientRestTest {
 
           final AgentInstance item = result.items().get(0);
           softly.assertThat(item.getAgentInstanceKey()).as("agentInstanceKey").isEqualTo(42L);
+          softly.assertThat(item.getAgentDefinitionKey()).as("agentDefinitionKey").isEqualTo(84L);
           softly.assertThat(item.getStatus()).as("status").isEqualTo(AgentInstanceStatus.COMPLETED);
           softly.assertThat(item.getProcessInstanceKey()).as("processInstanceKey").isEqualTo(10L);
           softly

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -142,6 +142,7 @@
       <column name="AGENT_INSTANCE_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
+      <column name="AGENT_DEFINITION_KEY" type="BIGINT"/>
       <column name="ELEMENT_ID" type="NVARCHAR(${userCharColumnSize})"/>
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
       <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
@@ -27,6 +27,7 @@ public class AgentInstanceEntityMapper {
     }
     return new AgentInstanceEntity(
         dbModel.agentInstanceKey(),
+        dbModel.agentDefinitionKey(),
         dbModel.elementInstanceKeys() != null ? dbModel.elementInstanceKeys() : List.of(),
         dbModel.status(),
         new AgentInstanceDefinition(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 public record AgentInstanceDbModel(
     long agentInstanceKey,
+    long agentDefinitionKey,
     String elementId,
     long processInstanceKey,
     long rootProcessInstanceKey,
@@ -63,6 +64,7 @@ public record AgentInstanceDbModel(
   // separately via the sibling <collection> element.
   public AgentInstanceDbModel(
       final long agentInstanceKey,
+      final long agentDefinitionKey,
       final String elementId,
       final long processInstanceKey,
       final long rootProcessInstanceKey,
@@ -89,6 +91,7 @@ public record AgentInstanceDbModel(
       final OffsetDateTime completionDate) {
     this(
         agentInstanceKey,
+        agentDefinitionKey,
         elementId,
         processInstanceKey,
         rootProcessInstanceKey,
@@ -133,6 +136,7 @@ public record AgentInstanceDbModel(
 
     return new AgentInstanceDbModel(
         agentInstanceKey,
+        agentDefinitionKey,
         elementId,
         processInstanceKey,
         rootProcessInstanceKey,
@@ -200,6 +204,7 @@ public record AgentInstanceDbModel(
   public Builder toBuilder() {
     return new Builder(tools)
         .agentInstanceKey(agentInstanceKey)
+        .agentDefinitionKey(agentDefinitionKey)
         .elementId(elementId)
         .processInstanceKey(processInstanceKey)
         .rootProcessInstanceKey(rootProcessInstanceKey)
@@ -229,6 +234,7 @@ public record AgentInstanceDbModel(
   public static class Builder implements ObjectBuilder<AgentInstanceDbModel> {
 
     private long agentInstanceKey;
+    private long agentDefinitionKey;
     private String elementId;
     private long processInstanceKey;
     private long rootProcessInstanceKey;
@@ -268,6 +274,11 @@ public record AgentInstanceDbModel(
 
     public Builder agentInstanceKey(final long agentInstanceKey) {
       this.agentInstanceKey = agentInstanceKey;
+      return this;
+    }
+
+    public Builder agentDefinitionKey(final long agentDefinitionKey) {
+      this.agentDefinitionKey = agentDefinitionKey;
       return this;
     }
 
@@ -400,6 +411,7 @@ public record AgentInstanceDbModel(
     public AgentInstanceDbModel build() {
       return new AgentInstanceDbModel(
           agentInstanceKey,
+          agentDefinitionKey,
           elementId,
           processInstanceKey,
           rootProcessInstanceKey,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
@@ -54,7 +54,8 @@ public class AgentInstanceWriter extends ProcessInstanceDependant implements Rdb
         mergeToQueue(
             agentInstance.agentInstanceKey(),
             b -> {
-              b.processDefinitionId(agentInstance.processDefinitionId())
+              b.agentDefinitionKey(agentInstance.agentDefinitionKey())
+                  .processDefinitionId(agentInstance.processDefinitionId())
                   .processDefinitionKey(agentInstance.processDefinitionKey())
                   .processDefinitionVersion(agentInstance.processDefinitionVersion())
                   .versionTag(agentInstance.versionTag())

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -17,7 +17,9 @@
   <!-- default: PostgreSQL, H2, MariaDB, MySQL -->
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
     INSERT INTO ${prefix}AGENT_INSTANCE (
-      AGENT_INSTANCE_KEY,ELEMENT_ID,
+      AGENT_INSTANCE_KEY,
+      AGENT_DEFINITION_KEY,
+      ELEMENT_ID,
       PROCESS_INSTANCE_KEY,
       ROOT_PROCESS_INSTANCE_KEY,
       PROCESS_DEFINITION_ID,
@@ -44,6 +46,7 @@
     )
     VALUES (
       #{agentInstanceKey},
+      #{agentDefinitionKey},
       #{elementId},
       #{processInstanceKey},
       #{rootProcessInstanceKey},
@@ -78,6 +81,7 @@
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
     UPDATE ${prefix}AGENT_INSTANCE
     SET
+      AGENT_DEFINITION_KEY       = #{agentDefinitionKey},
       PROCESS_DEFINITION_ID      = #{processDefinitionId},
       PROCESS_DEFINITION_KEY     = #{processDefinitionKey},
       PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
@@ -147,6 +151,7 @@
     type="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
     <constructor>
       <idArg column="AGENT_INSTANCE_KEY" javaType="_long" name="agentInstanceKey"/>
+      <arg column="AGENT_DEFINITION_KEY" javaType="_long" name="agentDefinitionKey"/>
       <arg column="ELEMENT_ID" javaType="java.lang.String" name="elementId"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="_long" name="processInstanceKey"/>
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="_long" name="rootProcessInstanceKey"/>
@@ -188,6 +193,7 @@
         SELECT * FROM (
           SELECT
             ai.AGENT_INSTANCE_KEY,
+            ai.AGENT_DEFINITION_KEY,
             ai.ELEMENT_ID,
             ai.PROCESS_INSTANCE_KEY,
             ai.ROOT_PROCESS_INSTANCE_KEY,

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
@@ -29,6 +29,7 @@ class AgentInstanceEntityMapperTest {
         buildModel(
             key -> {
               key.agentInstanceKey(100L);
+              key.agentDefinitionKey(500L);
               key.elementId("Task_1");
               key.processInstanceKey(200L);
               key.rootProcessInstanceKey(300L);
@@ -59,6 +60,7 @@ class AgentInstanceEntityMapperTest {
     final AgentInstanceEntity entity = AgentInstanceEntityMapper.toEntity(dbModel);
 
     assertThat(entity.agentInstanceKey()).isEqualTo(100L);
+    assertThat(entity.agentDefinitionKey()).isEqualTo(500L);
     assertThat(entity.elementId()).isEqualTo("Task_1");
     assertThat(entity.processInstanceKey()).isEqualTo(200L);
     assertThat(entity.rootProcessInstanceKey()).isEqualTo(300L);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2154,6 +2154,7 @@ public final class SearchQueryResponseMapper {
 
     return AgentInstanceResult.Builder.create()
         .agentInstanceKey(keyToString(entity.agentInstanceKey()))
+        .agentDefinitionKey(keyToString(entity.agentDefinitionKey()))
         .status(AgentInstanceStatusEnum.fromValue(entity.status().name()))
         .definition(definition)
         .metrics(metrics)

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1066,6 +1066,7 @@ class SearchQueryResponseMapperTest {
 
     // then
     assertThat(response.getRootProcessInstanceKey()).isEqualTo("999");
+    assertThat(response.getAgentDefinitionKey()).isEqualTo("654");
   }
 
   @Test

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1041,6 +1041,7 @@ class SearchQueryResponseMapperTest {
     final var entity =
         new AgentInstanceEntity(
             123L, // agentInstanceKey
+            654L, // agentDefinitionKey
             List.of(456L), // elementInstanceKeys
             AgentInstanceEntity.AgentInstanceStatus.IDLE,
             new AgentInstanceEntity.AgentInstanceDefinition("gpt-4o", "openai", "You are helpful"),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -153,6 +153,11 @@ public class AgentInstanceFetchIT {
               .assertThat(response.getAgentInstanceKey())
               .as("agentInstanceKey")
               .isEqualTo(agentInstanceKey1);
+          softly
+              .assertThat(response.getAgentDefinitionKey())
+              .as("agentDefinitionKey")
+              .isNotNull()
+              .isPositive();
           softly.assertThat(response.getElementId()).as("elementId").isEqualTo(AGENT_ELEMENT_ID);
           softly
               .assertThat(response.getProcessInstanceKey())
@@ -210,6 +215,11 @@ public class AgentInstanceFetchIT {
               .assertThat(response.getAgentInstanceKey())
               .as("agentInstanceKey")
               .isEqualTo(agentInstanceKey2);
+          softly
+              .assertThat(response.getAgentDefinitionKey())
+              .as("agentDefinitionKey")
+              .isNotNull()
+              .isPositive();
           softly.assertThat(response.getElementId()).as("elementId").isEqualTo(AGENT_ELEMENT_ID);
           softly
               .assertThat(response.getProcessInstanceKey())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -182,6 +182,8 @@ public class AgentInstanceSearchIT {
     assertThat(response.items())
         .extracting(AgentInstance::getAgentInstanceKey)
         .containsExactlyInAnyOrder(agentInstanceKey1, agentInstanceKey2, agentInstanceKey3);
+    assertThat(response.items())
+        .allSatisfy(ai -> assertThat(ai.getAgentDefinitionKey()).isNotNull().isPositive());
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -70,6 +70,8 @@ public class AgentInstanceMigrationIT {
     final var processInstanceKey =
         startProcessInstance(client, sourceProcess.getBpmnProcessId()).getProcessInstanceKey();
     final var agentInstanceKey = createAgentInstance(processInstanceKey, sourceElementId);
+    final long sourceAgentDefinitionKey =
+        client.newAgentInstanceGetRequest(agentInstanceKey).execute().getAgentDefinitionKey();
 
     activateAndCompleteJobs(client, agentJobType, "test-worker", 1);
     waitForElementInstances(
@@ -88,7 +90,8 @@ public class AgentInstanceMigrationIT {
 
     // then — the agent instance is migrated even though its owning element instance already
     // completed and is not part of the migrated element tree
-    assertAgentInstanceMigratedTo(agentInstanceKey, targetProcess, targetElementId);
+    assertAgentInstanceMigratedTo(
+        agentInstanceKey, targetProcess, targetElementId, sourceAgentDefinitionKey);
   }
 
   @Test
@@ -123,6 +126,8 @@ public class AgentInstanceMigrationIT {
     final var processInstanceKey =
         startProcessInstance(client, sourceProcess.getBpmnProcessId()).getProcessInstanceKey();
     final var agentInstanceKey = createAgentInstance(processInstanceKey, sourceElementId);
+    final long sourceAgentDefinitionKey =
+        client.newAgentInstanceGetRequest(agentInstanceKey).execute().getAgentDefinitionKey();
 
     // when
     client
@@ -135,7 +140,8 @@ public class AgentInstanceMigrationIT {
         .execute();
 
     // then
-    assertAgentInstanceMigratedTo(agentInstanceKey, targetProcess, targetElementId);
+    assertAgentInstanceMigratedTo(
+        agentInstanceKey, targetProcess, targetElementId, sourceAgentDefinitionKey);
   }
 
   private long createAgentInstance(final long processInstanceKey, final String elementId) {
@@ -164,7 +170,10 @@ public class AgentInstanceMigrationIT {
   }
 
   private void assertAgentInstanceMigratedTo(
-      final long agentInstanceKey, final Process targetProcess, final String targetElementId) {
+      final long agentInstanceKey,
+      final Process targetProcess,
+      final String targetElementId,
+      final long sourceAgentDefinitionKey) {
     await("agent instance reflects the target process definition after migration")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
@@ -189,6 +198,12 @@ public class AgentInstanceMigrationIT {
                         .assertThat(response.getElementId())
                         .as("elementId")
                         .isEqualTo(targetElementId);
+                    softly
+                        .assertThat(response.getAgentDefinitionKey())
+                        .as("agentDefinitionKey")
+                        .isNotNull()
+                        .isPositive()
+                        .isNotEqualTo(sourceAgentDefinitionKey);
                   });
             });
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
@@ -63,6 +63,7 @@ public class AgentInstanceIT {
                     .processDefinitionKey(model.processDefinitionKey() + 1)
                     .processDefinitionVersion(model.processDefinitionVersion() + 1)
                     .versionTag("v2")
+                    .agentDefinitionKey(model.agentDefinitionKey() + 1)
                     .elementId("migrated-element"));
     final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
     rdbmsWriters.getAgentInstanceWriter().update(migrated);
@@ -78,6 +79,7 @@ public class AgentInstanceIT {
     assertThat(entity.processDefinitionKey()).isEqualTo(migrated.processDefinitionKey());
     assertThat(entity.processDefinitionVersion()).isEqualTo(migrated.processDefinitionVersion());
     assertThat(entity.versionTag()).isEqualTo("v2");
+    assertThat(entity.agentDefinitionKey()).isEqualTo(migrated.agentDefinitionKey());
     assertThat(entity.elementId()).isEqualTo("migrated-element");
   }
 
@@ -104,7 +106,8 @@ public class AgentInstanceIT {
 
     // when — a second write to the same row is queued before the first is flushed, so it must
     // coalesce into the still-pending INSERT via UpsertMerger/Copyable.copy() instead of issuing
-    // a separate UPDATE
+    // a separate UPDATE. The update also re-resolves agentDefinitionKey (as a migration would), so
+    // the merge must carry the new key rather than leaving the create-time one on the pending row.
     final var updatedTools =
         List.of(new AgentInstanceToolDbValue("calculator", "does math", "el-2"));
     final var updated =
@@ -112,6 +115,7 @@ public class AgentInstanceIT {
             b ->
                 ((AgentInstanceDbModel.Builder) b)
                     .status(AgentInstanceStatus.THINKING)
+                    .agentDefinitionKey(created.agentDefinitionKey() + 1)
                     .toolValues(updatedTools));
     rdbmsWriters.getAgentInstanceWriter().update(updated);
     rdbmsWriters.flush();
@@ -126,6 +130,7 @@ public class AgentInstanceIT {
 
     assertThat(entity).isNotNull();
     assertThat(entity.status()).isEqualTo(AgentInstanceStatus.THINKING);
+    assertThat(entity.agentDefinitionKey()).isEqualTo(updated.agentDefinitionKey());
     assertThat(entity.tools()).hasSize(1);
     assertThat(entity.tools().getFirst().name()).isEqualTo("calculator");
     assertThat(entity.definition().model()).isEqualTo(created.model());
@@ -189,6 +194,7 @@ public class AgentInstanceIT {
   private void assertFieldsMatch(
       final AgentInstanceDbModel dbModel, final AgentInstanceEntity entity) {
     assertThat(entity.agentInstanceKey()).isEqualTo(dbModel.agentInstanceKey());
+    assertThat(entity.agentDefinitionKey()).isEqualTo(dbModel.agentDefinitionKey());
     assertThat(entity.elementId()).isEqualTo(dbModel.elementId());
     assertThat(entity.processInstanceKey()).isEqualTo(dbModel.processInstanceKey());
     assertThat(entity.processDefinitionKey()).isEqualTo(dbModel.processDefinitionKey());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentInstanceFixtures.java
@@ -28,6 +28,7 @@ public final class AgentInstanceFixtures extends CommonFixtures {
     final var builder =
         new Builder()
             .agentInstanceKey(key)
+            .agentDefinitionKey(nextKey())
             .elementId("element-" + key)
             .processInstanceKey(processInstanceKey)
             .rootProcessInstanceKey(processInstanceKey)

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformer.java
@@ -44,6 +44,7 @@ public class AgentInstanceEntityTransformer
 
     return new AgentInstanceEntity(
         source.getKey(),
+        source.getAgentDefinitionKey(),
         source.getElementInstanceKeys(),
         toStatus(source.getStatus()),
         definition,

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformerTest.java
@@ -24,6 +24,7 @@ class AgentInstanceEntityTransformerTest {
   private io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity buildSource() {
     final var source = new io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity();
     source.setKey(100L);
+    source.setAgentDefinitionKey(500L);
     source.setElementInstanceKeys(List.of(1L, 2L));
     source.setStatus(
         io.camunda.webapps.schema.entities.agentinstance.AgentInstanceStatus.COMPLETED);
@@ -60,6 +61,7 @@ class AgentInstanceEntityTransformerTest {
     final var result = transformer.apply(buildSource());
 
     assertThat(result.agentInstanceKey()).isEqualTo(100L);
+    assertThat(result.agentDefinitionKey()).isEqualTo(500L);
     assertThat(result.elementInstanceKeys()).containsExactly(1L, 2L);
     assertThat(result.status()).isEqualTo(AgentInstanceStatus.COMPLETED);
     assertThat(result.definition().model()).isEqualTo("gpt-4o");

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -18,6 +18,7 @@ import org.jspecify.annotations.Nullable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AgentInstanceEntity(
     Long agentInstanceKey,
+    Long agentDefinitionKey,
     List<Long> elementInstanceKeys,
     AgentInstanceStatus status,
     AgentInstanceDefinition definition,
@@ -39,6 +40,7 @@ public record AgentInstanceEntity(
 
   public AgentInstanceEntity {
     Objects.requireNonNull(agentInstanceKey, "agentInstanceKey");
+    Objects.requireNonNull(agentDefinitionKey, "agentDefinitionKey");
     Objects.requireNonNull(status, "status");
     Objects.requireNonNull(definition, "definition");
     Objects.requireNonNull(metrics, "metrics");

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
@@ -20,6 +20,7 @@ public class AgentInstanceTemplate extends AbstractTemplateDescriptor
   public static final String INDEX_VERSION = "8.10.0";
 
   public static final String KEY = "key";
+  public static final String AGENT_DEFINITION_KEY = "agentDefinitionKey";
   public static final String ELEMENT_ID = "elementId";
   public static final String ELEMENT_INSTANCE_KEYS = "elementInstanceKeys";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceEntity.java
@@ -31,6 +31,10 @@ public final class AgentInstanceEntity
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private long key;
 
+  /** Key of the agent definition this instance runs on, or {@code -1} when unset. */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long agentDefinitionKey = -1L;
+
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private String elementId;
 
@@ -133,6 +137,15 @@ public final class AgentInstanceEntity
 
   public AgentInstanceEntity setKey(final long key) {
     this.key = key;
+    return this;
+  }
+
+  public long getAgentDefinitionKey() {
+    return agentDefinitionKey;
+  }
+
+  public AgentInstanceEntity setAgentDefinitionKey(final long agentDefinitionKey) {
+    this.agentDefinitionKey = agentDefinitionKey;
     return this;
   }
 
@@ -369,6 +382,7 @@ public final class AgentInstanceEntity
     return Objects.hash(
         id,
         key,
+        agentDefinitionKey,
         elementId,
         processInstanceKey,
         bpmnProcessId,
@@ -407,6 +421,7 @@ public final class AgentInstanceEntity
     final var that = (AgentInstanceEntity) obj;
     return Objects.equals(id, that.id)
         && key == that.key
+        && agentDefinitionKey == that.agentDefinitionKey
         && Objects.equals(elementId, that.elementId)
         && processInstanceKey == that.processInstanceKey
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
@@ -442,6 +457,8 @@ public final class AgentInstanceEntity
         + '\''
         + ", key="
         + key
+        + ", agentDefinitionKey="
+        + agentDefinitionKey
         + ", elementId='"
         + elementId
         + '\''

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
@@ -8,6 +8,9 @@
       "key": {
         "type": "long"
       },
+      "agentDefinitionKey": {
+        "type": "long"
+      },
       "elementId": {
         "type": "keyword"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
@@ -8,6 +8,9 @@
       "key": {
         "type": "long"
       },
+      "agentDefinitionKey": {
+        "type": "long"
+      },
       "elementId": {
         "type": "keyword"
       },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.AGENT_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_ID;
@@ -96,6 +97,7 @@ public class AgentInstanceHandler
 
     entity
         .setKey(record.getKey())
+        .setAgentDefinitionKey(value.getAgentDefinitionKey())
         .setPartitionId(record.getPartitionId())
         .setElementId(value.getElementId())
         .setProcessInstanceKey(value.getProcessInstanceKey())
@@ -140,6 +142,7 @@ public class AgentInstanceHandler
     // always included.
     updateFields.put(BPMN_PROCESS_ID, entity.getBpmnProcessId());
     updateFields.put(PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
+    updateFields.put(AGENT_DEFINITION_KEY, entity.getAgentDefinitionKey());
     updateFields.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
     updateFields.put(VERSION_TAG, entity.getVersionTag());
     updateFields.put(ELEMENT_ID, entity.getElementId());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.AGENT_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_ID;
@@ -104,6 +105,7 @@ final class AgentInstanceHandlerTest {
     final long rootProcessInstanceKey = 250L;
     final String bpmnProcessId = "myProcess";
     final long processDefinitionKey = 400L;
+    final long agentDefinitionKey = 401L;
     final int processDefinitionVersion = 2;
     final String versionTag = "v2";
     final String tenantId = "<default>";
@@ -134,6 +136,7 @@ final class AgentInstanceHandlerTest {
             .withRootProcessInstanceKey(rootProcessInstanceKey)
             .withBpmnProcessId(bpmnProcessId)
             .withProcessDefinitionKey(processDefinitionKey)
+            .withAgentDefinitionKey(agentDefinitionKey)
             .withProcessDefinitionVersion(processDefinitionVersion)
             .withVersionTag(versionTag)
             .withTenantId(tenantId)
@@ -186,6 +189,7 @@ final class AgentInstanceHandlerTest {
     assertThat(entity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
     assertThat(entity.getBpmnProcessId()).isEqualTo(bpmnProcessId);
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+    assertThat(entity.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey);
     assertThat(entity.getProcessDefinitionVersion()).isEqualTo(processDefinitionVersion);
     assertThat(entity.getVersionTag()).isEqualTo(versionTag);
     assertThat(entity.getTenantId()).isEqualTo(tenantId);
@@ -207,6 +211,40 @@ final class AgentInstanceHandlerTest {
     assertThat(entity.getCreationDate()).isEqualTo(expectedTimestamp);
     assertThat(entity.getLastUpdatedDate()).isEqualTo(expectedTimestamp);
     assertThat(entity.getCompletionDate()).isNull();
+  }
+
+  @Test
+  void shouldReResolveAgentDefinitionKeyOnMigrated() {
+    // given — an entity created with an initial agent definition key
+    final var entity = new AgentInstanceEntity().setId("1");
+    final Record<AgentInstanceRecordValue> createdRecord =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r ->
+                r.withIntent(AgentInstanceIntent.CREATED)
+                    .withValue(
+                        ImmutableAgentInstanceRecordValue.builder()
+                            .from(buildMinimalRecordValue(1L))
+                            .withAgentDefinitionKey(700L)
+                            .build()));
+    underTest.updateEntity(createdRecord, entity);
+    assertThat(entity.getAgentDefinitionKey()).isEqualTo(700L);
+
+    // when — a MIGRATED record carries a re-resolved agent definition key
+    final Record<AgentInstanceRecordValue> migratedRecord =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r ->
+                r.withIntent(AgentInstanceIntent.MIGRATED)
+                    .withValue(
+                        ImmutableAgentInstanceRecordValue.builder()
+                            .from(buildMinimalRecordValue(1L))
+                            .withAgentDefinitionKey(800L)
+                            .build()));
+    underTest.updateEntity(migratedRecord, entity);
+
+    // then — the entity reflects the re-resolved key
+    assertThat(entity.getAgentDefinitionKey()).isEqualTo(800L);
   }
 
   @Test
@@ -394,6 +432,7 @@ final class AgentInstanceHandlerTest {
     // intent since flush() has no access to the record intent (see AgentInstanceHandler#flush).
     expectedUpdateFields.put(BPMN_PROCESS_ID, entity.getBpmnProcessId());
     expectedUpdateFields.put(PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
+    expectedUpdateFields.put(AGENT_DEFINITION_KEY, entity.getAgentDefinitionKey());
     expectedUpdateFields.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
     expectedUpdateFields.put(VERSION_TAG, entity.getVersionTag());
     expectedUpdateFields.put(ELEMENT_ID, entity.getElementId());
@@ -438,6 +477,7 @@ final class AgentInstanceHandlerTest {
   private AgentInstanceRecordValue buildMinimalRecordValue(final long agentInstanceKey) {
     return ImmutableAgentInstanceRecordValue.builder()
         .withAgentInstanceKey(agentInstanceKey)
+        .withAgentDefinitionKey(700L)
         .withRootProcessInstanceKey(50L)
         .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.IDLE)
         .withDefinition(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
@@ -66,6 +66,7 @@ public class AgentInstanceExportHandler implements RdbmsExportHandler<AgentInsta
     final Builder builder =
         new Builder()
             .agentInstanceKey(record.getKey())
+            .agentDefinitionKey(value.getAgentDefinitionKey())
             .elementId(value.getElementId())
             .processInstanceKey(value.getProcessInstanceKey())
             .rootProcessInstanceKey(value.getRootProcessInstanceKey())

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
@@ -113,6 +113,7 @@ class AgentInstanceExportHandlerTest {
     final AgentInstanceDbModel model = modelCaptor.getValue();
     // identity
     assertThat(model.agentInstanceKey()).isEqualTo(agentKey);
+    assertThat(model.agentDefinitionKey()).isEqualTo(700L);
     assertThat(model.elementId()).isEqualTo("myElement");
     assertThat(model.processInstanceKey()).isEqualTo(100L);
     assertThat(model.rootProcessInstanceKey()).isEqualTo(50L);
@@ -184,6 +185,7 @@ class AgentInstanceExportHandlerTest {
             .withProcessDefinitionVersion(4)
             .withVersionTag("v2.0")
             .withElementId("targetElement")
+            .withAgentDefinitionKey(888L)
             .build();
     final Record<AgentInstanceRecordValue> record =
         factory.generateRecord(
@@ -205,6 +207,7 @@ class AgentInstanceExportHandlerTest {
     assertThat(model.processDefinitionVersion()).isEqualTo(4);
     assertThat(model.versionTag()).isEqualTo("v2.0");
     assertThat(model.elementId()).isEqualTo("targetElement");
+    assertThat(model.agentDefinitionKey()).isEqualTo(888L);
     assertThat(model.completionDate()).isNull();
   }
 
@@ -335,6 +338,7 @@ class AgentInstanceExportHandlerTest {
             .build();
     return ImmutableAgentInstanceRecordValue.builder()
         .withAgentInstanceKey(agentInstanceKey)
+        .withAgentDefinitionKey(700L)
         .withElementInstanceKey(300L)
         .withElementInstanceKeys(List.of(200L, 300L))
         .withElementId("myElement")

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -438,6 +438,7 @@ components:
       type: object
       required:
         - agentInstanceKey
+        - agentDefinitionKey
         - status
         - definition
         - metrics
@@ -460,6 +461,10 @@ components:
           description: The unique key for this agent instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentInstanceKey'
+        agentDefinitionKey:
+          description: The key of the agent definition this agent instance runs on.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/AgentDefinitionKey'
         status:
           $ref: '#/components/schemas/AgentInstanceStatusEnum'
         definition:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -45,6 +45,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
 
   private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
   private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
+  private static final long AGENT_DEFINITION_KEY = 9007199254741018L;
   private static final long PROCESS_INSTANCE_KEY = 9007199254741001L;
   private static final long ROOT_PROCESS_INSTANCE_KEY = 9007199254741000L;
   private static final long PROCESS_DEFINITION_KEY = 9007199254740992L;
@@ -58,6 +59,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
   private static final AgentInstanceEntity AGENT_INSTANCE_ENTITY =
       new AgentInstanceEntity(
           AGENT_INSTANCE_KEY,
+          AGENT_DEFINITION_KEY,
           List.of(ELEMENT_INSTANCE_KEY),
           AgentInstanceStatus.COMPLETED,
           new AgentInstanceDefinition("gpt-4o", "openai", "You are a helpful assistant."),

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -84,6 +84,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
         "items": [
           {
             "agentInstanceKey": "%d",
+            "agentDefinitionKey": "%d",
             "status": "COMPLETED",
             "definition": {
               "model": "gpt-4o",
@@ -132,6 +133,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
       """
           .formatted(
               AGENT_INSTANCE_KEY,
+              AGENT_DEFINITION_KEY,
               PROCESS_INSTANCE_KEY,
               ROOT_PROCESS_INSTANCE_KEY,
               PROCESS_DEFINITION_KEY,
@@ -169,6 +171,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
             """
             {
               "agentInstanceKey": "%d",
+              "agentDefinitionKey": "%d",
               "status": "COMPLETED",
               "definition": {
                 "model": "gpt-4o",
@@ -209,6 +212,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
             """
                 .formatted(
                     AGENT_INSTANCE_KEY,
+                    AGENT_DEFINITION_KEY,
                     PROCESS_INSTANCE_KEY,
                     ROOT_PROCESS_INSTANCE_KEY,
                     PROCESS_DEFINITION_KEY,


### PR DESCRIPTION
## Description

Propagates the `agentDefinitionKey` field through the full agent-instance data pipeline so that consumers can pivot from a running agent instance to its definition.

### Changes

**Exporters (Elasticsearch/OpenSearch & RDBMS)**
- Updated `AgentInstanceHandler` (camunda exporter) and `AgentInstanceExportHandler` (RDBMS exporter) to read `agentDefinitionKey` from the Zeebe record and write it to the respective storage backends.
- Added `AGENT_DEFINITION_KEY` column to the RDBMS schema (`8.10.0` changeset) and to both the Elasticsearch and OpenSearch index templates.
- Updated `AgentInstanceMapper.xml` (MyBatis) to include `AGENT_DEFINITION_KEY` in `INSERT`, `UPDATE`, and `SELECT` operations.
- Updated `AgentInstanceDbModel` and its builder to carry the new field.

**Search & REST layer**
- Added `agentDefinitionKey` to `AgentInstanceEntity` (search domain record).
- Updated `AgentInstanceEntityTransformer` and `AgentInstanceEntityMapper` (RDBMS read side) to map the field.
- Exposed `agentDefinitionKey` in the REST response via `SearchQueryResponseMapper`, mapping unset sentinel values (`≤ 0`) to `null`.
- Added `agentDefinitionKey` field to the gateway REST OpenAPI spec (`agent-instances.yaml`) as nullable.
- Updated `AgentInstanceTemplate` descriptor constant.

**Java client**
- Added `getAgentDefinitionKey()` to the `AgentInstance` interface and implemented it in `AgentInstanceImpl`.

### Testing
- Unit tests updated across all layers (exporter handler, RDBMS mapper, entity transformer, REST controller, Java client).
- Added a dedicated test `shouldReResolveAgentDefinitionKeyOnMigrated` verifying that migration re-resolves the key correctly.
- Acceptance tests (`AgentInstanceFetchIT`, `AgentInstanceSearchIT`, `AgentInstanceMigrationIT`, `AgentInstanceIT`) extended to assert the field is present, positive, and updated on migration.

## Related issues

Closes #59091