### PR TITLE
ci: stream Claude Code tool-call transcript to the nightly fix-agent log

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -331,7 +331,56 @@ jobs:
           )
 
           cd "${ws_dir}"
-          claude -p "$prompt" --dangerously-skip-permissions
+
+          # --output-format stream-json (requires --verbose alongside --print) streams
+          # every tool call and its result to stdout as it happens, instead of only the
+          # agent's final summary text -- so the actual docker/playwright commands run
+          # during the Live Docker Verify loop (AGENTS.md) are visible in this step's
+          # log. The filter renders each event as one or more human-readable lines; the
+          # raw JSONL is also kept (uploaded as an artifact below) for anything it drops.
+          cat > /tmp/claude-stream-filter.jq <<'JQEOF'
+          def text_of(c):
+            if (c | type) == "string" then c
+            elif (c | type) == "array" then
+              ([c[]? | select(.type == "text") | .text] | join("\n"))
+            else (c | tostring)
+            end;
+
+          def clip(s):
+            if (s | length) > 1500 then s[0:1500] + "\n... [truncated]" else s end;
+
+          (try fromjson catch null) as $e
+          | if $e == null then empty
+            else
+              try (
+                if $e.type == "assistant" then
+                  ($e.message.content[]? |
+                    if .type == "text" then "> " + .text
+                    elif .type == "tool_use" then
+                      "$ " + .name + ": " + (
+                        if .input.command then .input.command
+                        elif .input.file_path then .input.file_path
+                        else (.input | tostring)
+                        end
+                      )
+                    else empty
+                    end)
+                elif $e.type == "user" then
+                  ($e.message.content[]? | select(.type == "tool_result") |
+                    "  -> " + clip(text_of(.content)))
+                elif $e.type == "result" then
+                  "\n=== AGENT RESULT (" + ($e.subtype // "unknown") + ") ===\n" + ($e.result // "(no result text)")
+                else
+                  empty
+                end
+              ) catch empty
+            end
+          JQEOF
+
+          claude -p "$prompt" --dangerously-skip-permissions \
+              --output-format stream-json --verbose \
+            | tee /tmp/claude-stream.jsonl \
+            | jq -R -r --unbuffered -f /tmp/claude-stream-filter.jq
 
       - name: Trigger on-demand verification runs and patch PR body
         if: always()
@@ -561,6 +610,7 @@ jobs:
           path: |
             /tmp/test_specs.json
             /tmp/fix-meta.json
+            /tmp/claude-stream.jsonl
           retention-days: 14
           if-no-files-found: warn
 


### PR DESCRIPTION
## Why

We recently ran a manual test dispatch of the nightly fix agent (dispatched
against a scratch branch, never touching `main`) to validate the new Live
Docker Verify "verified" outcome path added in #59965. It worked correctly,
but confirming that required inferring from the agent's self-reported summary
and step timing that it had actually stood up a Docker environment and run
Playwright twice — the CI log for the "Run Claude Code fix agent" step only
ever shows the agent's final text, because `claude -p` in plain mode doesn't
stream its internal tool calls to stdout.

## What changed

`.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml`: the `claude`
invocation now uses `--output-format stream-json --verbose` (required together
with `--print`) instead of plain `-p`. The JSON event stream is piped through
a jq filter that renders each event as a readable line:

- Assistant text → `> ...`
- Tool calls (Bash commands, file edits, etc.) → `$ ToolName: <command or path>`
- Tool results → `  -> <output, clipped to 1500 chars>`
- The final result → `=== AGENT RESULT (...) ===` + the same summary text as before

The filter is defensive: any non-JSON or unexpected-shape line is silently
skipped (`try ... catch empty`) rather than crashing the pipeline, since a
malformed line here should never fail the whole fix-agent run.

The raw JSONL transcript is also saved to `/tmp/claude-stream.jsonl` and
uploaded as part of the existing `nightly-fix-*` artifact, for anything the
readable filter drops.

## Verification

- `actionlint` and a Python/PyYAML parse pass clean on the edited file.
- Extracted the exact dedented script YAML produces (via PyYAML, matching how
  GitHub Actions resolves `run: |` blocks) and ran it locally against a
  synthetic stream-json fixture (mocked `claude` binary) — confirmed the
  heredoc terminator, `set -euo pipefail` propagation through the `tee | jq`
  pipe, and the jq filter all behave correctly end-to-end, including a
  plain-string `tool_result.content` shape and an injected non-JSON garbage
  line (silently skipped, exit 0).
- `shellcheck` on the extracted script: clean except the expected SC2148
  (no shebang, irrelevant for an extracted `run:` fragment).

No behavioral change to what the agent does — this only makes its existing
tool calls visible in the log.