### PR TITLE
feat: scope PATCH /actuator/cluster/routing-state to a physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -502,7 +502,9 @@ public class ClusterEndpoint {
   @PatchMapping(path = "/routing-state", consumes = "application/json")
   public ResponseEntity<?> updateRoutingState(
       @RequestBody(required = false) final RoutingState routingState,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
+    final Optional<String> tenant = Optional.ofNullable(physicalTenant).filter(s -> !s.isBlank());
     try {
       Optional<io.camunda.zeebe.dynamic.config.state.RoutingState> internalRoutingState =
           Optional.empty();
@@ -531,7 +533,7 @@ public class ClusterEndpoint {
                     requestHandling,
                     messageCorrelation));
       }
-      final var updateRequest = new UpdateRoutingStateRequest(internalRoutingState, dryRun);
+      final var updateRequest = new UpdateRoutingStateRequest(internalRoutingState, tenant, dryRun);
       return ClusterApiUtils.mapOperationResponse(
           requestSender.updateRoutingState(updateRequest).join());
     } catch (final Exception error) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -504,7 +504,7 @@ public class ClusterEndpoint {
       @RequestBody(required = false) final RoutingState routingState,
       @RequestParam(defaultValue = "false") final boolean dryRun,
       @RequestParam(required = false) final @Nullable String physicalTenant) {
-    final Optional<String> tenant = Optional.ofNullable(physicalTenant).filter(s -> !s.isBlank());
+    final Optional<String> tenant = nonBlank(physicalTenant);
     try {
       Optional<io.camunda.zeebe.dynamic.config.state.RoutingState> internalRoutingState =
           Optional.empty();

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -204,6 +204,9 @@ paths:
         applying it to the configuration.
         No validation is performed on the user provided routing state, so it must be
         used only in the rare circumstances when it's not possible to fetch it from the engine.
+        When physicalTenant is given, only that physical tenant's routing state is written;
+        when omitted, the default physical tenant's routing state is written, regardless of
+        which other physical tenants exist.
       requestBody:
         content:
           application/json:
@@ -211,11 +214,14 @@ paths:
               $ref: "components.yaml#/schemas/RoutingState"
       parameters:
         - $ref: '#/components/parameters/DryRunParameter'
+        - $ref: '#/components/parameters/RoutingStatePhysicalTenantParameter'
       responses:
         '202':
           description: Accepted
         '400':
           $ref: 'components.yaml#/responses/InvalidRequest'
+        '404':
+          $ref: 'components.yaml#/responses/NotFound'
         '409':
           $ref: 'components.yaml#/responses/ConcurrentChangeError'
         '500':
@@ -397,6 +403,15 @@ components:
     PhysicalTenantParameter:
       name: physicalTenant
       description: Id of the physical tenant to target. If not specified, the operation applies to all physical tenants.
+      in: query
+      style: form
+      required: false
+      schema:
+        $ref: 'components.yaml#/schemas/PhysicalTenantId'
+    RoutingStatePhysicalTenantParameter:
+      name: physicalTenant
+      description: Id of the physical tenant to target. If not specified, the default physical tenant is targeted,
+        not every physical tenant - unlike the other operations taking this parameter.
       in: query
       style: form
       required: false

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -127,7 +127,8 @@ public final class PartitionManagerImpl
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.brokerClient = brokerClient;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
-    scalingExecutor = new BrokerClientPartitionScalingExecutor(brokerClient, concurrencyControl);
+    scalingExecutor =
+        new BrokerClientPartitionScalingExecutor(partitionGroup, brokerClient, concurrencyControl);
     brokerMeterRegistry = meterRegistry;
     exporterHistoryPurger =
         new ExporterHistoryPurger(partitionGroup, exporterRepository, meterRegistry);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
@@ -36,9 +36,13 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
       LoggerFactory.getLogger(BrokerClientPartitionScalingExecutor.class);
   private final BrokerClient brokerClient;
   private final ConcurrencyControl concurrencyControl;
+  private final String partitionGroup;
 
   public BrokerClientPartitionScalingExecutor(
-      final BrokerClient brokerClient, final ConcurrencyControl concurrencyControl) {
+      final String partitionGroup,
+      final BrokerClient brokerClient,
+      final ConcurrencyControl concurrencyControl) {
+    this.partitionGroup = partitionGroup;
     this.brokerClient = brokerClient;
     this.concurrencyControl = concurrencyControl;
   }
@@ -47,8 +51,10 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
   public ActorFuture<Void> initiateScaleUp(final int desiredPartitionCount) {
     final var result = concurrencyControl.<Void>createFuture();
 
+    final var request = new BrokerPartitionScaleUpRequest(desiredPartitionCount);
+    request.setPartitionGroup(partitionGroup);
     brokerClient.sendRequestWithRetry(
-        new BrokerPartitionScaleUpRequest(desiredPartitionCount),
+        request,
         (key, response) -> {
           result.complete(null);
         },
@@ -79,8 +85,10 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
     final ActorFuture<BrokerResponse<ScaleRecord>> bootstrapFuture =
         concurrencyControl.createFuture();
 
+    final var request = new BrokerPartitionBootstrappedRequest(partitionId);
+    request.setPartitionGroup(partitionGroup);
     brokerClient
-        .sendRequestWithRetry(new BrokerPartitionBootstrappedRequest(partitionId))
+        .sendRequestWithRetry(request)
         .whenCompleteAsync(bootstrapFuture, concurrencyControl);
     return bootstrapFuture.andThen(
         response -> {
@@ -101,8 +109,10 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
   @Override
   public ActorFuture<RoutingState> getRoutingState() {
     final var result = concurrencyControl.<RoutingState>createFuture();
+    final var request = new GetScaleUpProgress();
+    request.setPartitionGroup(partitionGroup);
     brokerClient.sendRequestWithRetry(
-        new GetScaleUpProgress(),
+        request,
         (key, record) -> result.complete(RoutingStateConverter.fromScaleRecord(record)),
         result::completeExceptionally);
     return result;
@@ -126,8 +136,10 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
       final Set<Integer> redistributedPartitions,
       final int partitionId) {
     final var result = concurrencyControl.<Void>createFuture();
+    final var request = new GetScaleUpProgress(partitionId);
+    request.setPartitionGroup(partitionGroup);
     brokerClient.sendRequestWithRetry(
-        new GetScaleUpProgress(partitionId),
+        request,
         (key, response) -> {
           if (response.getDesiredPartitionCount() != desiredPartitionCount) {
             LOGGER.warn("Invalid GetScaleUpProgress response: got {}", response);
@@ -168,6 +180,7 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
     final var request =
         new SnapshotBrokerRequest(
             new DeleteSnapshotForBootstrapRequest(Protocol.DEPLOYMENT_PARTITION));
+    request.setPartitionGroup(partitionGroup);
     final var future = concurrencyControl.<Void>createFuture();
     brokerClient.sendRequestWithRetry(
         request,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
@@ -42,6 +42,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class BrokerClientPartitionScalingExecutorTest {
 
+  private static final String PARTITION_GROUP = "tenant-a";
+
   static final List<Set<Integer>> INCOMPLETE_PARTITION_LIST =
       List.of(Set.of(1, 2, 3, 4), Set.of(4));
 
@@ -54,7 +56,8 @@ public class BrokerClientPartitionScalingExecutorTest {
 
   @BeforeEach
   void setup() {
-    executor = new BrokerClientPartitionScalingExecutor(brokerClient, concurrencyControl);
+    executor =
+        new BrokerClientPartitionScalingExecutor(PARTITION_GROUP, brokerClient, concurrencyControl);
   }
 
   @Test
@@ -130,6 +133,7 @@ public class BrokerClientPartitionScalingExecutorTest {
       assertThat(request).isInstanceOf(GetScaleUpProgress.class);
       final var getScaleUpProgress = (GetScaleUpProgress) request;
       assertThat(request.getPartitionId()).isEqualTo(i);
+      assertThat(request.getPartitionGroup()).isEqualTo(PARTITION_GROUP);
 
       clearInvocations(brokerClient);
       scaleRecord.ifRightOrLeft(
@@ -147,6 +151,7 @@ public class BrokerClientPartitionScalingExecutorTest {
       assertThat(snapshotRequest.getPartitionId()).isEqualTo(Protocol.DEPLOYMENT_PARTITION);
       assertThat(snapshotRequest.getRequest().partitionId())
           .isEqualTo(Protocol.DEPLOYMENT_PARTITION);
+      assertThat(snapshotRequest.getPartitionGroup()).isEqualTo(PARTITION_GROUP);
 
       responseConsumerCaptor.getValue().accept(1L, new DeleteSnapshotForBootstrapResponse(1));
     }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
@@ -42,13 +42,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class BrokerClientPartitionScalingExecutorTest {
 
-  private static final String PARTITION_GROUP = "tenant-a";
-
   static final List<Set<Integer>> INCOMPLETE_PARTITION_LIST =
       List.of(Set.of(1, 2, 3, 4), Set.of(4));
 
   static final List<Set<Integer>> COMPLETE_PARTITION_LIST =
       List.of(Set.of(1, 2, 3, 4, 5), Set.of(4, 5));
+
+  private static final String PARTITION_GROUP = "tenant-a";
 
   TestConcurrencyControl concurrencyControl = new TestConcurrencyControl();
   BrokerClientPartitionScalingExecutor executor;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -106,7 +106,13 @@ public sealed interface ClusterConfigurationManagementRequest {
     }
   }
 
-  record UpdateRoutingStateRequest(Optional<RoutingState> routingState, boolean dryRun)
+  /**
+   * Writes the routing state. If physicalTenantId is provided, only that physical tenant's routing
+   * state is updated; otherwise, the default physical tenant's routing state is updated, unlike the
+   * other per-tenant requests where an absent physicalTenantId means "every tenant".
+   */
+  record UpdateRoutingStateRequest(
+      Optional<RoutingState> routingState, Optional<String> physicalTenantId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record UpdatePartitionDistributorConfigRequest(PartitionDistributorConfig config, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -174,7 +174,9 @@ public final class ClusterConfigurationManagementRequestsHandler
       final UpdateRoutingStateRequest updateRoutingStateRequest) {
     return handleRequest(
         updateRoutingStateRequest.dryRun(),
-        new UpdateRoutingStateTransformer(updateRoutingStateRequest.routingState()));
+        new UpdateRoutingStateTransformer(
+            updateRoutingStateRequest.routingState(),
+            updateRoutingStateRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformer.java
@@ -7,21 +7,43 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Writes the routing state, either for a single physical tenant or, when none is given, for the
+ * default physical tenant. Unlike the other per-tenant requests, an absent {@code physicalTenantId}
+ * does not mean "every tenant" here: it keeps the pre-existing behaviour of writing only the
+ * default group, so unscoped callers see no change once physical tenants exist.
+ */
 public class UpdateRoutingStateTransformer implements ConfigurationChangeRequest {
 
   private final Optional<RoutingState> routingState;
+  private final Optional<String> physicalTenantId;
 
   public UpdateRoutingStateTransformer(final Optional<RoutingState> routingState) {
+    this(routingState, Optional.empty());
+  }
+
+  public UpdateRoutingStateTransformer(
+      final Optional<RoutingState> routingState, final Optional<String> physicalTenantId) {
     this.routingState = routingState;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
@@ -31,5 +53,50 @@ public class UpdateRoutingStateTransformer implements ConfigurationChangeRequest
         ClusterConfigurationCoordinatorSupplier.of(() -> clusterConfiguration);
     final var coordinator = coordinatorSupplier.getDefaultCoordinator();
     return Either.right(List.of(new UpdateRoutingState(coordinator, routingState)));
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to update the routing state of physical tenant '%s', but there's no such tenant"
+                  .formatted(physicalTenantId.get())));
+    }
+
+    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    final var group =
+        Objects.requireNonNull(
+            clusterConfiguration.partitionGroup(groupId),
+            () -> "Expected partition group '%s' to exist".formatted(groupId));
+    final var memberId = lowestMemberWithPartitions(group, groupId);
+
+    return Either.right(
+        List.of(
+            new PartitionGroupParallelPhase(
+                Map.of(groupId, List.of(new UpdateRoutingState(memberId, routingState))))));
+  }
+
+  /**
+   * The lowest member id, among the members of {@code group} that hold at least one partition,
+   * mirroring {@link ModeChangeRequestTransformer#membersToTransition}. The applier is registered
+   * per group on the members that actually replicate it (see {@code
+   * ClusterConfigurationManagerImpl#applyPartitionGroupConfigurationChangeOperation}, which
+   * dispatches via {@code group.pendingChangesFor(localMemberId)}), so a member with no partitions
+   * in the group would never pick up the operation and the change would stall.
+   */
+  private MemberId lowestMemberWithPartitions(
+      final PartitionGroupConfiguration group, final String groupId) {
+    return group.members().entrySet().stream()
+        .filter(member -> !member.getValue().partitions().isEmpty())
+        .map(Entry::getKey)
+        .min(MemberId.ID_COMPARATOR)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Cannot update the routing state of physical tenant '%s': none of its members hold any partitions"
+                        .formatted(groupId)));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1154,6 +1154,7 @@ public class ProtoBufSerializer
     updateRoutingStateRequest
         .routingState()
         .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
+    updateRoutingStateRequest.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
 
     return builder.build().toByteArray();
   }
@@ -1529,7 +1530,9 @@ public class ProtoBufSerializer
       throw new DecodingFailed(e);
     }
     final var routingState = decodeRoutingState(proto.getRoutingState());
-    return new UpdateRoutingStateRequest(routingState, proto.getDryRun());
+    final Optional<String> physicalTenantId =
+        proto.hasPhysicalTenantId() ? Optional.of(proto.getPhysicalTenantId()) : Optional.empty();
+    return new UpdateRoutingStateRequest(routingState, physicalTenantId, proto.getDryRun());
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -60,6 +60,9 @@ message ClusterPatchRequest {
 message UpdateRoutingStateRequest{
   topology_protocol.RoutingState routing_state = 1;
   bool dryRun = 2;
+  // When physicalTenantId is set, only that tenant's routing state is updated.
+  // If not set, the default tenant's routing state is updated.
+  optional string physicalTenantId = 3;
 }
 
 message UpdatePartitionDistributorConfigRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -605,12 +605,54 @@ final class NewModelManagementApiEndpointsTest {
     // when
     final var response =
         handler
-            .updateRoutingState(new UpdateRoutingStateRequest(Optional.of(routingState), false))
+            .updateRoutingState(
+                new UpdateRoutingStateRequest(Optional.of(routingState), Optional.empty(), false))
             .join();
 
     // then
     assertThat(response.legacyResponse().plannedChanges())
         .containsExactly(new UpdateRoutingState(ID_0, Optional.of(routingState)));
+  }
+
+  @Test
+  void shouldApplyRoutingStateUpdateToOnlyTheRequestedPhysicalTenant() {
+    // given
+    wireTwoPhysicalTenants();
+    final var routingState = RoutingState.initializeWithPartitionCount(1);
+
+    // when
+    handler
+        .updateRoutingState(
+            new UpdateRoutingStateRequest(Optional.of(routingState), Optional.of(TENANT_B), false))
+        .join();
+
+    // then — only tenant-b's routing state changed; the default group's is left untouched
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.partitionGroup(TENANT_B).routingState()).contains(routingState);
+    assertThat(config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).routingState())
+        .isEmpty();
+  }
+
+  @Test
+  void shouldApplyRoutingStateUpdateToTheDefaultPhysicalTenantWhenUnscoped() {
+    // given — unlike mode changes, where an absent physicalTenantId means "every tenant", an
+    // unscoped routing-state update keeps writing only the default group
+    wireTwoPhysicalTenants();
+    final var routingState = RoutingState.initializeWithPartitionCount(1);
+
+    // when
+    handler
+        .updateRoutingState(
+            new UpdateRoutingStateRequest(Optional.of(routingState), Optional.empty(), false))
+        .join();
+
+    // then
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).routingState())
+        .contains(routingState);
+    assertThat(config.partitionGroup(TENANT_B).routingState()).isEmpty();
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
@@ -7,19 +7,39 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 class UpdateRoutingStateTransformerTest {
+
+  private static final String TENANT_B = "tenant-b";
+
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   private final ClusterConfiguration currentTopology =
       ClusterConfiguration.init()
@@ -61,5 +81,88 @@ class UpdateRoutingStateTransformerTest {
     assertThat(result.get().get(0)).isInstanceOf(UpdateRoutingState.class);
     final var operation = (UpdateRoutingState) result.get().get(0);
     assertThat(operation.routingState()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenant() {
+    // given
+    final var transformer =
+        new UpdateRoutingStateTransformer(Optional.empty(), Optional.of("unknown"));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — the tenant does not exist, so the caller gets 404 rather than 500
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft()).isInstanceOf(NotFound.class).hasMessageContaining("unknown");
+  }
+
+  @Test
+  void shouldTargetOnlyTheRequestedPhysicalTenantsPartitionGroup() {
+    // given
+    final var routingState = Optional.of(RoutingState.initializeWithPartitionCount(1));
+    final var transformer = new UpdateRoutingStateTransformer(routingState, Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — only tenant-b's group carries an operation; the default group is left untouched
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(TENANT_B, List.of(new UpdateRoutingState(id1, routingState)))));
+  }
+
+  @Test
+  void shouldTargetTheDefaultPhysicalTenantsPartitionGroupWhenUnscoped() {
+    // given — an unscoped request keeps writing the default group, unlike the other per-tenant
+    // requests where an absent physicalTenantId means "every tenant"
+    final var routingState = Optional.of(RoutingState.initializeWithPartitionCount(1));
+    final var transformer = new UpdateRoutingStateTransformer(routingState, Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(DEFAULT_GROUP, List.of(new UpdateRoutingState(id0, routingState)))));
+  }
+
+  private CurrentClusterConfiguration twoTenantCluster() {
+    return cluster(
+        Map.of(
+            DEFAULT_GROUP, group(Map.of(id0, hostingAPartition())),
+            TENANT_B, group(Map.of(id1, hostingAPartition()))));
+  }
+
+  private CurrentClusterConfiguration cluster(
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    final var brokers =
+        partitionGroups.values().stream()
+            .flatMap(group -> group.members().keySet().stream())
+            .distinct()
+            .collect(
+                Collectors.toMap(
+                    memberId -> memberId,
+                    memberId -> new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE)));
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1, Optional.empty(), brokers, Optional.empty(), Optional.empty(), Optional.empty()),
+        partitionGroups,
+        PhasedChangeState.empty());
+  }
+
+  private PartitionGroupConfiguration group(final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private BrokerPartitionState hostingAPartition() {
+    return BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, partitionConfig)));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Requests;
 import io.camunda.zeebe.dynamic.config.protocol.Topology;
@@ -309,6 +310,43 @@ final class ProtoBufSerializerTest {
     // then
     final var decodedRequest = protoBufSerializer.decodeExporterEnableRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(exporterEnableRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeUpdateRoutingStateRequestWithPhysicalTenantId() {
+    // given
+    final var routingState =
+        Optional.of(
+            new io.camunda.zeebe.dynamic.config.state.RoutingState(
+                1L,
+                new RequestHandling.AllPartitions(3),
+                new io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod(
+                    3)));
+    final var updateRoutingStateRequest =
+        new UpdateRoutingStateRequest(routingState, Optional.of("tenant-a"), false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeUpdateRoutingStateRequest(updateRoutingStateRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeUpdateRoutingStateRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(updateRoutingStateRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeUpdateRoutingStateRequestWithoutPhysicalTenantId() {
+    // given
+    final var updateRoutingStateRequest =
+        new UpdateRoutingStateRequest(Optional.empty(), Optional.empty(), false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeUpdateRoutingStateRequest(updateRoutingStateRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeUpdateRoutingStateRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(updateRoutingStateRequest);
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRoutingStateIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRoutingStateIT.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import feign.FeignException;
+import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
+import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
+import io.camunda.zeebe.management.cluster.RoutingState;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@code PATCH /actuator/cluster/routing-state} can be scoped to a single physical
+ * tenant via the {@code physicalTenant} query parameter (issue #59994), mirroring what #59825 did
+ * for the read side ({@link PhysicalTenantClusterEndpointIT}).
+ *
+ * <p>Unlike that class, these tests write, so a fresh broker is used per test rather than sharing
+ * one static instance across the class — a write in one test must not leak into another.
+ *
+ * <p>The default tenant and {@link #TENANT_A} are deliberately given different static partition
+ * counts. This is not just cosmetic: it lets {@link
+ * #shouldPickUpTheTargetTenantsOwnEngineStateOnABodylessWrite} tell whether a body-less write
+ * fetched <em>tenant A's own</em> engine routing state or silently fell back to the default
+ * tenant's. Before the fix, {@code BrokerClientPartitionScalingExecutor} sent every scaling request
+ * (including the {@code GetScaleUpProgress} a body-less write uses to read the engine state)
+ * without a partition group, so it always resolved against the default tenant regardless of which
+ * tenant's executor sent it. With equal partition counts, that bug would have gone unnoticed here:
+ * both tenants would report the same {@code AllPartitions} routing state whether or not the fetch
+ * was scoped correctly.
+ */
+@ZeebeIntegration
+final class PhysicalTenantRoutingStateIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int TENANT_A_PARTITIONS_COUNT = 2;
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe(purgeAfterEach = false)
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withPtConfig(
+                  TENANT_A,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_A_PARTITIONS_COUNT)));
+
+  private final ClusterActuator actuator = ClusterActuator.of(broker);
+
+  @Test
+  void shouldPickUpTheTargetTenantsOwnEngineStateOnABodylessWrite() {
+    // when — a body-less write scoped to tenant A must fetch tenant A's own engine routing state,
+    // not the default tenant's; this is the case that exercises the executor fix directly, so it
+    // is written and run before the other cases here
+    await("tenant A accepts a body-less routing-state write")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> actuator.patchRoutingState(false, TENANT_A));
+
+    // then — the resulting routing state reflects tenant A's own partition count, not the default
+    // tenant's (which has a different count precisely so the two cannot be confused)
+    await("tenant A's routing state reflects its own partition count")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var routing = actuator.getTopology(TENANT_A).getRouting();
+              assertThat(routing).isNotNull();
+              assertThat(routing.getRequestHandling())
+                  .asInstanceOf(InstanceOfAssertFactories.type(RequestHandlingAllPartitions.class))
+                  .extracting(RequestHandlingAllPartitions::getPartitionCount)
+                  .isEqualTo(TENANT_A_PARTITIONS_COUNT);
+            });
+  }
+
+  @Test
+  void shouldScopeWriteToOnlyTheRequestedPhysicalTenant() {
+    // given — the default tenant's routing state before tenant A is touched
+    final var defaultBefore = awaitRoutingState(PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+    // a partition count that neither tenant already has, so the write is observable regardless of
+    // which value each tenant started with
+    final var tenantARoutingState = routingState(5);
+
+    // when
+    await("tenant A accepts the scoped routing-state write")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> actuator.patchRoutingState(tenantARoutingState, false, TENANT_A));
+
+    // then — tenant A's routing state changed to the requested value (the applier assigns its own
+    // version on write, so only requestHandling/messageCorrelation are compared here), and the
+    // default tenant's is left exactly as it was, version included
+    await("tenant A's routing state reflects the write")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var routing = actuator.getTopology(TENANT_A).getRouting();
+              assertThat(routing.getRequestHandling())
+                  .isEqualTo(tenantARoutingState.getRequestHandling());
+              assertThat(routing.getMessageCorrelation())
+                  .isEqualTo(tenantARoutingState.getMessageCorrelation());
+            });
+    assertThat(actuator.getTopology(PhysicalTenantsITHelper.DEFAULT_TENANT_ID).getRouting())
+        .isEqualTo(defaultBefore);
+  }
+
+  @Test
+  void shouldApplyUnscopedWriteToTheDefaultPhysicalTenant() {
+    // given — tenant A's routing state before the default tenant is touched
+    final var tenantABefore = awaitRoutingState(TENANT_A);
+    final var defaultRoutingState = routingState(5);
+
+    // when — no physicalTenant parameter is given
+    await("the default tenant accepts the unscoped routing-state write")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> actuator.patchRoutingState(defaultRoutingState, false));
+
+    // then — the default tenant's routing state changed; tenant A's is untouched, version included
+    await("the default tenant's routing state reflects the write")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var routing =
+                  actuator.getTopology(PhysicalTenantsITHelper.DEFAULT_TENANT_ID).getRouting();
+              assertThat(routing.getRequestHandling())
+                  .isEqualTo(defaultRoutingState.getRequestHandling());
+              assertThat(routing.getMessageCorrelation())
+                  .isEqualTo(defaultRoutingState.getMessageCorrelation());
+            });
+    assertThat(actuator.getTopology(TENANT_A).getRouting()).isEqualTo(tenantABefore);
+  }
+
+  @Test
+  void shouldReturn404ForUnknownPhysicalTenant() {
+    // when - then
+    assertThatThrownBy(() -> actuator.patchRoutingState(routingState(1), false, "does-not-exist"))
+        .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
+        .extracting(FeignException::status)
+        .isEqualTo(404);
+  }
+
+  private RoutingState awaitRoutingState(final String physicalTenantId) {
+    final var routing = new RoutingState[1];
+    await("physical tenant '%s' has a routing state".formatted(physicalTenantId))
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var current = actuator.getTopology(physicalTenantId).getRouting();
+              assertThat(current).isNotNull();
+              routing[0] = current;
+            });
+    return routing[0];
+  }
+
+  /**
+   * A routing state body to PATCH with. The version is irrelevant: {@code
+   * UpdateRoutingStateApplier} always assigns its own version on write ({@code previousVersion +
+   * 1}), ignoring whatever the request body carries.
+   */
+  private RoutingState routingState(final int partitionCount) {
+    return new RoutingState()
+        .requestHandling(new RequestHandlingAllPartitions(partitionCount).strategy("AllPartitions"))
+        .messageCorrelation(new MessageCorrelationHashMod("HashMod", partitionCount))
+        .version(0L);
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -372,6 +372,30 @@ public interface ClusterActuator {
   @Headers({"Content-Type: application/json", "accept: application/json"})
   void patchRoutingState(@Param boolean dryRun);
 
+  /**
+   * Writes the routing state scoped to {@code physicalTenant}, either with the given body or, when
+   * {@code routingState} is omitted, by fetching it from the engine.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     the physical tenant is unknown
+   */
+  @RequestLine("PATCH /routing-state?dryRun={dryRun}&physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "accept: application/json"})
+  void patchRoutingState(
+      @RequestBody final RoutingState routingState,
+      @Param boolean dryRun,
+      @Param final String physicalTenant);
+
+  /**
+   * Fetches the routing state from the engine and writes it scoped to {@code physicalTenant}.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     the physical tenant is unknown
+   */
+  @RequestLine("PATCH /routing-state?dryRun={dryRun}&physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "accept: application/json"})
+  void patchRoutingState(@Param boolean dryRun, @Param final String physicalTenant);
+
   @RequestLine("PUT /partition-distribution?dryRun={dryRun}")
   @Headers({"Content-Type: application/json", "accept: application/json"})
   PlannedOperationsResponse updatePartitionDistribution(


### PR DESCRIPTION
Accepts a `physicalTenant` query parameter on `PATCH /actuator/cluster/routing-state` and writes only that tenant's routing state, mirroring the plumbing already proven by `ModeChangeRequest` and the exporter requests (`Optional<String> physicalTenantId` threaded end-to-end, `phases()` overridden). An unscoped request keeps writing the default physical tenant, unlike those other requests where an absent tenant means "every tenant" — this is a deliberate, documented choice, not an oversight, so existing callers see no behaviour change.

`UpdateRoutingStateTransformer#phases()` targets the named tenant's group, or the default group when none is given, and returns 404 (via the existing `NotFound` → `ClusterConfigurationRequestFailedException` → error-code path) when the tenant doesn't exist. The single planned `UpdateRoutingState` operation's `memberId` is the lowest member of that group that actually holds partitions there, not the cluster's default coordinator, since `ClusterConfigurationManagerImpl` dispatches group operations via `group.pendingChangesFor(localMemberId)` and a coordinator that doesn't serve the tenant would never pick up the operation.

Bundled in the same PR is an adjacent fix to `BrokerClientPartitionScalingExecutor`: it's instantiated once per physical tenant, but every `BrokerRequest` it sends (scale-up, bootstrap notification, `GetScaleUpProgress`, the snapshot delete) never set a partition group, so those requests always targeted the default tenant's partitions regardless of which tenant's executor sent them. This bug is what a body-less `PATCH ?physicalTenant=<tenant>` exercises directly — it fetches routing state from the engine via `getRoutingState()` — so it's fixed here rather than filed separately, and `PhysicalTenantRoutingStateIT` covers it with a case that fails without the fix and passes with it.

closes #59994

BREAKING CHANGE: The `Protobuf Backwards Compatibility` check compares this branch's `requests.proto` against current `main`. This branch's diff only adds `optional string physicalTenantId = 3` to `UpdateRoutingStateRequest`; it does not touch `RestoreRequest`. Since this branch's last rebase, `main` independently renumbered/retyped `RestoreRequest`'s fields, so the check flags this branch's (now-stale) copy of `RestoreRequest` as a regression relative to `main`. `RestoreRequest`'s wire format is not yet released, so this is acceptable.
