### PR TITLE
ci: add TEST_OWNER env var to reliability-testing-owned workflows

### DIFF
--- a/.github/workflows/camunda-delete-load-test.yml
+++ b/.github/workflows/camunda-delete-load-test.yml
@@ -29,6 +29,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/camunda-load-test-metrics-exporter-ci.yaml
+++ b/.github/workflows/camunda-load-test-metrics-exporter-ci.yaml
@@ -26,6 +26,9 @@ defaults:
   run:
     working-directory: ./load-tests/metrics-exporter
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   test:
     name: Tests

--- a/.github/workflows/camunda-load-test-metrics.yaml
+++ b/.github/workflows/camunda-load-test-metrics.yaml
@@ -50,6 +50,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   AT: ${{ inputs.at }}
   DURATION_SECONDS: ${{ inputs.duration-seconds }}
   NAMESPACE: ${{ inputs.namespace }}

--- a/.github/workflows/camunda-load-test-smoke-dispatch.yml
+++ b/.github/workflows/camunda-load-test-smoke-dispatch.yml
@@ -23,6 +23,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   detect-versions:
     name: Detect changed versions

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -48,6 +48,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
   TARGET_VERSION: ${{ inputs.target-version }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -239,6 +239,8 @@ on:
         required: false
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
   # Namespaces MUST start with c8 due to access policy
   NAMESPACE: ${{ startsWith(inputs.name, 'c8-') && inputs.name || format('c8-{0}', inputs.name) }}
 

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -72,6 +72,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/camunda-verify-and-cleanup-load-test.yml
+++ b/.github/workflows/camunda-verify-and-cleanup-load-test.yml
@@ -15,6 +15,7 @@ on:
         required: true
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/camunda-verify-load-test.yml
+++ b/.github/workflows/camunda-verify-load-test.yml
@@ -14,6 +14,7 @@ on:
         required: true
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
   NAMESPACE: ${{ inputs.namespace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      TEST_OWNER: '@camunda/reliability-testing'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -283,6 +285,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    env:
+      TEST_OWNER: '@camunda/reliability-testing'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/load-test-golden-update.yml
+++ b/.github/workflows/load-test-golden-update.yml
@@ -27,6 +27,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/pr-load-test-dispatch.yml
+++ b/.github/workflows/pr-load-test-dispatch.yml
@@ -33,6 +33,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   dispatch:
     name: Dispatch benchmark matrix


### PR DESCRIPTION
## Description

Workflows tagged with the `# owner: @camunda/reliability-testing` header comment are meant to be self-identifying at runtime too, so failure notifications, dashboards, and scripts can attribute a run to the owning team without parsing YAML comments.

Several workflows carried the owner comment but never set the corresponding `TEST_OWNER` environment variable, leaving that automation blind for those runs. This PR adds `TEST_OWNER: '@camunda/reliability-testing'` to the `env` block (workflow-level where possible, job-level in `ci.yml` where no workflow-level env block made sense) of every workflow that had the ownership comment but was missing the variable:

- `.github/workflows/camunda-release-load-test.yaml`
- `.github/workflows/camunda-load-test-smoke.yml`
- `.github/workflows/pr-load-test-dispatch.yml`
- `.github/workflows/camunda-load-test-metrics.yaml`
- `.github/workflows/camunda-delete-load-test.yml`
- `.github/workflows/camunda-load-test-metrics-exporter-ci.yaml`
- `.github/workflows/camunda-load-test-smoke-dispatch.yml`
- `.github/workflows/camunda-load-test.yml`
- `.github/workflows/camunda-verify-and-cleanup-load-test.yml`
- `.github/workflows/camunda-verify-load-test.yml`
- `.github/workflows/ci.yml` (job-level, relevant for INC-7140)
- `.github/workflows/load-test-golden-update.yml`

No behavioral changes to workflow logic — this only adds metadata that will be populated into CI Analytics.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

INC-7140

🤖 Generated with [Claude Code](https://claude.com/claude-code)