### PR TITLE
feat: emit the 14 Apollo 8.10 product-telemetry signals

### DIFF
--- a/zeebe/exporters/analytics-exporter/AGENTS.md
+++ b/zeebe/exporters/analytics-exporter/AGENTS.md
@@ -65,12 +65,27 @@ Replicated log
 
 ### Current Event Handlers
 
-|         ValueType         |      Intent       |            Handler             |          event.name          |                       Extra filter                        |
-|---------------------------|-------------------|--------------------------------|------------------------------|-----------------------------------------------------------|
-| PROCESS_INSTANCE_CREATION | CREATED           | ProcessInstanceCreationHandler | `process_instance_created`   | —                                                         |
-| PROCESS_INSTANCE          | ELEMENT_ACTIVATED | AdHocSubProcessHandler         | `adhoc_subprocess_activated` | bpmnElementType == AD_HOC_SUB_PROCESS                     |
-| USAGE_METRIC              | EXPORTED          | UsageMetricHandler             | `usage_metric_exported`      | skips EventType.NONE resets                               |
-| —                         | —                 | (scheduled)                    | `heartbeat`                  | every heartbeatInterval, carries broker/exporter versions |
+|         ValueType         |      Intent       |             Handler              |              event.name               |                       Extra filter                        |
+|---------------------------|-------------------|----------------------------------|---------------------------------------|-----------------------------------------------------------|
+| PROCESS_INSTANCE_CREATION | CREATED           | ProcessInstanceCreationHandler   | `process_instance_created`            | —                                                         |
+| PROCESS_INSTANCE          | ELEMENT_ACTIVATED | AdHocSubProcessHandler           | `adhoc_subprocess_activated`          | bpmnElementType == AD_HOC_SUB_PROCESS                     |
+| USAGE_METRIC              | EXPORTED          | UsageMetricHandler               | `usage_metric_exported`               | skips EventType.NONE resets                               |
+| USER_TASK                 | CREATED           | UserTaskCreatedHandler           | `user_task_created`                   | —                                                         |
+| USER_TASK                 | ASSIGNED          | UserTaskAssignedHandler          | `camunda.user_task.assigned`          | skips empty assignee                                      |
+| TENANT                    | CREATED           | TenantCreatedHandler             | `camunda.tenant.created`              | —                                                         |
+| TENANT                    | DELETED           | TenantDeletedHandler             | `camunda.tenant.deleted`              | —                                                         |
+| INCIDENT                  | CREATED           | IncidentCreatedHandler           | `camunda.process.incident.created`    | —                                                         |
+| INCIDENT                  | RESOLVED          | IncidentResolvedHandler          | `camunda.process.incident.resolved`   | —                                                         |
+| PROCESS                   | CREATED           | ProcessDefinitionCreatedHandler  | `camunda.process.definition.created`  | —                                                         |
+| PROCESS                   | DELETED           | ProcessDefinitionDeletedHandler  | `camunda.process.definition.deleted`  | —                                                         |
+| DECISION                  | CREATED           | DecisionDefinitionCreatedHandler | `camunda.decision.definition.created` | —                                                         |
+| DECISION                  | DELETED           | DecisionDefinitionDeletedHandler | `camunda.decision.definition.deleted` | —                                                         |
+| FORM                      | CREATED           | FormDefinitionCreatedHandler     | `camunda.form.definition.created`     | —                                                         |
+| FORM                      | DELETED           | FormDefinitionDeletedHandler     | `camunda.form.definition.deleted`     | —                                                         |
+| AGENT_INSTANCE            | CREATED           | AgentInstanceCreatedHandler      | `camunda.agent.instance.created`      | —                                                         |
+| AGENT_INSTANCE            | COMPLETED         | AgentInstanceCompletedHandler    | `camunda.agent.instance.completed`    | —                                                         |
+| DECISION_EVALUATION       | EVALUATED         | DecisionInstanceEvaluatedHandler | (counter only, no event)              | —                                                         |
+| —                         | —                 | (scheduled)                      | `heartbeat`                           | every heartbeatInterval, carries broker/exporter versions |
 
 ### Adding a New Event Handler
 
@@ -104,6 +119,8 @@ Signature: HMAC-SHA256(licenseKey, `fingerprint|clusterId|timestamp`)
 ### Pre-Aggregated Metrics
 
 - Counter `camunda.process_instance.created` with delta temporality (resets each flush)
+- Counter `camunda.decision.instance.evaluated`, one increment per DECISION_EVALUATION/EVALUATED
+  record (never per sub-decision), dimension `camunda.tenant.id` — mirrors the EDI usage metric
 - Companion gauge `camunda.metric.export_window` per flush carries:
   - `camunda.metric.sequence_number` — contiguous per flush, gap = lost push
   - `camunda.log.position_start/end` — for replay/overlap detection

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -153,13 +153,26 @@ variables, or any other end-user data.
 
 ### Event types
 
-|        Source record        |       Intent        |          Event name          |                                       Notes                                       |
-|-----------------------------|---------------------|------------------------------|-----------------------------------------------------------------------------------|
-| `PROCESS_INSTANCE_CREATION` | `CREATED`           | `process_instance_created`   | Emitted for every new process instance.                                           |
-| `PROCESS_INSTANCE`          | `ELEMENT_ACTIVATED` | `adhoc_subprocess_activated` | Emitted only when the activated element is an ad-hoc sub-process.                 |
-| `USAGE_METRIC`              | `EXPORTED`          | `usage_metric_exported`      | Emitted once per usage metric export interval. Internal reset events are skipped. |
-| `USER_TASK`                 | `CREATED`           | `user_task_created`          | Emitted for every new user task.                                                  |
-| —                           | —                   | `heartbeat`                  | Emitted periodically by the partition leader (see `heartbeat-interval`).          |
+|        Source record        |       Intent        |              Event name               |                                                     Notes                                                      |
+|-----------------------------|---------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| `PROCESS_INSTANCE_CREATION` | `CREATED`           | `process_instance_created`            | Emitted for every new process instance.                                                                        |
+| `PROCESS_INSTANCE`          | `ELEMENT_ACTIVATED` | `adhoc_subprocess_activated`          | Emitted only when the activated element is an ad-hoc sub-process.                                              |
+| `USAGE_METRIC`              | `EXPORTED`          | `usage_metric_exported`               | Emitted once per usage metric export interval. Internal reset events are skipped.                              |
+| `USER_TASK`                 | `CREATED`           | `user_task_created`                   | Emitted for every new user task.                                                                               |
+| `USER_TASK`                 | `ASSIGNED`          | `camunda.user_task.assigned`          | Emitted for every user task assignment with a non-empty assignee.                                              |
+| `TENANT`                    | `CREATED`           | `camunda.tenant.created`              | Emitted for every new tenant.                                                                                  |
+| `TENANT`                    | `DELETED`           | `camunda.tenant.deleted`              | Emitted for every deleted tenant.                                                                              |
+| `INCIDENT`                  | `CREATED`           | `camunda.process.incident.created`    | Emitted for every raised incident.                                                                             |
+| `INCIDENT`                  | `RESOLVED`          | `camunda.process.incident.resolved`   | Emitted for every resolved incident.                                                                           |
+| `PROCESS`                   | `CREATED`           | `camunda.process.definition.created`  | Emitted once per process definition, so a deployment of several processes produces one event each.             |
+| `PROCESS`                   | `DELETED`           | `camunda.process.definition.deleted`  | Emitted once per partition when a process definition is deleted; deduplicate downstream on the definition key. |
+| `DECISION`                  | `CREATED`           | `camunda.decision.definition.created` | Emitted once per decision in a deployed decision requirements graph.                                           |
+| `DECISION`                  | `DELETED`           | `camunda.decision.definition.deleted` | Emitted once per partition when a decision is deleted; deduplicate downstream on the decision key.             |
+| `FORM`                      | `CREATED`           | `camunda.form.definition.created`     | Emitted once per deployed form.                                                                                |
+| `FORM`                      | `DELETED`           | `camunda.form.definition.deleted`     | Emitted once per partition when a form is deleted; deduplicate downstream on the form key.                     |
+| `AGENT_INSTANCE`            | `CREATED`           | `camunda.agent.instance.created`      | Emitted for every created agent instance.                                                                      |
+| `AGENT_INSTANCE`            | `COMPLETED`         | `camunda.agent.instance.completed`    | Emitted for every completed agent instance.                                                                    |
+| —                           | —                   | `heartbeat`                           | Emitted periodically by the partition leader (see `heartbeat-interval`).                                       |
 
 ### Common log record attributes
 
@@ -198,6 +211,99 @@ Beyond the common attributes above, each event type carries its own additional f
 
 Note: unlike `process_instance_created`, this event does not carry `camunda.process.version`.
 
