### PR TITLE
fix: deduplicate definition-deletion events and related improvements

### DIFF
--- a/zeebe/exporters/analytics-exporter/AGENTS.md
+++ b/zeebe/exporters/analytics-exporter/AGENTS.md
@@ -90,10 +90,13 @@ Replicated log
 ### Adding a New Event Handler
 
 1. Create handler class implementing `AnalyticsHandler`
-2. Register in `AnalyticsExporter.configure()` with `handlerRegistry.register(valueType, intent, handler)`
-3. Filter is auto-updated — HandlerRegistry builds the RecordFilter from registered handlers
-4. If pre-aggregated metric needed: call `otelSdkManager.incrementMetric()` from handler
-5. Run existing tests + add handler-specific test cases
+2. Add the event name to `AnalyticsAttributes.Event` (or the metric name to `AnalyticsAttributes.Metric`)
+3. Register in `AnalyticsHandlerCatalog.build()` with `.register(valueType, intent, handler)` —
+   `AnalyticsExporter` does not change
+4. Add the `(ValueType, Intent)` pair to the exact-set assertion in `AnalyticsHandlerCatalogTest`
+5. Filter is auto-updated — HandlerRegistry builds the RecordFilter from registered handlers
+6. If pre-aggregated metric needed: call `otelSdkManager.incrementMetric()` from handler
+7. Run existing tests + add handler-specific test cases
 
 ### Attribute Naming
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -165,11 +165,11 @@ variables, or any other end-user data.
 | `INCIDENT`                  | `CREATED`           | `camunda.process.incident.created`    | Emitted for every raised incident.                                                                             |
 | `INCIDENT`                  | `RESOLVED`          | `camunda.process.incident.resolved`   | Emitted for every resolved incident.                                                                           |
 | `PROCESS`                   | `CREATED`           | `camunda.process.definition.created`  | Emitted once per process definition, so a deployment of several processes produces one event each.             |
-| `PROCESS`                   | `DELETED`           | `camunda.process.definition.deleted`  | Emitted once per partition when a process definition is deleted; deduplicate downstream on the definition key. |
+| `PROCESS`                   | `DELETED`           | `camunda.process.definition.deleted`  | Emitted once per deleted process definition.                                                                   |
 | `DECISION`                  | `CREATED`           | `camunda.decision.definition.created` | Emitted once per decision in a deployed decision requirements graph.                                           |
-| `DECISION`                  | `DELETED`           | `camunda.decision.definition.deleted` | Emitted once per partition when a decision is deleted; deduplicate downstream on the decision key.             |
+| `DECISION`                  | `DELETED`           | `camunda.decision.definition.deleted` | Emitted once per deleted decision definition.                                                                  |
 | `FORM`                      | `CREATED`           | `camunda.form.definition.created`     | Emitted once per deployed form.                                                                                |
-| `FORM`                      | `DELETED`           | `camunda.form.definition.deleted`     | Emitted once per partition when a form is deleted; deduplicate downstream on the form key.                     |
+| `FORM`                      | `DELETED`           | `camunda.form.definition.deleted`     | Emitted once per deleted form definition.                                                                      |
 | `AGENT_INSTANCE`            | `CREATED`           | `camunda.agent.instance.created`      | Emitted for every created agent instance.                                                                      |
 | `AGENT_INSTANCE`            | `COMPLETED`         | `camunda.agent.instance.completed`    | Emitted for every completed agent instance.                                                                    |
 | —                           | —                   | `heartbeat`                           | Emitted periodically by the partition leader (see `heartbeat-interval`).                                       |

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -153,26 +153,31 @@ variables, or any other end-user data.
 
 ### Event types
 
