### PR TITLE
ClusterAdmin Restore API definition

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -161,6 +161,9 @@ public class CamundaServicesConfiguration {
     // Collected here as well as registered per tenant, so the cluster-wide ClusterStatusServices
     // can fold over every tenant's topology below.
     final Map<String, TopologyServices> topologyServicesByTenant = new HashMap<>();
+    // Collected here as well as bound per tenant, so the cluster-wide ClusterRecoveryServices can
+    // resolve the restore environment of a tenant named in a cluster-admin restore's overrides.
+    final Map<String, TenantRestoreEnvironment> restoreEnvironmentByTenant = new HashMap<>();
 
     physicalTenantResolver
         .getAll()
@@ -188,6 +191,7 @@ public class CamundaServicesConfiguration {
                   new TenantRestoreEnvironment(
                       tenantConfig.getData().getSecondaryStorage().getType().name(),
                       tenantConfig.getData().getPrimaryStorage().getBackup().isContinuous());
+              restoreEnvironmentByTenant.put(tenantId, restoreEnvironment);
 
               // -- per-tenant process cache --
               final var processCacheConfig = tenantConfig.getApi().getRest().getProcessCache();
@@ -560,7 +564,8 @@ public class CamundaServicesConfiguration {
             physicalTenantId -> secondaryStorageReadiness.getObject().isReady(physicalTenantId)));
     builder.clusterTopologyServices(new ClusterTopologyServices(topologyServicesByTenant));
 
-    builder.clusterRecoveryServices(new ClusterRecoveryServices(clusterConfigurationRequestSender));
+    builder.clusterRecoveryServices(
+        new ClusterRecoveryServices(clusterConfigurationRequestSender, restoreEnvironmentByTenant));
 
     return builder.build();
   }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -169,6 +169,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/service/src/main/java/io/camunda/service/ClusterRecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRecoveryServices.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.util.Either;
 import java.util.Map;
@@ -70,10 +71,15 @@ public final class ClusterRecoveryServices {
       final Map<String, RestoreParameters> overrides,
       final boolean dryRun) {
     final ClusterRestoreRequest restoreRequest;
-    restoreRequest =
-        physicalTenantId
-            .map(tenantId -> tenantRestoreRequest(tenantId, parameters, dryRun))
-            .orElseGet(() -> clusterWideRestoreRequest(parameters, overrides, dryRun));
+    try {
+      restoreRequest =
+          physicalTenantId
+              .map(tenantId -> tenantRestoreRequest(tenantId, parameters, dryRun))
+              .orElseGet(() -> clusterWideRestoreRequest(parameters, overrides, dryRun));
+    } catch (final NotFound e) {
+      return CompletableFuture.completedFuture(
+          Either.left(new ErrorResponse(ErrorCode.NOT_FOUND, e.getMessage())));
+    }
     return clusterConfigurationRequestSender.clusterRestore(restoreRequest);
   }
 
