### PR TITLE
ClusterAdmin restore operation

### DIFF
--- a/service/src/test/java/io/camunda/service/ClusterRecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRecoveryServicesTest.java
@@ -36,16 +36,23 @@ final class ClusterRecoveryServicesTest {
 
   private static final String DEFAULT_TENANT = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
   private static final String TENANT_B = "tenant-b";
+  private static final String TENANT_C = "tenant-c";
   private static final TenantRestoreEnvironment DEFAULT_ENVIRONMENT =
       new TenantRestoreEnvironment("elasticsearch", false);
   private static final TenantRestoreEnvironment TENANT_B_ENVIRONMENT =
       new TenantRestoreEnvironment("rdbms", true);
+  private static final TenantRestoreEnvironment TENANT_C_ENVIRONMENT =
+      new TenantRestoreEnvironment("opensearch", false);
 
   private final ClusterConfigurationManagementRequestSender sender =
       mock(ClusterConfigurationManagementRequestSender.class);
   private final ClusterRecoveryServices services =
       new ClusterRecoveryServices(
-          sender, Map.of(DEFAULT_TENANT, DEFAULT_ENVIRONMENT, TENANT_B, TENANT_B_ENVIRONMENT));
+          sender,
+          Map.of(
+              DEFAULT_TENANT, DEFAULT_ENVIRONMENT,
+              TENANT_B, TENANT_B_ENVIRONMENT,
+              TENANT_C, TENANT_C_ENVIRONMENT));
 
   @Test
   void shouldRequestEveryPhysicalTenantWhenNoneIsGiven() {
@@ -130,7 +137,9 @@ final class ClusterRecoveryServicesTest {
 
   @Test
   void shouldRestoreEveryKnownPhysicalTenantWithItsOwnEnvironment() {
-    // given — a cluster-wide restore whose override spans a tenant on different secondary storage
+    // given — a cluster-wide restore whose override applies to only one tenant: the default tenant
+    // and tenant-c share the top-level backup selection, tenant-b restores from an additional,
+    // distinct backup given as its own override
     givenRestoreAccepted();
     final var defaultParameters = new RestoreParameters(List.of(100L), null, null);
     final var tenantBParameters = new RestoreParameters(List.of(55L), null, null);
@@ -141,7 +150,7 @@ final class ClusterRecoveryServicesTest {
         .join();
 
     // then — every physical tenant of the cluster is named, each with its own environment; the
-    // overridden tenant keeps its own selection, the other tenant gets the default selection
+    // overridden tenant keeps its own backup selection, the other two share the top-level one
     verify(sender)
         .clusterRestore(
             new ClusterRestoreRequest(
@@ -149,7 +158,9 @@ final class ClusterRecoveryServicesTest {
                     DEFAULT_TENANT,
                     new TenantRestoreArguments(defaultParameters, "elasticsearch", false),
                     TENANT_B,
-                    new TenantRestoreArguments(tenantBParameters, "rdbms", true)),
+                    new TenantRestoreArguments(tenantBParameters, "rdbms", true),
+                    TENANT_C,
+                    new TenantRestoreArguments(defaultParameters, "opensearch", false)),
                 true));
   }
 
@@ -181,7 +192,9 @@ final class ClusterRecoveryServicesTest {
                     DEFAULT_TENANT,
                     new TenantRestoreArguments(defaultParameters, "elasticsearch", false),
                     TENANT_B,
-                    new TenantRestoreArguments(defaultParameters, "rdbms", true)),
+                    new TenantRestoreArguments(defaultParameters, "rdbms", true),
+                    TENANT_C,
+                    new TenantRestoreArguments(defaultParameters, "opensearch", false)),
                 false));
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
@@ -9,23 +9,34 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.util.Either;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
  * Restores one or every physical tenant of the cluster, as requested through the cluster-admin API.
  *
