### PR TITLE
fix: fail backup-restore test when index cleanup doesn't finish in time

### DIFF
--- a/operate/qa/backup-restore-tests/pom.xml
+++ b/operate/qa/backup-restore-tests/pom.xml
@@ -139,6 +139,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!-- operate/pom.xml hardcodes this to true; override here so test output streams
+               live instead of only landing in a per-test file that's never surfaced when a
+               run is killed by CI's job timeout before the test class finishes. -->
+          <redirectTestOutputToFile>false</redirectTestOutputToFile>
           <systemPropertyVariables>
             <spring.profiles.active>test</spring.profiles.active>
           </systemPropertyVariables>

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -295,49 +295,69 @@ public class BackupRestoreTest {
           .getEsClient()
           .indices()
           .delete(new DeleteIndexRequest(ZEEBE_INDEX_PREFIX + "*"), RequestOptions.DEFAULT);
-      RetryOperation.newBuilder()
-          .noOfRetry(10)
-          .delayInterval(2000, TimeUnit.MILLISECONDS)
-          .retryPredicate(result -> !(boolean) result)
-          .retryConsumer(
-              () ->
-                  !testContext
-                      .getEsClient()
-                      .indices()
-                      .exists(
-                          new GetIndexRequest("operate*", ZEEBE_INDEX_PREFIX + "*"),
-                          RequestOptions.DEFAULT))
-          .build()
-          .retry();
+      // indices().exists() on a wildcard always returns true, even with no matches - the
+      // client hardcodes allow_no_indices=true on that request regardless of IndicesOptions.
+      // Listing the indices and checking for emptiness is the only way to tell "gone" apart
+      // from "still there".
+      final boolean indicesGone =
+          RetryOperation.<Boolean>newBuilder()
+              .noOfRetry(10)
+              .delayInterval(2000, TimeUnit.MILLISECONDS)
+              .retryPredicate(result -> !result)
+              .retryConsumer(
+                  () ->
+                      testContext
+                              .getEsClient()
+                              .indices()
+                              .get(
+                                  new GetIndexRequest("operate*", ZEEBE_INDEX_PREFIX + "*"),
+                                  RequestOptions.DEFAULT)
+                              .getIndices()
+                              .length
+                          == 0)
+              .build()
+              .retry();
+      if (!indicesGone) {
+        throw new OperateRuntimeException(
+            "Operate/Zeebe indices matching 'operate*' or '"
+                + ZEEBE_INDEX_PREFIX
+                + "*' still exist after waiting for deletion");
+      }
       testContext
           .getEsClient()
           .indices()
           .deleteIndexTemplate(
               new DeleteComposableIndexTemplateRequest("operate*"), RequestOptions.DEFAULT);
-      RetryOperation.newBuilder()
-          .noOfRetry(10)
-          .delayInterval(2000, TimeUnit.MILLISECONDS)
-          .retryPredicate(result -> !(boolean) result)
-          .retryConsumer(
-              () -> {
-                try {
-                  return testContext
-                      .getEsClient()
-                      .indices()
-                      .getIndexTemplate(
-                          new GetComposableIndexTemplateRequest("operate*"), RequestOptions.DEFAULT)
-                      .getIndexTemplates()
-                      .isEmpty();
-                } catch (final ElasticsearchStatusException e) {
-                  if (e.status().getStatus() == 404) {
-                    return true;
-                  } else {
-                    throw e;
-                  }
-                }
-              })
-          .build()
-          .retry();
+      final boolean templatesGone =
+          RetryOperation.<Boolean>newBuilder()
+              .noOfRetry(10)
+              .delayInterval(2000, TimeUnit.MILLISECONDS)
+              .retryPredicate(result -> !result)
+              .retryConsumer(
+                  () -> {
+                    try {
+                      return testContext
+                          .getEsClient()
+                          .indices()
+                          .getIndexTemplate(
+                              new GetComposableIndexTemplateRequest("operate*"),
+                              RequestOptions.DEFAULT)
+                          .getIndexTemplates()
+                          .isEmpty();
+                    } catch (final ElasticsearchStatusException e) {
+                      if (e.status().getStatus() == 404) {
+                        return true;
+                      } else {
+                        throw e;
+                      }
+                    }
+                  })
+              .build()
+              .retry();
+      if (!templatesGone) {
+        throw new OperateRuntimeException(
+            "Operate index templates matching 'operate*' still exist after waiting for deletion");
+      }
       LOGGER.info("************ Operate indices deleted ************");
     } catch (final IOException e) {
       throw new OperateRuntimeException(
@@ -386,6 +406,7 @@ public class BackupRestoreTest {
             .withLogConsumer(new Slf4jLogConsumer(LOGGER));
     operateContainer.withEnv("CAMUNDA_OPERATE_BACKUP_REPOSITORYNAME", REPOSITORY_NAME);
     operateContainer.withEnv("CAMUNDA_OPERATE_ARCHIVER_ILMENABLED", "true");
+    operateContainer.withEnv("CAMUNDA_OPERATE_ARCHIVER_WAITPERIODBEFOREARCHIVING", "10s");
 
     startOperate();
   }


### PR DESCRIPTION
Fixes BackupRestoreTest so it fails correctly instead of masking a real problem, and fixes the timeout that surfaced once it did.

- deleteOperateIndices() ignored a failed cleanup check and moved on anyway, causing a confusing "index already exists" failure later. Now it fails immediately when cleanup hasn't finished.
- The cleanup check itself was broken: it used indices().exists() on a wildcard, which always returns true in this ES client regardless of match. Switched to indices().get() to check correctly.
- Fixing that check exposed the job's 15-minute CI timeout, caused by a hardcoded 2-minute archiver wait in the test setup. Reduced it to 10s for this test.
- Stream test output live instead of buffering it to a file, so future failures are easier to diagnose.

Resolves #INC-7029