-|        Source record        |       Intent        |              Event name               |                                                     Notes                                                      |
-|-----------------------------|---------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| `PROCESS_INSTANCE_CREATION` | `CREATED`           | `process_instance_created`            | Emitted for every new process instance.                                                                        |
-| `PROCESS_INSTANCE`          | `ELEMENT_ACTIVATED` | `adhoc_subprocess_activated`          | Emitted only when the activated element is an ad-hoc sub-process.                                              |
-| `USAGE_METRIC`              | `EXPORTED`          | `usage_metric_exported`               | Emitted once per usage metric export interval. Internal reset events are skipped.                              |
-| `USER_TASK`                 | `CREATED`           | `user_task_created`                   | Emitted for every new user task.                                                                               |
-| `USER_TASK`                 | `ASSIGNED`          | `camunda.user_task.assigned`          | Emitted for every user task assignment with a non-empty assignee.                                              |
-| `TENANT`                    | `CREATED`           | `camunda.tenant.created`              | Emitted for every new tenant.                                                                                  |
-| `TENANT`                    | `DELETED`           | `camunda.tenant.deleted`              | Emitted for every deleted tenant.                                                                              |
-| `INCIDENT`                  | `CREATED`           | `camunda.process.incident.created`    | Emitted for every raised incident.                                                                             |
-| `INCIDENT`                  | `RESOLVED`          | `camunda.process.incident.resolved`   | Emitted for every resolved incident.                                                                           |
-| `PROCESS`                   | `CREATED`           | `camunda.process.definition.created`  | Emitted once per process definition, so a deployment of several processes produces one event each.             |
-| `PROCESS`                   | `DELETED`           | `camunda.process.definition.deleted`  | Emitted once per deleted process definition.                                                                   |
-| `DECISION`                  | `CREATED`           | `camunda.decision.definition.created` | Emitted once per decision in a deployed decision requirements graph.                                           |
-| `DECISION`                  | `DELETED`           | `camunda.decision.definition.deleted` | Emitted once per deleted decision definition.                                                                  |
-| `FORM`                      | `CREATED`           | `camunda.form.definition.created`     | Emitted once per deployed form.                                                                                |
-| `FORM`                      | `DELETED`           | `camunda.form.definition.deleted`     | Emitted once per deleted form definition.                                                                      |
-| `AGENT_INSTANCE`            | `CREATED`           | `camunda.agent.instance.created`      | Emitted for every created agent instance.                                                                      |
-| `AGENT_INSTANCE`            | `COMPLETED`         | `camunda.agent.instance.completed`    | Emitted for every completed agent instance.                                                                    |
-| —                           | —                   | `heartbeat`                           | Emitted periodically by the partition leader (see `heartbeat-interval`).                                       |
+|        Source record        |       Intent        |              Event name               |                                               Notes                                                |
+|-----------------------------|---------------------|---------------------------------------|----------------------------------------------------------------------------------------------------|
+| `PROCESS_INSTANCE_CREATION` | `CREATED`           | `process_instance_created`            | Emitted for every new process instance.                                                            |
+| `PROCESS_INSTANCE`          | `ELEMENT_ACTIVATED` | `adhoc_subprocess_activated`          | Emitted only when the activated element is an ad-hoc sub-process.                                  |
+| `USAGE_METRIC`              | `EXPORTED`          | `usage_metric_exported`               | Emitted once per usage metric export interval. Internal reset events are skipped.                  |
+| `USER_TASK`                 | `CREATED`           | `user_task_created`                   | Emitted for every new user task.                                                                   |
+| `USER_TASK`                 | `ASSIGNED`          | `camunda.user_task.assigned`          | Emitted for every user task assignment with a non-empty assignee.                                  |
+| `TENANT`                    | `CREATED`           | `camunda.tenant.created`              | Emitted for every new tenant.                                                                      |
+| `TENANT`                    | `DELETED`           | `camunda.tenant.deleted`              | Emitted for every deleted tenant.                                                                  |
+| `INCIDENT`                  | `CREATED`           | `camunda.process.incident.created`    | Emitted for every raised incident.                                                                 |
+| `INCIDENT`                  | `RESOLVED`          | `camunda.process.incident.resolved`   | Emitted for every resolved incident.                                                               |
+| `PROCESS`                   | `CREATED`           | `camunda.process.definition.created`  | Emitted once per process definition, so a deployment of several processes produces one event each. |
+| `PROCESS`                   | `DELETED`           | `camunda.process.definition.deleted`  | Emitted once per deleted process definition.                                                       |
+| `DECISION`                  | `CREATED`           | `camunda.decision.definition.created` | Emitted once per decision in a deployed decision requirements graph.                               |
+| `DECISION`                  | `DELETED`           | `camunda.decision.definition.deleted` | Emitted once per deleted decision definition.                                                      |
+| `FORM`                      | `CREATED`           | `camunda.form.definition.created`     | Emitted once per deployed form.                                                                    |
+| `FORM`                      | `DELETED`           | `camunda.form.definition.deleted`     | Emitted once per deleted form definition.                                                          |
+| `AGENT_INSTANCE`            | `CREATED`           | `camunda.agent.instance.created`      | Emitted for every created agent instance.                                                          |
+| `AGENT_INSTANCE`            | `COMPLETED`         | `camunda.agent.instance.completed`    | Emitted for every completed agent instance.                                                        |
+| —                           | —                   | `heartbeat`                           | Emitted periodically by the partition leader (see `heartbeat-interval`).                           |
+
+The five signals that predate the analytics data contract — `process_instance_created`,
+`adhoc_subprocess_activated`, `usage_metric_exported`, `user_task_created`, and `heartbeat` — keep
+their flat snake_case names, which are frozen for compatibility with already-ingested data; every
+signal added since uses the canonical dotted contract name.
 
 ### Common log record attributes
 