- * <p>A request naming exactly one physical tenant in {@code tenantArguments} is transformed exactly
- * like the same restore submitted through that tenant's own API. Fanning a cluster-wide request out
- * over several physical tenants at once is not implemented yet, so a request naming zero or more
- * than one tenant is rejected.
+ * <p>{@link #phases(CurrentClusterConfiguration)} is the entry point the new-model coordinator
+ * actually drives: each named physical tenant is projected to its own {@link ClusterConfiguration}
+ * view via {@link CurrentClusterConfiguration#toLegacy(String)} and restored exactly like the same
+ * restore submitted through that tenant's own API, then combined into one {@link
+ * PartitionGroupParallelPhase} so every named tenant restores in parallel. A cluster-wide request —
+ * one naming every physical tenant of the cluster — restores them all this way in a single change.
+ *
+ * <p>{@link #operations(ClusterConfiguration)} is the legacy single-group entry point predating
+ * multi-tenant support; it only has a single, ungrouped {@link ClusterConfiguration} to work with,
+ * so it continues to support a request naming exactly one physical tenant and rejects the rest.
  */
 public final class ClusterRestoreRequestTransformer implements ConfigurationChangeRequest {
 
@@ -49,9 +60,30 @@ public final class ClusterRestoreRequestTransformer implements ConfigurationChan
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
-    return singleTenantRestore()
-        .map(restore -> restore.phases(clusterConfiguration))
-        .orElseGet(() -> Either.left(clusterWideNotSupported()));
+    final Map<String, List<PartitionGroupOperation>> operationsPerTenant = new LinkedHashMap<>();
+    for (final var physicalTenantId : request.tenantArguments().keySet()) {
+      if (!clusterConfiguration.hasPartitionGroup(physicalTenantId)) {
+        return Either.left(
+            new NotFound(
+                "Expected to restore physical tenant '%s', but there's no such tenant"
+                    .formatted(physicalTenantId)));
+      }
+      final var transformer =
+          new RestoreRequestTransformer(request.toRestoreRequest(physicalTenantId), registry);
+      final var result = transformer.operations(clusterConfiguration.toLegacy(physicalTenantId));
+      if (result.isLeft()) {
+        return Either.left(result.getLeft());
+      }
+      final var operations =
+          result.get().stream().map(PartitionGroupOperation.class::cast).toList();
+      if (!operations.isEmpty()) {
+        operationsPerTenant.put(physicalTenantId, operations);
+      }
+    }
+    if (operationsPerTenant.isEmpty()) {
+      return Either.right(List.of());
+    }
+    return Either.right(List.of(new PartitionGroupParallelPhase(operationsPerTenant)));
   }
 
   private Optional<RestoreRequestTransformer> singleTenantRestore() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.Co
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
@@ -28,11 +29,11 @@ import java.util.Optional;
  * Restores one or every physical tenant of the cluster, as requested through the cluster-admin API.
  *
  * <p>{@link #phases(CurrentClusterConfiguration)} is the entry point the new-model coordinator
- * actually drives: each named physical tenant is projected to its own {@link ClusterConfiguration}
- * view via {@link CurrentClusterConfiguration#toLegacy(String)} and restored exactly like the same
- * restore submitted through that tenant's own API, then combined into one {@link
- * PartitionGroupParallelPhase} so every named tenant restores in parallel. A cluster-wide request —
- * one naming every physical tenant of the cluster — restores them all this way in a single change.
+ * actually drives: each named physical tenant is restored from its own {@link
+ * PartitionGroupConfiguration}, exactly like the same restore submitted through that tenant's own
+ * API, and the resulting plans are combined into one {@link PartitionGroupParallelPhase} so every
+ * named tenant restores in parallel. A cluster-wide request — one naming every physical tenant of
+ * the cluster — restores them all this way in a single change.
  *
  * <p>{@link #operations(ClusterConfiguration)} is the legacy single-group entry point predating
  * multi-tenant support; it only has a single, ungrouped {@link ClusterConfiguration} to work with,
@@ -62,7 +63,8 @@ public final class ClusterRestoreRequestTransformer implements ConfigurationChan
       final CurrentClusterConfiguration clusterConfiguration) {
     final Map<String, List<PartitionGroupOperation>> operationsPerTenant = new LinkedHashMap<>();
     for (final var physicalTenantId : request.tenantArguments().keySet()) {
-      if (!clusterConfiguration.hasPartitionGroup(physicalTenantId)) {
+      final var partitionGroup = clusterConfiguration.partitionGroup(physicalTenantId);
+      if (partitionGroup == null) {
         return Either.left(
             new NotFound(
                 "Expected to restore physical tenant '%s', but there's no such tenant"
@@ -70,14 +72,12 @@ public final class ClusterRestoreRequestTransformer implements ConfigurationChan
       }
       final var transformer =
           new RestoreRequestTransformer(request.toRestoreRequest(physicalTenantId), registry);
-      final var result = transformer.operations(clusterConfiguration.toLegacy(physicalTenantId));
+      final var result = transformer.groupOperations(partitionGroup);
       if (result.isLeft()) {
         return Either.left(result.getLeft());
       }
-      final var operations =
-          result.get().stream().map(PartitionGroupOperation.class::cast).toList();
-      if (!operations.isEmpty()) {
-        operationsPerTenant.put(physicalTenantId, operations);
+      if (!result.get().isEmpty()) {
+        operationsPerTenant.put(physicalTenantId, result.get());
       }
     }
     if (operationsPerTenant.isEmpty()) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.ConcurrentModificationException;
@@ -17,25 +18,38 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 /**
  * Validates a {@link RestoreRequest} against the current cluster configuration and produces the
- * change plan for the restore.
+ * change plan for the restore of the request's physical tenant.
+ *
+ * <p>{@link #phases(CurrentClusterConfiguration)} is the entry point the new-model coordinator
+ * drives: the plan is built from the request's own {@link PartitionGroupConfiguration}, where
+ * recovery is tracked per broker within the group. {@link #operations(ClusterConfiguration)} is the
+ * legacy single-group entry point, which only ever has one, ungrouped configuration to work with.
  *
  * <p>Validation failures are returned as an {@link Either#left(Object)} carrying a {@link
  * ClusterConfigurationRequestFailedException}, which the coordinator surfaces as an error response.
@@ -54,61 +68,169 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-
-    // Restore is only allowed in recovery
     if (!isClusterRecovering(clusterConfiguration)) {
       return Either.left(
           new ConcurrentModificationException(
               "Restore is only allowed while the cluster is in recovery mode."));
     }
+    final var members = recoveringMembers(clusterConfiguration);
+    return restorePlan(members).map(List::copyOf);
+  }
 
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    final var physicalTenantId = request.physicalTenantId();
+    final var partitionGroup = clusterConfiguration.partitionGroup(physicalTenantId);
+    if (partitionGroup == null) {
+      return Either.left(
+          new NotFound(
+              "Expected to restore physical tenant '%s', but there's no such tenant"
+                  .formatted(physicalTenantId)));
+    }
+    return groupOperations(partitionGroup)
+        .map(
+            operations ->
+                List.of(new PartitionGroupParallelPhase(Map.of(physicalTenantId, operations))));
+  }
+
+  /**
+   * The restore plan for the request's physical tenant on the new model, built from that tenant's
+   * partition group alone. Shared with {@link ClusterRestoreRequestTransformer}, which combines the
+   * plans of several physical tenants into one phase.
+   */
+  Either<Exception, List<PartitionGroupOperation>> groupOperations(
+      final PartitionGroupConfiguration partitionGroup) {
+    if (!isGroupRecovering(partitionGroup)) {
+      return Either.left(
+          new ConcurrentModificationException(
+              "Restore is only allowed while physical tenant '%s' is in recovery mode."
+                  .formatted(request.physicalTenantId())));
+    }
+    final var members = recoveringMembers(partitionGroup);
+    return restorePlan(members);
+  }
+
+  /**
+   * Resolves the request's backup selection, then turns it into the restore plan for the given
+   * brokers. A validator rejection, and anything the plan builder throws over a partition the
+   * validator did not resolve a selection for, is mapped to a request failure.
+   */
+  private Either<Exception, List<PartitionGroupOperation>> restorePlan(
+      final SortedMap<MemberId, Set<Integer>> partitionsPerMember) {
     final var validator = registry.getValidator(request.physicalTenantId(), RestoreRequest.class);
     if (validator.isEmpty()) {
       return Either.left(new InternalError("A validator is required but not present"));
     }
-    final var res = validator.get().validate(request);
-
-    if (res.isLeft()) {
-      return Either.left(mapFailure(res.getLeft()));
+    final var resolved = validator.get().validate(request);
+    if (resolved.isLeft()) {
+      return Either.left(mapFailure(resolved.getLeft()));
     }
     try {
       return Either.right(
-          buildOperations(clusterConfiguration, (RestoreResolvedRequest) res.get()));
+          restoreOperations(partitionsPerMember, (RestoreResolvedRequest) resolved.get()));
     } catch (final Exception e) {
       return Either.left(mapFailure(e));
     }
   }
 
-  private static List<ClusterConfigurationChangeOperation> buildOperations(
-      final ClusterConfiguration clusterConfiguration, final RestoreResolvedRequest resolved) {
-    final var members =
-        clusterConfiguration.members().entrySet().stream()
-            .filter(entry -> entry.getValue().state() == State.RECOVERING)
-            .map(Entry::getKey)
-            .sorted()
-            .toList();
+  /**
+   * The brokers to restore, each mapped to the partitions it holds, ordered by broker id. On the
+   * legacy model recovery is a broker-wide state, so every recovering broker takes part — including
+   * one holding no partition, which contributes no partition operation but still has to exit
+   * recovery, since entering it transitioned that broker too.
+   */
+  private static SortedMap<MemberId, Set<Integer>> recoveringMembers(
+      final ClusterConfiguration clusterConfiguration) {
+    final SortedMap<MemberId, Set<Integer>> partitionsPerMember = new TreeMap<>();
+    clusterConfiguration
+        .members()
+        .forEach(
+            (memberId, member) -> {
+              if (member.state() == State.RECOVERING) {
+                partitionsPerMember.put(memberId, member.partitions().keySet());
+              }
+            });
+    return partitionsPerMember;
+  }
 
-    final var operations = new ArrayList<ClusterConfigurationChangeOperation>();
-    for (final var memberId : members) {
-      for (final var partitionId : clusterConfiguration.getMember(memberId).partitions().keySet()) {
-        operations.add(new PartitionPreRestoreOperation(memberId, partitionId));
+  /**
+   * The brokers to restore, each mapped to the partitions it holds in the group, ordered by broker
+   * id. Only brokers holding a partition of the group take part: recovery is scoped to a broker
+   * within a group, so a broker holding none was never transitioned into it, and awaiting a mode
+   * change from it would never complete (see {@code
+   * ModeChangeRequestTransformer#membersToTransition}).
+   */
+  private static SortedMap<MemberId, Set<Integer>> recoveringMembers(
+      final PartitionGroupConfiguration partitionGroup) {
+    final SortedMap<MemberId, Set<Integer>> partitionsPerMember = new TreeMap<>();
+    partitionGroup
+        .members()
+        .forEach(
+            (memberId, broker) -> {
+              if (!broker.partitions().isEmpty()) {
+                partitionsPerMember.put(memberId, broker.partitions().keySet());
+              }
+            });
+    return partitionsPerMember;
+  }
+
+  /**
+   * The plan is phase-major: every partition of every broker is pre-restored, then every partition
+   * is restored, then every broker leaves recovery, and finally, the incarnation number is bumped
+   * once so the restored data is not mistaken for the purged generation.
+   */
+  private static List<PartitionGroupOperation> restoreOperations(
+      final SortedMap<MemberId, Set<Integer>> partitionsPerMember,
+      final RestoreResolvedRequest resolved) {
+    final var operations = new ArrayList<PartitionGroupOperation>();
+    for (final var member : partitionsPerMember.entrySet()) {
+      for (final var partitionId : member.getValue()) {
+        operations.add(new PartitionPreRestoreOperation(member.getKey(), partitionId));
       }
     }
-    for (final var memberId : members) {
-      for (final var partitionId : clusterConfiguration.getMember(memberId).partitions().keySet()) {
+    for (final var member : partitionsPerMember.entrySet()) {
+      for (final var partitionId : member.getValue()) {
         final var backupIds = resolved.backups().get(partitionId);
         operations.add(
-            new PartitionRestoreOperation(memberId, partitionId, toSortedSet(backupIds)));
+            new PartitionRestoreOperation(member.getKey(), partitionId, toSortedSet(backupIds)));
       }
     }
-    for (final var memberId : members) {
+    for (final var memberId : partitionsPerMember.keySet()) {
       operations.add(new ModeChangeOperation(memberId, Mode.PROCESSING));
     }
-    for (final var memberId : members) {
+    for (final var memberId : partitionsPerMember.keySet()) {
       operations.add(new AwaitModeChangeOperation(memberId, Mode.PROCESSING));
     }
-    operations.add(new UpdateIncarnationNumberOperation(members.getFirst()));
+    operations.add(new UpdateIncarnationNumberOperation(partitionsPerMember.firstKey()));
     return operations;
+  }
+
+  /** Whether every initialized broker of the cluster is in recovery. */
+  private static boolean isClusterRecovering(final ClusterConfiguration clusterConfiguration) {
+    final var initializedMembers =
+        clusterConfiguration.members().values().stream()
+            .filter(member -> member.state() != State.UNINITIALIZED && member.state() != State.LEFT)
+            .toList();
+    return !initializedMembers.isEmpty()
+        && initializedMembers.stream().allMatch(member -> member.state() == State.RECOVERING);
+  }
+
+  /**
+   * Whether every broker holding a partition of the group is in recovery.
+   *
+   * <p>Only brokers holding a partition are considered: the group's brokers carry no cluster-wide
+   * lifecycle state, and a broker holding no partition of the group has nothing to restore and is
+   * never transitioned into recovery for it. Counting such a broker would reject every restore of a
+   * physical tenant hosted on a subset of the cluster's brokers.
+   */
+  private static boolean isGroupRecovering(final PartitionGroupConfiguration groupConfiguration) {
+    final var brokersHoldingPartitions =
+        groupConfiguration.members().values().stream()
+            .filter(broker -> !broker.partitions().isEmpty())
+            .toList();
+    return !brokersHoldingPartitions.isEmpty()
+        && brokersHoldingPartitions.stream().allMatch(broker -> broker.mode() == Mode.RECOVERING);
   }
 
   private static SortedSet<Long> toSortedSet(final long[] backupIds) {
@@ -127,27 +249,5 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
       case final IllegalStateException e -> new InvalidState(e.getMessage(), e);
       default -> new InternalError(exception);
     };
-  }
-
-  /**
-   * Whether every broker holding a partition to restore is in recovery.
-   *
-   * <p>Only brokers that hold a partition are considered. On the multi-partition-group model this
-   * configuration is the projection of a single partition group, in which a broker that holds no
-   * partition of that group keeps its cluster-wide {@link State#ACTIVE} state: entering recovery
-   * never transitions it, because it has no partition to transition and awaiting a mode change from
-   * it would never complete (see {@code ModeChangeRequestTransformer#membersToTransition}).
-   * Counting such a broker would reject every restore of a physical tenant hosted on a subset of
-   * the cluster's brokers. Excluding it is equally correct on the legacy single-group model, where
-   * a partition-less broker has nothing to restore either.
-   */
-  private static boolean isClusterRecovering(final ClusterConfiguration clusterConfiguration) {
-    final var membersHoldingPartitions =
-        clusterConfiguration.members().values().stream()
-            .filter(member -> member.state() != State.UNINITIALIZED && member.state() != State.LEFT)
-            .filter(member -> !member.partitions().isEmpty())
-            .toList();
-    return !membersHoldingPartitions.isEmpty()
-        && membersHoldingPartitions.stream().allMatch(member -> member.state() == State.RECOVERING);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -129,12 +129,25 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
     };
   }
 
+  /**
+   * Whether every broker holding a partition to restore is in recovery.
+   *
+   * <p>Only brokers that hold a partition are considered. On the multi-partition-group model this
+   * configuration is the projection of a single partition group, in which a broker that holds no
+   * partition of that group keeps its cluster-wide {@link State#ACTIVE} state: entering recovery
+   * never transitions it, because it has no partition to transition and awaiting a mode change from
+   * it would never complete (see {@code ModeChangeRequestTransformer#membersToTransition}).
+   * Counting such a broker would reject every restore of a physical tenant hosted on a subset of
+   * the cluster's brokers. Excluding it is equally correct on the legacy single-group model, where
+   * a partition-less broker has nothing to restore either.
+   */
   private static boolean isClusterRecovering(final ClusterConfiguration clusterConfiguration) {
-    final var initializedMembers =
+    final var membersHoldingPartitions =
         clusterConfiguration.members().values().stream()
             .filter(member -> member.state() != State.UNINITIALIZED && member.state() != State.LEFT)
+            .filter(member -> !member.partitions().isEmpty())
             .toList();
-    return !initializedMembers.isEmpty()
-        && initializedMembers.stream().allMatch(member -> member.state() == State.RECOVERING);
+    return !membersHoldingPartitions.isEmpty()
+        && membersHoldingPartitions.stream().allMatch(member -> member.state() == State.RECOVERING);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
@@ -174,9 +174,14 @@ abstract class ClusterConfigurationManagementApiTestBase {
             return RestoreRequest.class;
           }
 
+          /** Resolves the requested backups on partition 1, the only partition these tests use. */
           @Override
           public Either<Exception, RestoreResolvedRequest> validate(final RestoreRequest request) {
-            return Either.right(new RestoreResolvedRequest(Map.of(), false));
+            final var backupIds =
+                request.arguments().parameters().backupIds().stream()
+                    .mapToLong(Long::longValue)
+                    .toArray();
+            return Either.right(new RestoreResolvedRequest(Map.of(1, backupIds), false));
           }
         });
 
@@ -837,7 +842,10 @@ abstract class ClusterConfigurationManagementApiTestBase {
     recordingCoordinator.setCurrentTopology(
         ClusterConfiguration.init()
             .addMember(
-                memberFactory.apply(0), MemberState.initializeAsActive(Map.of()).toRecovering()));
+                memberFactory.apply(0),
+                MemberState.initializeAsActive(
+                        Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))
+                    .toRecovering()));
     final var request =
         new RestoreRequest(
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -16,16 +17,33 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.Either;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +51,7 @@ final class ClusterRestoreRequestTransformerTest {
 
   private static final MemberId MEMBER = MemberId.from("0");
   private static final String TENANT_B = "tenant-b";
+  private static final String TENANT_C = "tenant-c";
 
   @Test
   void shouldRestoreTheRequestedPhysicalTenantFromItsOwnParameters() {
@@ -64,7 +83,7 @@ final class ClusterRestoreRequestTransformerTest {
     // when
     final var result = transformer.operations(recoveringConfiguration());
 
-    // then — fanning the restore out over the partition groups is not implemented yet
+    // then — the legacy single-group entry point has no per-tenant view to fall back to
     EitherAssert.assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
   }
 
@@ -74,14 +93,145 @@ final class ClusterRestoreRequestTransformerTest {
     final var args =
         new TenantRestoreArguments(
             new RestoreParameters(List.of(55L), null, null), "elasticsearch", false);
-    final var request = new ClusterRestoreRequest(Map.of(TENANT_B, args, "tenant-c", args), false);
+    final var request = new ClusterRestoreRequest(Map.of(TENANT_B, args, TENANT_C, args), false);
     final var transformer = new ClusterRestoreRequestTransformer(request, registry());
 
     // when
     final var result = transformer.operations(recoveringConfiguration());
 
-    // then — fanning the restore out over the partition groups is not implemented yet
+    // then — same as above: the legacy entry point only ever supports one physical tenant
     EitherAssert.assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRestoreOnlyTheNamedPhysicalTenantOnTheMultiGroupModel() {
+    // given — a broker that replicates a partition of all three physical tenants, all in recovery,
+    // but the request only names tenant-b
+    final var request = clusterRestoreRequest(Map.of(TENANT_B, args(55L)));
+    final var transformer = new ClusterRestoreRequestTransformer(request, registryOf(1, 2, 3));
+
+    // when
+    final var result = transformer.phases(threeTenantCluster());
+
+    // then — one phase, scoped to tenant-b's own partition; the other two tenants are untouched
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(TENANT_B, tenantBRestoreOperations(List.of(55L)))));
+  }
+
+  @Test
+  void shouldRestoreEveryNamedPhysicalTenantInOnePhase() {
+    // given — a cluster-wide request expanded to every known physical tenant, as
+    // ClusterRecoveryServices builds it, each with its own backup selection
+    final var request =
+        clusterRestoreRequest(
+            Map.of(DEFAULT_GROUP, args(100L), TENANT_B, args(55L), TENANT_C, args(77L)));
+    final var transformer = new ClusterRestoreRequestTransformer(request, registryOf(1, 2, 3));
+
+    // when
+    final var result = transformer.phases(threeTenantCluster());
+
+    // then — all three physical tenants restore in the same phase, each from its own backup
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    DEFAULT_GROUP, defaultRestoreOperations(List.of(100L)),
+                    TENANT_B, tenantBRestoreOperations(List.of(55L)),
+                    TENANT_C, tenantCRestoreOperations(List.of(77L)))));
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenantOnTheMultiGroupModel() {
+    // given — the request names a physical tenant the cluster does not have
+    final var request = clusterRestoreRequest(Map.of("unknown-tenant", args(55L)));
+    final var transformer = new ClusterRestoreRequestTransformer(request, registryOf(1, 2, 3));
+
+    // when
+    final var result = transformer.phases(threeTenantCluster());
+
+    // then — the caller gets 404 rather than a plan that can never apply
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown-tenant");
+  }
+
+  private static ClusterRestoreRequest clusterRestoreRequest(
+      final Map<String, TenantRestoreArguments> tenantArguments) {
+    return new ClusterRestoreRequest(tenantArguments, false);
+  }
+
+  private static TenantRestoreArguments args(final long backupId) {
+    return new TenantRestoreArguments(
+        new RestoreParameters(List.of(backupId), null, null), "elasticsearch", false);
+  }
+
+  private static List<PartitionGroupOperation> defaultRestoreOperations(
+      final List<Long> backupIds) {
+    return List.of(
+        new PartitionPreRestoreOperation(MEMBER, 1),
+        new PartitionRestoreOperation(MEMBER, 1, new TreeSet<>(backupIds)),
+        new ModeChangeOperation(MEMBER, Mode.PROCESSING),
+        new AwaitModeChangeOperation(MEMBER, Mode.PROCESSING),
+        new UpdateIncarnationNumberOperation(MEMBER));
+  }
+
+  private static List<PartitionGroupOperation> tenantBRestoreOperations(
+      final List<Long> backupIds) {
+    return List.of(
+        new PartitionPreRestoreOperation(MEMBER, 2),
+        new PartitionRestoreOperation(MEMBER, 2, new TreeSet<>(backupIds)),
+        new ModeChangeOperation(MEMBER, Mode.PROCESSING),
+        new AwaitModeChangeOperation(MEMBER, Mode.PROCESSING),
+        new UpdateIncarnationNumberOperation(MEMBER));
+  }
+
+  private static List<PartitionGroupOperation> tenantCRestoreOperations(
+      final List<Long> backupIds) {
+    return List.of(
+        new PartitionPreRestoreOperation(MEMBER, 3),
+        new PartitionRestoreOperation(MEMBER, 3, new TreeSet<>(backupIds)),
+        new ModeChangeOperation(MEMBER, Mode.PROCESSING),
+        new AwaitModeChangeOperation(MEMBER, Mode.PROCESSING),
+        new UpdateIncarnationNumberOperation(MEMBER));
+  }
+
+  /**
+   * The same broker replicates partition 1 for the default physical tenant, partition 2 for
+   * tenant-b and partition 3 for tenant-c, all in recovery — modeling one broker set serving more
+   * than two physical tenants.
+   */
+  private static CurrentClusterConfiguration threeTenantCluster() {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(MEMBER, new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
+        Map.of(
+            DEFAULT_GROUP, group(1, Mode.RECOVERING),
+            TENANT_B, group(2, Mode.RECOVERING),
+            TENANT_C, group(3, Mode.RECOVERING)),
+        PhasedChangeState.empty());
+  }
+
+  private static PartitionGroupConfiguration group(final int partitionId, final Mode mode) {
+    final var partitions =
+        Map.of(partitionId, PartitionState.active(1, DynamicPartitionConfig.init()));
+    return new PartitionGroupConfiguration(
+        1,
+        0,
+        Map.of(MEMBER, BrokerPartitionState.initialize(partitions).setMode(mode)),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
   }
 
   private static ClusterConfiguration recoveringConfiguration() {
@@ -92,6 +242,15 @@ final class ClusterRestoreRequestTransformerTest {
 
   /** Resolves every request to the backups it asked for, on the single partition of the member. */
   private static RequestValidatorRegistry registry() {
+    return registryOf(1);
+  }
+
+  /**
+   * Resolves every request to the backups it asked for, on every partition id given — a real
+   * validator only ever resolves the partitions of the physical tenant it validates for, but the
+   * fan-out test drives more than one, so this fake simply answers for all of them.
+   */
+  private static RequestValidatorRegistry registryOf(final int... partitionIds) {
     final var registry = new RequestValidatorRegistry();
     registry.registerValidator(
         null,
@@ -107,7 +266,11 @@ final class ClusterRestoreRequestTransformerTest {
                 request.arguments().parameters().backupIds().stream()
                     .mapToLong(Long::longValue)
                     .toArray();
-            return Either.right(new RestoreResolvedRequest(Map.of(1, backupIds), false));
+            final var backups = new HashMap<Integer, long[]>();
+            for (final int partitionId : partitionIds) {
+              backups.put(partitionId, backupIds);
+            }
+            return Either.right(new RestoreResolvedRequest(backups, false));
           }
         });
     return registry;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
@@ -145,6 +145,26 @@ final class ClusterRestoreRequestTransformerTest {
   }
 
   @Test
+  void shouldRestoreATenantHostedOnASubsetOfTheClusterBrokers() {
+    // given — tenant-b lives on one broker only and is in recovery, while the other broker keeps
+    // processing the default tenant. The projection of tenant-b's group still carries that other
+    // broker on its cluster-wide ACTIVE state, since a broker holding no partition of the group
+    // never transitions into recovery
+    final var request = clusterRestoreRequest(Map.of(TENANT_B, args(55L)));
+    final var transformer = new ClusterRestoreRequestTransformer(request, registryOf(2));
+
+    // when
+    final var result = transformer.phases(tenantOnSubsetOfBrokersCluster());
+
+    // then — the restore is planned rather than refused as a cluster that is not recovering
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(TENANT_B, tenantBRestoreOperations(List.of(55L)))));
+  }
+
+  @Test
   void shouldRejectAnUnknownPhysicalTenantOnTheMultiGroupModel() {
     // given — the request names a physical tenant the cluster does not have
     final var request = clusterRestoreRequest(Map.of("unknown-tenant", args(55L)));
@@ -222,13 +242,44 @@ final class ClusterRestoreRequestTransformerTest {
         PhasedChangeState.empty());
   }
 
+  /**
+   * A cluster of two brokers where only {@link #MEMBER} hosts tenant-b — the shape of a physical
+   * tenant placed on a subset of the cluster's brokers. Tenant-b is in recovery; the default
+   * tenant, hosted on the other broker alone, keeps processing.
+   */
+  private static CurrentClusterConfiguration tenantOnSubsetOfBrokersCluster() {
+    final var otherMember = MemberId.from("1");
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER,
+                new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE),
+                otherMember,
+                new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
+        Map.of(
+            DEFAULT_GROUP, group(otherMember, 1, Mode.PROCESSING),
+            TENANT_B, group(MEMBER, 2, Mode.RECOVERING)),
+        PhasedChangeState.empty());
+  }
+
   private static PartitionGroupConfiguration group(final int partitionId, final Mode mode) {
+    return group(MEMBER, partitionId, mode);
+  }
+
+  private static PartitionGroupConfiguration group(
+      final MemberId member, final int partitionId, final Mode mode) {
     final var partitions =
         Map.of(partitionId, PartitionState.active(1, DynamicPartitionConfig.init()));
     return new PartitionGroupConfiguration(
         1,
         0,
-        Map.of(MEMBER, BrokerPartitionState.initialize(partitions).setMode(mode)),
+        Map.of(member, BrokerPartitionState.initialize(partitions).setMode(mode)),
         Optional.empty(),
         Optional.empty(),
         Optional.empty());

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
@@ -20,23 +20,35 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidState;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.Either;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 final class RestoreRequestTransformerTest {
@@ -45,7 +57,7 @@ final class RestoreRequestTransformerTest {
 
   private static RestoreRequest restoreRequest() {
     return new RestoreRequest(
-        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+        DEFAULT_PHYSICAL_TENANT_ID,
         new TenantRestoreArguments(
             new RestoreParameters(List.of(1L), null, null), "elasticsearch", false),
         false);
@@ -106,10 +118,10 @@ final class RestoreRequestTransformerTest {
   }
 
   @Test
-  void shouldRestoreWhenABrokerOutsideThePartitionGroupIsStillActive() {
-    // given - memberTwo holds the partition to restore and is recovering, while memberOne holds
-    // none: the shape a physical tenant hosted on a subset of the cluster's brokers projects to,
-    // where entering recovery leaves the partition-less broker on its cluster-wide ACTIVE state
+  void shouldRejectWhenABrokerWithoutPartitionsIsStillActive() {
+    // given - memberOne holds no partition and is still active, while memberTwo holds the partition
+    // to restore and is recovering. On the legacy model recovery is a broker-wide state that every
+    // active broker enters, so memberOne having stayed behind means the cluster is not recovering
     final var memberOne = MemberId.from("0");
     final var memberTwo = MemberId.from("1");
     final var partitionState = Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()));
@@ -117,23 +129,19 @@ final class RestoreRequestTransformerTest {
         ClusterConfiguration.init()
             .addMember(memberOne, MemberState.initializeAsActive(Map.of()))
             .addMember(memberTwo, MemberState.initializeAsActive(partitionState).toRecovering());
-    final var resolved = new RestoreResolvedRequest(Map.of(1, new long[] {1L}), false);
     final var transformer =
         new RestoreRequestTransformer(
-            restoreRequest(), registryWithValidator(validatorReturning(Either.right(resolved))));
+            restoreRequest(),
+            registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
 
     // when
     final var result = transformer.operations(topology);
 
-    // then - the restore is planned for the recovering broker alone
-    EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            new PartitionPreRestoreOperation(memberTwo, 1),
-            new PartitionRestoreOperation(memberTwo, 1, new TreeSet<>(List.of(1L))),
-            new ModeChangeOperation(memberTwo, Mode.PROCESSING),
-            new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
-            new UpdateIncarnationNumberOperation(memberTwo));
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ConcurrentModificationException.class);
   }
 
   @Test
@@ -340,5 +348,159 @@ final class RestoreRequestTransformerTest {
             new AwaitModeChangeOperation(memberOne, Mode.PROCESSING),
             new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
             new UpdateIncarnationNumberOperation(memberOne));
+  }
+
+  @Test
+  void shouldRestoreThePhysicalTenantsPartitionGroup() {
+    // given - both brokers of the tenant's partition group replicate partition 1 and are recovering
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var resolved = new RestoreResolvedRequest(Map.of(1, new long[] {1L, 2L}), false);
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(), registryWithValidator(validatorReturning(Either.right(resolved))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    memberOne, recovering(1),
+                    memberTwo, recovering(1))));
+
+    // then - one phase scoped to the tenant's own group, phase-major within it
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    DEFAULT_PHYSICAL_TENANT_ID,
+                    List.of(
+                        new PartitionPreRestoreOperation(memberOne, 1),
+                        new PartitionPreRestoreOperation(memberTwo, 1),
+                        new PartitionRestoreOperation(memberOne, 1, new TreeSet<>(List.of(1L, 2L))),
+                        new PartitionRestoreOperation(memberTwo, 1, new TreeSet<>(List.of(1L, 2L))),
+                        new ModeChangeOperation(memberOne, Mode.PROCESSING),
+                        new ModeChangeOperation(memberTwo, Mode.PROCESSING),
+                        new AwaitModeChangeOperation(memberOne, Mode.PROCESSING),
+                        new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
+                        new UpdateIncarnationNumberOperation(memberOne)))));
+  }
+
+  @Test
+  void shouldRestoreWhenABrokerHoldingNoPartitionOfTheTenantIsStillProcessing() {
+    // given - memberTwo holds the partition to restore and is recovering, while memberOne holds no
+    // partition of this tenant: the shape of a physical tenant hosted on a subset of the cluster's
+    // brokers, where the partition-less broker is never transitioned into the tenant's recovery
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    memberOne, BrokerPartitionState.initialize(Map.of()),
+                    memberTwo, recovering(1))));
+
+    // then - the restore is planned for the recovering broker alone
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    DEFAULT_PHYSICAL_TENANT_ID,
+                    List.of(
+                        new PartitionPreRestoreOperation(memberTwo, 1),
+                        new PartitionRestoreOperation(memberTwo, 1, new TreeSet<>(List.of(1L))),
+                        new ModeChangeOperation(memberTwo, Mode.PROCESSING),
+                        new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
+                        new UpdateIncarnationNumberOperation(memberTwo)))));
+  }
+
+  @Test
+  void shouldRejectWhenThePhysicalTenantIsNotRecovering() {
+    // given - the tenant's group still processes partition 1, even though a validator would accept
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    MEMBER,
+                    BrokerPartitionState.initialize(
+                        Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()))))));
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ConcurrentModificationException.class);
+  }
+
+  @Test
+  void shouldRejectWhenThePhysicalTenantIsUnknown() {
+    // given - the cluster has no partition group for the tenant the request names
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
+
+    // when
+    final var result = transformer.phases(clusterWithoutPartitionGroups());
+
+    // then - the caller gets 404 rather than a plan that can never apply
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  private static BrokerPartitionState recovering(final int partitionId) {
+    return BrokerPartitionState.initialize(
+            Map.of(partitionId, PartitionState.active(1, DynamicPartitionConfig.init())))
+        .setMode(Mode.RECOVERING);
+  }
+
+  private static CurrentClusterConfiguration clusterWithDefaultGroup(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration(members.keySet()),
+        Map.of(
+            DEFAULT_PHYSICAL_TENANT_ID,
+            new PartitionGroupConfiguration(
+                1, 0, members, Optional.empty(), Optional.empty(), Optional.empty())),
+        PhasedChangeState.empty());
+  }
+
+  private static CurrentClusterConfiguration clusterWithoutPartitionGroups() {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration(Set.of(MEMBER)),
+        Map.of(),
+        PhasedChangeState.empty());
+  }
+
+  private static GlobalConfiguration globalConfiguration(final Set<MemberId> members) {
+    return new GlobalConfiguration(
+        1,
+        Optional.empty(),
+        members.stream()
+            .collect(
+                Collectors.toMap(
+                    Function.identity(),
+                    member -> new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE))),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
@@ -53,7 +53,11 @@ final class RestoreRequestTransformerTest {
 
   private static ClusterConfiguration recoveringTopology() {
     return ClusterConfiguration.init()
-        .addMember(MEMBER, MemberState.initializeAsActive(Map.of()).toRecovering());
+        .addMember(
+            MEMBER,
+            MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))
+                .toRecovering());
   }
 
   private static RestoreResolvedRequest resolvedRequest() {
@@ -95,6 +99,62 @@ final class RestoreRequestTransformerTest {
     final var result = transformer.operations(ClusterConfiguration.init());
 
     // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ConcurrentModificationException.class);
+  }
+
+  @Test
+  void shouldRestoreWhenABrokerOutsideThePartitionGroupIsStillActive() {
+    // given - memberTwo holds the partition to restore and is recovering, while memberOne holds
+    // none: the shape a physical tenant hosted on a subset of the cluster's brokers projects to,
+    // where entering recovery leaves the partition-less broker on its cluster-wide ACTIVE state
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var partitionState = Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()));
+    final var topology =
+        ClusterConfiguration.init()
+            .addMember(memberOne, MemberState.initializeAsActive(Map.of()))
+            .addMember(memberTwo, MemberState.initializeAsActive(partitionState).toRecovering());
+    final var resolved = new RestoreResolvedRequest(Map.of(1, new long[] {1L}), false);
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(), registryWithValidator(validatorReturning(Either.right(resolved))));
+
+    // when
+    final var result = transformer.operations(topology);
+
+    // then - the restore is planned for the recovering broker alone
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new PartitionPreRestoreOperation(memberTwo, 1),
+            new PartitionRestoreOperation(memberTwo, 1, new TreeSet<>(List.of(1L))),
+            new ModeChangeOperation(memberTwo, Mode.PROCESSING),
+            new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
+            new UpdateIncarnationNumberOperation(memberTwo));
+  }
+
+  @Test
+  void shouldRejectWhenABrokerHoldingAPartitionToRestoreIsStillActive() {
+    // given - both brokers hold the partition to restore, but only one of them is recovering
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var partitionState = Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()));
+    final var topology =
+        ClusterConfiguration.init()
+            .addMember(memberOne, MemberState.initializeAsActive(partitionState))
+            .addMember(memberTwo, MemberState.initializeAsActive(partitionState).toRecovering());
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
+
+    // when
+    final var result = transformer.operations(topology);
+
+    // then - restoring a partition still being processed elsewhere is refused
     EitherAssert.assertThat(result)
         .isLeft()
         .left()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
