### PR TITLE
test: end-to-end integration tests for secret resolution at job activation

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/multipartition/SecretResolutionMultiPartitionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/multipartition/SecretResolutionMultiPartitionIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.client.multipartition;
+
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.INPUT_TARGET;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.applyRecordWaitTime;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.assertNoIncidentWasRaised;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.assertNoRecordCarriesValue;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitActivationExported;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstances;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.deployProcessWithInput;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.newBrokerWithEmptySecretStore;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.pollUntilActivated;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionRequestPartitions;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.secretReference;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.uniqueSecretName;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.writeSecret;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers a secret used by jobs spread over several partitions. Each partition keeps its own pending
+ * references and runs its own background resolution, while the store and the values it holds belong
+ * to the broker and are shared by all of them, so a job is served whether its partition resolved
+ * the reference itself or another one had already done so.
+ *
+ * <p>An engine test runs a single partition, so neither the split state nor the shared store is
+ * exercised there.
+ */
+@ZeebeIntegration
+final class SecretResolutionMultiPartitionIT {
+
+  private static final int PARTITION_COUNT = 3;
+
+  /** A multiple of the partition count, so the gateway's round robin reaches every partition. */
+  private static final int INSTANCES = 12;
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker", partitionCount = PARTITION_COUNT)
+  private static TestStandaloneBroker broker;
+
+  @AutoClose private final CamundaClient client = broker.newClientBuilder().build();
+
+  private final String secretName = uniqueSecretName();
+  private final String secretValue = "value-of-" + secretName;
+  private final String processId = Strings.newRandomValidBpmnId();
+  private final String jobType = Strings.newRandomValidBpmnId();
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    // the annotation's partition count is what the topology is awaited against, the cluster
+    // configuration is what the broker is started with, so both are needed
+    broker =
+        newBrokerWithEmptySecretStore()
+            .withClusterConfig(cluster -> cluster.setPartitionCount(PARTITION_COUNT));
+  }
+
+  @BeforeEach
+  void setUp() {
+    applyRecordWaitTime();
+  }
+
+  @Test
+  void shouldServeJobsOfEveryPartitionWaitingOnTheSameSecret() {
+    // given
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithInput(client, processId, jobType, secretReference(secretName));
+    createProcessInstances(client, processId, INSTANCES);
+
+    // when
+    final Map<Long, ActivatedJob> activated = pollUntilActivated(client, jobType, INSTANCES);
+
+    // then - every job is served with the value, wherever it was created
+    assertThat(activated.values())
+        .allSatisfy(
+            job -> assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue));
+    final List<Integer> partitionsOfActivatedJobs =
+        activated.keySet().stream().map(Protocol::decodePartitionId).distinct().toList();
+    assertThat(partitionsOfActivatedJobs)
+        .as("the jobs are spread over every partition")
+        .hasSize(PARTITION_COUNT);
+
+    // and - the reference was resolved by a partition rather than served from thin air, and no
+    // partition ended up with an incident. Which partitions requested a resolution is not fixed:
+    // the values live on the broker, so a partition collecting its jobs after another one resolved
+    // the reference finds the value already there and never parks anything
+    activated.keySet().forEach(jobKey -> awaitActivationExported(jobType, jobKey));
+    assertThat(resolutionRequestPartitions(secretName)).isNotEmpty();
+    assertNoIncidentWasRaised();
+    assertNoRecordCarriesValue(secretValue);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionAfterRestartIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionAfterRestartIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.secret;
+
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.INPUT_TARGET;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.activateOneJob;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.applyRecordWaitTime;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.assertNoRecordCarriesValue;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitActivationExported;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitJobKeyOf;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstance;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.deployProcessWithInput;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.newBrokerWithEmptySecretStore;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionWasRequestedFor;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.secretReference;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.uniqueSecretName;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.writeSecret;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers what happens to a secret a broker already resolved once it restarts: the values it held
+ * are gone with the process, so the loop has to run again rather than the jobs of that secret
+ * becoming undeliverable.
+ *
+ * <p>The cache is in-memory by design, and an engine test cannot lose it the way a restart does.
+ */
+@ZeebeIntegration
+final class SecretResolutionAfterRestartIT {
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker")
+  private static TestStandaloneBroker broker;
+
+  @AutoClose private CamundaClient client;
+
+  private final String secretName = uniqueSecretName();
+  private final String secretValue = "value-of-" + secretName;
+  private final String processId = Strings.newRandomValidBpmnId();
+  private final String jobType = Strings.newRandomValidBpmnId();
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    broker = newBrokerWithEmptySecretStore();
+  }
+
+  @BeforeEach
+  void setUp() {
+    applyRecordWaitTime();
+    client = broker.newClientBuilder().build();
+  }
+
+  @Test
+  void shouldResolveTheSecretAgainAfterARestartEmptiedTheCache() {
+    // given - a secret this broker already resolved and served to a worker
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithInput(client, processId, jobType, secretReference(secretName));
+    createProcessInstance(client, processId);
+    assertThat(activateOneJob(client, jobType).getVariablesAsMap())
+        .containsEntry(INPUT_TARGET, secretValue);
+
+    // when
+    client.close();
+    broker.stop();
+    broker.start().awaitCompleteTopology();
+    client = broker.newClientBuilder().build();
+
+    // then - the value is gone with the process that held it, so the next job of the same reference
+    // is parked and resolved again before it is served
+    final long processInstanceKey = createProcessInstance(client, processId);
+    final long jobKey = awaitJobKeyOf(processInstanceKey);
+    final ActivatedJob job = activateOneJob(client, jobType);
+    assertThat(job.getKey()).isEqualTo(jobKey);
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    awaitActivationExported(jobType, jobKey);
+    assertThat(resolutionWasRequestedFor(secretName, jobKey))
+        .as("the job was parked and its reference resolved again after the restart")
+        .isTrue();
+    assertNoRecordCarriesValue(secretValue);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
@@ -43,6 +43,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.response.ActivateJobsResponse;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.StreamJobsResponse;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -60,6 +61,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
@@ -70,8 +72,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Covers what a worker actually receives for a job whose input mapping references a secret, on both
  * activation paths, against a real gateway, a real client and a real file-based secret store. That
- * includes a job that references more than one secret, and the two bounds the resolution runs into
- * once a value or a waiting-job list gets large.
+ * includes a job that references more than one secret, the two bounds the resolution runs into once
+ * a value or a waiting-job list gets large, and a secret a process reaches through a cluster
+ * variable rather than a literal of its own.
  *
  * <p>The engine suites ({@code JobSecretActivationInjectionTest}, {@code
  * JobSecretPushInjectionTest} and {@code SecretResolutionLifecycleTest}) already cover the
@@ -108,6 +111,8 @@ final class SecretResolutionJobActivationIT {
    */
   private static final Duration DROPPED_JOB_POLL_TIMEOUT = Duration.ofSeconds(5);
 
+  private static final String CLUSTER_VARIABLE_SECRET_FIELD = "apiToken";
+
   /** The variable a second secret is mapped into, for the jobs that reference two. */
   private static final String OTHER_INPUT_TARGET = "otherToken";
 
@@ -120,6 +125,7 @@ final class SecretResolutionJobActivationIT {
   private final String secretValue = "value-of-" + secretName;
   private final String otherSecretName = uniqueSecretName();
   private final String otherSecretValue = "value-of-" + otherSecretName;
+  private final String clusterVariableName = "cv" + UUID.randomUUID().toString().replace("-", "");
   private final String processId = Strings.newRandomValidBpmnId();
   private final String jobType = Strings.newRandomValidBpmnId();
 
@@ -435,6 +441,87 @@ final class SecretResolutionJobActivationIT {
   }
 
   @Test
+  void shouldActivateWithASecretReachedThroughAClusterVariable() {
+    // given - a cluster variable holding the reference, and a process reading it
+    writeSecret(broker, secretName, secretValue);
+    createSecretReferenceClusterVariable();
+    deployProcessReadingTheClusterVariable();
+    createProcessInstance(client, processId);
+
+    // when
+    final ActivatedJob job = onlyJob(poll().join());
+
+    // then
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(resolutionWasRequestedFor(secretName, job.getKey())).isTrue();
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldPushJobWithASecretReachedThroughAClusterVariable() {
+    // given
+    writeSecret(broker, secretName, secretValue);
+    createSecretReferenceClusterVariable();
+    deployProcessReadingTheClusterVariable();
+    final List<ActivatedJob> streamed = new CopyOnWriteArrayList<>();
+    final var stream = openJobStream(streamed::add);
+
+    try {
+      awaitStreamRegistered(broker, jobType);
+
+      // when
+      createProcessInstance(client, processId);
+
+      // then
+      Awaitility.await("until the job is pushed")
+          .atMost(AWAIT_TIMEOUT)
+          .untilAsserted(() -> assertThat(streamed).hasSize(1));
+    } finally {
+      stream.cancel(true);
+    }
+
+    assertThat(streamed)
+        .singleElement()
+        .satisfies(
+            job -> assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue));
+    final long jobKey = streamed.get(0).getKey();
+    awaitActivationExported(jobType, jobKey);
+    assertThat(resolutionWasRequestedFor(secretName, jobKey)).isTrue();
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldServeTheUpdatedReferenceAfterTheClusterVariableIsUpdated() {
+    // given - a worker served the secret the cluster variable pointed at when it was created
+    writeSecret(broker, secretName, secretValue);
+    writeSecret(broker, otherSecretName, otherSecretValue);
+    createSecretReferenceClusterVariable(secretName);
+    deployProcessReadingTheClusterVariable();
+    createProcessInstance(client, processId);
+    assertThat(onlyJob(poll().join()).getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+
+    // when - the variable is updated to hold the reference of another secret
+    client
+        .newGloballyScopedClusterVariableUpdateRequest()
+        .update(
+            clusterVariableName,
+            Map.of(CLUSTER_VARIABLE_SECRET_FIELD, secretReference(otherSecretName)))
+        .send()
+        .join();
+
+    // then - the update is scanned like the creation was, so the next job carries the new secret
+    final long processInstanceKey = createProcessInstance(client, processId);
+    final ActivatedJob job = onlyJob(poll().join());
+    assertThat(job.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, otherSecretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(resolutionWasRequestedFor(otherSecretName, job.getKey())).isTrue();
+    assertNoRecordCarriesValue(secretValue);
+    assertNoRecordCarriesValue(otherSecretValue);
+  }
+
+  @Test
   void shouldActivateOnceWithEveryReferenceOfAJobResolved() {
     // given - one of the two secrets of a job already in the cache, from an earlier job of its own
     writeSecret(broker, secretName, secretValue);
@@ -605,6 +692,32 @@ final class SecretResolutionJobActivationIT {
         .join();
   }
 
+  private void createSecretReferenceClusterVariable() {
+    createSecretReferenceClusterVariable(secretName);
+  }
+
+  private void createSecretReferenceClusterVariable(final String referencedSecret) {
+    client
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(
+            clusterVariableName,
+            Map.of(CLUSTER_VARIABLE_SECRET_FIELD, secretReference(referencedSecret)))
+        .kind(ClusterVariableKind.SECRET_REFERENCE)
+        .send()
+        .join();
+  }
+
+  private void deployProcessReadingTheClusterVariable() {
+    deployProcessWithInput(
+        client,
+        processId,
+        jobType,
+        "camunda.vars.cluster.%s.%s".formatted(clusterVariableName, CLUSTER_VARIABLE_SECRET_FIELD));
+  }
+
+  /**
+   * A long poll for one job of this test's type, kept apart from the harness's {@code pollJobs}.
+   */
   private CamundaFuture<ActivateJobsResponse> poll() {
     return poll(jobType);
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.secret;
+
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.AWAIT_TIMEOUT;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.INPUT_TARGET;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.JOB_TIMEOUT;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.LONG_POLL_TIMEOUT;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.applyRecordWaitTime;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.assertNoRecordCarriesValue;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitActivationExported;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitJobKeyOf;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitNoStreamRegistered;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitResolutionRequested;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitStreamRegistered;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstance;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.deployProcessWithInput;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.incidentsOf;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.newBrokerWithEmptySecretStore;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.onlyJob;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.pollJobs;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.primingPoll;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionFailureStates;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionWasRequestedFor;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.secretReference;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.uniqueSecretName;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.writeSecret;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.StreamJobsResponse;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResolutionState;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers what a worker actually receives for a job whose input mapping references a secret, on both
+ * activation paths, against a real gateway, a real client and a real file-based secret store.
+ *
+ * <p>The engine suites ({@code JobSecretActivationInjectionTest}, {@code
+ * JobSecretPushInjectionTest} and {@code SecretResolutionLifecycleTest}) already cover the
+ * processing of one command with a stubbed cache. What only this level can show is the part outside
+ * the stream processor: that a long poll blocked on an empty result is woken by the reactivation's
+ * workers-notified broadcast, that a reactivated job reaches a real remote job stream (which that
+ * broadcast never reaches), and that no exported record carries a value a worker was handed.
+ *
+ * <p>All of it shares one broker, since none of these tests need a broker of their own and starting
+ * one per group of tests is the expensive part. Every test uses its own secret name: the cache is
+ * per broker and shared with the gateway's secret endpoints, so a name reused across tests would be
+ * warm from the first test on and the cache-miss path would never run.
+ */
+@ZeebeIntegration
+final class SecretResolutionJobActivationIT {
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker")
+  private static TestStandaloneBroker broker;
+
+  @AutoClose private final CamundaClient client = broker.newClientBuilder().build();
+
+  private final String secretName = uniqueSecretName();
+  private final String secretValue = "value-of-" + secretName;
+  private final String processId = Strings.newRandomValidBpmnId();
+  private final String jobType = Strings.newRandomValidBpmnId();
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    broker = newBrokerWithEmptySecretStore();
+  }
+
+  @BeforeEach
+  void setUp() {
+    applyRecordWaitTime();
+  }
+
+  @Test
+  void shouldCompleteBlockedLongPollOnceTheSecretResolves() {
+    // given - a job whose secret the store holds but the cache does not
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithSecretInput();
+    final long processInstanceKey = createProcessInstance(client, processId);
+    awaitJobKeyOf(processInstanceKey);
+
+    // when - the request parks the job on its first attempt and stays open, so it is the
+    // reactivation that completes it
+    final ActivatedJob job = onlyJob(poll().join());
+
+    // then
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+
+    // and - the job took the park and background resolution route, rather than a warm cache
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(resolutionWasRequestedFor(secretName, job.getKey())).isTrue();
+    assertThat(incidentsOf(processInstanceKey)).isEmpty();
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldPushJobToStreamOnceTheSecretResolves() {
+    // given - a stream registered before the job exists, so the job is pushed rather than polled
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithSecretInput();
+    final List<ActivatedJob> streamed = new CopyOnWriteArrayList<>();
+    final var stream = openJobStream(streamed::add);
+    final long processInstanceKey;
+
+    try {
+      awaitStreamRegistered(broker, jobType);
+
+      // when
+      processInstanceKey = createProcessInstance(client, processId);
+
+      // then - the only push carries the value, so the job was never pushed while it was uncached
+      Awaitility.await("until the job is pushed")
+          .atMost(AWAIT_TIMEOUT)
+          .untilAsserted(() -> assertThat(streamed).hasSize(1));
+    } finally {
+      stream.cancel(true);
+    }
+
+    assertThat(streamed)
+        .singleElement()
+        .satisfies(
+            job -> assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue));
+    final long jobKey = streamed.get(0).getKey();
+    awaitActivationExported(jobType, jobKey);
+    assertThat(resolutionWasRequestedFor(secretName, jobKey)).isTrue();
+    assertThat(incidentsOf(processInstanceKey)).isEmpty();
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldActivateWithoutParkingWhenTheSecretIsAlreadyCached() {
+    // given - a first instance whose resolution left the value in the cache
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithSecretInput();
+    createProcessInstance(client, processId);
+    onlyJob(poll().join());
+
+    // when - a second instance runs against the warm cache
+    final long processInstanceKey = createProcessInstance(client, processId);
+    awaitJobKeyOf(processInstanceKey);
+    final ActivatedJob job = onlyJob(poll().join());
+
+    // then - it is activated with the value, and was never parked on the way there. A park would
+    // have been requested before the activation this awaits, so it cannot be in flight still
+    assertThat(job.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(resolutionWasRequestedFor(secretName, job.getKey())).isFalse();
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldParkJobEvenWhenTheWorkerDoesNotFetchTheSecretVariable() {
+    // given - a worker that asks for another variable than the one the secret is mapped into
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithSecretInput();
+    final long processInstanceKey =
+        createProcessInstance(client, processId, Map.of("other", "plain"));
+    awaitJobKeyOf(processInstanceKey);
+
+    // when
+    final ActivatedJob job =
+        onlyJob(
+            client
+                .newActivateJobsCommand()
+                .jobType(jobType)
+                .maxJobsToActivate(1)
+                .timeout(JOB_TIMEOUT)
+                .fetchVariables("other")
+                .requestTimeout(LONG_POLL_TIMEOUT)
+                .send()
+                .join());
+
+    // then - the job was still held back until its reference resolved, since the check is on the
+    // job's references and not on the variables the worker asked for
+    assertThat(job.getVariablesAsMap())
+        .containsEntry("other", "plain")
+        .doesNotContainKey(INPUT_TARGET);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(resolutionWasRequestedFor(secretName, job.getKey())).isTrue();
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldNotHandTheSecretValueToAListenerJobOfTheSameElement() {
+    // given - a task whose input mapping references a secret, plus an end execution listener on it
+    writeSecret(broker, secretName, secretValue);
+    final String listenerType = Strings.newRandomValidBpmnId();
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    task ->
+                        task.zeebeJobType(jobType)
+                            .zeebeInputExpression(secretReference(secretName), INPUT_TARGET)
+                            .zeebeEndExecutionListener(listenerType))
+                .endEvent()
+                .done(),
+            processId + ".bpmn")
+        .send()
+        .join();
+    final long processInstanceKey = createProcessInstance(client, processId);
+
+    // when - the task's worker receives the value and completes the job
+    final ActivatedJob taskJob = onlyJob(poll().join());
+    assertThat(taskJob.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    client.newCompleteCommand(taskJob.getKey()).send().join();
+
+    // then - the listener job of the same element sees the placeholder, since a listener job is
+    // created without secret references and only the referencing job's variables are injected
+    final ActivatedJob listenerJob = onlyJob(poll(listenerType).join());
+    assertThat(listenerJob.getVariablesAsMap())
+        .containsEntry(INPUT_TARGET, secretReference(secretName));
+    awaitActivationExported(listenerType, listenerJob.getKey());
+    assertThat(incidentsOf(processInstanceKey)).isEmpty();
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldRaiseIncidentForAnUnknownSecretAndDeliverAfterTheOperatorFixesIt() {
+    // given - a job referencing a secret the store does not hold
+    deployProcessWithSecretInput();
+    final long processInstanceKey = createProcessInstance(client, processId);
+    awaitJobKeyOf(processInstanceKey);
+    // with no stream registered the job is announced unchecked, so it is this poll that checks its
+    // references, parks it and requests the resolution that then fails
+    assertThat(primingPoll(client, jobType)).isEmpty();
+    final Record<IncidentRecordValue> incident = awaitSecretIncident(processInstanceKey);
+
+    // then - one incident naming the secret, and nothing activatable behind it
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.SECRET_RESOLUTION_ERROR);
+    assertThat(incident.getValue().getErrorMessage()).contains(secretName);
+    assertThat(incident.getValue().getJobKey()).isPositive();
+
+    // and - the secret was missing rather than its store, the other way round from
+    // SecretStoreUnavailableIT. Both raise this same incident, so without reading the state off the
+    // RESOLUTION_FAILED record neither test can tell which of the two it got
+    assertThat(resolutionFailureStates(secretName))
+        .as("the secret was missing, not its store")
+        .containsOnly(ResolutionState.NOT_FOUND);
+
+    // when - the operator adds the missing secret and resolves the incident
+    writeSecret(broker, secretName, secretValue);
+    client.newResolveIncidentCommand(incident.getKey()).send().join();
+
+    // then - the job is handed out again with the value, and no second incident was raised
+    final ActivatedJob job = onlyJob(poll().join());
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(incidentsOf(processInstanceKey)).hasSize(1);
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldPushJobToStreamAfterTheOperatorResolvesTheIncident() {
+    // given - a stream registered for a job whose secret the store does not hold
+    deployProcessWithSecretInput();
+    final List<ActivatedJob> streamed = new CopyOnWriteArrayList<>();
+    final var stream = openJobStream(streamed::add);
+    final long processInstanceKey;
+
+    try {
+      awaitStreamRegistered(broker, jobType);
+      processInstanceKey = createProcessInstance(client, processId);
+      final Record<IncidentRecordValue> incident = awaitSecretIncident(processInstanceKey);
+      assertThat(streamed).as("a job with an unresolved secret is never pushed").isEmpty();
+
+      // when - the operator adds the missing secret and resolves the incident
+      writeSecret(broker, secretName, secretValue);
+      client.newResolveIncidentCommand(incident.getKey()).send().join();
+
+      // then - resolving the incident hands the job back to the push path, which pushes it with the
+      // value once the reference resolves again
+      Awaitility.await("until the job is pushed")
+          .atMost(AWAIT_TIMEOUT)
+          .untilAsserted(() -> assertThat(streamed).hasSize(1));
+    } finally {
+      stream.cancel(true);
+    }
+
+    assertThat(streamed)
+        .singleElement()
+        .satisfies(
+            job -> assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue));
+    awaitActivationExported(jobType, streamed.get(0).getKey());
+    assertThat(incidentsOf(processInstanceKey)).hasSize(1);
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldAnnounceJobToPollingWorkersWhenTheStreamIsGone() {
+    // given - a job parked on a secret the store does not hold, with a stream registered
+    deployProcessWithSecretInput();
+    final List<ActivatedJob> streamed = new CopyOnWriteArrayList<>();
+    final var stream = openJobStream(streamed::add);
+    final Record<IncidentRecordValue> incident;
+
+    try {
+      awaitStreamRegistered(broker, jobType);
+      final long processInstanceKey = createProcessInstance(client, processId);
+      incident = awaitSecretIncident(processInstanceKey);
+    } finally {
+      // the stream is gone before the job becomes available again, so nothing can push it
+      stream.cancel(true);
+    }
+    awaitNoStreamRegistered(broker, jobType);
+
+    // when - the operator adds the secret and resolves the incident
+    writeSecret(broker, secretName, secretValue);
+    client.newResolveIncidentCommand(incident.getKey()).send().join();
+
+    // then - the reactivation announces the job type instead of pushing, so a poll receives it
+    final ActivatedJob job = onlyJob(poll().join());
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    assertThat(streamed).isEmpty();
+    awaitActivationExported(jobType, job.getKey());
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldInjectTheSecretAgainWhenAFailedJobIsRetried() {
+    // given - a job that was activated with its secret value and then failed with a retry left
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithSecretInput();
+    createProcessInstance(client, processId);
+    final ActivatedJob firstActivation = onlyJob(poll().join());
+    assertThat(firstActivation.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+
+    // when
+    client.newFailCommand(firstActivation.getKey()).retries(1).send().join();
+
+    // then - the retry carries the value again, never the placeholder it is stored with
+    final ActivatedJob job = onlyJob(poll().join());
+    assertThat(job.getKey()).isEqualTo(firstActivation.getKey());
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldTerminateInstanceWhoseJobIsParkedOnAnUnresolvableSecret() {
+    // given - a job parked on a secret the store does not hold, so it stays parked
+    deployProcessWithSecretInput();
+    final long processInstanceKey = createProcessInstance(client, processId);
+    awaitJobKeyOf(processInstanceKey);
+    assertThat(primingPoll(client, jobType)).isEmpty();
+    awaitResolutionRequested(secretName);
+
+    // when - the instance is cancelled while its job waits on that reference
+    client.newCancelInstanceCommand(processInstanceKey).send().join();
+
+    // then - the instance terminates, and the reference's drain skipping a job that is gone leaves
+    // the broker serving the next instance of the same reference once the secret is there
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(1)
+                .exists())
+        .as("the cancelled instance terminated")
+        .isTrue();
+
+    writeSecret(broker, secretName, secretValue);
+    final long nextInstanceKey = createProcessInstance(client, processId);
+    final ActivatedJob job = onlyJob(poll().join());
+    assertThat(job.getProcessInstanceKey()).isEqualTo(nextInstanceKey);
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  private Record<IncidentRecordValue> awaitSecretIncident(final long processInstanceKey) {
+    return RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withErrorType(ErrorType.SECRET_RESOLUTION_ERROR)
+        .getFirst();
+  }
+
+  private void deployProcessWithSecretInput() {
+    deployProcessWithInput(client, processId, jobType, secretReference(secretName));
+  }
+
+  private CamundaFuture<ActivateJobsResponse> poll() {
+    return poll(jobType);
+  }
+
+  private CamundaFuture<ActivateJobsResponse> poll(final String type) {
+    return pollJobs(client, type, 1, LONG_POLL_TIMEOUT);
+  }
+
+  private CamundaFuture<StreamJobsResponse> openJobStream(final Consumer<ActivatedJob> consumer) {
+    return client
+        .newStreamJobsCommand()
+        .jobType(jobType)
+        .consumer(consumer)
+        .workerName("streamer")
+        .timeout(JOB_TIMEOUT)
+        .send();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
@@ -61,7 +61,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Covers what a worker actually receives for a job whose input mapping references a secret, on both
- * activation paths, against a real gateway, a real client and a real file-based secret store.
+ * activation paths, against a real gateway, a real client and a real file-based secret store. That
+ * includes a job that references more than one secret.
  *
  * <p>The engine suites ({@code JobSecretActivationInjectionTest}, {@code
  * JobSecretPushInjectionTest} and {@code SecretResolutionLifecycleTest}) already cover the
@@ -78,6 +79,9 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 final class SecretResolutionJobActivationIT {
 
+  /** The variable a second secret is mapped into, for the jobs that reference two. */
+  private static final String OTHER_INPUT_TARGET = "otherToken";
+
   @TestZeebe(initMethod = "initTestStandaloneBroker")
   private static TestStandaloneBroker broker;
 
@@ -85,6 +89,8 @@ final class SecretResolutionJobActivationIT {
 
   private final String secretName = uniqueSecretName();
   private final String secretValue = "value-of-" + secretName;
+  private final String otherSecretName = uniqueSecretName();
+  private final String otherSecretValue = "value-of-" + otherSecretName;
   private final String processId = Strings.newRandomValidBpmnId();
   private final String jobType = Strings.newRandomValidBpmnId();
 
@@ -399,6 +405,75 @@ final class SecretResolutionJobActivationIT {
     assertNoRecordCarriesValue(secretValue);
   }
 
+  @Test
+  void shouldActivateOnceWithEveryReferenceOfAJobResolved() {
+    // given - one of the two secrets of a job already in the cache, from an earlier job of its own
+    writeSecret(broker, secretName, secretValue);
+    writeSecret(broker, otherSecretName, otherSecretValue);
+    final String warmUpProcessId = Strings.newRandomValidBpmnId();
+    final String warmUpJobType = Strings.newRandomValidBpmnId();
+    deployProcessWithInput(client, warmUpProcessId, warmUpJobType, secretReference(secretName));
+    createProcessInstance(client, warmUpProcessId);
+    assertThat(onlyJob(poll(warmUpJobType).join()).getVariablesAsMap())
+        .containsEntry(INPUT_TARGET, secretValue);
+
+    // when - a job references both, so one is cached and the other is not
+    deployProcessWithTwoSecretInputs();
+    final long processInstanceKey = createProcessInstance(client, processId);
+    final ActivatedJob job = onlyJob(poll().join());
+
+    // then - the job waited for the reference that was missing and was then activated once with
+    // both values, rather than handed out as soon as one of them could be injected
+    assertThat(job.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(job.getVariablesAsMap())
+        .containsEntry(INPUT_TARGET, secretValue)
+        .containsEntry(OTHER_INPUT_TARGET, otherSecretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(resolutionWasRequestedFor(otherSecretName, job.getKey()))
+        .as("the reference that was not cached was requested")
+        .isTrue();
+    assertThat(resolutionWasRequestedFor(secretName, job.getKey()))
+        .as("the reference that was cached was not requested again")
+        .isFalse();
+    assertThat(incidentsOf(processInstanceKey)).isEmpty();
+    assertNoRecordCarriesValue(secretValue);
+    assertNoRecordCarriesValue(otherSecretValue);
+  }
+
+  @Test
+  void shouldRaiseIncidentWhenOnlyOneOfTheReferencesOfAJobResolves() {
+    // given - a job referencing two secrets, one of which the store does not hold
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithTwoSecretInputs();
+    final long processInstanceKey = createProcessInstance(client, processId);
+    awaitJobKeyOf(processInstanceKey);
+    assertThat(primingPoll(client, jobType)).isEmpty();
+
+    // when - one reference resolves and the other cannot
+    final Record<IncidentRecordValue> incident = awaitSecretIncident(processInstanceKey);
+
+    // then - the job is not handed out with what could be resolved; it gets an incident naming the
+    // reference that failed, and the reactivation of the one that resolved leaves it alone since it
+    // is still parked on the other
+    assertThat(incident.getValue().getErrorMessage()).contains(otherSecretName);
+    assertThat(resolutionFailureStates(otherSecretName)).containsOnly(ResolutionState.NOT_FOUND);
+    assertThat(resolutionFailureStates(secretName)).isEmpty();
+
+    // when - the operator adds the missing secret and resolves the incident
+    writeSecret(broker, otherSecretName, otherSecretValue);
+    client.newResolveIncidentCommand(incident.getKey()).send().join();
+
+    // then - the job is handed out with both values, and no second incident was raised
+    final ActivatedJob job = onlyJob(poll().join());
+    assertThat(job.getVariablesAsMap())
+        .containsEntry(INPUT_TARGET, secretValue)
+        .containsEntry(OTHER_INPUT_TARGET, otherSecretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(incidentsOf(processInstanceKey)).hasSize(1);
+    assertNoRecordCarriesValue(secretValue);
+    assertNoRecordCarriesValue(otherSecretValue);
+  }
+
   private Record<IncidentRecordValue> awaitSecretIncident(final long processInstanceKey) {
     return RecordingExporter.incidentRecords(IncidentIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
@@ -408,6 +483,27 @@ final class SecretResolutionJobActivationIT {
 
   private void deployProcessWithSecretInput() {
     deployProcessWithInput(client, processId, jobType, secretReference(secretName));
+  }
+
+  /** A task whose input mappings read two secrets, into two different variables. */
+  private void deployProcessWithTwoSecretInputs() {
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    task ->
+                        task.zeebeJobType(jobType)
+                            .zeebeInputExpression(secretReference(secretName), INPUT_TARGET)
+                            .zeebeInputExpression(
+                                secretReference(otherSecretName), OTHER_INPUT_TARGET))
+                .endEvent()
+                .done(),
+            processId + ".bpmn")
+        .send()
+        .join();
   }
 
   private CamundaFuture<ActivateJobsResponse> poll() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
@@ -11,7 +11,9 @@ import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.AWAI
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.INPUT_TARGET;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.JOB_TIMEOUT;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.LONG_POLL_TIMEOUT;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.REACTIVATION_BATCH_SIZE;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.applyRecordWaitTime;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.assertNoIncidentWasRaised;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.assertNoRecordCarriesValue;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitActivationExported;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitJobKeyOf;
@@ -19,12 +21,16 @@ import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awai
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitResolutionRequested;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitStreamRegistered;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstance;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstances;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.deployProcessWithInput;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.incidentsOf;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.newBrokerWithEmptySecretStore;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.onlyJob;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.parkedJobKeys;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.pollJobs;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.pollUntilActivated;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.primingPoll;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.reactivationRounds;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionFailureStates;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionWasRequestedFor;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.secretReference;
@@ -50,8 +56,10 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
@@ -62,7 +70,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Covers what a worker actually receives for a job whose input mapping references a secret, on both
  * activation paths, against a real gateway, a real client and a real file-based secret store. That
- * includes a job that references more than one secret.
+ * includes a job that references more than one secret, and the two bounds the resolution runs into
+ * once a value or a waiting-job list gets large.
  *
  * <p>The engine suites ({@code JobSecretActivationInjectionTest}, {@code
  * JobSecretPushInjectionTest} and {@code SecretResolutionLifecycleTest}) already cover the
@@ -78,6 +87,26 @@ import org.junit.jupiter.api.Test;
  */
 @ZeebeIntegration
 final class SecretResolutionJobActivationIT {
+
+  /**
+   * Larger than the growth an activation batch has to spare, which is {@code
+   * EngineConfiguration#BATCH_SIZE_CALCULATION_BUFFER} (8 KB) rather than the whole message size.
+   */
+  private static final int OVERSIZED_SECRET_LENGTH = 16 * 1024;
+
+  /**
+   * More than the 100 jobs one reactivation command carries, so the chain has to follow up, and
+   * more than the 100 jobs one activation skips for uncached references ({@code
+   * EngineConfiguration#MAX_UNCACHED_SECRET_JOBS_SKIPPED_PER_ACTIVATION}), so the first poll cuts
+   * off at the skip cap and the client has to come back for the rest.
+   */
+  private static final int WAITING_JOBS = 150;
+
+  /**
+   * Only has to outlive the park, the resolution and the injection attempt of the one job the test
+   * expects to be dropped, since nothing is ever returned to end the request early.
+   */
+  private static final Duration DROPPED_JOB_POLL_TIMEOUT = Duration.ofSeconds(5);
 
   /** The variable a second secret is mapped into, for the jobs that reference two. */
   private static final String OTHER_INPUT_TARGET = "otherToken";
@@ -472,6 +501,76 @@ final class SecretResolutionJobActivationIT {
     assertThat(incidentsOf(processInstanceKey)).hasSize(1);
     assertNoRecordCarriesValue(secretValue);
     assertNoRecordCarriesValue(otherSecretValue);
+  }
+
+  @Test
+  void shouldRaiseIncidentWhenTheSecretValueOutgrowsTheActivationBatch() {
+    // given - a secret whose value cannot be injected without outgrowing the batch
+    final String oversizedValue = "v".repeat(OVERSIZED_SECRET_LENGTH);
+    writeSecret(broker, secretName, oversizedValue);
+    deployProcessWithSecretInput();
+    final long processInstanceKey = createProcessInstance(client, processId);
+
+    // when - the job is polled, which parks it, resolves the value and then attempts the injection.
+    // The dropped job is taken out of the activation, so this request has nothing left to return
+    // and only its own timeout ends it
+    final CamundaFuture<ActivateJobsResponse> pendingPoll =
+        pollJobs(client, jobType, 1, DROPPED_JOB_POLL_TIMEOUT);
+
+    // then - the job is not activated and the worker is left with an incident to act on
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.MESSAGE_SIZE_EXCEEDED);
+    assertThat(incident.getValue().getErrorMessage())
+        .contains(String.valueOf(incident.getValue().getJobKey()));
+    assertThat(pendingPoll.join().getJobs()).isEmpty();
+
+    // and - the value was resolved into the cache before the injection was rejected, so a value too
+    // large to hand out is still a value that must not reach a record. The incident above is
+    // written after the injection, so the records of that attempt are exported by now
+    assertNoRecordCarriesValue(oversizedValue);
+  }
+
+  @Test
+  void shouldDeliverEveryJobWaitingOnOneReference() {
+    // given - more jobs waiting on one reference than a single reactivation command carries
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithSecretInput();
+    final List<Long> processInstanceKeys = createProcessInstances(client, processId, WAITING_JOBS);
+
+    // when
+    final Map<Long, ActivatedJob> activated = pollUntilActivated(client, jobType, WAITING_JOBS);
+
+    // then - every waiting job was handed out, each with the resolved value
+    assertThat(activated.values())
+        .allSatisfy(
+            job -> assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue));
+    assertThat(activated.values())
+        .map(ActivatedJob::getProcessInstanceKey)
+        .containsExactlyInAnyOrderElementsOf(processInstanceKeys);
+    activated.keySet().forEach(jobKey -> awaitActivationExported(jobType, jobKey));
+    assertNoIncidentWasRaised();
+    assertNoRecordCarriesValue(secretValue);
+
+    // and - the reactivation drained the jobs it parked in chained rounds rather than one batch,
+    // which delivering them all does not by itself show. How many jobs end up parked is a matter of
+    // timing (a job whose poll finds the value already cached is never parked at all), so the round
+    // count is required against the jobs that actually were parked rather than against a fixed
+    // number
+    final Set<Long> parked = parkedJobKeys(secretName);
+    final List<List<Long>> rounds = reactivationRounds(secretName);
+    assertThat(rounds)
+        .as("no round carried more jobs than one reactivation command holds")
+        .allSatisfy(round -> assertThat(round).hasSizeLessThanOrEqualTo(REACTIVATION_BATCH_SIZE));
+    assertThat(rounds.stream().flatMap(List::stream).toList())
+        .as("every parked job was reactivated")
+        .containsAll(parked);
+    assertThat(rounds)
+        .as("the %d parked jobs took more than one reactivation round".formatted(parked.size()))
+        .hasSizeGreaterThanOrEqualTo(
+            (parked.size() + REACTIVATION_BATCH_SIZE - 1) / REACTIVATION_BATCH_SIZE);
   }
 
   private Record<IncidentRecordValue> awaitSecretIncident(final long processInstanceKey) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionTestHarness.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionTestHarness.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResolutionState;
+import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
+import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+
+/**
+ * The harness the secret resolution ITs share: the broker they all configure the same way, the
+ * process and instances they all deploy and create, and the exporter queries they all assert on.
+ *
+ * <p>Three of those queries are the reason this exists rather than each test writing its own. A
+ * record is exported after the command that wrote it was committed, so a client call returning is
+ * no proof that the records of that call are in {@link RecordingExporter} yet: an assertion made
+ * right after it may inspect a record set the activation has not reached. {@link
+ * #awaitActivationExported} is the anchor for that, and every assertion about what an activation
+ * did or did not write belongs behind it.
+ */
+public final class SecretResolutionTestHarness {
+
+  /** Short enough that a test does not wait on the default 5s between background cycles. */
+  public static final Duration RESOLUTION_INTERVAL = Duration.ofMillis(200);
+
+  /** Has to outlive the park, the background resolution and the reactivation of a job. */
+  public static final Duration LONG_POLL_TIMEOUT = Duration.ofSeconds(30);
+
+  /**
+   * Long enough that an activated job never times out back into a later poll, including in a test
+   * that moves the broker's clock forward to expire a cached value.
+   */
+  public static final Duration JOB_TIMEOUT = Duration.ofMinutes(30);
+
+  /**
+   * Covers a background cycle, an incident round and, for the suites that create many instances,
+   * the polls that collect them all.
+   */
+  public static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(60);
+
+  /** Keeps a priming poll from waiting for the job it is not there to collect. */
+  public static final Duration PRIMING_POLL_TIMEOUT = Duration.ofSeconds(1);
+
+  /** The variable a test's input mapping writes its secret into. */
+  public static final String INPUT_TARGET = "token";
+
+  /**
+   * Enough process instance commands in flight to be quick, few enough that the broker's
+   * backpressure does not reject them.
+   */
+  public static final int CREATION_WAVE_SIZE = 20;
+
+  /**
+   * The jobs one {@code BATCH_REACTIVATE_JOBS} command carries, mirroring {@code
+   * SecretReferenceBatchReactivateJobsProcessor#MAX_BATCH_SIZE}: what makes the reactivation of
+   * more jobs than this a chain of commands rather than one of them.
+   */
+  public static final int REACTIVATION_BATCH_SIZE = 100;
+
+  private SecretResolutionTestHarness() {}
+
+  /**
+   * A broker with an empty file-based secret store, so each test writes the one secret it needs
+   * under its own name, and a background resolution that does not keep tests waiting.
+   */
+  public static TestStandaloneBroker newBrokerWithEmptySecretStore() {
+    return new TestStandaloneBroker()
+        .withRecordingExporter(true)
+        .withUnauthenticatedAccess()
+        .withFileBasedSecretStore(directory -> {})
+        .withProcessingConfig(
+            processing -> processing.getEngine().getSecrets().setInterval(RESOLUTION_INTERVAL));
+  }
+
+  /**
+   * Gives the record streams of a test the same budget as its other awaits. Belongs in a {@code
+   * BeforeEach}: the {@code ZeebeIntegration} extension resets the recording exporter, and its
+   * maximum wait time with it, before every test.
+   */
+  public static void applyRecordWaitTime() {
+    RecordingExporter.setMaximumWaitTime(AWAIT_TIMEOUT.toMillis());
+  }
+
+  /**
+   * A name no other test uses. The secret cache is per broker and shared with the gateway's secret
+   * endpoints, so a name reused across tests runs against a warm cache and never exercises the
+   * cache-miss path. A reference is a FEEL path, so the name has to be a single alphanumeric
+   * segment.
+   */
+  public static String uniqueSecretName() {
+    return "s" + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  public static String secretReference(final String secretName) {
+    return "camunda.secrets." + secretName;
+  }
+
+  /** Writes one secret of the broker's file-based store, creating or replacing its file. */
+  public static void writeSecret(
+      final TestStandaloneBroker broker, final String secretName, final String value) {
+    try {
+      Files.writeString(
+          broker.getFileBasedSecretStoreDirectory().resolve(secretName),
+          value,
+          StandardCharsets.UTF_8);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to write the secret '" + secretName + "'", e);
+    }
+  }
+
+  /** Deploys a process with one service task whose input mapping reads {@code inputExpression}. */
+  public static void deployProcessWithInput(
+      final CamundaClient client,
+      final String processId,
+      final String jobType,
+      final String inputExpression) {
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    task ->
+                        task.zeebeJobType(jobType)
+                            .zeebeInputExpression(inputExpression, INPUT_TARGET))
+                .endEvent()
+                .done(),
+            processId + ".bpmn")
+        .send()
+        .join();
+  }
+
+  public static long createProcessInstance(final CamundaClient client, final String processId) {
+    return createProcessInstance(client, processId, Map.of());
+  }
+
+  public static long createProcessInstance(
+      final CamundaClient client, final String processId, final Map<String, Object> variables) {
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .variables(variables)
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  /**
+   * Creates the instances in waves of {@link #CREATION_WAVE_SIZE} rather than all at once, so the
+   * broker's backpressure does not reject them.
+   */
+  public static List<Long> createProcessInstances(
+      final CamundaClient client, final String processId, final int count) {
+    final List<Long> keys = new ArrayList<>();
+    while (keys.size() < count) {
+      final List<CamundaFuture<ProcessInstanceEvent>> wave = new ArrayList<>();
+      for (int i = keys.size(); i < Math.min(keys.size() + CREATION_WAVE_SIZE, count); i++) {
+        wave.add(client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send());
+      }
+      wave.forEach(future -> keys.add(future.join().getProcessInstanceKey()));
+    }
+    return keys;
+  }
+
+  public static CamundaFuture<ActivateJobsResponse> pollJobs(
+      final CamundaClient client,
+      final String jobType,
+      final int maxJobs,
+      final Duration requestTimeout) {
+    return client
+        .newActivateJobsCommand()
+        .jobType(jobType)
+        .maxJobsToActivate(maxJobs)
+        .timeout(JOB_TIMEOUT)
+        .requestTimeout(requestTimeout)
+        .send();
+  }
+
+  /**
+   * A poll whose only job is to make the activation path check a job's secret references. While no
+   * stream is registered a created job is announced to the workers unchecked, so a test that needs
+   * the job parked has to poll for it first.
+   */
+  public static List<ActivatedJob> primingPoll(final CamundaClient client, final String jobType) {
+    return pollJobs(client, jobType, 1, PRIMING_POLL_TIMEOUT).join().getJobs();
+  }
+
+  /** The one job of a response, so a poll that came back empty fails on the count. */
+  public static ActivatedJob onlyJob(final ActivateJobsResponse response) {
+    assertThat(response.getJobs()).hasSize(1);
+    return response.getJobs().get(0);
+  }
+
+  /** Long polls for one job of the type and returns it. */
+  public static ActivatedJob activateOneJob(final CamundaClient client, final String jobType) {
+    return onlyJob(pollJobs(client, jobType, 1, LONG_POLL_TIMEOUT).join());
+  }
+
+  /**
+   * Polls until every expected job was activated, and fails naming how many arrived if the await
+   * budget runs out first.
+   *
+   * <p>Each poll is given what is left of that budget rather than the full long poll timeout, so a
+   * last poll issued just before the deadline cannot keep the request open past it. Without that,
+   * the method can overrun its own budget by a whole long poll, and the test it runs in reports the
+   * overrun as a plain "wrong number of jobs".
+   */
+  public static Map<Long, ActivatedJob> pollUntilActivated(
+      final CamundaClient client, final String jobType, final int expected) {
+    final Map<Long, ActivatedJob> activated = new HashMap<>();
+    final long deadline = System.currentTimeMillis() + AWAIT_TIMEOUT.toMillis();
+    long remaining;
+    while (activated.size() < expected && (remaining = deadline - System.currentTimeMillis()) > 0) {
+      final var requestTimeout =
+          Duration.ofMillis(Math.min(remaining, LONG_POLL_TIMEOUT.toMillis()));
+      pollJobs(client, jobType, expected, requestTimeout)
+          .join()
+          .getJobs()
+          .forEach(job -> activated.put(job.getKey(), job));
+    }
+    assertThat(activated)
+        .as(
+            "every one of the %d jobs of type '%s' was activated within %s"
+                .formatted(expected, jobType, AWAIT_TIMEOUT))
+        .hasSize(expected);
+    return activated;
+  }
+
+  /** Waits for the job of a process instance to be created and returns its key. */
+  public static long awaitJobKeyOf(final long processInstanceKey) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getKey();
+  }
+
+  /**
+   * Waits for the activation that handed this job to a worker to be exported. Both paths append a
+   * {@code JOB_BATCH ACTIVATED} event naming the job, so this covers a long poll and a push alike.
+   *
+   * <p>Every assertion about what an activation wrote, or did not write, belongs behind this. The
+   * activation response reaches the client as soon as its records are committed, while exporting
+   * them follows, so an assertion made straight after the client call can read a record set that
+   * does not hold the activation yet: a search for a leaked secret value would pass without having
+   * seen the records that carry the job, and a search for a park that should not have happened
+   * would pass whether it did or not.
+   */
+  public static void awaitActivationExported(final String jobType, final long jobKey) {
+    assertThat(
+            RecordingExporter.jobBatchRecords(JobBatchIntent.ACTIVATED)
+                .withType(jobType)
+                .valueFilter(batch -> batch.getJobKeys().contains(jobKey))
+                .limit(1)
+                .exists())
+        .as("the activation of job %s was exported".formatted(jobKey))
+        .isTrue();
+  }
+
+  /**
+   * Whether the resolution of the secret was requested for this job, i.e. whether the job was
+   * parked on it. Reads what is recorded now, so it belongs behind an await of the record that
+   * would follow the request, such as {@link #awaitActivationExported}.
+   */
+  public static boolean resolutionWasRequestedFor(final String secretName, final long jobKey) {
+    return resolutionRequestsFor(secretName).anyMatch(value -> value.getJobKeys().contains(jobKey));
+  }
+
+  /** Waits until the resolution of the secret is requested for any job. */
+  public static void awaitResolutionRequested(final String secretName) {
+    Awaitility.await("until the resolution of secret '%s' is requested".formatted(secretName))
+        .atMost(AWAIT_TIMEOUT)
+        .until(() -> resolutionRequestsFor(secretName).findAny().isPresent());
+  }
+
+  /**
+   * The states the resolution of the secret failed with, as recorded now. Both a store that is gone
+   * and a secret the store answers for and does not have end in the same {@code
+   * SECRET_RESOLUTION_ERROR} incident, so this is what tells a test which of the two it got.
+   */
+  public static List<ResolutionState> resolutionFailureStates(final String secretName) {
+    return RecordingExporter.getRecords().stream()
+        .filter(record -> record.getIntent() == SecretReferenceIntent.RESOLUTION_FAILED)
+        .filter(record -> isReferenceRecordFor(record, secretName))
+        .map(record -> ((SecretReferenceRecordValue) record.getValue()).getResolutionState())
+        .toList();
+  }
+
+  /** The jobs the resolution of the secret was requested for, i.e. the jobs it parked. */
+  public static Set<Long> parkedJobKeys(final String secretName) {
+    final Set<Long> parked = new LinkedHashSet<>();
+    resolutionRequestsFor(secretName).forEach(request -> parked.addAll(request.getJobKeys()));
+    return parked;
+  }
+
+  /**
+   * The jobs each {@code BATCH_JOBS_REACTIVATED} of the secret carried, one list per round of the
+   * reactivation chain, in the order the rounds were written.
+   */
+  public static List<List<Long>> reactivationRounds(final String secretName) {
+    return RecordingExporter.getRecords().stream()
+        .filter(record -> record.getIntent() == SecretReferenceIntent.BATCH_JOBS_REACTIVATED)
+        .filter(record -> isReferenceRecordFor(record, secretName))
+        .map(record -> ((SecretReferenceRecordValue) record.getValue()).getJobKeys())
+        .toList();
+  }
+
+  /** The partitions that requested a resolution of the secret. */
+  public static List<Integer> resolutionRequestPartitions(final String secretName) {
+    return RecordingExporter.getRecords().stream()
+        .filter(record -> record.getIntent() == SecretReferenceIntent.RESOLUTION_REQUESTED)
+        .filter(record -> isReferenceRecordFor(record, secretName))
+        .map(record -> record.getPartitionId())
+        .distinct()
+        .toList();
+  }
+
+  /**
+   * Asserts that nothing exported so far carries the value a worker was handed. Inspects what is
+   * recorded now, so it belongs behind {@link #awaitActivationExported}.
+   */
+  public static void assertNoRecordCarriesValue(final String secretValue) {
+    assertThat(RecordingExporter.getRecords())
+        .as("no exported record carries the resolved secret value")
+        .noneMatch(record -> record.toJson().contains(secretValue));
+  }
+
+  /**
+   * The incidents raised for a process instance, as recorded now: a count of them is only ever
+   * asserted to be complete, so this must not wait for one more.
+   */
+  public static List<IncidentRecordValue> incidentsOf(final long processInstanceKey) {
+    return RecordingExporter.getRecords().stream()
+        .filter(record -> record.getIntent() == IncidentIntent.CREATED)
+        .filter(record -> record.getValue() instanceof IncidentRecordValue)
+        .map(record -> (IncidentRecordValue) record.getValue())
+        .filter(incident -> incident.getProcessInstanceKey() == processInstanceKey)
+        .toList();
+  }
+
+  /** Asserts that no incident was raised at all, as recorded now. */
+  public static void assertNoIncidentWasRaised() {
+    assertThat(
+            RecordingExporter.getRecords().stream()
+                .filter(record -> record.getIntent() == IncidentIntent.CREATED))
+        .as("no incident was raised")
+        .isEmpty();
+  }
+
+  public static void awaitStreamRegistered(
+      final TestStandaloneBroker broker, final String jobType) {
+    final var actuator = JobStreamActuator.of(broker);
+    Awaitility.await("until a stream for job type '%s' is registered".formatted(jobType))
+        .atMost(AWAIT_TIMEOUT)
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(actuator)
+                    .remoteStreams()
+                    .haveJobType(1, jobType));
+  }
+
+  public static void awaitNoStreamRegistered(
+      final TestStandaloneBroker broker, final String jobType) {
+    final var actuator = JobStreamActuator.of(broker);
+    Awaitility.await("until no stream for job type '%s' is registered".formatted(jobType))
+        .atMost(AWAIT_TIMEOUT)
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(actuator)
+                    .remoteStreams()
+                    .doNotHaveJobType(jobType));
+  }
+
+  private static Stream<SecretReferenceRecordValue> resolutionRequestsFor(final String secretName) {
+    return RecordingExporter.getRecords().stream()
+        .filter(record -> record.getIntent() == SecretReferenceIntent.RESOLUTION_REQUESTED)
+        .filter(record -> isReferenceRecordFor(record, secretName))
+        .map(record -> (SecretReferenceRecordValue) record.getValue());
+  }
+
+  private static boolean isReferenceRecordFor(final Record<?> record, final String secretName) {
+    return record.getValue() instanceof final SecretReferenceRecordValue value
+        && secretName.equals(value.getSecretReference());
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretRotationOnCacheExpiryIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretRotationOnCacheExpiryIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.secret;
+
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.INPUT_TARGET;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.activateOneJob;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.applyRecordWaitTime;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.assertNoRecordCarriesValue;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitActivationExported;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitJobKeyOf;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstance;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.deployProcessWithInput;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.newBrokerWithEmptySecretStore;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionWasRequestedFor;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.secretReference;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.uniqueSecretName;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.writeSecret;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.AddTimeRequest;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers what a worker receives after the secret it uses is rotated in the store: the cached value
+ * until it expires, and the rotated one afterwards.
+ *
+ * <p>Only reachable here. The cache's expiry is driven by the broker's actor clock, which is what
+ * lets {@code /actuator/clock} reach it, and neither the clock service nor the configured ttl
+ * exists in an engine test. The ttl also cannot go below a minute, so the test moves the clock
+ * rather than waiting.
+ */
+@ZeebeIntegration
+final class SecretRotationOnCacheExpiryIT {
+
+  private static final Duration CACHE_TTL = Duration.ofMinutes(1);
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker")
+  private static TestStandaloneBroker broker;
+
+  @AutoClose private final CamundaClient client = broker.newClientBuilder().build();
+
+  private final String secretName = uniqueSecretName();
+  private final String processId = Strings.newRandomValidBpmnId();
+  private final String jobType = Strings.newRandomValidBpmnId();
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    broker =
+        newBrokerWithEmptySecretStore()
+            .withUnifiedConfig(config -> config.getSecrets().getCache().setTtl(CACHE_TTL))
+            .withProperty("zeebe.clock.controlled", true);
+  }
+
+  @BeforeEach
+  void setUp() {
+    applyRecordWaitTime();
+  }
+
+  @Test
+  void shouldServeTheRotatedSecretOnceTheCachedValueExpires() {
+    // given - a first activation that read the secret into the cache
+    final String firstValue = "first-" + secretName;
+    final String rotatedValue = "rotated-" + secretName;
+    writeSecret(broker, secretName, firstValue);
+    deployProcessWithInput(client, processId, jobType, secretReference(secretName));
+    createProcessInstance(client, processId);
+    assertThat(activateOneJob(client, jobType).getVariablesAsMap())
+        .containsEntry(INPUT_TARGET, firstValue);
+
+    // when - the secret is rotated in the store while the cached value is still within its ttl
+    writeSecret(broker, secretName, rotatedValue);
+    final long cachedInstanceKey = createProcessInstance(client, processId);
+    final long cachedJobKey = awaitJobKeyOf(cachedInstanceKey);
+
+    // then - the activation keeps serving the cached value without going through the store, since
+    // nothing reads it for a reference whose value is held
+    final ActivatedJob cachedJob = activateOneJob(client, jobType);
+    assertThat(cachedJob.getKey()).isEqualTo(cachedJobKey);
+    assertThat(cachedJob.getVariablesAsMap()).containsEntry(INPUT_TARGET, firstValue);
+    awaitActivationExported(jobType, cachedJobKey);
+    assertThat(resolutionWasRequestedFor(secretName, cachedJobKey)).isFalse();
+
+    // when - time moves past the ttl of the cached value
+    ActorClockActuator.of(broker).addTime(new AddTimeRequest(CACHE_TTL.toMillis() * 2));
+    final long rotatedInstanceKey = createProcessInstance(client, processId);
+    final long rotatedJobKey = awaitJobKeyOf(rotatedInstanceKey);
+
+    // then - the job is parked and its reference resolved again, which serves the rotated value
+    final ActivatedJob rotatedJob = activateOneJob(client, jobType);
+    assertThat(rotatedJob.getKey()).isEqualTo(rotatedJobKey);
+    assertThat(rotatedJob.getVariablesAsMap()).containsEntry(INPUT_TARGET, rotatedValue);
+    awaitActivationExported(jobType, rotatedJobKey);
+    assertThat(resolutionWasRequestedFor(secretName, rotatedJobKey))
+        .as("the expired value was resolved again rather than served from the cache")
+        .isTrue();
+    assertNoRecordCarriesValue(firstValue);
+    assertNoRecordCarriesValue(rotatedValue);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretStoreUnavailableIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretStoreUnavailableIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.secret;
+
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.INPUT_TARGET;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.activateOneJob;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.applyRecordWaitTime;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.assertNoRecordCarriesValue;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitActivationExported;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitJobKeyOf;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstance;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.deployProcessWithInput;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.newBrokerWithEmptySecretStore;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.primingPoll;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionFailureStates;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.secretReference;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.uniqueSecretName;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.writeSecret;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResolutionState;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the store-level failure of the background resolution, as opposed to a secret the store
+ * answers for and does not have: the store is taken away entirely, the retries run out, and every
+ * job waiting on the reference ends up with an incident an operator can act on.
+ *
+ * <p>Reaching that branch means a store that actually fails, which is a real store and a real
+ * configuration rather than a stub answering on demand.
+ */
+@ZeebeIntegration
+final class SecretStoreUnavailableIT {
+
+  private static final Duration RETRY_DELAY = Duration.ofMillis(200);
+  private static final int RETRY_MAX_ATTEMPTS = 2;
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker")
+  private static TestStandaloneBroker broker;
+
+  @AutoClose private final CamundaClient client = broker.newClientBuilder().build();
+
+  private final String secretName = uniqueSecretName();
+  private final String secretValue = "value-of-" + secretName;
+  private final String processId = Strings.newRandomValidBpmnId();
+  private final String jobType = Strings.newRandomValidBpmnId();
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    broker =
+        newBrokerWithEmptySecretStore()
+            .withProcessingConfig(
+                processing -> {
+                  final var secrets = processing.getEngine().getSecrets();
+                  // the ladder is only here to be exhausted, so it is walked down quickly
+                  secrets.setRetryMaxAttempts(RETRY_MAX_ATTEMPTS);
+                  secrets.setRetryInitialDelay(RETRY_DELAY);
+                  secrets.setRetryMaxDelay(RETRY_DELAY);
+                });
+  }
+
+  @BeforeEach
+  void setUp() {
+    applyRecordWaitTime();
+  }
+
+  @AfterEach
+  void restoreStore() {
+    if (Files.exists(movedAwayDirectory())) {
+      move(movedAwayDirectory(), storeDirectory());
+    }
+  }
+
+  @Test
+  void shouldIncidentWaitingJobsWhenTheStoreStaysUnavailable() {
+    // given - a job whose secret the store holds, but the store itself is gone
+    writeSecret(broker, secretName, secretValue);
+    deployProcessWithInput(client, processId, jobType, secretReference(secretName));
+    final long processInstanceKey = createProcessInstance(client, processId);
+    awaitJobKeyOf(processInstanceKey);
+    move(storeDirectory(), movedAwayDirectory());
+
+    // when - a poll parks the job and requests a resolution the store cannot answer
+    assertThat(primingPoll(client, jobType)).isEmpty();
+
+    // then - the retries run out and the waiting job gets an incident naming its secret
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withErrorType(ErrorType.SECRET_RESOLUTION_ERROR)
+            .getFirst();
+    assertThat(incident.getValue().getErrorMessage()).contains(secretName);
+
+    // and - the reference failed because the store was unavailable, which is the branch this test
+    // is here for: a secret the store answers for and does not have raises the same incident, so
+    // without this the test would stay green if a missing store degraded into a missing secret. The
+    // record is exported before the incident above, which the incident's own await has waited for
+    assertThat(resolutionFailureStates(secretName))
+        .as("the reference was failed by the store outage, not by a per-secret failure")
+        .containsOnly(ResolutionState.STORE_UNAVAILABLE);
+
+    // when - the store is back and the operator resolves the incident
+    move(movedAwayDirectory(), storeDirectory());
+    client.newResolveIncidentCommand(incident.getKey()).send().join();
+
+    // then - the job is handed out again, now with the value the store holds
+    final ActivatedJob job = activateOneJob(client, jobType);
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, secretValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertNoRecordCarriesValue(secretValue);
+  }
+
+  private Path storeDirectory() {
+    return broker.getFileBasedSecretStoreDirectory();
+  }
+
+  private Path movedAwayDirectory() {
+    return storeDirectory().resolveSibling(storeDirectory().getFileName() + "-unavailable");
+  }
+
+  private static void move(final Path from, final Path to) {
+    try {
+      Files.move(from, to);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to move '" + from + "' to '" + to + "'", e);
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantSecretIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantSecretIsolationIT.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.configuration.Secrets.FileStore;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers that the secret a job is handed comes from its own physical tenant's store: two tenants
+ * configure a store of their own, both holding a secret of the same name with a different value,
+ * and each tenant's worker only ever sees its own.
+ *
+ * <p>A store is configured and built per physical tenant at broker startup, so nothing below the
+ * running application can show that the engine of one tenant's partitions reads the right one.
+ */
+@ZeebeIntegration
+final class PhysicalTenantSecretIsolationIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+
+  private static final String SECRET_NAME = "s" + UUID.randomUUID().toString().replace("-", "");
+  private static final String SECRET_VALUE_A = "value-of-tenant-a";
+  private static final String SECRET_VALUE_B = "value-of-tenant-b";
+
+  private static final String INPUT_TARGET = "token";
+
+  // random, like every other id this suite uses, so nothing this test deploys can collide with
+  // what another test left behind
+  private static final String PROCESS_ID = Strings.newRandomValidBpmnId();
+  private static final String JOB_TYPE = Strings.newRandomValidBpmnId();
+
+  private static final Duration RESOLUTION_INTERVAL = Duration.ofMillis(200);
+  private static final Duration LONG_POLL_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration JOB_TIMEOUT = Duration.ofMinutes(5);
+
+  private static final Map<String, String> VALUE_BY_TENANT =
+      Map.of(TENANT_A, SECRET_VALUE_A, TENANT_B, SECRET_VALUE_B);
+
+  private static final Map<String, Path> STORE_BY_TENANT =
+      Map.of(TENANT_A, createStore(TENANT_A), TENANT_B, createStore(TENANT_B));
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      withPerTenantSecretStores(
+          TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess()));
+
+  @AutoClose private CamundaClient tenantAClient;
+  @AutoClose private CamundaClient tenantBClient;
+
+  @AfterAll
+  static void deleteStores() {
+    STORE_BY_TENANT.values().forEach(PhysicalTenantSecretIsolationIT::deleteQuietly);
+  }
+
+  @Test
+  void shouldHandEachTenantTheSecretOfItsOwnStore() {
+    // given
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    tenantBClient = TENANTS.newClientBuilder(broker, TENANT_B).build();
+    deployAndCreateInstance(tenantAClient);
+    deployAndCreateInstance(tenantBClient);
+
+    // when
+    final ActivatedJob jobOfTenantA = activateOneJob(tenantAClient);
+    final ActivatedJob jobOfTenantB = activateOneJob(tenantBClient);
+
+    // then - the same reference resolves to a different value per tenant
+    assertThat(jobOfTenantA.getVariablesAsMap()).containsEntry(INPUT_TARGET, SECRET_VALUE_A);
+    assertThat(jobOfTenantB.getVariablesAsMap()).containsEntry(INPUT_TARGET, SECRET_VALUE_B);
+  }
+
+  private static TestStandaloneBroker withPerTenantSecretStores(final TestStandaloneBroker broker) {
+    STORE_BY_TENANT.forEach(
+        (tenantId, directory) -> {
+          final var store = new FileStore();
+          store.setPath(directory.toString());
+          broker.withPtConfig(
+              tenantId,
+              camunda -> {
+                camunda.getSecrets().getStores().getFile().put("default", store);
+                camunda.getProcessing().getEngine().getSecrets().setInterval(RESOLUTION_INTERVAL);
+              });
+        });
+    return broker;
+  }
+
+  /** One directory per tenant, each holding the same secret name with the tenant's own value. */
+  private static Path createStore(final String tenantId) {
+    try {
+      final Path directory = Files.createTempDirectory("secret-store-" + tenantId + "-");
+      Files.writeString(
+          directory.resolve(SECRET_NAME), VALUE_BY_TENANT.get(tenantId), StandardCharsets.UTF_8);
+      return directory;
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to write the store of tenant " + tenantId, e);
+    }
+  }
+
+  private static void deleteQuietly(final Path directory) {
+    try {
+      FileUtil.deleteFolderIfExists(directory);
+    } catch (final IOException e) {
+      // a leftover temp directory is not worth failing a passing test over
+    }
+  }
+
+  private static void deployAndCreateInstance(final CamundaClient client) {
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    task ->
+                        task.zeebeJobType(JOB_TYPE)
+                            .zeebeInputExpression("camunda.secrets." + SECRET_NAME, INPUT_TARGET))
+                .endEvent()
+                .done(),
+            PROCESS_ID + ".bpmn")
+        .send()
+        .join();
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+  }
+
+  private static ActivatedJob activateOneJob(final CamundaClient client) {
+    final var jobs =
+        client
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE)
+            .maxJobsToActivate(1)
+            .timeout(JOB_TIMEOUT)
+            .requestTimeout(LONG_POLL_TIMEOUT)
+            .send()
+            .join()
+            .getJobs();
+    assertThat(jobs).hasSize(1);
+    return jobs.get(0);
+  }
+}


### PR DESCRIPTION
## Description

End-to-end integration tests for secret resolution at job activation, covering both the long poll
(#56563) and the job push (#56564) against a real gateway, a real client and a real file-based
secret store.

The engine suites already cover the processing of one activation command against a stubbed cache, so
these tests deliberately do not repeat that. They assert what only lives outside the stream
processor:

- a long poll that finds the job parked returns nothing and stays open, so it is the reactivation's
  workers-notified broadcast that has to complete it
- a job stream never receives that broadcast, so a reactivated job only reaches a streaming worker
  because the reactivation pushes it
- a job that references two secrets waits for both and is then activated once with both values
- the cache expiry is driven by the broker's actor clock, so a rotated secret reaches workers only
  once the cached value expires
- the values a broker holds are in memory, so a restart has to send the loop round again rather than
  leave those jobs undeliverable
- a store is built per physical tenant, so a job must be handed the secret of its own tenant's store
- no exported record carries a value a worker was handed

22 tests in 6 classes on a shared harness, one commit per class:

| Class | Tests | Covers |
|---|---|---|
| `SecretResolutionTestHarness` | - | the broker, process, polls and exporter queries the suite shares |
| `SecretResolutionJobActivationIT` | 17 | blocked long poll woken by the reactivation, push to a real stream, warm cache, park despite a `fetchVariables` exclusion, listener job of the same element seeing the placeholder, incident and operator fix on both paths, announce when the stream is gone, re-injection on retry, cancel while parked, a job with two references (mixed cached/uncached, and one resolving while the other fails), a secret value that outgrows the activation batch, 150 jobs waiting on one reference, and a secret reached through a `SECRET_REFERENCE` cluster variable on both paths and after that variable is updated |
| `SecretRotationOnCacheExpiryIT` | 1 | rotation picked up once the cached value expires |
| `SecretResolutionAfterRestartIT` | 1 | resolution running again after a restart emptied the cache |
| `SecretStoreUnavailableIT` | 1 | store outage, retries exhausted, incident an operator clears |
| `SecretResolutionMultiPartitionIT` | 1 | one secret shared by jobs of three partitions |
| `PhysicalTenantSecretIsolationIT` | 1 | two tenants, same secret name, different values |

Four harness rules are worth knowing when adding to this suite, and are documented in the code:

- an assertion on the exported records has to be anchored. `RecordingExporter` is filled after the
  records of a command are committed, while the client call that wrote them returns as soon as they
  are, so a scan made straight after a poll can inspect a record set the activation has not reached.
  `awaitActivationExported` is the anchor, and every assertion about what an activation did or did
  not write belongs behind it.
- while no stream is registered, a created job is announced to the workers **without** its
  references being checked, and the long poll that follows owns the check. A test that needs a job
  parked has to poll for it first.
- the secret cache is per broker and shared with the gateway's secret endpoints, so every test uses
  its own secret name or it runs against a warm cache and never exercises the cache-miss path. The
  name also has to be a single alphanumeric FEEL segment.
- a multi-partition test needs `@TestZeebe(partitionCount = N)`, which only drives the topology
  await, on top of the broker's own `withClusterConfig(setPartitionCount)`.

## Findings

Writing these surfaced one bug, reported separately as #60060: injecting secret values may grow an
activation batch by at most `BATCH_SIZE_CALCULATION_BUFFER` (8 KB) rather than by the free message
size, so a job carrying a larger value is rejected with a `MESSAGE_SIZE_EXCEEDED` incident whose
message names 4 MB. The test pins the current behaviour and asserts the error type and job key
rather than that message, so fixing the wording will not break it, but fixing the limit will (noted
on #60060).

Two cases were deliberately left to the engine level rather than added here, since they need a
scripted cache stub that only an engine test has: a cache eviction between the reference check and
the injection, and one between the reactivation and the hand-out inside a single
`BATCH_REACTIVATE_JOBS` command.

Two more were left out after review, for reasons given in the review thread: a store outage that
recovers before the retries run out (nothing in the record stream marks a retry attempt, so an
end-to-end version would have to race the scheduler on a blind timer, and the ladder is covered in
`SecretResolutionSchedulerTest`), and the `ACCESS_DENIED` / `INVALID_REF` classifications (neither is
reachable through the file store, and all three permanent codes map to `ResolutionState.NOT_FOUND`
until #57855 refines them).

## Related issues

Closes #56565

Part of #56556. Follows #56563 (long polling) and #56564 (job push).