@@ -106,9 +112,10 @@ public final class ClusterRecoveryServices {
 
   private TenantRestoreEnvironment restoreEnvironmentFor(final String physicalTenantId) {
     final var environment = restoreEnvironmentByPhysicalTenant.get(physicalTenantId);
-    if (environment != null) {
-      return environment;
+    if (environment == null) {
+      throw new NotFound(
+          "No physical tenant '%s' is configured in this cluster.".formatted(physicalTenantId));
     }
-    throw new NotFound("No restore environment bound for physical tenant " + physicalTenantId);
+    return environment;
   }
 }

--- a/service/src/main/java/io/camunda/service/ClusterRecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRecoveryServices.java
@@ -8,13 +8,19 @@
 package io.camunda.service;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.util.Either;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -26,10 +32,13 @@ import org.jspecify.annotations.Nullable;
 public final class ClusterRecoveryServices {
 
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
+  private final Map<String, TenantRestoreEnvironment> restoreEnvironmentByPhysicalTenant;
 
   public ClusterRecoveryServices(
-      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender) {
+      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender,
+      final Map<String, TenantRestoreEnvironment> restoreEnvironmentByPhysicalTenant) {
     this.clusterConfigurationRequestSender = clusterConfigurationRequestSender;
+    this.restoreEnvironmentByPhysicalTenant = restoreEnvironmentByPhysicalTenant;
   }
 
   /**
@@ -42,5 +51,64 @@ public final class ClusterRecoveryServices {
       final @Nullable String physicalTenantId, final Mode mode, final boolean dryRun) {
     return clusterConfigurationRequestSender.modeChange(
         new ModeChangeRequest(Optional.ofNullable(physicalTenantId), mode, dryRun));
+  }
+
+  /**
+   * Restores physical tenants from backups. The request targets a single physical tenant, or every
+   * physical tenant of the cluster when it names none.
+   *
+   * @param physicalTenantId the physical tenant to restore, or empty to restore every physical
+   *     tenant of the cluster
+   * @param parameters the backup selection applied to every targeted physical tenant that has no
+   *     entry in {@code overrides}
+   * @param overrides the backup selection of individual physical tenants, keyed by physical tenant
+   *     id; only meaningful for a cluster-wide restore
+   */
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> restore(
+      final Optional<String> physicalTenantId,
+      final RestoreParameters parameters,
+      final Map<String, RestoreParameters> overrides,
+      final boolean dryRun) {
+    final ClusterRestoreRequest restoreRequest;
+    restoreRequest =
+        physicalTenantId
+            .map(tenantId -> tenantRestoreRequest(tenantId, parameters, dryRun))
+            .orElseGet(() -> clusterWideRestoreRequest(parameters, overrides, dryRun));
+    return clusterConfigurationRequestSender.clusterRestore(restoreRequest);
+  }
+
+  private ClusterRestoreRequest tenantRestoreRequest(
+      final String physicalTenantId, final RestoreParameters parameters, final boolean dryRun) {
+    final var args = toArguments(physicalTenantId, parameters);
+    return new ClusterRestoreRequest(Map.of(physicalTenantId, args), dryRun);
+  }
+
+  private ClusterRestoreRequest clusterWideRestoreRequest(
+      final RestoreParameters parameters,
+      final Map<String, RestoreParameters> overrides,
+      final boolean dryRun) {
+    final var restoreArgumentsMap =
+        restoreEnvironmentByPhysicalTenant.keySet().stream()
+            .collect(
+                Collectors.toMap(
+                    tenantId -> tenantId,
+                    tenantId ->
+                        toArguments(tenantId, overrides.getOrDefault(tenantId, parameters))));
+    return new ClusterRestoreRequest(restoreArgumentsMap, dryRun);
+  }
+
+  private TenantRestoreArguments toArguments(
+      final String physicalTenantId, final RestoreParameters parameters) {
+    final var environment = restoreEnvironmentFor(physicalTenantId);
+    return new TenantRestoreArguments(
+        parameters, environment.databaseType(), environment.continuousBackups());
+  }
+
+  private TenantRestoreEnvironment restoreEnvironmentFor(final String physicalTenantId) {
+    final var environment = restoreEnvironmentByPhysicalTenant.get(physicalTenantId);
+    if (environment != null) {
+      return environment;
+    }
+    throw new NotFound("No restore environment bound for physical tenant " + physicalTenantId);
   }
 }

--- a/service/src/test/java/io/camunda/service/ClusterRecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRecoveryServicesTest.java
@@ -8,9 +8,9 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,7 +22,6 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.state.Mode;
@@ -158,7 +157,10 @@ final class ClusterRecoveryServicesTest {
   void shouldDropAnOverrideForAPhysicalTenantTheClusterDoesNotKnow() {
     // given — a cluster-wide restore whose override names a tenant this cluster has no environment
     // for; only the known tenants are ever restored, so the unknown override is simply not carried
-    // into the request rather than surfacing as an error
+    // into the request rather than surfacing as an error. Rejecting it belongs with the
+    // cluster-wide
+    // fan-out that ClusterRestoreRequestTransformer does not implement yet — it rejects every
+    // multi-tenant restore an override could apply to.
     givenRestoreAccepted();
     final var defaultParameters = new RestoreParameters(List.of(1L), null, null);
 
@@ -185,15 +187,21 @@ final class ClusterRecoveryServicesTest {
 
   @Test
   void shouldRejectASingleTenantRestoreOfAnUnknownPhysicalTenant() {
-    // when / then — the request never reaches the wire; there is no environment to build it with
-    assertThatThrownBy(
-            () ->
-                services.restore(
-                    Optional.of("unknown-tenant"),
-                    new RestoreParameters(List.of(1L), null, null),
-                    Map.of(),
-                    false))
-        .isInstanceOf(NotFound.class);
+    // when — the request never reaches the wire; there is no environment to build it with
+    final var result =
+        services
+            .restore(
+                Optional.of("unknown-tenant"),
+                new RestoreParameters(List.of(1L), null, null),
+                Map.of(),
+                false)
+            .join();
+
+    // then — reported as an error response so the REST layer can map it to 404
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().code()).isEqualTo(ErrorCode.NOT_FOUND);
+    assertThat(result.getLeft().message()).contains("unknown-tenant");
+    verify(sender, never()).clusterRestore(any());
   }
 
   private void givenRestoreAccepted() {

--- a/service/src/test/java/io/camunda/service/ClusterRecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRecoveryServicesTest.java
@@ -8,15 +8,21 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.state.Mode;
@@ -29,11 +35,18 @@ import org.junit.jupiter.api.Test;
 
 final class ClusterRecoveryServicesTest {
 
+  private static final String DEFAULT_TENANT = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
   private static final String TENANT_B = "tenant-b";
+  private static final TenantRestoreEnvironment DEFAULT_ENVIRONMENT =
+      new TenantRestoreEnvironment("elasticsearch", false);
+  private static final TenantRestoreEnvironment TENANT_B_ENVIRONMENT =
+      new TenantRestoreEnvironment("rdbms", true);
 
   private final ClusterConfigurationManagementRequestSender sender =
       mock(ClusterConfigurationManagementRequestSender.class);
-  private final ClusterRecoveryServices services = new ClusterRecoveryServices(sender);
+  private final ClusterRecoveryServices services =
+      new ClusterRecoveryServices(
+          sender, Map.of(DEFAULT_TENANT, DEFAULT_ENVIRONMENT, TENANT_B, TENANT_B_ENVIRONMENT));
 
   @Test
   void shouldRequestEveryPhysicalTenantWhenNoneIsGiven() {
@@ -98,6 +111,100 @@ final class ClusterRecoveryServicesTest {
     // then
     assertThat(result.isLeft()).isTrue();
     assertThat(result.getLeft().code()).isEqualTo(ErrorCode.INVALID_STATE);
+  }
+
+  @Test
+  void shouldRestoreTheRequestedPhysicalTenantWithItsOwnEnvironment() {
+    // given — tenant-b runs rdbms with continuous backups, unlike the default tenant
+    givenRestoreAccepted();
+    final var parameters = new RestoreParameters(List.of(55L), null, null);
+
+    // when
+    services.restore(Optional.of(TENANT_B), parameters, Map.of(), false).join();
+
+    // then
+    verify(sender)
+        .clusterRestore(
+            new ClusterRestoreRequest(
+                Map.of(TENANT_B, new TenantRestoreArguments(parameters, "rdbms", true)), false));
+  }
+
+  @Test
+  void shouldRestoreEveryKnownPhysicalTenantWithItsOwnEnvironment() {
+    // given — a cluster-wide restore whose override spans a tenant on different secondary storage
+    givenRestoreAccepted();
+    final var defaultParameters = new RestoreParameters(List.of(100L), null, null);
+    final var tenantBParameters = new RestoreParameters(List.of(55L), null, null);
+
+    // when
+    services
+        .restore(Optional.empty(), defaultParameters, Map.of(TENANT_B, tenantBParameters), true)
+        .join();
+
+    // then — every physical tenant of the cluster is named, each with its own environment; the
+    // overridden tenant keeps its own selection, the other tenant gets the default selection
+    verify(sender)
+        .clusterRestore(
+            new ClusterRestoreRequest(
+                Map.of(
+                    DEFAULT_TENANT,
+                    new TenantRestoreArguments(defaultParameters, "elasticsearch", false),
+                    TENANT_B,
+                    new TenantRestoreArguments(tenantBParameters, "rdbms", true)),
+                true));
+  }
+
+  @Test
+  void shouldDropAnOverrideForAPhysicalTenantTheClusterDoesNotKnow() {
+    // given — a cluster-wide restore whose override names a tenant this cluster has no environment
+    // for; only the known tenants are ever restored, so the unknown override is simply not carried
+    // into the request rather than surfacing as an error
+    givenRestoreAccepted();
+    final var defaultParameters = new RestoreParameters(List.of(1L), null, null);
+
+    // when
+    services
+        .restore(
+            Optional.empty(),
+            defaultParameters,
+            Map.of("unknown-tenant", new RestoreParameters(List.of(2L), null, null)),
+            false)
+        .join();
+
+    // then
+    verify(sender)
+        .clusterRestore(
+            new ClusterRestoreRequest(
+                Map.of(
+                    DEFAULT_TENANT,
+                    new TenantRestoreArguments(defaultParameters, "elasticsearch", false),
+                    TENANT_B,
+                    new TenantRestoreArguments(defaultParameters, "rdbms", true)),
+                false));
+  }
+
+  @Test
+  void shouldRejectASingleTenantRestoreOfAnUnknownPhysicalTenant() {
+    // when / then — the request never reaches the wire; there is no environment to build it with
+    assertThatThrownBy(
+            () ->
+                services.restore(
+                    Optional.of("unknown-tenant"),
+                    new RestoreParameters(List.of(1L), null, null),
+                    Map.of(),
+                    false))
+        .isInstanceOf(NotFound.class);
+  }
+
+  private void givenRestoreAccepted() {
+    when(sender.clusterRestore(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new ClusterConfigurationChangeResponse(
+                        9L,
+                        new LegacyConfigurationChangeResponse(Map.of(), Map.of(), List.of()),
+                        null))));
   }
 
   private void givenModeChangeAccepted() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
@@ -105,4 +106,6 @@ public interface ClusterConfigurationManagementApi {
   ActorFuture<CurrentClusterConfiguration> getTopology();
 
   ActorFuture<ClusterConfigurationChangeResponse> restore(RestoreRequest request);
+
+  ActorFuture<ClusterConfigurationChangeResponse> clusterRestore(ClusterRestoreRequest request);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
@@ -221,4 +222,21 @@ public sealed interface ClusterConfigurationManagementRequest {
 
   record RestoreResolvedRequest(Map<Integer, long[]> backups, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
+
+  record ClusterRestoreRequest(Map<String, TenantRestoreArguments> tenantArguments, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {
+
+    public TenantRestoreArguments argumentsFor(final String physicalTenantId) {
+      final var arguments = tenantArguments.get(physicalTenantId);
+      if (arguments == null) {
+        throw new NoSuchElementException(
+            "No restore arguments for physical tenant '%s'".formatted(physicalTenantId));
+      }
+      return arguments;
+    }
+
+    public RestoreRequest toRestoreRequest(final String physicalTenantId) {
+      return new RestoreRequest(physicalTenantId, argumentsFor(physicalTenantId), dryRun);
+    }
+  }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
@@ -322,6 +323,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.RESTORE.topic(),
         request,
         serializer::encodeRestoreRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      clusterRestore(final ClusterRestoreRequest request) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.CLUSTER_ADMIN_RESTORE.topic(),
+        request,
+        serializer::encodeClusterRestoreRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
@@ -288,6 +289,13 @@ public final class ClusterConfigurationManagementRequestsHandler
   public ActorFuture<ClusterConfigurationChangeResponse> restore(final RestoreRequest request) {
     return handleRequest(
         request.dryRun(), new RestoreRequestTransformer(request, validatorRegistry));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> clusterRestore(
+      final ClusterRestoreRequest request) {
+    return handleRequest(
+        request.dryRun(), new ClusterRestoreRequestTransformer(request, validatorRegistry));
   }
 
   private ActorFuture<ClusterConfigurationChangeResponse> handleRequest(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -56,6 +56,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerPurgeRequestHandler();
     registerModeChangeHandler();
     registerRestoreHandler();
+    registerClusterRestoreHandler();
     registerForceRemoveZoneHandler();
     registerAddZoneHandler();
     registerUpdateZonePrioritiesHandler();
@@ -251,6 +252,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.RESTORE.topic(),
         serializer::decodeRestoreRequest,
         request -> mapResponse(clusterConfigurationManagementApi.restore(request)),
+        this::encodeResponse);
+  }
+
+  private void registerClusterRestoreHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.CLUSTER_ADMIN_RESTORE.topic(),
+        serializer::decodeClusterRestoreRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.clusterRestore(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -28,6 +28,7 @@ public enum ClusterConfigurationRequestTopics {
   UPDATE_PARTITION_DISTRIBUTION("topology-cluster-update-partition-distribution"),
   MODE_CHANGE("topology-mode-change"),
   RESTORE("cluster-restore"),
+  CLUSTER_ADMIN_RESTORE("cluster-admin-restore"),
   ZONE_MIGRATION("topology-cluster-zone-migration"),
   ADD_ZONE("topology-add-zone"),
   FORCE_REMOVE_ZONE("topology-force-remove-zone"),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Restores one or every physical tenant of the cluster, as requested through the cluster-admin API.
+ *
+ * <p>A request naming exactly one physical tenant in {@code tenantArguments} is transformed exactly
+ * like the same restore submitted through that tenant's own API. Fanning a cluster-wide request out
+ * over several physical tenants at once is not implemented yet, so a request naming zero or more
+ * than one tenant is rejected.
+ */
+public final class ClusterRestoreRequestTransformer implements ConfigurationChangeRequest {
+
+  private final ClusterRestoreRequest request;
+  private final RequestValidatorRegistry registry;
+
+  public ClusterRestoreRequestTransformer(
+      final ClusterRestoreRequest request, final RequestValidatorRegistry registry) {
+    this.request = request;
+    this.registry = registry;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    return singleTenantRestore()
+        .map(restore -> restore.operations(clusterConfiguration))
+        .orElseGet(() -> Either.left(clusterWideNotSupported()));
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    return singleTenantRestore()
+        .map(restore -> restore.phases(clusterConfiguration))
+        .orElseGet(() -> Either.left(clusterWideNotSupported()));
+  }
+
+  private Optional<RestoreRequestTransformer> singleTenantRestore() {
+    final var tenantArguments = request.tenantArguments();
+    if (tenantArguments.size() != 1) {
+      return Optional.empty();
+    }
+    final var physicalTenantId = tenantArguments.keySet().iterator().next();
+    return Optional.of(
+        new RestoreRequestTransformer(request.toRestoreRequest(physicalTenantId), registry));
+  }
+
+  private static InvalidRequest clusterWideNotSupported() {
+    return new InvalidRequest(
+        "Restoring every physical tenant of the cluster in one request is not supported yet; "
+            + "provide a physicalTenantId to restore a single physical tenant.");
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
@@ -152,4 +153,8 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeRestoreRequest(RestoreRequest request);
 
   RestoreRequest decodeRestoreRequest(byte[] encodedRequest);
+
+  byte[] encodeClusterRestoreRequest(ClusterRestoreRequest request);
+
+  ClusterRestoreRequest decodeClusterRestoreRequest(byte[] encodedRequest);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
@@ -103,6 +104,7 @@ import io.camunda.zeebe.dynamic.config.state.TenantAvailability;
 import io.camunda.zeebe.util.Either;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1669,6 +1671,34 @@ public class ProtoBufSerializer
           request.getPhysicalTenantId(),
           decodeRestoreArguments(request.getArguments()),
           request.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public byte[] encodeClusterRestoreRequest(final ClusterRestoreRequest request) {
+    final var builder = Requests.ClusterRestoreRequest.newBuilder().setDryRun(request.dryRun());
+    request
+        .tenantArguments()
+        .forEach(
+            (physicalTenantId, arguments) ->
+                builder.putTenantArguments(physicalTenantId, encodeRestoreArguments(arguments)));
+
+    return builder.build().toByteArray();
+  }
+
+  @Override
+  public ClusterRestoreRequest decodeClusterRestoreRequest(final byte[] encodedRequest) {
+    try {
+      final var request = Requests.ClusterRestoreRequest.parseFrom(encodedRequest);
+      final var tenantArguments = new LinkedHashMap<String, TenantRestoreArguments>();
+      request
+          .getTenantArgumentsMap()
+          .forEach(
+              (physicalTenantId, arguments) ->
+                  tenantArguments.put(physicalTenantId, decodeRestoreArguments(arguments)));
+      return new ClusterRestoreRequest(tenantArguments, request.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -14,4 +14,13 @@ public sealed interface ClusterConfigurationChangeOperation
     permits PartitionGroupOperation, GlobalChangeOperation {
 
   MemberId memberId();
+
+  /**
+   * The id of the broker that applies this operation, including its zone if it belongs to one.
+   * Offered so that callers which report operations outside this module — the REST layer, which
+   * does not depend on {@link MemberId} — do not have to derive the id themselves.
+   */
+  default String brokerId() {
+    return memberId().id();
+  }
 }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -168,6 +168,11 @@ message RestoreRequest {
   bool dryRun = 3;
 }
 
+message ClusterRestoreRequest {
+  map<string, RestoreArguments> tenantArguments = 1;
+  bool dryRun = 2;
+}
+
 message TopologyChangeResponse {
   int64 changeId = 1;
   map<string, topology_protocol.MemberState> currentTopology = 2;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Test;
+
+final class ClusterRestoreRequestTransformerTest {
+
+  private static final MemberId MEMBER = MemberId.from("0");
+  private static final String TENANT_B = "tenant-b";
+
+  @Test
+  void shouldRestoreTheRequestedPhysicalTenantFromItsOwnParameters() {
+    // given — a request naming exactly one physical tenant
+    final var request =
+        new ClusterRestoreRequest(
+            Map.of(
+                TENANT_B,
+                new TenantRestoreArguments(
+                    new RestoreParameters(List.of(55L), null, null), "elasticsearch", false)),
+            false);
+    final var transformer = new ClusterRestoreRequestTransformer(request, registry());
+
+    // when
+    final var result = transformer.operations(recoveringConfiguration());
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .contains(new PartitionRestoreOperation(MEMBER, 1, new TreeSet<>(List.of(55L))));
+  }
+
+  @Test
+  void shouldRejectARestoreOfEveryPhysicalTenant() {
+    // given a request naming no physical tenant
+    final var request = new ClusterRestoreRequest(Map.of(), false);
+    final var transformer = new ClusterRestoreRequestTransformer(request, registry());
+
+    // when
+    final var result = transformer.operations(recoveringConfiguration());
+
+    // then — fanning the restore out over the partition groups is not implemented yet
+    EitherAssert.assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectARestoreNamingMoreThanOnePhysicalTenant() {
+    // given a request naming two physical tenants at once
+    final var args =
+        new TenantRestoreArguments(
+            new RestoreParameters(List.of(55L), null, null), "elasticsearch", false);
+    final var request = new ClusterRestoreRequest(Map.of(TENANT_B, args, "tenant-c", args), false);
+    final var transformer = new ClusterRestoreRequestTransformer(request, registry());
+
+    // when
+    final var result = transformer.operations(recoveringConfiguration());
+
+    // then — fanning the restore out over the partition groups is not implemented yet
+    EitherAssert.assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  private static ClusterConfiguration recoveringConfiguration() {
+    final var partitions = Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()));
+    return ClusterConfiguration.init()
+        .addMember(MEMBER, MemberState.initializeAsActive(partitions).toRecovering());
+  }
+
+  /** Resolves every request to the backups it asked for, on the single partition of the member. */
+  private static RequestValidatorRegistry registry() {
+    final var registry = new RequestValidatorRegistry();
+    registry.registerValidator(
+        null,
+        new ClusterConfigurationRequestValidator<RestoreRequest, RestoreResolvedRequest>() {
+          @Override
+          public Class<RestoreRequest> requestType() {
+            return RestoreRequest.class;
+          }
+
+          @Override
+          public Either<Exception, RestoreResolvedRequest> validate(final RestoreRequest request) {
+            final var backupIds =
+                request.arguments().parameters().backupIds().stream()
+                    .mapToLong(Long::longValue)
+                    .toArray();
+            return Either.right(new RestoreResolvedRequest(Map.of(1, backupIds), false));
+          }
+        });
+    return registry;
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
@@ -30,6 +31,8 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Requests;
 import io.camunda.zeebe.dynamic.config.protocol.Topology;
@@ -108,6 +111,49 @@ final class ProtoBufSerializerTest {
 
     // then
     final var decodedRequest = protoBufSerializer.decodeModeChangeRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeClusterRestoreRequestForOnePhysicalTenant() {
+    // given
+    final var request =
+        new ClusterRestoreRequest(
+            Map.of(
+                "tenant-b",
+                new TenantRestoreArguments(
+                    new RestoreParameters(List.of(100L, 101L), null, null),
+                    "elasticsearch",
+                    false)),
+            true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeClusterRestoreRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeClusterRestoreRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeClusterRestoreRequestWithPerTenantArguments() {
+    // given — a cluster-wide restore naming several physical tenants at once
+    final var request =
+        new ClusterRestoreRequest(
+            Map.of(
+                "tenant-b",
+                new TenantRestoreArguments(
+                    new RestoreParameters(List.of(55L), null, null), "rdbms", true),
+                "tenant-c",
+                new TenantRestoreArguments(
+                    new RestoreParameters(List.of(), "2024-02-01T10:00:00Z", null), "rdbms", true)),
+            false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeClusterRestoreRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeClusterRestoreRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(request);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -30,9 +30,9 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Requests;
 import io.camunda.zeebe.dynamic.config.protocol.Topology;

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -6,12 +6,14 @@
 # `/v2` suffix.
 #
 # Do not "align" the override by moving the base into it: `{host}:{port}/cluster/v2` plus the path
-# key resolves to `/cluster/v2/cluster/v2/status`. Shortening the keys to `/status` and `/mode`
-# instead is not an option either — both are already taken by `cluster.yaml` in the `rest-api.yaml`
-# path map, and `OpenApiYamlLoader.KNOWN_ROOTS` matches on the literal `/cluster/v2/` prefix to skip
-# the runtime `/v2` prefixing that every other path gets.
+# key resolves to `/cluster/v2/cluster/v2/status`. Shortening the keys to `/status`, `/mode` and
+# `/restore` instead is not an option either — all three are already taken by `cluster.yaml` in the
+# `rest-api.yaml` path map, and `OpenApiYamlLoader.KNOWN_ROOTS` matches on the literal `/cluster/v2/`
+# prefix to skip the runtime `/v2` prefixing that every other path gets.
 #
-# Cluster endpoints that are scoped to a single physical tenant live in `cluster.yaml`.
+# Cluster endpoints that are scoped to a single physical tenant live in `cluster.yaml`, which also
+# owns the parameters and schemas the three operations below share (`DryRunParameter`,
+# `ModeParameter`, `RestoreRequest`, `ClusterModeChangeResponse`, `ClusterRestoreResponse`).
 #
 # The identical `servers` block below is duplicated per path item on purpose, not YAML-anchored.
 # Two independent, concrete failures came out of trying to share it via a YAML anchor/alias:
@@ -191,6 +193,87 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
 
+  /cluster/v2/restore:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Recovery
+      operationId: restoreAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Restore one or every physical tenant from a backup
+      description: >-
+        Restores physical tenants from backups. The restore is described either by a list of backup
+        IDs or by a time range (`from`/`to`) that selects the backups to restore. Restores are only
+        accepted while the targeted physical tenants are in recovery mode; requests are rejected
+        otherwise. The request is validated and acknowledged, but the restore itself is performed
+        asynchronously.
+
+
+        If the `physicalTenantId` parameter is provided, only that physical tenant is restored and
+        `overrides` must be omitted.
+
+
+        If it is not provided, every physical tenant of the cluster is restored: those named in
+        `overrides` with their own backup selection, all others with the selection at the top level
+        of the request body.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+        - $ref: 'cluster.yaml#/components/parameters/DryRunParameter'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClusterRestoreRequest'
+        required: true
+      responses:
+        "202":
+          description: >-
+            The restore request was accepted; returns the planned cluster change covering every
+            requested physical tenant.
+          content:
+            application/json:
+              schema:
+                $ref: 'cluster.yaml#/components/schemas/ClusterRestoreResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: >-
+            The requested `physicalTenantId`, or a physical tenant named in `overrides`, does not
+            exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "409":
+          description: >-
+            A targeted physical tenant is not in recovery mode, so the restore cannot be accepted.
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
 ## Schema definitions
 
 components:
@@ -223,6 +306,26 @@ components:
             - HEALTHY
             - DEGRADED
             - DOWN
+    ClusterRestoreRequest:
+      description: >-
+        Describes a restore request issued by a cluster admin. The backup selection at the top level
+        applies to every targeted physical tenant, except for the ones listed in `overrides`.
+      type: object
+      allOf:
+        - $ref: 'cluster.yaml#/components/schemas/RestoreRequest'
+      properties:
+        overrides:
+          description: >-
+            The backup selection to apply to individual physical tenants, keyed by physical tenant
+            id. Only allowed for a cluster-wide restore, that is when no `physicalTenantId`
+            parameter is given.
+          type: object
+          nullable: true
+          additionalProperties:
+            $ref: 'cluster.yaml#/components/schemas/RestoreRequest'
+          example:
+            tenant-a:
+              backupIds: [ 55 ]
 
     ClusterTopologyResponse:
       description: The topology of the whole cluster, aggregated over all physical tenants.

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -129,7 +129,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterModeChangeResponse'
+                $ref: '#/components/schemas/ClusterRestoreResponse'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -429,6 +429,87 @@ components:
           type: string
           nullable: true
           example: RECOVERING
+
+    ClusterRestoreResponse:
+      description: The planned changes resulting from a restore request.
+      type: object
+      required:
+        - changeId
+        - plannedChanges
+      properties:
+        changeId:
+          description: The ID of the cluster change that was triggered by the request.
+          type: string
+          example: "7"
+        plannedChanges:
+          description: >-
+            The operations that will be applied to complete the restore, grouped by the physical
+            tenant they belong to. Groups are restored in parallel; the operations within a group
+            are applied in the given order.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterRestorePlannedChange'
+
+    ClusterRestorePlannedChange:
+      description: The operations of a restore that apply to one physical tenant.
+      type: object
+      required:
+        - physicalTenantId
+        - operations
+      properties:
+        physicalTenantId:
+          description: >-
+            The physical tenant the operations apply to; null for operations that are not scoped to
+            a single physical tenant, such as broker lifecycle operations.
+          type: string
+          nullable: true
+          example: default
+        operations:
+          description: The ordered list of operations that will be applied to the physical tenant.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterRestoreOperation'
+
+    ClusterRestoreOperation:
+      description: >-
+        A single operation that is part of a restore. Which of the optional properties are reported
+        depends on the operation: partition operations carry `partitionId`, the operation that
+        restores a partition also carries the `backupIds` it restores from, and the operations that
+        return the broker to processing carry `mode`.
+      type: object
+      required:
+        - operation
+        - brokerId
+      properties:
+        operation:
+          description: The type of the operation.
+          type: string
+          example: PartitionRestoreOperation
+        brokerId:
+          description: The ID of the broker that applies the operation, including its zone if it belongs to one.
+          type: string
+          example: "1"
+        partitionId:
+          description: The partition the operation applies to; null for operations that are not partition scoped.
+          type: integer
+          format: int32
+          nullable: true
+          example: 1
+        backupIds:
+          description: >-
+            The IDs of the backups the partition is restored from; null for every operation other
+            than the one that restores a partition.
+          type: array
+          nullable: true
+          items:
+            type: integer
+            format: int64
+          example: [ 100, 101 ]
+        mode:
+          description: The target mode of the operation, if applicable.
+          type: string
+          nullable: true
+          example: PROCESSING
 
     RestoreRequest:
       description: >-

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -480,6 +480,9 @@ components:
       required:
         - operation
         - brokerId
+        - partitionId
+        - backupIds
+        - mode
       properties:
         operation:
           description: The type of the operation.
@@ -497,10 +500,9 @@ components:
           example: 1
         backupIds:
           description: >-
-            The IDs of the backups the partition is restored from; null for every operation other
+            The IDs of the backups the partition is restored from; empty for every operation other
             than the one that restores a partition.
           type: array
-          nullable: true
           items:
             type: integer
             format: int64

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -506,6 +506,8 @@ paths:
   # Cluster-wide endpoints. Path keys must stay absolute — see `cluster-admin.yaml` for why.
   /cluster/v2/mode:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1mode'
+  /cluster/v2/restore:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1restore'
   /cluster/v2/status:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1status'
   /cluster/v2/topology:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
@@ -157,10 +157,10 @@ final class ClusterModeChangeMapper {
         operation instanceof final PartitionChangeOperation partitionChange
             ? partitionChange.partitionId()
             : null;
-    final @Nullable List<Long> backupIds =
+    final List<Long> backupIds =
         operation instanceof final PartitionRestoreOperation restore
             ? List.copyOf(restore.backupIds())
-            : null;
+            : List.of();
     return ClusterRestoreOperation.Builder.create()
         .operation(operation.getClass().getSimpleName())
         .brokerId(operation.brokerId())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
@@ -12,6 +12,9 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
 import io.camunda.gateway.protocol.model.ClusterModeChangePlannedChange;
 import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
+import io.camunda.gateway.protocol.model.ClusterRestoreOperation;
+import io.camunda.gateway.protocol.model.ClusterRestorePlannedChange;
+import io.camunda.gateway.protocol.model.ClusterRestoreResponse;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
@@ -19,6 +22,8 @@ import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
@@ -31,9 +36,9 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Maps the cluster configuration change plan of a mode transition onto the REST response, shared by
- * the per-physical-tenant {@link RecoveryController} and the cluster-wide {@link
- * ClusterRecoveryController}.
+ * Maps the cluster configuration change plan of a mode transition or a restore onto the REST
+ * response, shared by the per-physical-tenant {@link RecoveryController} and the cluster-wide
+ * {@link ClusterRecoveryController}.
  */
 @NullMarked
 final class ClusterModeChangeMapper {
@@ -52,19 +57,51 @@ final class ClusterModeChangeMapper {
       final ClusterConfigurationChangeResponse response) {
     return ClusterModeChangeResponse.Builder.create()
         .changeId(Long.toString(response.changeId()))
-        .plannedChanges(toPlannedChanges(response))
+        .plannedChanges(
+            groupByPhysicalTenant(response).stream()
+                .map(
+                    group ->
+                        ClusterModeChangePlannedChange.Builder.create()
+                            .physicalTenantId(group.physicalTenantId())
+                            .operations(
+                                group.operations().stream()
+                                    .map(ClusterModeChangeMapper::toClusterModeChangeOperation)
+                                    .toList())
+                            .build())
+                .toList())
+        .build();
+  }
+
+  static ClusterRestoreResponse toClusterRestoreResponse(
+      final ClusterConfigurationChangeResponse response) {
+    return ClusterRestoreResponse.Builder.create()
+        .changeId(Long.toString(response.changeId()))
+        .plannedChanges(
+            groupByPhysicalTenant(response).stream()
+                .map(
+                    group ->
+                        ClusterRestorePlannedChange.Builder.create()
+                            .physicalTenantId(group.physicalTenantId())
+                            .operations(
+                                group.operations().stream()
+                                    .map(ClusterModeChangeMapper::toClusterRestoreOperation)
+                                    .toList())
+                            .build())
+                .toList())
         .build();
   }
 
   /**
-   * Flattens the phases of the change plan into one entry per physical tenant, keyed by the
+   * Flattens the phases of the change plan into one group per physical tenant, keyed by the
    * partition group the operations were planned for. Sorted by tenant so that a response never
-   * depends on the iteration order of the plan's group map.
+   * depends on the iteration order of the plan's group map. Operations that are not scoped to a
+   * single physical tenant land in a trailing group with a null tenant.
    */
-  private static List<ClusterModeChangePlannedChange> toPlannedChanges(
+  private static List<PlannedGroup> groupByPhysicalTenant(
       final ClusterConfigurationChangeResponse response) {
-    final Map<String, List<ClusterModeChangeOperation>> operationsPerTenant = new TreeMap<>();
-    final List<ClusterModeChangeOperation> clusterWideOperations = new ArrayList<>();
+    final Map<String, List<ClusterConfigurationChangeOperation>> operationsPerTenant =
+        new TreeMap<>();
+    final List<ClusterConfigurationChangeOperation> clusterWideOperations = new ArrayList<>();
     for (final Phase phase : requireNonNull(response.response()).phases()) {
       switch (phase) {
         case final PartitionGroupParallelPhase parallelPhase ->
@@ -74,34 +111,21 @@ final class ClusterModeChangeMapper {
                     (physicalTenantId, operations) ->
                         operationsPerTenant
                             .computeIfAbsent(physicalTenantId, tenant -> new ArrayList<>())
-                            .addAll(toClusterModeChangeOperations(operations)));
+                            .addAll(operations));
         // Broker lifecycle operations belong to the cluster, not to any single physical tenant.
         case final GlobalPhase globalPhase ->
-            clusterWideOperations.addAll(toClusterModeChangeOperations(globalPhase.operations()));
+            clusterWideOperations.addAll(globalPhase.operations());
       }
     }
 
-    final var plannedChanges = new ArrayList<ClusterModeChangePlannedChange>();
+    final var groups = new ArrayList<PlannedGroup>();
     operationsPerTenant.forEach(
         (physicalTenantId, operations) ->
-            plannedChanges.add(toPlannedChange(physicalTenantId, operations)));
+            groups.add(new PlannedGroup(physicalTenantId, operations)));
     if (!clusterWideOperations.isEmpty()) {
-      plannedChanges.add(toPlannedChange(null, clusterWideOperations));
+      groups.add(new PlannedGroup(null, clusterWideOperations));
     }
-    return plannedChanges;
-  }
-
-  private static ClusterModeChangePlannedChange toPlannedChange(
-      final @Nullable String physicalTenantId, final List<ClusterModeChangeOperation> operations) {
-    return ClusterModeChangePlannedChange.Builder.create()
-        .physicalTenantId(physicalTenantId)
-        .operations(operations)
-        .build();
-  }
-
-  private static List<ClusterModeChangeOperation> toClusterModeChangeOperations(
-      final List<? extends ClusterConfigurationChangeOperation> operations) {
-    return operations.stream().map(ClusterModeChangeMapper::toClusterModeChangeOperation).toList();
+    return groups;
   }
 
   private static Status mapErrorStatus(final ErrorResponse.ErrorCode code) {
@@ -116,15 +140,45 @@ final class ClusterModeChangeMapper {
 
   private static ClusterModeChangeOperation toClusterModeChangeOperation(
       final ClusterConfigurationChangeOperation operation) {
-    final @Nullable String mode =
-        switch (operation) {
-          case final ModeChangeOperation modeChange -> modeChange.mode().name();
-          case final AwaitModeChangeOperation awaitModeChange -> awaitModeChange.mode().name();
-          default -> null;
-        };
     return ClusterModeChangeOperation.Builder.create()
         .operation(operation.getClass().getSimpleName())
-        .mode(mode)
+        .mode(modeOf(operation))
         .build();
   }
+
+  /**
+   * Reports the operation with the detail a restore plan is reviewed by: which broker applies it,
+   * which partition it targets, and which backups that partition is restored from. Properties that
+   * the operation does not carry are left null.
+   */
+  private static ClusterRestoreOperation toClusterRestoreOperation(
+      final ClusterConfigurationChangeOperation operation) {
+    final @Nullable Integer partitionId =
+        operation instanceof final PartitionChangeOperation partitionChange
+            ? partitionChange.partitionId()
+            : null;
+    final @Nullable List<Long> backupIds =
+        operation instanceof final PartitionRestoreOperation restore
+            ? List.copyOf(restore.backupIds())
+            : null;
+    return ClusterRestoreOperation.Builder.create()
+        .operation(operation.getClass().getSimpleName())
+        .brokerId(operation.brokerId())
+        .partitionId(partitionId)
+        .backupIds(backupIds)
+        .mode(modeOf(operation))
+        .build();
+  }
+
+  private static @Nullable String modeOf(final ClusterConfigurationChangeOperation operation) {
+    return switch (operation) {
+      case final ModeChangeOperation modeChange -> modeChange.mode().name();
+      case final AwaitModeChangeOperation awaitModeChange -> awaitModeChange.mode().name();
+      default -> null;
+    };
+  }
+
+  /** The operations of a change plan that apply to one physical tenant, in the planned order. */
+  private record PlannedGroup(
+      @Nullable String physicalTenantId, List<ClusterConfigurationChangeOperation> operations) {}
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
@@ -56,11 +56,7 @@ public final class ClusterRecoveryController {
       @RequestParam final Mode mode,
       @RequestParam(required = false) final @Nullable String physicalTenantId,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
-    if (physicalTenantId != null && physicalTenantId.isBlank()) {
-      throw new ServiceException(
-          "Expected physicalTenantId to identify a physical tenant, but it was empty.",
-          Status.INVALID_ARGUMENT);
-    }
+    rejectBlankPhysicalTenantId(physicalTenantId);
     LOG.debug(
         "Requested cluster mode change to {} for {}",
         mode,
@@ -80,6 +76,7 @@ public final class ClusterRecoveryController {
       @RequestParam(required = false) final @Nullable String physicalTenantId,
       @RequestBody final io.camunda.gateway.protocol.model.ClusterRestoreRequest restoreRequest,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
+    rejectBlankPhysicalTenantId(physicalTenantId);
     LOG.info(
         "Requested restore for {}: {}",
         physicalTenantId == null ? "all tenants" : physicalTenantId,
@@ -87,7 +84,7 @@ public final class ClusterRecoveryController {
     final var overrides = restoreRequest.getOverrides();
     if (physicalTenantId != null && overrides != null && !overrides.isEmpty()) {
       throw new ServiceException(
-          "Expected to restore physical tenant '%s', but the request also carries tenantArguments for "
+          "Expected to restore physical tenant '%s', but the request also carries overrides for "
                   .formatted(physicalTenantId)
               + "other physical tenants. Overrides are only allowed for a cluster-wide restore.",
           Status.INVALID_ARGUMENT);
@@ -110,5 +107,13 @@ public final class ClusterRecoveryController {
                 .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
         ClusterModeChangeMapper::toClusterRestoreResponse,
         HttpStatus.ACCEPTED);
+  }
+
+  private static void rejectBlankPhysicalTenantId(final @Nullable String physicalTenantId) {
+    if (physicalTenantId != null && physicalTenantId.isBlank()) {
+      throw new ServiceException(
+          "Expected physicalTenantId to identify a physical tenant, but it was empty.",
+          Status.INVALID_ARGUMENT);
+    }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
@@ -10,17 +10,24 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -66,5 +73,42 @@ public final class ClusterRecoveryController {
                 .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
         ClusterModeChangeMapper::toClusterModeChangeResponse,
         HttpStatus.OK);
+  }
+
+  @CamundaPostMapping(path = "/restore")
+  public CompletableFuture<ResponseEntity<Object>> restore(
+      @RequestParam(required = false) final @Nullable String physicalTenantId,
+      @RequestBody final io.camunda.gateway.protocol.model.ClusterRestoreRequest restoreRequest,
+      @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
+    LOG.info(
+        "Requested restore for {}: {}",
+        physicalTenantId == null ? "all tenants" : physicalTenantId,
+        restoreRequest);
+    final var overrides = restoreRequest.getOverrides();
+    if (physicalTenantId != null && overrides != null && !overrides.isEmpty()) {
+      throw new ServiceException(
+          "Expected to restore physical tenant '%s', but the request also carries tenantArguments for "
+                  .formatted(physicalTenantId)
+              + "other physical tenants. Overrides are only allowed for a cluster-wide restore.",
+          Status.INVALID_ARGUMENT);
+    }
+    final var parameters = RestoreRequestMapper.toRestoreParameters(restoreRequest);
+    final var overrideParameters =
+        overrides == null
+            ? Map.<String, RestoreParameters>of()
+            : overrides.entrySet().stream()
+                .collect(
+                    Collectors.toMap(
+                        Entry::getKey,
+                        entry -> RestoreRequestMapper.toRestoreParameters(entry.getValue())));
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterRecoveryServices()
+                .restore(
+                    Optional.ofNullable(physicalTenantId), parameters, overrideParameters, dryRun)
+                .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
+        ClusterModeChangeMapper::toClusterRestoreResponse,
+        HttpStatus.ACCEPTED);
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -86,7 +86,7 @@ public final class RecoveryController {
                 .recoveryServices(physicalTenantId)
                 .restore(parameters, dryRun, authentication)
                 .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
-        ClusterModeChangeMapper::toClusterModeChangeResponse,
+        ClusterModeChangeMapper::toClusterRestoreResponse,
         HttpStatus.ACCEPTED);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -15,6 +15,7 @@ import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -22,17 +23,23 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 
@@ -40,6 +47,7 @@ import org.springframework.test.json.JsonCompareMode;
 class ClusterRecoveryControllerTest extends RestControllerTest {
 
   private static final String MODE_URL = "/cluster/v2/mode";
+  private static final String RESTORE_URL = "/cluster/v2/restore";
 
   @MockitoBean ClusterRecoveryServices clusterRecoveryServices;
   @MockitoBean ServiceRegistry serviceRegistry;
@@ -185,20 +193,236 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
         .changeMode(Mockito.any(), Mockito.any(), Mockito.anyBoolean());
   }
 
+  @Test
+  void shouldRestoreEveryPhysicalTenantWithTheSameParametersWhenNoOverridesAreGiven() {
+    // given
+    givenRestoreAccepted(9L);
+
+    // when
+    webClient
+        .post()
+        .uri(RESTORE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100, 101]}")
+        .exchange()
+        .expectStatus()
+        .isAccepted()
+        .expectBody()
+        .jsonPath("$.changeId")
+        .isEqualTo("9");
+
+    // then
+    Mockito.verify(clusterRecoveryServices)
+        .restore(
+            Optional.empty(),
+            new RestoreParameters(List.of(100L, 101L), null, null),
+            Map.of(),
+            false);
+  }
+
+  @Test
+  void shouldRestoreTheOverriddenPhysicalTenantsWithTheirOwnParameters() {
+    // given
+    givenRestoreAccepted(9L);
+
+    // when
+    webClient
+        .post()
+        .uri(RESTORE_URL + "?dryRun=true")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "backupIds": [ 100 ],
+              "overrides": {
+                "tenant-b": { "backupIds": [ 55 ] },
+                "tenant-c": { "from": "2024-01-01T10:00:00Z", "to": "2024-01-01T12:00:00Z" }
+              }
+            }
+            """)
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+
+    // then
+    Mockito.verify(clusterRecoveryServices)
+        .restore(
+            Optional.empty(),
+            new RestoreParameters(List.of(100L), null, null),
+            Map.of(
+                "tenant-b",
+                new RestoreParameters(List.of(55L), null, null),
+                "tenant-c",
+                new RestoreParameters(List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z")),
+            true);
+  }
+
+  @Test
+  void shouldRestoreTheRequestedPhysicalTenantOnly() {
+    // given
+    givenRestoreAccepted(9L);
+
+    // when
+    webClient
+        .post()
+        .uri(RESTORE_URL + "?physicalTenantId=tenant-b")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [ 55 ]}")
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+
+    // then
+    Mockito.verify(clusterRecoveryServices)
+        .restore(
+            Optional.of("tenant-b"),
+            new RestoreParameters(List.of(55L), null, null),
+            Map.of(),
+            false);
+  }
+
+  @Test
+  void shouldRejectOverridesOnATenantScopedRestore() {
+    // when / then
+    webClient
+        .post()
+        .uri(RESTORE_URL + "?physicalTenantId=tenant-b")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            "{\"backupIds\": [ 55 ], \"overrides\": { \"tenant-c\": { \"backupIds\": [1] } }}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    Mockito.verify(clusterRecoveryServices, Mockito.never())
+        .restore(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
+  }
+
+  @Test
+  void shouldReportTheBackupsEveryPlannedPartitionRestoreRestoresFrom() {
+    // given — the plan a restore produces: a partition is pre-restored, restored from its backups,
+    // and the broker is returned to processing
+    final var broker = MemberId.from("1");
+    when(clusterRecoveryServices.restore(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    plannedChange(
+                        9L,
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                "default",
+                                List.of(
+                                    new PartitionPreRestoreOperation(broker, 1),
+                                    new PartitionRestoreOperation(
+                                        broker, 1, new TreeSet<>(List.of(100L, 101L))),
+                                    new ModeChangeOperation(broker, Mode.PROCESSING))))))));
+
+    // when / then — an operator reviewing the plan can see which backups land on which partition
+    webClient
+        .post()
+        .uri(RESTORE_URL + "?dryRun=true")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100, 101]}")
+        .exchange()
+        .expectStatus()
+        .isAccepted()
+        .expectBody()
+        .json(
+            """
+            {
+              "changeId": "9",
+              "plannedChanges": [
+                {
+                  "physicalTenantId": "default",
+                  "operations": [
+                    {
+                      "operation": "PartitionPreRestoreOperation",
+                      "brokerId": "1",
+                      "partitionId": 1,
+                      "backupIds": null,
+                      "mode": null
+                    },
+                    {
+                      "operation": "PartitionRestoreOperation",
+                      "brokerId": "1",
+                      "partitionId": 1,
+                      "backupIds": [ 100, 101 ],
+                      "mode": null
+                    },
+                    {
+                      "operation": "ModeChangeOperation",
+                      "brokerId": "1",
+                      "partitionId": null,
+                      "backupIds": null,
+                      "mode": "PROCESSING"
+                    }
+                  ]
+                }
+              ]
+            }
+            """,
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldMapRestoreOutsideOfRecoveryModeToConflict() {
+    // given
+    when(clusterRecoveryServices.restore(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(
+                    new ErrorResponse(
+                        ErrorCode.INVALID_STATE, "the cluster is not in recovery mode"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri(RESTORE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [ 100 ]}")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  private void givenRestoreAccepted(final long changeId) {
+    when(clusterRecoveryServices.restore(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(plannedChange(changeId))));
+  }
+
+  /**
+   * A mode change plan that transitions each of the given physical tenants, defaulting to the
+   * single-tenant plan a cluster without additional partition groups produces.
+   */
   private ClusterConfigurationChangeResponse plannedChange(
       final long changeId, final String... physicalTenantIds) {
-    final var operation = new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING);
-    final Map<String, List<PartitionGroupOperation>> operationsPerTenant = new HashMap<>();
-    for (final var physicalTenantId : physicalTenantIds) {
-      operationsPerTenant.put(physicalTenantId, List.of(operation));
+    final var tenants =
+        physicalTenantIds.length == 0 ? new String[] {"default"} : physicalTenantIds;
+    final Map<String, List<PartitionGroupOperation>> groupOperations = new HashMap<>();
+    for (final var physicalTenantId : tenants) {
+      groupOperations.put(
+          physicalTenantId, List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING)));
     }
+    return plannedChange(changeId, new PartitionGroupParallelPhase(groupOperations));
+  }
+
+  private ClusterConfigurationChangeResponse plannedChange(
+      final long changeId, final PartitionGroupParallelPhase phase) {
+    final var flatOperations =
+        phase.groupOperations().values().stream()
+            .flatMap(List::stream)
+            .map(ClusterConfigurationChangeOperation.class::cast)
+            .toList();
     return new ClusterConfigurationChangeResponse(
         changeId,
-        new LegacyConfigurationChangeResponse(
-            Map.of(), Map.of(), List.<ClusterConfigurationChangeOperation>of(operation)),
+        new LegacyConfigurationChangeResponse(Map.of(), Map.of(), flatOperations),
         new CurrentConfigurationChangeResponse(
             CurrentClusterConfiguration.uninitialized(),
             CurrentClusterConfiguration.uninitialized(),
-            List.of(new PartitionGroupParallelPhase(operationsPerTenant))));
+            List.of(phase)));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -194,6 +194,23 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectABlankPhysicalTenantOnARestoreAsAMalformedRequest() {
+    // when / then — the parameter both operations share is rejected the same way, rather than a
+    // restore being scoped to an empty physical tenant id
+    webClient
+        .post()
+        .uri(RESTORE_URL + "?physicalTenantId=")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [ 55 ]}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    Mockito.verify(clusterRecoveryServices, Mockito.never())
+        .restore(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
+  }
+
+  @Test
   void shouldRestoreEveryPhysicalTenantWithTheSameParametersWhenNoOverridesAreGiven() {
     // given
     givenRestoreAccepted(9L);
@@ -364,6 +381,28 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
             }
             """,
             JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldMapARestoreOfAnUnknownPhysicalTenantToNotFound() {
+    // given
+    when(clusterRecoveryServices.restore(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(
+                    new ErrorResponse(
+                        ErrorCode.NOT_FOUND, "no physical tenant is configured for: tenant-x"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri(RESTORE_URL + "?physicalTenantId=tenant-x")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [ 55 ]}")
+        .exchange()
+        .expectStatus()
+        .isNotFound();
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -341,7 +341,7 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
                       "operation": "PartitionPreRestoreOperation",
                       "brokerId": "1",
                       "partitionId": 1,
-                      "backupIds": null,
+                      "backupIds": [ ],
                       "mode": null
                     },
                     {
@@ -355,7 +355,7 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
                       "operation": "ModeChangeOperation",
                       "brokerId": "1",
                       "partitionId": null,
-                      "backupIds": null,
+                      "backupIds": [ ],
                       "mode": "PROCESSING"
                     }
                   ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -475,6 +475,11 @@ public class RecoveryControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(configuration)));
   }
 
+  // The database type and continuous-backups flag are no longer resolved here: RecoveryServices
+  // (mocked above) now binds them per physical tenant. The controller only has to forward the
+  // backup selection and dryRun untouched, regardless of secondary storage — see
+  // RecoveryServicesTest#shouldStampItsBoundRestoreEnvironmentIntoTheRequest for that part.
+
   @ParameterizedTest
   @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
   void shouldForwardBackupIds(final String baseUrl) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.protocol.rest.ClusterModeChangeResponse;
+import io.camunda.client.protocol.rest.ClusterRestoreResponse;
 import io.camunda.client.protocol.rest.RestoreStatusResponse;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -89,7 +90,7 @@ public final class InProcessRestoreTestUtil {
         .isEqualTo(202);
     try {
       return Long.parseLong(
-          OBJECT_MAPPER.readValue(response.body(), ClusterModeChangeResponse.class).getChangeId());
+          OBJECT_MAPPER.readValue(response.body(), ClusterRestoreResponse.class).getChangeId());
     } catch (final IOException e) {
       throw new UncheckedIOException("Failed to parse restore REST response", e);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce the REST API handling of the Cluster Admin restore request.

The transformer logic and it's test coverage will follow up on a different PR. Consider the transformer a draft.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #59537
