### PR TITLE
Add AgentDefinition REST get & search endpoints

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.AdHocSubProcessActivityServices;
+import io.camunda.service.AgentDefinitionServices;
 import io.camunda.service.AgentHistoryServices;
 import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.ApiServicesExecutorProvider;
@@ -262,6 +263,15 @@ public class CamundaServicesConfiguration {
                       tenantId,
                       new AdHocSubProcessActivityServices(
                           tenantId, brokerClient, securityContextProvider, executor, converter))
+                  .agentDefinitionServices(
+                      tenantId,
+                      new AgentDefinitionServices(
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .agentHistoryServices(
                       tenantId,
                       new AgentHistoryServices(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -49,6 +49,7 @@ import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.ProcessDefinitionEntity.ProcessDefinitionState;
+import io.camunda.search.filter.AgentDefinitionFilter;
 import io.camunda.search.filter.AgentInstanceFilter;
 import io.camunda.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.search.filter.AuditLogFilter;
@@ -1558,6 +1559,43 @@ public class SearchQueryFilterMapper {
           .map(mapToKeyOperations("deploymentKey", validationErrors))
           .ifPresent(builder::deploymentKeyOperations);
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
+    }
+
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
+  }
+
+  static Either<List<String>, AgentDefinitionFilter> toAgentDefinitionFilter(
+      final io.camunda.gateway.protocol.model.@Nullable AgentDefinitionFilter filter) {
+    final var builder = FilterBuilders.agentDefinition();
+    final List<String> validationErrors = new ArrayList<>();
+    if (filter != null) {
+      ofNullable(filter.getAgentDefinitionKey())
+          .map(mapToKeyOperations("agentDefinitionKey", validationErrors))
+          .ifPresent(builder::agentDefinitionKeyOperations);
+      ofNullable(filter.getAgentType())
+          .map(mapToStringOperations())
+          .ifPresent(builder::agentTypeOperations);
+      ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
+      ofNullable(filter.getElementId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::elementIdOperations);
+      ofNullable(filter.getProcessDefinitionId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::processDefinitionIdOperations);
+      ofNullable(filter.getProcessDefinitionKey())
+          .map(mapToKeyOperations("processDefinitionKey", validationErrors))
+          .ifPresent(builder::processDefinitionKeyOperations);
+      ofNullable(filter.getProcessDefinitionVersion())
+          .map(mapToIntegerOperations("processDefinitionVersion", validationErrors))
+          .ifPresent(builder::processDefinitionVersionOperations);
+      ofNullable(filter.getProcessDefinitionVersionTag())
+          .map(mapToStringOperations())
+          .ifPresent(builder::processDefinitionVersionTagOperations);
+      ofNullable(filter.getTenantId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::tenantIdOperations);
     }
 
     return validationErrors.isEmpty()

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -24,6 +24,7 @@ import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
@@ -250,6 +251,23 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper::applyProcessInstanceSortField);
     final var filter = toProcessInstanceFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::processInstanceSearchQuery);
+  }
+
+  public static Either<ProblemDetail, AgentDefinitionQuery> toAgentDefinitionQuery(
+      final @Nullable AgentDefinitionSearchQuery request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.agentDefinitionSearchQuery().build());
+    }
+
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        SearchQuerySortRequestMapper.toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromAgentDefinitionSearchQuerySortRequest(
+                request.getSort()),
+            SortOptionBuilders::agentDefinition,
+            SearchQuerySortRequestMapper::applyAgentDefinitionSortField);
+    final var filter = SearchQueryFilterMapper.toAgentDefinitionFilter(request.getFilter());
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::agentDefinitionSearchQuery);
   }
 
   public static Either<ProblemDetail, AgentInstanceQuery> toAgentInstanceQuery(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -16,6 +16,9 @@ import static java.util.Objects.requireNonNullElse;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
+import io.camunda.gateway.protocol.model.AgentDefinitionResult;
+import io.camunda.gateway.protocol.model.AgentDefinitionSearchQueryResult;
+import io.camunda.gateway.protocol.model.AgentDefinitionTypeEnum;
 import io.camunda.gateway.protocol.model.AgentInstanceDefinition;
 import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryCommitStatusEnum;
@@ -179,6 +182,7 @@ import io.camunda.gateway.protocol.model.VariableSearchQueryResult;
 import io.camunda.gateway.protocol.model.VariableSearchResult;
 import io.camunda.gateway.protocol.model.WaitStateElementTypeEnum;
 import io.camunda.gateway.protocol.model.WaitStateTypeEnum;
+import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
@@ -1188,6 +1192,25 @@ public final class SearchQueryResponseMapper {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionDefinition).toList();
   }
 
