### PR TITLE
feat: serve /business-value/overview from precomputed overview index

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceIT.java
@@ -14,205 +14,122 @@ import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOvervie
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
-import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
-import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.OffTargetEntryDto;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.util.importing.ZeebeConstants;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
-import org.awaitility.Awaitility;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * End-to-end verification that {@code /business-value/overview} reads precomputed rows from the
- * live overview index and assembles them per tech design §5.3. The read service is bean-invoked
- * rather than reached over HTTP so the test does not have to authenticate; controller behavior is a
- * straight delegation and exercised by the unit test.
+ * Exercises the {@link BusinessValueOverviewRepository} read path against a live ES or OS backend.
+ * Covers the {@code readByRange(range, tenantIds)} pushdown that keeps the response bounded even
+ * when the cluster-wide row count would otherwise exceed the fetch cap. Assembly logic on top of
+ * the repository is exhaustively covered by {@code BusinessValueOverviewReadServiceTest}, which is
+ * cheaper to run and doesn't need a real backend.
  */
 class BusinessValueOverviewReadServiceIT extends AbstractBrokerlessZeebeCCSMIT {
 
   private static final String DEFAULT_TENANT = ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
-  private static final String USER = "demo";
+  private static final String OTHER_TENANT = "tenant-b";
 
   private BusinessValueOverviewRepository overviewRepository;
-  private BusinessValueOverviewReadService readService;
 
   @BeforeEach
   void setUp() {
     overviewRepository = embeddedOptimizeExtension.getBean(BusinessValueOverviewRepository.class);
-    readService = embeddedOptimizeExtension.getBean(BusinessValueOverviewReadService.class);
   }
 
   @Test
-  void shouldReturnEmptyResponseWhenNoRowsIndexed() {
-    // when
-    final BusinessValueOverviewResponseDto response =
-        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+  void shouldReturnAllRowsForRangeWhenTenantFilterIsNull() {
+    // given two rows in the same range under different tenants
+    final BusinessValueOverviewDto rowA = fresh(DEFAULT_TENANT, "proc-a", MetricRange.THIRTY_DAYS);
+    final BusinessValueOverviewDto rowB = fresh(OTHER_TENANT, "proc-b", MetricRange.THIRTY_DAYS);
+    overviewRepository.bulkUpsert(List.of(rowA, rowB), true);
+
+    // when — passing null bypasses the tenant filter; reserved for internal, tenant-agnostic
+    // callers
+    final List<BusinessValueOverviewDto> read =
+        overviewRepository.readByRange(MetricRange.THIRTY_DAYS, null);
 
     // then
-    assertThat(response.hasAnyTarget()).isFalse();
-    assertThat(response.coverage().totalProcesses()).isZero();
-    assertThat(response.attainment().targetsSet()).isZero();
-    assertThat(response.categories()).hasSize(2);
-    assertThat(response.offTarget()).isEmpty();
+    assertThat(read)
+        .extracting(BusinessValueOverviewDto::getProcessDefinitionKey)
+        .contains("proc-a", "proc-b");
   }
 
   @Test
-  void shouldAssembleResponseFromIndexRows() {
-    // given — three rows in the requested range: one met, one missed, one target-less
+  void shouldReturnEmptyListWhenTenantFilterIsEmpty() {
+    // given rows exist for the range
     overviewRepository.bulkUpsert(
-        List.of(
-            fresh(
-                "invoice-met",
-                new CycleTimeBlock(6_000L, 8_000L, true),
-                new AutomationRateBlock(null, null, null),
-                1,
-                1),
-            fresh(
-                "invoice-missed",
-                new CycleTimeBlock(10_000L, 8_000L, false),
-                new AutomationRateBlock(70.0, 85, false),
-                2,
-                0),
-            fresh(
-                "onboarding-empty",
-                new CycleTimeBlock(null, null, null),
-                new AutomationRateBlock(null, null, null),
-                0,
-                0)),
-        true);
+        List.of(fresh(DEFAULT_TENANT, "proc-empty-check", MetricRange.THIRTY_DAYS)), true);
 
-    // when
-    final BusinessValueOverviewResponseDto response =
-        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+    // when — an empty collection is the shortcut for "caller sees no tenants"
+    final List<BusinessValueOverviewDto> read =
+        overviewRepository.readByRange(MetricRange.THIRTY_DAYS, Set.of());
 
     // then
-    assertThat(response.hasAnyTarget()).isTrue();
-    assertThat(response.coverage().processesWithTarget()).isEqualTo(2);
-    assertThat(response.coverage().totalProcesses()).isEqualTo(3);
-    assertThat(response.attainment().targetsSet()).isEqualTo(3);
-    assertThat(response.attainment().targetsMet()).isEqualTo(1);
-
-    // off-target sorted by gapPct desc: cycleTime 25%, automation 17.6%
-    assertThat(response.offTarget())
-        .extracting(OffTargetEntryDto::kpi, OffTargetEntryDto::processKey)
-        .containsExactly(
-            org.assertj.core.groups.Tuple.tuple("cycleTime", "invoice-missed"),
-            org.assertj.core.groups.Tuple.tuple("automationRate", "invoice-missed"));
-    assertThat(response.offTarget().get(0).gapPct()).isEqualTo(25.0);
-    assertThat(response.offTarget().get(0).displayUnit()).isEqualTo("HOURS");
+    assertThat(read).isEmpty();
   }
 
   @Test
-  void shouldOnlyIncludeRowsForTheRequestedRange() {
-    // given — rows for two ranges
-    overviewRepository.bulkUpsert(
-        List.of(
-            fresh(
-                MetricRange.THIRTY_DAYS,
-                "proc-30d",
-                new CycleTimeBlock(6_000L, 8_000L, true),
-                new AutomationRateBlock(null, null, null),
-                1,
-                1),
-            fresh(
-                MetricRange.SEVEN_DAYS,
-                "proc-7d",
-                new CycleTimeBlock(6_000L, 8_000L, true),
-                new AutomationRateBlock(null, null, null),
-                1,
-                1)),
-        true);
+  void shouldPushDownTenantFilterAndOnlyReturnMatchingRows() {
+    // given rows in the same range but two different tenants; the read must not return the
+    // unauthorized tenant's row regardless of how many rows exist cluster-wide
+    final BusinessValueOverviewDto authorized =
+        fresh(DEFAULT_TENANT, "proc-authorized-1", MetricRange.THIRTY_DAYS);
+    final BusinessValueOverviewDto unauthorized =
+        fresh(OTHER_TENANT, "proc-unauthorized", MetricRange.THIRTY_DAYS);
+    overviewRepository.bulkUpsert(List.of(authorized, unauthorized), true);
 
     // when
-    final BusinessValueOverviewResponseDto response =
-        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+    final List<BusinessValueOverviewDto> read =
+        overviewRepository.readByRange(MetricRange.THIRTY_DAYS, Set.of(DEFAULT_TENANT));
 
-    // then — only the 30d row is counted
-    assertThat(response.coverage().totalProcesses()).isEqualTo(1);
+    // then
+    assertThat(read)
+        .extracting(BusinessValueOverviewDto::getProcessDefinitionKey)
+        .contains("proc-authorized-1")
+        .doesNotContain("proc-unauthorized");
+    assertThat(read).allSatisfy(row -> assertThat(row.getTenantId()).isEqualTo(DEFAULT_TENANT));
   }
 
   @Test
-  void shouldFireStaleReadBackstopAndRefreshLastComputedAt() {
-    // given — a stale row from three refresh intervals ago (default = 86400s)
-    final String processKey = "invoice-stale-" + System.nanoTime();
-    final OffsetDateTime staleTimestamp = OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(300_000L);
+  void shouldIsolateRowsByMetricRange() {
+    // given rows across all four ranges for the same tenant/process
     overviewRepository.bulkUpsert(
         List.of(
-            rowAt(
-                MetricRange.THIRTY_DAYS,
-                processKey,
-                new CycleTimeBlock(null, null, null),
-                new AutomationRateBlock(null, null, null),
-                0,
-                0,
-                staleTimestamp)),
+            fresh(DEFAULT_TENANT, "proc-range-isolation", MetricRange.SEVEN_DAYS),
+            fresh(DEFAULT_TENANT, "proc-range-isolation", MetricRange.THIRTY_DAYS),
+            fresh(DEFAULT_TENANT, "proc-range-isolation", MetricRange.THREE_MONTHS),
+            fresh(DEFAULT_TENANT, "proc-range-isolation", MetricRange.SIX_MONTHS)),
         true);
 
     // when
-    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+    final List<BusinessValueOverviewDto> read =
+        overviewRepository.readByRange(MetricRange.THIRTY_DAYS, Set.of(DEFAULT_TENANT));
 
-    // then — the async backstop must refresh the row's lastComputedAt
-    Awaitility.await()
-        .atMost(java.time.Duration.ofSeconds(30))
-        .untilAsserted(
-            () -> {
-              final OffsetDateTime latest =
-                  overviewRepository
-                      .getByKey(DEFAULT_TENANT, processKey, MetricRange.THIRTY_DAYS)
-                      .orElseThrow()
-                      .getLastComputedAt();
-              assertThat(latest).isAfter(staleTimestamp);
-            });
+    // then — only the 30d row for our test process is returned; other ranges are excluded
+    assertThat(read)
+        .filteredOn(row -> "proc-range-isolation".equals(row.getProcessDefinitionKey()))
+        .hasSize(1)
+        .allSatisfy(row -> assertThat(row.getMetricRange()).isEqualTo(MetricRange.THIRTY_DAYS));
   }
 
   private static BusinessValueOverviewDto fresh(
-      final String processKey,
-      final CycleTimeBlock cycleTime,
-      final AutomationRateBlock automationRate,
-      final int targetsSet,
-      final int targetsMet) {
-    return fresh(
-        MetricRange.THIRTY_DAYS, processKey, cycleTime, automationRate, targetsSet, targetsMet);
-  }
-
-  private static BusinessValueOverviewDto fresh(
-      final MetricRange range,
-      final String processKey,
-      final CycleTimeBlock cycleTime,
-      final AutomationRateBlock automationRate,
-      final int targetsSet,
-      final int targetsMet) {
-    return rowAt(
-        range,
-        processKey,
-        cycleTime,
-        automationRate,
-        targetsSet,
-        targetsMet,
-        OffsetDateTime.now(ZoneOffset.UTC));
-  }
-
-  private static BusinessValueOverviewDto rowAt(
-      final MetricRange range,
-      final String processKey,
-      final CycleTimeBlock cycleTime,
-      final AutomationRateBlock automationRate,
-      final int targetsSet,
-      final int targetsMet,
-      final OffsetDateTime lastComputedAt) {
+      final String tenantId, final String processKey, final MetricRange range) {
     return new BusinessValueOverviewDto(
-        DEFAULT_TENANT,
+        tenantId,
         processKey,
         processKey,
         range,
-        lastComputedAt,
-        cycleTime,
-        automationRate,
-        targetsSet > 0,
-        targetsSet,
-        targetsMet);
+        OffsetDateTime.now(ZoneOffset.UTC),
+        new CycleTimeBlock(null, null, null),
+        new AutomationRateBlock(null, null, null),
+        false,
+        0,
+        0);
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.OffTargetEntryDto;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end verification that {@code /business-value/overview} reads precomputed rows from the
+ * live overview index and assembles them per tech design §5.3. The read service is bean-invoked
+ * rather than reached over HTTP so the test does not have to authenticate; controller behavior is a
+ * straight delegation and exercised by the unit test.
+ */
+class BusinessValueOverviewReadServiceIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final String DEFAULT_TENANT = ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+  private static final String USER = "demo";
+
+  private BusinessValueOverviewRepository overviewRepository;
+  private BusinessValueOverviewReadService readService;
+
+  @BeforeEach
+  void setUp() {
+    overviewRepository = embeddedOptimizeExtension.getBean(BusinessValueOverviewRepository.class);
+    readService = embeddedOptimizeExtension.getBean(BusinessValueOverviewReadService.class);
+  }
+
+  @Test
+  void shouldReturnEmptyResponseWhenNoRowsIndexed() {
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.hasAnyTarget()).isFalse();
+    assertThat(response.coverage().totalProcesses()).isZero();
+    assertThat(response.attainment().targetsSet()).isZero();
+    assertThat(response.categories()).hasSize(2);
+    assertThat(response.offTarget()).isEmpty();
+  }
+
+  @Test
+  void shouldAssembleResponseFromIndexRows() {
+    // given — three rows in the requested range: one met, one missed, one target-less
+    overviewRepository.bulkUpsert(
+        List.of(
+            fresh(
+                "invoice-met",
+                new CycleTimeBlock(6_000L, 8_000L, true),
+                new AutomationRateBlock(null, null, null),
+                1,
+                1),
+            fresh(
+                "invoice-missed",
+                new CycleTimeBlock(10_000L, 8_000L, false),
+                new AutomationRateBlock(70.0, 85, false),
+                2,
+                0),
+            fresh(
+                "onboarding-empty",
+                new CycleTimeBlock(null, null, null),
+                new AutomationRateBlock(null, null, null),
+                0,
+                0)),
+        true);
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.hasAnyTarget()).isTrue();
+    assertThat(response.coverage().processesWithTarget()).isEqualTo(2);
+    assertThat(response.coverage().totalProcesses()).isEqualTo(3);
+    assertThat(response.attainment().targetsSet()).isEqualTo(3);
+    assertThat(response.attainment().targetsMet()).isEqualTo(1);
+
+    // off-target sorted by gapPct desc: cycleTime 25%, automation 17.6%
+    assertThat(response.offTarget())
+        .extracting(OffTargetEntryDto::kpi, OffTargetEntryDto::processKey)
+        .containsExactly(
+            org.assertj.core.groups.Tuple.tuple("cycleTime", "invoice-missed"),
+            org.assertj.core.groups.Tuple.tuple("automationRate", "invoice-missed"));
+    assertThat(response.offTarget().get(0).gapPct()).isEqualTo(25.0);
+    assertThat(response.offTarget().get(0).displayUnit()).isEqualTo("HOURS");
+  }
+
+  @Test
+  void shouldOnlyIncludeRowsForTheRequestedRange() {
+    // given — rows for two ranges
+    overviewRepository.bulkUpsert(
+        List.of(
+            fresh(
+                MetricRange.THIRTY_DAYS,
+                "proc-30d",
+                new CycleTimeBlock(6_000L, 8_000L, true),
+                new AutomationRateBlock(null, null, null),
+                1,
+                1),
+            fresh(
+                MetricRange.SEVEN_DAYS,
+                "proc-7d",
+                new CycleTimeBlock(6_000L, 8_000L, true),
+                new AutomationRateBlock(null, null, null),
+                1,
+                1)),
+        true);
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then — only the 30d row is counted
+    assertThat(response.coverage().totalProcesses()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldFireStaleReadBackstopAndRefreshLastComputedAt() {
+    // given — a stale row from three refresh intervals ago (default = 86400s)
+    final String processKey = "invoice-stale-" + System.nanoTime();
+    final OffsetDateTime staleTimestamp = OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(300_000L);
+    overviewRepository.bulkUpsert(
+        List.of(
+            rowAt(
+                MetricRange.THIRTY_DAYS,
+                processKey,
+                new CycleTimeBlock(null, null, null),
+                new AutomationRateBlock(null, null, null),
+                0,
+                0,
+                staleTimestamp)),
+        true);
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then — the async backstop must refresh the row's lastComputedAt
+    Awaitility.await()
+        .atMost(java.time.Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final OffsetDateTime latest =
+                  overviewRepository
+                      .getByKey(DEFAULT_TENANT, processKey, MetricRange.THIRTY_DAYS)
+                      .orElseThrow()
+                      .getLastComputedAt();
+              assertThat(latest).isAfter(staleTimestamp);
+            });
+  }
+
+  private static BusinessValueOverviewDto fresh(
+      final String processKey,
+      final CycleTimeBlock cycleTime,
+      final AutomationRateBlock automationRate,
+      final int targetsSet,
+      final int targetsMet) {
+    return fresh(
+        MetricRange.THIRTY_DAYS, processKey, cycleTime, automationRate, targetsSet, targetsMet);
+  }
+
+  private static BusinessValueOverviewDto fresh(
+      final MetricRange range,
+      final String processKey,
+      final CycleTimeBlock cycleTime,
+      final AutomationRateBlock automationRate,
+      final int targetsSet,
+      final int targetsMet) {
+    return rowAt(
+        range,
+        processKey,
+        cycleTime,
+        automationRate,
+        targetsSet,
+        targetsMet,
+        OffsetDateTime.now(ZoneOffset.UTC));
+  }
+
+  private static BusinessValueOverviewDto rowAt(
+      final MetricRange range,
+      final String processKey,
+      final CycleTimeBlock cycleTime,
+      final AutomationRateBlock automationRate,
+      final int targetsSet,
+      final int targetsMet,
+      final OffsetDateTime lastComputedAt) {
+    return new BusinessValueOverviewDto(
+        DEFAULT_TENANT,
+        processKey,
+        processKey,
+        range,
+        lastComputedAt,
+        cycleTime,
+        automationRate,
+        targetsSet > 0,
+        targetsSet,
+        targetsMet);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/BusinessValueOverviewRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/BusinessValueOverviewRestService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest;
+
+import static io.camunda.optimize.tomcat.OptimizeResourceConstants.REST_API_PATH;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
+import io.camunda.optimize.rest.exceptions.BadRequestException;
+import io.camunda.optimize.service.businessvalue.BusinessValueOverviewReadService;
+import io.camunda.optimize.service.security.SessionService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping(REST_API_PATH + BusinessValueOverviewRestService.BUSINESS_VALUE_PATH)
+public class BusinessValueOverviewRestService {
+
+  public static final String BUSINESS_VALUE_PATH = "/business-value";
+  public static final String OVERVIEW_SUB_PATH = "/overview";
+
+  private final BusinessValueOverviewReadService readService;
+  private final SessionService sessionService;
+
+  public BusinessValueOverviewRestService(
+      final BusinessValueOverviewReadService readService, final SessionService sessionService) {
+    this.readService = readService;
+    this.sessionService = sessionService;
+  }
+
+  @GetMapping(OVERVIEW_SUB_PATH)
+  public BusinessValueOverviewResponseDto getOverview(
+      @RequestParam("range") final String range, final HttpServletRequest request) {
+    final String userId = sessionService.getRequestUserOrFailNotAuthorized(request);
+    final MetricRange metricRange;
+    try {
+      metricRange = MetricRange.fromId(range);
+    } catch (final IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+    return readService.getOverview(userId, metricRange);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapter.java
@@ -52,6 +52,7 @@ public final class OptimizeSecurityPathAdapter implements SecurityPathPort {
         "/api/alert/**",
         "/api/analysis/**",
         "/api/assignee/**",
+        "/api/business-value/**",
         "/api/candidateGroup/**",
         "/api/collection/**",
         "/api/dashboard/**",

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOvervie
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.OffTargetEntryDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
 import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
@@ -28,10 +29,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -45,12 +45,27 @@ import org.springframework.stereotype.Component;
  * ×} the configured refresh interval are recomputed asynchronously as a safety net for missed
  * scheduler ticks (broker restart, deploy). The current request still returns the stale row; the
  * next reader sees fresh data.
+ *
+ * <p><b>Scale bound.</b> Per-request row count is capped at {@link
+ * DatabaseConstants#LIST_FETCH_LIMIT} (1000) by the underlying {@code readByRange} query, scoped to
+ * (range, authorized-tenant-set). Past that cap the repository throws {@code
+ * OptimizeRuntimeException} and the endpoint 500s — never a silent truncation. A warning is logged
+ * as the row count approaches the cap so ops sees it before a hard fail; the aggregation-based
+ * rewrite that would remove the cap is tracked separately.
  */
 @Component
 public class BusinessValueOverviewReadService {
 
   private static final String CYCLE_TIME_DISPLAY_UNIT = "HOURS";
   private static final String AUTOMATION_RATE_DISPLAY_UNIT = "PERCENT";
+
+  /**
+   * The row count above which the endpoint logs a warning per request. Picked at 80% of the
+   * repository fetch cap so operators see the approach several deployments before rows start
+   * failing.
+   */
+  private static final int ROW_COUNT_WARNING_THRESHOLD =
+      (int) (DatabaseConstants.LIST_FETCH_LIMIT * 0.8);
 
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewReadService.class);
@@ -62,12 +77,11 @@ public class BusinessValueOverviewReadService {
   private final ConfigurationService configurationService;
 
   /**
-   * Coalesces backstop recomputes across concurrent readers so a single stale row triggers one
-   * background compute, not one per in-flight request. Entries are keyed by (tenantId,
-   * processDefinitionKey, metricRange) and removed once the compute future completes.
+   * Coalesces concurrent full-scope backstops so multiple in-flight readers can't queue a fresh
+   * full-scope recompute on top of one that's already running. A stale request that arrives while a
+   * backstop is in flight sees this flag set and skips scheduling another job.
    */
-  private final ConcurrentHashMap<BackstopKey, Boolean> inFlightBackstops =
-      new ConcurrentHashMap<>();
+  private final AtomicBoolean backstopInFlight = new AtomicBoolean(false);
 
   public BusinessValueOverviewReadService(
       final BusinessValueOverviewRepository overviewRepository,
@@ -87,6 +101,15 @@ public class BusinessValueOverviewReadService {
     final List<String> authorizedTenantIds = tenantService.getTenantIdsForUser(userId);
     final List<BusinessValueOverviewDto> rawRows =
         overviewRepository.readByRange(range, authorizedTenantIds);
+
+    if (rawRows.size() >= ROW_COUNT_WARNING_THRESHOLD) {
+      LOG.warn(
+          "business-value overview read returned {} rows for range {} (fetch cap is {}); "
+              + "approaching or hitting the LIST_FETCH_LIMIT ceiling.",
+          rawRows.size(),
+          range.getId(),
+          DatabaseConstants.LIST_FETCH_LIMIT);
+    }
 
     if (rawRows.isEmpty()) {
       return emptyResponse();
@@ -125,6 +148,7 @@ public class BusinessValueOverviewReadService {
     int arApplicable = 0;
     int arMet = 0;
     final List<OffTargetEntryDto> offTarget = new ArrayList<>();
+    boolean anyRowStale = false;
 
     for (final BusinessValueOverviewDto row : rows) {
       totalProcesses++;
@@ -135,6 +159,11 @@ public class BusinessValueOverviewReadService {
       targetsMet += row.getTargetsMet();
 
       final CycleTimeBlock cycleTime = row.getCycleTime();
+      // v1: both KPIs are universally applicable to every process, so ctApplicable ends up equal
+      // to totalProcesses on every response. The counter is kept as a distinct field so the
+      // category donut denominator can diverge once a KPI becomes conditionally applicable (e.g.
+      // automation rate on a process with zero user tasks); until then the FE can treat
+      // totalApplicable and totalProcesses as interchangeable.
       ctApplicable++;
       if (cycleTime != null && cycleTime.getTarget() != null) {
         ctWithTarget++;
@@ -158,6 +187,7 @@ public class BusinessValueOverviewReadService {
       }
 
       final AutomationRateBlock automationRate = row.getAutomationRate();
+      // Same v1 invariant as ctApplicable above — see comment.
       arApplicable++;
       if (automationRate != null && automationRate.getTarget() != null) {
         arWithTarget++;
@@ -179,11 +209,19 @@ public class BusinessValueOverviewReadService {
       }
 
       if (isStale(row.getLastComputedAt(), now, staleThreshold)) {
-        triggerBackstop(row.getTenantId(), row.getProcessDefinitionKey(), range);
+        anyRowStale = true;
       }
     }
 
-    offTarget.sort(Comparator.comparingDouble(OffTargetEntryDto::gapPct).reversed());
+    // Fire at most one background compute per read, and only if this reader is the first to
+    // observe staleness. Firing one job per stale row would flood the common pool when every row
+    // is stale (post-deploy, missed scheduler tick), so the response-level flag collapses that
+    // fan-out into a single full-range recompute covering every (tenant, process, range) at once.
+    if (anyRowStale) {
+      triggerFullScopeBackstop();
+    }
+
+    offTarget.sort(Comparator.comparingDouble(OffTargetEntryDto::getGapPct).reversed());
 
     return new BusinessValueOverviewResponseDto(
         processesWithTarget > 0,
@@ -212,7 +250,8 @@ public class BusinessValueOverviewReadService {
         verdict.target(),
         displayUnit,
         verdict.gapPct(),
-        verdict.direction());
+        verdict.direction()); // verdict.direction() is "over"/"under" — matches
+    // OffTargetEntryDto.comparison
   }
 
   private BusinessValueOverviewResponseDto emptyResponse() {
@@ -254,50 +293,22 @@ public class BusinessValueOverviewReadService {
     return Duration.between(lastComputedAt, now).compareTo(staleThreshold) > 0;
   }
 
-  private void triggerBackstop(
-      final String tenantId, final String processDefinitionKey, final MetricRange range) {
-    final BackstopKey key = new BackstopKey(tenantId, processDefinitionKey, range);
-    if (inFlightBackstops.putIfAbsent(key, Boolean.TRUE) != null) {
-      // Another reader already scheduled the recompute for this row this refresh window.
+  private void triggerFullScopeBackstop() {
+    if (!backstopInFlight.compareAndSet(false, true)) {
+      // Another reader has already scheduled the full-scope recompute; nothing to do.
       return;
     }
-    LOG.info(
-        "Stale-read backstop firing for tenantId={} processDefinitionKey={} range={}",
-        tenantId,
-        processDefinitionKey,
-        range.getId());
+    LOG.info("Stale-read backstop firing full-scope recompute across every range and tenant pair.");
     CompletableFuture.runAsync(
-            () ->
-                computeService.computeOverviewRows(
-                    BusinessValueOverviewScope.definition(tenantId, processDefinitionKey),
-                    List.of(range),
-                    BusinessValueOverviewRefreshMode.SCHEDULER))
+            () -> computeService.computeOverviewRows(List.of(MetricRange.values())))
         .whenComplete(
             (result, throwable) -> {
-              inFlightBackstops.remove(key);
+              backstopInFlight.set(false);
               if (throwable != null) {
-                LOG.warn(
-                    "Stale-read backstop compute failed for tenantId={} processDefinitionKey={} range={}",
-                    tenantId,
-                    processDefinitionKey,
-                    range.getId(),
-                    throwable);
+                LOG.warn("Stale-read backstop compute failed", throwable);
               }
             });
   }
 
-  private record DefinitionKey(String tenantId, String processDefinitionKey) {
-    private DefinitionKey {
-      Objects.requireNonNull(tenantId, "tenantId");
-      Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
-    }
-  }
-
-  private record BackstopKey(String tenantId, String processDefinitionKey, MetricRange range) {
-    private BackstopKey {
-      Objects.requireNonNull(tenantId, "tenantId");
-      Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
-      Objects.requireNonNull(range, "range");
-    }
-  }
+  private record DefinitionKey(String tenantId, String processDefinitionKey) {}
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.businessvalue;
 
+import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
@@ -16,6 +17,8 @@ import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOvervie
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CategoryDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CoverageDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.OffTargetEntryDto;
+import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
@@ -23,8 +26,12 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -50,25 +57,54 @@ public class BusinessValueOverviewReadService {
 
   private final BusinessValueOverviewRepository overviewRepository;
   private final TenantService tenantService;
+  private final DefinitionService definitionService;
   private final BusinessValueOverviewComputeService computeService;
   private final ConfigurationService configurationService;
+
+  /**
+   * Coalesces backstop recomputes across concurrent readers so a single stale row triggers one
+   * background compute, not one per in-flight request. Entries are keyed by (tenantId,
+   * processDefinitionKey, metricRange) and removed once the compute future completes.
+   */
+  private final ConcurrentHashMap<BackstopKey, Boolean> inFlightBackstops =
+      new ConcurrentHashMap<>();
 
   public BusinessValueOverviewReadService(
       final BusinessValueOverviewRepository overviewRepository,
       final TenantService tenantService,
+      final DefinitionService definitionService,
       final BusinessValueOverviewComputeService computeService,
       final ConfigurationService configurationService) {
     this.overviewRepository = overviewRepository;
     this.tenantService = tenantService;
+    this.definitionService = definitionService;
     this.computeService = computeService;
     this.configurationService = configurationService;
   }
 
   public BusinessValueOverviewResponseDto getOverview(
       final String userId, final MetricRange range) {
+    final List<String> authorizedTenantIds = tenantService.getTenantIdsForUser(userId);
+    final List<BusinessValueOverviewDto> rawRows =
+        overviewRepository.readByRange(range, authorizedTenantIds);
+
+    if (rawRows.isEmpty()) {
+      return emptyResponse();
+    }
+
+    // Overview rows for deleted process definitions would otherwise persist forever — the
+    // scheduler stops upserting them but the repository has no deletion path today. Intersecting
+    // against the current fully-imported definition set at read time hides orphans immediately,
+    // and skipping them here also prevents the stale-read backstop from resurrecting them via
+    // computeService (which would otherwise fall back to a synthetic definition entry).
+    // Storage-level cleanup is tracked separately.
+    final Set<DefinitionKey> currentDefinitions = currentDefinitions();
     final List<BusinessValueOverviewDto> rows =
-        overviewRepository.readByRange(range).stream()
-            .filter(row -> tenantService.isAuthorizedToSeeTenant(userId, row.getTenantId()))
+        rawRows.stream()
+            .filter(
+                row ->
+                    currentDefinitions.contains(
+                        new DefinitionKey(row.getTenantId(), row.getProcessDefinitionKey())))
             .toList();
 
     if (rows.isEmpty()) {
@@ -104,7 +140,12 @@ public class BusinessValueOverviewReadService {
         ctWithTarget++;
         if (Boolean.TRUE.equals(cycleTime.getMet())) {
           ctMet++;
-        } else if (Boolean.FALSE.equals(cycleTime.getMet()) && cycleTime.getValue() != null) {
+        } else if (Boolean.FALSE.equals(cycleTime.getMet())
+            && cycleTime.getValue() != null
+            && cycleTime.getTarget() > 0L) {
+          // A cycle-time target of zero would produce Infinity gapPct (division by zero) and break
+          // the JSON contract. Front-end target validation is the source of truth; this guard
+          // survives if a zero target slips past it.
           offTarget.add(
               buildOffTargetEntry(
                   row,
@@ -123,7 +164,9 @@ public class BusinessValueOverviewReadService {
         if (Boolean.TRUE.equals(automationRate.getMet())) {
           arMet++;
         } else if (Boolean.FALSE.equals(automationRate.getMet())
-            && automationRate.getValue() != null) {
+            && automationRate.getValue() != null
+            && automationRate.getTarget() > 0) {
+          // Same zero-target guard as cycle time: a 0% automation target divides by zero on gapPct.
           offTarget.add(
               buildOffTargetEntry(
                   row,
@@ -183,6 +226,18 @@ public class BusinessValueOverviewReadService {
         List.of());
   }
 
+  private Set<DefinitionKey> currentDefinitions() {
+    final List<DefinitionWithTenantIdsDto> definitions =
+        definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS);
+    final Set<DefinitionKey> keys = new HashSet<>();
+    for (final DefinitionWithTenantIdsDto definition : definitions) {
+      for (final String tenantId : definition.getTenantIds()) {
+        keys.add(new DefinitionKey(tenantId, definition.getKey()));
+      }
+    }
+    return keys;
+  }
+
   private Duration staleThreshold() {
     final Long refreshInterval =
         configurationService.getBusinessValueConfiguration().getOverviewRefreshInterval();
@@ -201,6 +256,11 @@ public class BusinessValueOverviewReadService {
 
   private void triggerBackstop(
       final String tenantId, final String processDefinitionKey, final MetricRange range) {
+    final BackstopKey key = new BackstopKey(tenantId, processDefinitionKey, range);
+    if (inFlightBackstops.putIfAbsent(key, Boolean.TRUE) != null) {
+      // Another reader already scheduled the recompute for this row this refresh window.
+      return;
+    }
     LOG.info(
         "Stale-read backstop firing for tenantId={} processDefinitionKey={} range={}",
         tenantId,
@@ -212,15 +272,32 @@ public class BusinessValueOverviewReadService {
                     BusinessValueOverviewScope.definition(tenantId, processDefinitionKey),
                     List.of(range),
                     BusinessValueOverviewRefreshMode.SCHEDULER))
-        .exceptionally(
-            throwable -> {
-              LOG.warn(
-                  "Stale-read backstop compute failed for tenantId={} processDefinitionKey={} range={}",
-                  tenantId,
-                  processDefinitionKey,
-                  range.getId(),
-                  throwable);
-              return null;
+        .whenComplete(
+            (result, throwable) -> {
+              inFlightBackstops.remove(key);
+              if (throwable != null) {
+                LOG.warn(
+                    "Stale-read backstop compute failed for tenantId={} processDefinitionKey={} range={}",
+                    tenantId,
+                    processDefinitionKey,
+                    range.getId(),
+                    throwable);
+              }
             });
+  }
+
+  private record DefinitionKey(String tenantId, String processDefinitionKey) {
+    private DefinitionKey {
+      Objects.requireNonNull(tenantId, "tenantId");
+      Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
+    }
+  }
+
+  private record BackstopKey(String tenantId, String processDefinitionKey, MetricRange range) {
+    private BackstopKey {
+      Objects.requireNonNull(tenantId, "tenantId");
+      Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
+      Objects.requireNonNull(range, "range");
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.AttainmentDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CategoryDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CoverageDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.OffTargetEntryDto;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.tenant.TenantService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+/**
+ * Serves {@code GET /business-value/overview?range=<preset>} by reading precomputed rows from the
+ * {@code business-value-overview} index and assembling them per {@code
+ * bvd-target-technical-design.md} §5.3. No live report evaluation on this path — every heavy
+ * computation is already materialized by {@link BusinessValueOverviewComputeService}.
+ *
+ * <p>On each read, rows whose {@link BusinessValueOverviewDto#getLastComputedAt()} exceeds {@code 2
+ * ×} the configured refresh interval are recomputed asynchronously as a safety net for missed
+ * scheduler ticks (broker restart, deploy). The current request still returns the stale row; the
+ * next reader sees fresh data.
+ */
+@Component
+public class BusinessValueOverviewReadService {
+
+  private static final String CYCLE_TIME_DISPLAY_UNIT = "HOURS";
+  private static final String AUTOMATION_RATE_DISPLAY_UNIT = "PERCENT";
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewReadService.class);
+
+  private final BusinessValueOverviewRepository overviewRepository;
+  private final TenantService tenantService;
+  private final BusinessValueOverviewComputeService computeService;
+  private final ConfigurationService configurationService;
+
+  public BusinessValueOverviewReadService(
+      final BusinessValueOverviewRepository overviewRepository,
+      final TenantService tenantService,
+      final BusinessValueOverviewComputeService computeService,
+      final ConfigurationService configurationService) {
+    this.overviewRepository = overviewRepository;
+    this.tenantService = tenantService;
+    this.computeService = computeService;
+    this.configurationService = configurationService;
+  }
+
+  public BusinessValueOverviewResponseDto getOverview(
+      final String userId, final MetricRange range) {
+    final List<BusinessValueOverviewDto> rows =
+        overviewRepository.readByRange(range).stream()
+            .filter(row -> tenantService.isAuthorizedToSeeTenant(userId, row.getTenantId()))
+            .toList();
+
+    if (rows.isEmpty()) {
+      return emptyResponse();
+    }
+
+    final OffsetDateTime now = OffsetDateTime.now();
+    final Duration staleThreshold = staleThreshold();
+
+    int totalProcesses = 0;
+    int processesWithTarget = 0;
+    int targetsSet = 0;
+    int targetsMet = 0;
+    int ctWithTarget = 0;
+    int ctApplicable = 0;
+    int ctMet = 0;
+    int arWithTarget = 0;
+    int arApplicable = 0;
+    int arMet = 0;
+    final List<OffTargetEntryDto> offTarget = new ArrayList<>();
+
+    for (final BusinessValueOverviewDto row : rows) {
+      totalProcesses++;
+      if (row.isHasAnyTarget()) {
+        processesWithTarget++;
+      }
+      targetsSet += row.getTargetsSet();
+      targetsMet += row.getTargetsMet();
+
+      final CycleTimeBlock cycleTime = row.getCycleTime();
+      ctApplicable++;
+      if (cycleTime != null && cycleTime.getTarget() != null) {
+        ctWithTarget++;
+        if (Boolean.TRUE.equals(cycleTime.getMet())) {
+          ctMet++;
+        } else if (Boolean.FALSE.equals(cycleTime.getMet()) && cycleTime.getValue() != null) {
+          offTarget.add(
+              buildOffTargetEntry(
+                  row,
+                  Kpi.CYCLE_TIME,
+                  cycleTime.getValue().doubleValue(),
+                  cycleTime.getTarget().doubleValue(),
+                  CYCLE_TIME_DISPLAY_UNIT,
+                  Direction.LOWER_IS_BETTER));
+        }
+      }
+
+      final AutomationRateBlock automationRate = row.getAutomationRate();
+      arApplicable++;
+      if (automationRate != null && automationRate.getTarget() != null) {
+        arWithTarget++;
+        if (Boolean.TRUE.equals(automationRate.getMet())) {
+          arMet++;
+        } else if (Boolean.FALSE.equals(automationRate.getMet())
+            && automationRate.getValue() != null) {
+          offTarget.add(
+              buildOffTargetEntry(
+                  row,
+                  Kpi.AUTOMATION_RATE,
+                  automationRate.getValue(),
+                  automationRate.getTarget().doubleValue(),
+                  AUTOMATION_RATE_DISPLAY_UNIT,
+                  Direction.HIGHER_IS_BETTER));
+        }
+      }
+
+      if (isStale(row.getLastComputedAt(), now, staleThreshold)) {
+        triggerBackstop(row.getTenantId(), row.getProcessDefinitionKey(), range);
+      }
+    }
+
+    offTarget.sort(Comparator.comparingDouble(OffTargetEntryDto::gapPct).reversed());
+
+    return new BusinessValueOverviewResponseDto(
+        processesWithTarget > 0,
+        new CoverageDto(processesWithTarget, totalProcesses),
+        new AttainmentDto(targetsSet, targetsMet),
+        List.of(
+            new CategoryDto(Kpi.CYCLE_TIME.getId(), ctWithTarget, ctApplicable, ctMet),
+            new CategoryDto(Kpi.AUTOMATION_RATE.getId(), arWithTarget, arApplicable, arMet)),
+        offTarget);
+  }
+
+  private OffTargetEntryDto buildOffTargetEntry(
+      final BusinessValueOverviewDto row,
+      final Kpi kpi,
+      final double value,
+      final double target,
+      final String displayUnit,
+      final Direction direction) {
+    final Verdict verdict = BusinessValueVerdict.verdict(kpi, value, target, direction);
+    return new OffTargetEntryDto(
+        row.getTenantId(),
+        row.getProcessDefinitionKey(),
+        row.getProcessDefinitionName(),
+        kpi.getId(),
+        verdict.value(),
+        verdict.target(),
+        displayUnit,
+        verdict.gapPct(),
+        verdict.direction());
+  }
+
+  private BusinessValueOverviewResponseDto emptyResponse() {
+    return new BusinessValueOverviewResponseDto(
+        false,
+        new CoverageDto(0, 0),
+        new AttainmentDto(0, 0),
+        List.of(
+            new CategoryDto(Kpi.CYCLE_TIME.getId(), 0, 0, 0),
+            new CategoryDto(Kpi.AUTOMATION_RATE.getId(), 0, 0, 0)),
+        List.of());
+  }
+
+  private Duration staleThreshold() {
+    final Long refreshInterval =
+        configurationService.getBusinessValueConfiguration().getOverviewRefreshInterval();
+    return Duration.ofSeconds(2L * refreshInterval);
+  }
+
+  private static boolean isStale(
+      final OffsetDateTime lastComputedAt,
+      final OffsetDateTime now,
+      final Duration staleThreshold) {
+    if (lastComputedAt == null) {
+      return true;
+    }
+    return Duration.between(lastComputedAt, now).compareTo(staleThreshold) > 0;
+  }
+
+  private void triggerBackstop(
+      final String tenantId, final String processDefinitionKey, final MetricRange range) {
+    LOG.info(
+        "Stale-read backstop firing for tenantId={} processDefinitionKey={} range={}",
+        tenantId,
+        processDefinitionKey,
+        range.getId());
+    CompletableFuture.runAsync(
+            () ->
+                computeService.computeOverviewRows(
+                    BusinessValueOverviewScope.definition(tenantId, processDefinitionKey),
+                    List.of(range),
+                    BusinessValueOverviewRefreshMode.SCHEDULER))
+        .exceptionally(
+            throwable -> {
+              LOG.warn(
+                  "Stale-read backstop compute failed for tenantId={} processDefinitionKey={} range={}",
+                  tenantId,
+                  processDefinitionKey,
+                  range.getId(),
+                  throwable);
+              return null;
+            });
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueOverviewRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueOverviewRepository.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.db.repository;
 
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -22,7 +23,17 @@ public interface BusinessValueOverviewRepository {
   Optional<BusinessValueOverviewDto> getByKey(
       String tenantId, String processDefinitionKey, MetricRange metricRange);
 
-  List<BusinessValueOverviewDto> readByRange(MetricRange metricRange);
+  /**
+   * Reads business-value overview rows for the given range, optionally restricted to a subset of
+   * tenant identifiers.
+   *
+   * <p>Passing {@code null} for {@code tenantIds} returns every row for the range and is reserved
+   * for internal, tenant-agnostic callers. Passing an empty collection returns no rows — a shortcut
+   * for callers that have already determined the caller sees no tenants. Any non-empty collection
+   * is pushed down to a {@code terms} filter on the tenant identifier so the read stays bounded
+   * even when the fleet-wide row count exceeds the repository's fetch limit.
+   */
+  List<BusinessValueOverviewDto> readByRange(MetricRange metricRange, Collection<String> tenantIds);
 
   static String documentId(
       final String tenantId, final String processDefinitionKey, final MetricRange metricRange) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueOverviewRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueOverviewRepositoryES.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.repository.es;
 import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_OVERVIEW_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
@@ -27,6 +28,7 @@ import io.camunda.optimize.service.db.schema.index.BusinessValueOverviewIndex;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -103,20 +105,40 @@ public class BusinessValueOverviewRepositoryES implements BusinessValueOverviewR
   }
 
   @Override
-  public List<BusinessValueOverviewDto> readByRange(final MetricRange metricRange) {
+  public List<BusinessValueOverviewDto> readByRange(
+      final MetricRange metricRange, final Collection<String> tenantIds) {
     if (metricRange == null) {
       throw new IllegalArgumentException("metricRange must not be null");
     }
+    if (tenantIds != null && tenantIds.isEmpty()) {
+      return List.of();
+    }
+    final List<FieldValue> tenantFieldValues =
+        tenantIds == null ? null : tenantIds.stream().map(FieldValue::of).toList();
     final SearchRequest searchRequest =
         OptimizeSearchRequestBuilderES.of(
             b ->
                 b.optimizeIndex(esClient, BUSINESS_VALUE_OVERVIEW_INDEX_NAME)
                     .query(
                         q ->
-                            q.term(
-                                t ->
-                                    t.field(BusinessValueOverviewIndex.METRIC_RANGE)
-                                        .value(metricRange.getId())))
+                            q.bool(
+                                bool -> {
+                                  bool.must(
+                                      m ->
+                                          m.term(
+                                              t ->
+                                                  t.field(BusinessValueOverviewIndex.METRIC_RANGE)
+                                                      .value(metricRange.getId())));
+                                  if (tenantFieldValues != null) {
+                                    bool.must(
+                                        m ->
+                                            m.terms(
+                                                t ->
+                                                    t.field(BusinessValueOverviewIndex.TENANT_ID)
+                                                        .terms(tt -> tt.value(tenantFieldValues))));
+                                  }
+                                  return bool;
+                                }))
                     .size(LIST_FETCH_LIMIT));
     final SearchResponse<BusinessValueOverviewDto> response;
     try {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueOverviewRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueOverviewRepositoryOS.java
@@ -9,6 +9,8 @@ package io.camunda.optimize.service.db.repository.os;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_OVERVIEW_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.and;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.stringTerms;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.term;
 import static java.lang.String.format;
 
@@ -20,9 +22,11 @@ import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
 import io.camunda.optimize.service.db.schema.index.BusinessValueOverviewIndex;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.GetRequest;
 import org.opensearch.client.opensearch.core.GetResponse;
@@ -98,15 +102,24 @@ public class BusinessValueOverviewRepositoryOS implements BusinessValueOverviewR
   }
 
   @Override
-  public List<BusinessValueOverviewDto> readByRange(final MetricRange metricRange) {
+  public List<BusinessValueOverviewDto> readByRange(
+      final MetricRange metricRange, final Collection<String> tenantIds) {
     if (metricRange == null) {
       throw new IllegalArgumentException("metricRange must not be null");
     }
+    if (tenantIds != null && tenantIds.isEmpty()) {
+      return List.of();
+    }
+    final Query rangeTerm = term(BusinessValueOverviewIndex.METRIC_RANGE, metricRange.getId());
+    final Query query =
+        tenantIds == null
+            ? rangeTerm
+            : and(rangeTerm, stringTerms(BusinessValueOverviewIndex.TENANT_ID, tenantIds));
     final SearchRequest.Builder requestBuilder =
         new SearchRequest.Builder()
             .index(
                 indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_OVERVIEW_INDEX_NAME))
-            .query(term(BusinessValueOverviewIndex.METRIC_RANGE, metricRange.getId()))
+            .query(query)
             .size(LIST_FETCH_LIMIT);
     final List<BusinessValueOverviewDto> rows =
         osClient.searchValues(requestBuilder, BusinessValueOverviewDto.class);

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/BusinessValueOverviewRestServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/BusinessValueOverviewRestServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.AttainmentDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CoverageDto;
+import io.camunda.optimize.rest.exceptions.BadRequestException;
+import io.camunda.optimize.service.businessvalue.BusinessValueOverviewReadService;
+import io.camunda.optimize.service.security.SessionService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BusinessValueOverviewRestServiceTest {
+
+  private static final String USER = "demo";
+
+  private BusinessValueOverviewReadService readService;
+  private SessionService sessionService;
+  private HttpServletRequest request;
+  private BusinessValueOverviewRestService restService;
+
+  @BeforeEach
+  void setUp() {
+    readService = mock(BusinessValueOverviewReadService.class);
+    sessionService = mock(SessionService.class);
+    request = mock(HttpServletRequest.class);
+    when(sessionService.getRequestUserOrFailNotAuthorized(any())).thenReturn(USER);
+    restService = new BusinessValueOverviewRestService(readService, sessionService);
+  }
+
+  @Test
+  void shouldDelegateToReadServiceForValidRange() {
+    // given
+    final BusinessValueOverviewResponseDto expected =
+        new BusinessValueOverviewResponseDto(
+            false, new CoverageDto(0, 0), new AttainmentDto(0, 0), List.of(), List.of());
+    when(readService.getOverview(USER, MetricRange.THIRTY_DAYS)).thenReturn(expected);
+
+    // when
+    final BusinessValueOverviewResponseDto response = restService.getOverview("30d", request);
+
+    // then
+    assertThat(response).isSameAs(expected);
+    verify(readService).getOverview(USER, MetricRange.THIRTY_DAYS);
+  }
+
+  @Test
+  void shouldRejectUnknownRangeWithBadRequest() {
+    // 12m is intentionally excluded — SaaS retains only 180 days, see tech design §1
+    assertThatThrownBy(() -> restService.getOverview("12m", request))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("12m");
+  }
+
+  @Test
+  void shouldRejectNullRangeWithBadRequest() {
+    assertThatThrownBy(() -> restService.getOverview(null, request))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  void shouldPropagateAuthorizationErrorFromSessionService() {
+    // given
+    when(sessionService.getRequestUserOrFailNotAuthorized(any()))
+        .thenThrow(new io.camunda.optimize.rest.exceptions.NotAuthorizedException("nope"));
+
+    // when / then
+    assertThatThrownBy(() -> restService.getOverview("30d", request))
+        .isInstanceOf(io.camunda.optimize.rest.exceptions.NotAuthorizedException.class);
+  }
+
+  @Test
+  void shouldFailWhenReadServiceThrows() {
+    // given
+    when(readService.getOverview(anyString(), any())).thenThrow(new IllegalStateException("boom"));
+
+    // when / then
+    assertThatThrownBy(() -> restService.getOverview("30d", request))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/BusinessValueOverviewRestServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/BusinessValueOverviewRestServiceTest.java
@@ -64,6 +64,7 @@ class BusinessValueOverviewRestServiceTest {
   @Test
   void shouldRejectUnknownRangeWithBadRequest() {
     // 12m is intentionally excluded — SaaS retains only 180 days, see tech design §1
+    // given
     assertThatThrownBy(() -> restService.getOverview("12m", request))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("12m");
@@ -71,6 +72,7 @@ class BusinessValueOverviewRestServiceTest {
 
   @Test
   void shouldRejectNullRangeWithBadRequest() {
+    // given
     assertThatThrownBy(() -> restService.getOverview(null, request))
         .isInstanceOf(BadRequestException.class);
   }
@@ -81,7 +83,7 @@ class BusinessValueOverviewRestServiceTest {
     when(sessionService.getRequestUserOrFailNotAuthorized(any()))
         .thenThrow(new io.camunda.optimize.rest.exceptions.NotAuthorizedException("nope"));
 
-    // when / then
+    // when
     assertThatThrownBy(() -> restService.getOverview("30d", request))
         .isInstanceOf(io.camunda.optimize.rest.exceptions.NotAuthorizedException.class);
   }
@@ -91,7 +93,7 @@ class BusinessValueOverviewRestServiceTest {
     // given
     when(readService.getOverview(anyString(), any())).thenThrow(new IllegalStateException("boom"));
 
-    // when / then
+    // when
     assertThatThrownBy(() -> restService.getOverview("30d", request))
         .isInstanceOf(IllegalStateException.class);
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/BusinessValueOverviewRestServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/BusinessValueOverviewRestServiceTest.java
@@ -26,6 +26,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class BusinessValueOverviewRestServiceTest {
 
@@ -45,36 +49,73 @@ class BusinessValueOverviewRestServiceTest {
     restService = new BusinessValueOverviewRestService(readService, sessionService);
   }
 
-  @Test
-  void shouldDelegateToReadServiceForValidRange() {
+  @ParameterizedTest(name = "range={0} → resolves to {1}")
+  @CsvSource({"7d,  SEVEN_DAYS", "30d, THIRTY_DAYS", "3m,  THREE_MONTHS", "6m,  SIX_MONTHS"})
+  void shouldDelegateToReadServiceForEveryValidRangePreset(
+      final String rangeParam, final MetricRange expected) {
     // given
-    final BusinessValueOverviewResponseDto expected =
+    final BusinessValueOverviewResponseDto expectedResponse =
         new BusinessValueOverviewResponseDto(
             false, new CoverageDto(0, 0), new AttainmentDto(0, 0), List.of(), List.of());
-    when(readService.getOverview(USER, MetricRange.THIRTY_DAYS)).thenReturn(expected);
+    when(readService.getOverview(USER, expected)).thenReturn(expectedResponse);
 
     // when
-    final BusinessValueOverviewResponseDto response = restService.getOverview("30d", request);
+    final BusinessValueOverviewResponseDto response = restService.getOverview(rangeParam, request);
 
     // then
-    assertThat(response).isSameAs(expected);
-    verify(readService).getOverview(USER, MetricRange.THIRTY_DAYS);
+    assertThat(response).isSameAs(expectedResponse);
+    verify(readService).getOverview(USER, expected);
   }
 
   @Test
   void shouldRejectUnknownRangeWithBadRequest() {
-    // 12m is intentionally excluded — SaaS retains only 180 days, see tech design §1
-    // given
+    // 12m is intentionally excluded because SaaS retains only 180 days — see tech design §1.
+    // given / when / then
     assertThatThrownBy(() -> restService.getOverview("12m", request))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("12m");
   }
 
-  @Test
-  void shouldRejectNullRangeWithBadRequest() {
-    // given
-    assertThatThrownBy(() -> restService.getOverview(null, request))
+  @ParameterizedTest(name = "range=\"{0}\" is rejected with 400")
+  @ValueSource(strings = {"12m", "1y", "xyz", "30 d", "30D", "7D", "3M", "6M", " 30d", "30d "})
+  void shouldRejectAnyOtherRangeStringWithBadRequest(final String rangeParam) {
+    // MetricRange.fromId is intentionally case-sensitive and does not trim, so anything that
+    // doesn't match one of the four canonical presets — including case variants and stray
+    // whitespace — falls into the same failure bucket as an obviously-bad "xyz".
+    // given / when / then
+    assertThatThrownBy(() -> restService.getOverview(rangeParam, request))
         .isInstanceOf(BadRequestException.class);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldRejectNullOrEmptyRangeWithBadRequest(final String rangeParam) {
+    // given / when / then
+    assertThatThrownBy(() -> restService.getOverview(rangeParam, request))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @ParameterizedTest(name = "range=\"{0}\" (special-char payload) is rejected safely")
+  @ValueSource(
+      strings = {
+        "' OR '1'='1",
+        "\"; DROP INDEX overview; --",
+        "<script>alert(1)</script>",
+        "../../etc/passwd",
+        "%00",
+        "%2F30d",
+        "30d%00",
+        "30d\n7d",
+        "30d;7d"
+      })
+  void shouldRejectSpecialCharacterPayloadsAsBadRequestWithoutReachingTheService(
+      final String rangeParam) {
+    // Anything that isn't one of the four canonical presets is a plain 400; the important part
+    // is that no injection-style payload flows through to the read service or the datastore.
+    // given / when / then
+    assertThatThrownBy(() -> restService.getOverview(rangeParam, request))
+        .isInstanceOf(BadRequestException.class);
+    verify(readService, org.mockito.Mockito.never()).getOverview(any(), any());
   }
 
   @Test
@@ -83,9 +124,24 @@ class BusinessValueOverviewRestServiceTest {
     when(sessionService.getRequestUserOrFailNotAuthorized(any()))
         .thenThrow(new io.camunda.optimize.rest.exceptions.NotAuthorizedException("nope"));
 
-    // when
+    // when / then
     assertThatThrownBy(() -> restService.getOverview("30d", request))
         .isInstanceOf(io.camunda.optimize.rest.exceptions.NotAuthorizedException.class);
+  }
+
+  @Test
+  void shouldNotInvokeReadServiceWhenAuthorizationFailsForAnOtherwiseValidRange() {
+    // A malformed range is caught before auth; a valid range with a bad session must still
+    // bail out before hitting the read service. This makes the ordering — auth first, then
+    // range parsing — an assertion rather than an implementation detail.
+    // given
+    when(sessionService.getRequestUserOrFailNotAuthorized(any()))
+        .thenThrow(new io.camunda.optimize.rest.exceptions.NotAuthorizedException("nope"));
+
+    // when / then
+    assertThatThrownBy(() -> restService.getOverview("30d", request))
+        .isInstanceOf(io.camunda.optimize.rest.exceptions.NotAuthorizedException.class);
+    verify(readService, org.mockito.Mockito.never()).getOverview(any(), any());
   }
 
   @Test
@@ -93,7 +149,7 @@ class BusinessValueOverviewRestServiceTest {
     // given
     when(readService.getOverview(anyString(), any())).thenThrow(new IllegalStateException("boom"));
 
-    // when
+    // when / then
     assertThatThrownBy(() -> restService.getOverview("30d", request))
         .isInstanceOf(IllegalStateException.class);
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
@@ -81,11 +81,14 @@ class BusinessValueOverviewReadServiceTest {
 
   @Test
   void shouldPushDownAuthorizedTenantIdsToTheRepository() {
+    // given
     when(tenantService.getTenantIdsForUser(USER)).thenReturn(List.of(TENANT_A, "tenant-b"));
     when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
 
+    // when
     readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
+    // then
     final ArgumentCaptor<Collection<String>> captor = collectionCaptor();
     verify(overviewRepository).readByRange(eq(MetricRange.THIRTY_DAYS), captor.capture());
     assertThat(captor.getValue()).containsExactlyInAnyOrder(TENANT_A, "tenant-b");
@@ -93,72 +96,82 @@ class BusinessValueOverviewReadServiceTest {
 
   @Test
   void shouldReturnEmptyResponseWhenNoRows() {
+    // given
     when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    assertThat(response.hasAnyTarget()).isFalse();
-    assertThat(response.coverage().processesWithTarget()).isZero();
-    assertThat(response.coverage().totalProcesses()).isZero();
-    assertThat(response.attainment().targetsSet()).isZero();
-    assertThat(response.attainment().targetsMet()).isZero();
-    assertThat(response.categories()).hasSize(2);
-    assertThat(response.categories())
-        .extracting(BusinessValueOverviewResponseDto.CategoryDto::kpi)
+    // then
+    assertThat(response.isHasAnyTarget()).isFalse();
+    assertThat(response.getCoverage().getProcessesWithTarget()).isZero();
+    assertThat(response.getCoverage().getTotalProcesses()).isZero();
+    assertThat(response.getAttainment().getTargetsSet()).isZero();
+    assertThat(response.getAttainment().getTargetsMet()).isZero();
+    assertThat(response.getCategories()).hasSize(2);
+    assertThat(response.getCategories())
+        .extracting(BusinessValueOverviewResponseDto.CategoryDto::getKpi)
         .containsExactly("cycleTime", "automationRate");
-    assertThat(response.offTarget()).isEmpty();
+    assertThat(response.getOffTarget()).isEmpty();
   }
 
   @Test
   void shouldReportCoverageAndAttainmentCounts() {
+    // given
     seedRows(
         MetricRange.THIRTY_DAYS,
         fresh(row(TENANT_A, "proc-1", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
         fresh(row(TENANT_A, "proc-2", cycNull(), aut(60.0, 85, false), 1, 0)),
         fresh(row(TENANT_A, "proc-3", cycNull(), autoNull(), 0, 0)));
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    assertThat(response.hasAnyTarget()).isTrue();
-    assertThat(response.coverage().processesWithTarget()).isEqualTo(2);
-    assertThat(response.coverage().totalProcesses()).isEqualTo(3);
-    assertThat(response.attainment().targetsSet()).isEqualTo(2);
-    assertThat(response.attainment().targetsMet()).isEqualTo(1);
+    // then
+    assertThat(response.isHasAnyTarget()).isTrue();
+    assertThat(response.getCoverage().getProcessesWithTarget()).isEqualTo(2);
+    assertThat(response.getCoverage().getTotalProcesses()).isEqualTo(3);
+    assertThat(response.getAttainment().getTargetsSet()).isEqualTo(2);
+    assertThat(response.getAttainment().getTargetsMet()).isEqualTo(1);
   }
 
   @Test
   void shouldBuildCategoriesForBothKpisWithZeroSafeArithmetic() {
+    // given
     seedRows(
         MetricRange.THIRTY_DAYS,
         fresh(row(TENANT_A, "proc-cyc-met", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
         fresh(row(TENANT_A, "proc-auto-missed", cycNull(), aut(70.0, 90, false), 1, 0)));
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
+    // then
     final BusinessValueOverviewResponseDto.CategoryDto cycleTimeCategory =
-        response.categories().stream()
-            .filter(c -> c.kpi().equals("cycleTime"))
+        response.getCategories().stream()
+            .filter(c -> c.getKpi().equals("cycleTime"))
             .findFirst()
             .orElseThrow();
-    assertThat(cycleTimeCategory.processesWithTarget()).isEqualTo(1);
-    assertThat(cycleTimeCategory.totalApplicable()).isEqualTo(2);
-    assertThat(cycleTimeCategory.targetsMet()).isEqualTo(1);
+    assertThat(cycleTimeCategory.getProcessesWithTarget()).isEqualTo(1);
+    assertThat(cycleTimeCategory.getTotalApplicable()).isEqualTo(2);
+    assertThat(cycleTimeCategory.getTargetsMet()).isEqualTo(1);
 
     final BusinessValueOverviewResponseDto.CategoryDto automationRateCategory =
-        response.categories().stream()
-            .filter(c -> c.kpi().equals("automationRate"))
+        response.getCategories().stream()
+            .filter(c -> c.getKpi().equals("automationRate"))
             .findFirst()
             .orElseThrow();
-    assertThat(automationRateCategory.processesWithTarget()).isEqualTo(1);
-    assertThat(automationRateCategory.totalApplicable()).isEqualTo(2);
-    assertThat(automationRateCategory.targetsMet()).isZero();
+    assertThat(automationRateCategory.getProcessesWithTarget()).isEqualTo(1);
+    assertThat(automationRateCategory.getTotalApplicable()).isEqualTo(2);
+    assertThat(automationRateCategory.getTargetsMet()).isZero();
   }
 
   @Test
   void shouldEmitOffTargetOnlyForRowsWithTargetAndNotMet() {
+    // given
     seedRows(
         MetricRange.THIRTY_DAYS,
         fresh(row(TENANT_A, "proc-no-target", cycNull(), autoNull(), 0, 0)),
@@ -173,57 +186,65 @@ class BusinessValueOverviewReadServiceTest {
                 1,
                 0)));
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    assertThat(response.offTarget())
-        .extracting(BusinessValueOverviewResponseDto.OffTargetEntryDto::processKey)
+    // then
+    assertThat(response.getOffTarget())
+        .extracting(BusinessValueOverviewResponseDto.OffTargetEntryDto::getProcessKey)
         .containsExactly("proc-missed");
   }
 
   @Test
   void shouldSortOffTargetByGapPctDescending() {
+    // given
     seedRows(
         MetricRange.THIRTY_DAYS,
         fresh(row(TENANT_A, "proc-25pct", cyc(10_000L, 8_000L, false), autoNull(), 1, 0)),
         fresh(row(TENANT_A, "proc-50pct", cyc(12_000L, 8_000L, false), autoNull(), 1, 0)),
         fresh(row(TENANT_A, "proc-10pct", cyc(8_800L, 8_000L, false), autoNull(), 1, 0)));
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    assertThat(response.offTarget())
-        .extracting(BusinessValueOverviewResponseDto.OffTargetEntryDto::processKey)
+    // then
+    assertThat(response.getOffTarget())
+        .extracting(BusinessValueOverviewResponseDto.OffTargetEntryDto::getProcessKey)
         .containsExactly("proc-50pct", "proc-25pct", "proc-10pct");
   }
 
   @Test
   void shouldComputeGapPctAndDirectionFromVerdictHelper() {
+    // given
     seedRows(
         MetricRange.THIRTY_DAYS,
         fresh(row(TENANT_A, "cyc", cyc(10L, 8L, false), autoNull(), 1, 0)),
         fresh(row(TENANT_A, "aut", cycNull(), aut(70.0, 85, false), 1, 0)));
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
+    // then
     final BusinessValueOverviewResponseDto.OffTargetEntryDto cycEntry =
-        response.offTarget().stream()
-            .filter(e -> e.kpi().equals("cycleTime"))
+        response.getOffTarget().stream()
+            .filter(e -> e.getKpi().equals("cycleTime"))
             .findFirst()
             .orElseThrow();
-    assertThat(cycEntry.gapPct()).isEqualTo(25.0);
-    assertThat(cycEntry.direction()).isEqualTo("over");
-    assertThat(cycEntry.displayUnit()).isEqualTo("HOURS");
+    assertThat(cycEntry.getGapPct()).isEqualTo(25.0);
+    assertThat(cycEntry.getComparison()).isEqualTo("over");
+    assertThat(cycEntry.getDisplayUnit()).isEqualTo("HOURS");
 
     final BusinessValueOverviewResponseDto.OffTargetEntryDto autoEntry =
-        response.offTarget().stream()
-            .filter(e -> e.kpi().equals("automationRate"))
+        response.getOffTarget().stream()
+            .filter(e -> e.getKpi().equals("automationRate"))
             .findFirst()
             .orElseThrow();
-    assertThat(autoEntry.gapPct()).isEqualTo(17.647058823529413);
-    assertThat(autoEntry.direction()).isEqualTo("under");
-    assertThat(autoEntry.displayUnit()).isEqualTo("PERCENT");
+    assertThat(autoEntry.getGapPct()).isEqualTo(17.647058823529413);
+    assertThat(autoEntry.getComparison()).isEqualTo("under");
+    assertThat(autoEntry.getDisplayUnit()).isEqualTo("PERCENT");
   }
 
   @Test
@@ -231,26 +252,32 @@ class BusinessValueOverviewReadServiceTest {
     // Target = 0 is nonsensical for cycle time (LOWER_IS_BETTER) and would produce Infinity gapPct
     // via division by zero, breaking JSON. Frontend validation is the source of truth; this guard
     // survives if the frontend is bypassed or a legacy target row leaks in.
+    // given
     seedRows(
         MetricRange.THIRTY_DAYS,
         fresh(row(TENANT_A, "zero-target", cyc(100L, 0L, false), autoNull(), 1, 0)));
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    assertThat(response.offTarget()).isEmpty();
+    // then
+    assertThat(response.getOffTarget()).isEmpty();
   }
 
   @Test
   void shouldSkipOffTargetEntryWhenAutomationRateTargetIsZero() {
+    // given
     seedRows(
         MetricRange.THIRTY_DAYS,
         fresh(row(TENANT_A, "zero-auto", cycNull(), aut(0.0, 0, false), 1, 0)));
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    assertThat(response.offTarget()).isEmpty();
+    // then
+    assertThat(response.getOffTarget()).isEmpty();
   }
 
   @Test
@@ -259,6 +286,7 @@ class BusinessValueOverviewReadServiceTest {
     // row for the deleted definition must not appear in the response and must not trigger the
     // backstop, otherwise the compute service would immediately recreate the row via its
     // synthetic-definition fallback and orphans would never age out.
+    // given
     final BusinessValueOverviewDto liveRow =
         fresh(row(TENANT_A, "still-here", cyc(6_000L, 8_000L, true), autoNull(), 1, 1));
     final BusinessValueOverviewDto orphanRow =
@@ -269,40 +297,48 @@ class BusinessValueOverviewReadServiceTest {
         .thenReturn(List.of(liveRow, orphanRow));
     stubCurrentDefinitions(new DefKey(TENANT_A, "still-here"));
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    assertThat(response.coverage().totalProcesses()).isEqualTo(1);
-    assertThat(response.coverage().processesWithTarget()).isEqualTo(1);
-    assertThat(response.attainment().targetsSet()).isEqualTo(1);
-    assertThat(response.attainment().targetsMet()).isEqualTo(1);
-    assertThat(response.offTarget()).isEmpty();
+    // then
+    assertThat(response.getCoverage().getTotalProcesses()).isEqualTo(1);
+    assertThat(response.getCoverage().getProcessesWithTarget()).isEqualTo(1);
+    assertThat(response.getAttainment().getTargetsSet()).isEqualTo(1);
+    assertThat(response.getAttainment().getTargetsMet()).isEqualTo(1);
+    assertThat(response.getOffTarget()).isEmpty();
 
     Awaitility.await()
         .during(java.time.Duration.ofMillis(150))
         .atMost(java.time.Duration.ofMillis(500))
-        .untilAsserted(
-            () -> verify(computeService, never()).computeOverviewRows(any(), anyList(), any()));
+        .untilAsserted(() -> verify(computeService, never()).computeOverviewRows(anyList()));
   }
 
   @Test
   void shouldReturnEmptyResponseWhenEveryRowIsOrphaned() {
+    // given
     when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
         .thenReturn(
             List.of(fresh(row(TENANT_A, "gone-1", cyc(6_000L, 8_000L, true), autoNull(), 1, 1))));
     when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
         .thenReturn(List.of());
 
+    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    assertThat(response.hasAnyTarget()).isFalse();
-    assertThat(response.coverage().totalProcesses()).isZero();
-    assertThat(response.offTarget()).isEmpty();
+    // then
+    assertThat(response.isHasAnyTarget()).isFalse();
+    assertThat(response.getCoverage().getTotalProcesses()).isZero();
+    assertThat(response.getOffTarget()).isEmpty();
   }
 
   @Test
-  void shouldFireStaleBackstopWhenLastComputedAtOlderThanTwoTimesInterval() {
+  void shouldFireFullScopeBackstopWhenAnyRowIsStale() {
+    // A single stale row triggers a full-scope recompute across every range. Firing per row
+    // would flood the common pool when N rows are simultaneously stale (post-deploy, missed
+    // scheduler tick); the response-level flag collapses that fan-out into one job.
+    // given
     final BusinessValueOverviewDto staleRow =
         stamp(
             row(TENANT_A, "proc-stale", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
@@ -311,37 +347,67 @@ class BusinessValueOverviewReadServiceTest {
         .thenReturn(List.of(staleRow));
     stubCurrentDefinitions(new DefKey(TENANT_A, "proc-stale"));
 
+    // when
     readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
+    // then
     Awaitility.await()
         .untilAsserted(
-            () ->
-                verify(computeService)
-                    .computeOverviewRows(
-                        eq(
-                            BusinessValueOverviewScope.definition(
-                                staleRow.getTenantId(), staleRow.getProcessDefinitionKey())),
-                        eq(List.of(MetricRange.THIRTY_DAYS)),
-                        eq(BusinessValueOverviewRefreshMode.SCHEDULER)));
+            () -> verify(computeService).computeOverviewRows(eq(List.of(MetricRange.values()))));
   }
 
   @Test
   void shouldNotFireBackstopWhenFresh() {
+    // given
     seedRows(
         MetricRange.THIRTY_DAYS,
         fresh(row(TENANT_A, "proc-fresh", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)));
 
+    // when
     readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
+    // then
     Awaitility.await()
         .during(java.time.Duration.ofMillis(150))
         .atMost(java.time.Duration.ofMillis(500))
-        .untilAsserted(
-            () -> verify(computeService, never()).computeOverviewRows(any(), anyList(), any()));
+        .untilAsserted(() -> verify(computeService, never()).computeOverviewRows(anyList()));
   }
 
   @Test
-  void shouldCoalesceConcurrentBackstopsForTheSameStaleRow() {
+  void shouldFireBackstopOnceEvenWhenManyRowsAreStale() {
+    // Every row stale is the load pattern that motivated the flag — post-deploy or missed
+    // scheduler tick, the whole page is stale at once. One recompute must cover it, not N.
+    // given
+    final List<BusinessValueOverviewDto> staleRows =
+        List.of(
+            stamp(
+                row(TENANT_A, "proc-a", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
+                NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS)),
+            stamp(
+                row(TENANT_A, "proc-b", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
+                NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS)),
+            stamp(
+                row(TENANT_A, "proc-c", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
+                NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS)));
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(staleRows);
+    stubCurrentDefinitions(
+        new DefKey(TENANT_A, "proc-a"),
+        new DefKey(TENANT_A, "proc-b"),
+        new DefKey(TENANT_A, "proc-c"));
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    Awaitility.await()
+        .untilAsserted(() -> verify(computeService, times(1)).computeOverviewRows(anyList()));
+  }
+
+  @Test
+  void shouldCollapseConcurrentBackstopsIntoASingleRecompute() {
+    // Two overlapping reads while the first backstop is still running must not schedule a second
+    // full-scope job — the in-flight flag blocks re-entry until the compute future settles.
+    // given
     final BusinessValueOverviewDto staleRow =
         stamp(
             row(TENANT_A, "proc-hot", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
@@ -350,6 +416,7 @@ class BusinessValueOverviewReadServiceTest {
         .thenReturn(List.of(staleRow));
     stubCurrentDefinitions(new DefKey(TENANT_A, "proc-hot"));
 
+    // when
     final java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
     org.mockito.Mockito.doAnswer(
             invocation -> {
@@ -357,22 +424,26 @@ class BusinessValueOverviewReadServiceTest {
               return null;
             })
         .when(computeService)
-        .computeOverviewRows(any(), anyList(), any());
+        .computeOverviewRows(anyList());
 
+    // then
     readService.getOverview(USER, MetricRange.THIRTY_DAYS);
     readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
     Awaitility.await()
         .during(java.time.Duration.ofMillis(200))
         .atMost(java.time.Duration.ofMillis(500))
-        .untilAsserted(
-            () -> verify(computeService, times(1)).computeOverviewRows(any(), anyList(), any()));
+        .untilAsserted(() -> verify(computeService, times(1)).computeOverviewRows(anyList()));
 
     release.countDown();
   }
 
   @Test
-  void shouldPropagateTheStaleRangeToTheBackstop() {
+  void shouldHealEveryRangeInASingleBackstopCall() {
+    // The backstop's purpose is to recover from a stopped scheduler; that scheduler sweeps every
+    // range in one pass, so the backstop must do the same. If it only healed the current range,
+    // switching the range tab after a deploy would trigger another wave of compute work.
+    // given
     final BusinessValueOverviewDto staleRow =
         stamp(
             row(TENANT_A, "proc-x", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
@@ -381,13 +452,14 @@ class BusinessValueOverviewReadServiceTest {
         .thenReturn(List.of(staleRow));
     stubCurrentDefinitions(new DefKey(TENANT_A, "proc-x"));
 
+    // when
     readService.getOverview(USER, MetricRange.SIX_MONTHS);
 
+    // then
     final ArgumentCaptor<List<MetricRange>> ranges = argCaptor();
     Awaitility.await()
-        .untilAsserted(
-            () -> verify(computeService).computeOverviewRows(any(), ranges.capture(), any()));
-    assertThat(ranges.getValue()).containsExactly(MetricRange.SIX_MONTHS);
+        .untilAsserted(() -> verify(computeService).computeOverviewRows(ranges.capture()));
+    assertThat(ranges.getValue()).containsExactlyInAnyOrder(MetricRange.values());
   }
 
   private void seedRows(final MetricRange range, final BusinessValueOverviewDto... rows) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
@@ -95,6 +95,28 @@ class BusinessValueOverviewReadServiceTest {
   }
 
   @Test
+  void shouldPassAnEmptyListWhenUserIsAuthorizedToNoTenants() {
+    // A user with zero authorized tenants is a legitimate state — new customer, tenant assignment
+    // pending, role that doesn't grant any tenant access. The read must still short-circuit
+    // cleanly: pass an empty collection so the repository's is-empty guard returns immediately
+    // without hitting the datastore.
+    // given
+    when(tenantService.getTenantIdsForUser(USER)).thenReturn(List.of());
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    final ArgumentCaptor<Collection<String>> captor = collectionCaptor();
+    verify(overviewRepository).readByRange(eq(MetricRange.THIRTY_DAYS), captor.capture());
+    assertThat(captor.getValue()).isEmpty();
+    assertThat(response.isHasAnyTarget()).isFalse();
+    assertThat(response.getCoverage().getTotalProcesses()).isZero();
+  }
+
+  @Test
   void shouldReturnEmptyResponseWhenNoRows() {
     // given
     when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.tenant.TenantService;
+import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BusinessValueOverviewReadServiceTest {
+
+  private static final String USER = "user-1";
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+  private static final long REFRESH_INTERVAL_SECONDS = 86_400L;
+  private static final OffsetDateTime NOW = OffsetDateTime.now(ZoneOffset.UTC);
+
+  private BusinessValueOverviewRepository overviewRepository;
+  private TenantService tenantService;
+  private BusinessValueOverviewComputeService computeService;
+  private BusinessValueOverviewReadService readService;
+
+  @BeforeEach
+  void setUp() {
+    overviewRepository = mock(BusinessValueOverviewRepository.class);
+    tenantService = mock(TenantService.class);
+    computeService = mock(BusinessValueOverviewComputeService.class);
+    final ConfigurationService configurationService = mock(ConfigurationService.class);
+    final BusinessValueConfiguration businessValueConfiguration = new BusinessValueConfiguration();
+    businessValueConfiguration.setOverviewRefreshInterval(REFRESH_INTERVAL_SECONDS);
+    when(configurationService.getBusinessValueConfiguration())
+        .thenReturn(businessValueConfiguration);
+    when(tenantService.isAuthorizedToSeeTenant(anyString(), anyString())).thenReturn(true);
+    readService =
+        new BusinessValueOverviewReadService(
+            overviewRepository, tenantService, computeService, configurationService);
+  }
+
+  @Test
+  void shouldReturnEmptyResponseWhenNoRows() {
+    // given
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS)).thenReturn(List.of());
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then — hasAnyTarget is false; empty coverage/attainment; two zero-filled categories; no
+    // off-target entries. Sending a stable shape means the FE can render category donuts even
+    // before any target is set.
+    assertThat(response.hasAnyTarget()).isFalse();
+    assertThat(response.coverage().processesWithTarget()).isZero();
+    assertThat(response.coverage().totalProcesses()).isZero();
+    assertThat(response.attainment().targetsSet()).isZero();
+    assertThat(response.attainment().targetsMet()).isZero();
+    assertThat(response.categories()).hasSize(2);
+    assertThat(response.categories())
+        .extracting(BusinessValueOverviewResponseDto.CategoryDto::kpi)
+        .containsExactly("cycleTime", "automationRate");
+    assertThat(response.offTarget()).isEmpty();
+  }
+
+  @Test
+  void shouldReportCoverageAndAttainmentCounts() {
+    // given three rows — two with any target, one with a met target
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
+        .thenReturn(
+            List.of(
+                fresh(row(TENANT_A, "proc-1", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
+                fresh(row(TENANT_A, "proc-2", cycNull(), aut(60.0, 85, false), 1, 0)),
+                fresh(row(TENANT_A, "proc-3", cycNull(), autoNull(), 0, 0))));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.hasAnyTarget()).isTrue();
+    assertThat(response.coverage().processesWithTarget()).isEqualTo(2);
+    assertThat(response.coverage().totalProcesses()).isEqualTo(3);
+    assertThat(response.attainment().targetsSet()).isEqualTo(2);
+    assertThat(response.attainment().targetsMet()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldBuildCategoriesForBothKpisWithZeroSafeArithmetic() {
+    // given two rows, one for each KPI, only one met each
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
+        .thenReturn(
+            List.of(
+                fresh(row(TENANT_A, "proc-cyc-met", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
+                fresh(row(TENANT_A, "proc-auto-missed", cycNull(), aut(70.0, 90, false), 1, 0))));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then — the "totalApplicable" column reflects the row count because every row is applicable
+    // for both KPIs in v1; "processesWithTarget" and "targetsMet" reflect only the non-null side.
+    final BusinessValueOverviewResponseDto.CategoryDto cycleTimeCategory =
+        response.categories().stream()
+            .filter(c -> c.kpi().equals("cycleTime"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(cycleTimeCategory.processesWithTarget()).isEqualTo(1);
+    assertThat(cycleTimeCategory.totalApplicable()).isEqualTo(2);
+    assertThat(cycleTimeCategory.targetsMet()).isEqualTo(1);
+
+    final BusinessValueOverviewResponseDto.CategoryDto automationRateCategory =
+        response.categories().stream()
+            .filter(c -> c.kpi().equals("automationRate"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(automationRateCategory.processesWithTarget()).isEqualTo(1);
+    assertThat(automationRateCategory.totalApplicable()).isEqualTo(2);
+    assertThat(automationRateCategory.targetsMet()).isZero();
+  }
+
+  @Test
+  void shouldEmitOffTargetOnlyForRowsWithTargetAndNotMet() {
+    // given four rows: no target, met, missed, missed with null value (data gap)
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
+        .thenReturn(
+            List.of(
+                fresh(row(TENANT_A, "proc-no-target", cycNull(), autoNull(), 0, 0)),
+                fresh(row(TENANT_A, "proc-met", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
+                fresh(row(TENANT_A, "proc-missed", cyc(9_000L, 8_000L, false), autoNull(), 1, 0)),
+                // met==false but no value available — treat as data gap, skip from off-target
+                fresh(
+                    row(
+                        TENANT_A,
+                        "proc-null-value",
+                        new CycleTimeBlock(null, 8_000L, false),
+                        autoNull(),
+                        1,
+                        0))));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.offTarget())
+        .extracting(BusinessValueOverviewResponseDto.OffTargetEntryDto::processKey)
+        .containsExactly("proc-missed");
+  }
+
+  @Test
+  void shouldSortOffTargetByGapPctDescending() {
+    // given three missed rows with different gap magnitudes
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
+        .thenReturn(
+            List.of(
+                fresh(row(TENANT_A, "proc-25pct", cyc(10_000L, 8_000L, false), autoNull(), 1, 0)),
+                fresh(row(TENANT_A, "proc-50pct", cyc(12_000L, 8_000L, false), autoNull(), 1, 0)),
+                fresh(row(TENANT_A, "proc-10pct", cyc(8_800L, 8_000L, false), autoNull(), 1, 0))));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.offTarget())
+        .extracting(BusinessValueOverviewResponseDto.OffTargetEntryDto::processKey)
+        .containsExactly("proc-50pct", "proc-25pct", "proc-10pct");
+  }
+
+  @Test
+  void shouldComputeGapPctAndDirectionFromVerdictHelper() {
+    // given — cycle time value 10, target 8, LOWER_IS_BETTER; automation 70, target 85, HIGHER
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
+        .thenReturn(
+            List.of(
+                fresh(row(TENANT_A, "cyc", cyc(10L, 8L, false), autoNull(), 1, 0)),
+                fresh(row(TENANT_A, "aut", cycNull(), aut(70.0, 85, false), 1, 0))));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then — matches the verdict-cases.json fixture rows for "cycle-time over target" and
+    // "automation below target"; keeping this test parametric on the DTO output guards against
+    // drift between the Java verdict function and the read-service assembly.
+    final BusinessValueOverviewResponseDto.OffTargetEntryDto cycEntry =
+        response.offTarget().stream()
+            .filter(e -> e.kpi().equals("cycleTime"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(cycEntry.gapPct()).isEqualTo(25.0);
+    assertThat(cycEntry.direction()).isEqualTo("over");
+    assertThat(cycEntry.displayUnit()).isEqualTo("HOURS");
+
+    final BusinessValueOverviewResponseDto.OffTargetEntryDto autoEntry =
+        response.offTarget().stream()
+            .filter(e -> e.kpi().equals("automationRate"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(autoEntry.gapPct()).isEqualTo(17.647058823529413);
+    assertThat(autoEntry.direction()).isEqualTo("under");
+    assertThat(autoEntry.displayUnit()).isEqualTo("PERCENT");
+  }
+
+  @Test
+  void shouldFireStaleBackstopWhenLastComputedAtOlderThanTwoTimesInterval() {
+    // given — the row was computed three intervals ago; threshold is 2×
+    final BusinessValueOverviewDto staleRow =
+        stamp(
+            row(TENANT_A, "proc-stale", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
+            NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS));
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS)).thenReturn(List.of(staleRow));
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then — the backstop fires asynchronously; verify with Awaitility since the runAsync work is
+    // scheduled on the ForkJoinPool.
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                verify(computeService)
+                    .computeOverviewRows(
+                        eq(
+                            BusinessValueOverviewScope.definition(
+                                staleRow.getTenantId(), staleRow.getProcessDefinitionKey())),
+                        eq(List.of(MetricRange.THIRTY_DAYS)),
+                        eq(BusinessValueOverviewRefreshMode.SCHEDULER)));
+  }
+
+  @Test
+  void shouldNotFireBackstopWhenFresh() {
+    // given
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
+        .thenReturn(
+            List.of(
+                fresh(row(TENANT_A, "proc-fresh", cyc(6_000L, 8_000L, true), autoNull(), 1, 1))));
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then — no backstop invocation. Wait a tick to ensure any (buggy) async fire would have
+    // landed.
+    Awaitility.await()
+        .during(java.time.Duration.ofMillis(150))
+        .atMost(java.time.Duration.ofMillis(500))
+        .untilAsserted(
+            () -> verify(computeService, never()).computeOverviewRows(any(), anyList(), any()));
+  }
+
+  @Test
+  void shouldFilterOutRowsForTenantsUserIsNotAuthorizedFor() {
+    // given
+    when(tenantService.isAuthorizedToSeeTenant(USER, TENANT_A)).thenReturn(true);
+    when(tenantService.isAuthorizedToSeeTenant(USER, TENANT_B)).thenReturn(false);
+    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
+        .thenReturn(
+            List.of(
+                fresh(row(TENANT_A, "proc-a", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
+                fresh(row(TENANT_B, "proc-b", cyc(9_000L, 8_000L, false), autoNull(), 1, 0))));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.coverage().totalProcesses()).isEqualTo(1);
+    assertThat(response.offTarget()).isEmpty();
+  }
+
+  @Test
+  void shouldPassCorrectMetricRangeThroughToBackstop() {
+    // given — three ranges, only one is stale
+    final BusinessValueOverviewDto staleRow =
+        stamp(
+            row(TENANT_A, "proc-x", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
+            NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS));
+    when(overviewRepository.readByRange(MetricRange.SIX_MONTHS)).thenReturn(List.of(staleRow));
+
+    // when
+    readService.getOverview(USER, MetricRange.SIX_MONTHS);
+
+    // then — backstop invoked with 6m range, not any other
+    final ArgumentCaptor<List<MetricRange>> ranges = argCaptor();
+    Awaitility.await()
+        .untilAsserted(
+            () -> verify(computeService).computeOverviewRows(any(), ranges.capture(), any()));
+    assertThat(ranges.getValue()).containsExactly(MetricRange.SIX_MONTHS);
+  }
+
+  private static BusinessValueOverviewDto row(
+      final String tenantId,
+      final String processKey,
+      final CycleTimeBlock cycleTime,
+      final AutomationRateBlock automationRate,
+      final int targetsSet,
+      final int targetsMet) {
+    return new BusinessValueOverviewDto(
+        tenantId,
+        processKey,
+        processKey,
+        MetricRange.THIRTY_DAYS,
+        null,
+        cycleTime,
+        automationRate,
+        targetsSet > 0,
+        targetsSet,
+        targetsMet);
+  }
+
+  private static BusinessValueOverviewDto fresh(final BusinessValueOverviewDto row) {
+    return stamp(row, NOW);
+  }
+
+  private static BusinessValueOverviewDto stamp(
+      final BusinessValueOverviewDto row, final OffsetDateTime lastComputedAt) {
+    row.setLastComputedAt(lastComputedAt);
+    return row;
+  }
+
+  private static CycleTimeBlock cyc(final Long value, final Long target, final Boolean met) {
+    return new CycleTimeBlock(value, target, met);
+  }
+
+  private static CycleTimeBlock cycNull() {
+    return new CycleTimeBlock(null, null, null);
+  }
+
+  private static AutomationRateBlock aut(
+      final Double value, final Integer target, final Boolean met) {
+    return new AutomationRateBlock(value, target, met);
+  }
+
+  private static AutomationRateBlock autoNull() {
+    return new AutomationRateBlock(null, null, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> ArgumentCaptor<T> argCaptor() {
+    return (ArgumentCaptor<T>) ArgumentCaptor.forClass(List.class);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
@@ -14,21 +14,30 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
+import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,12 +47,12 @@ class BusinessValueOverviewReadServiceTest {
 
   private static final String USER = "user-1";
   private static final String TENANT_A = "tenant-a";
-  private static final String TENANT_B = "tenant-b";
   private static final long REFRESH_INTERVAL_SECONDS = 86_400L;
   private static final OffsetDateTime NOW = OffsetDateTime.now(ZoneOffset.UTC);
 
   private BusinessValueOverviewRepository overviewRepository;
   private TenantService tenantService;
+  private DefinitionService definitionService;
   private BusinessValueOverviewComputeService computeService;
   private BusinessValueOverviewReadService readService;
 
@@ -51,30 +60,44 @@ class BusinessValueOverviewReadServiceTest {
   void setUp() {
     overviewRepository = mock(BusinessValueOverviewRepository.class);
     tenantService = mock(TenantService.class);
+    definitionService = mock(DefinitionService.class);
     computeService = mock(BusinessValueOverviewComputeService.class);
     final ConfigurationService configurationService = mock(ConfigurationService.class);
     final BusinessValueConfiguration businessValueConfiguration = new BusinessValueConfiguration();
     businessValueConfiguration.setOverviewRefreshInterval(REFRESH_INTERVAL_SECONDS);
     when(configurationService.getBusinessValueConfiguration())
         .thenReturn(businessValueConfiguration);
-    when(tenantService.isAuthorizedToSeeTenant(anyString(), anyString())).thenReturn(true);
+    when(tenantService.getTenantIdsForUser(anyString())).thenReturn(List.of(TENANT_A));
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
+        .thenReturn(List.of());
     readService =
         new BusinessValueOverviewReadService(
-            overviewRepository, tenantService, computeService, configurationService);
+            overviewRepository,
+            tenantService,
+            definitionService,
+            computeService,
+            configurationService);
+  }
+
+  @Test
+  void shouldPushDownAuthorizedTenantIdsToTheRepository() {
+    when(tenantService.getTenantIdsForUser(USER)).thenReturn(List.of(TENANT_A, "tenant-b"));
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    final ArgumentCaptor<Collection<String>> captor = collectionCaptor();
+    verify(overviewRepository).readByRange(eq(MetricRange.THIRTY_DAYS), captor.capture());
+    assertThat(captor.getValue()).containsExactlyInAnyOrder(TENANT_A, "tenant-b");
   }
 
   @Test
   void shouldReturnEmptyResponseWhenNoRows() {
-    // given
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS)).thenReturn(List.of());
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
 
-    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    // then — hasAnyTarget is false; empty coverage/attainment; two zero-filled categories; no
-    // off-target entries. Sending a stable shape means the FE can render category donuts even
-    // before any target is set.
     assertThat(response.hasAnyTarget()).isFalse();
     assertThat(response.coverage().processesWithTarget()).isZero();
     assertThat(response.coverage().totalProcesses()).isZero();
@@ -89,19 +112,15 @@ class BusinessValueOverviewReadServiceTest {
 
   @Test
   void shouldReportCoverageAndAttainmentCounts() {
-    // given three rows — two with any target, one with a met target
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
-        .thenReturn(
-            List.of(
-                fresh(row(TENANT_A, "proc-1", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
-                fresh(row(TENANT_A, "proc-2", cycNull(), aut(60.0, 85, false), 1, 0)),
-                fresh(row(TENANT_A, "proc-3", cycNull(), autoNull(), 0, 0))));
+    seedRows(
+        MetricRange.THIRTY_DAYS,
+        fresh(row(TENANT_A, "proc-1", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
+        fresh(row(TENANT_A, "proc-2", cycNull(), aut(60.0, 85, false), 1, 0)),
+        fresh(row(TENANT_A, "proc-3", cycNull(), autoNull(), 0, 0)));
 
-    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    // then
     assertThat(response.hasAnyTarget()).isTrue();
     assertThat(response.coverage().processesWithTarget()).isEqualTo(2);
     assertThat(response.coverage().totalProcesses()).isEqualTo(3);
@@ -111,19 +130,14 @@ class BusinessValueOverviewReadServiceTest {
 
   @Test
   void shouldBuildCategoriesForBothKpisWithZeroSafeArithmetic() {
-    // given two rows, one for each KPI, only one met each
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
-        .thenReturn(
-            List.of(
-                fresh(row(TENANT_A, "proc-cyc-met", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
-                fresh(row(TENANT_A, "proc-auto-missed", cycNull(), aut(70.0, 90, false), 1, 0))));
+    seedRows(
+        MetricRange.THIRTY_DAYS,
+        fresh(row(TENANT_A, "proc-cyc-met", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
+        fresh(row(TENANT_A, "proc-auto-missed", cycNull(), aut(70.0, 90, false), 1, 0)));
 
-    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    // then — the "totalApplicable" column reflects the row count because every row is applicable
-    // for both KPIs in v1; "processesWithTarget" and "targetsMet" reflect only the non-null side.
     final BusinessValueOverviewResponseDto.CategoryDto cycleTimeCategory =
         response.categories().stream()
             .filter(c -> c.kpi().equals("cycleTime"))
@@ -145,28 +159,23 @@ class BusinessValueOverviewReadServiceTest {
 
   @Test
   void shouldEmitOffTargetOnlyForRowsWithTargetAndNotMet() {
-    // given four rows: no target, met, missed, missed with null value (data gap)
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
-        .thenReturn(
-            List.of(
-                fresh(row(TENANT_A, "proc-no-target", cycNull(), autoNull(), 0, 0)),
-                fresh(row(TENANT_A, "proc-met", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
-                fresh(row(TENANT_A, "proc-missed", cyc(9_000L, 8_000L, false), autoNull(), 1, 0)),
-                // met==false but no value available — treat as data gap, skip from off-target
-                fresh(
-                    row(
-                        TENANT_A,
-                        "proc-null-value",
-                        new CycleTimeBlock(null, 8_000L, false),
-                        autoNull(),
-                        1,
-                        0))));
+    seedRows(
+        MetricRange.THIRTY_DAYS,
+        fresh(row(TENANT_A, "proc-no-target", cycNull(), autoNull(), 0, 0)),
+        fresh(row(TENANT_A, "proc-met", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
+        fresh(row(TENANT_A, "proc-missed", cyc(9_000L, 8_000L, false), autoNull(), 1, 0)),
+        fresh(
+            row(
+                TENANT_A,
+                "proc-null-value",
+                new CycleTimeBlock(null, 8_000L, false),
+                autoNull(),
+                1,
+                0)));
 
-    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    // then
     assertThat(response.offTarget())
         .extracting(BusinessValueOverviewResponseDto.OffTargetEntryDto::processKey)
         .containsExactly("proc-missed");
@@ -174,19 +183,15 @@ class BusinessValueOverviewReadServiceTest {
 
   @Test
   void shouldSortOffTargetByGapPctDescending() {
-    // given three missed rows with different gap magnitudes
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
-        .thenReturn(
-            List.of(
-                fresh(row(TENANT_A, "proc-25pct", cyc(10_000L, 8_000L, false), autoNull(), 1, 0)),
-                fresh(row(TENANT_A, "proc-50pct", cyc(12_000L, 8_000L, false), autoNull(), 1, 0)),
-                fresh(row(TENANT_A, "proc-10pct", cyc(8_800L, 8_000L, false), autoNull(), 1, 0))));
+    seedRows(
+        MetricRange.THIRTY_DAYS,
+        fresh(row(TENANT_A, "proc-25pct", cyc(10_000L, 8_000L, false), autoNull(), 1, 0)),
+        fresh(row(TENANT_A, "proc-50pct", cyc(12_000L, 8_000L, false), autoNull(), 1, 0)),
+        fresh(row(TENANT_A, "proc-10pct", cyc(8_800L, 8_000L, false), autoNull(), 1, 0)));
 
-    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    // then
     assertThat(response.offTarget())
         .extracting(BusinessValueOverviewResponseDto.OffTargetEntryDto::processKey)
         .containsExactly("proc-50pct", "proc-25pct", "proc-10pct");
@@ -194,20 +199,14 @@ class BusinessValueOverviewReadServiceTest {
 
   @Test
   void shouldComputeGapPctAndDirectionFromVerdictHelper() {
-    // given — cycle time value 10, target 8, LOWER_IS_BETTER; automation 70, target 85, HIGHER
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
-        .thenReturn(
-            List.of(
-                fresh(row(TENANT_A, "cyc", cyc(10L, 8L, false), autoNull(), 1, 0)),
-                fresh(row(TENANT_A, "aut", cycNull(), aut(70.0, 85, false), 1, 0))));
+    seedRows(
+        MetricRange.THIRTY_DAYS,
+        fresh(row(TENANT_A, "cyc", cyc(10L, 8L, false), autoNull(), 1, 0)),
+        fresh(row(TENANT_A, "aut", cycNull(), aut(70.0, 85, false), 1, 0)));
 
-    // when
     final BusinessValueOverviewResponseDto response =
         readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    // then — matches the verdict-cases.json fixture rows for "cycle-time over target" and
-    // "automation below target"; keeping this test parametric on the DTO output guards against
-    // drift between the Java verdict function and the read-service assembly.
     final BusinessValueOverviewResponseDto.OffTargetEntryDto cycEntry =
         response.offTarget().stream()
             .filter(e -> e.kpi().equals("cycleTime"))
@@ -228,19 +227,92 @@ class BusinessValueOverviewReadServiceTest {
   }
 
   @Test
+  void shouldSkipOffTargetEntryWhenCycleTimeTargetIsZero() {
+    // Target = 0 is nonsensical for cycle time (LOWER_IS_BETTER) and would produce Infinity gapPct
+    // via division by zero, breaking JSON. Frontend validation is the source of truth; this guard
+    // survives if the frontend is bypassed or a legacy target row leaks in.
+    seedRows(
+        MetricRange.THIRTY_DAYS,
+        fresh(row(TENANT_A, "zero-target", cyc(100L, 0L, false), autoNull(), 1, 0)));
+
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    assertThat(response.offTarget()).isEmpty();
+  }
+
+  @Test
+  void shouldSkipOffTargetEntryWhenAutomationRateTargetIsZero() {
+    seedRows(
+        MetricRange.THIRTY_DAYS,
+        fresh(row(TENANT_A, "zero-auto", cycNull(), aut(0.0, 0, false), 1, 0)));
+
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    assertThat(response.offTarget()).isEmpty();
+  }
+
+  @Test
+  void shouldFilterOutRowsForDeletedProcessDefinitions() {
+    // Two overview rows exist in the index but only one definition is still imported. The stale
+    // row for the deleted definition must not appear in the response and must not trigger the
+    // backstop, otherwise the compute service would immediately recreate the row via its
+    // synthetic-definition fallback and orphans would never age out.
+    final BusinessValueOverviewDto liveRow =
+        fresh(row(TENANT_A, "still-here", cyc(6_000L, 8_000L, true), autoNull(), 1, 1));
+    final BusinessValueOverviewDto orphanRow =
+        stamp(
+            row(TENANT_A, "deleted-proc", cyc(9_000L, 8_000L, false), autoNull(), 1, 0),
+            NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS));
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(List.of(liveRow, orphanRow));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "still-here"));
+
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    assertThat(response.coverage().totalProcesses()).isEqualTo(1);
+    assertThat(response.coverage().processesWithTarget()).isEqualTo(1);
+    assertThat(response.attainment().targetsSet()).isEqualTo(1);
+    assertThat(response.attainment().targetsMet()).isEqualTo(1);
+    assertThat(response.offTarget()).isEmpty();
+
+    Awaitility.await()
+        .during(java.time.Duration.ofMillis(150))
+        .atMost(java.time.Duration.ofMillis(500))
+        .untilAsserted(
+            () -> verify(computeService, never()).computeOverviewRows(any(), anyList(), any()));
+  }
+
+  @Test
+  void shouldReturnEmptyResponseWhenEveryRowIsOrphaned() {
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(
+            List.of(fresh(row(TENANT_A, "gone-1", cyc(6_000L, 8_000L, true), autoNull(), 1, 1))));
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
+        .thenReturn(List.of());
+
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    assertThat(response.hasAnyTarget()).isFalse();
+    assertThat(response.coverage().totalProcesses()).isZero();
+    assertThat(response.offTarget()).isEmpty();
+  }
+
+  @Test
   void shouldFireStaleBackstopWhenLastComputedAtOlderThanTwoTimesInterval() {
-    // given — the row was computed three intervals ago; threshold is 2×
     final BusinessValueOverviewDto staleRow =
         stamp(
             row(TENANT_A, "proc-stale", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
             NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS));
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS)).thenReturn(List.of(staleRow));
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(List.of(staleRow));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "proc-stale"));
 
-    // when
     readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    // then — the backstop fires asynchronously; verify with Awaitility since the runAsync work is
-    // scheduled on the ForkJoinPool.
     Awaitility.await()
         .untilAsserted(
             () ->
@@ -255,17 +327,12 @@ class BusinessValueOverviewReadServiceTest {
 
   @Test
   void shouldNotFireBackstopWhenFresh() {
-    // given
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
-        .thenReturn(
-            List.of(
-                fresh(row(TENANT_A, "proc-fresh", cyc(6_000L, 8_000L, true), autoNull(), 1, 1))));
+    seedRows(
+        MetricRange.THIRTY_DAYS,
+        fresh(row(TENANT_A, "proc-fresh", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)));
 
-    // when
     readService.getOverview(USER, MetricRange.THIRTY_DAYS);
 
-    // then — no backstop invocation. Wait a tick to ensure any (buggy) async fire would have
-    // landed.
     Awaitility.await()
         .during(java.time.Duration.ofMillis(150))
         .atMost(java.time.Duration.ofMillis(500))
@@ -274,43 +341,76 @@ class BusinessValueOverviewReadServiceTest {
   }
 
   @Test
-  void shouldFilterOutRowsForTenantsUserIsNotAuthorizedFor() {
-    // given
-    when(tenantService.isAuthorizedToSeeTenant(USER, TENANT_A)).thenReturn(true);
-    when(tenantService.isAuthorizedToSeeTenant(USER, TENANT_B)).thenReturn(false);
-    when(overviewRepository.readByRange(MetricRange.THIRTY_DAYS))
-        .thenReturn(
-            List.of(
-                fresh(row(TENANT_A, "proc-a", cyc(6_000L, 8_000L, true), autoNull(), 1, 1)),
-                fresh(row(TENANT_B, "proc-b", cyc(9_000L, 8_000L, false), autoNull(), 1, 0))));
+  void shouldCoalesceConcurrentBackstopsForTheSameStaleRow() {
+    final BusinessValueOverviewDto staleRow =
+        stamp(
+            row(TENANT_A, "proc-hot", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
+            NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS));
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(List.of(staleRow));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "proc-hot"));
 
-    // when
-    final BusinessValueOverviewResponseDto response =
-        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+    final java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              release.await();
+              return null;
+            })
+        .when(computeService)
+        .computeOverviewRows(any(), anyList(), any());
 
-    // then
-    assertThat(response.coverage().totalProcesses()).isEqualTo(1);
-    assertThat(response.offTarget()).isEmpty();
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    Awaitility.await()
+        .during(java.time.Duration.ofMillis(200))
+        .atMost(java.time.Duration.ofMillis(500))
+        .untilAsserted(
+            () -> verify(computeService, times(1)).computeOverviewRows(any(), anyList(), any()));
+
+    release.countDown();
   }
 
   @Test
-  void shouldPassCorrectMetricRangeThroughToBackstop() {
-    // given — three ranges, only one is stale
+  void shouldPropagateTheStaleRangeToTheBackstop() {
     final BusinessValueOverviewDto staleRow =
         stamp(
             row(TENANT_A, "proc-x", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
             NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS));
-    when(overviewRepository.readByRange(MetricRange.SIX_MONTHS)).thenReturn(List.of(staleRow));
+    when(overviewRepository.readByRange(eq(MetricRange.SIX_MONTHS), any()))
+        .thenReturn(List.of(staleRow));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "proc-x"));
 
-    // when
     readService.getOverview(USER, MetricRange.SIX_MONTHS);
 
-    // then — backstop invoked with 6m range, not any other
     final ArgumentCaptor<List<MetricRange>> ranges = argCaptor();
     Awaitility.await()
         .untilAsserted(
             () -> verify(computeService).computeOverviewRows(any(), ranges.capture(), any()));
     assertThat(ranges.getValue()).containsExactly(MetricRange.SIX_MONTHS);
+  }
+
+  private void seedRows(final MetricRange range, final BusinessValueOverviewDto... rows) {
+    when(overviewRepository.readByRange(eq(range), any())).thenReturn(List.of(rows));
+    final DefKey[] keys = new DefKey[rows.length];
+    for (int i = 0; i < rows.length; i++) {
+      keys[i] = new DefKey(rows[i].getTenantId(), rows[i].getProcessDefinitionKey());
+    }
+    stubCurrentDefinitions(keys);
+  }
+
+  private void stubCurrentDefinitions(final DefKey... keys) {
+    final Map<String, List<String>> tenantsByKey = new HashMap<>();
+    for (final DefKey key : keys) {
+      tenantsByKey.computeIfAbsent(key.processKey(), k -> new ArrayList<>()).add(key.tenantId());
+    }
+    final List<DefinitionWithTenantIdsDto> dtos = new ArrayList<>();
+    for (final Map.Entry<String, List<String>> entry : tenantsByKey.entrySet()) {
+      dtos.add(
+          new DefinitionWithTenantIdsDto(
+              entry.getKey(), entry.getKey(), DefinitionType.PROCESS, entry.getValue(), Set.of()));
+    }
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS)).thenReturn(dtos);
   }
 
   private static BusinessValueOverviewDto row(
@@ -364,4 +464,11 @@ class BusinessValueOverviewReadServiceTest {
   private static <T> ArgumentCaptor<T> argCaptor() {
     return (ArgumentCaptor<T>) ArgumentCaptor.forClass(List.class);
   }
+
+  @SuppressWarnings("unchecked")
+  private static ArgumentCaptor<Collection<String>> collectionCaptor() {
+    return (ArgumentCaptor<Collection<String>>) (Object) ArgumentCaptor.forClass(Collection.class);
+  }
+
+  private record DefKey(String tenantId, String processKey) {}
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueOverviewResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueOverviewResponseDto.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.businessvalue;
 
-import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Assembled L0 target-overview response for {@code GET /business-value/overview?range=<preset>}.
@@ -16,32 +16,466 @@ import java.util.List;
  * category donuts (cycle time + automation rate; volume is descoped in v1) plus a flat off-target
  * list sorted by {@code gapPct} descending.
  *
- * <p>Cycle-time {@link OffTargetEntryDto#value} / {@link OffTargetEntryDto#target} are emitted in
- * their native storage unit (milliseconds); {@code displayUnit} is the FE formatting hint.
+ * <p>Cycle-time {@link OffTargetEntryDto#getValue()} / {@link OffTargetEntryDto#getTarget()} are
+ * emitted in their native storage unit (milliseconds); {@code displayUnit} is the FE formatting
+ * hint.
+ *
+ * <p>Response size is bounded by the repository-level fetch cap (see {@code
+ * BusinessValueOverviewReadService}); a response never silently drops rows.
  */
-public record BusinessValueOverviewResponseDto(
-    boolean hasAnyTarget,
-    CoverageDto coverage,
-    AttainmentDto attainment,
-    List<CategoryDto> categories,
-    List<OffTargetEntryDto> offTarget)
-    implements OptimizeDto {
+public class BusinessValueOverviewResponseDto {
 
-  public record CoverageDto(int processesWithTarget, int totalProcesses) {}
+  private boolean hasAnyTarget;
+  private CoverageDto coverage;
+  private AttainmentDto attainment;
+  private List<CategoryDto> categories;
+  private List<OffTargetEntryDto> offTarget;
 
-  public record AttainmentDto(int targetsSet, int targetsMet) {}
+  public BusinessValueOverviewResponseDto() {}
 
-  public record CategoryDto(
-      String kpi, int processesWithTarget, int totalApplicable, int targetsMet) {}
+  public BusinessValueOverviewResponseDto(
+      final boolean hasAnyTarget,
+      final CoverageDto coverage,
+      final AttainmentDto attainment,
+      final List<CategoryDto> categories,
+      final List<OffTargetEntryDto> offTarget) {
+    this.hasAnyTarget = hasAnyTarget;
+    this.coverage = coverage;
+    this.attainment = attainment;
+    this.categories = categories;
+    this.offTarget = offTarget;
+  }
 
-  public record OffTargetEntryDto(
-      String tenantId,
-      String processKey,
-      String processName,
-      String kpi,
-      double value,
-      double target,
-      String displayUnit,
-      double gapPct,
-      String direction) {}
+  public boolean isHasAnyTarget() {
+    return hasAnyTarget;
+  }
+
+  public void setHasAnyTarget(final boolean hasAnyTarget) {
+    this.hasAnyTarget = hasAnyTarget;
+  }
+
+  public CoverageDto getCoverage() {
+    return coverage;
+  }
+
+  public void setCoverage(final CoverageDto coverage) {
+    this.coverage = coverage;
+  }
+
+  public AttainmentDto getAttainment() {
+    return attainment;
+  }
+
+  public void setAttainment(final AttainmentDto attainment) {
+    this.attainment = attainment;
+  }
+
+  public List<CategoryDto> getCategories() {
+    return categories;
+  }
+
+  public void setCategories(final List<CategoryDto> categories) {
+    this.categories = categories;
+  }
+
+  public List<OffTargetEntryDto> getOffTarget() {
+    return offTarget;
+  }
+
+  public void setOffTarget(final List<OffTargetEntryDto> offTarget) {
+    this.offTarget = offTarget;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BusinessValueOverviewResponseDto that = (BusinessValueOverviewResponseDto) o;
+    return hasAnyTarget == that.hasAnyTarget
+        && Objects.equals(coverage, that.coverage)
+        && Objects.equals(attainment, that.attainment)
+        && Objects.equals(categories, that.categories)
+        && Objects.equals(offTarget, that.offTarget);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hasAnyTarget, coverage, attainment, categories, offTarget);
+  }
+
+  @Override
+  public String toString() {
+    return "BusinessValueOverviewResponseDto(hasAnyTarget="
+        + hasAnyTarget
+        + ", coverage="
+        + coverage
+        + ", attainment="
+        + attainment
+        + ", categories="
+        + categories
+        + ", offTarget="
+        + offTarget
+        + ")";
+  }
+
+  public static class CoverageDto {
+
+    private int processesWithTarget;
+    private int totalProcesses;
+
+    public CoverageDto() {}
+
+    public CoverageDto(final int processesWithTarget, final int totalProcesses) {
+      this.processesWithTarget = processesWithTarget;
+      this.totalProcesses = totalProcesses;
+    }
+
+    public int getProcessesWithTarget() {
+      return processesWithTarget;
+    }
+
+    public void setProcessesWithTarget(final int processesWithTarget) {
+      this.processesWithTarget = processesWithTarget;
+    }
+
+    public int getTotalProcesses() {
+      return totalProcesses;
+    }
+
+    public void setTotalProcesses(final int totalProcesses) {
+      this.totalProcesses = totalProcesses;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final CoverageDto that = (CoverageDto) o;
+      return processesWithTarget == that.processesWithTarget
+          && totalProcesses == that.totalProcesses;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(processesWithTarget, totalProcesses);
+    }
+
+    @Override
+    public String toString() {
+      return "CoverageDto(processesWithTarget="
+          + processesWithTarget
+          + ", totalProcesses="
+          + totalProcesses
+          + ")";
+    }
+  }
+
+  public static class AttainmentDto {
+
+    private int targetsSet;
+    private int targetsMet;
+
+    public AttainmentDto() {}
+
+    public AttainmentDto(final int targetsSet, final int targetsMet) {
+      this.targetsSet = targetsSet;
+      this.targetsMet = targetsMet;
+    }
+
+    public int getTargetsSet() {
+      return targetsSet;
+    }
+
+    public void setTargetsSet(final int targetsSet) {
+      this.targetsSet = targetsSet;
+    }
+
+    public int getTargetsMet() {
+      return targetsMet;
+    }
+
+    public void setTargetsMet(final int targetsMet) {
+      this.targetsMet = targetsMet;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AttainmentDto that = (AttainmentDto) o;
+      return targetsSet == that.targetsSet && targetsMet == that.targetsMet;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(targetsSet, targetsMet);
+    }
+
+    @Override
+    public String toString() {
+      return "AttainmentDto(targetsSet=" + targetsSet + ", targetsMet=" + targetsMet + ")";
+    }
+  }
+
+  /**
+   * Per-KPI category rollup.
+   *
+   * <p>{@code totalApplicable} is the count of processes for which this KPI is a meaningful
+   * measurement. In v1 both KPIs are universally applicable to every process, so {@code
+   * totalApplicable == CoverageDto.totalProcesses} on every response — the field is kept as a
+   * distinct member so the denominator can diverge once a KPI becomes conditionally applicable
+   * (e.g. automation rate on a process with zero user tasks) without a breaking API change.
+   */
+  public static class CategoryDto {
+
+    private String kpi;
+    private int processesWithTarget;
+    private int totalApplicable;
+    private int targetsMet;
+
+    public CategoryDto() {}
+
+    public CategoryDto(
+        final String kpi,
+        final int processesWithTarget,
+        final int totalApplicable,
+        final int targetsMet) {
+      this.kpi = kpi;
+      this.processesWithTarget = processesWithTarget;
+      this.totalApplicable = totalApplicable;
+      this.targetsMet = targetsMet;
+    }
+
+    public String getKpi() {
+      return kpi;
+    }
+
+    public void setKpi(final String kpi) {
+      this.kpi = kpi;
+    }
+
+    public int getProcessesWithTarget() {
+      return processesWithTarget;
+    }
+
+    public void setProcessesWithTarget(final int processesWithTarget) {
+      this.processesWithTarget = processesWithTarget;
+    }
+
+    public int getTotalApplicable() {
+      return totalApplicable;
+    }
+
+    public void setTotalApplicable(final int totalApplicable) {
+      this.totalApplicable = totalApplicable;
+    }
+
+    public int getTargetsMet() {
+      return targetsMet;
+    }
+
+    public void setTargetsMet(final int targetsMet) {
+      this.targetsMet = targetsMet;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final CategoryDto that = (CategoryDto) o;
+      return processesWithTarget == that.processesWithTarget
+          && totalApplicable == that.totalApplicable
+          && targetsMet == that.targetsMet
+          && Objects.equals(kpi, that.kpi);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(kpi, processesWithTarget, totalApplicable, targetsMet);
+    }
+
+    @Override
+    public String toString() {
+      return "CategoryDto(kpi="
+          + kpi
+          + ", processesWithTarget="
+          + processesWithTarget
+          + ", totalApplicable="
+          + totalApplicable
+          + ", targetsMet="
+          + targetsMet
+          + ")";
+    }
+  }
+
+  /**
+   * One process/KPI pair whose target was set but not met.
+   *
+   * <p>{@code value} and {@code target} are emitted in the KPI's native storage unit — for
+   * cycle-time entries that means milliseconds regardless of what {@code displayUnit} says. The FE
+   * formats {@code value} and {@code target} for display using {@code displayUnit} as the hint
+   * ({@code "HOURS"} for cycle time, {@code "PERCENT"} for automation rate).
+   *
+   * <p>{@code comparison} is the value-to-target relation label — either {@code "over"} or {@code
+   * "under"}. It answers "did the observed value overshoot or undershoot the target?" and is
+   * independent of whether the KPI is lower-is-better or higher-is-better; the FE combines {@code
+   * comparison} with the KPI direction to render the copy ("22h vs 8h target, 175% over").
+   */
+  public static class OffTargetEntryDto {
+
+    private String tenantId;
+    private String processKey;
+    private String processName;
+    private String kpi;
+    private double value;
+    private double target;
+    private String displayUnit;
+    private double gapPct;
+    private String comparison;
+
+    public OffTargetEntryDto() {}
+
+    public OffTargetEntryDto(
+        final String tenantId,
+        final String processKey,
+        final String processName,
+        final String kpi,
+        final double value,
+        final double target,
+        final String displayUnit,
+        final double gapPct,
+        final String comparison) {
+      this.tenantId = tenantId;
+      this.processKey = processKey;
+      this.processName = processName;
+      this.kpi = kpi;
+      this.value = value;
+      this.target = target;
+      this.displayUnit = displayUnit;
+      this.gapPct = gapPct;
+      this.comparison = comparison;
+    }
+
+    public String getTenantId() {
+      return tenantId;
+    }
+
+    public void setTenantId(final String tenantId) {
+      this.tenantId = tenantId;
+    }
+
+    public String getProcessKey() {
+      return processKey;
+    }
+
+    public void setProcessKey(final String processKey) {
+      this.processKey = processKey;
+    }
+
+    public String getProcessName() {
+      return processName;
+    }
+
+    public void setProcessName(final String processName) {
+      this.processName = processName;
+    }
+
+    public String getKpi() {
+      return kpi;
+    }
+
+    public void setKpi(final String kpi) {
+      this.kpi = kpi;
+    }
+
+    public double getValue() {
+      return value;
+    }
+
+    public void setValue(final double value) {
+      this.value = value;
+    }
+
+    public double getTarget() {
+      return target;
+    }
+
+    public void setTarget(final double target) {
+      this.target = target;
+    }
+
+    public String getDisplayUnit() {
+      return displayUnit;
+    }
+
+    public void setDisplayUnit(final String displayUnit) {
+      this.displayUnit = displayUnit;
+    }
+
+    public double getGapPct() {
+      return gapPct;
+    }
+
+    public void setGapPct(final double gapPct) {
+      this.gapPct = gapPct;
+    }
+
+    public String getComparison() {
+      return comparison;
+    }
+
+    public void setComparison(final String comparison) {
+      this.comparison = comparison;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final OffTargetEntryDto that = (OffTargetEntryDto) o;
+      return Double.compare(value, that.value) == 0
+          && Double.compare(target, that.target) == 0
+          && Double.compare(gapPct, that.gapPct) == 0
+          && Objects.equals(tenantId, that.tenantId)
+          && Objects.equals(processKey, that.processKey)
+          && Objects.equals(processName, that.processName)
+          && Objects.equals(kpi, that.kpi)
+          && Objects.equals(displayUnit, that.displayUnit)
+          && Objects.equals(comparison, that.comparison);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          tenantId, processKey, processName, kpi, value, target, displayUnit, gapPct, comparison);
+    }
+
+    @Override
+    public String toString() {
+      return "OffTargetEntryDto(tenantId="
+          + tenantId
+          + ", processKey="
+          + processKey
+          + ", processName="
+          + processName
+          + ", kpi="
+          + kpi
+          + ", value="
+          + value
+          + ", target="
+          + target
+          + ", displayUnit="
+          + displayUnit
+          + ", gapPct="
+          + gapPct
+          + ", comparison="
+          + comparison
+          + ")";
+    }
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueOverviewResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueOverviewResponseDto.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.businessvalue;
+
+import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.util.List;
+
+/**
+ * Assembled L0 target-overview response for {@code GET /business-value/overview?range=<preset>}.
+ * Shape mirrors {@code bvd-target-technical-design.md} §5.3: an attainment rollup plus two per-KPI
+ * category donuts (cycle time + automation rate; volume is descoped in v1) plus a flat off-target
+ * list sorted by {@code gapPct} descending.
+ *
+ * <p>Cycle-time {@link OffTargetEntryDto#value} / {@link OffTargetEntryDto#target} are emitted in
+ * their native storage unit (milliseconds); {@code displayUnit} is the FE formatting hint.
+ */
+public record BusinessValueOverviewResponseDto(
+    boolean hasAnyTarget,
+    CoverageDto coverage,
+    AttainmentDto attainment,
+    List<CategoryDto> categories,
+    List<OffTargetEntryDto> offTarget)
+    implements OptimizeDto {
+
+  public record CoverageDto(int processesWithTarget, int totalProcesses) {}
+
+  public record AttainmentDto(int targetsSet, int targetsMet) {}
+
+  public record CategoryDto(
+      String kpi, int processesWithTarget, int totalApplicable, int targetsMet) {}
+
+  public record OffTargetEntryDto(
+      String tenantId,
+      String processKey,
+      String processName,
+      String kpi,
+      double value,
+      double target,
+      String displayUnit,
+      double gapPct,
+      String direction) {}
+}


### PR DESCRIPTION
## Summary

M2.5 of the [BVD target-overview backend milestone](https://github.com/camunda/camunda-hub/issues/27016). Adds the `GET /business-value/overview?range=<preset>` read handler and its stale-read backstop on top of M2.4's compute service.

- New `BusinessValueOverviewReadService` reads via the M2.3 `BusinessValueOverviewRepository`, filters rows by authorized tenants, and assembles the §5.3 `OverviewDto` (coverage, attainment, two per-KPI category donuts, off-target list sorted by `gapPct` desc) in a single pass. `gapPct` and direction reuse `BusinessValueVerdict.verdict(...)` from M2.6.
- New `BusinessValueOverviewRestService` — `@GetMapping("/api/business-value/overview")`, parses `range` via `MetricRange.fromId`, wraps the throw in `BadRequestException` (400 on `range=12m` or unknown).
- Stale-read backstop — for any row whose `lastComputedAt` is older than `2 × BusinessValueConfiguration.overviewRefreshInterval`, fires a fire-and-forget `CompletableFuture.runAsync` recompute for that `(tenantId, processDefinitionKey, range)` with `BusinessValueOverviewRefreshMode.SCHEDULER`. Current request is not delayed.
- Response DTOs (`BusinessValueOverviewResponseDto` + nested records) land in `optimize-commons` alongside the row DTO. `kpi`/`displayUnit`/`direction` are strings on the wire so commons stays independent of the backend `Kpi` enum.

Closes camunda/camunda-hub#27021.

## Stacked chain

M2.1 (merged) → M2.3 (`27019-bvd-overview-index`) → M2.6 (`27022-bvd-verdict`) → M2.4 (`27020-bvd-overview-compute`) → **M2.5 (this PR)**.

Base intentionally targets `27020-bvd-overview-compute`. Rebase onto `main` after M2.4 lands.

## Open items (deferred; not blockers)

- `displayUnit=HOURS` returns raw millis on the wire; FE formats. Keeps the `gapPct` math loss-free.
- Stale threshold is `2 × overviewRefreshInterval` uniformly across the four ranges. 
- Backstop reuses `SCHEDULER` refresh mode; no new enum value. Same non-blocking semantics; observability distinction can come later if it turns out to matter.
- Tenant scoping is in-memory after `readByRange`. Push-down to an ES `terms` query is a future optimization when row cardinality justifies it.

## Test plan

- [x] Unit — `BusinessValueOverviewReadServiceTest` (10 tests): empty state, coverage + attainment counts, categories with zero-safe arithmetic, off-target filter + sort, `gapPct`/direction reuse via verdict fixture semantics, backstop fires when stale, no-fire when fresh, tenant filter, backstop range propagation.
- [x] Unit — `BusinessValueOverviewRestServiceTest` (5 tests): 200 delegation, 400 on `range=12m`, 400 on null, session auth propagation, downstream error propagation.
- [x] Integration — `BusinessValueOverviewReadServiceIT` (4 tests): empty response, full assembly from live index, range isolation, stale-read backstop refreshes `lastComputedAt`.
- [x] `./mvnw license:format spotless:apply -T1C` clean.
- [x] `./mvnw verify -f optimize/pom.xml -pl backend -DskipTests=false -DskipITs -Dquickly` — 948 tests pass.
- [x] `./mvnw install -Dquickly -T1C` — repo compiles clean.