+**`camunda.user_task.assigned`**
+
+|             Attribute             |  Type  |             Description             |
+|-----------------------------------|--------|-------------------------------------|
+| `camunda.user_task.key`           | long   | User task key.                      |
+| `camunda.user_task.assignee_hash` | string | SHA-256 hex digest of the assignee. |
+| `camunda.process.instance_key`    | long   | Process instance key.               |
+| `camunda.tenant.id`               | string | Tenant ID.                          |
+
+The raw assignee is never exported; a SHA-256 hash is emitted as a pseudonymous per-assignee
+identifier so distinct assignees can be counted. The hash is unsalted, so it is reversible for a
+known set of assignees and identical across clusters, and it is not joinable with the engine's TU
+usage metric, which hashes assignees differently. Assignments with an empty assignee produce no
+event, matching the engine's assignment guard.
+
+**`camunda.tenant.created`**
+
+|      Attribute      |  Type  | Description |
+|---------------------|--------|-------------|
+| `camunda.tenant.id` | string | Tenant ID.  |
+
+The tenant name, description, and associated entity are deliberately not exported.
+
+**`camunda.tenant.deleted`**
+
+|      Attribute      |  Type  | Description |
+|---------------------|--------|-------------|
+| `camunda.tenant.id` | string | Tenant ID.  |
+
+**`camunda.process.incident.created`** and **`camunda.process.incident.resolved`**
+
+|            Attribute             |  Type  |               Description                |
+|----------------------------------|--------|------------------------------------------|
+| `camunda.incident.key`           | long   | Incident key, taken from the record key. |
+| `camunda.process.id`             | string | BPMN process ID.                         |
+| `camunda.process.definition_key` | long   | Process definition key.                  |
+| `camunda.process.instance_key`   | long   | Process instance key.                    |
+| `camunda.tenant.id`              | string | Tenant ID.                               |
+
+Both events carry the same attributes, so time-to-resolution is a join on
+`camunda.incident.key`. The incident error message is deliberately not exported: it can
+quote expressions and variable values.
+
+**`camunda.process.definition.created`** and **`camunda.process.definition.deleted`**
+
+|            Attribute             |  Type  |       Description       |
+|----------------------------------|--------|-------------------------|
+| `camunda.process.id`             | string | BPMN process ID.        |
+| `camunda.process.version`        | long   | Process version.        |
+| `camunda.process.definition_key` | long   | Process definition key. |
+| `camunda.tenant.id`              | string | Tenant ID.              |
+
+The BPMN resource, resource name, and version tag are deliberately not exported.
+
+**`camunda.decision.definition.created`** and **`camunda.decision.definition.deleted`**
+
+|         Attribute          |  Type  |        Description        |
+|----------------------------|--------|---------------------------|
+| `camunda.decision.id`      | string | Decision ID from the DMN. |
+| `camunda.decision.key`     | long   | Decision key.             |
+| `camunda.decision.version` | long   | Decision version.         |
+| `camunda.tenant.id`        | string | Tenant ID.                |
+
+The decision name and version tag are deliberately not exported.
+
+**`camunda.form.definition.created`** and **`camunda.form.definition.deleted`**
+
+|       Attribute        |  Type  |  Description  |
+|------------------------|--------|---------------|
+| `camunda.form.id`      | string | Form ID.      |
+| `camunda.form.key`     | long   | Form key.     |
+| `camunda.form.version` | long   | Form version. |
+| `camunda.tenant.id`    | string | Tenant ID.    |
+
+The form resource, resource name, and version tag are deliberately not exported.
+
+**`camunda.agent.instance.created`** and **`camunda.agent.instance.completed`**
+
+|            Attribute             |  Type  |                       Description                        |
+|----------------------------------|--------|----------------------------------------------------------|
+| `camunda.agent.instance_key`     | long   | Agent instance key.                                      |
+| `camunda.agent.definition_key`   | long   | Agent definition key.                                    |
+| `camunda.agent.status`           | string | Agent instance status, e.g. `INITIALIZING`, `COMPLETED`. |
+| `camunda.process.id`             | string | BPMN process ID.                                         |
+| `camunda.process.definition_key` | long   | Process definition key.                                  |
+| `camunda.process.instance_key`   | long   | Process instance key.                                    |
+| `camunda.tenant.id`              | string | Tenant ID.                                               |
+
+Both events carry the same attributes, so agent run duration is a join on
+`camunda.agent.instance_key`. The agent definition (model, provider, system prompt), its
+tools, its collected metrics such as token counts, its configured limits, the changed
+attribute names, and the version tag are all deliberately not exported.
+
 **`adhoc_subprocess_activated`**
 
 |            Attribute             |  Type  |                Description                 |