+  private static List<AgentDefinitionResult> toAgentDefinitions(
+      final List<AgentDefinitionEntity> definitions) {
+    return definitions.stream().map(SearchQueryResponseMapper::toAgentDefinition).toList();
+  }
+
+  public static AgentDefinitionResult toAgentDefinition(final AgentDefinitionEntity d) {
+    return AgentDefinitionResult.Builder.create()
+        .agentDefinitionKey(keyToString(d.agentDefinitionKey()))
+        .agentType(AgentDefinitionTypeEnum.fromValue(d.agentType().name()))
+        .name(d.name())
+        .elementId(d.elementId())
+        .processDefinitionId(d.processDefinitionId())
+        .processDefinitionKey(keyToString(d.processDefinitionKey()))
+        .processDefinitionVersion(d.processDefinitionVersion())
+        .processDefinitionVersionTag(d.processDefinitionVersionTag())
+        .tenantId(d.tenantId())
+        .build();
+  }
+
   private static List<DecisionRequirementsResult> toDecisionRequirements(
       final List<DecisionRequirementsEntity> instances) {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionRequirements).toList();
@@ -2103,6 +2126,18 @@ public final class SearchQueryResponseMapper {
         .resourceId(entity.resourceId())
         .tenantId(entity.tenantId())
         .resourceKey(keyToString(entity.resourceKey()))
+        .build();
+  }
+
+  public static AgentDefinitionSearchQueryResult toAgentDefinitionSearchQueryResponse(
+      final SearchQueryResult<AgentDefinitionEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return AgentDefinitionSearchQueryResult.Builder.create()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toAgentDefinitions)
+                .orElseGet(Collections::emptyList))
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -12,6 +12,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_UNKN
 
 import io.camunda.gateway.protocol.model.*;
 import io.camunda.gateway.protocol.model.GlobalTaskListenerSearchQuerySortRequest.FieldEnum;
+import io.camunda.search.sort.AgentDefinitionSort;
 import io.camunda.search.sort.AgentInstanceHistorySort;
 import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.search.sort.AuthorizationSort;