@@ -34,6 +34,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.awaitility.Awaitility;
@@ -95,8 +96,11 @@ final class ClusterAdminRestoreAcceptanceIT {
         final var tenantBClient = TENANTS.newClientBuilder(broker, TENANT_B).build()) {
       final var processId = "forced-restore-process";
       final var jobType = "forced-restore-job";
+      final var probeProcessId = "forced-restore-probe";
 
       // given — the default tenant keeps processing throughout; only tenant-b gets a backup
+      deployProbeProcess(defaultClient, probeProcessId);
+      deployProbeProcess(tenantBClient, probeProcessId);
       deployAndCreateInstance(defaultClient, processId, jobType);
       deployAndCreateInstance(tenantBClient, processId, jobType);
       takeSnapshot(TENANT_B);
@@ -104,10 +108,10 @@ final class ClusterAdminRestoreAcceptanceIT {
 
       // when — only tenant-b is put into RECOVERING, scoped by physicalTenantId
       InProcessRestoreTestUtil.changeClusterMode(defaultClient, TENANT_B, "RECOVERING", false);
-      awaitCommandsRejected(tenantBClient, processId);
+      awaitCommandsRejected(tenantBClient, probeProcessId);
 
       // and — the default tenant is left untouched by the scoped mode change
-      assertThat(createInstance(defaultClient, processId)).isPositive();
+      assertThat(createInstance(defaultClient, probeProcessId)).isPositive();
 
       // and — the restore is forced onto tenant-b alone. The mode change above may not have fully
       // settled yet even though tenant-b's commands are already rejected (rejection can start
@@ -118,11 +122,11 @@ final class ClusterAdminRestoreAcceptanceIT {
 
       // then — tenant-b processes commands again once its restore completes, and its baseline job
       // is still there to complete, proving partition data (not just topology/mode) was restored
-      awaitCommandsAccepted(tenantBClient, processId);
+      awaitCommandsAccepted(tenantBClient, probeProcessId);
       activateAndComplete(tenantBClient, jobType);
 
       // and — the default tenant was never affected by the other tenant's restore
-      assertThat(createInstance(defaultClient, processId)).isPositive();
+      assertThat(createInstance(defaultClient, probeProcessId)).isPositive();
     }
   }
 
@@ -133,9 +137,13 @@ final class ClusterAdminRestoreAcceptanceIT {
         final var tenantCClient = TENANTS.newClientBuilder(broker, TENANT_C).build()) {
       final var processId = "cluster-wide-restore-process";
       final var jobType = "cluster-wide-restore-job";
+      final var probeProcessId = "cluster-wide-restore-probe";
       final var backupId = 42;
 
       // given — every physical tenant has a pending job, backed up from the same selection
+      deployProbeProcess(defaultClient, probeProcessId);
+      deployProbeProcess(tenantBClient, probeProcessId);
+      deployProbeProcess(tenantCClient, probeProcessId);
       deployAndCreateInstance(defaultClient, processId, jobType);
       deployAndCreateInstance(tenantBClient, processId, jobType);
       deployAndCreateInstance(tenantCClient, processId, jobType);
@@ -148,18 +156,18 @@ final class ClusterAdminRestoreAcceptanceIT {
 
       // when — the whole cluster is put into RECOVERING, no physicalTenantId naming every tenant
       InProcessRestoreTestUtil.changeClusterMode(defaultClient, null, "RECOVERING", false);
-      awaitCommandsRejected(defaultClient, processId);
-      awaitCommandsRejected(tenantBClient, processId);
-      awaitCommandsRejected(tenantCClient, processId);
+      awaitCommandsRejected(defaultClient, probeProcessId);
+      awaitCommandsRejected(tenantBClient, probeProcessId);
+      awaitCommandsRejected(tenantCClient, probeProcessId);
 
       // and — a cluster-wide restore is triggered, no overrides: every tenant shares the selection
       awaitRestoreTriggered(
           () -> InProcessRestoreTestUtil.triggerClusterRestore(defaultClient, backupId, Map.of()));
 
       // then — every tenant processes commands again once its restore completes
-      awaitCommandsAccepted(defaultClient, processId);
-      awaitCommandsAccepted(tenantBClient, processId);
-      awaitCommandsAccepted(tenantCClient, processId);
+      awaitCommandsAccepted(defaultClient, probeProcessId);
+      awaitCommandsAccepted(tenantBClient, probeProcessId);
+      awaitCommandsAccepted(tenantCClient, probeProcessId);
 
       // and — every tenant's baseline job is still there to complete, proving partition data (not
       // just topology/mode) was restored on all three
@@ -178,10 +186,14 @@ final class ClusterAdminRestoreAcceptanceIT {
       final var baselineJobType = "override-it-baseline-job";
       final var overrideProcessId = "override-it-override-process";
       final var overrideJobType = "override-it-override-job";
+      final var probeProcessId = "override-it-probe";
       final long baselineBackupId = 100;
       final long overrideBackupId = 200;
 
       // given — every physical tenant has a pending job from the baseline process
+      deployProbeProcess(defaultClient, probeProcessId);
+      deployProbeProcess(tenantBClient, probeProcessId);
+      deployProbeProcess(tenantCClient, probeProcessId);
       deployAndCreateInstance(defaultClient, baselineProcessId, baselineJobType);
       deployAndCreateInstance(tenantBClient, baselineProcessId, baselineJobType);
       deployAndCreateInstance(tenantCClient, baselineProcessId, baselineJobType);
@@ -203,9 +215,9 @@ final class ClusterAdminRestoreAcceptanceIT {
 
       // when — the whole cluster is put into RECOVERING over the cluster-admin endpoint ...
       InProcessRestoreTestUtil.changeClusterMode(defaultClient, null, "RECOVERING", false);
-      awaitCommandsRejected(defaultClient, baselineProcessId);
-      awaitCommandsRejected(tenantBClient, baselineProcessId);
-      awaitCommandsRejected(tenantCClient, overrideProcessId);
+      awaitCommandsRejected(defaultClient, probeProcessId);
+      awaitCommandsRejected(tenantBClient, probeProcessId);
+      awaitCommandsRejected(tenantCClient, probeProcessId);
 
       // ... and a cluster-wide restore is triggered: tenant-c overridden to its own, additional
       // backup, default and tenant-b left on the top-level (baseline) selection
@@ -215,9 +227,9 @@ final class ClusterAdminRestoreAcceptanceIT {
                   defaultClient, baselineBackupId, Map.of(TENANT_C, overrideBackupId)));
 
       // then — every tenant processes commands again once its restore completes
-      awaitCommandsAccepted(defaultClient, baselineProcessId);
-      awaitCommandsAccepted(tenantBClient, baselineProcessId);
-      awaitCommandsAccepted(tenantCClient, overrideProcessId);
+      awaitCommandsAccepted(defaultClient, probeProcessId);
+      awaitCommandsAccepted(tenantBClient, probeProcessId);
+      awaitCommandsAccepted(tenantCClient, probeProcessId);
 
       // and — default and tenant-b restored from the baseline backup: the baseline job is still
       // there to complete
@@ -233,18 +245,42 @@ final class ClusterAdminRestoreAcceptanceIT {
   }
 
   /**
-   * Deploys a single-service-task process (idempotent under retry, so a transient rejection while
-   * the cluster settles is simply retried) and creates one instance, leaving one job of the given
+   * Deploys the process the readiness probes create instances of: it carries no service task, so a
+   * probe instance leaves no job behind. The processes whose pending jobs later prove that
+   * backed-up partition data was restored must not be the ones probed for readiness — a probe
+   * instance of such a process would mint a fresh job of the asserted type, letting the job
+   * assertions pass off work the probe itself created rather than work the backup captured.
+   *
+   * <p>Deploy it before the backup is taken, so the restored state still knows it.
+   */
+  private static void deployProbeProcess(final CamundaClient client, final String processId) {
+    deploy(
+        client, processId, Bpmn.createExecutableProcess(processId).startEvent().endEvent().done());
+  }
+
+  /**
+   * Deploys a single-service-task process and creates one instance, leaving one job of the given
    * type pending.
    */
   private static void deployAndCreateInstance(
       final CamundaClient client, final String processId, final String jobType) {
-    final BpmnModelInstance process =
+    deploy(
+        client,
+        processId,
         Bpmn.createExecutableProcess(processId)
             .startEvent()
             .serviceTask("task", t -> t.zeebeJobType(jobType))
             .endEvent()
-            .done();
+            .done());
+    Awaitility.await("instance of " + processId + " is created")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(createInstance(client, processId)).isPositive());
+  }
+
+  /** Deploys a process, idempotent under retry so a transient rejection is simply retried. */
+  private static void deploy(
+      final CamundaClient client, final String processId, final BpmnModelInstance process) {
     Awaitility.await("process " + processId + " is deployed")
         .atMost(Duration.ofSeconds(30))
         .ignoreExceptions()
@@ -258,10 +294,6 @@ final class ClusterAdminRestoreAcceptanceIT {
                             .join()
                             .getProcesses())
                     .isNotEmpty());
-    Awaitility.await("instance of " + processId + " is created")
-        .atMost(Duration.ofSeconds(30))
-        .ignoreExceptions()
-        .untilAsserted(() -> assertThat(createInstance(client, processId)).isPositive());
   }
 
   /** Activates at least one job of the given type and completes every job it finds. */
@@ -336,15 +368,30 @@ final class ClusterAdminRestoreAcceptanceIT {
         .untilAsserted(trigger);
   }
 
+  /**
+   * Takes a snapshot on every partition of the tenant and waits for it to be persisted.
+   * Snapshotting is asynchronous, and a tenant may already carry a snapshot from an earlier call
+   * here, so the wait is for each partition's snapshot ID to <em>change</em>: merely waiting for a
+   * non-null ID would return immediately on the second call and let the backup be taken before the
+   * work it is meant to capture is snapshotted.
+   */
   private void takeSnapshot(final String tenantId) {
     final var partitions = PartitionsActuator.of(broker);
+    final var previousSnapshotIds = new HashMap<Integer, String>();
+    partitions
+        .query(tenantId)
+        .forEach((id, status) -> previousSnapshotIds.put(id, status.snapshotId()));
     partitions.takeSnapshot(tenantId);
-    Awaitility.await("snapshot is taken for tenant " + tenantId)
+    Awaitility.await("a new snapshot is taken for tenant " + tenantId)
         .atMost(Duration.ofSeconds(60))
         .untilAsserted(
             () ->
-                assertThat(partitions.query(tenantId).values())
-                    .allSatisfy(status -> assertThat(status.snapshotId()).isNotNull()));
+                assertThat(partitions.query(tenantId))
+                    .allSatisfy(
+                        (partitionId, status) ->
+                            assertThat(status.snapshotId())
+                                .isNotNull()
+                                .isNotEqualTo(previousSnapshotIds.get(partitionId))));
   }
 
   private void takeBackup(final String tenantId, final long backupId) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Data;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Acceptance test for restoring in-place over the cluster-admin API ({@code POST
+ * cluster/v2/restore}), as opposed to {@link InProcessRestoreAcceptance} which restores over the
+ * per-physical-tenant API ({@code POST v2/restore}).
+ *
+ * <p>One broker serves three physical tenants — {@code default}, {@code tenantb} and {@code
+ * tenantc} — each its own partition group with its own primary storage backup store. No secondary
+ * storage is needed: backup/restore acts on primary storage only, independently of it (see {@code
+ * ClusterRecoveryServicesTest} in the {@code service} module for coverage of the per-tenant
+ * secondary-storage environment that {@code overrides} coexists with).
+ *
+ * <p>Covers the three shapes {@link
+ * io.camunda.zeebe.dynamic.config.api.ClusterRestoreRequestTransformer} supports: a request naming
+ * one physical tenant, forcing the restore onto just that tenant while the rest of the cluster is
+ * left alone; a request naming every known physical tenant of the cluster — the shape {@code
+ * ClusterRecoveryServices} builds when the request omits {@code physicalTenantId} — restoring them
+ * all from the same backup in one change; and that same cluster-wide shape with one tenant's backup
+ * selection overridden to a different, additional backup, proving the override reaches exactly the
+ * tenant it names and nowhere else.
+ */
+@Timeout(240)
+@ZeebeIntegration
+final class ClusterAdminRestoreAcceptanceIT {
+
+  private static final String DEFAULT_TENANT = PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+  private static final String TENANT_B = "tenantb";
+  private static final String TENANT_C = "tenantc";
+
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @TempDir private static Path defaultBackupDir;
+  @TempDir private static Path tenantBBackupDir;
+  @TempDir private static Path tenantCBackupDir;
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(DEFAULT_TENANT, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .withTenant(TENANT_C, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      configureBackupStores(
+          TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess()));
+
+  @Test
+  void shouldRestoreOnlyTheForcedPhysicalTenant() {
+    try (final var defaultClient = TENANTS.newClientBuilder(broker, DEFAULT_TENANT).build();
+        final var tenantBClient = TENANTS.newClientBuilder(broker, TENANT_B).build()) {
+      final var processId = "forced-restore-process";
+      final var jobType = "forced-restore-job";
+
+      // given — the default tenant keeps processing throughout; only tenant-b gets a backup
+      deployAndCreateInstance(defaultClient, processId, jobType);
+      deployAndCreateInstance(tenantBClient, processId, jobType);
+      takeSnapshot(TENANT_B);
+      takeBackup(TENANT_B, 41);
+
+      // when — only tenant-b is put into RECOVERING, scoped by physicalTenantId
+      InProcessRestoreTestUtil.changeClusterMode(defaultClient, TENANT_B, "RECOVERING", false);
+      awaitCommandsRejected(tenantBClient, processId);
+
+      // and — the default tenant is left untouched by the scoped mode change
+      assertThat(createInstance(defaultClient, processId)).isPositive();
+
+      // and — the restore is forced onto tenant-b alone. The mode change above may not have fully
+      // settled yet even though tenant-b's commands are already rejected (rejection can start
+      // before the configuration change that caused it is marked complete), so a transient 409
+      // while it clears is retried rather than failing outright.
+      awaitRestoreTriggered(
+          () -> InProcessRestoreTestUtil.triggerClusterRestore(defaultClient, TENANT_B, 41));
+
+      // then — tenant-b processes commands again once its restore completes, and its baseline job
+      // is still there to complete, proving partition data (not just topology/mode) was restored
+      awaitCommandsAccepted(tenantBClient, processId);
+      activateAndComplete(tenantBClient, jobType);
+
+      // and — the default tenant was never affected by the other tenant's restore
+      assertThat(createInstance(defaultClient, processId)).isPositive();
+    }
+  }
+
+  @Test
+  void shouldRestoreEveryPhysicalTenantOfTheClusterWhenNoneIsNamed() {
+    try (final var defaultClient = TENANTS.newClientBuilder(broker, DEFAULT_TENANT).build();
+        final var tenantBClient = TENANTS.newClientBuilder(broker, TENANT_B).build();
+        final var tenantCClient = TENANTS.newClientBuilder(broker, TENANT_C).build()) {
+      final var processId = "cluster-wide-restore-process";
+      final var jobType = "cluster-wide-restore-job";
+      final var backupId = 42;
+
+      // given — every physical tenant has a pending job, backed up from the same selection
+      deployAndCreateInstance(defaultClient, processId, jobType);
+      deployAndCreateInstance(tenantBClient, processId, jobType);
+      deployAndCreateInstance(tenantCClient, processId, jobType);
+      takeSnapshot(DEFAULT_TENANT);
+      takeSnapshot(TENANT_B);
+      takeSnapshot(TENANT_C);
+      takeBackup(DEFAULT_TENANT, backupId);
+      takeBackup(TENANT_B, backupId);
+      takeBackup(TENANT_C, backupId);
+
+      // when — the whole cluster is put into RECOVERING, no physicalTenantId naming every tenant
+      InProcessRestoreTestUtil.changeClusterMode(defaultClient, null, "RECOVERING", false);
+      awaitCommandsRejected(defaultClient, processId);
+      awaitCommandsRejected(tenantBClient, processId);
+      awaitCommandsRejected(tenantCClient, processId);
+
+      // and — a cluster-wide restore is triggered, no overrides: every tenant shares the selection
+      awaitRestoreTriggered(
+          () -> InProcessRestoreTestUtil.triggerClusterRestore(defaultClient, backupId, Map.of()));
+
+      // then — every tenant processes commands again once its restore completes
+      awaitCommandsAccepted(defaultClient, processId);
+      awaitCommandsAccepted(tenantBClient, processId);
+      awaitCommandsAccepted(tenantCClient, processId);
+
+      // and — every tenant's baseline job is still there to complete, proving partition data (not
+      // just topology/mode) was restored on all three
+      activateAndComplete(defaultClient, jobType);
+      activateAndComplete(tenantBClient, jobType);
+      activateAndComplete(tenantCClient, jobType);
+    }
+  }
+
+  @Test
+  void shouldRestoreTheOverriddenTenantFromItsOwnBackupWhileOthersShareTheDefault() {
+    try (final var defaultClient = TENANTS.newClientBuilder(broker, DEFAULT_TENANT).build();
+        final var tenantBClient = TENANTS.newClientBuilder(broker, TENANT_B).build();
+        final var tenantCClient = TENANTS.newClientBuilder(broker, TENANT_C).build()) {
+      final var baselineProcessId = "override-it-baseline-process";
+      final var baselineJobType = "override-it-baseline-job";
+      final var overrideProcessId = "override-it-override-process";
+      final var overrideJobType = "override-it-override-job";
+      final long baselineBackupId = 100;
+      final long overrideBackupId = 200;
+
+      // given — every physical tenant has a pending job from the baseline process
+      deployAndCreateInstance(defaultClient, baselineProcessId, baselineJobType);
+      deployAndCreateInstance(tenantBClient, baselineProcessId, baselineJobType);
+      deployAndCreateInstance(tenantCClient, baselineProcessId, baselineJobType);
+
+      // and — a completed baseline backup on all three tenants
+      takeSnapshot(DEFAULT_TENANT);
+      takeSnapshot(TENANT_B);
+      takeSnapshot(TENANT_C);
+      takeBackup(DEFAULT_TENANT, baselineBackupId);
+      takeBackup(TENANT_B, baselineBackupId);
+      takeBackup(TENANT_C, baselineBackupId);
+
+      // and — tenant-c alone completes its baseline job and moves on to different work, then takes
+      // an additional backup capturing that later state
+      activateAndComplete(tenantCClient, baselineJobType);
+      deployAndCreateInstance(tenantCClient, overrideProcessId, overrideJobType);
+      takeSnapshot(TENANT_C);
+      takeBackup(TENANT_C, overrideBackupId);
+
+      // when — the whole cluster is put into RECOVERING over the cluster-admin endpoint ...
+      InProcessRestoreTestUtil.changeClusterMode(defaultClient, null, "RECOVERING", false);
+      awaitCommandsRejected(defaultClient, baselineProcessId);
+      awaitCommandsRejected(tenantBClient, baselineProcessId);
+      awaitCommandsRejected(tenantCClient, overrideProcessId);
+
+      // ... and a cluster-wide restore is triggered: tenant-c overridden to its own, additional
+      // backup, default and tenant-b left on the top-level (baseline) selection
+      awaitRestoreTriggered(
+          () ->
+              InProcessRestoreTestUtil.triggerClusterRestore(
+                  defaultClient, baselineBackupId, Map.of(TENANT_C, overrideBackupId)));
+
+      // then — every tenant processes commands again once its restore completes
+      awaitCommandsAccepted(defaultClient, baselineProcessId);
+      awaitCommandsAccepted(tenantBClient, baselineProcessId);
+      awaitCommandsAccepted(tenantCClient, overrideProcessId);
+
+      // and — default and tenant-b restored from the baseline backup: the baseline job is still
+      // there to complete
+      activateAndComplete(defaultClient, baselineJobType);
+      activateAndComplete(tenantBClient, baselineJobType);
+
+      // and — tenant-c restored from its own overridden backup, not the baseline: the baseline job
+      // it had already completed before that backup was taken never reappears, but the job the
+      // override backup captured does
+      assertThat(activatedJobTypes(tenantCClient, baselineJobType)).isEmpty();
+      activateAndComplete(tenantCClient, overrideJobType);
+    }
+  }
+
+  /**
+   * Deploys a single-service-task process (idempotent under retry, so a transient rejection while
+   * the cluster settles is simply retried) and creates one instance, leaving one job of the given
+   * type pending.
+   */
+  private static void deployAndCreateInstance(
+      final CamundaClient client, final String processId, final String jobType) {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    Awaitility.await("process " + processId + " is deployed")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+    Awaitility.await("instance of " + processId + " is created")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(createInstance(client, processId)).isPositive());
+  }
+
+  /** Activates at least one job of the given type and completes every job it finds. */
+  private static void activateAndComplete(final CamundaClient client, final String jobType) {
+    Awaitility.await("a job of type " + jobType + " is activated and completed")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var jobs =
+                  client
+                      .newActivateJobsCommand()
+                      .jobType(jobType)
+                      .maxJobsToActivate(1)
+                      .send()
+                      .join()
+                      .getJobs();
+              assertThat(jobs).isNotEmpty();
+              jobs.forEach(job -> client.newCompleteCommand(job.getKey()).send().join());
+            });
+  }
+
+  /** Activates up to one job of the given type, for a negative "it isn't there" assertion. */
+  private static List<String> activatedJobTypes(final CamundaClient client, final String jobType) {
+    return client
+        .newActivateJobsCommand()
+        .jobType(jobType)
+        .maxJobsToActivate(1)
+        .send()
+        .join()
+        .getJobs()
+        .stream()
+        .map(job -> job.getType())
+        .toList();
+  }
+
+  private static long createInstance(final CamundaClient client, final String processId) {
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  private static void awaitCommandsRejected(final CamundaClient client, final String processId) {
+    Awaitility.await("recovering tenant stops accepting commands")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(() -> createInstance(client, processId))
+                    .isInstanceOf(Exception.class));
+  }
+
+  private static void awaitCommandsAccepted(final CamundaClient client, final String processId) {
+    Awaitility.await("restored tenant accepts commands again")
+        .atMost(Duration.ofMinutes(2))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(createInstance(client, processId)).isPositive());
+  }
+
+  /**
+   * Retries the given restore trigger until it is accepted. The mode change preceding it may not
+   * have fully settled yet even though the affected tenant's commands are already rejected —
+   * rejection can start before the configuration change that caused it is marked complete — so a
+   * transient 409 (another configuration change still in progress) is retried rather than failing
+   * outright. Safe to retry: nothing has started until the trigger is actually accepted.
+   */
+  private static void awaitRestoreTriggered(final ThrowingRunnable trigger) {
+    Awaitility.await("cluster-admin restore is accepted once the prior change clears")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(trigger);
+  }
+
+  private void takeSnapshot(final String tenantId) {
+    final var partitions = PartitionsActuator.of(broker);
+    partitions.takeSnapshot(tenantId);
+    Awaitility.await("snapshot is taken for tenant " + tenantId)
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () ->
+                assertThat(partitions.query(tenantId).values())
+                    .allSatisfy(status -> assertThat(status.snapshotId()).isNotNull()));
+  }
+
+  private void takeBackup(final String tenantId, final long backupId) {
+    final var uri = backupsUri(tenantId);
+    final var body = "{\"backupId\": " + backupId + "}";
+    final var request =
+        HttpRequest.newBuilder(uri)
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString(body))
+            .build();
+    assertThat(send(request).statusCode())
+        .describedAs("take backup %d for tenant %s", backupId, tenantId)
+        .isEqualTo(202);
+
+    Awaitility.await("backup %d for tenant %s completes".formatted(backupId, tenantId))
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions() // 404 NOT_FOUND until the backup is registered
+        .untilAsserted(
+            () -> {
+              final var status =
+                  send(HttpRequest.newBuilder(URI.create(uri + "/" + backupId)).GET().build());
+              assertThat(status.statusCode()).isEqualTo(200);
+              assertThat(OBJECT_MAPPER.readTree(status.body()).path("state").asText())
+                  .isEqualTo("COMPLETED");
+            });
+  }
+
+  private URI backupsUri(final String tenantId) {
+    final var base = broker.restAddress().toString().replaceAll("/+$", "");
+    return URI.create(
+        DEFAULT_TENANT.equals(tenantId)
+            ? base + "/v2/backups/runtime"
+            : base + "/physical-tenants/" + tenantId + "/v2/backups/runtime");
+  }
+
+  private static HttpResponse<String> send(final HttpRequest request) {
+    try {
+      return HTTP.send(request, BodyHandlers.ofString());
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static TestStandaloneBroker configureBackupStores(final TestStandaloneBroker broker) {
+    return broker
+        .withDataConfig(ClusterAdminRestoreAcceptanceIT::configureFilesystemBackup)
+        .withPtConfig(
+            TENANT_B, camunda -> configureFilesystemBackupForTenant(camunda, tenantBBackupDir))
+        .withPtConfig(
+            TENANT_C, camunda -> configureFilesystemBackupForTenant(camunda, tenantCBackupDir));
+  }
+
+  private static void configureFilesystemBackup(final Data data) {
+    final var backup = data.getPrimaryStorage().getBackup();
+    backup.setStore(BackupStoreType.FILESYSTEM);
+    backup.getFilesystem().setBasePath(defaultBackupDir.toAbsolutePath().toString());
+  }
+
+  private static void configureFilesystemBackupForTenant(
+      final Camunda camunda, final Path backupDir) {
+    final PrimaryStorageBackup backup = camunda.getData().getPrimaryStorage().getBackup();
+    backup.setStore(BackupStoreType.FILESYSTEM);
+    backup.getFilesystem().setBasePath(backupDir.toAbsolutePath().toString());
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
@@ -12,7 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.protocol.rest.ClusterModeChangeResponse;
+import io.camunda.client.protocol.rest.ClusterRestoreRequest;
 import io.camunda.client.protocol.rest.ClusterRestoreResponse;
+import io.camunda.client.protocol.rest.RestoreRequest;
 import io.camunda.client.protocol.rest.RestoreStatusResponse;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -39,10 +41,12 @@ import org.awaitility.Awaitility;
 
 /**
  * Shared helpers for the in-process restore tests ({@link InProcessRestoreAcceptance}, {@link
- * InProcessRestoreRetryOnCorruptionIT}, {@link InProcessRdbmsRangeRestoreIT} and {@link
- * InProcessRestoreStatusIT}), which all trigger a restore over the cluster's REST endpoint while a
- * broker is in {@code RECOVERING} mode. Also exposes {@link #changeMode} for triggering a cluster
- * mode change over {@code v2/mode}, reused by {@code ModeChangeAcceptanceIT} outside this package.
+ * InProcessRestoreRetryOnCorruptionIT}, {@link InProcessRdbmsRangeRestoreIT}, {@link
+ * InProcessRestoreStatusIT} and {@link ClusterAdminRestoreAcceptanceIT}), which all trigger a
+ * restore over the cluster's REST endpoint while a broker is in {@code RECOVERING} mode. Also
+ * exposes {@link #changeMode} for triggering a mode change over {@code v2/mode}, reused by {@code
+ * ModeChangeAcceptanceIT} outside this package, and {@link #changeClusterMode} for the
+ * cluster-admin equivalent over {@code cluster/v2/mode}.
  */
 public final class InProcessRestoreTestUtil {
 
@@ -96,6 +100,84 @@ public final class InProcessRestoreTestUtil {
     }
   }
 
+  /**
+   * POSTs a cluster-admin restore request with the given body to {@code cluster/v2/restore}, scoped
+   * to the given physical tenant, or to every physical tenant of the cluster when {@code
+   * physicalTenantId} is {@code null}. Returns the raw response.
+   */
+  static HttpResponse<String> sendClusterRestoreRequest(
+      final CamundaClient client, final String physicalTenantId, final ClusterRestoreRequest body) {
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      final var tenantQueryParam =
+          physicalTenantId == null ? "" : "&physicalTenantId=" + physicalTenantId;
+      final var uri =
+          URI.create(
+              "%scluster/v2/restore?dryRun=false%s"
+                  .formatted(client.getConfiguration().getRestAddress(), tenantQueryParam));
+      final var request =
+          HttpRequest.newBuilder(uri)
+              .header("Content-Type", "application/json")
+              .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(body)))
+              .build();
+      return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to trigger cluster restore via REST endpoint", e);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(
+          "Interrupted while triggering cluster restore via REST endpoint", e);
+    }
+  }
+
+  /**
+   * Triggers a cluster-admin restore of the given physical tenant (or every physical tenant of the
+   * cluster, when {@code physicalTenantId} is {@code null}) for the given backup id over {@code
+   * cluster/v2/restore}, asserting the request is accepted (202), and returns the id of the cluster
+   * configuration change it started.
+   */
+  static long triggerClusterRestore(
+      final CamundaClient client, final String physicalTenantId, final long backupId) {
+    final var body = new ClusterRestoreRequest().backupIds(List.of(backupId));
+    final var response = sendClusterRestoreRequest(client, physicalTenantId, body);
+    assertThat(response.statusCode())
+        .describedAs("cluster restore REST response: %s".formatted(response.body()))
+        .isEqualTo(202);
+    try {
+      return Long.parseLong(
+          OBJECT_MAPPER.readValue(response.body(), ClusterRestoreResponse.class).getChangeId());
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to parse cluster restore REST response", e);
+    }
+  }
+
+  /**
+   * Triggers a cluster-wide restore for the given top-level backup id, overriding it with its own
+   * backup id for every physical tenant named in {@code overrideBackupIdByTenant}, over {@code
+   * cluster/v2/restore}. {@code overrides} is only accepted on a cluster-wide restore, so this
+   * always omits {@code physicalTenantId}. Asserts the request is accepted (202) and returns the id
+   * of the cluster configuration change it started.
+   */
+  static long triggerClusterRestore(
+      final CamundaClient client,
+      final long backupId,
+      final Map<String, Long> overrideBackupIdByTenant) {
+    final var body = new ClusterRestoreRequest().backupIds(List.of(backupId));
+    overrideBackupIdByTenant.forEach(
+        (tenantId, overrideBackupId) ->
+            body.putOverridesItem(
+                tenantId, new RestoreRequest().backupIds(List.of(overrideBackupId))));
+    final var response = sendClusterRestoreRequest(client, null, body);
+    assertThat(response.statusCode())
+        .describedAs("cluster restore REST response: %s".formatted(response.body()))
+        .isEqualTo(202);
+    try {
+      return Long.parseLong(
+          OBJECT_MAPPER.readValue(response.body(), ClusterRestoreResponse.class).getChangeId());
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to parse cluster restore REST response", e);
+    }
+  }
+
   /** GETs the current restore status from {@code v2/restore} and returns the parsed response. */
   static RestoreStatusResponse getRestoreStatus(final CamundaClient client) {
     try (final var httpClient = HttpClient.newHttpClient()) {
@@ -139,6 +221,45 @@ public final class InProcessRestoreTestUtil {
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException("Interrupted while triggering mode change via REST endpoint", e);
+    }
+  }
+
+  /**
+   * Triggers a cluster-admin mode change to the given mode over {@code cluster/v2/mode}, scoped to
+   * the given physical tenant, or to every physical tenant of the cluster when {@code
+   * physicalTenantId} is {@code null}. Unlike {@link #changeMode}, which is derived from the
+   * client's own configured REST address and so only ever reaches the tenant that address is
+   * already scoped to, this always targets the bare cluster-admin path — the only way to move more
+   * than one physical tenant at once. Asserts the request is accepted (200) and returns the id of
+   * the cluster configuration change it started.
+   */
+  static long changeClusterMode(
+      final CamundaClient client,
+      final String physicalTenantId,
+      final String mode,
+      final boolean dryRun) {
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      final var tenantQueryParam =
+          physicalTenantId == null ? "" : "&physicalTenantId=" + physicalTenantId;
+      final var uri =
+          URI.create(
+              "%scluster/v2/mode?mode=%s&dryRun=%s%s"
+                  .formatted(
+                      client.getConfiguration().getRestAddress(), mode, dryRun, tenantQueryParam));
+      final var request =
+          HttpRequest.newBuilder(uri).method("PATCH", HttpRequest.BodyPublishers.noBody()).build();
+      final var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      assertThat(response.statusCode())
+          .describedAs("cluster mode change REST response: %s".formatted(response.body()))
+          .isEqualTo(200);
+      return Long.parseLong(
+          OBJECT_MAPPER.readValue(response.body(), ClusterModeChangeResponse.class).getChangeId());
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to trigger cluster mode change via REST endpoint", e);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(
+          "Interrupted while triggering cluster mode change via REST endpoint", e);
     }
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -133,6 +133,10 @@ public interface PartitionsActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, PartitionStatus> takeSnapshot();
 
+  @RequestLine("POST /takeSnapshot?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Map<Integer, PartitionStatus> takeSnapshot(@feign.Param final String physicalTenant);
+
   @JsonIgnoreProperties(ignoreUnknown = true)
   record PartitionStatus(
       String role,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Finalize the ClusterAdmin restore procedure request transformer. The PT RestoreRequestTransformer is used to generate the operations and drive the validation of the tenant's target backups.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59537
