### PR TITLE
fix: apply CI image override to QA testcontainer brokers

### DIFF
--- a/qa/testcontainer/src/main/java/io/camunda/container/CamundaContainer.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/CamundaContainer.java
@@ -37,8 +37,10 @@ import org.testcontainers.utility.TestcontainersConfiguration;
 public abstract sealed class CamundaContainer<SELF extends CamundaContainer<SELF>>
     extends GenericContainer<SELF> {
   public static final String CAMUNDA_CONTAINER_IMAGE_PROPERTY = "camunda.container.image";
+  public static final String CAMUNDA_CONTAINER_IMAGE_ENV = "CAMUNDA_CONTAINER_IMAGE";
   public static final String DEFAULT_CAMUNDA_CONTAINER_IMAGE = "camunda/camunda";
   public static final String CAMUNDA_CONTAINER_VERSION_PROPERTY = "camunda.container.version";
+  public static final String CAMUNDA_CONTAINER_VERSION_ENV = "CAMUNDA_CONTAINER_VERSION";
   public static final String DEFAULT_CAMUNDA_VERSION = "8.10-SNAPSHOT";
   public static final String DEFAULT_CAMUNDA_DATA_PATH = "/usr/local/camunda/data";
   public static final String DEFAULT_CAMUNDA_LOGS_PATH = "/usr/local/camunda/logs";
@@ -95,14 +97,32 @@ public abstract sealed class CamundaContainer<SELF extends CamundaContainer<SELF
 
   /** Returns the default Camunda docker image, without a tag */
   public static String getDefaultImage() {
-    return TestcontainersConfiguration.getInstance()
-        .getEnvVarOrProperty(CAMUNDA_CONTAINER_IMAGE_PROPERTY, DEFAULT_CAMUNDA_CONTAINER_IMAGE);
+    return resolve(
+        CAMUNDA_CONTAINER_IMAGE_PROPERTY,
+        System.getenv(CAMUNDA_CONTAINER_IMAGE_ENV),
+        DEFAULT_CAMUNDA_CONTAINER_IMAGE);
   }
 
   /** Returns the default Camunda docker image tag/version */
   public static String getDefaultVersion() {
-    return TestcontainersConfiguration.getInstance()
-        .getEnvVarOrProperty(CAMUNDA_CONTAINER_VERSION_PROPERTY, DEFAULT_CAMUNDA_VERSION);
+    return resolve(
+        CAMUNDA_CONTAINER_VERSION_PROPERTY,
+        System.getenv(CAMUNDA_CONTAINER_VERSION_ENV),
+        DEFAULT_CAMUNDA_VERSION);
+  }
+
+  /**
+   * Resolves an image coordinate honoring, in order: a {@code TESTCONTAINERS_}-prefixed env var or
+   * a {@code .testcontainers.properties} entry (via Testcontainers), then the plain unprefixed env
+   * var, then the hardcoded default. The plain env var is honored explicitly because
+   * Testcontainers' {@code getEnvVarOrProperty} only reads env vars carrying the {@code
+   * TESTCONTAINERS_} prefix, so a CI-provided {@code CAMUNDA_CONTAINER_IMAGE}/{@code
+   * CAMUNDA_CONTAINER_VERSION} override would otherwise be silently ignored and tests would fall
+   * back to the Docker Hub nightly image.
+   */
+  static String resolve(final String property, final String envValue, final String fallback) {
+    final String envOrDefault = (envValue != null && !envValue.isBlank()) ? envValue : fallback;
+    return TestcontainersConfiguration.getInstance().getEnvVarOrProperty(property, envOrDefault);
   }
 
   /**

--- a/qa/testcontainer/src/test/java/io/camunda/container/CamundaContainerImageResolutionTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/CamundaContainerImageResolutionTest.java
@@ -9,6 +9,7 @@ package io.camunda.container;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -16,18 +17,19 @@ import org.junit.jupiter.api.Test;
  * unprefixed env var value, so a CI-provided image override takes effect instead of silently
  * falling back to the Docker Hub nightly image.
  *
- * <p>The property argument uses a name with no matching {@code TESTCONTAINERS_}-prefixed env var or
- * {@code .testcontainers.properties} entry, so Testcontainers' lookup misses and the resolver's
- * unprefixed-env fallback is exercised.
+ * <p>Each test uses a per-run unique property name so no {@code TESTCONTAINERS_}-prefixed env var
+ * or {@code .testcontainers.properties} entry in a developer's local Testcontainers configuration
+ * can match it. Testcontainers' lookup therefore always misses and the resolver's unprefixed-env
+ * fallback is exercised deterministically.
  */
 class CamundaContainerImageResolutionTest {
 
-  private static final String UNSET_PROPERTY = "camunda.container.test.unset.image";
+  private final String unsetProperty = "camunda.container.test." + UUID.randomUUID();
 
   @Test
   void shouldUseFallbackWhenEnvValueMissing() {
     // when -- no Testcontainers source and no plain env value
-    final String resolved = CamundaContainer.resolve(UNSET_PROPERTY, null, "camunda/camunda");
+    final String resolved = CamundaContainer.resolve(unsetProperty, null, "camunda/camunda");
 
     // then -- the hardcoded fallback is used
     assertThat(resolved).isEqualTo("camunda/camunda");
@@ -36,7 +38,7 @@ class CamundaContainerImageResolutionTest {
   @Test
   void shouldUseFallbackWhenEnvValueBlank() {
     // when -- the plain env value is present but blank
-    final String resolved = CamundaContainer.resolve(UNSET_PROPERTY, "  ", "camunda/camunda");
+    final String resolved = CamundaContainer.resolve(unsetProperty, "  ", "camunda/camunda");
 
     // then -- the hardcoded fallback is used
     assertThat(resolved).isEqualTo("camunda/camunda");
@@ -47,7 +49,7 @@ class CamundaContainerImageResolutionTest {
     // when -- a plain (unprefixed) env value is provided and no Testcontainers source is set
     final String resolved =
         CamundaContainer.resolve(
-            UNSET_PROPERTY, "localhost:5000/camunda/camunda", "camunda/camunda");
+            unsetProperty, "localhost:5000/camunda/camunda", "camunda/camunda");
 
     // then -- the plain env value wins over the hardcoded fallback
     assertThat(resolved).isEqualTo("localhost:5000/camunda/camunda");

--- a/qa/testcontainer/src/test/java/io/camunda/container/CamundaContainerImageResolutionTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/CamundaContainerImageResolutionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.container;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link CamundaContainer#resolve(String, String, String)} honors the plain
+ * unprefixed env var value, so a CI-provided image override takes effect instead of silently
+ * falling back to the Docker Hub nightly image.
+ *
+ * <p>The property argument uses a name with no matching {@code TESTCONTAINERS_}-prefixed env var or
+ * {@code .testcontainers.properties} entry, so Testcontainers' lookup misses and the resolver's
+ * unprefixed-env fallback is exercised.
+ */
+class CamundaContainerImageResolutionTest {
+
+  private static final String UNSET_PROPERTY = "camunda.container.test.unset.image";
+
+  @Test
+  void shouldUseFallbackWhenEnvValueMissing() {
+    // when -- no Testcontainers source and no plain env value
+    final String resolved = CamundaContainer.resolve(UNSET_PROPERTY, null, "camunda/camunda");
+
+    // then -- the hardcoded fallback is used
+    assertThat(resolved).isEqualTo("camunda/camunda");
+  }
+
+  @Test
+  void shouldUseFallbackWhenEnvValueBlank() {
+    // when -- the plain env value is present but blank
+    final String resolved = CamundaContainer.resolve(UNSET_PROPERTY, "  ", "camunda/camunda");
+
+    // then -- the hardcoded fallback is used
+    assertThat(resolved).isEqualTo("camunda/camunda");
+  }
+
+  @Test
+  void shouldHonorUnprefixedEnvValueOverFallback() {
+    // when -- a plain (unprefixed) env value is provided and no Testcontainers source is set
+    final String resolved =
+        CamundaContainer.resolve(
+            UNSET_PROPERTY, "localhost:5000/camunda/camunda", "camunda/camunda");
+
+    // then -- the plain env value wins over the hardcoded fallback
+    assertThat(resolved).isEqualTo("localhost:5000/camunda/camunda");
+  }
+}


### PR DESCRIPTION
## Description

QA integration tests that build a broker via `CamundaContainer` (e.g. `VolumeDataRestorationIT`) always pulled `camunda/camunda:8.10-SNAPSHOT` from Docker Hub instead of the PR-built image the `integration-tests` CI job intends.

The CI job exports plain `CAMUNDA_CONTAINER_IMAGE` / `CAMUNDA_CONTAINER_VERSION` env vars, but `CamundaContainer` resolves the image through Testcontainers' `getEnvVarOrProperty`, which only reads env vars carrying the `TESTCONTAINERS_` prefix (or a `.testcontainers.properties` entry). The unprefixed vars were therefore silently ignored.

**Consequence:** a containerised broker built from current `main` restored a volume into an in-process broker built from the PR branch. Any PR branched before a record-format change on `main` failed deterministically with a replay error (`NoApplierForVersion`, unknown enum constant), with no rerun escape.

## Solution

Resolve the image and version coordinates through a small seam that passes the plain unprefixed env var as the *default* to `getEnvVarOrProperty`. This preserves existing precedence — a `TESTCONTAINERS_`-prefixed env var or `.testcontainers.properties` entry still wins — and adds the unprefixed env var as a fallback ahead of the hardcoded Docker Hub default, so the CI-provided override finally takes effect.

**Precedence (high → low):** `TESTCONTAINERS_*` env / `.testcontainers.properties` → plain `CAMUNDA_CONTAINER_*` env → hardcoded default.

I chose this (the "honor the unprefixed vars" option from the issue) over renaming the CI env vars because it fixes the trap for **all** consumers — local runs and future callers — not just the one CI job.

## Verification

Disassembled Testcontainers `getConfigurable` to confirm `getEnvVarOrProperty` reads only the prefixed env var and the properties files, never an arbitrary JVM system property. Added `CamundaContainerImageResolutionTest` covering the fallback precedence (passes).

Closes #58503