@@ -1039,6 +1040,35 @@ public class SearchQuerySortRequestMapper {
         case AFTER_NON_GLOBAL -> builder.afterNonGlobal();
         case PRIORITY -> builder.priority();
         case SOURCE -> builder.source();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  static List<SearchQuerySortRequest<AgentDefinitionSearchQuerySortRequest.FieldEnum>>
+      fromAgentDefinitionSearchQuerySortRequest(
+          final List<AgentDefinitionSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
+  static List<String> applyAgentDefinitionSortField(
+      final AgentDefinitionSearchQuerySortRequest.FieldEnum field,
+      final AgentDefinitionSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case AGENT_DEFINITION_KEY -> builder.agentDefinitionKey();
+        case AGENT_TYPE -> builder.agentType();
+        case NAME -> builder.name();
+        case ELEMENT_ID -> builder.elementId();
+        case PROCESS_DEFINITION_ID -> builder.processDefinitionId();
+        case PROCESS_DEFINITION_KEY -> builder.processDefinitionKey();
+        case PROCESS_DEFINITION_VERSION -> builder.processDefinitionVersion();
+        case PROCESS_DEFINITION_VERSION_TAG -> builder.processDefinitionVersionTag();
+        case TENANT_ID -> builder.tenantId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -10,6 +10,7 @@ package io.camunda.gateway.mapping.http.search;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.gateway.protocol.model.AgentDefinitionTypeEnum;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
@@ -21,6 +22,7 @@ import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
 import io.camunda.gateway.protocol.model.JobWaitStateDetails;
 import io.camunda.gateway.protocol.model.ProcessInstanceWaitStateStatisticsResult;
+import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
@@ -1367,6 +1369,83 @@ class SearchQueryResponseMapperTest {
 
     // then
     assertThat(result.getKind()).isEqualTo(ClusterVariableKindEnum.SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldMapAgentDefinition() {
+    // given
+    final var entity =
+        new AgentDefinitionEntity(
+            123L, // agentDefinitionKey
+            AgentDefinitionEntity.AgentType.AI_AGENT_TASK, // agentType
+            "My Agent", // name
+            "agentElement", // elementId
+            "processId", // processDefinitionId
+            456L, // processDefinitionKey
+            2, // processDefinitionVersion
+            "v1", // processDefinitionVersionTag
+            "tenant"); // tenantId
+
+    // when
+    final var result = SearchQueryResponseMapper.toAgentDefinition(entity);
+
+    // then
+    assertThat(result.getAgentDefinitionKey()).isEqualTo("123");
+    assertThat(result.getAgentType()).isEqualTo(AgentDefinitionTypeEnum.AI_AGENT_TASK);
+    assertThat(result.getName()).isEqualTo("My Agent");
+    assertThat(result.getElementId()).isEqualTo("agentElement");
+    assertThat(result.getProcessDefinitionId()).isEqualTo("processId");
+    assertThat(result.getProcessDefinitionKey()).isEqualTo("456");
+    assertThat(result.getProcessDefinitionVersion()).isEqualTo(2);
+    assertThat(result.getProcessDefinitionVersionTag()).isEqualTo("v1");
+    assertThat(result.getTenantId()).isEqualTo("tenant");
+  }
+
+  @Test
+  void shouldMapAgentDefinitionWithNullVersionTag() {
+    // given
+    final var entity =
+        new AgentDefinitionEntity(
+            123L,
+            AgentDefinitionEntity.AgentType.EXTERNAL_AGENT,
+            "My Agent",
+            "agentElement",
+            "processId",
+            456L,
+            1,
+            null, // processDefinitionVersionTag is nullable
+            "tenant");
+
+    // when
+    final var result = SearchQueryResponseMapper.toAgentDefinition(entity);
+
+    // then
+    assertThat(result.getProcessDefinitionVersionTag()).isNull();
+  }
+
+  @Test
+  void shouldMapAgentDefinitionSearchQueryResponse() {
+    // given
+    final var entity =
+        new AgentDefinitionEntity(
+            123L,
+            AgentDefinitionEntity.AgentType.AI_AGENT_SUB_PROCESS,
+            "My Agent",
+            "agentElement",
+            "processId",
+            456L,
+            1,
+            "v1",
+            "tenant");
+
+    // when
+    final var response =
+        SearchQueryResponseMapper.toAgentDefinitionSearchQueryResponse(
+            new SearchQueryResult<AgentDefinitionEntity>(1, false, List.of(entity), null, null));
+
+    // then
+    assertThat(response.getItems()).hasSize(1);
+    assertThat(response.getItems().getFirst().getAgentDefinitionKey()).isEqualTo("123");
   }
 
   @Nested

--- a/search/search-client/src/main/java/io/camunda/search/clients/AgentDefinitionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AgentDefinitionSearchClient.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.auth.SecurityContext;
+
+public interface AgentDefinitionSearchClient {
+
+  AgentDefinitionEntity getAgentDefinition(final long key);
+
+  SearchQueryResult<AgentDefinitionEntity> searchAgentDefinitions(AgentDefinitionQuery filter);
+
+  AgentDefinitionSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -14,6 +14,7 @@ import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_MULTIPLE
 import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.search.clients.reader.SearchEntityReader;
 import io.camunda.search.clients.reader.SearchQueryStatisticsReader;
+import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
@@ -69,6 +70,7 @@ import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
 import io.camunda.search.filter.WaitStateStatisticsFilter;
 import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
+import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
@@ -173,6 +175,18 @@ public class CamundaSearchClients implements SearchClientsProxy {
                     currentPhysicalTenantId, this.resourceAccessControllerByTenant.keySet()));
       }
     }
+  }
+
+  @Override
+  public AgentDefinitionEntity getAgentDefinition(final long key) {
+    return doGetWithReader(requireScopedReaders().agentDefinitionReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("Agent Definition", key));
+  }
+
+  @Override
+  public SearchQueryResult<AgentDefinitionEntity> searchAgentDefinitions(
+      final AgentDefinitionQuery query) {
+    return doSearchWithReader(requireScopedReaders().agentDefinitionReader(), query);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -12,7 +12,8 @@ import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import io.camunda.security.core.auth.SecurityContext;
 
 public interface SearchClientsProxy
-    extends AgentHistorySearchClient,
+    extends AgentDefinitionSearchClient,
+        AgentHistorySearchClient,
         AgentInstanceSearchClient,
         AuditLogSearchClient,
         AuthorizationSearchClient,

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.impl;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
@@ -57,6 +58,7 @@ import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.exception.NoSecondaryStorageException;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
@@ -107,6 +109,17 @@ import io.camunda.security.core.auth.SecurityContext;
 import java.util.List;
 
 public class NoDBSearchClientsProxy implements SearchClientsProxy {
+
+  @Override
+  public AgentDefinitionEntity getAgentDefinition(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<AgentDefinitionEntity> searchAgentDefinitions(
+      final AgentDefinitionQuery query) {
+    throw new NoSecondaryStorageException();
+  }
 
   @Override
   public AgentInstanceEntity getAgentInstance(final long key) {

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.impl;
 import static java.util.Collections.emptyList;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
@@ -58,6 +59,7 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
@@ -109,6 +111,17 @@ import java.util.List;
 import java.util.Map;
 
 public class NoopSearchClientsProxy implements SearchClientsProxy {
+
+  @Override
+  public AgentDefinitionEntity getAgentDefinition(final long key) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<AgentDefinitionEntity> searchAgentDefinitions(
+      final AgentDefinitionQuery query) {
+    return SearchQueryResult.empty();
+  }
 
   @Override
   public AgentInstanceEntity getAgentInstance(final long key) {

--- a/service/src/main/java/io/camunda/service/AgentDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/AgentDefinitionServices.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static io.camunda.security.core.auth.RequiredAuthorization.withRequiredAuthorization;
+import static io.camunda.service.authorization.Authorizations.AGENT_DEFINITION_READ_AUTHORIZATION;
+
+import io.camunda.search.clients.AgentDefinitionSearchClient;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.service.search.core.SearchQueryService;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+
+public final class AgentDefinitionServices
+    extends SearchQueryService<
+        AgentDefinitionServices, AgentDefinitionQuery, AgentDefinitionEntity> {
+
+  private final AgentDefinitionSearchClient agentDefinitionSearchClient;
+
+  public AgentDefinitionServices(
+      final String physicalTenantId,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final AgentDefinitionSearchClient agentDefinitionSearchClient,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        physicalTenantId,
+        brokerClient,
+        securityContextProvider,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+    this.agentDefinitionSearchClient = agentDefinitionSearchClient;
+  }
+
+  @Override
+  public SearchQueryResult<AgentDefinitionEntity> search(
+      final AgentDefinitionQuery query, final CamundaAuthentication authentication) {
+    return executeSearchRequest(
+        () ->
+            agentDefinitionSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, AGENT_DEFINITION_READ_AUTHORIZATION))
+                .searchAgentDefinitions(query));
+  }
+
+  public AgentDefinitionEntity getByKey(
+      final long agentDefinitionKey, final CamundaAuthentication authentication) {
+    return executeSearchRequest(
+        () ->
+            agentDefinitionSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication,
+                        withRequiredAuthorization(
+                            AGENT_DEFINITION_READ_AUTHORIZATION,
+                            AgentDefinitionEntity::processDefinitionId)))
+                .getAgentDefinition(agentDefinitionKey));
+  }
+}

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -22,6 +22,7 @@ import static io.camunda.security.api.model.authz.PermissionType.RESTORE;
 import static io.camunda.security.api.model.authz.PermissionType.REVEAL;
 import static io.camunda.security.api.model.authz.PermissionType.UPDATE;
 
+import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
@@ -50,6 +51,10 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.security.core.auth.RequiredAuthorization;
 
 public abstract class Authorizations {
+
+  public static final RequiredAuthorization<AgentDefinitionEntity>
+      AGENT_DEFINITION_READ_AUTHORIZATION =
+          RequiredAuthorization.of(a -> a.processDefinition().readProcessDefinition());
 
   public static final RequiredAuthorization<AgentInstanceEntity> AGENT_INSTANCE_READ_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.service.registry;
 
 import io.camunda.service.AdHocSubProcessActivityServices;
+import io.camunda.service.AgentDefinitionServices;
 import io.camunda.service.AgentHistoryServices;
 import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.AuditLogServices;
@@ -59,6 +60,7 @@ import java.util.function.Consumer;
  */
 public record DefaultServiceRegistry(
     Map<String, AdHocSubProcessActivityServices> adHocSubProcessActivityByTenant,
+    Map<String, AgentDefinitionServices> agentDefinitionByTenant,
     Map<String, AgentHistoryServices> agentHistoryByTenant,
     Map<String, AgentInstanceServices> agentInstanceByTenant,
     Map<String, AuditLogServices> auditLogByTenant,
@@ -113,6 +115,11 @@ public record DefaultServiceRegistry(
   public AdHocSubProcessActivityServices adHocSubProcessActivityServices(
       final String physicalTenantId) {
     return byTenant(adHocSubProcessActivityByTenant, physicalTenantId);
+  }
+
+  @Override
+  public AgentDefinitionServices agentDefinitionServices(final String physicalTenantId) {
+    return byTenant(agentDefinitionByTenant, physicalTenantId);
   }
 
   @Override
@@ -352,6 +359,7 @@ public record DefaultServiceRegistry(
 
     private final Map<String, AdHocSubProcessActivityServices> adHocSubProcessActivityByTenant =
         new HashMap<>();
+    private final Map<String, AgentDefinitionServices> agentDefinitionByTenant = new HashMap<>();
     private final Map<String, AgentHistoryServices> agentHistoryByTenant = new HashMap<>();
     private final Map<String, AgentInstanceServices> agentInstanceByTenant = new HashMap<>();
     private final Map<String, AuditLogServices> auditLogByTenant = new HashMap<>();
@@ -400,6 +408,12 @@ public record DefaultServiceRegistry(
     public Builder adHocSubProcessActivityServices(
         final String tenantId, final AdHocSubProcessActivityServices service) {
       adHocSubProcessActivityByTenant.put(tenantId, service);
+      return this;
+    }
+
+    public Builder agentDefinitionServices(
+        final String tenantId, final AgentDefinitionServices service) {
+      agentDefinitionByTenant.put(tenantId, service);
       return this;
     }
 
@@ -618,6 +632,7 @@ public record DefaultServiceRegistry(
     public DefaultServiceRegistry build() {
       return new DefaultServiceRegistry(
           Map.copyOf(adHocSubProcessActivityByTenant),
+          Map.copyOf(agentDefinitionByTenant),
           Map.copyOf(agentHistoryByTenant),
           Map.copyOf(agentInstanceByTenant),
           Map.copyOf(auditLogByTenant),

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.service.registry;
 
 import io.camunda.service.AdHocSubProcessActivityServices;
+import io.camunda.service.AgentDefinitionServices;
 import io.camunda.service.AgentHistoryServices;
 import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.AuditLogServices;
@@ -61,6 +62,8 @@ public interface ServiceRegistry {
   // -- tenant-scoped --
 
   AdHocSubProcessActivityServices adHocSubProcessActivityServices(String physicalTenantId);
+
+  AgentDefinitionServices agentDefinitionServices(String physicalTenantId);
 
   AgentHistoryServices agentHistoryServices(String physicalTenantId);
 

--- a/service/src/test/java/io/camunda/service/AgentDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AgentDefinitionServiceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.AgentDefinitionSearchClient;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.exception.ResourceAccessDeniedException;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.service.authorization.Authorizations;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class AgentDefinitionServiceTest {
+
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
+  private CamundaAuthentication authentication;
+  private AgentDefinitionServices services;
+  private AgentDefinitionSearchClient client;
+
+  @BeforeEach
+  public void before() {
+    authentication = mock(CamundaAuthentication.class);
+    client = mock(AgentDefinitionSearchClient.class);
+    when(client.withSecurityContext(any())).thenReturn(client);
+    services =
+        new AgentDefinitionServices(
+            PHYSICAL_TENANT_ID,
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            client,
+            mock(ApiServicesExecutorProvider.class),
+            null);
+  }
+
+  @Test
+  public void shouldReturnAgentDefinitions() {
+    // given
+    final var result = mock(SearchQueryResult.class);
+    when(client.searchAgentDefinitions(any())).thenReturn(result);
+
+    final AgentDefinitionQuery searchQuery =
+        SearchQueryBuilders.agentDefinitionSearchQuery().build();
+
+    // when
+    final SearchQueryResult<AgentDefinitionEntity> searchQueryResult =
+        services.search(searchQuery, authentication);
+
+    // then
+    assertThat(searchQueryResult).isEqualTo(result);
+  }
+
+  @Test
+  public void shouldGetAgentDefinitionByKey() {
+    // given
+    final var definitionEntity = mock(AgentDefinitionEntity.class);
+    when(definitionEntity.agentDefinitionKey()).thenReturn(42L);
+    when(definitionEntity.processDefinitionId()).thenReturn("processId");
+    when(client.getAgentDefinition(eq(42L))).thenReturn(definitionEntity);
+
+    // when
+    final AgentDefinitionEntity agentDefinition = services.getByKey(42L, authentication);
+
+    // then
+    assertThat(agentDefinition.agentDefinitionKey()).isEqualTo(42L);
+  }
+
+  @Test
+  void shouldGetByKeyThrowForbiddenExceptionOnUnauthorizedAgentDefinitionKey() {
+    // given
+    when(client.getAgentDefinition(any(Long.class)))
+        .thenThrow(
+            new ResourceAccessDeniedException(Authorizations.AGENT_DEFINITION_READ_AUTHORIZATION));
+
+    // when
+    final ThrowingCallable executable = () -> services.getByKey(1L, authentication);
+
+    // then
+    final var exception =
+        assertThatExceptionOfType(ServiceException.class).isThrownBy(executable).actual();
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_PROCESS_DEFINITION' on resource 'PROCESS_DEFINITION'");
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.gateway.protocol.model.AgentDefinitionTypeFilterProperty;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryCommitStatusFilterProperty;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleFilterProperty;
 import io.camunda.gateway.protocol.model.AgentInstanceStatusFilterProperty;
@@ -51,6 +52,7 @@ import io.camunda.gateway.protocol.model.StringFilterProperty;
 import io.camunda.gateway.protocol.model.UserTaskStateFilterProperty;
 import io.camunda.gateway.protocol.model.WaitStateElementTypeFilterProperty;
 import io.camunda.gateway.protocol.model.WaitStateTypeFilterProperty;
+import io.camunda.zeebe.gateway.rest.deserializer.AgentDefinitionTypeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AgentInstanceHistoryCommitStatusFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AgentInstanceHistoryRoleFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AgentInstanceStatusFilterPropertyDeserializer;
@@ -162,6 +164,9 @@ public class JacksonConfig {
     module.addDeserializer(
         ProcessInstanceModificationTerminateInstruction.class,
         new ProcessInstanceModificationTerminateInstructionDeserializer());
+    module.addDeserializer(
+        AgentDefinitionTypeFilterProperty.class,
+        new AgentDefinitionTypeFilterPropertyDeserializer());
     module.addDeserializer(
         AgentInstanceStatusFilterProperty.class,
         new AgentInstanceStatusFilterPropertyDeserializer());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentDefinitionController.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.protocol.model.AgentDefinitionResult;
+import io.camunda.gateway.protocol.model.AgentDefinitionSearchQuery;
+import io.camunda.gateway.protocol.model.AgentDefinitionSearchQueryResult;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/agent-definitions")
+public class AgentDefinitionController {
+
+  private final ServiceRegistry serviceRegistry;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public AgentDefinitionController(
+      final ServiceRegistry serviceRegistry,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.serviceRegistry = serviceRegistry;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @RequiresSecondaryStorage
+  @CamundaGetMapping(path = "/{agentDefinitionKey}")
+  public ResponseEntity<AgentDefinitionResult> getAgentDefinition(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable("agentDefinitionKey") final long agentDefinitionKey) {
+    try {
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toAgentDefinition(
+              serviceRegistry
+                  .agentDefinitionServices(physicalTenantId)
+                  .getByKey(
+                      agentDefinitionKey, authenticationProvider.getCamundaAuthentication())));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/search")
+  public ResponseEntity<AgentDefinitionSearchQueryResult> searchAgentDefinitions(
+      @PhysicalTenantId final String physicalTenantId,
+      @RequestBody(required = false) final AgentDefinitionSearchQuery request) {
+    return SearchQueryRequestMapper.toAgentDefinitionQuery(request)
+        .fold(RestErrorMapper::mapProblemToResponse, query -> search(physicalTenantId, query));
+  }
+
+  private ResponseEntity<AgentDefinitionSearchQueryResult> search(
+      final String physicalTenantId, final AgentDefinitionQuery query) {
+    final var agentDefinitionServices = serviceRegistry.agentDefinitionServices(physicalTenantId);
+    try {
+      final var result =
+          agentDefinitionServices.search(query, authenticationProvider.getCamundaAuthentication());
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toAgentDefinitionSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AgentDefinitionTypeFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AgentDefinitionTypeFilterPropertyDeserializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.gateway.protocol.model.AdvancedAgentDefinitionTypeFilter;
+import io.camunda.gateway.protocol.model.AgentDefinitionTypeEnum;
+import io.camunda.gateway.protocol.model.AgentDefinitionTypeFilterProperty;
+
+public class AgentDefinitionTypeFilterPropertyDeserializer
+    extends FilterDeserializer<AgentDefinitionTypeFilterProperty, AgentDefinitionTypeEnum> {
+
+  @Override
+  protected Class<? extends AgentDefinitionTypeFilterProperty> getFinalType() {
+    return AdvancedAgentDefinitionTypeFilter.class;
+  }
+
+  @Override
+  protected Class<AgentDefinitionTypeEnum> getImplicitValueType() {
+    return AgentDefinitionTypeEnum.class;
+  }
+
+  @Override
+  protected AgentDefinitionTypeFilterProperty createFromImplicitValue(
+      final AgentDefinitionTypeEnum value) {
+    return AdvancedAgentDefinitionTypeFilter.Builder.create().$eq(value).build();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentDefinitionQueryControllerTest.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.filter.AgentDefinitionFilter;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.search.sort.AgentDefinitionSort;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.service.AgentDefinitionServices;
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(value = AgentDefinitionController.class)
+public class AgentDefinitionQueryControllerTest extends RestControllerTest {
+
+  static final String EXPECTED_SEARCH_RESPONSE =
+      """
+          {
+              "items": [
+                  {
+                      "agentDefinitionKey": "1",
+                      "agentType": "AI_AGENT_TASK",
+                      "name": "name",
+                      "elementId": "elementId",
+                      "processDefinitionId": "processId",
+                      "processDefinitionKey": "2",
+                      "processDefinitionVersion": 1,
+                      "processDefinitionVersionTag": "v1",
+                      "tenantId": "t"
+                  }
+              ],
+              "page": {
+                  "totalItems": 1,
+                  "startCursor": "f",
+                  "endCursor": "v",
+                  "hasMoreTotalItems": false
+              }
+          }""";
+
+  static final AgentDefinitionEntity AGENT_DEFINITION_ENTITY =
+      new AgentDefinitionEntity(
+          1L, AgentType.AI_AGENT_TASK, "name", "elementId", "processId", 2L, 1, "v1", "t");
+
+  static final SearchQueryResult<AgentDefinitionEntity> SEARCH_QUERY_RESULT =
+      new Builder<AgentDefinitionEntity>()
+          .total(1L)
+          .items(List.of(AGENT_DEFINITION_ENTITY))
+          .startCursor("f")
+          .endCursor("v")
+          .build();
+
+  static final String AGENT_DEFINITIONS_SEARCH_URL = "/v2/agent-definitions/search";
+  static final String AGENT_DEFINITIONS_GET_URL = "/v2/agent-definitions/%d";
+
+  @MockitoBean AgentDefinitionServices agentDefinitionServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setupServices() {
+    when(serviceRegistry.agentDefinitionServices(any())).thenReturn(agentDefinitionServices);
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithEmptyBody() {
+    // given
+    when(agentDefinitionServices.search(any(AgentDefinitionQuery.class), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_DEFINITIONS_SEARCH_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentDefinitionServices).search(eq(new AgentDefinitionQuery.Builder().build()), any());
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithEmptyQuery() {
+    // given
+    when(agentDefinitionServices.search(any(AgentDefinitionQuery.class), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    final String request = "{}";
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_DEFINITIONS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentDefinitionServices).search(eq(new AgentDefinitionQuery.Builder().build()), any());
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithAllFilters() {
+    // given
+    when(agentDefinitionServices.search(any(AgentDefinitionQuery.class), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    final var request =
+        """
+            {
+              "filter":{
+                "agentDefinitionKey": "1",
+                "agentType": "AI_AGENT_TASK",
+                "name": "name",
+                "elementId": "elementId",
+                "processDefinitionId": "processId",
+                "processDefinitionKey": "2",
+                "processDefinitionVersion": 1,
+                "processDefinitionVersionTag": "v1",
+                "tenantId": "t"
+              }
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_DEFINITIONS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentDefinitionServices)
+        .search(
+            eq(
+                new AgentDefinitionQuery.Builder()
+                    .filter(
+                        new AgentDefinitionFilter.Builder()
+                            .agentDefinitionKeys(1L)
+                            .agentTypes("AI_AGENT_TASK")
+                            .names("name")
+                            .elementIds("elementId")
+                            .processDefinitionIds("processId")
+                            .processDefinitionKeys(2L)
+                            .processDefinitionVersions(1)
+                            .processDefinitionVersionTags("v1")
+                            .tenantIds("t")
+                            .build())
+                    .build()),
+            any());
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithFullSorting() {
+    // given
+    when(agentDefinitionServices.search(any(AgentDefinitionQuery.class), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    final var request =
+        """
+            {
+                "sort": [
+                    {
+                        "field": "agentDefinitionKey",
+                        "order": "ASC"
+                    },
+                    {
+                        "field": "agentType",
+                        "order": "DESC"
+                    },
+                    {
+                         "field": "name"
+                    },
+                    {
+                         "field": "elementId"
+                    },
+                    {
+                         "field": "processDefinitionId"
+                    },
+                    {
+                         "field": "processDefinitionKey"
+                    },
+                    {
+                         "field": "processDefinitionVersion"
+                    },
+                    {
+                         "field": "processDefinitionVersionTag"
+                    },
+                    {
+                         "field": "tenantId"
+                    }
+                ]
+            }""";
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_DEFINITIONS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentDefinitionServices)
+        .search(
+            eq(
+                new AgentDefinitionQuery.Builder()
+                    .sort(
+                        new AgentDefinitionSort.Builder()
+                            .agentDefinitionKey()
+                            .asc()
+                            .agentType()
+                            .desc()
+                            .name()
+                            .asc()
+                            .elementId()
+                            .asc()
+                            .processDefinitionId()
+                            .asc()
+                            .processDefinitionKey()
+                            .asc()
+                            .processDefinitionVersion()
+                            .asc()
+                            .processDefinitionVersionTag()
+                            .asc()
+                            .tenantId()
+                            .asc()
+                            .build())
+                    .build()),
+            any());
+  }
+
+  @Test
+  void shouldInvalidateAgentDefinitionsSearchQueryWithBadSortField() {
+    // given
+    final var request =
+        """
+            {
+                "sort": [
+                    {
+                        "field": "unknownField",
+                        "order": "ASC"
+                    }
+                ]
+            }""";
+    final var expectedResponse =
+        """
+            {
+              "type": "about:blank",
+              "title": "Bad Request",
+              "status": 400,
+              "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [agentDefinitionKey, agentType, name, elementId, processDefinitionId, processDefinitionKey, processDefinitionVersion, processDefinitionVersionTag, tenantId]",
+              "instance": "%s"
+            }"""
+            .formatted(AGENT_DEFINITIONS_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_DEFINITIONS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(agentDefinitionServices, never()).search(any(AgentDefinitionQuery.class), any());
+  }
+
+  @Test
+  public void shouldGetAgentDefinitionByKey() {
+    // given
+    final Long agentDefinitionKey = 1L;
+    when(agentDefinitionServices.getByKey(eq(agentDefinitionKey), any()))
+        .thenReturn(AGENT_DEFINITION_ENTITY);
+    final var expectedResponse =
+        """
+            {
+              "agentDefinitionKey": "1",
+              "agentType": "AI_AGENT_TASK",
+              "name": "name",
+              "elementId": "elementId",
+              "processDefinitionId": "processId",
+              "processDefinitionKey": "2",
+              "processDefinitionVersion": 1,
+              "processDefinitionVersionTag": "v1",
+              "tenantId": "t"
+            }""";
+    // when/then
+    webClient
+        .get()
+        .uri(AGENT_DEFINITIONS_GET_URL.formatted(agentDefinitionKey))
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  public void shouldReturn404ForNotFoundAgentDefinitionByKey() {
+    // given
+    final Long agentDefinitionKey = 1L;
+    when(agentDefinitionServices.getByKey(eq(agentDefinitionKey), any()))
+        .thenThrow(
+            ErrorMapper.mapSearchError(
+                new CamundaSearchException(
+                    "Agent definition with key 1 was not found.",
+                    CamundaSearchException.Reason.NOT_FOUND)));
+
+    // when/then
+    final var expectedResponse =
+        """
+            {
+              "type": "about:blank",
+              "title": "NOT_FOUND",
+              "status": 404,
+              "detail": "Agent definition with key 1 was not found.",
+              "instance": "%s"
+            }"""
+            .formatted(AGENT_DEFINITIONS_GET_URL.formatted(agentDefinitionKey));
+    webClient
+        .get()
+        .uri(AGENT_DEFINITIONS_GET_URL.formatted(agentDefinitionKey))
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  public void shouldReturn500ForInternalErrorGetAgentDefinitionByKey() {
+    // given
+    final Long agentDefinitionKey = 1L;
+    when(agentDefinitionServices.getByKey(eq(agentDefinitionKey), any()))
+        .thenThrow(new RuntimeException("Failed to get agent definition."));
+
+    // when/then
+    final var expectedResponse =
+        """
+            {
+              "type": "about:blank",
+              "title": "java.lang.RuntimeException",
+              "status": 500,
+              "detail": "Unexpected error occurred during the request processing: Failed to get agent definition.",
+              "instance": "%s"
+            }"""
+            .formatted(AGENT_DEFINITIONS_GET_URL.formatted(agentDefinitionKey));
+    webClient
+        .get()
+        .uri(AGENT_DEFINITIONS_GET_URL.formatted(agentDefinitionKey))
+        .exchange()
+        .expectStatus()
+        .is5xxServerError()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  public void shouldReturn403ForForbiddenAgentDefinitionByKey() {
+    // given
+    final Long agentDefinitionKey = 1L;
+    when(agentDefinitionServices.getByKey(eq(agentDefinitionKey), any()))
+        .thenThrow(
+            ErrorMapper.createForbiddenException(
+                RequiredAuthorization.of(a -> a.processDefinition().readProcessDefinition())));
+
+    // when/then
+    final var expectedResponse =
+        """
+            {
+              "type": "about:blank",
+              "status": 403,
+              "title": "FORBIDDEN",
+              "detail": "Unauthorized to perform operation 'READ_PROCESS_DEFINITION' on resource 'PROCESS_DEFINITION'",
+              "instance": "%s"
+            }"""
+            .formatted(AGENT_DEFINITIONS_GET_URL.formatted(agentDefinitionKey));
+    webClient
+        .get()
+        .uri(AGENT_DEFINITIONS_GET_URL.formatted(agentDefinitionKey))
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(agentDefinitionServices).getByKey(eq(agentDefinitionKey), any());
+  }
+
+  @Test
+  public void shouldReturn400ForInvalidKey() {
+    // given
+    final String agentDefinitionKey = "invalidKey";
+
+    // when/then
+    final var expectedResponse =
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "Bad Request",
+              "detail": "Failed to convert 'agentDefinitionKey' with value: 'invalidKey'",
+              "instance": "/v2/agent-definitions/invalidKey"
+            }""";
+
+    webClient
+        .get()
+        .uri("/v2/agent-definitions/%s".formatted(agentDefinitionKey))
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+}


### PR DESCRIPTION
## Description

Adds the HTTP REST endpoints for agent definitions: `GET /v2/agent-definitions/{agentDefinitionKey}` (fetch a single agent definition by key) and `POST /v2/agent-definitions/search` (search/filter/sort agent definitions).

**Why:** agent definitions (the deploy-time configuration of an AI agent task/sub-process, created by `AgentDefinitionHandler` and made searchable by the ES/OS reader) were not yet reachable from the REST API. Without these endpoints there was no way for API clients, the future orchestration-cluster webapp, or the upcoming Java client (#59086) to list or drill into agent definitions — the data existed only inside Elasticsearch/OpenSearch.

This PR wires the storage-agnostic `AgentDefinitionReader` all the way through to HTTP:

1. `AGENT_DEFINITION_READ_AUTHORIZATION` — reuses process-definition read authorization (`processDefinition().readProcessDefinition()`), since an agent definition is only as readable as the process definition that owns it.
2. `AgentDefinitionSearchClient` wired into `SearchClientsProxy` (ES/OS-backed today; the RDBMS implementation is a stub that throws `UnsupportedOperationException` until #59079 lands).
3. `AgentDefinitionServices` — the domain service layer enforcing the authorization above for both `search()` and `getByKey()`.
4. HTTP mappers translating between the generated OpenAPI request/response models (`AgentDefinitionSearchQuery`/`AgentDefinitionResult`/...) and the search-domain `AgentDefinitionFilter`/`AgentDefinitionSort`/`AgentDefinitionQuery`/`AgentDefinitionEntity`.
5. `AgentDefinitionController`, exposing the two endpoints per the OpenAPI contract in `agent-definitions.yaml`, plus the `AgentDefinitionTypeFilterPropertyDeserializer` needed to deserialize the `agentType` filter's oneOf JSON schema.

### What this enables

- Listing/filtering agent definitions by key, agent type, name, element ID, owning process definition (ID/key/version/version tag), and tenant.
- Sorting search results by any of the same fields.
- Fetching a single agent definition by key (404 if not found).
- Tenant- and authorization-scoped access consistent with sibling process-definition-owned resources.

### Out of scope

- The RDBMS-backed reader (#59079) — calls will surface `UnsupportedOperationException` from the stub `AgentDefinitionDbReader` when RDBMS is the active secondary storage, until #59079 lands.
- The Java client bindings for these endpoints (#59086).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59081