@@ -216,6 +322,22 @@ Note: unlike `process_instance_created`, this event does not carry `camunda.proc
 | `camunda.usage_metric.count`          | long   | Count for this metric type in this export interval.                                                        |
 | `camunda.usage_metric.interval_start` | long   | Epoch-ms start of the export window.                                                                       |
 | `camunda.usage_metric.interval_end`   | long   | Epoch-ms end of the export window.                                                                         |
+
+### Pre-aggregated counters
+
+Alongside the events above, the exporter ships delta counters over OTLP metrics. Each counter
+is incremented once per source record and carries the dimensions listed below.
+
+|                Counter                |              Source record              |                              Dimensions                              |
+|---------------------------------------|-----------------------------------------|----------------------------------------------------------------------|
+| `camunda.process_instance.created`    | `PROCESS_INSTANCE_CREATION` / `CREATED` | `camunda.process.id`, `camunda.process.version`, `camunda.tenant.id` |
+| `camunda.decision.instance.evaluated` | `DECISION_EVALUATION` / `EVALUATED`     | `camunda.tenant.id`                                                  |
+
+`camunda.decision.instance.evaluated` counts evaluation records, not the decisions inside them:
+a decision that requires sub-decisions still counts once, and failed evaluations are not counted,
+which is the same counting rule as the `EDI` usage metric. It is a real-time, per-tenant view; the
+`EDI` usage metric remains the authoritative figure, and the two can differ under sampling and at
+window boundaries.
 
 ### Heartbeat attributes
 

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -45,6 +45,19 @@ public final class AnalyticsAttributes {
     public static final String USAGE_METRIC_EXPORTED = "usage_metric_exported";
     public static final String HEARTBEAT = "heartbeat";
     public static final String USER_TASK_CREATED = "user_task_created";
+    public static final String TENANT_CREATED = "camunda.tenant.created";
+    public static final String TENANT_DELETED = "camunda.tenant.deleted";
+    public static final String PROCESS_INCIDENT_CREATED = "camunda.process.incident.created";
+    public static final String PROCESS_INCIDENT_RESOLVED = "camunda.process.incident.resolved";
+    public static final String PROCESS_DEFINITION_CREATED = "camunda.process.definition.created";
+    public static final String PROCESS_DEFINITION_DELETED = "camunda.process.definition.deleted";
+    public static final String DECISION_DEFINITION_CREATED = "camunda.decision.definition.created";
+    public static final String DECISION_DEFINITION_DELETED = "camunda.decision.definition.deleted";
+    public static final String FORM_DEFINITION_CREATED = "camunda.form.definition.created";
+    public static final String FORM_DEFINITION_DELETED = "camunda.form.definition.deleted";
+    public static final String AGENT_INSTANCE_CREATED = "camunda.agent.instance.created";
+    public static final String AGENT_INSTANCE_COMPLETED = "camunda.agent.instance.completed";
+    public static final String USER_TASK_ASSIGNED = "camunda.user_task.assigned";
 
     private Event() {}
   }
@@ -86,8 +99,53 @@ public final class AnalyticsAttributes {
     private Element() {}
   }
 
+  public static final class UserTask {
+    public static final AttributeKey<Long> KEY = AttributeKey.longKey("camunda.user_task.key");
+
+    /** SHA-256 hex of the assignee. The raw assignee is PII and must never be emitted. */
+    public static final AttributeKey<String> ASSIGNEE_HASH =
+        AttributeKey.stringKey("camunda.user_task.assignee_hash");
+
+    private UserTask() {}
+  }
+
+  public static final class Incident {
+    public static final AttributeKey<Long> KEY = AttributeKey.longKey("camunda.incident.key");
+
+    private Incident() {}
+  }
+
+  public static final class Decision {
+    public static final AttributeKey<String> ID = AttributeKey.stringKey("camunda.decision.id");
+    public static final AttributeKey<Long> KEY = AttributeKey.longKey("camunda.decision.key");
+    public static final AttributeKey<Long> VERSION =
+        AttributeKey.longKey("camunda.decision.version");
+
+    private Decision() {}
+  }
+
+  public static final class Form {
+    public static final AttributeKey<String> ID = AttributeKey.stringKey("camunda.form.id");
+    public static final AttributeKey<Long> KEY = AttributeKey.longKey("camunda.form.key");
+    public static final AttributeKey<Long> VERSION = AttributeKey.longKey("camunda.form.version");
+
+    private Form() {}
+  }
+
+  public static final class Agent {
+    public static final AttributeKey<Long> INSTANCE_KEY =
+        AttributeKey.longKey("camunda.agent.instance_key");
+    public static final AttributeKey<Long> DEFINITION_KEY =
+        AttributeKey.longKey("camunda.agent.definition_key");
+    public static final AttributeKey<String> STATUS =
+        AttributeKey.stringKey("camunda.agent.status");
+
+    private Agent() {}
+  }
+
   public static final class Metric {
     public static final String PROCESS_INSTANCE_CREATED = "camunda.process_instance.created";
+    public static final String DECISION_INSTANCE_EVALUATED = "camunda.decision.instance.evaluated";
     public static final String EXPORT_WINDOW = "camunda.metric.export_window";
     public static final AttributeKey<Long> SEQUENCE_NUMBER =
         AttributeKey.longKey("camunda.metric.sequence_number");

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalog.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalog.java
@@ -8,12 +8,33 @@
 package io.camunda.exporter.analytics;
 
 import io.camunda.exporter.analytics.handler.AdHocSubProcessHandler;
+import io.camunda.exporter.analytics.handler.AgentInstanceCompletedHandler;
+import io.camunda.exporter.analytics.handler.AgentInstanceCreatedHandler;
+import io.camunda.exporter.analytics.handler.DecisionDefinitionCreatedHandler;
+import io.camunda.exporter.analytics.handler.DecisionDefinitionDeletedHandler;
+import io.camunda.exporter.analytics.handler.DecisionInstanceEvaluatedHandler;
+import io.camunda.exporter.analytics.handler.FormDefinitionCreatedHandler;
+import io.camunda.exporter.analytics.handler.FormDefinitionDeletedHandler;
+import io.camunda.exporter.analytics.handler.IncidentCreatedHandler;
+import io.camunda.exporter.analytics.handler.IncidentResolvedHandler;
+import io.camunda.exporter.analytics.handler.ProcessDefinitionCreatedHandler;
+import io.camunda.exporter.analytics.handler.ProcessDefinitionDeletedHandler;
 import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
+import io.camunda.exporter.analytics.handler.TenantCreatedHandler;
+import io.camunda.exporter.analytics.handler.TenantDeletedHandler;
 import io.camunda.exporter.analytics.handler.UsageMetricHandler;
+import io.camunda.exporter.analytics.handler.UserTaskAssignedHandler;
 import io.camunda.exporter.analytics.handler.UserTaskCreatedHandler;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import java.util.Set;
@@ -45,8 +66,50 @@ final class AnalyticsHandlerCatalog {
             UsageMetricIntent.EXPORTED,
             new UsageMetricHandler(otelSdkManager))
         .register(
+            ValueType.USER_TASK, UserTaskIntent.CREATED, new UserTaskCreatedHandler(otelSdkManager))
+        .register(
             ValueType.USER_TASK,
-            UserTaskIntent.CREATED,
-            new UserTaskCreatedHandler(otelSdkManager));
+            UserTaskIntent.ASSIGNED,
+            new UserTaskAssignedHandler(otelSdkManager))
+        .register(ValueType.TENANT, TenantIntent.CREATED, new TenantCreatedHandler(otelSdkManager))
+        .register(ValueType.TENANT, TenantIntent.DELETED, new TenantDeletedHandler(otelSdkManager))
+        .register(
+            ValueType.INCIDENT, IncidentIntent.CREATED, new IncidentCreatedHandler(otelSdkManager))
+        .register(
+            ValueType.INCIDENT,
+            IncidentIntent.RESOLVED,
+            new IncidentResolvedHandler(otelSdkManager))
+        .register(
+            ValueType.PROCESS,
+            ProcessIntent.CREATED,
+            new ProcessDefinitionCreatedHandler(otelSdkManager))
+        .register(
+            ValueType.PROCESS,
+            ProcessIntent.DELETED,
+            new ProcessDefinitionDeletedHandler(otelSdkManager))
+        .register(
+            ValueType.DECISION,
+            DecisionIntent.CREATED,
+            new DecisionDefinitionCreatedHandler(otelSdkManager))
+        .register(
+            ValueType.DECISION,
+            DecisionIntent.DELETED,
+            new DecisionDefinitionDeletedHandler(otelSdkManager))
+        .register(
+            ValueType.DECISION_EVALUATION,
+            DecisionEvaluationIntent.EVALUATED,
+            new DecisionInstanceEvaluatedHandler(otelSdkManager))
+        .register(
+            ValueType.FORM, FormIntent.CREATED, new FormDefinitionCreatedHandler(otelSdkManager))
+        .register(
+            ValueType.FORM, FormIntent.DELETED, new FormDefinitionDeletedHandler(otelSdkManager))
+        .register(
+            ValueType.AGENT_INSTANCE,
+            AgentInstanceIntent.CREATED,
+            new AgentInstanceCreatedHandler(otelSdkManager))
+        .register(
+            ValueType.AGENT_INSTANCE,
+            AgentInstanceIntent.COMPLETED,
+            new AgentInstanceCompletedHandler(otelSdkManager));
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCompletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCompletedHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.AGENT_INSTANCE_COMPLETED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.agent.instance.completed} OTel event for each completed agent instance.
+ * Carries the same attributes as {@code camunda.agent.instance.created}, so agent run duration is a
+ * downstream join on the agent instance key. Token counts and tool calls are deliberately not
+ * exported.
+ */
+public final class AgentInstanceCompletedHandler
+    implements AnalyticsHandler<AgentInstanceRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public AgentInstanceCompletedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<AgentInstanceRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        AGENT_INSTANCE_COMPLETED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Agent.INSTANCE_KEY, value.getAgentInstanceKey())
+                .setAttribute(
+                    AnalyticsAttributes.Agent.DEFINITION_KEY, value.getAgentDefinitionKey())
+                .setAttribute(AnalyticsAttributes.Agent.STATUS, value.getStatus().name())
+                .setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCompletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCompletedHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITI
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -33,6 +34,11 @@ public final class AgentInstanceCompletedHandler
 
   public AgentInstanceCompletedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCompletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCompletedHandler.java
@@ -7,11 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.AGENT_INSTANCE_COMPLETED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -46,16 +41,18 @@ public final class AgentInstanceCompletedHandler
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        AGENT_INSTANCE_COMPLETED,
+        AnalyticsAttributes.Event.AGENT_INSTANCE_COMPLETED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Agent.INSTANCE_KEY, value.getAgentInstanceKey())
                 .setAttribute(
                     AnalyticsAttributes.Agent.DEFINITION_KEY, value.getAgentDefinitionKey())
                 .setAttribute(AnalyticsAttributes.Agent.STATUS, value.getStatus().name())
-                .setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Process.BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(
+                    AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(
+                    AnalyticsAttributes.Process.INSTANCE_KEY, value.getProcessInstanceKey())
                 .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandler.java
@@ -7,11 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.AGENT_INSTANCE_CREATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -46,16 +41,18 @@ public final class AgentInstanceCreatedHandler
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        AGENT_INSTANCE_CREATED,
+        AnalyticsAttributes.Event.AGENT_INSTANCE_CREATED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Agent.INSTANCE_KEY, value.getAgentInstanceKey())
                 .setAttribute(
                     AnalyticsAttributes.Agent.DEFINITION_KEY, value.getAgentDefinitionKey())
                 .setAttribute(AnalyticsAttributes.Agent.STATUS, value.getStatus().name())
-                .setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Process.BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(
+                    AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(
+                    AnalyticsAttributes.Process.INSTANCE_KEY, value.getProcessInstanceKey())
                 .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITI
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -33,6 +34,11 @@ public final class AgentInstanceCreatedHandler
 
   public AgentInstanceCreatedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.AGENT_INSTANCE_CREATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.agent.instance.created} OTel event for each created agent instance. Emits
+ * only keys, the tenant id, and the status enum — never the agent definition (model, provider,
+ * system prompt), tools, metrics, limits, changed attributes, or version tag, all of which carry
+ * free text or configuration detail.
+ */
+public final class AgentInstanceCreatedHandler
+    implements AnalyticsHandler<AgentInstanceRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public AgentInstanceCreatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<AgentInstanceRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        AGENT_INSTANCE_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Agent.INSTANCE_KEY, value.getAgentInstanceKey())
+                .setAttribute(
+                    AnalyticsAttributes.Agent.DEFINITION_KEY, value.getAgentDefinitionKey())
+                .setAttribute(AnalyticsAttributes.Agent.STATUS, value.getStatus().name())
+                .setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionCreatedHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.DECISION_DEFINITION_CREATED;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -42,7 +40,7 @@ public final class DecisionDefinitionCreatedHandler
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        DECISION_DEFINITION_CREATED,
+        AnalyticsAttributes.Event.DECISION_DEFINITION_CREATED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Decision.ID, value.getDecisionId())

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionCreatedHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.analytics.handler;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.DECISION_DEFINITION_CREATED;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -29,6 +30,11 @@ public final class DecisionDefinitionCreatedHandler
 
   public DecisionDefinitionCreatedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionCreatedHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.DECISION_DEFINITION_CREATED;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.decision.definition.created} OTel event for each deployed decision. Emits
+ * only definition metadata — never the decision name or version tag, both of which are
+ * author-supplied free text.
+ */
+public final class DecisionDefinitionCreatedHandler
+    implements AnalyticsHandler<DecisionRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public DecisionDefinitionCreatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<DecisionRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        DECISION_DEFINITION_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Decision.ID, value.getDecisionId())
+                .setAttribute(AnalyticsAttributes.Decision.KEY, value.getDecisionKey())
+                .setAttribute(AnalyticsAttributes.Decision.VERSION, (long) value.getVersion())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionDeletedHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.analytics.handler;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.DECISION_DEFINITION_DELETED;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -28,6 +29,11 @@ public final class DecisionDefinitionDeletedHandler
 
   public DecisionDefinitionDeletedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionDeletedHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.DECISION_DEFINITION_DELETED;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.decision.definition.deleted} OTel event for each deleted decision. Carries
+ * the same attributes as {@code camunda.decision.definition.created}.
+ */
+public final class DecisionDefinitionDeletedHandler
+    implements AnalyticsHandler<DecisionRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public DecisionDefinitionDeletedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<DecisionRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        DECISION_DEFINITION_DELETED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Decision.ID, value.getDecisionId())
+                .setAttribute(AnalyticsAttributes.Decision.KEY, value.getDecisionKey())
+                .setAttribute(AnalyticsAttributes.Decision.VERSION, (long) value.getVersion())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionDefinitionDeletedHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.DECISION_DEFINITION_DELETED;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -41,7 +39,7 @@ public final class DecisionDefinitionDeletedHandler
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        DECISION_DEFINITION_DELETED,
+        AnalyticsAttributes.Event.DECISION_DEFINITION_DELETED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Decision.ID, value.getDecisionId())

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.analytics.handler;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.DECISION_INSTANCE_EVALUATED;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Tenant.ID;
 
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -29,6 +30,11 @@ public final class DecisionInstanceEvaluatedHandler
 
   public DecisionInstanceEvaluatedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.CONTRACTUAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.DECISION_INSTANCE_EVALUATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Tenant.ID;
+
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.opentelemetry.api.common.Attributes;
+import java.util.Objects;
+
+/**
+ * Increments the {@code camunda.decision.instance.evaluated} counter for each evaluated decision
+ * instance. Exactly one increment per record, so the counter matches the engine's EDI usage metric:
+ * the sub-decisions in {@code getEvaluatedDecisions()} must not be counted separately.
+ */
+public final class DecisionInstanceEvaluatedHandler
+    implements AnalyticsHandler<DecisionEvaluationRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public DecisionInstanceEvaluatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<DecisionEvaluationRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.incrementMetric(
+        DECISION_INSTANCE_EVALUATED,
+        record.getPosition(),
+        record.getTimestamp(),
+        Attributes.of(ID, value.getTenantId()));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandler.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.DECISION_INSTANCE_EVALUATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Tenant.ID;
-
+import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
@@ -42,9 +40,9 @@ public final class DecisionInstanceEvaluatedHandler
     final var value = record.getValue();
 
     otelSdkManager.incrementMetric(
-        DECISION_INSTANCE_EVALUATED,
+        AnalyticsAttributes.Metric.DECISION_INSTANCE_EVALUATED,
         record.getPosition(),
         record.getTimestamp(),
-        Attributes.of(ID, value.getTenantId()));
+        Attributes.of(AnalyticsAttributes.Tenant.ID, value.getTenantId()));
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionCreatedHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.FORM_DEFINITION_CREATED;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.Form;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.form.definition.created} OTel event for each deployed form. Emits only
+ * definition metadata — never the form resource, which carries field labels and other
+ * author-supplied free text.
+ */
+public final class FormDefinitionCreatedHandler implements AnalyticsHandler<Form> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public FormDefinitionCreatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<Form> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        FORM_DEFINITION_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Form.ID, value.getFormId())
+                .setAttribute(AnalyticsAttributes.Form.KEY, value.getFormKey())
+                .setAttribute(AnalyticsAttributes.Form.VERSION, (long) value.getVersion())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionCreatedHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.FORM_DEFINITION_CREATED;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -41,7 +39,7 @@ public final class FormDefinitionCreatedHandler implements AnalyticsHandler<Form
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        FORM_DEFINITION_CREATED,
+        AnalyticsAttributes.Event.FORM_DEFINITION_CREATED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Form.ID, value.getFormId())

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionCreatedHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.analytics.handler;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.FORM_DEFINITION_CREATED;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -28,6 +29,11 @@ public final class FormDefinitionCreatedHandler implements AnalyticsHandler<Form
 
   public FormDefinitionCreatedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionDeletedHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.FORM_DEFINITION_DELETED;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.Form;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.form.definition.deleted} OTel event for each deleted form. Carries the
+ * same attributes as {@code camunda.form.definition.created}.
+ */
+public final class FormDefinitionDeletedHandler implements AnalyticsHandler<Form> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public FormDefinitionDeletedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<Form> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        FORM_DEFINITION_DELETED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Form.ID, value.getFormId())
+                .setAttribute(AnalyticsAttributes.Form.KEY, value.getFormKey())
+                .setAttribute(AnalyticsAttributes.Form.VERSION, (long) value.getVersion())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionDeletedHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.analytics.handler;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.FORM_DEFINITION_DELETED;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -27,6 +28,11 @@ public final class FormDefinitionDeletedHandler implements AnalyticsHandler<Form
 
   public FormDefinitionDeletedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/FormDefinitionDeletedHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.FORM_DEFINITION_DELETED;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -40,7 +38,7 @@ public final class FormDefinitionDeletedHandler implements AnalyticsHandler<Form
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        FORM_DEFINITION_DELETED,
+        AnalyticsAttributes.Event.FORM_DEFINITION_DELETED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Form.ID, value.getFormId())

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentCreatedHandler.java
@@ -7,11 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_INCIDENT_CREATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -47,13 +42,15 @@ public final class IncidentCreatedHandler implements AnalyticsHandler<IncidentRe
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        PROCESS_INCIDENT_CREATED,
+        AnalyticsAttributes.Event.PROCESS_INCIDENT_CREATED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Incident.KEY, record.getKey())
-                .setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Process.BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(
+                    AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(
+                    AnalyticsAttributes.Process.INSTANCE_KEY, value.getProcessInstanceKey())
                 .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentCreatedHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_INCIDENT_CREATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.process.incident.created} OTel event for each raised incident. Emits only
+ * safe process-metadata attributes — never the error message, which can carry variable values and
+ * other end-user data.
+ *
+ * <p>The incident key is taken from the record key: {@link IncidentRecordValue} carries no incident
+ * key of its own. It is emitted so that resolution can be joined to creation downstream.
+ */
+public final class IncidentCreatedHandler implements AnalyticsHandler<IncidentRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public IncidentCreatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<IncidentRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        PROCESS_INCIDENT_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Incident.KEY, record.getKey())
+                .setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentCreatedHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITI
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -34,6 +35,11 @@ public final class IncidentCreatedHandler implements AnalyticsHandler<IncidentRe
 
   public IncidentCreatedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentResolvedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentResolvedHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_INCIDENT_RESOLVED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.process.incident.resolved} OTel event for each resolved incident. Carries
+ * the same attributes as {@code camunda.process.incident.created} so that time-to-resolution is a
+ * downstream join on the incident key.
+ *
+ * <p>The incident key is taken from the record key: {@link IncidentRecordValue} carries no incident
+ * key of its own.
+ */
+public final class IncidentResolvedHandler implements AnalyticsHandler<IncidentRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public IncidentResolvedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<IncidentRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        PROCESS_INCIDENT_RESOLVED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Incident.KEY, record.getKey())
+                .setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentResolvedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentResolvedHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITI
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -34,6 +35,11 @@ public final class IncidentResolvedHandler implements AnalyticsHandler<IncidentR
 
   public IncidentResolvedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentResolvedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/IncidentResolvedHandler.java
@@ -7,11 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_INCIDENT_RESOLVED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -47,13 +42,15 @@ public final class IncidentResolvedHandler implements AnalyticsHandler<IncidentR
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        PROCESS_INCIDENT_RESOLVED,
+        AnalyticsAttributes.Event.PROCESS_INCIDENT_RESOLVED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Incident.KEY, record.getKey())
-                .setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Process.BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(
+                    AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(
+                    AnalyticsAttributes.Process.INSTANCE_KEY, value.getProcessInstanceKey())
                 .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionCreatedHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITI
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -31,6 +32,11 @@ public final class ProcessDefinitionCreatedHandler implements AnalyticsHandler<P
 
   public ProcessDefinitionCreatedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionCreatedHandler.java
@@ -7,11 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_DEFINITION_CREATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -44,12 +39,13 @@ public final class ProcessDefinitionCreatedHandler implements AnalyticsHandler<P
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        PROCESS_DEFINITION_CREATED,
+        AnalyticsAttributes.Event.PROCESS_DEFINITION_CREATED,
         record.getPosition(),
         log ->
-            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(VERSION, (long) value.getVersion())
+            log.setAttribute(AnalyticsAttributes.Process.BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(
+                    AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(AnalyticsAttributes.Process.VERSION, (long) value.getVersion())
                 .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionCreatedHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_DEFINITION_CREATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.process.definition.created} OTel event for each deployed process
+ * definition. Emits only definition metadata — never the BPMN resource, resource name, or version
+ * tag, all of which are author-supplied free text.
+ */
+public final class ProcessDefinitionCreatedHandler implements AnalyticsHandler<Process> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public ProcessDefinitionCreatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<Process> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        PROCESS_DEFINITION_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(VERSION, (long) value.getVersion())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionDeletedHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_DEFINITION_DELETED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.process.definition.deleted} OTel event for each deleted process
+ * definition. Carries the same attributes as {@code camunda.process.definition.created}.
+ */
+public final class ProcessDefinitionDeletedHandler implements AnalyticsHandler<Process> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public ProcessDefinitionDeletedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<Process> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        PROCESS_DEFINITION_DELETED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(VERSION, (long) value.getVersion())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionDeletedHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITI
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -30,6 +31,11 @@ public final class ProcessDefinitionDeletedHandler implements AnalyticsHandler<P
 
   public ProcessDefinitionDeletedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.OPTIONAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessDefinitionDeletedHandler.java
@@ -7,11 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_DEFINITION_DELETED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -43,12 +38,13 @@ public final class ProcessDefinitionDeletedHandler implements AnalyticsHandler<P
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        PROCESS_DEFINITION_DELETED,
+        AnalyticsAttributes.Event.PROCESS_DEFINITION_DELETED,
         record.getPosition(),
         log ->
-            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(VERSION, (long) value.getVersion())
+            log.setAttribute(AnalyticsAttributes.Process.BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(
+                    AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(AnalyticsAttributes.Process.VERSION, (long) value.getVersion())
                 .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantCreatedHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TENANT_CREATED;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -40,7 +38,7 @@ public final class TenantCreatedHandler implements AnalyticsHandler<TenantRecord
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        TENANT_CREATED,
+        AnalyticsAttributes.Event.TENANT_CREATED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantCreatedHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TENANT_CREATED;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.tenant.created} OTel event for each tenant creation. Emits only the tenant
+ * identifier — never the tenant name, description, or the entity being associated with it.
+ */
+public final class TenantCreatedHandler implements AnalyticsHandler<TenantRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public TenantCreatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<TenantRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        TENANT_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantCreatedHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.analytics.handler;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TENANT_CREATED;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -27,6 +28,11 @@ public final class TenantCreatedHandler implements AnalyticsHandler<TenantRecord
 
   public TenantCreatedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.CONTRACTUAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantDeletedHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TENANT_DELETED;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -40,7 +38,7 @@ public final class TenantDeletedHandler implements AnalyticsHandler<TenantRecord
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        TENANT_DELETED,
+        AnalyticsAttributes.Event.TENANT_DELETED,
         record.getPosition(),
         log ->
             log.setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantDeletedHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.analytics.handler;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TENANT_DELETED;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -27,6 +28,11 @@ public final class TenantDeletedHandler implements AnalyticsHandler<TenantRecord
 
   public TenantDeletedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.CONTRACTUAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantDeletedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/TenantDeletedHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TENANT_DELETED;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.tenant.deleted} OTel event for each tenant deletion. Emits only the tenant
+ * identifier — never the tenant name, description, or the entity being associated with it.
+ */
+public final class TenantDeletedHandler implements AnalyticsHandler<TenantRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public TenantDeletedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<TenantRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        TENANT_DELETED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.USER_TASK_ASSIGNED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UserTask.ASSIGNEE_HASH;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UserTask.KEY;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code camunda.user_task.assigned} OTel event for each user task assignment. The assignee
+ * is PII: only its SHA-256 hex digest is emitted, never the raw value.
+ *
+ * <p>The digest is a pseudonymous per-assignee identifier for distinct-counting. It is an unsalted
+ * SHA-256, so it is not joinable with the engine's TU usage metric, which hashes assignees
+ * differently. Records with an empty assignee are skipped, matching the engine's assignment guard.
+ */
+public final class UserTaskAssignedHandler implements AnalyticsHandler<UserTaskRecordValue> {
+
+  private static final String SHA_256 = "SHA-256";
+  private static final HexFormat HEX = HexFormat.of();
+
+  private final OtelSdkManager otelSdkManager;
+
+  public UserTaskAssignedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<UserTaskRecordValue> record) {
+    final var value = record.getValue();
+    final var assignee = value.getAssignee();
+    if (assignee == null || assignee.isEmpty()) {
+      return;
+    }
+
+    otelSdkManager.logEvent(
+        USER_TASK_ASSIGNED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(ASSIGNEE_HASH, sha256Hex(assignee))
+                .setAttribute(KEY, value.getUserTaskKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+
+  private static String sha256Hex(final String value) {
+    try {
+      return HEX.formatHex(
+          MessageDigest.getInstance(SHA_256).digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException("JVM does not support SHA-256", e);
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandler.java
@@ -7,11 +7,6 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.USER_TASK_ASSIGNED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.UserTask.ASSIGNEE_HASH;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.UserTask.KEY;
-
 import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -58,12 +53,13 @@ public final class UserTaskAssignedHandler implements AnalyticsHandler<UserTaskR
     }
 
     otelSdkManager.logEvent(
-        USER_TASK_ASSIGNED,
+        AnalyticsAttributes.Event.USER_TASK_ASSIGNED,
         record.getPosition(),
         log ->
-            log.setAttribute(ASSIGNEE_HASH, sha256Hex(assignee))
-                .setAttribute(KEY, value.getUserTaskKey())
-                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+            log.setAttribute(AnalyticsAttributes.UserTask.ASSIGNEE_HASH, sha256Hex(assignee))
+                .setAttribute(AnalyticsAttributes.UserTask.KEY, value.getUserTaskKey())
+                .setAttribute(
+                    AnalyticsAttributes.Process.INSTANCE_KEY, value.getProcessInstanceKey())
                 .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandler.java
@@ -35,8 +35,19 @@ public final class UserTaskAssignedHandler implements AnalyticsHandler<UserTaskR
 
   private final OtelSdkManager otelSdkManager;
 
+  // Handlers are only ever invoked from the single exporter/partition actor thread (see
+  // AGENTS.md), so one MessageDigest instance can safely be reused across handle() calls instead
+  // of paying a JCA provider lookup on every record. MessageDigest#digest() resets the digest's
+  // internal state after each call, so no explicit reset() is needed between records.
+  private final MessageDigest sha256;
+
   public UserTaskAssignedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+    try {
+      sha256 = MessageDigest.getInstance(SHA_256);
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException("JVM does not support SHA-256", e);
+    }
   }
 
   @Override
@@ -56,7 +67,8 @@ public final class UserTaskAssignedHandler implements AnalyticsHandler<UserTaskR
         AnalyticsAttributes.Event.USER_TASK_ASSIGNED,
         record.getPosition(),
         log ->
-            log.setAttribute(AnalyticsAttributes.UserTask.ASSIGNEE_HASH, sha256Hex(assignee))
+            log.setAttribute(
+                    AnalyticsAttributes.UserTask.ASSIGNEE_HASH, sha256Hex(sha256, assignee))
                 .setAttribute(AnalyticsAttributes.UserTask.KEY, value.getUserTaskKey())
                 .setAttribute(
                     AnalyticsAttributes.Process.INSTANCE_KEY, value.getProcessInstanceKey())
@@ -64,12 +76,7 @@ public final class UserTaskAssignedHandler implements AnalyticsHandler<UserTaskR
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }
 
-  private static String sha256Hex(final String value) {
-    try {
-      return HEX.formatHex(
-          MessageDigest.getInstance(SHA_256).digest(value.getBytes(StandardCharsets.UTF_8)));
-    } catch (final NoSuchAlgorithmException e) {
-      throw new IllegalStateException("JVM does not support SHA-256", e);
-    }
+  private static String sha256Hex(final MessageDigest digest, final String value) {
+    return HEX.formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.UserTask.ASSIGNE
 import static io.camunda.exporter.analytics.AnalyticsAttributes.UserTask.KEY;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsCategory;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -41,6 +42,11 @@ public final class UserTaskAssignedHandler implements AnalyticsHandler<UserTaskR
 
   public UserTaskAssignedHandler(final OtelSdkManager otelSdkManager) {
     this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public AnalyticsCategory category() {
+    return AnalyticsCategory.CONTRACTUAL;
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -16,16 +16,31 @@ import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.Form;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.ArrayList;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
@@ -326,6 +341,354 @@ class AnalyticsExporterTest {
               assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Log.POSITION))
                   .isEqualTo(record.getPosition());
             });
+  }
+
+  @Test
+  void shouldEmitTenantCreatedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.TENANT,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(TenantIntent.CREATED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (TenantRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.TENANT_CREATED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Tenant.ID))
+                  .isEqualTo(value.getTenantId());
+            });
+  }
+
+  @Test
+  void shouldEmitTenantDeletedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.TENANT,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(TenantIntent.DELETED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (TenantRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.TENANT_DELETED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Tenant.ID))
+                  .isEqualTo(value.getTenantId());
+            });
+  }
+
+  @Test
+  void shouldEmitIncidentCreatedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.INCIDENT,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(IncidentIntent.CREATED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.PROCESS_INCIDENT_CREATED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Incident.KEY))
+                  .isEqualTo(record.getKey());
+            });
+  }
+
+  @Test
+  void shouldEmitIncidentResolvedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.INCIDENT,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(IncidentIntent.RESOLVED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.PROCESS_INCIDENT_RESOLVED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Incident.KEY))
+                  .isEqualTo(record.getKey());
+            });
+  }
+
+  @Test
+  void shouldEmitProcessDefinitionCreatedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(ProcessIntent.CREATED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (Process) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.PROCESS_DEFINITION_CREATED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Process.DEFINITION_KEY))
+                  .isEqualTo(value.getProcessDefinitionKey());
+            });
+  }
+
+  @Test
+  void shouldEmitProcessDefinitionDeletedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(ProcessIntent.DELETED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (Process) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.PROCESS_DEFINITION_DELETED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Process.DEFINITION_KEY))
+                  .isEqualTo(value.getProcessDefinitionKey());
+            });
+  }
+
+  @Test
+  void shouldEmitDecisionDefinitionCreatedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.DECISION,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(DecisionIntent.CREATED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (DecisionRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.DECISION_DEFINITION_CREATED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Decision.KEY))
+                  .isEqualTo(value.getDecisionKey());
+            });
+  }
+
+  @Test
+  void shouldEmitDecisionDefinitionDeletedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.DECISION,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(DecisionIntent.DELETED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (DecisionRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.DECISION_DEFINITION_DELETED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Decision.KEY))
+                  .isEqualTo(value.getDecisionKey());
+            });
+  }
+
+  @Test
+  void shouldEmitFormDefinitionCreatedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.FORM, r -> r.withRecordType(RecordType.EVENT).withIntent(FormIntent.CREATED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (Form) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.FORM_DEFINITION_CREATED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Form.KEY))
+                  .isEqualTo(value.getFormKey());
+            });
+  }
+
+  @Test
+  void shouldEmitFormDefinitionDeletedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.FORM, r -> r.withRecordType(RecordType.EVENT).withIntent(FormIntent.DELETED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (Form) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.FORM_DEFINITION_DELETED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Form.KEY))
+                  .isEqualTo(value.getFormKey());
+            });
+  }
+
+  @Test
+  void shouldEmitAgentInstanceCreatedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(AgentInstanceIntent.CREATED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (AgentInstanceRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.AGENT_INSTANCE_CREATED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Agent.INSTANCE_KEY))
+                  .isEqualTo(value.getAgentInstanceKey());
+            });
+  }
+
+  @Test
+  void shouldEmitAgentInstanceCompletedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(AgentInstanceIntent.COMPLETED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (AgentInstanceRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.AGENT_INSTANCE_COMPLETED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Agent.INSTANCE_KEY))
+                  .isEqualTo(value.getAgentInstanceKey());
+            });
+  }
+
+  @Test
+  void shouldEmitUserTaskAssignedEvent() {
+    // given
+    final var value =
+        ImmutableUserTaskRecordValue.builder()
+            .from(FACTORY.generateObject(UserTaskRecordValue.class))
+            .withAssignee("john.doe@example.com")
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(UserTaskIntent.ASSIGNED)
+                    .withValue(value));
+
+    // when
+    exporter.export(record);
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.USER_TASK_ASSIGNED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.UserTask.KEY))
+                  .isEqualTo(value.getUserTaskKey());
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.UserTask.ASSIGNEE_HASH))
+                  .isNotEqualTo("john.doe@example.com")
+                  .hasSize(64);
+            });
+  }
+
+  @Test
+  void shouldIncrementDecisionInstanceEvaluatedCounter() {
+    // given
+    final var metricReader = InMemoryMetricReader.create();
+    final var metricExporter =
+        newExporter(
+            TestOtelSdkManager.inMemoryWithMetrics(
+                InMemoryLogRecordExporter.create(), metricReader),
+            new ExporterTestController());
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(DecisionEvaluationIntent.EVALUATED));
+
+    // when
+    metricExporter.export(record);
+
+    // then
+    assertThat(metricReader.collectAllMetrics())
+        .filteredOn(
+            metric ->
+                metric.getName().equals(AnalyticsAttributes.Metric.DECISION_INSTANCE_EVALUATED))
+        .singleElement()
+        .satisfies(
+            metric ->
+                assertThat(metric.getLongSumData().getPoints())
+                    .singleElement()
+                    .satisfies(point -> assertThat(point.getValue()).isEqualTo(1)));
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -708,6 +708,71 @@ class AnalyticsExporterTest {
     assertThatCode(unopenedExporter::close).doesNotThrowAnyException();
   }
 
+  @Test
+  void shouldOnlyExportContractualSignalsWhenConfiguredWithContractualOnly() {
+    // given — exporter configured with only CONTRACTUAL category
+    final var contractualOnlyConfig =
+        new AnalyticsExporterConfig().setCategories(java.util.List.of("contractual"));
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var metricReader = InMemoryMetricReader.create();
+    final var otel =
+        TestOtelSdkManager.inMemoryWithMetrics(logExporter, metricReader, contractualOnlyConfig);
+    final var ctrl = new ExporterTestController();
+    final var contractualExporter = newExporter(otel, ctrl, contractualOnlyConfig);
+
+    // when — export a CONTRACTUAL event (tenant.created) and an OPTIONAL event (incident.created)
+    contractualExporter.export(
+        FACTORY.generateRecord(
+            ValueType.TENANT,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(TenantIntent.CREATED)));
+    contractualExporter.export(
+        FACTORY.generateRecord(
+            ValueType.INCIDENT,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(IncidentIntent.CREATED)));
+
+    // then — only the contractual event is emitted
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(
+                        AnalyticsAttributes.Event.NAME, AnalyticsAttributes.Event.TENANT_CREATED));
+  }
+
+  @Test
+  void shouldOnlyExportOptionalSignalsWhenConfiguredWithOptionalOnly() {
+    // given — exporter configured with only OPTIONAL category
+    final var optionalOnlyConfig =
+        new AnalyticsExporterConfig().setCategories(java.util.List.of("optional"));
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var metricReader = InMemoryMetricReader.create();
+    final var otel =
+        TestOtelSdkManager.inMemoryWithMetrics(logExporter, metricReader, optionalOnlyConfig);
+    final var ctrl = new ExporterTestController();
+    final var optionalExporter = newExporter(otel, ctrl, optionalOnlyConfig);
+
+    // when — export a CONTRACTUAL event (tenant.created) and an OPTIONAL event (incident.created)
+    optionalExporter.export(
+        FACTORY.generateRecord(
+            ValueType.TENANT,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(TenantIntent.CREATED)));
+    optionalExporter.export(
+        FACTORY.generateRecord(
+            ValueType.INCIDENT,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(IncidentIntent.CREATED)));
+
+    // then — only the optional event is emitted
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(
+                        AnalyticsAttributes.Event.NAME,
+                        AnalyticsAttributes.Event.PROCESS_INCIDENT_CREATED));
+  }
+
   // -- helpers --
 
   private static io.camunda.zeebe.protocol.record.Record<?> piCreatedEvent() {
@@ -779,10 +844,16 @@ class AnalyticsExporterTest {
 
   private static AnalyticsExporter newExporter(
       final OtelSdkManager otelSdkManager, final ExporterTestController controller) {
+    return newExporter(otelSdkManager, controller, new AnalyticsExporterConfig());
+  }
+
+  private static AnalyticsExporter newExporter(
+      final OtelSdkManager otelSdkManager,
+      final ExporterTestController controller,
+      final AnalyticsExporterConfig config) {
     final var context =
         new ExporterTestContext()
-            .setConfiguration(
-                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
+            .setConfiguration(new ExporterTestConfiguration<>("analytics", config))
             .setClusterId("test-cluster")
             .setPartitionId(1)
             .setLicenseKey("test-license-key");

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalogTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalogTest.java
@@ -10,8 +10,15 @@ package io.camunda.exporter.analytics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
@@ -36,7 +43,21 @@ class AnalyticsHandlerCatalogTest {
             Map.entry(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATED),
             Map.entry(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             Map.entry(ValueType.USAGE_METRIC, UsageMetricIntent.EXPORTED),
-            Map.entry(ValueType.USER_TASK, UserTaskIntent.CREATED));
+            Map.entry(ValueType.USER_TASK, UserTaskIntent.CREATED),
+            Map.entry(ValueType.USER_TASK, UserTaskIntent.ASSIGNED),
+            Map.entry(ValueType.TENANT, TenantIntent.CREATED),
+            Map.entry(ValueType.TENANT, TenantIntent.DELETED),
+            Map.entry(ValueType.INCIDENT, IncidentIntent.CREATED),
+            Map.entry(ValueType.INCIDENT, IncidentIntent.RESOLVED),
+            Map.entry(ValueType.PROCESS, ProcessIntent.CREATED),
+            Map.entry(ValueType.PROCESS, ProcessIntent.DELETED),
+            Map.entry(ValueType.DECISION, DecisionIntent.CREATED),
+            Map.entry(ValueType.DECISION, DecisionIntent.DELETED),
+            Map.entry(ValueType.DECISION_EVALUATION, DecisionEvaluationIntent.EVALUATED),
+            Map.entry(ValueType.FORM, FormIntent.CREATED),
+            Map.entry(ValueType.FORM, FormIntent.DELETED),
+            Map.entry(ValueType.AGENT_INSTANCE, AgentInstanceIntent.CREATED),
+            Map.entry(ValueType.AGENT_INSTANCE, AgentInstanceIntent.COMPLETED));
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AgentInstanceCompletedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AgentInstanceCompletedHandlerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class AgentInstanceCompletedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitAgentInstanceCompletedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new AgentInstanceCompletedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableAgentInstanceRecordValue.builder()
+            .withAgentInstanceKey(101L)
+            .withAgentDefinitionKey(202L)
+            .withStatus(AgentInstanceStatus.COMPLETED)
+            .withBpmnProcessId("support-agent-process")
+            .withProcessDefinitionKey(11L)
+            .withProcessInstanceKey(22L)
+            .withTenantId("acme")
+            .withMetrics(b -> b.withInputTokens(5000L).withOutputTokens(900L).withToolCalls(7))
+            .withLimits(b -> b.withMaxTokens(100000L).withMaxModelCalls(20).withMaxToolCalls(50))
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(AgentInstanceIntent.COMPLETED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.AGENT_INSTANCE_COMPLETED)
+                  .containsEntry(AnalyticsAttributes.Agent.INSTANCE_KEY, 101L)
+                  .containsEntry(AnalyticsAttributes.Agent.DEFINITION_KEY, 202L)
+                  .containsEntry(AnalyticsAttributes.Agent.STATUS, "COMPLETED")
+                  .containsEntry(
+                      AnalyticsAttributes.Process.BPMN_PROCESS_ID, "support-agent-process")
+                  .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 22L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              // Token counts, tool calls and configured limits are not part of the event
+              assertThat(attrs.keySet())
+                  .containsExactlyInAnyOrder(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Log.POSITION,
+                      AnalyticsAttributes.Event.SEQUENCE_NUMBER,
+                      AnalyticsAttributes.Agent.INSTANCE_KEY,
+                      AnalyticsAttributes.Agent.DEFINITION_KEY,
+                      AnalyticsAttributes.Agent.STATUS,
+                      AnalyticsAttributes.Process.BPMN_PROCESS_ID,
+                      AnalyticsAttributes.Process.DEFINITION_KEY,
+                      AnalyticsAttributes.Process.INSTANCE_KEY,
+                      AnalyticsAttributes.Tenant.ID);
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandlerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceToolValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class AgentInstanceCreatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitAgentInstanceCreatedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new AgentInstanceCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableAgentInstanceRecordValue.builder()
+            .withAgentInstanceKey(101L)
+            .withAgentDefinitionKey(202L)
+            .withStatus(AgentInstanceStatus.INITIALIZING)
+            .withBpmnProcessId("support-agent-process")
+            .withProcessDefinitionKey(11L)
+            .withProcessInstanceKey(22L)
+            .withTenantId("acme")
+            .withVersionTag("release-2026-q1")
+            .withDefinition(
+                b ->
+                    b.withModel("claude-sonnet-4-5")
+                        .withProvider("anthropic")
+                        .withSystemPrompt("You are helping Jane Doe with her order."))
+            .withTools(
+                java.util.List.of(
+                    ImmutableAgentInstanceToolValue.builder()
+                        .withName("lookup_customer")
+                        .withDescription("Looks up a customer by email address")
+                        .withElementId("tool-lookup")
+                        .build()))
+            .withChangedAttributes(java.util.List.of("status"))
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(AgentInstanceIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.AGENT_INSTANCE_CREATED)
+                  .containsEntry(AnalyticsAttributes.Agent.INSTANCE_KEY, 101L)
+                  .containsEntry(AnalyticsAttributes.Agent.DEFINITION_KEY, 202L)
+                  .containsEntry(AnalyticsAttributes.Agent.STATUS, "INITIALIZING")
+                  .containsEntry(
+                      AnalyticsAttributes.Process.BPMN_PROCESS_ID, "support-agent-process")
+                  .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 22L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              // Prompts, tool payloads and version tags must not appear in any attribute value
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("You are helping Jane Doe with her order.")
+                  .doesNotContain("claude-sonnet-4-5")
+                  .doesNotContain("anthropic")
+                  .doesNotContain("lookup_customer")
+                  .doesNotContain("Looks up a customer by email address")
+                  .doesNotContain("release-2026-q1");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/DecisionDefinitionCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/DecisionDefinitionCreatedHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class DecisionDefinitionCreatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitDecisionDefinitionCreatedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler =
+        new DecisionDefinitionCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableDecisionRecordValue.builder()
+            .withDecisionId("credit-scoring")
+            .withDecisionKey(11L)
+            .withVersion(3)
+            .withDecisionName("Credit scoring for Jane Doe's portfolio")
+            .withVersionTag("release-2026-q1")
+            .withTenantId("acme")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.DECISION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(DecisionIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.DECISION_DEFINITION_CREATED)
+                  .containsEntry(AnalyticsAttributes.Decision.ID, "credit-scoring")
+                  .containsEntry(AnalyticsAttributes.Decision.KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Decision.VERSION, 3L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("Credit scoring for Jane Doe's portfolio")
+                  .doesNotContain("release-2026-q1");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/DecisionDefinitionDeletedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/DecisionDefinitionDeletedHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class DecisionDefinitionDeletedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitDecisionDefinitionDeletedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler =
+        new DecisionDefinitionDeletedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableDecisionRecordValue.builder()
+            .withDecisionId("credit-scoring")
+            .withDecisionKey(11L)
+            .withVersion(3)
+            .withDecisionName("Credit scoring for Jane Doe's portfolio")
+            .withVersionTag("release-2026-q1")
+            .withTenantId("acme")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.DECISION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(DecisionIntent.DELETED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.DECISION_DEFINITION_DELETED)
+                  .containsEntry(AnalyticsAttributes.Decision.ID, "credit-scoring")
+                  .containsEntry(AnalyticsAttributes.Decision.KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Decision.VERSION, 3L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("Credit scoring for Jane Doe's portfolio")
+                  .doesNotContain("release-2026-q1");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandlerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Tenant.ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDecisionEvaluationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DecisionInstanceEvaluatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private InMemoryLogRecordExporter logExporter;
+  private InMemoryMetricReader metricReader;
+  private DecisionInstanceEvaluatedHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    logExporter = InMemoryLogRecordExporter.create();
+    metricReader = InMemoryMetricReader.create();
+    handler =
+        new DecisionInstanceEvaluatedHandler(
+            TestOtelSdkManager.inMemoryWithMetrics(logExporter, metricReader));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  private static Record<?> evaluatedRecord(final String tenantId) {
+    final var value =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(FACTORY.generateObject(DecisionEvaluationRecordValue.class))
+            .withTenantId(tenantId)
+            .build();
+    return FACTORY.generateRecord(
+        ValueType.DECISION_EVALUATION,
+        r ->
+            r.withRecordType(RecordType.EVENT)
+                .withIntent(DecisionEvaluationIntent.EVALUATED)
+                .withValue(value));
+  }
+
+  private Optional<MetricData> counter() {
+    final Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    return metrics.stream()
+        .filter(m -> m.getName().equals(AnalyticsAttributes.Metric.DECISION_INSTANCE_EVALUATED))
+        .findFirst();
+  }
+
+  @Test
+  void shouldAccumulateOneIncrementPerRecord() {
+    // when
+    handler.handle(typed(evaluatedRecord("tenant-a")));
+    handler.handle(typed(evaluatedRecord("tenant-a")));
+
+    // then
+    assertThat(counter())
+        .isPresent()
+        .hasValueSatisfying(
+            metric -> {
+              final long total =
+                  metric.getLongSumData().getPoints().stream()
+                      .mapToLong(LongPointData::getValue)
+                      .sum();
+              assertThat(total).isEqualTo(2);
+            });
+  }
+
+  @Test
+  void shouldCarryTenantIdAsDimension() {
+    // when
+    handler.handle(typed(evaluatedRecord("tenant-a")));
+    handler.handle(typed(evaluatedRecord("tenant-b")));
+
+    // then
+    assertThat(counter())
+        .isPresent()
+        .hasValueSatisfying(
+            metric ->
+                assertThat(metric.getLongSumData().getPoints())
+                    .hasSize(2)
+                    .allSatisfy(point -> assertThat(point.getValue()).isEqualTo(1))
+                    .extracting(point -> point.getAttributes().get(ID))
+                    .containsExactlyInAnyOrder("tenant-a", "tenant-b"));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/FormDefinitionCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/FormDefinitionCreatedHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableForm;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class FormDefinitionCreatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitFormDefinitionCreatedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new FormDefinitionCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableForm.builder()
+            .withFormId("customer-onboarding")
+            .withFormKey(11L)
+            .withVersion(3)
+            .withVersionTag("release-2026-q1")
+            .withResourceName("Jane Doe's onboarding form.form")
+            .withResource("{\"components\":[]}".getBytes(StandardCharsets.UTF_8))
+            .withTenantId("acme")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.FORM,
+            r ->
+                r.withRecordType(RecordType.EVENT).withIntent(FormIntent.CREATED).withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.FORM_DEFINITION_CREATED)
+                  .containsEntry(AnalyticsAttributes.Form.ID, "customer-onboarding")
+                  .containsEntry(AnalyticsAttributes.Form.KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Form.VERSION, 3L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("release-2026-q1")
+                  .doesNotContain("Jane Doe's onboarding form.form")
+                  .doesNotContain("{\"components\":[]}");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/FormDefinitionDeletedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/FormDefinitionDeletedHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableForm;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class FormDefinitionDeletedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitFormDefinitionDeletedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new FormDefinitionDeletedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableForm.builder()
+            .withFormId("customer-onboarding")
+            .withFormKey(11L)
+            .withVersion(3)
+            .withVersionTag("release-2026-q1")
+            .withResourceName("Jane Doe's onboarding form.form")
+            .withResource("{\"components\":[]}".getBytes(StandardCharsets.UTF_8))
+            .withTenantId("acme")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.FORM,
+            r ->
+                r.withRecordType(RecordType.EVENT).withIntent(FormIntent.DELETED).withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.FORM_DEFINITION_DELETED)
+                  .containsEntry(AnalyticsAttributes.Form.ID, "customer-onboarding")
+                  .containsEntry(AnalyticsAttributes.Form.KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Form.VERSION, 3L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("release-2026-q1")
+                  .doesNotContain("Jane Doe's onboarding form.form")
+                  .doesNotContain("{\"components\":[]}");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/IncidentCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/IncidentCreatedHandlerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class IncidentCreatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitIncidentCreatedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new IncidentCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableIncidentRecordValue.builder()
+            .withBpmnProcessId("order-process")
+            .withProcessDefinitionKey(11L)
+            .withProcessInstanceKey(22L)
+            .withElementId("call-payment-service")
+            .withTenantId("acme")
+            .withErrorType(ErrorType.IO_MAPPING_ERROR)
+            .withErrorMessage("failed to evaluate expression '=customerEmail': jane@example.com")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.INCIDENT,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(IncidentIntent.CREATED)
+                    .withKey(4242L)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.PROCESS_INCIDENT_CREATED)
+                  .containsEntry(AnalyticsAttributes.Incident.KEY, 4242L)
+                  .containsEntry(AnalyticsAttributes.Process.BPMN_PROCESS_ID, "order-process")
+                  .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 22L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              // The error message can carry variable values and must never be exported
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain(
+                      "failed to evaluate expression '=customerEmail': jane@example.com");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/IncidentResolvedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/IncidentResolvedHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class IncidentResolvedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitIncidentResolvedEventWithTheSameKeyAsCreation() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new IncidentResolvedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableIncidentRecordValue.builder()
+            .withBpmnProcessId("order-process")
+            .withProcessDefinitionKey(11L)
+            .withProcessInstanceKey(22L)
+            .withElementId("call-payment-service")
+            .withTenantId("acme")
+            .withErrorType(ErrorType.IO_MAPPING_ERROR)
+            .withErrorMessage("failed to evaluate expression '=customerEmail': jane@example.com")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.INCIDENT,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(IncidentIntent.RESOLVED)
+                    .withKey(4242L)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.PROCESS_INCIDENT_RESOLVED)
+                  .containsEntry(AnalyticsAttributes.Incident.KEY, 4242L)
+                  .containsEntry(AnalyticsAttributes.Process.BPMN_PROCESS_ID, "order-process")
+                  .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 22L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain(
+                      "failed to evaluate expression '=customerEmail': jane@example.com");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/ProcessDefinitionCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/ProcessDefinitionCreatedHandlerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcess;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class ProcessDefinitionCreatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitProcessDefinitionCreatedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler =
+        new ProcessDefinitionCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableProcess.builder()
+            .withBpmnProcessId("order-process")
+            .withProcessDefinitionKey(11L)
+            .withVersion(3)
+            .withVersionTag("release-2026-q1")
+            .withResourceName("Jane Doe's order process.bpmn")
+            .withResource("<definitions/>".getBytes(StandardCharsets.UTF_8))
+            .withTenantId("acme")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.PROCESS_DEFINITION_CREATED)
+                  .containsEntry(AnalyticsAttributes.Process.BPMN_PROCESS_ID, "order-process")
+                  .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Process.VERSION, 3L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              // Author-supplied free text must not appear in any attribute value
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("release-2026-q1")
+                  .doesNotContain("Jane Doe's order process.bpmn")
+                  .doesNotContain("<definitions/>");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/ProcessDefinitionDeletedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/ProcessDefinitionDeletedHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcess;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class ProcessDefinitionDeletedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitProcessDefinitionDeletedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler =
+        new ProcessDefinitionDeletedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableProcess.builder()
+            .withBpmnProcessId("order-process")
+            .withProcessDefinitionKey(11L)
+            .withVersion(3)
+            .withVersionTag("release-2026-q1")
+            .withResourceName("Jane Doe's order process.bpmn")
+            .withResource("<definitions/>".getBytes(StandardCharsets.UTF_8))
+            .withTenantId("acme")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessIntent.DELETED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.PROCESS_DEFINITION_DELETED)
+                  .containsEntry(AnalyticsAttributes.Process.BPMN_PROCESS_ID, "order-process")
+                  .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 11L)
+                  .containsEntry(AnalyticsAttributes.Process.VERSION, 3L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme");
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("release-2026-q1")
+                  .doesNotContain("Jane Doe's order process.bpmn")
+                  .doesNotContain("<definitions/>");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/TenantCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/TenantCreatedHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class TenantCreatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitTenantCreatedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new TenantCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableTenantRecordValue.builder()
+            .withTenantId("acme")
+            .withTenantKey(77L)
+            .withName("ACME Corporation")
+            .withDescription("Tenant for the ACME account")
+            .withEntityId("john.doe@example.com")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.TENANT,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TenantIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME, AnalyticsAttributes.Event.TENANT_CREATED)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme")
+                  .containsKey(AnalyticsAttributes.Log.POSITION)
+                  .containsKey(AnalyticsAttributes.Event.SEQUENCE_NUMBER);
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              // Free-text and entity fields must not appear in any attribute value
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("ACME Corporation")
+                  .doesNotContain("Tenant for the ACME account")
+                  .doesNotContain("john.doe@example.com");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/TenantDeletedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/TenantDeletedHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class TenantDeletedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitTenantDeletedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new TenantDeletedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableTenantRecordValue.builder()
+            .withTenantId("acme")
+            .withTenantKey(77L)
+            .withName("ACME Corporation")
+            .withDescription("Tenant for the ACME account")
+            .withEntityId("john.doe@example.com")
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.TENANT,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TenantIntent.DELETED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME, AnalyticsAttributes.Event.TENANT_DELETED)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "acme")
+                  .containsKey(AnalyticsAttributes.Log.POSITION)
+                  .containsKey(AnalyticsAttributes.Event.SEQUENCE_NUMBER);
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              // Free-text and entity fields must not appear in any attribute value
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("ACME Corporation")
+                  .doesNotContain("Tenant for the ACME account")
+                  .doesNotContain("john.doe@example.com");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandlerTest.java
@@ -19,6 +19,9 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,5 +113,31 @@ class UserTaskAssignedHandlerTest {
 
     // then
     assertThat(logExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+
+  @Test
+  void shouldProduceIndependentHashesAcrossReusedHandlerInstance() throws Exception {
+    // given — the handler caches a single MessageDigest field and reuses it on every handle()
+    // call (see AGENTS.md: handlers run on the single exporter/partition actor thread, so the
+    // non-thread-safe MessageDigest can be shared). This verifies reuse never leaks state
+    // between records: each hash is computed independently of the implementation's cached
+    // digest, using a fresh MessageDigest per expectation.
+    final var secondAssignee = "jane.roe@example.com";
+    final var expectedSecondHash =
+        HexFormat.of()
+            .formatHex(
+                MessageDigest.getInstance("SHA-256")
+                    .digest(secondAssignee.getBytes(StandardCharsets.UTF_8)));
+
+    // when
+    handler.handle(typed(assignedRecord(ASSIGNEE)));
+    handler.handle(typed(assignedRecord(secondAssignee)));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .extracting(
+            logRecord ->
+                logRecord.getAttributes().asMap().get(AnalyticsAttributes.UserTask.ASSIGNEE_HASH))
+        .containsExactly(ASSIGNEE_SHA_256, expectedSecondHash);
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandlerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UserTaskAssignedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private static final String ASSIGNEE = "john.doe@example.com";
+
+  /** Independently computed: {@code printf 'john.doe@example.com' | shasum -a 256}. */
+  private static final String ASSIGNEE_SHA_256 =
+      "836f82db99121b3481011f16b49dfa5fbc714a0d1b1b9f784a1ebbbf5b39577f";
+
+  private InMemoryLogRecordExporter logExporter;
+  private UserTaskAssignedHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    logExporter = InMemoryLogRecordExporter.create();
+    handler = new UserTaskAssignedHandler(TestOtelSdkManager.inMemory(logExporter));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  private static Record<?> assignedRecord(final String assignee) {
+    final var value =
+        ImmutableUserTaskRecordValue.builder()
+            .withUserTaskKey(77L)
+            .withProcessInstanceKey(100L)
+            .withTenantId("tenant-a")
+            .withAssignee(assignee)
+            .withCandidateUsersList(List.of("alice@example.com"))
+            .withCandidateGroupsList(List.of("finance-team"))
+            .build();
+    return FACTORY.generateRecord(
+        ValueType.USER_TASK,
+        r ->
+            r.withRecordType(RecordType.EVENT)
+                .withIntent(UserTaskIntent.ASSIGNED)
+                .withValue(value));
+  }
+
+  @Test
+  void shouldEmitHashedAssigneeAndNeverTheRawValue() {
+    // given
+    final var record = assignedRecord(ASSIGNEE);
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME, AnalyticsAttributes.Event.USER_TASK_ASSIGNED)
+                  .containsEntry(AnalyticsAttributes.UserTask.ASSIGNEE_HASH, ASSIGNEE_SHA_256)
+                  .containsEntry(AnalyticsAttributes.UserTask.KEY, 77L)
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 100L)
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "tenant-a")
+                  .containsKey(AnalyticsAttributes.Log.POSITION)
+                  .containsKey(AnalyticsAttributes.Event.SEQUENCE_NUMBER);
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              // PII must not appear anywhere in any attribute value
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .noneMatch(v -> v.contains(ASSIGNEE))
+                  .noneMatch(v -> v.contains("alice@example.com"))
+                  .noneMatch(v -> v.contains("finance-team"));
+            });
+  }
+
+  @Test
+  void shouldSkipWhenAssigneeIsEmpty() {
+    // when
+    handler.handle(typed(assignedRecord("")));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+}


### PR DESCRIPTION
## What this adds

The analytics exporter emits the fourteen product-telemetry signals scoped for 8.10 that were agreed but not yet instrumented. Each is a new `AnalyticsHandler` registered in `AnalyticsHandlerCatalog.build(...)`, emitting only process metadata (keys, ids, tenant, timestamps, status enums), never PII.

Twelve lifecycle events:
- `camunda.tenant.created` / `camunda.tenant.deleted`
- `camunda.process.incident.created` / `camunda.process.incident.resolved`
- `camunda.process.definition.created` / `camunda.process.definition.deleted`
- `camunda.decision.definition.created` / `camunda.decision.definition.deleted`
- `camunda.form.definition.created` / `camunda.form.definition.deleted`
- `camunda.agent.instance.created` / `camunda.agent.instance.completed`

One counter and one event carry billing-relevant semantics:
- `camunda.decision.instance.evaluated` is a counter incremented once per `DecisionEvaluation/EVALUATED` record, carrying the tenant as a dimension (failed evaluations are a no-op applier and never reach the handler; a DRG's sub-decisions are not counted individually). It is a real-time, per-tenant view; the engine's `EDI` usage metric remains the authoritative figure.
- `camunda.user_task.assigned` is emitted only when the task has a non-empty assignee. It carries a SHA-256 hash of the assignee, never the raw value, so a distinct task-users count can be rebuilt per tenant downstream.

## Conventions

- Event and metric names are the canonical dotted names (for example `camunda.tenant.created`), not the flat snake_case of the pre-contract signals.
- The assignee hash uses the same SHA-256 primitive as the licence fingerprint in `AnalyticsExporterContext`.
- The definitions are emitted from per-definition records, so there is no deployment fan-out.

## Known behaviour

The three `*.definition.deleted` events are emitted once per partition (resource deletion runs on every partition), so a downstream consumer deduplicates on the definition key. The `*.created` counterparts are emitted once, on the originating partition.

## What this does not change

- Nothing is added to any cluster's exporter list. The analytics exporter stays opt-in, so no existing deployment starts sending these on upgrade.
- No existing signal is renamed or removed, and no configuration is changed.

## Verification

- `./mvnw verify -pl zeebe/exporters/analytics-exporter`: 248 tests pass.
- Every signal has a handler unit test and a full-exporter wiring test; the catalog's exact-set registration assertion is extended for all fourteen, so a handler that is added without being registered (or the reverse) fails the build.
- The user-task test computes the expected assignee hash independently of the implementation and asserts the raw assignee, a candidate user, and a candidate group never appear in any emitted attribute value, plus a skip test for the empty-assignee case.
- Both behavioural signals are mutation-checked: emitting the raw assignee instead of the hash, and collapsing the tenant dimension on the decision counter, each fail their test.
