### PR TITLE
feat: add job registry index for async delete jobs

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
@@ -39,16 +39,17 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
-  void shouldFindOldestQueuedJob() {
+  void shouldFindOnlyQueuedJob() {
+    // given
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE,
-            TargetEntityType.PROCESS_DEFINITION,
-            "2251799813685251");
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
 
+    // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.PROCESS_DEFINITION_DATA_DELETE);
+        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
 
+    // then
     assertThat(found).isPresent();
     assertThat(found.get().getId()).isEqualTo(created.getId());
     assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
@@ -56,33 +57,48 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
 
   @Test
   void shouldNotFindQueuedJobWhenNoneAreQueued() {
+    // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
 
+    // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.PROCESS_DEFINITION_DATA_DELETE);
+        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
 
+    // then
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  void shouldNotFindQueuedJobWhenIndexIsEmpty() {
+    // given no job entries at all
+
+    // when
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
+
+    // then
     assertThat(found).isEmpty();
   }
 
   @Test
   void shouldReturnOldestQueuedJobWhenMultipleAreQueued() {
+    // given
     // Pin the clock so the two entries get distinct, ordered createdAt values -- otherwise both
     // could land in the same millisecond and the sort-by-oldest assertion would be flaky.
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
     final JobRegistryEntryDto olderEntry =
-        jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
 
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
-    jobRegistryWriter.createJobEntry(
-        JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+    jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
 
+    // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.PROCESS_DEFINITION_DATA_DELETE);
+        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
 
+    // then
     assertThat(found).isPresent();
     assertThat(found.get().getId()).isEqualTo(olderEntry.getId());
     assertThat(found.get().getTargetEntityId()).isEqualTo("1");
@@ -90,18 +106,39 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
 
   @Test
   void shouldSkipCompletedEntryAndReturnTheQueuedOne() {
+    // given
     final JobRegistryEntryDto completedEntry =
-        jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
     jobRegistryWriter.updateJobStatus(completedEntry.getId(), JobStatus.COMPLETED, null);
 
     final JobRegistryEntryDto queuedEntry =
-        jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
 
+    // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.PROCESS_DEFINITION_DATA_DELETE);
+        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
 
+    // then
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(queuedEntry.getId());
+    assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
+  }
+
+  @Test
+  void shouldSkipFailedEntryAndReturnTheQueuedOne() {
+    // given
+    final JobRegistryEntryDto failedEntry =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.updateJobStatus(failedEntry.getId(), JobStatus.FAILED, "boom");
+
+    final JobRegistryEntryDto queuedEntry =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+
+    // when
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
+
+    // then
     assertThat(found).isPresent();
     assertThat(found.get().getId()).isEqualTo(queuedEntry.getId());
     assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
@@ -109,44 +146,46 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
 
   @Test
   void shouldFindJobByJobTypeAndTargetEntityId() {
+    // given
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE,
-            TargetEntityType.PROCESS_DEFINITION,
-            "2251799813685251");
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
 
+    // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findByJobTypeAndTargetEntityId(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, "2251799813685251");
+        jobRegistryReader.findByJobTypeAndTargetEntityId(JobType.DELETE, "2251799813685251");
 
+    // then
     assertThat(found).isPresent();
     assertThat(found.get().getId()).isEqualTo(created.getId());
   }
 
   @Test
   void shouldFindJobByJobTypeAndTargetEntityIdRegardlessOfStatus() {
+    // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
 
+    // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findByJobTypeAndTargetEntityId(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, "1");
+        jobRegistryReader.findByJobTypeAndTargetEntityId(JobType.DELETE, "1");
 
+    // then
     assertThat(found).isPresent();
     assertThat(found.get().getStatus()).isEqualTo(JobStatus.COMPLETED);
   }
 
   @Test
   void shouldNotFindJobForUnknownTargetEntityId() {
-    jobRegistryWriter.createJobEntry(
-        JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+    // given
+    jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
 
+    // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findByJobTypeAndTargetEntityId(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, "does-not-exist");
+        jobRegistryReader.findByJobTypeAndTargetEntityId(JobType.DELETE, "does-not-exist");
 
+    // then
     assertThat(found).isEmpty();
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
@@ -17,6 +17,7 @@ import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,44 +47,45 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
             JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
 
     // when
-    final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
+    final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
 
     // then
-    assertThat(found).isPresent();
-    assertThat(found.get().getId()).isEqualTo(created.getId());
-    assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
+    assertThat(found)
+        .singleElement()
+        .satisfies(
+            entry -> {
+              assertThat(entry.getId()).isEqualTo(created.getId());
+              assertThat(entry.getStatus()).isEqualTo(JobStatus.QUEUED);
+            });
   }
 
   @Test
-  void shouldNotFindQueuedJobWhenNoneAreQueued() {
+  void shouldNotFindQueuedJobsWhenNoneAreQueued() {
     // given
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
 
     // when
-    final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
+    final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
 
     // then
     assertThat(found).isEmpty();
   }
 
   @Test
-  void shouldNotFindQueuedJobWhenIndexIsEmpty() {
+  void shouldNotFindQueuedJobsWhenIndexIsEmpty() {
     // given no job entries at all
 
     // when
-    final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
+    final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
 
     // then
     assertThat(found).isEmpty();
   }
 
   @Test
-  void shouldReturnOldestQueuedJobWhenMultipleAreQueued() {
+  void shouldReturnQueuedJobsOldestFirstWhenMultipleAreQueued() {
     // given
     // Pin the clock so the two entries get distinct, ordered createdAt values -- otherwise both
     // could land in the same millisecond and the sort-by-oldest assertion would be flaky.
@@ -92,16 +94,35 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
         jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
 
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
+    final JobRegistryEntryDto newerEntry =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+
+    // when
+    final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
+
+    // then
+    assertThat(found)
+        .extracting(JobRegistryEntryDto::getId)
+        .containsExactly(olderEntry.getId(), newerEntry.getId());
+  }
+
+  @Test
+  void shouldRespectLimitWhenMultipleAreQueued() {
+    // given
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
+    final JobRegistryEntryDto olderEntry =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
     jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
 
     // when
-    final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
+    final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(1);
 
     // then
-    assertThat(found).isPresent();
-    assertThat(found.get().getId()).isEqualTo(olderEntry.getId());
-    assertThat(found.get().getTargetEntityId()).isEqualTo("1");
+    assertThat(found)
+        .singleElement()
+        .satisfies(entry -> assertThat(entry.getId()).isEqualTo(olderEntry.getId()));
   }
 
   @Test
@@ -115,13 +136,16 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
         jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
 
     // when
-    final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
+    final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
 
     // then
-    assertThat(found).isPresent();
-    assertThat(found.get().getId()).isEqualTo(queuedEntry.getId());
-    assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
+    assertThat(found)
+        .singleElement()
+        .satisfies(
+            entry -> {
+              assertThat(entry.getId()).isEqualTo(queuedEntry.getId());
+              assertThat(entry.getStatus()).isEqualTo(JobStatus.QUEUED);
+            });
   }
 
   @Test
@@ -135,17 +159,20 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
         jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
 
     // when
-    final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findOldestQueuedJob(JobType.DELETE);
+    final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
 
     // then
-    assertThat(found).isPresent();
-    assertThat(found.get().getId()).isEqualTo(queuedEntry.getId());
-    assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
+    assertThat(found)
+        .singleElement()
+        .satisfies(
+            entry -> {
+              assertThat(entry.getId()).isEqualTo(queuedEntry.getId());
+              assertThat(entry.getStatus()).isEqualTo(JobStatus.QUEUED);
+            });
   }
 
   @Test
-  void shouldFindJobByJobTypeAndTargetEntityId() {
+  void shouldFindLastJobByJobTypeAndTargetEntityId() {
     // given
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(
@@ -153,7 +180,8 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
 
     // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findByJobTypeAndTargetEntityId(JobType.DELETE, "2251799813685251");
+        jobRegistryReader.findLastByJobTypeAndTargetEntityId(
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
 
     // then
     assertThat(found).isPresent();
@@ -161,7 +189,7 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
-  void shouldFindJobByJobTypeAndTargetEntityIdRegardlessOfStatus() {
+  void shouldFindLastJobByJobTypeAndTargetEntityIdRegardlessOfStatus() {
     // given
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
@@ -169,7 +197,8 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
 
     // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findByJobTypeAndTargetEntityId(JobType.DELETE, "1");
+        jobRegistryReader.findLastByJobTypeAndTargetEntityId(
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
 
     // then
     assertThat(found).isPresent();
@@ -183,7 +212,8 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
 
     // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findByJobTypeAndTargetEntityId(JobType.DELETE, "does-not-exist");
+        jobRegistryReader.findLastByJobTypeAndTargetEntityId(
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "does-not-exist");
 
     // then
     assertThat(found).isEmpty();

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
@@ -106,4 +106,47 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
     assertThat(found.get().getId()).isEqualTo(queuedEntry.getId());
     assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
   }
+
+  @Test
+  void shouldFindJobByJobTypeAndTargetEntityId() {
+    final JobRegistryEntryDto created =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE,
+            TargetEntityType.PROCESS_DEFINITION,
+            "2251799813685251");
+
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findByJobTypeAndTargetEntityId(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, "2251799813685251");
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(created.getId());
+  }
+
+  @Test
+  void shouldFindJobByJobTypeAndTargetEntityIdRegardlessOfStatus() {
+    final JobRegistryEntryDto created =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
+
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findByJobTypeAndTargetEntityId(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, "1");
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getStatus()).isEqualTo(JobStatus.COMPLETED);
+  }
+
+  @Test
+  void shouldNotFindJobForUnknownTargetEntityId() {
+    jobRegistryWriter.createJobEntry(
+        JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findByJobTypeAndTargetEntityId(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, "does-not-exist");
+
+    assertThat(found).isEmpty();
+  }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.security.util.LocalDateUtil;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private JobRegistryReader jobRegistryReader;
+  private JobRegistryWriter jobRegistryWriter;
+
+  @BeforeEach
+  void setup() {
+    jobRegistryReader = embeddedOptimizeExtension.getBean(JobRegistryReader.class);
+    jobRegistryWriter = embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+  }
+
+  @AfterEach
+  void resetClock() {
+    LocalDateUtil.reset();
+  }
+
+  @Test
+  void shouldFindOldestQueuedJob() {
+    final JobRegistryEntryDto created =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE,
+            TargetEntityType.PROCESS_DEFINITION,
+            "2251799813685251");
+
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findOldestQueuedJob(JobType.PROCESS_DEFINITION_DATA_DELETE);
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(created.getId());
+    assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
+  }
+
+  @Test
+  void shouldNotFindQueuedJobWhenNoneAreQueued() {
+    final JobRegistryEntryDto created =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
+
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findOldestQueuedJob(JobType.PROCESS_DEFINITION_DATA_DELETE);
+
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  void shouldReturnOldestQueuedJobWhenMultipleAreQueued() {
+    // Pin the clock so the two entries get distinct, ordered createdAt values -- otherwise both
+    // could land in the same millisecond and the sort-by-oldest assertion would be flaky.
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
+    final JobRegistryEntryDto olderEntry =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
+    jobRegistryWriter.createJobEntry(
+        JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findOldestQueuedJob(JobType.PROCESS_DEFINITION_DATA_DELETE);
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(olderEntry.getId());
+    assertThat(found.get().getTargetEntityId()).isEqualTo("1");
+  }
+
+  @Test
+  void shouldSkipCompletedEntryAndReturnTheQueuedOne() {
+    final JobRegistryEntryDto completedEntry =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.updateJobStatus(completedEntry.getId(), JobStatus.COMPLETED, null);
+
+    final JobRegistryEntryDto queuedEntry =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findOldestQueuedJob(JobType.PROCESS_DEFINITION_DATA_DELETE);
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(queuedEntry.getId());
+    assertThat(found.get().getStatus()).isEqualTo(JobStatus.QUEUED);
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
@@ -173,19 +173,30 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
 
   @Test
   void shouldFindLastJobByJobTypeAndTargetEntityId() {
+    final String targetEntityId = "2251799813685251";
     // given
-    final JobRegistryEntryDto created =
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
+    jobRegistryWriter.createJobEntry(
+        JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, targetEntityId);
+
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:02.000+00:00"));
+    final JobRegistryEntryDto lastEntry =
         jobRegistryWriter.createJobEntry(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, targetEntityId);
+
+    // not the last but persisted after the last one
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
+    jobRegistryWriter.createJobEntry(
+        JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, targetEntityId);
 
     // when
     final Optional<JobRegistryEntryDto> found =
         jobRegistryReader.findLastByJobTypeAndTargetEntityId(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, targetEntityId);
 
     // then
     assertThat(found).isPresent();
-    assertThat(found.get().getId()).isEqualTo(created.getId());
+    assertThat(found.get().getId()).isEqualTo(lastEntry.getId());
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/writer/JobRegistryWriterIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/writer/JobRegistryWriterIT.java
@@ -85,18 +85,29 @@ public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
-  void shouldUpdateJobStatusToRunningWithoutCompletionTimestamp() {
+  void shouldClearErrorMessageWhenRetryCompletesSuccessfully() {
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(
             JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
 
-    jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.RUNNING, null);
+    // Move the entry into a FAILED state first, so errorMessage is populated. A retry that
+    // completes successfully must clear it back to null -- the JobRegistryEntryUpdateDto relies
+    // on nulls actually serializing for that partial-doc update to work, and a test starting
+    // straight from QUEUED can't catch a regression there.
+    jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.FAILED, "boom");
+    final List<JobRegistryEntryDto> afterFailure =
+        databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
+            JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
+    assertThat(afterFailure.get(0).getErrorMessage()).isNotNull();
+
+    jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
 
     final List<JobRegistryEntryDto> stored =
         databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
             JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
     assertThat(stored).hasSize(1);
-    assertThat(stored.get(0).getStatus()).isEqualTo(JobStatus.RUNNING);
-    assertThat(stored.get(0).getCompletedAt()).isNull();
+    assertThat(stored.get(0).getStatus()).isEqualTo(JobStatus.COMPLETED);
+    assertThat(stored.get(0).getCompletedAt()).isNotNull();
+    assertThat(stored.get(0).getErrorMessage()).isNull();
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/writer/JobRegistryWriterIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/writer/JobRegistryWriterIT.java
@@ -30,65 +30,82 @@ public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
 
   @Test
   void shouldCreateQueuedJobEntry() {
+    // given
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE,
-            TargetEntityType.PROCESS_DEFINITION,
-            "2251799813685251");
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
 
+    // when
     final List<JobRegistryEntryDto> stored =
         databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
             JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
 
-    assertThat(stored).hasSize(1);
-    final JobRegistryEntryDto persisted = stored.get(0);
-    assertThat(persisted.getId()).isEqualTo(created.getId());
-    assertThat(persisted.getJobType()).isEqualTo(JobType.PROCESS_DEFINITION_DATA_DELETE);
-    assertThat(persisted.getTargetEntityType()).isEqualTo(TargetEntityType.PROCESS_DEFINITION);
-    assertThat(persisted.getTargetEntityId()).isEqualTo("2251799813685251");
-    assertThat(persisted.getStatus()).isEqualTo(JobStatus.QUEUED);
-    assertThat(persisted.getCompletedAt()).isNull();
+    // then
+    assertThat(stored)
+        .singleElement()
+        .satisfies(
+            jobRegistry -> {
+              assertThat(jobRegistry.getId()).isEqualTo(created.getId());
+              assertThat(jobRegistry.getJobType()).isEqualTo(JobType.DELETE);
+              assertThat(jobRegistry.getTargetEntityType())
+                  .isEqualTo(TargetEntityType.PROCESS_DEFINITION);
+              assertThat(jobRegistry.getTargetEntityId()).isEqualTo("2251799813685251");
+              assertThat(jobRegistry.getStatus()).isEqualTo(JobStatus.QUEUED);
+              assertThat(jobRegistry.getUpdatedAt()).isNull();
+            });
   }
 
   @Test
   void shouldUpdateJobStatusToCompletedWithCompletionTimestamp() {
+    // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
 
+    // when
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
 
+    // then
     final List<JobRegistryEntryDto> stored =
         databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
             JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
-    assertThat(stored).hasSize(1);
-    assertThat(stored.get(0).getStatus()).isEqualTo(JobStatus.COMPLETED);
-    assertThat(stored.get(0).getCompletedAt()).isNotNull();
-    assertThat(stored.get(0).getErrorMessage()).isNull();
+    assertThat(stored)
+        .singleElement()
+        .satisfies(
+            jobRegistry -> {
+              assertThat(jobRegistry.getStatus()).isEqualTo(JobStatus.COMPLETED);
+              assertThat(jobRegistry.getUpdatedAt()).isNotNull();
+              assertThat(jobRegistry.getErrorMessage()).isNull();
+            });
   }
 
   @Test
   void shouldUpdateJobStatusToFailedWithErrorMessage() {
+    // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
 
+    // when
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.FAILED, "boom");
 
+    // then
     final List<JobRegistryEntryDto> stored =
         databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
             JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
-    assertThat(stored).hasSize(1);
-    assertThat(stored.get(0).getStatus()).isEqualTo(JobStatus.FAILED);
-    assertThat(stored.get(0).getErrorMessage()).isEqualTo("boom");
-    assertThat(stored.get(0).getCompletedAt()).isNotNull();
+    assertThat(stored)
+        .singleElement()
+        .satisfies(
+            jobRegistry -> {
+              assertThat(jobRegistry.getStatus()).isEqualTo(JobStatus.FAILED);
+              assertThat(jobRegistry.getErrorMessage()).isEqualTo("boom");
+              assertThat(jobRegistry.getUpdatedAt()).isNotNull();
+            });
   }
 
   @Test
   void shouldClearErrorMessageWhenRetryCompletesSuccessfully() {
+    // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
 
     // Move the entry into a FAILED state first, so errorMessage is populated. A retry that
     // completes successfully must clear it back to null -- the JobRegistryEntryUpdateDto relies
@@ -98,16 +115,24 @@ public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
     final List<JobRegistryEntryDto> afterFailure =
         databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
             JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
-    assertThat(afterFailure.get(0).getErrorMessage()).isNotNull();
+    assertThat(afterFailure)
+        .singleElement()
+        .satisfies(e -> assertThat(e.getErrorMessage()).isNotNull());
 
+    // when
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
 
+    // then
     final List<JobRegistryEntryDto> stored =
         databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
             JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
-    assertThat(stored).hasSize(1);
-    assertThat(stored.get(0).getStatus()).isEqualTo(JobStatus.COMPLETED);
-    assertThat(stored.get(0).getCompletedAt()).isNotNull();
-    assertThat(stored.get(0).getErrorMessage()).isNull();
+    assertThat(stored)
+        .singleElement()
+        .satisfies(
+            jobRegistry -> {
+              assertThat(jobRegistry.getStatus()).isEqualTo(JobStatus.COMPLETED);
+              assertThat(jobRegistry.getUpdatedAt()).isNotNull();
+              assertThat(jobRegistry.getErrorMessage()).isNull();
+            });
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/writer/JobRegistryWriterIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/writer/JobRegistryWriterIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private JobRegistryWriter jobRegistryWriter;
+
+  @BeforeEach
+  void setup() {
+    jobRegistryWriter = embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+  }
+
+  @Test
+  void shouldCreateQueuedJobEntry() {
+    final JobRegistryEntryDto created =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE,
+            TargetEntityType.PROCESS_DEFINITION,
+            "2251799813685251");
+
+    final List<JobRegistryEntryDto> stored =
+        databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
+            JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
+
+    assertThat(stored).hasSize(1);
+    final JobRegistryEntryDto persisted = stored.get(0);
+    assertThat(persisted.getId()).isEqualTo(created.getId());
+    assertThat(persisted.getJobType()).isEqualTo(JobType.PROCESS_DEFINITION_DATA_DELETE);
+    assertThat(persisted.getTargetEntityType()).isEqualTo(TargetEntityType.PROCESS_DEFINITION);
+    assertThat(persisted.getTargetEntityId()).isEqualTo("2251799813685251");
+    assertThat(persisted.getStatus()).isEqualTo(JobStatus.QUEUED);
+    assertThat(persisted.getCompletedAt()).isNull();
+  }
+
+  @Test
+  void shouldUpdateJobStatusToCompletedWithCompletionTimestamp() {
+    final JobRegistryEntryDto created =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+
+    jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
+
+    final List<JobRegistryEntryDto> stored =
+        databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
+            JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
+    assertThat(stored).hasSize(1);
+    assertThat(stored.get(0).getStatus()).isEqualTo(JobStatus.COMPLETED);
+    assertThat(stored.get(0).getCompletedAt()).isNotNull();
+    assertThat(stored.get(0).getErrorMessage()).isNull();
+  }
+
+  @Test
+  void shouldUpdateJobStatusToFailedWithErrorMessage() {
+    final JobRegistryEntryDto created =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+
+    jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.FAILED, "boom");
+
+    final List<JobRegistryEntryDto> stored =
+        databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
+            JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
+    assertThat(stored).hasSize(1);
+    assertThat(stored.get(0).getStatus()).isEqualTo(JobStatus.FAILED);
+    assertThat(stored.get(0).getErrorMessage()).isEqualTo("boom");
+    assertThat(stored.get(0).getCompletedAt()).isNotNull();
+  }
+
+  @Test
+  void shouldUpdateJobStatusToRunningWithoutCompletionTimestamp() {
+    final JobRegistryEntryDto created =
+        jobRegistryWriter.createJobEntry(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+
+    jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.RUNNING, null);
+
+    final List<JobRegistryEntryDto> stored =
+        databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
+            JOB_REGISTRY_INDEX_NAME, JobRegistryEntryDto.class);
+    assertThat(stored).hasSize(1);
+    assertThat(stored.get(0).getStatus()).isEqualTo(JobStatus.RUNNING);
+    assertThat(stored.get(0).getCompletedAt()).isNull();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDto.java
@@ -8,8 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.job;
 
 import io.camunda.optimize.service.security.util.LocalDateUtil;
+import io.camunda.optimize.service.util.IdGenerator;
 import java.time.OffsetDateTime;
-import java.util.UUID;
 
 public class JobRegistryEntryDto {
 
@@ -20,11 +20,11 @@ public class JobRegistryEntryDto {
   private JobStatus status;
   private String errorMessage;
   private OffsetDateTime createdAt;
-  private OffsetDateTime completedAt;
+  private OffsetDateTime updatedAt;
 
   public JobRegistryEntryDto(
       final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
-    id = UUID.randomUUID().toString();
+    id = IdGenerator.getNextId();
     this.jobType = jobType;
     this.targetEntityType = targetEntityType;
     this.targetEntityId = targetEntityId;
@@ -90,11 +90,11 @@ public class JobRegistryEntryDto {
     this.createdAt = createdAt;
   }
 
-  public OffsetDateTime getCompletedAt() {
-    return completedAt;
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
   }
 
-  public void setCompletedAt(final OffsetDateTime completedAt) {
-    this.completedAt = completedAt;
+  public void setUpdatedAt(final OffsetDateTime updatedAt) {
+    this.updatedAt = updatedAt;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDto.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.job;
+
+import io.camunda.optimize.service.security.util.LocalDateUtil;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public class JobRegistryEntryDto {
+
+  private String id;
+  private JobType jobType;
+  private TargetEntityType targetEntityType;
+  private String targetEntityId;
+  private JobStatus status;
+  private String errorMessage;
+  private OffsetDateTime createdAt;
+  private OffsetDateTime completedAt;
+
+  public JobRegistryEntryDto(
+      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+    id = UUID.randomUUID().toString();
+    this.jobType = jobType;
+    this.targetEntityType = targetEntityType;
+    this.targetEntityId = targetEntityId;
+    status = JobStatus.QUEUED;
+    createdAt = LocalDateUtil.getCurrentDateTime();
+  }
+
+  protected JobRegistryEntryDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public JobType getJobType() {
+    return jobType;
+  }
+
+  public void setJobType(final JobType jobType) {
+    this.jobType = jobType;
+  }
+
+  public TargetEntityType getTargetEntityType() {
+    return targetEntityType;
+  }
+
+  public void setTargetEntityType(final TargetEntityType targetEntityType) {
+    this.targetEntityType = targetEntityType;
+  }
+
+  public String getTargetEntityId() {
+    return targetEntityId;
+  }
+
+  public void setTargetEntityId(final String targetEntityId) {
+    this.targetEntityId = targetEntityId;
+  }
+
+  public JobStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(final JobStatus status) {
+    this.status = status;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(final OffsetDateTime createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public OffsetDateTime getCompletedAt() {
+    return completedAt;
+  }
+
+  public void setCompletedAt(final OffsetDateTime completedAt) {
+    this.completedAt = completedAt;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryUpdateDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryUpdateDto.java
@@ -9,6 +9,9 @@ package io.camunda.optimize.dto.optimize.query.job;
 
 import java.time.OffsetDateTime;
 
+// Nulls must serialize - a retry that completes successfully needs to clear a stale
+// errorMessage left by a prior FAILED state, so this class deliberately has no
+// @JsonInclude(NON_NULL).
 public class JobRegistryEntryUpdateDto {
 
   private JobStatus status;

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryUpdateDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryUpdateDto.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.job;
+
+import java.time.OffsetDateTime;
+
+public class JobRegistryEntryUpdateDto {
+
+  private JobStatus status;
+  private String errorMessage;
+  private OffsetDateTime completedAt;
+
+  public JobRegistryEntryUpdateDto(
+      final JobStatus status, final String errorMessage, final OffsetDateTime completedAt) {
+    this.status = status;
+    this.errorMessage = errorMessage;
+    this.completedAt = completedAt;
+  }
+
+  protected JobRegistryEntryUpdateDto() {}
+
+  public JobStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(final JobStatus status) {
+    this.status = status;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public OffsetDateTime getCompletedAt() {
+    return completedAt;
+  }
+
+  public void setCompletedAt(final OffsetDateTime completedAt) {
+    this.completedAt = completedAt;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryUpdateDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryUpdateDto.java
@@ -16,13 +16,13 @@ public class JobRegistryEntryUpdateDto {
 
   private JobStatus status;
   private String errorMessage;
-  private OffsetDateTime completedAt;
+  private OffsetDateTime updatedAt;
 
   public JobRegistryEntryUpdateDto(
-      final JobStatus status, final String errorMessage, final OffsetDateTime completedAt) {
+      final JobStatus status, final String errorMessage, final OffsetDateTime updatedAt) {
     this.status = status;
     this.errorMessage = errorMessage;
-    this.completedAt = completedAt;
+    this.updatedAt = updatedAt;
   }
 
   protected JobRegistryEntryUpdateDto() {}
@@ -43,11 +43,11 @@ public class JobRegistryEntryUpdateDto {
     this.errorMessage = errorMessage;
   }
 
-  public OffsetDateTime getCompletedAt() {
-    return completedAt;
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
   }
 
-  public void setCompletedAt(final OffsetDateTime completedAt) {
-    this.completedAt = completedAt;
+  public void setUpdatedAt(final OffsetDateTime updatedAt) {
+    this.updatedAt = updatedAt;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobStatus.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobStatus.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.job;
+
+public enum JobStatus {
+  QUEUED,
+  RUNNING,
+  COMPLETED,
+  FAILED
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobStatus.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobStatus.java
@@ -9,7 +9,6 @@ package io.camunda.optimize.dto.optimize.query.job;
 
 public enum JobStatus {
   QUEUED,
-  RUNNING,
   COMPLETED,
   FAILED
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobType.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.job;
+
+public enum JobType {
+  PROCESS_DEFINITION_DATA_DELETE
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobType.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobType.java
@@ -8,5 +8,5 @@
 package io.camunda.optimize.dto.optimize.query.job;
 
 public enum JobType {
-  PROCESS_DEFINITION_DATA_DELETE
+  DELETE
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/TargetEntityType.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/TargetEntityType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.job;
+
+public enum TargetEntityType {
+  PROCESS_DEFINITION
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.reader;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.schema.index.JobRegistryIndex;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
+import java.util.Optional;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class JobRegistryReaderES extends JobRegistryReader {
+
+  private final OptimizeElasticsearchClient esClient;
+
+  public JobRegistryReaderES(final OptimizeElasticsearchClient esClient) {
+    this.esClient = esClient;
+  }
+
+  @Override
+  protected Optional<JobRegistryEntryDto> performFindOldestQueuedJob(final JobType jobType)
+      throws IOException {
+    final Query query =
+        Query.of(
+            q ->
+                q.bool(
+                    b ->
+                        b.must(
+                                m ->
+                                    m.term(
+                                        t ->
+                                            t.field(JobRegistryIndex.JOB_TYPE)
+                                                .value(jobType.name())))
+                            .must(
+                                m ->
+                                    m.term(
+                                        t ->
+                                            t.field(JobRegistryIndex.STATUS)
+                                                .value(JobStatus.QUEUED.name())))));
+
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            s ->
+                s.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
+                    .query(query)
+                    .sort(
+                        sort ->
+                            sort.field(
+                                f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Asc)))
+                    .size(1));
+
+    final SearchResponse<JobRegistryEntryDto> searchResponse =
+        esClient.search(searchRequest, JobRegistryEntryDto.class);
+
+    if (searchResponse.hits().total().value() == 0) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -123,7 +123,7 @@ public class JobRegistryReaderES implements JobRegistryReader {
       final SearchResponse<JobRegistryEntryDto> searchResponse =
           esClient.search(searchRequest, JobRegistryEntryDto.class);
 
-      if (searchResponse.hits().total().value() == 0) {
+      if (searchResponse.hits().hits().isEmpty()) {
         return Optional.empty();
       }
       return Optional.ofNullable(searchResponse.hits().hits().get(0).source());

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -76,4 +76,45 @@ public class JobRegistryReaderES extends JobRegistryReader {
     }
     return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
   }
+
+  @Override
+  protected Optional<JobRegistryEntryDto> performFindByJobTypeAndTargetEntityId(
+      final JobType jobType, final String targetEntityId) throws IOException {
+    final Query query =
+        Query.of(
+            q ->
+                q.bool(
+                    b ->
+                        b.must(
+                                m ->
+                                    m.term(
+                                        t ->
+                                            t.field(JobRegistryIndex.JOB_TYPE)
+                                                .value(jobType.name())))
+                            .must(
+                                m ->
+                                    m.term(
+                                        t ->
+                                            t.field(JobRegistryIndex.TARGET_ENTITY_ID)
+                                                .value(targetEntityId)))));
+
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            s ->
+                s.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
+                    .query(query)
+                    .sort(
+                        sort ->
+                            sort.field(
+                                f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Desc)))
+                    .size(1));
+
+    final SearchResponse<JobRegistryEntryDto> searchResponse =
+        esClient.search(searchRequest, JobRegistryEntryDto.class);
+
+    if (searchResponse.hits().total().value() == 0) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -13,23 +13,30 @@ import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
 import io.camunda.optimize.service.db.reader.JobRegistryReader;
 import io.camunda.optimize.service.db.schema.index.JobRegistryIndex;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Component
 @Conditional(ElasticSearchCondition.class)
-public class JobRegistryReaderES extends JobRegistryReader {
+public class JobRegistryReaderES implements JobRegistryReader {
 
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryReaderES.class);
   private final OptimizeElasticsearchClient esClient;
 
   public JobRegistryReaderES(final OptimizeElasticsearchClient esClient) {
@@ -37,8 +44,46 @@ public class JobRegistryReaderES extends JobRegistryReader {
   }
 
   @Override
-  protected Optional<JobRegistryEntryDto> performFindOldestQueuedJob(final JobType jobType)
-      throws IOException {
+  public List<JobRegistryEntryDto> findOldestQueuedJobs(final int limit) {
+    LOG.debug("Fetching up to [{}] oldest QUEUED job registry entries.", limit);
+    final Query query =
+        Query.of(q -> q.term(t -> t.field(JobRegistryIndex.STATUS).value(JobStatus.QUEUED.name())));
+
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            s ->
+                s.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
+                    .query(query)
+                    .sort(
+                        sort ->
+                            sort.field(
+                                f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Asc)))
+                    .size(limit));
+
+    try {
+      final SearchResponse<JobRegistryEntryDto> searchResponse =
+          esClient.search(searchRequest, JobRegistryEntryDto.class);
+      return searchResponse.hits().hits().stream()
+          .map(Hit::source)
+          .filter(Objects::nonNull)
+          .toList();
+    } catch (final IOException e) {
+      final String message =
+          String.format(
+              "Was not able to fetch oldest QUEUED job registry entries (limit [%s]).", limit);
+      LOG.error(message, e);
+      throw new OptimizeRuntimeException(message, e);
+    }
+  }
+
+  @Override
+  public Optional<JobRegistryEntryDto> findLastByJobTypeAndTargetEntityId(
+      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+    LOG.debug(
+        "Fetching job registry entry for [{}] target type [{}] target [{}].",
+        jobType,
+        targetEntityType,
+        targetEntityId);
     final Query query =
         Query.of(
             q ->
@@ -54,43 +99,8 @@ public class JobRegistryReaderES extends JobRegistryReader {
                                 m ->
                                     m.term(
                                         t ->
-                                            t.field(JobRegistryIndex.STATUS)
-                                                .value(JobStatus.QUEUED.name())))));
-
-    final SearchRequest searchRequest =
-        OptimizeSearchRequestBuilderES.of(
-            s ->
-                s.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
-                    .query(query)
-                    .sort(
-                        sort ->
-                            sort.field(
-                                f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Asc)))
-                    .size(1));
-
-    final SearchResponse<JobRegistryEntryDto> searchResponse =
-        esClient.search(searchRequest, JobRegistryEntryDto.class);
-
-    if (searchResponse.hits().total().value() == 0) {
-      return Optional.empty();
-    }
-    return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
-  }
-
-  @Override
-  protected Optional<JobRegistryEntryDto> performFindByJobTypeAndTargetEntityId(
-      final JobType jobType, final String targetEntityId) throws IOException {
-    final Query query =
-        Query.of(
-            q ->
-                q.bool(
-                    b ->
-                        b.must(
-                                m ->
-                                    m.term(
-                                        t ->
-                                            t.field(JobRegistryIndex.JOB_TYPE)
-                                                .value(jobType.name())))
+                                            t.field(JobRegistryIndex.TARGET_ENTITY_TYPE)
+                                                .value(targetEntityType.name())))
                             .must(
                                 m ->
                                     m.term(
@@ -109,12 +119,21 @@ public class JobRegistryReaderES extends JobRegistryReader {
                                 f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Desc)))
                     .size(1));
 
-    final SearchResponse<JobRegistryEntryDto> searchResponse =
-        esClient.search(searchRequest, JobRegistryEntryDto.class);
+    try {
+      final SearchResponse<JobRegistryEntryDto> searchResponse =
+          esClient.search(searchRequest, JobRegistryEntryDto.class);
 
-    if (searchResponse.hits().total().value() == 0) {
-      return Optional.empty();
+      if (searchResponse.hits().total().value() == 0) {
+        return Optional.empty();
+      }
+      return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+    } catch (final IOException e) {
+      final String message =
+          String.format(
+              "Was not able to fetch job registry entry for [%s] target type [%s] target [%s].",
+              jobType, targetEntityType, targetEntityId);
+      LOG.error(message, e);
+      throw new OptimizeRuntimeException(message, e);
     }
-    return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
@@ -26,7 +26,6 @@ import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -65,7 +64,7 @@ public class JobRegistryWriterES implements JobRegistryWriter {
       if (!indexResponse.result().equals(Created)) {
         throw createJobEntryFailure(entry.getId(), null);
       }
-    } catch (final IOException e) {
+    } catch (final Exception e) {
       throw createJobEntryFailure(entry.getId(), e);
     }
     return entry;
@@ -99,7 +98,7 @@ public class JobRegistryWriterES implements JobRegistryWriter {
     }
   }
 
-  private OptimizeRuntimeException createJobEntryFailure(final String id, final IOException cause) {
+  private OptimizeRuntimeException createJobEntryFailure(final String id, final Exception cause) {
     final String message =
         String.format("Could not write job registry entry with id [%s] to database.", id);
     if (cause == null) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.writer;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.UpdateResponse;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryUpdateDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.builders.OptimizeIndexRequestBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeUpdateRequestBuilderES;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class JobRegistryWriterES extends JobRegistryWriter {
+
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryWriterES.class);
+  private final OptimizeElasticsearchClient esClient;
+
+  public JobRegistryWriterES(final OptimizeElasticsearchClient esClient) {
+    this.esClient = esClient;
+  }
+
+  @Override
+  protected void performCreatingJobEntry(final JobRegistryEntryDto entry) throws IOException {
+    esClient.index(
+        OptimizeIndexRequestBuilderES.of(
+            b ->
+                b.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
+                    .id(entry.getId())
+                    .refresh(Refresh.True)
+                    .document(entry)));
+  }
+
+  @Override
+  protected void performUpdatingJobStatus(final String id, final JobRegistryEntryUpdateDto update)
+      throws IOException {
+    final UpdateResponse<JobRegistryEntryUpdateDto> updateResponse =
+        esClient.update(
+            new OptimizeUpdateRequestBuilderES<
+                    JobRegistryEntryUpdateDto, JobRegistryEntryUpdateDto>()
+                .optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
+                .id(id)
+                .doc(update)
+                .refresh(Refresh.True)
+                .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
+                .build(),
+            JobRegistryEntryUpdateDto.class);
+
+    if (!updateResponse.shards().failures().isEmpty()) {
+      final String message =
+          String.format("Was not able to update job registry entry with id [%s].", id);
+      LOG.error(message);
+      throw new OptimizeRuntimeException(message);
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
@@ -7,19 +7,24 @@
  */
 package io.camunda.optimize.service.db.es.writer;
 
+import static co.elastic.clients.elasticsearch._types.Result.Created;
 import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
 
-import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.IndexResponse;
 import co.elastic.clients.elasticsearch.core.UpdateResponse;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryUpdateDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.es.builders.OptimizeIndexRequestBuilderES;
 import io.camunda.optimize.service.db.es.builders.OptimizeUpdateRequestBuilderES;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
 import org.slf4j.Logger;
@@ -28,7 +33,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Conditional(ElasticSearchCondition.class)
-public class JobRegistryWriterES extends JobRegistryWriter {
+public class JobRegistryWriterES implements JobRegistryWriter {
 
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryWriterES.class);
   private final OptimizeElasticsearchClient esClient;
@@ -38,19 +43,40 @@ public class JobRegistryWriterES extends JobRegistryWriter {
   }
 
   @Override
-  protected void performCreatingJobEntry(final JobRegistryEntryDto entry) throws IOException {
-    esClient.index(
-        OptimizeIndexRequestBuilderES.of(
-            b ->
-                b.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
-                    .id(entry.getId())
-                    .refresh(Refresh.True)
-                    .document(entry)));
+  public JobRegistryEntryDto createJobEntry(
+      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+    final JobRegistryEntryDto entry =
+        new JobRegistryEntryDto(jobType, targetEntityType, targetEntityId);
+    LOG.debug(
+        "Creating job registry entry with id [{}] for [{}] target [{}].",
+        entry.getId(),
+        jobType,
+        targetEntityId);
+    try {
+      final IndexResponse indexResponse =
+          esClient.index(
+              OptimizeIndexRequestBuilderES.of(
+                  b ->
+                      b.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
+                          .id(entry.getId())
+                          .refresh(Refresh.True)
+                          .document(entry)));
+
+      if (!indexResponse.result().equals(Created)) {
+        throw createJobEntryFailure(entry.getId(), null);
+      }
+    } catch (final IOException e) {
+      throw createJobEntryFailure(entry.getId(), e);
+    }
+    return entry;
   }
 
   @Override
-  protected void performUpdatingJobStatus(final String id, final JobRegistryEntryUpdateDto update)
-      throws IOException {
+  public void updateJobStatus(final String id, final JobStatus status, final String errorMessage) {
+    LOG.debug("Updating job registry entry [{}] to status [{}].", id, status);
+    final JobRegistryEntryUpdateDto update =
+        new JobRegistryEntryUpdateDto(status, errorMessage, LocalDateUtil.getCurrentDateTime());
+
     final UpdateResponse<JobRegistryEntryUpdateDto> updateResponse;
     try {
       updateResponse =
@@ -64,19 +90,34 @@ public class JobRegistryWriterES extends JobRegistryWriter {
                   .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
                   .build(),
               JobRegistryEntryUpdateDto.class);
-    } catch (final ElasticsearchException e) {
-      final String message =
-          String.format(
-              "Was not able to update job registry entry with id [%s]. It may not exist.", id);
-      LOG.error(message, e);
-      throw new OptimizeRuntimeException(message, e);
+    } catch (final Exception e) {
+      throw updateJobStatusFailure(id, e);
     }
 
     if (!updateResponse.shards().failures().isEmpty()) {
-      final String message =
-          String.format("Was not able to update job registry entry with id [%s].", id);
-      LOG.error(message);
-      throw new OptimizeRuntimeException(message);
+      throw updateJobStatusFailure(id, null);
     }
+  }
+
+  private OptimizeRuntimeException createJobEntryFailure(final String id, final IOException cause) {
+    final String message =
+        String.format("Could not write job registry entry with id [%s] to database.", id);
+    if (cause == null) {
+      LOG.error(message);
+      return new OptimizeRuntimeException(message);
+    }
+    LOG.error(message, cause);
+    return new OptimizeRuntimeException(message, cause);
+  }
+
+  private OptimizeRuntimeException updateJobStatusFailure(final String id, final Exception cause) {
+    final String message =
+        String.format("Was not able to update job registry entry with id [%s].", id);
+    if (cause == null) {
+      LOG.error(message);
+      return new OptimizeRuntimeException(message);
+    }
+    LOG.error(message, cause);
+    return new OptimizeRuntimeException(message, cause);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.es.writer;
 import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch.core.UpdateResponse;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
@@ -50,17 +51,26 @@ public class JobRegistryWriterES extends JobRegistryWriter {
   @Override
   protected void performUpdatingJobStatus(final String id, final JobRegistryEntryUpdateDto update)
       throws IOException {
-    final UpdateResponse<JobRegistryEntryUpdateDto> updateResponse =
-        esClient.update(
-            new OptimizeUpdateRequestBuilderES<
-                    JobRegistryEntryUpdateDto, JobRegistryEntryUpdateDto>()
-                .optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
-                .id(id)
-                .doc(update)
-                .refresh(Refresh.True)
-                .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
-                .build(),
-            JobRegistryEntryUpdateDto.class);
+    final UpdateResponse<JobRegistryEntryUpdateDto> updateResponse;
+    try {
+      updateResponse =
+          esClient.update(
+              new OptimizeUpdateRequestBuilderES<
+                      JobRegistryEntryUpdateDto, JobRegistryEntryUpdateDto>()
+                  .optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
+                  .id(id)
+                  .doc(update)
+                  .refresh(Refresh.True)
+                  .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
+                  .build(),
+              JobRegistryEntryUpdateDto.class);
+    } catch (final ElasticsearchException e) {
+      final String message =
+          String.format(
+              "Was not able to update job registry entry with id [%s]. It may not exist.", id);
+      LOG.error(message, e);
+      throw new OptimizeRuntimeException(message, e);
+    }
 
     if (!updateResponse.shards().failures().isEmpty()) {
       final String message =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -12,24 +12,30 @@ import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDE
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.client.dsl.QueryDSL;
 import io.camunda.optimize.service.db.reader.JobRegistryReader;
 import io.camunda.optimize.service.db.schema.index.JobRegistryIndex;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Component
 @Conditional(OpenSearchCondition.class)
-public class JobRegistryReaderOS extends JobRegistryReader {
+public class JobRegistryReaderOS implements JobRegistryReader {
 
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryReaderOS.class);
   private final OptimizeOpenSearchClient osClient;
 
   public JobRegistryReaderOS(final OptimizeOpenSearchClient osClient) {
@@ -37,17 +43,17 @@ public class JobRegistryReaderOS extends JobRegistryReader {
   }
 
   @Override
-  protected Optional<JobRegistryEntryDto> performFindOldestQueuedJob(final JobType jobType) {
+  public List<JobRegistryEntryDto> findOldestQueuedJobs(final int limit) {
+    LOG.debug("Fetching up to [{}] oldest QUEUED job registry entries.", limit);
     final BoolQuery boolQuery =
         new BoolQuery.Builder()
-            .must(QueryDSL.term(JobRegistryIndex.JOB_TYPE, jobType.name()))
             .must(QueryDSL.term(JobRegistryIndex.STATUS, JobStatus.QUEUED.name()))
             .build();
 
     final SearchRequest.Builder searchReqBuilder =
         new SearchRequest.Builder()
             .index(JOB_REGISTRY_INDEX_NAME)
-            .size(1)
+            .size(limit)
             .query(boolQuery.toQuery())
             .sort(
                 new SortOptions.Builder()
@@ -55,22 +61,26 @@ public class JobRegistryReaderOS extends JobRegistryReader {
                     .build());
 
     final String errorMessage =
-        String.format("Was not able to fetch oldest QUEUED job registry entry for [%s].", jobType);
+        String.format(
+            "Was not able to fetch oldest QUEUED job registry entries (limit [%s]).", limit);
     final SearchResponse<JobRegistryEntryDto> searchResponse =
         osClient.search(searchReqBuilder, JobRegistryEntryDto.class, errorMessage);
 
-    if (searchResponse.hits().hits().isEmpty()) {
-      return Optional.empty();
-    }
-    return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+    return searchResponse.hits().hits().stream().map(Hit::source).filter(Objects::nonNull).toList();
   }
 
   @Override
-  protected Optional<JobRegistryEntryDto> performFindByJobTypeAndTargetEntityId(
-      final JobType jobType, final String targetEntityId) {
+  public Optional<JobRegistryEntryDto> findLastByJobTypeAndTargetEntityId(
+      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+    LOG.debug(
+        "Fetching job registry entry for [{}] target type [{}] target [{}].",
+        jobType,
+        targetEntityType,
+        targetEntityId);
     final BoolQuery boolQuery =
         new BoolQuery.Builder()
             .must(QueryDSL.term(JobRegistryIndex.JOB_TYPE, jobType.name()))
+            .must(QueryDSL.term(JobRegistryIndex.TARGET_ENTITY_TYPE, targetEntityType.name()))
             .must(QueryDSL.term(JobRegistryIndex.TARGET_ENTITY_ID, targetEntityId))
             .build();
 
@@ -86,8 +96,8 @@ public class JobRegistryReaderOS extends JobRegistryReader {
 
     final String errorMessage =
         String.format(
-            "Was not able to fetch job registry entry for [%s] target [%s].",
-            jobType, targetEntityId);
+            "Was not able to fetch job registry entry for [%s] target type [%s] target [%s].",
+            jobType, targetEntityType, targetEntityId);
     final SearchResponse<JobRegistryEntryDto> searchResponse =
         osClient.search(searchReqBuilder, JobRegistryEntryDto.class, errorMessage);
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -64,4 +64,36 @@ public class JobRegistryReaderOS extends JobRegistryReader {
     }
     return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
   }
+
+  @Override
+  protected Optional<JobRegistryEntryDto> performFindByJobTypeAndTargetEntityId(
+      final JobType jobType, final String targetEntityId) {
+    final BoolQuery boolQuery =
+        new BoolQuery.Builder()
+            .must(QueryDSL.term(JobRegistryIndex.JOB_TYPE, jobType.name()))
+            .must(QueryDSL.term(JobRegistryIndex.TARGET_ENTITY_ID, targetEntityId))
+            .build();
+
+    final SearchRequest.Builder searchReqBuilder =
+        new SearchRequest.Builder()
+            .index(JOB_REGISTRY_INDEX_NAME)
+            .size(1)
+            .query(boolQuery.toQuery())
+            .sort(
+                new SortOptions.Builder()
+                    .field(f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Desc))
+                    .build());
+
+    final String errorMessage =
+        String.format(
+            "Was not able to fetch job registry entry for [%s] target [%s].",
+            jobType, targetEntityId);
+    final SearchResponse<JobRegistryEntryDto> searchResponse =
+        osClient.search(searchReqBuilder, JobRegistryEntryDto.class, errorMessage);
+
+    if (searchResponse.hits().hits().isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.reader;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
+
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.os.client.dsl.QueryDSL;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.schema.index.JobRegistryIndex;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Optional;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class JobRegistryReaderOS extends JobRegistryReader {
+
+  private final OptimizeOpenSearchClient osClient;
+
+  public JobRegistryReaderOS(final OptimizeOpenSearchClient osClient) {
+    this.osClient = osClient;
+  }
+
+  @Override
+  protected Optional<JobRegistryEntryDto> performFindOldestQueuedJob(final JobType jobType) {
+    final BoolQuery boolQuery =
+        new BoolQuery.Builder()
+            .must(QueryDSL.term(JobRegistryIndex.JOB_TYPE, jobType.name()))
+            .must(QueryDSL.term(JobRegistryIndex.STATUS, JobStatus.QUEUED.name()))
+            .build();
+
+    final SearchRequest.Builder searchReqBuilder =
+        new SearchRequest.Builder()
+            .index(JOB_REGISTRY_INDEX_NAME)
+            .size(1)
+            .query(boolQuery.toQuery())
+            .sort(
+                new SortOptions.Builder()
+                    .field(f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Asc))
+                    .build());
+
+    final String errorMessage =
+        String.format("Was not able to fetch oldest QUEUED job registry entry for [%s].", jobType);
+    final SearchResponse<JobRegistryEntryDto> searchResponse =
+        osClient.search(searchReqBuilder, JobRegistryEntryDto.class, errorMessage);
+
+    if (searchResponse.hits().hits().isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
@@ -61,10 +61,8 @@ public class JobRegistryWriterOS extends JobRegistryWriter {
     final UpdateResponse<Void> updateResponse = osClient.update(request, errorMessage);
 
     if (updateResponse.shards().failed() > 0) {
-      final String message =
-          String.format("Was not able to update job registry entry with id [%s].", id);
-      LOG.error(message);
-      throw new OptimizeRuntimeException(message);
+      LOG.error(errorMessage);
+      throw new OptimizeRuntimeException(errorMessage);
     }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.writer;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
+
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryUpdateDto;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.UpdateRequest;
+import org.opensearch.client.opensearch.core.UpdateResponse;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class JobRegistryWriterOS extends JobRegistryWriter {
+
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryWriterOS.class);
+  private final OptimizeOpenSearchClient osClient;
+
+  public JobRegistryWriterOS(final OptimizeOpenSearchClient osClient) {
+    this.osClient = osClient;
+  }
+
+  @Override
+  protected void performCreatingJobEntry(final JobRegistryEntryDto entry) {
+    final IndexRequest.Builder<JobRegistryEntryDto> request =
+        new IndexRequest.Builder<JobRegistryEntryDto>()
+            .index(JOB_REGISTRY_INDEX_NAME)
+            .id(entry.getId())
+            .document(entry)
+            .refresh(Refresh.True);
+    osClient.index(request);
+  }
+
+  @Override
+  protected void performUpdatingJobStatus(final String id, final JobRegistryEntryUpdateDto update) {
+    final UpdateRequest.Builder<Void, JobRegistryEntryUpdateDto> request =
+        new UpdateRequest.Builder<Void, JobRegistryEntryUpdateDto>()
+            .index(JOB_REGISTRY_INDEX_NAME)
+            .id(id)
+            .doc(update)
+            .refresh(Refresh.True)
+            .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT);
+
+    final String errorMessage =
+        String.format("Was not able to update job registry entry with id [%s].", id);
+    final UpdateResponse<Void> updateResponse = osClient.update(request, errorMessage);
+
+    if (updateResponse.shards().failed() > 0) {
+      final String message =
+          String.format("Was not able to update job registry entry with id [%s].", id);
+      LOG.error(message);
+      throw new OptimizeRuntimeException(message);
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
@@ -12,12 +12,18 @@ import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES
 
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryUpdateDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.IndexResponse;
 import org.opensearch.client.opensearch.core.UpdateRequest;
 import org.opensearch.client.opensearch.core.UpdateResponse;
 import org.slf4j.Logger;
@@ -26,7 +32,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Conditional(OpenSearchCondition.class)
-public class JobRegistryWriterOS extends JobRegistryWriter {
+public class JobRegistryWriterOS implements JobRegistryWriter {
 
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryWriterOS.class);
   private final OptimizeOpenSearchClient osClient;
@@ -36,18 +42,40 @@ public class JobRegistryWriterOS extends JobRegistryWriter {
   }
 
   @Override
-  protected void performCreatingJobEntry(final JobRegistryEntryDto entry) {
+  public JobRegistryEntryDto createJobEntry(
+      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+    final JobRegistryEntryDto entry =
+        new JobRegistryEntryDto(jobType, targetEntityType, targetEntityId);
+    LOG.debug(
+        "Creating job registry entry with id [{}] for [{}] target [{}].",
+        entry.getId(),
+        jobType,
+        targetEntityId);
+
     final IndexRequest.Builder<JobRegistryEntryDto> request =
         new IndexRequest.Builder<JobRegistryEntryDto>()
             .index(JOB_REGISTRY_INDEX_NAME)
             .id(entry.getId())
             .document(entry)
             .refresh(Refresh.True);
-    osClient.index(request);
+    final IndexResponse indexResponse = osClient.index(request);
+
+    if (!indexResponse.result().equals(Result.Created)) {
+      final String message =
+          String.format(
+              "Could not write job registry entry with id [%s] to database.", entry.getId());
+      LOG.error(message);
+      throw new OptimizeRuntimeException(message);
+    }
+    return entry;
   }
 
   @Override
-  protected void performUpdatingJobStatus(final String id, final JobRegistryEntryUpdateDto update) {
+  public void updateJobStatus(final String id, final JobStatus status, final String errorMessage) {
+    LOG.debug("Updating job registry entry [{}] to status [{}].", id, status);
+    final JobRegistryEntryUpdateDto update =
+        new JobRegistryEntryUpdateDto(status, errorMessage, LocalDateUtil.getCurrentDateTime());
+
     final UpdateRequest.Builder<Void, JobRegistryEntryUpdateDto> request =
         new UpdateRequest.Builder<Void, JobRegistryEntryUpdateDto>()
             .index(JOB_REGISTRY_INDEX_NAME)
@@ -56,13 +84,13 @@ public class JobRegistryWriterOS extends JobRegistryWriter {
             .refresh(Refresh.True)
             .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT);
 
-    final String errorMessage =
+    final String updateErrorMessage =
         String.format("Was not able to update job registry entry with id [%s].", id);
-    final UpdateResponse<Void> updateResponse = osClient.update(request, errorMessage);
+    final UpdateResponse<Void> updateResponse = osClient.update(request, updateErrorMessage);
 
     if (updateResponse.shards().failed() > 0) {
-      LOG.error(errorMessage);
-      throw new OptimizeRuntimeException(errorMessage);
+      LOG.error(updateErrorMessage);
+      throw new OptimizeRuntimeException(updateErrorMessage);
     }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
@@ -9,51 +9,22 @@ package io.camunda.optimize.service.db.reader;
 
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
-import java.io.IOException;
+import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
+import java.util.List;
 import java.util.Optional;
-import org.slf4j.Logger;
 
-public abstract class JobRegistryReader {
-
-  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryReader.class);
-
-  /** Returns the oldest QUEUED job registry entry of the given jobType. */
-  public Optional<JobRegistryEntryDto> findOldestQueuedJob(final JobType jobType) {
-    LOG.debug("Fetching oldest QUEUED job registry entry for [{}].", jobType);
-    try {
-      return performFindOldestQueuedJob(jobType);
-    } catch (final IOException e) {
-      final String message =
-          String.format(
-              "Was not able to fetch oldest QUEUED job registry entry for [%s].", jobType);
-      LOG.error(message, e);
-      throw new OptimizeRuntimeException(message, e);
-    }
-  }
+public interface JobRegistryReader {
 
   /**
-   * Returns the most recent job registry entry for the given jobType and targetEntityId, if one
-   * exists (in any status).
+   * Returns up to {@code limit} of the oldest QUEUED job registry entries, across all job types,
+   * ordered oldest first.
    */
-  public Optional<JobRegistryEntryDto> findByJobTypeAndTargetEntityId(
-      final JobType jobType, final String targetEntityId) {
-    LOG.debug("Fetching job registry entry for [{}] target [{}].", jobType, targetEntityId);
-    try {
-      return performFindByJobTypeAndTargetEntityId(jobType, targetEntityId);
-    } catch (final IOException e) {
-      final String message =
-          String.format(
-              "Was not able to fetch job registry entry for [%s] target [%s].",
-              jobType, targetEntityId);
-      LOG.error(message, e);
-      throw new OptimizeRuntimeException(message, e);
-    }
-  }
+  List<JobRegistryEntryDto> findOldestQueuedJobs(int limit);
 
-  protected abstract Optional<JobRegistryEntryDto> performFindOldestQueuedJob(final JobType jobType)
-      throws IOException;
-
-  protected abstract Optional<JobRegistryEntryDto> performFindByJobTypeAndTargetEntityId(
-      final JobType jobType, final String targetEntityId) throws IOException;
+  /**
+   * Returns the most recent job registry entry for the given jobType, targetEntityType, and
+   * targetEntityId, if one exists (in any status).
+   */
+  Optional<JobRegistryEntryDto> findLastByJobTypeAndTargetEntityId(
+      JobType jobType, TargetEntityType targetEntityType, String targetEntityId);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.reader;
+
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import java.io.IOException;
+import java.util.Optional;
+import org.slf4j.Logger;
+
+public abstract class JobRegistryReader {
+
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryReader.class);
+
+  /** Returns the oldest QUEUED job registry entry of the given jobType. */
+  public Optional<JobRegistryEntryDto> findOldestQueuedJob(final JobType jobType) {
+    LOG.debug("Fetching oldest QUEUED job registry entry for [{}].", jobType);
+    try {
+      return performFindOldestQueuedJob(jobType);
+    } catch (final IOException e) {
+      final String message =
+          String.format(
+              "Was not able to fetch oldest QUEUED job registry entry for [%s].", jobType);
+      LOG.error(message, e);
+      throw new OptimizeRuntimeException(message, e);
+    }
+  }
+
+  protected abstract Optional<JobRegistryEntryDto> performFindOldestQueuedJob(final JobType jobType)
+      throws IOException;
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
@@ -32,6 +32,28 @@ public abstract class JobRegistryReader {
     }
   }
 
+  /**
+   * Returns the most recent job registry entry for the given jobType and targetEntityId, if one
+   * exists (in any status).
+   */
+  public Optional<JobRegistryEntryDto> findByJobTypeAndTargetEntityId(
+      final JobType jobType, final String targetEntityId) {
+    LOG.debug("Fetching job registry entry for [{}] target [{}].", jobType, targetEntityId);
+    try {
+      return performFindByJobTypeAndTargetEntityId(jobType, targetEntityId);
+    } catch (final IOException e) {
+      final String message =
+          String.format(
+              "Was not able to fetch job registry entry for [%s] target [%s].",
+              jobType, targetEntityId);
+      LOG.error(message, e);
+      throw new OptimizeRuntimeException(message, e);
+    }
+  }
+
   protected abstract Optional<JobRegistryEntryDto> performFindOldestQueuedJob(final JobType jobType)
       throws IOException;
+
+  protected abstract Optional<JobRegistryEntryDto> performFindByJobTypeAndTargetEntityId(
+      final JobType jobType, final String targetEntityId) throws IOException;
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/JobRegistryWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/JobRegistryWriter.java
@@ -8,57 +8,14 @@
 package io.camunda.optimize.service.db.writer;
 
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
-import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryUpdateDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
 import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
-import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
-import io.camunda.optimize.service.security.util.LocalDateUtil;
-import java.io.IOException;
-import org.slf4j.Logger;
 
-public abstract class JobRegistryWriter {
+public interface JobRegistryWriter {
 
-  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryWriter.class);
+  JobRegistryEntryDto createJobEntry(
+      JobType jobType, TargetEntityType targetEntityType, String targetEntityId);
 
-  public JobRegistryEntryDto createJobEntry(
-      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
-    final JobRegistryEntryDto entry =
-        new JobRegistryEntryDto(jobType, targetEntityType, targetEntityId);
-    LOG.debug(
-        "Creating job registry entry with id [{}] for [{}] target [{}].",
-        entry.getId(),
-        jobType,
-        targetEntityId);
-    try {
-      performCreatingJobEntry(entry);
-    } catch (final IOException e) {
-      final String message =
-          String.format(
-              "Could not write job registry entry with id [%s] to database.", entry.getId());
-      LOG.error(message, e);
-      throw new OptimizeRuntimeException(message, e);
-    }
-    return entry;
-  }
-
-  public void updateJobStatus(final String id, final JobStatus status, final String errorMessage) {
-    LOG.debug("Updating job registry entry [{}] to status [{}].", id, status);
-    final JobRegistryEntryUpdateDto update =
-        new JobRegistryEntryUpdateDto(status, errorMessage, LocalDateUtil.getCurrentDateTime());
-    try {
-      performUpdatingJobStatus(id, update);
-    } catch (final IOException e) {
-      final String message =
-          String.format("Could not update job registry entry with id [%s] in database.", id);
-      LOG.error(message, e);
-      throw new OptimizeRuntimeException(message, e);
-    }
-  }
-
-  protected abstract void performCreatingJobEntry(final JobRegistryEntryDto entry)
-      throws IOException;
-
-  protected abstract void performUpdatingJobStatus(
-      final String id, final JobRegistryEntryUpdateDto update) throws IOException;
+  void updateJobStatus(String id, JobStatus status, String errorMessage);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/JobRegistryWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/JobRegistryWriter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryUpdateDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.security.util.LocalDateUtil;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import org.slf4j.Logger;
+
+public abstract class JobRegistryWriter {
+
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobRegistryWriter.class);
+
+  public JobRegistryEntryDto createJobEntry(
+      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+    final JobRegistryEntryDto entry =
+        new JobRegistryEntryDto(jobType, targetEntityType, targetEntityId);
+    LOG.debug(
+        "Creating job registry entry with id [{}] for [{}] target [{}].",
+        entry.getId(),
+        jobType,
+        targetEntityId);
+    try {
+      performCreatingJobEntry(entry);
+    } catch (final IOException e) {
+      final String message =
+          String.format(
+              "Could not write job registry entry with id [%s] to database.", entry.getId());
+      LOG.error(message, e);
+      throw new OptimizeRuntimeException(message, e);
+    }
+    return entry;
+  }
+
+  public void updateJobStatus(final String id, final JobStatus status, final String errorMessage) {
+    LOG.debug("Updating job registry entry [{}] to status [{}].", id, status);
+    final OffsetDateTime completedAt =
+        (status == JobStatus.COMPLETED || status == JobStatus.FAILED)
+            ? LocalDateUtil.getCurrentDateTime()
+            : null;
+    final JobRegistryEntryUpdateDto update =
+        new JobRegistryEntryUpdateDto(status, errorMessage, completedAt);
+    try {
+      performUpdatingJobStatus(id, update);
+    } catch (final IOException e) {
+      final String message =
+          String.format("Could not update job registry entry with id [%s] in database.", id);
+      LOG.error(message, e);
+      throw new OptimizeRuntimeException(message, e);
+    }
+  }
+
+  protected abstract void performCreatingJobEntry(final JobRegistryEntryDto entry)
+      throws IOException;
+
+  protected abstract void performUpdatingJobStatus(
+      final String id, final JobRegistryEntryUpdateDto update) throws IOException;
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/JobRegistryWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/JobRegistryWriter.java
@@ -15,7 +15,6 @@ import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import java.io.IOException;
-import java.time.OffsetDateTime;
 import org.slf4j.Logger;
 
 public abstract class JobRegistryWriter {
@@ -45,12 +44,8 @@ public abstract class JobRegistryWriter {
 
   public void updateJobStatus(final String id, final JobStatus status, final String errorMessage) {
     LOG.debug("Updating job registry entry [{}] to status [{}].", id, status);
-    final OffsetDateTime completedAt =
-        (status == JobStatus.COMPLETED || status == JobStatus.FAILED)
-            ? LocalDateUtil.getCurrentDateTime()
-            : null;
     final JobRegistryEntryUpdateDto update =
-        new JobRegistryEntryUpdateDto(status, errorMessage, completedAt);
+        new JobRegistryEntryUpdateDto(status, errorMessage, LocalDateUtil.getCurrentDateTime());
     try {
       performUpdatingJobStatus(id, update);
     } catch (final IOException e) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDtoTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDtoTest.java
@@ -17,28 +17,24 @@ class JobRegistryEntryDtoTest {
   void shouldInitializeQueuedEntryWithGeneratedIdAndCreationTimestamp() {
     final JobRegistryEntryDto entry =
         new JobRegistryEntryDto(
-            JobType.PROCESS_DEFINITION_DATA_DELETE,
-            TargetEntityType.PROCESS_DEFINITION,
-            "2251799813685251");
+            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
 
     assertThat(entry.getId()).isNotBlank();
-    assertThat(entry.getJobType()).isEqualTo(JobType.PROCESS_DEFINITION_DATA_DELETE);
+    assertThat(entry.getJobType()).isEqualTo(JobType.DELETE);
     assertThat(entry.getTargetEntityType()).isEqualTo(TargetEntityType.PROCESS_DEFINITION);
     assertThat(entry.getTargetEntityId()).isEqualTo("2251799813685251");
     assertThat(entry.getStatus()).isEqualTo(JobStatus.QUEUED);
     assertThat(entry.getErrorMessage()).isNull();
     assertThat(entry.getCreatedAt()).isNotNull();
-    assertThat(entry.getCompletedAt()).isNull();
+    assertThat(entry.getUpdatedAt()).isNull();
   }
 
   @Test
   void shouldGenerateDifferentIdsForEachEntry() {
     final JobRegistryEntryDto first =
-        new JobRegistryEntryDto(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        new JobRegistryEntryDto(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
     final JobRegistryEntryDto second =
-        new JobRegistryEntryDto(
-            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+        new JobRegistryEntryDto(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
 
     assertThat(first.getId()).isNotEqualTo(second.getId());
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDtoTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDtoTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JobRegistryEntryDtoTest {
+
+  @Test
+  void shouldInitializeQueuedEntryWithGeneratedIdAndCreationTimestamp() {
+    final JobRegistryEntryDto entry =
+        new JobRegistryEntryDto(
+            JobType.PROCESS_DEFINITION_DATA_DELETE,
+            TargetEntityType.PROCESS_DEFINITION,
+            "2251799813685251");
+
+    assertThat(entry.getId()).isNotBlank();
+    assertThat(entry.getJobType()).isEqualTo(JobType.PROCESS_DEFINITION_DATA_DELETE);
+    assertThat(entry.getTargetEntityType()).isEqualTo(TargetEntityType.PROCESS_DEFINITION);
+    assertThat(entry.getTargetEntityId()).isEqualTo("2251799813685251");
+    assertThat(entry.getStatus()).isEqualTo(JobStatus.QUEUED);
+    assertThat(entry.getErrorMessage()).isNull();
+    assertThat(entry.getCreatedAt()).isNotNull();
+    assertThat(entry.getCompletedAt()).isNull();
+  }
+
+  @Test
+  void shouldGenerateDifferentIdsForEachEntry() {
+    final JobRegistryEntryDto first =
+        new JobRegistryEntryDto(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+    final JobRegistryEntryDto second =
+        new JobRegistryEntryDto(
+            JobType.PROCESS_DEFINITION_DATA_DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+
+    assertThat(first.getId()).isNotEqualTo(second.getId());
+  }
+}

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactory.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.upgrade.plan.factories;
 
 import io.camunda.optimize.service.db.es.schema.index.BusinessValueOverviewIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
+import io.camunda.optimize.service.db.es.schema.index.JobRegistryIndexES;
 import io.camunda.optimize.upgrade.plan.UpgradeExecutionDependencies;
 import io.camunda.optimize.upgrade.plan.UpgradePlan;
 import io.camunda.optimize.upgrade.plan.UpgradePlanBuilder;
@@ -23,6 +24,7 @@ public class Upgrade89to810PlanFactory implements UpgradePlanFactory {
         .toVersion("8.10.0")
         .addUpgradeStep(new CreateIndexStep(new BusinessValueTargetIndexES()))
         .addUpgradeStep(new CreateIndexStep(new BusinessValueOverviewIndexES()))
+        .addUpgradeStep(new CreateIndexStep(new JobRegistryIndexES()))
         .build();
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactoryIT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/factories/Upgrade89to810PlanFactoryIT.java
@@ -11,17 +11,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.service.db.es.schema.index.BusinessValueOverviewIndexES;
 import io.camunda.optimize.service.db.es.schema.index.BusinessValueTargetIndexES;
+import io.camunda.optimize.service.db.es.schema.index.JobRegistryIndexES;
 import io.camunda.optimize.service.db.os.schema.index.BusinessValueOverviewIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.BusinessValueTargetIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.JobRegistryIndexOS;
 import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.AbstractUpgradeIT;
 import io.camunda.optimize.upgrade.plan.UpgradePlan;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies that {@link Upgrade89to810PlanFactory} creates the {@code business-value-target} and
- * {@code business-value-overview} indices on an 8.9 cluster, so upgraded and fresh-install schemas
- * stay in parity.
+ * Verifies that {@link Upgrade89to810PlanFactory} creates the {@code business-value-target}, {@code
+ * business-value-overview}, and {@code job-registry} indices on an 8.9 cluster, so upgraded and
+ * fresh-install schemas stay in parity.
  */
 public class Upgrade89to810PlanFactoryIT extends AbstractUpgradeIT {
 
@@ -66,6 +68,25 @@ public class Upgrade89to810PlanFactoryIT extends AbstractUpgradeIT {
         .isNotEmpty();
   }
 
+  @Test
+  public void shouldCreateJobRegistryIndexOnUpgrade() {
+    // given an 8.9 cluster (schema version is set to the previous minor)
+    setMetadataVersion(FROM_PATCH);
+    final IndexMappingCreator jobRegistryIndex = jobRegistryIndex();
+    assertThat(getIndicesForMapping(jobRegistryIndex))
+        .as("job-registry index must not exist before the upgrade runs")
+        .isEmpty();
+
+    // when the 8.9 -> 8.10 upgrade plan runs
+    final UpgradePlan plan = new Upgrade89to810PlanFactory().createUpgradePlan(upgradeDependencies);
+    upgradeProcedure.performUpgrade(plan);
+
+    // then the job-registry index exists in the database
+    assertThat(getIndicesForMapping(jobRegistryIndex))
+        .as("job-registry index must exist after the upgrade runs")
+        .isNotEmpty();
+  }
+
   private IndexMappingCreator businessValueTargetIndex() {
     return isElasticSearchUpgrade()
         ? new BusinessValueTargetIndexES()
@@ -76,5 +97,9 @@ public class Upgrade89to810PlanFactoryIT extends AbstractUpgradeIT {
     return isElasticSearchUpgrade()
         ? new BusinessValueOverviewIndexES()
         : new BusinessValueOverviewIndexOS();
+  }
+
+  private IndexMappingCreator jobRegistryIndex() {
+    return isElasticSearchUpgrade() ? new JobRegistryIndexES() : new JobRegistryIndexOS();
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -47,6 +47,7 @@ public final class DatabaseConstants {
   public static final String UPDATE_LOG_ENTRY_INDEX_NAME = "update-log";
   public static final String TERMINATED_USER_SESSION_INDEX_NAME = "terminated-user-session";
   public static final String WEB_SESSION_INDEX_NAME = "web-session";
+  public static final String JOB_REGISTRY_INDEX_NAME = "job-registry";
   public static final String TENANT_INDEX_NAME = "tenant";
   public static final String VARIABLE_LABEL_INDEX_NAME = "variable-label";
   public static final String PROCESS_OVERVIEW_INDEX_NAME = "process-overview";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
@@ -32,6 +32,7 @@ import io.camunda.optimize.service.db.es.schema.index.DashboardShareIndexES;
 import io.camunda.optimize.service.db.es.schema.index.DecisionDefinitionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ExternalProcessVariableIndexES;
 import io.camunda.optimize.service.db.es.schema.index.InstantPreviewDashboardMetadataIndexES;
+import io.camunda.optimize.service.db.es.schema.index.JobRegistryIndexES;
 import io.camunda.optimize.service.db.es.schema.index.MetadataIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessDefinitionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessOverviewIndexES;
@@ -387,6 +388,7 @@ public class ElasticSearchSchemaManager
         new DashboardIndexES(),
         new DashboardShareIndexES(),
         new DecisionDefinitionIndexES(),
+        new JobRegistryIndexES(),
         new MetadataIndexES(),
         new ProcessDefinitionIndexES(),
         new ReportShareIndexES(),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/JobRegistryIndexES.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/JobRegistryIndexES.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.schema.index;
+
+import co.elastic.clients.elasticsearch.indices.IndexSettings;
+import io.camunda.optimize.service.db.schema.index.JobRegistryIndex;
+import java.io.IOException;
+
+public class JobRegistryIndexES extends JobRegistryIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder builder) throws IOException {
+    return builder.numberOfShards(Integer.toString(value));
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
@@ -30,6 +30,7 @@ import io.camunda.optimize.service.db.os.schema.index.DashboardShareIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.DecisionDefinitionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ExternalProcessVariableIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.InstantPreviewDashboardMetadataIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.JobRegistryIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.MetadataIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessDefinitionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessOverviewIndexOS;
@@ -558,6 +559,7 @@ public class OpenSearchSchemaManager
         new DashboardIndexOS(),
         new DashboardShareIndexOS(),
         new DecisionDefinitionIndexOS(),
+        new JobRegistryIndexOS(),
         new MetadataIndexOS(),
         new ProcessDefinitionIndexOS(),
         new ReportShareIndexOS(),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/JobRegistryIndexOS.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/JobRegistryIndexOS.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.schema.index;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchUtil;
+import io.camunda.optimize.service.db.schema.index.JobRegistryIndex;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+
+public class JobRegistryIndexOS extends JobRegistryIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder contentBuilder) {
+    return OptimizeOpenSearchUtil.addStaticSetting(key, value, contentBuilder);
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
@@ -18,6 +18,7 @@ import io.camunda.optimize.service.db.es.schema.index.DecisionDefinitionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.DecisionInstanceIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ExternalProcessVariableIndexES;
 import io.camunda.optimize.service.db.es.schema.index.InstantPreviewDashboardMetadataIndexES;
+import io.camunda.optimize.service.db.es.schema.index.JobRegistryIndexES;
 import io.camunda.optimize.service.db.es.schema.index.MetadataIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessDefinitionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessInstanceIndexES;
@@ -44,6 +45,7 @@ import io.camunda.optimize.service.db.os.schema.index.DecisionDefinitionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.DecisionInstanceIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ExternalProcessVariableIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.InstantPreviewDashboardMetadataIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.JobRegistryIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.MetadataIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessDefinitionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessInstanceIndexOS;
@@ -126,6 +128,7 @@ public class IndexLookupUtil {
         DashboardShareIndexES.class.getSimpleName(), index -> new DashboardShareIndexOS());
     lookupMap.put(
         DecisionDefinitionIndexES.class.getSimpleName(), index -> new DecisionDefinitionIndexOS());
+    lookupMap.put(JobRegistryIndexES.class.getSimpleName(), index -> new JobRegistryIndexOS());
     lookupMap.put(MetadataIndexES.class.getSimpleName(), index -> new MetadataIndexOS());
     lookupMap.put(
         ProcessDefinitionIndexES.class.getSimpleName(), index -> new ProcessDefinitionIndexOS());
@@ -182,6 +185,7 @@ public class IndexLookupUtil {
         DashboardShareIndexOS.class.getSimpleName(), index -> new DashboardShareIndexES());
     lookupMap.put(
         DecisionDefinitionIndexOS.class.getSimpleName(), index -> new DecisionDefinitionIndexES());
+    lookupMap.put(JobRegistryIndexOS.class.getSimpleName(), index -> new JobRegistryIndexES());
     lookupMap.put(MetadataIndexOS.class.getSimpleName(), index -> new MetadataIndexES());
     lookupMap.put(
         ProcessDefinitionIndexOS.class.getSimpleName(), index -> new ProcessDefinitionIndexES());

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.schema.index;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.IGNORE_ABOVE_CHAR_LIMIT;
+import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FORMAT;
+
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+
+public abstract class JobRegistryIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+
+  public static final int VERSION = 1;
+
+  public static final String ID = "id";
+  public static final String JOB_TYPE = "jobType";
+  public static final String TARGET_ENTITY_TYPE = "targetEntityType";
+  public static final String TARGET_ENTITY_ID = "targetEntityId";
+  public static final String STATUS = "status";
+  public static final String ERROR_MESSAGE = "errorMessage";
+  public static final String CREATED_AT = "createdAt";
+  public static final String COMPLETED_AT = "completedAt";
+
+  @Override
+  public TypeMapping.Builder addProperties(final TypeMapping.Builder builder) {
+    return builder
+        .properties(ID, p -> p.keyword(k -> k))
+        .properties(JOB_TYPE, p -> p.keyword(k -> k))
+        .properties(TARGET_ENTITY_TYPE, p -> p.keyword(k -> k))
+        .properties(TARGET_ENTITY_ID, p -> p.keyword(k -> k))
+        .properties(STATUS, p -> p.keyword(k -> k))
+        .properties(ERROR_MESSAGE, p -> p.keyword(k -> k.ignoreAbove(IGNORE_ABOVE_CHAR_LIMIT)))
+        .properties(CREATED_AT, p -> p.date(d -> d.format(OPTIMIZE_DATE_FORMAT)))
+        .properties(COMPLETED_AT, p -> p.date(d -> d.format(OPTIMIZE_DATE_FORMAT)));
+  }
+
+  @Override
+  public String getIndexName() {
+    return DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return VERSION;
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
@@ -25,7 +25,7 @@ public abstract class JobRegistryIndex<TBuilder> extends DefaultIndexMappingCrea
   public static final String STATUS = "status";
   public static final String ERROR_MESSAGE = "errorMessage";
   public static final String CREATED_AT = "createdAt";
-  public static final String COMPLETED_AT = "completedAt";
+  public static final String UPDATED_AT = "updatedAt";
 
   @Override
   public TypeMapping.Builder addProperties(final TypeMapping.Builder builder) {
@@ -37,7 +37,7 @@ public abstract class JobRegistryIndex<TBuilder> extends DefaultIndexMappingCrea
         .properties(STATUS, p -> p.keyword(k -> k))
         .properties(ERROR_MESSAGE, p -> p.keyword(k -> k.ignoreAbove(IGNORE_ABOVE_CHAR_LIMIT)))
         .properties(CREATED_AT, p -> p.date(d -> d.format(OPTIMIZE_DATE_FORMAT)))
-        .properties(COMPLETED_AT, p -> p.date(d -> d.format(OPTIMIZE_DATE_FORMAT)));
+        .properties(UPDATED_AT, p -> p.date(d -> d.format(OPTIMIZE_DATE_FORMAT)));
   }
 
   @Override


### PR DESCRIPTION
## Summary
- Add a persistent `job-registry` index to Optimize (ES + OS), tracking async job state for the process-definition delete feature.
- Writer: insert `QUEUED` entries, update status to `COMPLETED`/`FAILED`.
- Reader: `findOldestQueuedJobs(limit)`, that will be used by the dispatcher.
- Reader: `findByJobTypeAndTargetEntityId(jobType, targetEntityType, targetEntityId)`, for the importer to suppress writing data for an entity that already has a delete request registered against it.

Closes #59837

## Test plan
- [x] `JobRegistryEntryDtoTest` (unit)
- [x] `JobRegistryWriterIT` — insert as QUEUED, update to COMPLETED/FAILED, retry clears stale errorMessage
- [x] `JobRegistryReaderIT` — finds sole queued entry, empty when none queued, oldest-first under multiple queued, skips completed entries, lookup by jobType+targetEntityType+targetEntityId regardless of status
- [x] `Upgrade89to810PlanFactoryIT` — `job-registry` index absent before the 8.9→8.10 upgrade plan runs, present after


🤖 Generated with [Claude Code](https://claude.com/claude-code)