@@ -337,7 +342,10 @@ is incremented once per source record and carries the dimensions listed below.
 a decision that requires sub-decisions still counts once, and failed evaluations are not counted,
 which is the same counting rule as the `EDI` usage metric. It is a real-time, per-tenant view; the
 `EDI` usage metric remains the authoritative figure, and the two can differ under sampling and at
-window boundaries.
+window boundaries. The counter also takes every `EVALUATED` record, whereas only version 2 of that
+record feeds `EDI` (version 1 is applied as a no-op), so records written by a broker older than 8.8
+would count here but not there — that is outside the supported upgrade sources for 8.10, where the
+two agree.
 
 ### Heartbeat attributes
 

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -40,7 +40,13 @@ public final class AnalyticsAttributes {
         AttributeKey.longKey("camunda.event.time_max");
 
     // Event name values
+
+    /**
+     * Shares its simple name with {@link Metric#PROCESS_INSTANCE_CREATED}, which holds a different
+     * string: a static import of the wrong one compiles. Import the qualified form.
+     */
     public static final String PROCESS_INSTANCE_CREATED = "process_instance_created";
+
     public static final String ADHOC_SUBPROCESS_ACTIVATED = "adhoc_subprocess_activated";
     public static final String USAGE_METRIC_EXPORTED = "usage_metric_exported";
     public static final String HEARTBEAT = "heartbeat";
@@ -155,7 +161,12 @@ public final class AnalyticsAttributes {
   }
 
   public static final class Metric {
+    /**
+     * Shares its simple name with {@link Event#PROCESS_INSTANCE_CREATED}, which holds a different
+     * string: a static import of the wrong one compiles. Import the qualified form.
+     */
     public static final String PROCESS_INSTANCE_CREATED = "camunda.process_instance.created";
+
     public static final String DECISION_INSTANCE_EVALUATED = "camunda.decision.instance.evaluated";
     public static final String EXPORT_WINDOW = "camunda.metric.export_window";
     public static final AttributeKey<Long> SEQUENCE_NUMBER =

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
@@ -13,6 +13,9 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.Form;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import java.util.Set;
 
 /**
@@ -27,7 +30,8 @@ import java.util.Set;
  *       over-approximation: the set is flat across all value types, so a record may pass intent
  *       filtering even if its (ValueType, Intent) pair has no handler. Exact routing happens in
  *       {@link HandlerRegistry#handle}.
- *   <li><b>Partition ownership</b> — only events whose key encodes the local partition ID pass.
+ *   <li><b>Partition ownership</b> — only events whose ownership key encodes the local partition ID
+ *       pass. See {@link #partitionOwnershipKey(Record)}.
  * </ol>
  *
  * <p>Layers 1-3 are metadata-based and evaluated in phase 1 of the broker's filter pipeline (before
@@ -44,10 +48,14 @@ import java.util.Set;
  * <p>Without this filter, the analytics exporter on every partition would emit the same logical
  * event, leading to N× duplication in a cluster with N partitions.
  *
- * <p>The key-based check works because all {@code DistributedTypedRecordProcessor} implementations
- * in the engine preserve the originating partition ID in follow-up event keys — either via {@code
- * command.getKey()} directly, or via keys embedded in the distributed command's value that were
- * generated on the originating partition.
+ * <p>Most {@code DistributedTypedRecordProcessor} implementations in the engine preserve the
+ * originating partition ID in follow-up event keys — either via {@code command.getKey()} directly,
+ * or via keys embedded in the distributed command's value that were generated on the originating
+ * partition. {@code ResourceDeletionDeleteProcessor} is the exception: it appends the {@code
+ * PROCESS}, {@code DECISION} and {@code FORM} {@code DELETED} follow-up events under a key from its
+ * own {@code keyGenerator}, so on every partition {@code record.getKey()} decodes to that
+ * partition. For those value types {@link #partitionOwnershipKey(Record)} substitutes the
+ * definition key carried in the record value, which was minted on the originating partition.
  */
 record AnalyticsRecordFilter(
     Set<ValueType> acceptedValueTypes, Set<Intent> acceptedIntents, int partitionId)
@@ -75,6 +83,23 @@ record AnalyticsRecordFilter(
 
   @Override
   public boolean acceptRecord(final Record<?> record) {
-    return Protocol.decodePartitionId(record.getKey()) == partitionId;
+    return Protocol.decodePartitionId(partitionOwnershipKey(record)) == partitionId;
+  }
+
+  /**
+   * Returns the key whose encoded partition ID identifies the partition that owns the record.
+   *
+   * <p>For deployment definitions the value's definition key is authoritative, because the engine
+   * does not always derive the event key from it. For {@code CREATED} the two are the same key, so
+   * routing all of these value types through the value is equivalent to {@link Record#getKey()}
+   * there.
+   */
+  private static long partitionOwnershipKey(final Record<?> record) {
+    return switch (record.getValueType()) {
+      case PROCESS -> ((Process) record.getValue()).getProcessDefinitionKey();
+      case DECISION -> ((DecisionRecordValue) record.getValue()).getDecisionKey();
+      case FORM -> ((Form) record.getValue()).getFormKey();
+      default -> record.getKey();
+    };
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
@@ -10,16 +10,26 @@ package io.camunda.exporter.analytics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableForm;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcess;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -28,6 +38,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 class AnalyticsRecordFilterTest {
 
   private static final int TEST_PARTITION_ID = 1;
+  private static final int REMOTE_PARTITION = 3;
+  private static final int CLUSTER_PARTITION_COUNT = 5;
   private static final ProtocolFactory FACTORY = new ProtocolFactory();
 
   private final AnalyticsRecordFilter filter =
@@ -121,5 +133,122 @@ class AnalyticsRecordFilterTest {
 
     // when / then
     assertThat(filter.acceptRecord(record)).isFalse();
+  }
+
+  /**
+   * The engine's {@code ResourceDeletionDeleteProcessor} runs on every partition and mints the
+   * DELETED event key locally, so only the definition key in the value identifies the originating
+   * partition. Exactly one partition of the cluster may emit the event; anything else is an N-fold
+   * over-count.
+   */
+  @ParameterizedTest
+  @MethodSource("deletedDefinitionsOwnedByRemotePartition")
+  void shouldAcceptDeletedDefinitionOnOriginatingPartitionOnly(final Record<?> record) {
+    // given — the definition was minted on REMOTE_PARTITION, the event key on the local one
+    final var acceptingPartitions =
+        IntStream.rangeClosed(1, CLUSTER_PARTITION_COUNT)
+            .filter(partition -> definitionFilter(partition).acceptRecord(record))
+            .boxed()
+            .toList();
+
+    // when / then
+    assertThat(acceptingPartitions).containsExactly(REMOTE_PARTITION);
+  }
+
+  private static Stream<Named<Record<?>>> deletedDefinitionsOwnedByRemotePartition() {
+    final long definitionKey = Protocol.encodePartitionId(REMOTE_PARTITION, 7);
+    return Stream.of(
+        Named.of("PROCESS", deletedProcess(definitionKey)),
+        Named.of("DECISION", deletedDecision(definitionKey)),
+        Named.of("FORM", deletedForm(definitionKey)));
+  }
+
+  @Test
+  void shouldAcceptCreatedDefinitionFromLocalPartition() {
+    // given — for CREATED the event key and the value's definition key are the same key
+    final long definitionKey = Protocol.encodePartitionId(TEST_PARTITION_ID, 7);
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS,
+            r ->
+                r.withKey(definitionKey)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessIntent.CREATED)
+                    .withValue(process(definitionKey)));
+
+    // when / then
+    assertThat(definitionFilter(TEST_PARTITION_ID).acceptRecord(record)).isTrue();
+  }
+
+  private static AnalyticsRecordFilter definitionFilter(final int partitionId) {
+    return new AnalyticsRecordFilter(
+        Set.of(ValueType.PROCESS, ValueType.DECISION, ValueType.FORM),
+        Set.of(
+            ProcessIntent.CREATED,
+            ProcessIntent.DELETED,
+            DecisionIntent.DELETED,
+            FormIntent.DELETED),
+        partitionId);
+  }
+
+  private static Record<?> deletedProcess(final long processDefinitionKey) {
+    return FACTORY.generateRecord(
+        ValueType.PROCESS,
+        r ->
+            r.withKey(locallyMintedEventKey())
+                .withRecordType(RecordType.EVENT)
+                .withIntent(ProcessIntent.DELETED)
+                .withValue(process(processDefinitionKey)));
+  }
+
+  private static Record<?> deletedDecision(final long decisionKey) {
+    return FACTORY.generateRecord(
+        ValueType.DECISION,
+        r ->
+            r.withKey(locallyMintedEventKey())
+                .withRecordType(RecordType.EVENT)
+                .withIntent(DecisionIntent.DELETED)
+                .withValue(
+                    ImmutableDecisionRecordValue.builder()
+                        .withDecisionId("credit-scoring")
+                        .withDecisionKey(decisionKey)
+                        .withDecisionName("Credit scoring")
+                        .withVersion(3)
+                        .withTenantId("acme")
+                        .build()));
+  }
+
+  private static Record<?> deletedForm(final long formKey) {
+    return FACTORY.generateRecord(
+        ValueType.FORM,
+        r ->
+            r.withKey(locallyMintedEventKey())
+                .withRecordType(RecordType.EVENT)
+                .withIntent(FormIntent.DELETED)
+                .withValue(
+                    ImmutableForm.builder()
+                        .withFormId("customer-onboarding")
+                        .withFormKey(formKey)
+                        .withVersion(3)
+                        .withResourceName("onboarding.form")
+                        .withResource("{\"components\":[]}".getBytes(StandardCharsets.UTF_8))
+                        .withTenantId("acme")
+                        .build()));
+  }
+
+  private static ImmutableProcess process(final long processDefinitionKey) {
+    return ImmutableProcess.builder()
+        .withBpmnProcessId("order-process")
+        .withProcessDefinitionKey(processDefinitionKey)
+        .withVersion(3)
+        .withResourceName("order-process.bpmn")
+        .withResource("<definitions/>".getBytes(StandardCharsets.UTF_8))
+        .withTenantId("acme")
+        .build();
+  }
+
+  /** Every partition mints the same event key for its own copy of the DELETED follow-up event. */
+  private static long locallyMintedEventKey() {
+    return Protocol.encodePartitionId(TEST_PARTITION_ID, 99);
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/DecisionInstanceEvaluatedHandlerTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableDecisionEvaluationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
@@ -25,6 +26,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,10 +54,16 @@ class DecisionInstanceEvaluatedHandlerTest {
   }
 
   private static Record<?> evaluatedRecord(final String tenantId) {
+    return evaluatedRecord(tenantId, List.of(FACTORY.generateObject(EvaluatedDecisionValue.class)));
+  }
+
+  private static Record<?> evaluatedRecord(
+      final String tenantId, final List<EvaluatedDecisionValue> evaluatedDecisions) {
     final var value =
         ImmutableDecisionEvaluationRecordValue.builder()
             .from(FACTORY.generateObject(DecisionEvaluationRecordValue.class))
             .withTenantId(tenantId)
+            .withEvaluatedDecisions(evaluatedDecisions)
             .build();
     return FACTORY.generateRecord(
         ValueType.DECISION_EVALUATION,
@@ -89,6 +97,33 @@ class DecisionInstanceEvaluatedHandlerTest {
                       .sum();
               assertThat(total).isEqualTo(2);
             });
+  }
+
+  @Test
+  void shouldCountOncePerRecordWhenSeveralDecisionsAreEvaluated() {
+    // given a DRG evaluation: the requested decision plus its required sub-decisions
+    final Record<DecisionEvaluationRecordValue> record =
+        typed(
+            evaluatedRecord(
+                "tenant-a",
+                List.of(
+                    FACTORY.generateObject(EvaluatedDecisionValue.class),
+                    FACTORY.generateObject(EvaluatedDecisionValue.class),
+                    FACTORY.generateObject(EvaluatedDecisionValue.class))));
+    assertThat(record.getValue().getEvaluatedDecisions()).hasSize(3);
+
+    // when
+    handler.handle(record);
+
+    // then
+    assertThat(counter())
+        .isPresent()
+        .hasValueSatisfying(
+            metric ->
+                assertThat(metric.getLongSumData().getPoints())
+                    .singleElement()
+                    .extracting(LongPointData::getValue)
+                    .isEqualTo(1L));
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskAssignedHandlerTest.java
@@ -37,6 +37,12 @@ class UserTaskAssignedHandlerTest {
   private static final String ASSIGNEE_SHA_256 =
       "836f82db99121b3481011f16b49dfa5fbc714a0d1b1b9f784a1ebbbf5b39577f";
 
+  private static final String WHITESPACE_ASSIGNEE = "  ";
+
+  /** SHA-256 of two space characters, independently computed with {@code shasum -a 256}. */
+  private static final String WHITESPACE_ASSIGNEE_SHA_256 =
+      "6c179f21e6f62b629055d8ab40f454ed02e48b68563913473b857d3638e23b28";
+
   private InMemoryLogRecordExporter logExporter;
   private UserTaskAssignedHandler handler;
 
@@ -139,5 +145,29 @@ class UserTaskAssignedHandlerTest {
             logRecord ->
                 logRecord.getAttributes().asMap().get(AnalyticsAttributes.UserTask.ASSIGNEE_HASH))
         .containsExactly(ASSIGNEE_SHA_256, expectedSecondHash);
+  }
+
+  @Test
+  void shouldSkipWhenAssigneeIsNull() {
+    // when
+    handler.handle(typed(assignedRecord(null)));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+
+  @Test
+  void shouldEmitWhenAssigneeIsWhitespaceOnly() {
+    // when
+    handler.handle(typed(assignedRecord(WHITESPACE_ASSIGNEE)));
+
+    // then the guard is isEmpty, not isBlank, so this matches what the engine's TU metric counts
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(
+                        AnalyticsAttributes.UserTask.ASSIGNEE_HASH, WHITESPACE_ASSIGNEE_SHA_256));
   }
 }


### PR DESCRIPTION
## What this contains

Improvements to the analytics exporter. It targets the 14-signal events branch rather than `main`, so its diff is only the increment over that branch.

### Correctness fix

The three `camunda.*.definition.deleted` events were emitted **once per partition** in a multi-partition cluster, an N-fold over-count. Resource deletion runs on every partition and writes the DELETED follow-up with a locally-minted key, so the exporter's partition-ownership filter passed on every partition. The filter now dedups those events on the definition key carried in the record value (minted on the originating partition); the `*.created` events already carry that key and are unchanged. This also adds the filter-level test that was missing (which is why the bug was invisible to the suite): a five-partition assertion that exactly the originating partition emits, mutation-checked.

### Smaller fixes

- **Boundary tests:** the decision counter increments by one per evaluation record even when a DRG evaluates several decisions; the user-task handler skips a null assignee and emits a whitespace-only one, matching the engine's non-empty guard. Each new assertion is mutation-checked.
- **Handler-authoring guide:** the module `AGENTS.md` pointed new handlers at `AnalyticsExporter.configure()`; registration is in `AnalyticsHandlerCatalog.build()`, and two required steps (the attribute constant and the exact-set catalog-test entry) were missing.
- **README:** the event-name convention (the five pre-contract signals keep flat names; new signals use dotted contract names) and a version caveat on the decision counter.
- A warning comment on the two colliding `PROCESS_INSTANCE_CREATED` constants (event vs metric) whose simple names differ only by nested class.

### Verification

`./mvnw verify -pl zeebe/exporters/analytics-exporter`: 255 tests pass.

### Deliberately out of scope

Process-instance-counter accuracy (extending the count to the process-activation site so it matches the licence RPI population) and the removal of the forwarded `usage_metric_exported` signal are coupled and rework a live signal, so they are left as a validated follow-up. Salting the assignee hash is also left out; the hash ships unsalted, as documented on that signal.
