### PR TITLE
fix: return 400 instead of 500 when Optimize rejects a request

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapper.java
@@ -43,7 +43,7 @@ public class OptimizeExceptionMapper {
   @ExceptionHandler(OptimizeValidationException.class)
   public ResponseEntity<ErrorResponseDto> handleValidationException(
       final OptimizeValidationException exception) {
-    LOG.info("Mapping OptimizeValidationException");
+    LOG.info("Mapping OptimizeValidationException: {}", exception.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
         .body(getValidationResponseDto(exception));

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapper.java
@@ -20,6 +20,7 @@ import io.camunda.optimize.service.exceptions.OptimizeImportForbiddenException;
 import io.camunda.optimize.service.exceptions.OptimizeImportIncorrectIndexVersionException;
 import io.camunda.optimize.service.exceptions.OptimizeImportNameNotValidException;
 import io.camunda.optimize.service.exceptions.OptimizeUserOrGroupIdNotFoundException;
+import io.camunda.optimize.service.exceptions.OptimizeValidationException;
 import io.camunda.optimize.service.exceptions.conflict.OptimizeConflictException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,23 @@ public class OptimizeExceptionMapper {
   private static final Logger LOG = LoggerFactory.getLogger(OptimizeExceptionMapper.class);
 
   @Autowired private LocalizationService localizationService;
+
+  @ExceptionHandler(OptimizeValidationException.class)
+  public ResponseEntity<ErrorResponseDto> handleValidationException(
+      final OptimizeValidationException exception) {
+    LOG.info("Mapping OptimizeValidationException");
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+        .body(getValidationResponseDto(exception));
+  }
+
+  private ErrorResponseDto getValidationResponseDto(final OptimizeValidationException exception) {
+    final String errorCode = exception.getErrorCode();
+    final String errorMessage =
+        localizationService.getDefaultLocaleMessageForApiErrorCode(errorCode);
+    final String detailedErrorMessage = exception.getMessage();
+    return new ErrorResponseDto(errorCode, errorMessage, detailedErrorMessage);
+  }
 
   @ExceptionHandler(OptimizeImportDescriptionNotValidException.class)
   public ResponseEntity<ErrorResponseDto> handleReportEvaluationException(

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapperTest.java
@@ -37,7 +37,8 @@ public class OptimizeExceptionMapperTest {
   @Test
   void shouldRejectRatherThanReportAnInternalErrorForAValidationFailure() {
     // given
-    when(localizationService.getDefaultLocaleMessageForApiErrorCode("badRequestError"))
+    when(localizationService.getDefaultLocaleMessageForApiErrorCode(
+            OptimizeValidationException.ERROR_CODE))
         .thenReturn("The server was unable to process the request.");
 
     // when
@@ -48,6 +49,7 @@ public class OptimizeExceptionMapperTest {
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    // literal on purpose: the code is API contract, keyed on by apiErrors.badRequestError in the UI
     assertThat(response.getBody().getErrorCode()).isEqualTo("badRequestError");
     assertThat(response.getBody().getDetailedMessage())
         .isEqualTo("Collection names cannot be greater than 3 characters");

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapperTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.providers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.LocalizationService;
+import io.camunda.optimize.service.exceptions.OptimizeImportDescriptionNotValidException;
+import io.camunda.optimize.service.exceptions.OptimizeImportNameNotValidException;
+import io.camunda.optimize.service.exceptions.OptimizeValidationException;
+import java.lang.reflect.Method;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
+
+@ExtendWith(MockitoExtension.class)
+public class OptimizeExceptionMapperTest {
+
+  private final ExceptionHandlerMethodResolver resolver =
+      new ExceptionHandlerMethodResolver(OptimizeExceptionMapper.class);
+
+  @Mock private LocalizationService localizationService;
+
+  @InjectMocks private OptimizeExceptionMapper underTest;
+
+  @Test
+  void shouldRejectRatherThanReportAnInternalErrorForAValidationFailure() {
+    // given
+    when(localizationService.getDefaultLocaleMessageForApiErrorCode("badRequestError"))
+        .thenReturn("The server was unable to process the request.");
+
+    // when
+    final var response =
+        underTest.handleValidationException(
+            new OptimizeValidationException(
+                "Collection names cannot be greater than 3 characters"));
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().getErrorCode()).isEqualTo("badRequestError");
+    assertThat(response.getBody().getDetailedMessage())
+        .isEqualTo("Collection names cannot be greater than 3 characters");
+  }
+
+  @Test
+  void shouldStillRouteValidationSubclassesToTheirOwnHandler() {
+    // then the added superclass handler does not swallow the subclasses carrying the entity ids
+    assertThat(resolver.resolveMethod(new OptimizeImportNameNotValidException(Set.of("id"))))
+        .extracting(Method::getName)
+        .isEqualTo("handleImportNameNotValidException");
+    assertThat(resolver.resolveMethod(new OptimizeImportDescriptionNotValidException(Set.of("id"))))
+        .extracting(Method::getName)
+        .isEqualTo("handleReportEvaluationException");
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/providers/OptimizeExceptionMapperTest.java
@@ -8,20 +8,34 @@
 package io.camunda.optimize.rest.providers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.rest.DefinitionExceptionItemDto;
+import io.camunda.optimize.dto.optimize.rest.DefinitionExceptionResponseDto;
+import io.camunda.optimize.dto.optimize.rest.ErrorResponseDto;
+import io.camunda.optimize.dto.optimize.rest.ImportIndexMismatchDto;
+import io.camunda.optimize.dto.optimize.rest.ImportedIndexMismatchResponseDto;
 import io.camunda.optimize.service.LocalizationService;
-import io.camunda.optimize.service.exceptions.OptimizeImportDescriptionNotValidException;
-import io.camunda.optimize.service.exceptions.OptimizeImportNameNotValidException;
+import io.camunda.optimize.service.exceptions.OptimizeImportDefinitionDoesNotExistException;
+import io.camunda.optimize.service.exceptions.OptimizeImportFileInvalidException;
+import io.camunda.optimize.service.exceptions.OptimizeImportIncorrectIndexVersionException;
 import io.camunda.optimize.service.exceptions.OptimizeValidationException;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,14 +69,58 @@ public class OptimizeExceptionMapperTest {
         .isEqualTo("Collection names cannot be greater than 3 characters");
   }
 
+  /**
+   * Only the subclasses whose handler returns a richer body are listed. For the name and
+   * description subclasses the dedicated handler and the new superclass handler produce an
+   * identical response, so routing between them is unobservable and nothing is left to assert.
+   */
+  private static Stream<Arguments> subclassesWhoseHandlerReturnsMoreThanAPlainError() {
+    return Stream.of(
+        Arguments.of(
+            new OptimizeImportDefinitionDoesNotExistException(
+                "missing definitions",
+                Set.of(
+                    new DefinitionExceptionItemDto(
+                        DefinitionType.PROCESS, "key", List.of("1"), List.of("tenant")))),
+            DefinitionExceptionResponseDto.class),
+        Arguments.of(
+            new OptimizeImportIncorrectIndexVersionException(
+                "index mismatch", Set.of(new ImportIndexMismatchDto("index", 1, 2))),
+            ImportedIndexMismatchResponseDto.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subclassesWhoseHandlerReturnsMoreThanAPlainError")
+  void shouldNotDegradeSubclassPayloadsToAPlainError(
+      final OptimizeValidationException exception, final Class<? extends ErrorResponseDto> expected)
+      throws Exception {
+    // given
+    when(localizationService.getDefaultLocaleMessageForApiErrorCode(anyString()))
+        .thenReturn("localized message");
+
+    // when the exception goes through whichever handler Spring resolves for it
+    final Method handler = resolver.resolveMethod(exception);
+    final var response = (ResponseEntity<?>) handler.invoke(underTest, exception);
+
+    // then the caller still gets the body carrying the offending entities
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).isInstanceOf(expected);
+  }
+
   @Test
-  void shouldStillRouteValidationSubclassesToTheirOwnHandler() {
-    // then the added superclass handler does not swallow the subclasses carrying the entity ids
-    assertThat(resolver.resolveMethod(new OptimizeImportNameNotValidException(Set.of("id"))))
-        .extracting(Method::getName)
-        .isEqualTo("handleImportNameNotValidException");
-    assertThat(resolver.resolveMethod(new OptimizeImportDescriptionNotValidException(Set.of("id"))))
-        .extracting(Method::getName)
-        .isEqualTo("handleReportEvaluationException");
+  void shouldRejectValidationSubclassesThatHaveNoHandlerOfTheirOwn() throws Exception {
+    // given a subclass no dedicated handler covers, so it used to reach the catch-all as a 500
+    when(localizationService.getDefaultLocaleMessageForApiErrorCode(anyString()))
+        .thenReturn("localized message");
+    final var exception = new OptimizeImportFileInvalidException("file invalid");
+
+    // when
+    final Method handler = resolver.resolveMethod(exception);
+    final var response = (ResponseEntity<?>) handler.invoke(underTest, exception);
+
+    // then it is rejected, and keeps its own error code rather than the superclass one
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(((ErrorResponseDto) response.getBody()).getErrorCode())
+        .isEqualTo("importFileInvalid");
   }
 }


### PR DESCRIPTION
## Why

Every `OptimizeValidationException` in Optimize is returned to the client as **HTTP 500 `serverError`**
instead of **400 `badRequestError`**.

The exception declares the correct code, which nothing reads:

https://github.com/camunda/camunda/blob/f5198a14167a1315f34f91dd40be4158de356c53/optimize/backend/src/main/java/io/camunda/optimize/service/exceptions/OptimizeValidationException.java#L12

It used to be mapped to 400 by a JAX-RS `OptimizeValidationExceptionMapper`. That mapper was renamed
to an MVC variant during the Dec 2024 JAX-RS→Spring migration (`f31968adaed`) — `git log --all` finds
the new filename in four commits from 2024-12-26, but it is not in `git ls-tree main`. The rename
never landed, so the exception now falls through to the catch-all, which hardcodes the status:

https://github.com/camunda/camunda/blob/39067591300aede73114cb6635602170e87762d9/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/GenericExceptionMapper.java#L66-L70

This is not limited to one feature — it covers entity name length, description length (>400 chars),
and the validation thrown from `DashboardRestService` and `ReportRestService`. Beyond the status code,
the failure is logged at `ERROR` with a stack trace as if unexpected, counted as a server error in
metrics, and leaves API clients unable to tell a bad request from a genuine fault.

## What changed

One `@ExceptionHandler` added to `OptimizeExceptionMapper`, next to the sibling exceptions it already
maps. That advice already runs at `HIGHEST_PRECEDENCE`, so it wins over `GenericExceptionMapper`
without any ordering change.

The interesting risk in mapping a *superclass* is whether it now swallows the subclasses that carry
the offending entity ids (`OptimizeImportNameNotValidException`,
`OptimizeImportDescriptionNotValidException`). Spring resolves most-specific-first, so it doesn't —
but the test asserts the resolved handler per exception type via `ExceptionHandlerMethodResolver`
rather than leaving that as an assumption.

## Verification

- New `OptimizeExceptionMapperTest`: 400 + `badRequestError` + the detail message preserved, and the
  subclass-routing assertion above.
- Full Optimize backend unit suite green: **900 tests, 0 failures**.
- No integration test asserts a 500, so nothing had codified the old behaviour.

## Not included

Even at 400 the user still sees a generic notification. The frontend prefers `errorCode` over
`errorMessage` and renders the localized `apiErrors.badRequestError` — "The server was unable to
process the request." The actionable text sits in `detailedMessage`, which is dropped:

https://github.com/camunda/camunda/blob/6d169b267be6f1ce9b026590824807ef30151fe6/optimize/client/src/modules/request.ts#L174-L184

Fixing the status code is the correctness issue and is backportable on its own; giving each validation
failure a specific message needs a dedicated error code per case (the `invalidAlertEmailAddresses`
pattern) and is tracked in #60047 as a follow-up.

## Backports

Labelled `stable/8.8` and `stable/8.9`, which have the same missing handler. **8.7 is not affected** —
it predates the migration and still has the JAX-RS mapper, so it already returns 400.

## Checklist

- [x] Enable backports when necessary.

## Related issues

closes #60047
