### PR TITLE
feat: plan a rebalance (in dry-run mode)

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStep.java
@@ -7,14 +7,16 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionLeaders;
 import io.camunda.zeebe.rebalance.ProtoBufRebalanceSerializer;
 import io.camunda.zeebe.rebalance.RebalanceCoordinator;
 import io.camunda.zeebe.rebalance.RebalanceRequestServer;
-import io.camunda.zeebe.rebalance.RebalanceRunner;
+import io.camunda.zeebe.rebalance.SequentialRebalanceRunner;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
+import java.time.Clock;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,8 +64,12 @@ public class RebalanceCoordinatorStep implements StartupStep<BrokerStartupContex
                   new RebalanceCoordinator(
                       localMember,
                       rebalanceCoordinatorActor,
-                      RebalanceRunner.none(),
-                      () -> brokerStartupContext.getRequestIdGenerator().nextId());
+                      new SequentialRebalanceRunner(
+                          rebalanceCoordinatorActor,
+                          new TopologyPartitionLeaders(
+                              brokerStartupContext.getBrokerClient().getTopologyManager())),
+                      () -> brokerStartupContext.getRequestIdGenerator().nextId(),
+                      Clock.systemUTC());
               rebalanceRequestServer =
                   new RebalanceRequestServer(
                       brokerStartupContext.getClusterServices().getCommunicationService(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionLeaders.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionLeaders.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.topology;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.rebalance.PartitionLeaders;
+import java.util.Optional;
+import org.jspecify.annotations.NullMarked;
+
+/** Identifies which member currently leads each partition, as the cluster topology sees it. */
+@NullMarked
+public final class TopologyPartitionLeaders implements PartitionLeaders {
+
+  private final BrokerTopologyManager topologyManager;
+
+  public TopologyPartitionLeaders(final BrokerTopologyManager topologyManager) {
+    this.topologyManager = topologyManager;
+  }
+
+  @Override
+  public PartitionGroupLeaders forGroup(final String physicalTenantId) {
+    final var topology = topologyManager.getTopology(physicalTenantId);
+    if (topology == null) {
+      throw new IllegalStateException(
+          "Topology for physical tenant %s is unavailable".formatted(physicalTenantId));
+    }
+    return new TopologyGroupLeaders(topology);
+  }
+
+  private record TopologyGroupLeaders(BrokerClusterState topology)
+      implements PartitionGroupLeaders {
+    @Override
+    public Optional<MemberId> currentLeader(final int partitionId) {
+      return Optional.ofNullable(topology.getLeaderForPartition(partitionId))
+          .map(BrokerMemberId::memberId);
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionLeadersTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionLeadersTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import org.junit.jupiter.api.Test;
+
+final class TopologyPartitionLeadersTest {
+
+  private final BrokerClusterState topology = mock(BrokerClusterState.class);
+  private final BrokerTopologyManager topologyManager = mock(BrokerTopologyManager.class);
+  private final TopologyPartitionLeaders partitionLeaders =
+      new TopologyPartitionLeaders(topologyManager);
+
+  @Test
+  void shouldReportTheLeaderTheTopologyKnows() {
+    // given
+    when(topologyManager.getTopology("tenant-a")).thenReturn(topology);
+    when(topology.getLeaderForPartition(3)).thenReturn(BrokerMemberId.from("2"));
+
+    // when
+    final var leader = partitionLeaders.forGroup("tenant-a").currentLeader(3);
+
+    // then
+    assertThat(leader).contains(MemberId.from("2"));
+  }
+
+  @Test
+  void shouldReportNoLeaderForAPartitionTheKnownTopologyHasNoneFor() {
+    // given
+    when(topologyManager.getTopology("tenant-a")).thenReturn(topology);
+    when(topology.getLeaderForPartition(3)).thenReturn(null);
+
+    // when
+    final var leader = partitionLeaders.forGroup("tenant-a").currentLeader(3);
+
+    // then
+    assertThat(leader).isEmpty();
+  }
+
+  @Test
+  void shouldFailToObtainAGroupViewWhenTheTopologyIsNotYetKnown() {
+    // given
+    when(topologyManager.getTopology("tenant-a")).thenReturn(null);
+
+    // when / then
+    assertThatThrownBy(() -> partitionLeaders.forGroup("tenant-a"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tenant-a");
+  }
+
+  @Test
+  void shouldObtainTheTopologyOnceForAllLookupsOnTheSameGroupView() {
+    // given
+    when(topologyManager.getTopology("tenant-a")).thenReturn(topology);
+    when(topology.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from("1"));
+    when(topology.getLeaderForPartition(2)).thenReturn(BrokerMemberId.from("2"));
+
+    // when
+    final var groupLeaders = partitionLeaders.forGroup("tenant-a");
+    groupLeaders.currentLeader(1);
+    groupLeaders.currentLeader(2);
+
+    // then
+    verify(topologyManager, times(1)).getTopology("tenant-a");
+  }
+}

--- a/zeebe/rebalance/pom.xml
+++ b/zeebe/rebalance/pom.xml
@@ -35,6 +35,12 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-atomix-cluster</artifactId>
     </dependency>
 

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterConfigurationCoordinatorCheck.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterConfigurationCoordinatorCheck.java
@@ -14,14 +14,12 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSuppli
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Broker-supplied check that the node asking for a leadership transfer really is the cluster's
  * current coordinator.
  */
-@NullMarked
 public final class ClusterConfigurationCoordinatorCheck
     implements LeadershipTransferCoordinatorCheck {
 

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionLeaders.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionLeaders.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.rebalance;
 
 import io.atomix.cluster.MemberId;
 import java.util.Optional;
-import org.jspecify.annotations.NullMarked;
 
 /**
  * Identifies which member currently leads each partition, as the cluster topology sees it.
@@ -18,7 +17,6 @@ import org.jspecify.annotations.NullMarked;
  * configuration, which says which members replicate a partition and with what priority but not
  * which of them holds leadership right now.
  */
-@NullMarked
 public interface PartitionLeaders {
   /**
    * Obtains a view of the leaders known for a physical tenant's partition group, backed by a single
@@ -30,7 +28,6 @@ public interface PartitionLeaders {
   PartitionGroupLeaders forGroup(String physicalTenantId);
 
   /** A snapshot of which member leads each partition of a single physical tenant's group. */
-  @NullMarked
   interface PartitionGroupLeaders {
     /**
      * The member leading the given partition, or empty if the topology is known to have no leader

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionLeaders.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionLeaders.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.atomix.cluster.MemberId;
+import java.util.Optional;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Identifies which member currently leads each partition, as the cluster topology sees it.
+ *
+ * <p>The rebalancing coordinator reads leadership from here rather than from the cluster
+ * configuration, which says which members replicate a partition and with what priority but not
+ * which of them holds leadership right now.
+ */
+@NullMarked
+public interface PartitionLeaders {
+  /**
+   * Obtains a view of the leaders known for a physical tenant's partition group, backed by a single
+   * topology snapshot.
+   *
+   * @param physicalTenantId the partition group to look up leaders for
+   * @throws IllegalStateException if the topology for the physical tenant is unavailable
+   */
+  PartitionGroupLeaders forGroup(String physicalTenantId);
+
+  /** A snapshot of which member leads each partition of a single physical tenant's group. */
+  @NullMarked
+  interface PartitionGroupLeaders {
+    /**
+     * The member leading the given partition, or empty if the topology is known to have no leader
+     * for it.
+     *
+     * @param partitionId the partition id
+     */
+    Optional<MemberId> currentLeader(int partitionId);
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.atomix.cluster.MemberId;
+import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A single partition's status within a rebalance.
+ *
+ * <p>The desired leader is picked once, when the rebalance is planned. The current leader is what
+ * the coordinator last observed.
+ *
+ * @param physicalTenantId the partition group this partition belongs to; partition ids are unique
+ *     only within a group
+ * @param partitionId the partition id
+ * @param currentLeader the leader last observed, or {@code null} if the partition has none
+ * @param desiredLeader the leader this rebalance wants
+ * @param progress where the rebalance has got to with this partition
+ * @param outcome the terminal outcome for this partition in the rebalance (only set if {@code
+ *     progress} is {@link PartitionRebalanceProgress#COMPLETED})
+ */
+@NullMarked
+public record PartitionRebalance(
+    String physicalTenantId,
+    int partitionId,
+    @Nullable MemberId currentLeader,
+    MemberId desiredLeader,
+    PartitionRebalanceProgress progress,
+    @Nullable PartitionRebalanceOutcome outcome) {
+
+  public PartitionRebalance {
+    if (progress == PartitionRebalanceProgress.COMPLETED && outcome == null) {
+      throw new IllegalArgumentException(
+          "A partition rebalance completed for partition %d of %s must have an outcome"
+              .formatted(partitionId, physicalTenantId));
+    }
+    if (progress != PartitionRebalanceProgress.COMPLETED && outcome != null) {
+      throw new IllegalArgumentException(
+          "A partition rebalance for partition %d of %s with progress %s must not have an "
+              + "outcome".formatted(partitionId, physicalTenantId, progress));
+    }
+  }
+
+  public PartitionRebalance(
+      final String physicalTenantId,
+      final int partitionId,
+      final @Nullable MemberId currentLeader,
+      final MemberId desiredLeader,
+      final PartitionRebalanceProgress progress) {
+    this(physicalTenantId, partitionId, currentLeader, desiredLeader, progress, null);
+  }
+
+  /** A partition still waiting for the rebalance to transfer its leadership. */
+  public static PartitionRebalance pending(
+      final String physicalTenantId,
+      final int partitionId,
+      final @Nullable MemberId currentLeader,
+      final MemberId desiredLeader) {
+    return new PartitionRebalance(
+        physicalTenantId,
+        partitionId,
+        currentLeader,
+        desiredLeader,
+        PartitionRebalanceProgress.PENDING);
+  }
+
+  /** A partition the rebalance had nothing to do for: it was already led by its desired leader. */
+  public static PartitionRebalance alreadyLeader(
+      final String physicalTenantId, final int partitionId, final MemberId leader) {
+    return new PartitionRebalance(
+        physicalTenantId,
+        partitionId,
+        leader,
+        leader,
+        PartitionRebalanceProgress.COMPLETED,
+        PartitionRebalanceOutcome.ALREADY_LEADER);
+  }
+
+  /** Whether leadership is where this rebalance wants it. */
+  public boolean isBalanced() {
+    return Objects.equals(desiredLeader, currentLeader);
+  }
+
+  /** Completes the partition with a given outcome. */
+  public PartitionRebalance completed(final PartitionRebalanceOutcome completedOutcome) {
+    return new PartitionRebalance(
+        physicalTenantId,
+        partitionId,
+        currentLeader,
+        desiredLeader,
+        PartitionRebalanceProgress.COMPLETED,
+        completedOutcome);
+  }
+
+  /** Records that leadership reached the desired leader. */
+  public PartitionRebalance transferred() {
+    return new PartitionRebalance(
+        physicalTenantId,
+        partitionId,
+        desiredLeader,
+        desiredLeader,
+        PartitionRebalanceProgress.COMPLETED,
+        PartitionRebalanceOutcome.TRANSFERRED);
+  }
+
+  @Override
+  public String toString() {
+    return "partition %d of %s".formatted(partitionId, physicalTenantId);
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
@@ -108,9 +108,4 @@ public record PartitionRebalance(
         PartitionRebalanceProgress.COMPLETED,
         PartitionRebalanceOutcome.TRANSFERRED);
   }
-
-  @Override
-  public String toString() {
-    return "partition %d of %s".formatted(partitionId, physicalTenantId);
-  }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.rebalance;
 
 import io.atomix.cluster.MemberId;
 import java.util.Objects;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -27,7 +26,6 @@ import org.jspecify.annotations.Nullable;
  * @param outcome the terminal outcome for this partition in the rebalance (only set if {@code
  *     progress} is {@link PartitionRebalanceProgress#COMPLETED})
  */
-@NullMarked
 public record PartitionRebalance(
     String physicalTenantId,
     int partitionId,

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcome.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcome.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+/**
+ * The terminal outcome for a single partition within a rebalance.
+ *
+ * <p>Mirrors {@link io.atomix.raft.LeadershipTransferResult} so that a partition's outcome
+ * preserves exactly what the leader reported. The only additions are outcomes the rebalance
+ * coordinator itself produces: {@link #NO_LEADER}, {@link #NO_RESPONSE} and {@link #CANCELLED}.
+ */
+public enum PartitionRebalanceOutcome {
+  /** The desired leader was promoted and took over leadership. */
+  TRANSFERRED,
+  /** The desired leader is already the leader; nothing to do. */
+  ALREADY_LEADER,
+  /** The desired leader is not a member of the partition. */
+  NOT_MEMBER,
+  /**
+   * The desired leader has not acknowledged an append in this term, so its log has not converged.
+   */
+  NOT_REPLICATING,
+  /** The desired leader is out of contact with this leader. */
+  UNREACHABLE,
+  /**
+   * The request did not come from the current coordinator, the lowest-id member of the leader's
+   * committed configuration.
+   */
+  NOT_COORDINATOR,
+  /** The request carried a cluster configuration version other than the leader's current one. */
+  STALE_CONFIGURATION,
+  /** The leader was already running another transfer. */
+  TRANSFER_IN_PROGRESS,
+  /** The desired leader's replication lag was above the configured threshold. */
+  LAG_TOO_HIGH,
+  /** This leader has not committed the initial entry of its term yet. */
+  LEADER_INITIALIZING,
+  /**
+   * A Raft configuration change is in progress, so the log head the desired leader would catch up
+   * to cannot be frozen.
+   */
+  CONFIGURATION_CHANGE_IN_PROGRESS,
+  /** The leader could not freeze the partition for the transfer. */
+  PAUSE_FAILED,
+  /** The desired leader did not finish replicating within the configured timeout. */
+  REPLICATION_TIMED_OUT,
+  /** TimeoutNow did not move leadership within the configured number of attempts. */
+  TIMEOUT_NOW_EXHAUSTED,
+  /** Leadership changed to a member other than the desired leader during the transfer. */
+  LEADER_CHANGED,
+  /** The partition had no leader when the rebalance reached it. */
+  NO_LEADER,
+  /** The partition's leader could not be reached to ask for the transfer. */
+  NO_RESPONSE,
+  /** The rebalance was cancelled before this partition's transfer completed. */
+  CANCELLED
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalanceProgress.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalanceProgress.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+/**
+ * Where a rebalance has got to with one partition, independent of what the outcome was (see {@link
+ * PartitionRebalanceOutcome}).
+ */
+public enum PartitionRebalanceProgress {
+  /** The rebalance has not reached this partition yet. */
+  PENDING,
+  /** The partition's leader accepted the transfer and is running it. */
+  TRANSFERRING,
+  /** The rebalance is done with this partition (successfully or not). */
+  COMPLETED
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -289,40 +289,44 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
         decodeErrorCode(error.getErrorCode()), error.getErrorMessage());
   }
 
-  private Rebalance.RebalanceOutcome encodeOutcome(final RebalanceOutcome outcome) {
+  private Rebalance.CompletedRebalance.RebalanceOutcome encodeOutcome(
+      final RebalanceOutcome outcome) {
     return switch (outcome) {
-      case COMPLETED -> Rebalance.RebalanceOutcome.REBALANCE_COMPLETED;
-      case CANCELLED -> Rebalance.RebalanceOutcome.REBALANCE_CANCELLED;
-      case FAILED -> Rebalance.RebalanceOutcome.REBALANCE_FAILED;
+      case COMPLETED -> Rebalance.CompletedRebalance.RebalanceOutcome.COMPLETED;
+      case CANCELLED -> Rebalance.CompletedRebalance.RebalanceOutcome.CANCELLED;
+      case FAILED -> Rebalance.CompletedRebalance.RebalanceOutcome.FAILED;
     };
   }
 
-  private RebalanceOutcome decodeOutcome(final Rebalance.RebalanceOutcome outcome) {
+  private RebalanceOutcome decodeOutcome(
+      final Rebalance.CompletedRebalance.RebalanceOutcome outcome) {
     return switch (outcome) {
-      case REBALANCE_COMPLETED -> RebalanceOutcome.COMPLETED;
-      case REBALANCE_CANCELLED -> RebalanceOutcome.CANCELLED;
-      case REBALANCE_FAILED -> RebalanceOutcome.FAILED;
+      case COMPLETED -> RebalanceOutcome.COMPLETED;
+      case CANCELLED -> RebalanceOutcome.CANCELLED;
+      case FAILED -> RebalanceOutcome.FAILED;
       case REBALANCE_OUTCOME_UNSPECIFIED, UNRECOGNIZED ->
           throw new DecodingFailed("Rebalance outcome is missing or unrecognized: " + outcome);
     };
   }
 
-  private Rebalance.RebalanceErrorCode encodeErrorCode(final RebalanceErrorCode code) {
+  private Rebalance.RebalanceErrorResponse.RebalanceErrorCode encodeErrorCode(
+      final RebalanceErrorCode code) {
     return switch (code) {
-      case REBALANCE_IN_PROGRESS -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_IN_PROGRESS;
-      case NOT_COORDINATOR -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_NOT_COORDINATOR;
+      case REBALANCE_IN_PROGRESS -> Rebalance.RebalanceErrorResponse.RebalanceErrorCode.IN_PROGRESS;
+      case NOT_COORDINATOR -> Rebalance.RebalanceErrorResponse.RebalanceErrorCode.NOT_COORDINATOR;
       case CONFIGURATION_CHANGE_IN_PROGRESS ->
-          Rebalance.RebalanceErrorCode.REBALANCE_ERROR_CONFIGURATION_CHANGE_IN_PROGRESS;
-      case INTERNAL_ERROR -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_UNSPECIFIED;
+          Rebalance.RebalanceErrorResponse.RebalanceErrorCode.CONFIGURATION_CHANGE_IN_PROGRESS;
+      case INTERNAL_ERROR ->
+          Rebalance.RebalanceErrorResponse.RebalanceErrorCode.REBALANCE_ERROR_UNSPECIFIED;
     };
   }
 
-  private RebalanceErrorCode decodeErrorCode(final Rebalance.RebalanceErrorCode code) {
+  private RebalanceErrorCode decodeErrorCode(
+      final Rebalance.RebalanceErrorResponse.RebalanceErrorCode code) {
     return switch (code) {
-      case REBALANCE_ERROR_IN_PROGRESS -> RebalanceErrorCode.REBALANCE_IN_PROGRESS;
-      case REBALANCE_ERROR_NOT_COORDINATOR -> RebalanceErrorCode.NOT_COORDINATOR;
-      case REBALANCE_ERROR_CONFIGURATION_CHANGE_IN_PROGRESS ->
-          RebalanceErrorCode.CONFIGURATION_CHANGE_IN_PROGRESS;
+      case IN_PROGRESS -> RebalanceErrorCode.REBALANCE_IN_PROGRESS;
+      case NOT_COORDINATOR -> RebalanceErrorCode.NOT_COORDINATOR;
+      case CONFIGURATION_CHANGE_IN_PROGRESS -> RebalanceErrorCode.CONFIGURATION_CHANGE_IN_PROGRESS;
       case REBALANCE_ERROR_UNSPECIFIED, UNRECOGNIZED -> RebalanceErrorCode.INTERNAL_ERROR;
     };
   }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -16,10 +16,8 @@ import io.camunda.zeebe.rebalance.protocol.Rebalance;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.time.Instant;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSerializer {
 
   @Override

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -8,12 +8,16 @@
 package io.camunda.zeebe.rebalance;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Timestamp;
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.serializer.DecodingFailed;
 import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
 import io.camunda.zeebe.rebalance.protocol.Rebalance;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
+import java.time.Instant;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSerializer {
@@ -131,16 +135,147 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
               .setRebalanceId(running.rebalanceId())
               .setOverrides(encodeOverrides(running.overrides()))
               .setDryRun(running.dryRun())
-              .setCancelRequested(running.cancelRequested()));
+              .setCancelRequested(running.cancelRequested())
+              .addAllPartitions(running.partitions().stream().map(this::encodePartition).toList()));
     }
     final var lastCompleted = status.lastCompleted();
     if (lastCompleted != null) {
       builder.setLastCompleted(
           Rebalance.CompletedRebalance.newBuilder()
               .setRebalanceId(lastCompleted.rebalanceId())
-              .setOutcome(encodeOutcome(lastCompleted.outcome())));
+              .setOutcome(encodeOutcome(lastCompleted.outcome()))
+              .setDryRun(lastCompleted.dryRun())
+              .addAllPartitions(
+                  lastCompleted.partitions().stream().map(this::encodePartition).toList())
+              .setStartedAt(toTimestamp(lastCompleted.startedAt()))
+              .setFinishedAt(toTimestamp(lastCompleted.finishedAt())));
     }
     return builder.build();
+  }
+
+  private Rebalance.PartitionRebalance encodePartition(final PartitionRebalance partition) {
+    final var builder =
+        Rebalance.PartitionRebalance.newBuilder()
+            .setPhysicalTenantId(partition.physicalTenantId())
+            .setPartitionId(partition.partitionId())
+            .setDesiredLeader(partition.desiredLeader().id())
+            .setProgress(encodePartitionProgress(partition.progress()));
+    if (partition.currentLeader() != null) {
+      builder.setCurrentLeader(partition.currentLeader().id());
+    }
+    if (partition.outcome() != null) {
+      builder.setOutcome(encodePartitionOutcome(partition.outcome()));
+    }
+    return builder.build();
+  }
+
+  private PartitionRebalance decodePartition(final Rebalance.PartitionRebalance partition) {
+    if (!partition.hasDesiredLeader()) {
+      throw new DecodingFailed("A partition rebalance is missing its desired leader: " + partition);
+    }
+    final var progress = decodePartitionProgress(partition.getProgress());
+    return new PartitionRebalance(
+        partition.getPhysicalTenantId(),
+        partition.getPartitionId(),
+        partition.hasCurrentLeader() ? MemberId.from(partition.getCurrentLeader()) : null,
+        MemberId.from(partition.getDesiredLeader()),
+        progress,
+        decodePartitionOutcome(progress, partition));
+  }
+
+  private Rebalance.PartitionRebalance.Progress encodePartitionProgress(
+      final PartitionRebalanceProgress progress) {
+    return switch (progress) {
+      case PENDING -> Rebalance.PartitionRebalance.Progress.PENDING;
+      case TRANSFERRING -> Rebalance.PartitionRebalance.Progress.TRANSFERRING;
+      case COMPLETED -> Rebalance.PartitionRebalance.Progress.COMPLETED;
+    };
+  }
+
+  private PartitionRebalanceProgress decodePartitionProgress(
+      final Rebalance.PartitionRebalance.Progress progress) {
+    return switch (progress) {
+      case PENDING -> PartitionRebalanceProgress.PENDING;
+      case TRANSFERRING -> PartitionRebalanceProgress.TRANSFERRING;
+      case COMPLETED -> PartitionRebalanceProgress.COMPLETED;
+      case PROGRESS_UNSPECIFIED, UNRECOGNIZED ->
+          throw new DecodingFailed(
+              "Partition rebalance progress is missing or unrecognized: " + progress);
+    };
+  }
+
+  /**
+   * An outcome is required once {@code progress} is {@link PartitionRebalanceProgress#COMPLETED}
+   * and must not otherwise be present, matching {@link PartitionRebalance}'s own invariant.
+   */
+  private @Nullable PartitionRebalanceOutcome decodePartitionOutcome(
+      final PartitionRebalanceProgress progress, final Rebalance.PartitionRebalance partition) {
+    if (progress != PartitionRebalanceProgress.COMPLETED) {
+      if (partition.hasOutcome()) {
+        throw new DecodingFailed(
+            "A partition rebalance with progress %s must not have an outcome: %s"
+                .formatted(progress, partition));
+      }
+      return null;
+    }
+    if (!partition.hasOutcome()) {
+      throw new DecodingFailed(
+          "A completed partition rebalance is missing its outcome: " + partition);
+    }
+    return decodePartitionOutcomeValue(partition.getOutcome());
+  }
+
+  private Rebalance.PartitionRebalance.Outcome encodePartitionOutcome(
+      final PartitionRebalanceOutcome outcome) {
+    return switch (outcome) {
+      case TRANSFERRED -> Rebalance.PartitionRebalance.Outcome.TRANSFERRED;
+      case ALREADY_LEADER -> Rebalance.PartitionRebalance.Outcome.ALREADY_LEADER;
+      case NOT_MEMBER -> Rebalance.PartitionRebalance.Outcome.NOT_MEMBER;
+      case NOT_REPLICATING -> Rebalance.PartitionRebalance.Outcome.NOT_REPLICATING;
+      case UNREACHABLE -> Rebalance.PartitionRebalance.Outcome.UNREACHABLE;
+      case NOT_COORDINATOR -> Rebalance.PartitionRebalance.Outcome.NOT_COORDINATOR;
+      case STALE_CONFIGURATION -> Rebalance.PartitionRebalance.Outcome.STALE_CONFIGURATION;
+      case TRANSFER_IN_PROGRESS -> Rebalance.PartitionRebalance.Outcome.TRANSFER_IN_PROGRESS;
+      case LAG_TOO_HIGH -> Rebalance.PartitionRebalance.Outcome.LAG_TOO_HIGH;
+      case LEADER_INITIALIZING -> Rebalance.PartitionRebalance.Outcome.LEADER_INITIALIZING;
+      case CONFIGURATION_CHANGE_IN_PROGRESS ->
+          Rebalance.PartitionRebalance.Outcome.CONFIGURATION_CHANGE_IN_PROGRESS;
+      case PAUSE_FAILED -> Rebalance.PartitionRebalance.Outcome.PAUSE_FAILED;
+      case REPLICATION_TIMED_OUT -> Rebalance.PartitionRebalance.Outcome.REPLICATION_TIMED_OUT;
+      case TIMEOUT_NOW_EXHAUSTED -> Rebalance.PartitionRebalance.Outcome.TIMEOUT_NOW_EXHAUSTED;
+      case LEADER_CHANGED -> Rebalance.PartitionRebalance.Outcome.LEADER_CHANGED;
+      case NO_LEADER -> Rebalance.PartitionRebalance.Outcome.NO_LEADER;
+      case NO_RESPONSE -> Rebalance.PartitionRebalance.Outcome.NO_RESPONSE;
+      case CANCELLED -> Rebalance.PartitionRebalance.Outcome.CANCELLED;
+    };
+  }
+
+  private PartitionRebalanceOutcome decodePartitionOutcomeValue(
+      final Rebalance.PartitionRebalance.Outcome outcome) {
+    return switch (outcome) {
+      case TRANSFERRED -> PartitionRebalanceOutcome.TRANSFERRED;
+      case ALREADY_LEADER -> PartitionRebalanceOutcome.ALREADY_LEADER;
+      case NOT_MEMBER -> PartitionRebalanceOutcome.NOT_MEMBER;
+      case NOT_REPLICATING -> PartitionRebalanceOutcome.NOT_REPLICATING;
+      case UNREACHABLE -> PartitionRebalanceOutcome.UNREACHABLE;
+      case NOT_COORDINATOR -> PartitionRebalanceOutcome.NOT_COORDINATOR;
+      case STALE_CONFIGURATION -> PartitionRebalanceOutcome.STALE_CONFIGURATION;
+      case TRANSFER_IN_PROGRESS -> PartitionRebalanceOutcome.TRANSFER_IN_PROGRESS;
+      case LAG_TOO_HIGH -> PartitionRebalanceOutcome.LAG_TOO_HIGH;
+      case LEADER_INITIALIZING -> PartitionRebalanceOutcome.LEADER_INITIALIZING;
+      case CONFIGURATION_CHANGE_IN_PROGRESS ->
+          PartitionRebalanceOutcome.CONFIGURATION_CHANGE_IN_PROGRESS;
+      case PAUSE_FAILED -> PartitionRebalanceOutcome.PAUSE_FAILED;
+      case REPLICATION_TIMED_OUT -> PartitionRebalanceOutcome.REPLICATION_TIMED_OUT;
+      case TIMEOUT_NOW_EXHAUSTED -> PartitionRebalanceOutcome.TIMEOUT_NOW_EXHAUSTED;
+      case LEADER_CHANGED -> PartitionRebalanceOutcome.LEADER_CHANGED;
+      case NO_LEADER -> PartitionRebalanceOutcome.NO_LEADER;
+      case NO_RESPONSE -> PartitionRebalanceOutcome.NO_RESPONSE;
+      case CANCELLED -> PartitionRebalanceOutcome.CANCELLED;
+      case OUTCOME_UNSPECIFIED, UNRECOGNIZED ->
+          throw new DecodingFailed(
+              "Partition rebalance outcome is missing or unrecognized: " + outcome);
+    };
   }
 
   private RebalanceStatus decodeStatus(final Rebalance.RebalanceStatusResponse status) {
@@ -154,12 +289,18 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
         running.getRebalanceId(),
         decodeOverrides(running.getOverrides()),
         running.getDryRun(),
-        running.getCancelRequested());
+        running.getCancelRequested(),
+        running.getPartitionsList().stream().map(this::decodePartition).toList());
   }
 
   private RebalanceStatus.Completed decodeCompleted(final Rebalance.CompletedRebalance completed) {
     return new RebalanceStatus.Completed(
-        completed.getRebalanceId(), decodeOutcome(completed.getOutcome()));
+        completed.getRebalanceId(),
+        decodeOutcome(completed.getOutcome()),
+        completed.getDryRun(),
+        completed.getPartitionsList().stream().map(this::decodePartition).toList(),
+        fromTimestamp(completed.getStartedAt()),
+        fromTimestamp(completed.getFinishedAt()));
   }
 
   private RebalanceErrorResponse decodeError(final Rebalance.RebalanceErrorResponse error) {
@@ -189,6 +330,8 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
     return switch (code) {
       case REBALANCE_IN_PROGRESS -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_IN_PROGRESS;
       case NOT_COORDINATOR -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_NOT_COORDINATOR;
+      case CONFIGURATION_CHANGE_IN_PROGRESS ->
+          Rebalance.RebalanceErrorCode.REBALANCE_ERROR_CONFIGURATION_CHANGE_IN_PROGRESS;
       case INTERNAL_ERROR -> Rebalance.RebalanceErrorCode.REBALANCE_ERROR_UNSPECIFIED;
     };
   }
@@ -197,7 +340,20 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
     return switch (code) {
       case REBALANCE_ERROR_IN_PROGRESS -> RebalanceErrorCode.REBALANCE_IN_PROGRESS;
       case REBALANCE_ERROR_NOT_COORDINATOR -> RebalanceErrorCode.NOT_COORDINATOR;
+      case REBALANCE_ERROR_CONFIGURATION_CHANGE_IN_PROGRESS ->
+          RebalanceErrorCode.CONFIGURATION_CHANGE_IN_PROGRESS;
       case REBALANCE_ERROR_UNSPECIFIED, UNRECOGNIZED -> RebalanceErrorCode.INTERNAL_ERROR;
     };
+  }
+
+  private static Timestamp toTimestamp(final Instant instant) {
+    return Timestamp.newBuilder()
+        .setSeconds(instant.getEpochSecond())
+        .setNanos(instant.getNano())
+        .build();
+  }
+
+  private static Instant fromTimestamp(final Timestamp timestamp) {
+    return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
   }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -171,14 +171,13 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
     if (!partition.hasDesiredLeader()) {
       throw new DecodingFailed("A partition rebalance is missing its desired leader: " + partition);
     }
-    final var progress = decodePartitionProgress(partition.getProgress());
     return new PartitionRebalance(
         partition.getPhysicalTenantId(),
         partition.getPartitionId(),
         partition.hasCurrentLeader() ? MemberId.from(partition.getCurrentLeader()) : null,
         MemberId.from(partition.getDesiredLeader()),
-        progress,
-        decodePartitionOutcome(progress, partition));
+        decodePartitionProgress(partition.getProgress()),
+        decodePartitionOutcome(partition));
   }
 
   private Rebalance.PartitionRebalance.Progress encodePartitionProgress(
@@ -202,25 +201,9 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
     };
   }
 
-  /**
-   * An outcome is required once {@code progress} is {@link PartitionRebalanceProgress#COMPLETED}
-   * and must not otherwise be present, matching {@link PartitionRebalance}'s own invariant.
-   */
   private @Nullable PartitionRebalanceOutcome decodePartitionOutcome(
-      final PartitionRebalanceProgress progress, final Rebalance.PartitionRebalance partition) {
-    if (progress != PartitionRebalanceProgress.COMPLETED) {
-      if (partition.hasOutcome()) {
-        throw new DecodingFailed(
-            "A partition rebalance with progress %s must not have an outcome: %s"
-                .formatted(progress, partition));
-      }
-      return null;
-    }
-    if (!partition.hasOutcome()) {
-      throw new DecodingFailed(
-          "A completed partition rebalance is missing its outcome: " + partition);
-    }
-    return decodePartitionOutcomeValue(partition.getOutcome());
+      final Rebalance.PartitionRebalance partition) {
+    return partition.hasOutcome() ? decodePartitionOutcomeValue(partition.getOutcome()) : null;
   }
 
   private Rebalance.PartitionRebalance.Outcome encodePartitionOutcome(

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceApi.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceApi.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.rebalance;
 
+import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.ConfigurationChangeInProgressException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.RebalanceInProgressException;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -23,6 +24,8 @@ public interface RebalanceApi {
    * @throws RebalanceInProgressException If a rebalance is already running.
    * @throws NotCoordinatorException If the request is received by a broker that is not the current
    *     coordinator.
+   * @throws ConfigurationChangeInProgressException If a cluster configuration change is pending, so
+   *     there is no settled configuration to plan the rebalance against.
    */
   ActorFuture<RebalanceStatus> triggerRebalance(TriggerRebalanceRequest request);
 

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceApi.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceApi.java
@@ -11,10 +11,8 @@ import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.ConfigurationC
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.RebalanceInProgressException;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import org.jspecify.annotations.NullMarked;
 
 /** Interface for the rebalance coordinator. */
-@NullMarked
 public interface RebalanceApi {
   /**
    * Starts a cluster-wide rebalance and reports the status it starts from. Fails with {@link

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
@@ -11,11 +11,14 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.ConfigurationChangeInProgressException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.RebalanceInProgressException;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Nulls;
+import java.time.Clock;
 import java.util.function.LongSupplier;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -42,8 +45,13 @@ public final class RebalanceCoordinator
   private final ConcurrencyControl executor;
   private final RebalanceRunner runner;
   private final LongSupplier rebalanceIdGenerator;
+  private final Clock clock;
 
-  private boolean coordinating;
+  /**
+   * The configuration this member coordinates under, or {@code null} while it does not coordinate.
+   */
+  private @Nullable CurrentClusterConfiguration configuration;
+
   private @Nullable RebalanceRun running;
 
   private RebalanceStatus.@Nullable Completed lastCompleted;
@@ -52,15 +60,23 @@ public final class RebalanceCoordinator
       final MemberId localMemberId,
       final ConcurrencyControl executor,
       final RebalanceRunner runner,
-      final LongSupplier rebalanceIdGenerator) {
+      final LongSupplier rebalanceIdGenerator,
+      final Clock clock) {
     this.localMemberId = localMemberId;
     this.executor = executor;
     this.runner = runner;
     this.rebalanceIdGenerator = rebalanceIdGenerator;
+    this.clock = clock;
   }
 
   @Override
   public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
+    onClusterConfigurationUpdated(CurrentClusterConfiguration.fromLegacy(clusterConfiguration));
+  }
+
+  @Override
+  public void onClusterConfigurationUpdated(
+      final CurrentClusterConfiguration clusterConfiguration) {
     executor.run(() -> updateCoordinatorRole(clusterConfiguration));
   }
 
@@ -72,7 +88,7 @@ public final class RebalanceCoordinator
     final ActorFuture<Void> result = executor.createFuture();
     executor.run(
         () -> {
-          coordinating = false;
+          configuration = null;
           discardState();
           result.complete(Nulls.uncheckedCastToNonNull(null));
         });
@@ -84,7 +100,15 @@ public final class RebalanceCoordinator
     final ActorFuture<RebalanceStatus> result = executor.createFuture();
     executor.run(
         () -> {
-          if (rejectIfNotCoordinating(result)) {
+          final var coordinatedConfiguration = coordinatedConfiguration(result);
+          if (coordinatedConfiguration == null) {
+            return;
+          }
+          if (!coordinatedConfiguration.phasedChangeState().pending().isEmpty()) {
+            result.completeExceptionally(
+                new ConfigurationChangeInProgressException(
+                    "Cannot start a rebalance while a cluster configuration change is in "
+                        + "progress"));
             return;
           }
           final var inFlight = running;
@@ -96,13 +120,21 @@ public final class RebalanceCoordinator
           }
           final var rebalance =
               new RebalanceRun(
-                  rebalanceIdGenerator.getAsLong(), request.overrides(), request.dryRun());
+                  rebalanceIdGenerator.getAsLong(),
+                  request.overrides(),
+                  request.dryRun(),
+                  coordinatedConfiguration,
+                  clock.instant());
           running = rebalance;
           LOG.info("Starting {}rebalance {}", rebalance.dryRun() ? "dry-run " : "", rebalance.id());
-          // Answer before running so the operator sees the rebalance they started, whatever it goes
-          // on to do.
-          result.complete(status());
-          start(rebalance);
+          if (rebalance.dryRun()) {
+            // A dry run only reads the plan, so it is over within the request and answers with the
+            // plan itself.
+            start(rebalance, () -> result.complete(status()));
+          } else {
+            result.complete(status());
+            start(rebalance, () -> {});
+          }
         });
     return result;
   }
@@ -112,7 +144,7 @@ public final class RebalanceCoordinator
     final ActorFuture<RebalanceStatus> result = executor.createFuture();
     executor.run(
         () -> {
-          if (rejectIfNotCoordinating(result)) {
+          if (coordinatedConfiguration(result) == null) {
             return;
           }
           result.complete(status());
@@ -125,7 +157,7 @@ public final class RebalanceCoordinator
     final ActorFuture<CancelRebalanceResponse> result = executor.createFuture();
     executor.run(
         () -> {
-          if (rejectIfNotCoordinating(result)) {
+          if (coordinatedConfiguration(result) == null) {
             return;
           }
           final var inFlight = running;
@@ -142,15 +174,21 @@ public final class RebalanceCoordinator
     return result;
   }
 
-  private void start(final RebalanceRun rebalance) {
+  private void start(final RebalanceRun rebalance, final Runnable whenFinished) {
     final ActorFuture<Void> run;
     try {
       run = runner.run(rebalance);
     } catch (final Exception e) {
       finish(rebalance, e);
+      whenFinished.run();
       return;
     }
-    executor.runOnCompletion(run, (ignored, error) -> finish(rebalance, error));
+    executor.runOnCompletion(
+        run,
+        (ignored, error) -> {
+          finish(rebalance, error);
+          whenFinished.run();
+        });
   }
 
   private void finish(final RebalanceRun rebalance, final @Nullable Throwable error) {
@@ -168,28 +206,36 @@ public final class RebalanceCoordinator
     } else {
       outcome = RebalanceOutcome.COMPLETED;
     }
-    lastCompleted = new RebalanceStatus.Completed(rebalance.id(), outcome);
+    final var finishedAt = clock.instant();
+    rebalance.finish(finishedAt);
+    lastCompleted =
+        new RebalanceStatus.Completed(
+            rebalance.id(),
+            outcome,
+            rebalance.dryRun(),
+            rebalance.partitions(),
+            rebalance.startedAt(),
+            finishedAt);
     LOG.info("Rebalance {} finished as {}", rebalance.id(), outcome);
   }
 
-  private void updateCoordinatorRole(final ClusterConfiguration clusterConfiguration) {
+  private void updateCoordinatorRole(final CurrentClusterConfiguration clusterConfiguration) {
     if (clusterConfiguration.isUninitialized()) {
       return;
     }
     final var coordinator =
-        ClusterConfigurationCoordinatorSupplier.ofMembers(clusterConfiguration.members().keySet())
+        ClusterConfigurationCoordinatorSupplier.ofMembers(clusterConfiguration.getMembers())
             .getDefaultCoordinator();
     final var nowCoordinating = localMemberId.equals(coordinator);
-    if (nowCoordinating == coordinating) {
-      return;
+    if (nowCoordinating != (configuration != null)) {
+      if (nowCoordinating) {
+        LOG.info("Coordinating rebalances as the lowest-id member of the cluster configuration");
+      } else {
+        LOG.info("No longer coordinating rebalances, {} is now the lowest-id member", coordinator);
+        discardState();
+      }
     }
-    coordinating = nowCoordinating;
-    if (nowCoordinating) {
-      LOG.info("Coordinating rebalances as the lowest-id member of the cluster configuration");
-    } else {
-      LOG.info("No longer coordinating rebalances, {} is now the lowest-id member", coordinator);
-      discardState();
-    }
+    configuration = nowCoordinating ? clusterConfiguration : null;
   }
 
   private void discardState() {
@@ -202,14 +248,19 @@ public final class RebalanceCoordinator
     lastCompleted = null;
   }
 
-  private boolean rejectIfNotCoordinating(final ActorFuture<?> result) {
-    if (coordinating) {
-      return false;
+  /**
+   * The configuration this member coordinates under, or {@code null} - having refused {@code
+   * result} - if it is not the coordinator.
+   */
+  private @Nullable CurrentClusterConfiguration coordinatedConfiguration(
+      final ActorFuture<?> result) {
+    final var current = configuration;
+    if (current == null) {
+      result.completeExceptionally(
+          new NotCoordinatorException(
+              "Member %s is not the rebalancing coordinator".formatted(localMemberId.id())));
     }
-    result.completeExceptionally(
-        new NotCoordinatorException(
-            "Member %s is not the rebalancing coordinator".formatted(localMemberId.id())));
-    return true;
+    return current;
   }
 
   private RebalanceStatus status() {
@@ -221,7 +272,8 @@ public final class RebalanceCoordinator
                 inFlight.id(),
                 inFlight.overrides(),
                 inFlight.dryRun(),
-                inFlight.isCancelRequested());
+                inFlight.isCancelRequested(),
+                inFlight.partitions());
     return new RebalanceStatus(runningStatus, lastCompleted);
   }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Nulls;
 import java.time.Clock;
 import java.util.function.LongSupplier;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +34,6 @@ import org.slf4j.LoggerFactory;
  * coordinator. A member that stops being eligible to act as the coordinator drops any currently
  * running rebalance.
  */
-@NullMarked
 public final class RebalanceCoordinator
     implements RebalanceApi, ClusterConfigurationUpdateListener {
 

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceErrorResponse.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceErrorResponse.java
@@ -15,6 +15,11 @@ public record RebalanceErrorResponse(RebalanceErrorCode code, String message) {
     REBALANCE_IN_PROGRESS,
     /** The member that received the request is not the current coordinator. */
     NOT_COORDINATOR,
+    /**
+     * A cluster configuration change is pending, so the configuration to plan against is not
+     * settled.
+     */
+    CONFIGURATION_CHANGE_IN_PROGRESS,
     INTERNAL_ERROR
   }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceOverrides.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceOverrides.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.rebalance;
 
 import java.time.Duration;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -22,7 +21,6 @@ import org.jspecify.annotations.Nullable;
  * @param maxTransferAttempts The maximum number of TimeoutNow requests the current leader sends
  *     (including the initial request).
  */
-@NullMarked
 public record RebalanceOverrides(
     @Nullable Long replicationLagThreshold,
     @Nullable Duration replicationTimeout,

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestFailedException.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestFailedException.java
@@ -43,4 +43,20 @@ public abstract sealed class RebalanceRequestFailedException extends RuntimeExce
       return RebalanceErrorCode.NOT_COORDINATOR;
     }
   }
+
+  /**
+   * Signals that a cluster configuration change is pending, so there is no settled configuration to
+   * plan a rebalance against.
+   */
+  public static final class ConfigurationChangeInProgressException
+      extends RebalanceRequestFailedException {
+    public ConfigurationChangeInProgressException(final String message) {
+      super(message);
+    }
+
+    @Override
+    public RebalanceErrorCode getErrorCode() {
+      return RebalanceErrorCode.CONFIGURATION_CHANGE_IN_PROGRESS;
+    }
+  }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestSender.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestSender.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import org.jspecify.annotations.NullMarked;
 
 /**
  * Forwards rebalance requests to the coordinator (the lowest-id member of the cluster).
@@ -21,7 +20,6 @@ import org.jspecify.annotations.NullMarked;
  * <p>Rebalances are run asynchronously, so these requests only ever start, check, or stop one (none
  * of them waits for a rebalance to finish).
  */
-@NullMarked
 public final class RebalanceRequestSender {
   private static final Duration TIMEOUT = Duration.ofSeconds(10);
 

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestServer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestServer.java
@@ -16,14 +16,12 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.jspecify.annotations.NullMarked;
 
 /**
  * Receives the forwarded rebalance requests on every member and answers them from the local {@link
  * RebalanceApi} implementation. On any node other than the current coordinator, the API refuses
  * requests with {@link RebalanceErrorCode#NOT_COORDINATOR}.
  */
-@NullMarked
 public final class RebalanceRequestServer implements AutoCloseable {
   private final ClusterCommunicationService communicationService;
   private final RebalanceRequestsSerializer serializer;

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestsSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRequestsSerializer.java
@@ -8,10 +8,8 @@
 package io.camunda.zeebe.rebalance;
 
 import io.camunda.zeebe.util.Either;
-import org.jspecify.annotations.NullMarked;
 
 /** Serializes rebalance requests to be forwarded to the coordinator. */
-@NullMarked
 public interface RebalanceRequestsSerializer {
 
   byte[] encodeTriggerRebalanceRequest(TriggerRebalanceRequest request);

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
@@ -7,7 +7,13 @@
  */
 package io.camunda.zeebe.rebalance;
 
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.UnaryOperator;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A rebalance the coordinator is running.
@@ -20,14 +26,25 @@ public final class RebalanceRun {
   private final long id;
   private final RebalanceOverrides overrides;
   private final boolean dryRun;
+  private final CurrentClusterConfiguration configuration;
+  private final Instant startedAt;
+  private final List<PartitionRebalance> partitions = new ArrayList<>();
 
   private boolean cancelRequested;
   private boolean abandoned;
+  private @Nullable Instant finishedAt;
 
-  public RebalanceRun(final long id, final RebalanceOverrides overrides, final boolean dryRun) {
+  public RebalanceRun(
+      final long id,
+      final RebalanceOverrides overrides,
+      final boolean dryRun,
+      final CurrentClusterConfiguration configuration,
+      final Instant startedAt) {
     this.id = id;
     this.overrides = overrides;
     this.dryRun = dryRun;
+    this.configuration = configuration;
+    this.startedAt = startedAt;
   }
 
   public long id() {
@@ -44,9 +61,56 @@ public final class RebalanceRun {
     return dryRun;
   }
 
+  /** The committed cluster configuration this rebalance was admitted under. */
+  public CurrentClusterConfiguration configuration() {
+    return configuration;
+  }
+
+  /** When this rebalance was created. */
+  public Instant startedAt() {
+    return startedAt;
+  }
+
+  /** When this rebalance finished, or {@code null} while it is still running. */
+  public @Nullable Instant finishedAt() {
+    return finishedAt;
+  }
+
+  /** Records that this rebalance finished at the given instant. */
+  public void finish(final Instant finishedAt) {
+    this.finishedAt = finishedAt;
+  }
+
   /**
-   * Asks the rebalance to stop. A cancellation never interrupts a partition transfer which is
-   * currently in flight.
+   * The partitions this rebalance covers, in the order it works through them, each with where the
+   * rebalance has got to with it. Empty until the runner has planned the rebalance.
+   */
+  public List<PartitionRebalance> partitions() {
+    return List.copyOf(partitions);
+  }
+
+  /** Fixes the partitions this rebalance covers, and the leaders it moves leadership between. */
+  public void plan(final List<PartitionRebalance> planned) {
+    partitions.clear();
+    partitions.addAll(planned);
+  }
+
+  public PartitionRebalance partition(final int index) {
+    return partitions.get(index);
+  }
+
+  public int partitionCount() {
+    return partitions.size();
+  }
+
+  /** Records what became of the partition at {@code index} as the rebalance works through it. */
+  public void updatePartition(final int index, final UnaryOperator<PartitionRebalance> updater) {
+    partitions.set(index, updater.apply(partitions.get(index)));
+  }
+
+  /**
+   * Asks the rebalance to stop. A cancellation never interrupts the transfer in flight, so the
+   * runner is expected to observe this between partitions rather than part-way through one.
    */
   public void requestCancel() {
     cancelRequested = true;

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
@@ -12,7 +12,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.UnaryOperator;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -20,7 +19,6 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>Access is confined to the coordinator's actor thread.
  */
-@NullMarked
 public final class RebalanceRun {
 
   private final long id;

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRunner.java
@@ -9,10 +9,8 @@ package io.camunda.zeebe.rebalance;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import org.jspecify.annotations.NullMarked;
 
 /** Drives the leadership transfers of one rebalance, one partition at a time. */
-@NullMarked
 @FunctionalInterface
 public interface RebalanceRunner {
   /**

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.rebalance;
 
 import java.time.Instant;
 import java.util.List;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -20,7 +19,6 @@ import org.jspecify.annotations.Nullable;
  * @param lastCompleted the last rebalance this coordinator finished, or {@code null} if it has not
  *     finished one since becoming coordinator (not preserved over restarts)
  */
-@NullMarked
 public record RebalanceStatus(@Nullable Running running, @Nullable Completed lastCompleted) {
   /** No running rebalance, no previously completed rebalance. */
   public static RebalanceStatus idle() {

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.rebalance;
 
+import java.time.Instant;
+import java.util.List;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -33,15 +35,32 @@ public record RebalanceStatus(@Nullable Running running, @Nullable Completed las
    * @param dryRun true if this rebalance is a dry-run (no pauses or transfers will be performed)
    * @param cancelRequested the rebalance has been requested to stop (will take effect after any
    *     in-flight transfer finishes)
+   * @param partitions every partition this rebalance covers and where it has got to with each, or
+   *     empty while the rebalance is still being planned
    */
   public record Running(
-      long rebalanceId, RebalanceOverrides overrides, boolean dryRun, boolean cancelRequested) {}
+      long rebalanceId,
+      RebalanceOverrides overrides,
+      boolean dryRun,
+      boolean cancelRequested,
+      List<PartitionRebalance> partitions) {}
 
   /**
    * Outcome of the last completed rebalance.
    *
    * @param rebalanceId identifies this rebalance in the coordinator's logs
    * @param outcome the outcome of the rebalance
+   * @param dryRun true if this rebalance was a dry-run (no pauses or transfers were performed)
+   * @param partitions every partition the rebalance covered and what became of each; for a dry run,
+   *     the plan it would have carried out
+   * @param startedAt when this rebalance was created
+   * @param finishedAt when this rebalance finished
    */
-  public record Completed(long rebalanceId, RebalanceOutcome outcome) {}
+  public record Completed(
+      long rebalanceId,
+      RebalanceOutcome outcome,
+      boolean dryRun,
+      List<PartitionRebalance> partitions,
+      Instant startedAt,
+      Instant finishedAt) {}
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +22,6 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Runs entirely on the coordinator's actor thread.
  */
-@NullMarked
 public final class SequentialRebalanceRunner implements RebalanceRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(SequentialRebalanceRunner.class);

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a single rebalance request, one partition at a time.
+ *
+ * <p>Runs entirely on the coordinator's actor thread.
+ */
+@NullMarked
+public final class SequentialRebalanceRunner implements RebalanceRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SequentialRebalanceRunner.class);
+
+  private final ConcurrencyControl executor;
+  private final PartitionLeaders partitionLeaders;
+
+  public SequentialRebalanceRunner(
+      final ConcurrencyControl executor, final PartitionLeaders partitionLeaders) {
+    this.executor = executor;
+    this.partitionLeaders = partitionLeaders;
+  }
+
+  @Override
+  public ActorFuture<Void> run(final RebalanceRun rebalance) {
+    rebalance.plan(plan(rebalance.configuration()));
+    logPlan(rebalance);
+    return executor.createCompletedFuture();
+  }
+
+  /** Decides what the rebalance will do to each partition. */
+  private List<PartitionRebalance> plan(final CurrentClusterConfiguration configuration) {
+    return configuration.partitionGroups().entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .flatMap(entry -> planGroup(entry.getKey(), entry.getValue()))
+        .toList();
+  }
+
+  private Stream<PartitionRebalance> planGroup(
+      final String physicalTenantId, final PartitionGroupConfiguration group) {
+    final var groupLeaders = partitionLeaders.forGroup(physicalTenantId);
+    return group
+        .partitionIds()
+        .mapToObj(partitionId -> planPartition(physicalTenantId, group, groupLeaders, partitionId));
+  }
+
+  private PartitionRebalance planPartition(
+      final String physicalTenantId,
+      final PartitionGroupConfiguration group,
+      final PartitionLeaders.PartitionGroupLeaders groupLeaders,
+      final int partitionId) {
+    final var desiredLeader =
+        group
+            .getDesiredLeader(partitionId)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No member of physical tenant %s's partition group is eligible to lead "
+                            + "partition %d, so it cannot be planned"
+                                .formatted(physicalTenantId, partitionId)));
+    final var currentLeader = groupLeaders.currentLeader(partitionId);
+    if (currentLeader.map(desiredLeader::equals).orElse(false)) {
+      return PartitionRebalance.alreadyLeader(physicalTenantId, partitionId, desiredLeader);
+    }
+    return PartitionRebalance.pending(
+        physicalTenantId, partitionId, currentLeader.orElse(null), desiredLeader);
+  }
+
+  private void logPlan(final RebalanceRun rebalance) {
+    final var toTransfer =
+        rebalance.partitions().stream()
+            .filter(partition -> partition.progress() == PartitionRebalanceProgress.PENDING)
+            .toList();
+    LOG.info(
+        "Rebalance {} covers {} partitions, {} of them already led by the leader it wants. It will "
+            + "transfer, in order: {}",
+        rebalance.id(),
+        rebalance.partitionCount(),
+        rebalance.partitionCount() - toTransfer.size(),
+        toTransfer.stream()
+            .map(
+                partition ->
+                    "%s from %s to %s"
+                        .formatted(partition, partition.currentLeader(), partition.desiredLeader()))
+            .toList());
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/TriggerRebalanceRequest.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/TriggerRebalanceRequest.java
@@ -7,15 +7,12 @@
  */
 package io.camunda.zeebe.rebalance;
 
-import org.jspecify.annotations.NullMarked;
-
 /**
  * Asks the coordinator to start a cluster-wide rebalance.
  *
  * @param overrides any overrides for rebalance settings applying to this run
  * @param dryRun run pre-checks and report the plan without pausing or transferring anything
  */
-@NullMarked
 public record TriggerRebalanceRequest(RebalanceOverrides overrides, boolean dryRun) {
   public static TriggerRebalanceRequest withConfiguredSettings() {
     return new TriggerRebalanceRequest(RebalanceOverrides.none(), false);

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/package-info.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.rebalance;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -1,6 +1,8 @@
 syntax = 'proto3';
 package rebalance_requests;
 
+import "google/protobuf/timestamp.proto";
+
 option java_package = "io.camunda.zeebe.rebalance.protocol";
 
 message TriggerRebalanceRequest {
@@ -27,11 +29,62 @@ message RunningRebalance {
   RebalanceOverrides overrides = 2;
   bool dryRun = 3;
   bool cancelRequested = 4;
+  // Empty until the rebalance has been planned.
+  repeated PartitionRebalance partitions = 5;
 }
 
 message CompletedRebalance {
   uint64 rebalanceId = 1;
   RebalanceOutcome outcome = 2;
+  bool dryRun = 3;
+  repeated PartitionRebalance partitions = 4;
+  google.protobuf.Timestamp startedAt = 5;
+  google.protobuf.Timestamp finishedAt = 6;
+}
+
+message PartitionRebalance {
+  // Nested so that its values do not collide with RebalanceOutcome's: proto enum values are
+  // scoped to the enclosing message, not to the enum.
+  enum Progress {
+    PROGRESS_UNSPECIFIED = 0;
+    PENDING = 1;
+    TRANSFERRING = 2;
+    COMPLETED = 3;
+  }
+
+  // What became of the partition once Progress reaches COMPLETED. Deliberately separate from
+  // Progress: progress is where the rebalance has got to, outcome is what it did.
+  enum Outcome {
+    OUTCOME_UNSPECIFIED = 0;
+    TRANSFERRED = 1;
+    ALREADY_LEADER = 2;
+    NOT_MEMBER = 3;
+    NOT_REPLICATING = 4;
+    UNREACHABLE = 5;
+    NOT_COORDINATOR = 6;
+    STALE_CONFIGURATION = 7;
+    TRANSFER_IN_PROGRESS = 8;
+    LAG_TOO_HIGH = 9;
+    LEADER_INITIALIZING = 10;
+    CONFIGURATION_CHANGE_IN_PROGRESS = 11;
+    PAUSE_FAILED = 12;
+    REPLICATION_TIMED_OUT = 13;
+    TIMEOUT_NOW_EXHAUSTED = 14;
+    LEADER_CHANGED = 15;
+    NO_LEADER = 16;
+    NO_RESPONSE = 17;
+    CANCELLED = 18;
+  }
+
+  // The partition group the partition belongs to; partition ids are unique only within a group.
+  string physicalTenantId = 1;
+  uint32 partitionId = 2;
+  // Absent while the partition has no leader.
+  optional string currentLeader = 3;
+  optional string desiredLeader = 4;
+  Progress progress = 5;
+  // Absent while progress is PENDING or TRANSFERRING; required once progress is COMPLETED.
+  optional Outcome outcome = 6;
 }
 
 message CancelRebalanceResponse {
@@ -62,4 +115,5 @@ enum RebalanceErrorCode {
   REBALANCE_ERROR_UNSPECIFIED = 0;
   REBALANCE_ERROR_IN_PROGRESS = 1;
   REBALANCE_ERROR_NOT_COORDINATOR = 2;
+  REBALANCE_ERROR_CONFIGURATION_CHANGE_IN_PROGRESS = 3;
 }

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -34,6 +34,15 @@ message RunningRebalance {
 }
 
 message CompletedRebalance {
+  // Nested so that its values do not collide with RebalanceErrorCode's: proto enum values are
+  // scoped to the enclosing message, not to the enum.
+  enum RebalanceOutcome {
+    REBALANCE_OUTCOME_UNSPECIFIED = 0;
+    COMPLETED = 1;
+    CANCELLED = 2;
+    FAILED = 3;
+  }
+
   uint64 rebalanceId = 1;
   RebalanceOutcome outcome = 2;
   bool dryRun = 3;
@@ -91,13 +100,6 @@ message CancelRebalanceResponse {
   bool wasRunning = 1;
 }
 
-enum RebalanceOutcome {
-  REBALANCE_OUTCOME_UNSPECIFIED = 0;
-  REBALANCE_COMPLETED = 1;
-  REBALANCE_CANCELLED = 2;
-  REBALANCE_FAILED = 3;
-}
-
 message Response {
   oneof response {
     RebalanceErrorResponse error = 1;
@@ -107,13 +109,13 @@ message Response {
 }
 
 message RebalanceErrorResponse {
+  enum RebalanceErrorCode {
+    REBALANCE_ERROR_UNSPECIFIED = 0;
+    IN_PROGRESS = 1;
+    NOT_COORDINATOR = 2;
+    CONFIGURATION_CHANGE_IN_PROGRESS = 3;
+  }
+
   RebalanceErrorCode errorCode = 1;
   string errorMessage = 2;
-}
-
-enum RebalanceErrorCode {
-  REBALANCE_ERROR_UNSPECIFIED = 0;
-  REBALANCE_ERROR_IN_PROGRESS = 1;
-  REBALANCE_ERROR_NOT_COORDINATOR = 2;
-  REBALANCE_ERROR_CONFIGURATION_CHANGE_IN_PROGRESS = 3;
 }

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcomeAlignmentTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcomeAlignmentTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.raft.LeadershipTransferResult;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link PartitionRebalanceOutcome} is the rebalance-domain representation of {@link
+ * LeadershipTransferResult}: every Raft transfer result must have an identically named outcome, so
+ * that a new result added to Raft cannot silently collapse into nothing on the rebalance side.
+ */
+final class PartitionRebalanceOutcomeAlignmentTest {
+
+  @Test
+  void shouldHaveAnIdenticallyNamedOutcomeForEveryTransferResult() {
+    // given
+    final var transferResultNames = namesOf(LeadershipTransferResult.class);
+    final var outcomeNames = namesOf(PartitionRebalanceOutcome.class);
+
+    // then
+    assertThat(transferResultNames).allMatch(outcomeNames::contains);
+  }
+
+  @Test
+  void shouldOnlyAddCoordinatorOriginatedOutcomesBeyondTransferResults() {
+    // given
+    final var transferResultNames = namesOf(LeadershipTransferResult.class);
+    final var outcomeNames = namesOf(PartitionRebalanceOutcome.class);
+
+    // when
+    final var additionalOutcomeNames =
+        outcomeNames.stream()
+            .filter(name -> !transferResultNames.contains(name))
+            .collect(Collectors.toSet());
+
+    // then
+    assertThat(additionalOutcomeNames)
+        .containsExactlyInAnyOrder("NO_LEADER", "NO_RESPONSE", "CANCELLED");
+  }
+
+  private static Set<String> namesOf(final Class<? extends Enum<?>> enumType) {
+    return Arrays.stream(enumType.getEnumConstants()).map(Enum::name).collect(Collectors.toSet());
+  }
+}

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
@@ -206,7 +206,7 @@ final class ProtoBufRebalanceSerializerTest {
                     .setLastCompleted(
                         Rebalance.CompletedRebalance.newBuilder()
                             .setRebalanceId(7)
-                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .setOutcome(Rebalance.CompletedRebalance.RebalanceOutcome.COMPLETED)
                             .addPartitions(
                                 Rebalance.PartitionRebalance.newBuilder()
                                     .setPhysicalTenantId("default")
@@ -246,7 +246,7 @@ final class ProtoBufRebalanceSerializerTest {
                     .setLastCompleted(
                         Rebalance.CompletedRebalance.newBuilder()
                             .setRebalanceId(7)
-                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .setOutcome(Rebalance.CompletedRebalance.RebalanceOutcome.COMPLETED)
                             .addPartitions(
                                 Rebalance.PartitionRebalance.newBuilder()
                                     .setPhysicalTenantId("default")
@@ -269,7 +269,7 @@ final class ProtoBufRebalanceSerializerTest {
                     .setLastCompleted(
                         Rebalance.CompletedRebalance.newBuilder()
                             .setRebalanceId(7)
-                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .setOutcome(Rebalance.CompletedRebalance.RebalanceOutcome.COMPLETED)
                             .addPartitions(
                                 Rebalance.PartitionRebalance.newBuilder()
                                     .setPhysicalTenantId("default")
@@ -293,7 +293,7 @@ final class ProtoBufRebalanceSerializerTest {
                     .setLastCompleted(
                         Rebalance.CompletedRebalance.newBuilder()
                             .setRebalanceId(7)
-                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .setOutcome(Rebalance.CompletedRebalance.RebalanceOutcome.COMPLETED)
                             .addPartitions(
                                 Rebalance.PartitionRebalance.newBuilder()
                                     .setPhysicalTenantId("default")
@@ -318,7 +318,7 @@ final class ProtoBufRebalanceSerializerTest {
                     .setLastCompleted(
                         Rebalance.CompletedRebalance.newBuilder()
                             .setRebalanceId(7)
-                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .setOutcome(Rebalance.CompletedRebalance.RebalanceOutcome.COMPLETED)
                             .addPartitions(
                                 Rebalance.PartitionRebalance.newBuilder()
                                     .setPhysicalTenantId("default")
@@ -344,7 +344,7 @@ final class ProtoBufRebalanceSerializerTest {
                     .setLastCompleted(
                         Rebalance.CompletedRebalance.newBuilder()
                             .setRebalanceId(7)
-                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .setOutcome(Rebalance.CompletedRebalance.RebalanceOutcome.COMPLETED)
                             .addPartitions(
                                 Rebalance.PartitionRebalance.newBuilder()
                                     .setPhysicalTenantId("default")

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
@@ -298,13 +298,14 @@ final class ProtoBufRebalanceSerializerTest {
                                 Rebalance.PartitionRebalance.newBuilder()
                                     .setPhysicalTenantId("default")
                                     .setPartitionId(3)
+                                    .setDesiredLeader("1")
                                     .setProgress(Rebalance.PartitionRebalance.Progress.COMPLETED))))
             .build()
             .toByteArray();
 
     // when/then
     assertThatThrownBy(() -> serializer.decodeRebalanceStatusResponse(encoded))
-        .isInstanceOf(DecodingFailed.class);
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
@@ -10,15 +10,21 @@ package io.camunda.zeebe.rebalance;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.serializer.DecodingFailed;
 import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
 import io.camunda.zeebe.rebalance.protocol.Rebalance;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 final class ProtoBufRebalanceSerializerTest {
+
+  private static final Instant STARTED_AT = Instant.parse("2024-01-01T00:00:00Z");
+  private static final Instant FINISHED_AT = Instant.parse("2024-01-01T00:00:05Z");
 
   private final ProtoBufRebalanceSerializer serializer = new ProtoBufRebalanceSerializer();
 
@@ -83,8 +89,24 @@ final class ProtoBufRebalanceSerializerTest {
     final var status =
         new RebalanceStatus(
             new RebalanceStatus.Running(
-                42, new RebalanceOverrides(null, Duration.ofSeconds(15), null), true, true),
-            new RebalanceStatus.Completed(41, RebalanceOutcome.CANCELLED));
+                42,
+                new RebalanceOverrides(null, Duration.ofSeconds(15), null),
+                true,
+                true,
+                List.of(
+                    new PartitionRebalance(
+                        "default",
+                        1,
+                        MemberId.from("0"),
+                        MemberId.from("1"),
+                        PartitionRebalanceProgress.TRANSFERRING))),
+            new RebalanceStatus.Completed(
+                41,
+                RebalanceOutcome.CANCELLED,
+                false,
+                List.of(PartitionRebalance.alreadyLeader("tenant-a", 2, MemberId.from("2"))),
+                STARTED_AT,
+                FINISHED_AT));
 
     // when
     final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
@@ -97,7 +119,56 @@ final class ProtoBufRebalanceSerializerTest {
   @EnumSource(RebalanceOutcome.class)
   void shouldRoundTripEveryOutcome(final RebalanceOutcome outcome) {
     // given
-    final var status = new RebalanceStatus(null, new RebalanceStatus.Completed(7, outcome));
+    final var status =
+        new RebalanceStatus(
+            null,
+            new RebalanceStatus.Completed(7, outcome, false, List.of(), STARTED_AT, FINISHED_AT));
+
+    // when
+    final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
+
+    // then
+    assertThat(decoded.get()).isEqualTo(status);
+  }
+
+  @ParameterizedTest
+  @EnumSource(PartitionRebalanceProgress.class)
+  void shouldRoundTripEveryPartitionProgress(final PartitionRebalanceProgress progress) {
+    // given
+    final var partition =
+        progress == PartitionRebalanceProgress.COMPLETED
+            ? PartitionRebalance.alreadyLeader("default", 3, MemberId.from("1"))
+            : new PartitionRebalance("default", 3, null, MemberId.from("1"), progress);
+    final var status =
+        new RebalanceStatus(
+            null,
+            new RebalanceStatus.Completed(
+                7, RebalanceOutcome.COMPLETED, false, List.of(partition), STARTED_AT, FINISHED_AT));
+
+    // when
+    final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
+
+    // then
+    assertThat(decoded.get()).isEqualTo(status);
+  }
+
+  @ParameterizedTest
+  @EnumSource(PartitionRebalanceOutcome.class)
+  void shouldRoundTripEveryPartitionOutcome(final PartitionRebalanceOutcome outcome) {
+    // given
+    final var partition =
+        new PartitionRebalance(
+            "default",
+            3,
+            MemberId.from("1"),
+            MemberId.from("1"),
+            PartitionRebalanceProgress.COMPLETED,
+            outcome);
+    final var status =
+        new RebalanceStatus(
+            null,
+            new RebalanceStatus.Completed(
+                7, RebalanceOutcome.COMPLETED, false, List.of(partition), STARTED_AT, FINISHED_AT));
 
     // when
     final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
@@ -107,13 +178,178 @@ final class ProtoBufRebalanceSerializerTest {
   }
 
   @Test
-  void shouldRejectAnUnspecifiedOutcome() {
+  void shouldRoundTripAPartitionWithNoCurrentLeader() {
+    // given
+    final var partition =
+        new PartitionRebalance(
+            "default", 4, null, MemberId.from("1"), PartitionRebalanceProgress.PENDING);
+    final var status =
+        new RebalanceStatus(
+            null,
+            new RebalanceStatus.Completed(
+                7, RebalanceOutcome.COMPLETED, true, List.of(partition), STARTED_AT, FINISHED_AT));
+
+    // when
+    final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
+
+    // then
+    assertThat(decoded.get().lastCompleted().partitions()).containsExactly(partition);
+  }
+
+  @Test
+  void shouldRejectAPartitionWithNoDesiredLeader() {
+    // given
+    final var encoded =
+        Rebalance.Response.newBuilder()
+            .setStatus(
+                Rebalance.RebalanceStatusResponse.newBuilder()
+                    .setLastCompleted(
+                        Rebalance.CompletedRebalance.newBuilder()
+                            .setRebalanceId(7)
+                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .addPartitions(
+                                Rebalance.PartitionRebalance.newBuilder()
+                                    .setPhysicalTenantId("default")
+                                    .setPartitionId(4)
+                                    .setProgress(Rebalance.PartitionRebalance.Progress.PENDING))))
+            .build()
+            .toByteArray();
+
+    // when/then
+    assertThatThrownBy(() -> serializer.decodeRebalanceStatusResponse(encoded))
+        .isInstanceOf(DecodingFailed.class);
+  }
+
+  @Test
+  void shouldRejectAnUnspecifiedRebalanceOutcome() {
     // given
     final var encoded =
         Rebalance.Response.newBuilder()
             .setStatus(
                 Rebalance.RebalanceStatusResponse.newBuilder()
                     .setLastCompleted(Rebalance.CompletedRebalance.newBuilder().setRebalanceId(7)))
+            .build()
+            .toByteArray();
+
+    // when/then
+    assertThatThrownBy(() -> serializer.decodeRebalanceStatusResponse(encoded))
+        .isInstanceOf(DecodingFailed.class);
+  }
+
+  @Test
+  void shouldRejectAnUnspecifiedPartitionProgress() {
+    // given
+    final var encoded =
+        Rebalance.Response.newBuilder()
+            .setStatus(
+                Rebalance.RebalanceStatusResponse.newBuilder()
+                    .setLastCompleted(
+                        Rebalance.CompletedRebalance.newBuilder()
+                            .setRebalanceId(7)
+                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .addPartitions(
+                                Rebalance.PartitionRebalance.newBuilder()
+                                    .setPhysicalTenantId("default")
+                                    .setPartitionId(3))))
+            .build()
+            .toByteArray();
+
+    // when/then
+    assertThatThrownBy(() -> serializer.decodeRebalanceStatusResponse(encoded))
+        .isInstanceOf(DecodingFailed.class);
+  }
+
+  @Test
+  void shouldRejectAnUnrecognizedPartitionProgress() {
+    // given
+    final var encoded =
+        Rebalance.Response.newBuilder()
+            .setStatus(
+                Rebalance.RebalanceStatusResponse.newBuilder()
+                    .setLastCompleted(
+                        Rebalance.CompletedRebalance.newBuilder()
+                            .setRebalanceId(7)
+                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .addPartitions(
+                                Rebalance.PartitionRebalance.newBuilder()
+                                    .setPhysicalTenantId("default")
+                                    .setPartitionId(3)
+                                    .setProgressValue(999))))
+            .build()
+            .toByteArray();
+
+    // when/then
+    assertThatThrownBy(() -> serializer.decodeRebalanceStatusResponse(encoded))
+        .isInstanceOf(DecodingFailed.class);
+  }
+
+  @Test
+  void shouldRejectACompletedPartitionWithNoOutcome() {
+    // given
+    final var encoded =
+        Rebalance.Response.newBuilder()
+            .setStatus(
+                Rebalance.RebalanceStatusResponse.newBuilder()
+                    .setLastCompleted(
+                        Rebalance.CompletedRebalance.newBuilder()
+                            .setRebalanceId(7)
+                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .addPartitions(
+                                Rebalance.PartitionRebalance.newBuilder()
+                                    .setPhysicalTenantId("default")
+                                    .setPartitionId(3)
+                                    .setProgress(Rebalance.PartitionRebalance.Progress.COMPLETED))))
+            .build()
+            .toByteArray();
+
+    // when/then
+    assertThatThrownBy(() -> serializer.decodeRebalanceStatusResponse(encoded))
+        .isInstanceOf(DecodingFailed.class);
+  }
+
+  @Test
+  void shouldRejectACompletedPartitionWithAnUnspecifiedOutcome() {
+    // given
+    final var encoded =
+        Rebalance.Response.newBuilder()
+            .setStatus(
+                Rebalance.RebalanceStatusResponse.newBuilder()
+                    .setLastCompleted(
+                        Rebalance.CompletedRebalance.newBuilder()
+                            .setRebalanceId(7)
+                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .addPartitions(
+                                Rebalance.PartitionRebalance.newBuilder()
+                                    .setPhysicalTenantId("default")
+                                    .setPartitionId(3)
+                                    .setProgress(Rebalance.PartitionRebalance.Progress.COMPLETED)
+                                    .setOutcome(
+                                        Rebalance.PartitionRebalance.Outcome.OUTCOME_UNSPECIFIED))))
+            .build()
+            .toByteArray();
+
+    // when/then
+    assertThatThrownBy(() -> serializer.decodeRebalanceStatusResponse(encoded))
+        .isInstanceOf(DecodingFailed.class);
+  }
+
+  @Test
+  void shouldRejectACompletedPartitionWithAnUnrecognizedOutcome() {
+    // given
+    final var encoded =
+        Rebalance.Response.newBuilder()
+            .setStatus(
+                Rebalance.RebalanceStatusResponse.newBuilder()
+                    .setLastCompleted(
+                        Rebalance.CompletedRebalance.newBuilder()
+                            .setRebalanceId(7)
+                            .setOutcome(Rebalance.RebalanceOutcome.REBALANCE_COMPLETED)
+                            .addPartitions(
+                                Rebalance.PartitionRebalance.newBuilder()
+                                    .setPhysicalTenantId("default")
+                                    .setPartitionId(3)
+                                    .setProgress(Rebalance.PartitionRebalance.Progress.COMPLETED)
+                                    .setOutcomeValue(999))))
             .build()
             .toByteArray();
 

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
@@ -12,14 +12,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.ConfigurationChangeInProgressException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.RebalanceInProgressException;
 import io.camunda.zeebe.scheduler.ActorTask;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -34,9 +42,13 @@ final class RebalanceCoordinatorTest {
 
   private static final MemberId LOWEST_ID_MEMBER = MemberId.from("1");
   private static final MemberId OTHER_MEMBER = MemberId.from("2");
+  private static final Instant FIXED_INSTANT = Instant.parse("2024-01-01T00:00:00Z");
+  private static final PartitionRebalance PLAN =
+      PartitionRebalance.pending("default", 1, LOWEST_ID_MEMBER, OTHER_MEMBER);
 
   private final TestConcurrencyControl executor = new TestConcurrencyControl();
   private final AtomicLong nextRebalanceId = new AtomicLong(100);
+  private final Clock clock = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
 
   @Test
   void shouldRefuseRequestsBeforeAnyConfigurationArrives() {
@@ -72,14 +84,14 @@ final class RebalanceCoordinatorTest {
 
     // when
     final var triggered =
-        coordinator.triggerRebalance(new TriggerRebalanceRequest(overrides, true));
+        coordinator.triggerRebalance(new TriggerRebalanceRequest(overrides, false));
 
     // then
     final var running = triggered.join().running();
     assertThat(running).isNotNull();
     assertThat(running.rebalanceId()).isEqualTo(100);
     assertThat(running.overrides()).isEqualTo(overrides);
-    assertThat(running.dryRun()).isTrue();
+    assertThat(running.dryRun()).isFalse();
     assertThat(running.cancelRequested()).isFalse();
     assertThat(triggered.join().lastCompleted()).isNull();
   }
@@ -117,7 +129,66 @@ final class RebalanceCoordinatorTest {
     assertThat(status.running()).isNotNull();
     assertThat(status.running().rebalanceId()).isEqualTo(101);
     assertThat(status.lastCompleted())
-        .isEqualTo(new RebalanceStatus.Completed(100, RebalanceOutcome.COMPLETED));
+        .isEqualTo(
+            new RebalanceStatus.Completed(
+                100,
+                RebalanceOutcome.COMPLETED,
+                false,
+                List.of(PLAN),
+                FIXED_INSTANT,
+                FIXED_INSTANT));
+  }
+
+  @Test
+  void shouldReportWhereTheRebalanceHasGotToWithEachPartition() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // when
+    runner.rebalance.updatePartition(0, partition -> partition.transferred());
+
+    // then
+    assertThat(coordinator.getRebalanceStatus().join().running().partitions())
+        .containsExactly(PLAN.transferred());
+  }
+
+  @Test
+  void shouldAnswerADryRunWithThePlanItWouldHaveCarriedOut() {
+    // given
+    final var coordinator = coordinatingWith(new PlanningRunner());
+
+    // when
+    final var triggered =
+        coordinator.triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), true));
+
+    // then
+    final var status = triggered.join();
+    assertThat(status.running()).isNull();
+    assertThat(status.lastCompleted())
+        .isEqualTo(
+            new RebalanceStatus.Completed(
+                100,
+                RebalanceOutcome.COMPLETED,
+                true,
+                List.of(PLAN),
+                FIXED_INSTANT,
+                FIXED_INSTANT));
+  }
+
+  @Test
+  void shouldRunARebalanceAgainstTheConfigurationItWasAdmittedUnder() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+
+    // when
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // then
+    assertThat(runner.rebalance.configuration().getMembers())
+        .containsExactlyInAnyOrder(LOWEST_ID_MEMBER, OTHER_MEMBER);
   }
 
   @Test
@@ -134,7 +205,9 @@ final class RebalanceCoordinatorTest {
     // then
     assertThat(status.join().running()).isNull();
     assertThat(status.join().lastCompleted())
-        .isEqualTo(new RebalanceStatus.Completed(100, RebalanceOutcome.FAILED));
+        .isEqualTo(
+            new RebalanceStatus.Completed(
+                100, RebalanceOutcome.FAILED, false, List.of(PLAN), FIXED_INSTANT, FIXED_INSTANT));
   }
 
   @Test
@@ -166,7 +239,14 @@ final class RebalanceCoordinatorTest {
 
     // then
     assertThat(status.join().lastCompleted())
-        .isEqualTo(new RebalanceStatus.Completed(100, RebalanceOutcome.CANCELLED));
+        .isEqualTo(
+            new RebalanceStatus.Completed(
+                100,
+                RebalanceOutcome.CANCELLED,
+                false,
+                List.of(PLAN),
+                FIXED_INSTANT,
+                FIXED_INSTANT));
   }
 
   @Test
@@ -185,7 +265,9 @@ final class RebalanceCoordinatorTest {
     // then
     final var status = coordinator.getRebalanceStatus();
     assertThat(status.join().lastCompleted())
-        .isEqualTo(new RebalanceStatus.Completed(100, RebalanceOutcome.CANCELLED));
+        .isEqualTo(
+            new RebalanceStatus.Completed(
+                100, RebalanceOutcome.CANCELLED, false, List.of(), FIXED_INSTANT, FIXED_INSTANT));
   }
 
   @Test
@@ -205,7 +287,9 @@ final class RebalanceCoordinatorTest {
     runner.deliver();
     final var status = coordinator.getRebalanceStatus();
     assertThat(status.join().lastCompleted())
-        .isEqualTo(new RebalanceStatus.Completed(100, RebalanceOutcome.CANCELLED));
+        .isEqualTo(
+            new RebalanceStatus.Completed(
+                100, RebalanceOutcome.CANCELLED, false, List.of(), FIXED_INSTANT, FIXED_INSTANT));
   }
 
   @Test
@@ -216,10 +300,7 @@ final class RebalanceCoordinatorTest {
     coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
 
     // when
-    coordinator.onClusterConfigurationUpdated(
-        ClusterConfiguration.init()
-            .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()))
-            .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of())));
+    configurationWithANewLowestIdMember(coordinator);
     final var cancelled = coordinator.cancelRebalance();
 
     // then
@@ -280,10 +361,7 @@ final class RebalanceCoordinatorTest {
     coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
 
     // when
-    coordinator.onClusterConfigurationUpdated(
-        ClusterConfiguration.init()
-            .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()))
-            .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of())));
+    configurationWithANewLowestIdMember(coordinator);
 
     // then
     final var status = coordinator.getRebalanceStatus();
@@ -298,10 +376,7 @@ final class RebalanceCoordinatorTest {
     coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
 
     // when
-    coordinator.onClusterConfigurationUpdated(
-        ClusterConfiguration.init()
-            .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()))
-            .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of())));
+    configurationWithANewLowestIdMember(coordinator);
 
     // then
     assertThat(runner.rebalance.isAbandoned()).isTrue();
@@ -313,10 +388,7 @@ final class RebalanceCoordinatorTest {
     final var runner = new BlockedRunner();
     final var coordinator = coordinatingWith(runner);
     coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
-    coordinator.onClusterConfigurationUpdated(
-        ClusterConfiguration.init()
-            .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()))
-            .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of())));
+    configurationWithANewLowestIdMember(coordinator);
 
     // when
     configurationWithBothMembers(coordinator);
@@ -325,6 +397,92 @@ final class RebalanceCoordinatorTest {
     // then
     final var status = coordinator.getRebalanceStatus();
     assertThat(status.join()).isEqualTo(RebalanceStatus.idle());
+  }
+
+  @Test
+  void shouldRecordDeterministicTimestampsUnderAFixedClock() {
+    // given
+    final var startedAt = Instant.parse("2024-01-01T00:00:00Z");
+    final var finishedAt = Instant.parse("2024-01-01T00:00:05Z");
+    final var stepClock = new StepClock(startedAt);
+    final var runner = new BlockedRunner();
+    final var coordinator =
+        new RebalanceCoordinator(
+            LOWEST_ID_MEMBER, executor, runner, nextRebalanceId::getAndIncrement, stepClock);
+    coordinator.onClusterConfigurationUpdated(
+        CurrentClusterConfiguration.fromLegacy(
+            ClusterConfiguration.init()
+                .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
+                .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of()))));
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // when
+    stepClock.advanceTo(finishedAt);
+    runner.finish();
+
+    // then
+    final var status = coordinator.getRebalanceStatus();
+    assertThat(status.join().lastCompleted())
+        .isEqualTo(
+            new RebalanceStatus.Completed(
+                100, RebalanceOutcome.COMPLETED, false, List.of(PLAN), startedAt, finishedAt));
+  }
+
+  @Test
+  void shouldRefuseADryRunWhileAConfigurationChangeIsPending() {
+    // given
+    final var runner = new CountingRunner();
+    final var coordinator = startCoordinator(LOWEST_ID_MEMBER, runner);
+    configurationWithAPendingChange(coordinator);
+
+    // when
+    final var triggered =
+        coordinator.triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), true));
+
+    // then
+    assertThatThrownBy(triggered::join)
+        .hasCauseInstanceOf(ConfigurationChangeInProgressException.class);
+    assertThat(runner.invocations).isZero();
+    final var status = coordinator.getRebalanceStatus().join();
+    assertThat(status.running()).isNull();
+    assertThat(status.lastCompleted()).isNull();
+  }
+
+  @Test
+  void shouldRefuseANonDryRunWhileAConfigurationChangeIsPending() {
+    // given
+    final var runner = new CountingRunner();
+    final var coordinator = startCoordinator(LOWEST_ID_MEMBER, runner);
+    configurationWithAPendingChange(coordinator);
+
+    // when
+    final var triggered =
+        coordinator.triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), false));
+
+    // then
+    assertThatThrownBy(triggered::join)
+        .hasCauseInstanceOf(ConfigurationChangeInProgressException.class);
+    assertThat(runner.invocations).isZero();
+    final var status = coordinator.getRebalanceStatus().join();
+    assertThat(status.running()).isNull();
+    assertThat(status.lastCompleted()).isNull();
+  }
+
+  @Test
+  void shouldAcceptARequestOnceTheConfigurationChangeHasCompleted() {
+    // given
+    final var runner = new CountingRunner();
+    final var coordinator = startCoordinator(LOWEST_ID_MEMBER, runner);
+    configurationWithAPendingChange(coordinator);
+
+    // when
+    configurationWithBothMembers(coordinator);
+    final var triggered =
+        coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // then
+    assertThat(triggered.join().running().rebalanceId()).isEqualTo(100);
+    assertThat(runner.invocations).isEqualTo(1);
   }
 
   private RebalanceCoordinator coordinatingWith(final RebalanceRunner runner) {
@@ -336,14 +494,45 @@ final class RebalanceCoordinatorTest {
   private RebalanceCoordinator startCoordinator(
       final MemberId localMemberId, final RebalanceRunner runner) {
     return new RebalanceCoordinator(
-        localMemberId, executor, runner, nextRebalanceId::getAndIncrement);
+        localMemberId, executor, runner, nextRebalanceId::getAndIncrement, clock);
   }
 
   private void configurationWithBothMembers(final RebalanceCoordinator coordinator) {
     coordinator.onClusterConfigurationUpdated(
-        ClusterConfiguration.init()
-            .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
-            .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of())));
+        CurrentClusterConfiguration.fromLegacy(
+            ClusterConfiguration.init()
+                .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
+                .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of()))));
+  }
+
+  private void configurationWithAPendingChange(final RebalanceCoordinator coordinator) {
+    coordinator.onClusterConfigurationUpdated(
+        CurrentClusterConfiguration.fromLegacy(
+            ClusterConfiguration.init()
+                .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
+                .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of()))
+                .startConfigurationChange(
+                    List.of(new PartitionLeaveOperation(OTHER_MEMBER, 1, 1)))));
+  }
+
+  private void configurationWithANewLowestIdMember(final RebalanceCoordinator coordinator) {
+    coordinator.onClusterConfigurationUpdated(
+        CurrentClusterConfiguration.fromLegacy(
+            ClusterConfiguration.init()
+                .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()))
+                .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))));
+  }
+
+  private static final class CountingRunner implements RebalanceRunner {
+
+    private int invocations;
+
+    @Override
+    public ActorFuture<Void> run(final RebalanceRun rebalance) {
+      invocations++;
+      rebalance.plan(List.of(PLAN));
+      return CompletableActorFuture.completed();
+    }
   }
 
   private static final class BlockedRunner implements RebalanceRunner {
@@ -354,6 +543,7 @@ final class RebalanceCoordinatorTest {
     @Override
     public ActorFuture<Void> run(final RebalanceRun rebalance) {
       this.rebalance = rebalance;
+      rebalance.plan(List.of(PLAN));
       return completion;
     }
 
@@ -507,6 +697,43 @@ final class RebalanceCoordinatorTest {
     @Override
     public Void get(final long timeout, final TimeUnit unit) {
       throw new UnsupportedOperationException();
+    }
+  }
+
+  private static final class StepClock extends Clock {
+
+    private Instant now;
+
+    StepClock(final Instant now) {
+      this.now = now;
+    }
+
+    void advanceTo(final Instant instant) {
+      now = instant;
+    }
+
+    @Override
+    public ZoneId getZone() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Clock withZone(final ZoneId zone) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Instant instant() {
+      return now;
+    }
+  }
+
+  private static final class PlanningRunner implements RebalanceRunner {
+
+    @Override
+    public ActorFuture<Void> run(final RebalanceRun rebalance) {
+      rebalance.plan(List.of(PLAN));
+      return CompletableActorFuture.completed();
     }
   }
 }

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
@@ -16,6 +16,7 @@ import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
 import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
+import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.ConfigurationChangeInProgressException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.RebalanceInProgressException;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -100,7 +102,8 @@ final class RebalanceForwardingTest {
     final var request =
         new TriggerRebalanceRequest(new RebalanceOverrides(2048L, Duration.ofSeconds(20), 3), true);
     COORDINATOR.status =
-        new RebalanceStatus(new RebalanceStatus.Running(9, request.overrides(), true, false), null);
+        new RebalanceStatus(
+            new RebalanceStatus.Running(9, request.overrides(), true, false, List.of()), null);
 
     // when
     final var response = sender.triggerRebalance(request).join();
@@ -114,7 +117,15 @@ final class RebalanceForwardingTest {
   void shouldForwardAStatusQuery() {
     // given
     COORDINATOR.status =
-        new RebalanceStatus(null, new RebalanceStatus.Completed(8, RebalanceOutcome.COMPLETED));
+        new RebalanceStatus(
+            null,
+            new RebalanceStatus.Completed(
+                8,
+                RebalanceOutcome.COMPLETED,
+                false,
+                List.of(PartitionRebalance.alreadyLeader("default", 1, MemberId.from("1"))),
+                Instant.parse("2024-01-01T00:00:00Z"),
+                Instant.parse("2024-01-01T00:00:05Z")));
 
     // when
     final var response = sender.getRebalanceStatus().join();
@@ -150,6 +161,25 @@ final class RebalanceForwardingTest {
         .isEqualTo(
             new RebalanceErrorResponse(
                 RebalanceErrorCode.REBALANCE_IN_PROGRESS, "Rebalance 7 is already running"));
+  }
+
+  @Test
+  void shouldReportARefusalDueToAPendingConfigurationChange() {
+    // given
+    COORDINATOR.failure =
+        new ConfigurationChangeInProgressException(
+            "Cannot start a rebalance while a cluster configuration change is in progress");
+
+    // when
+    final var response =
+        sender.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings()).join();
+
+    // then
+    assertThat(response.getLeft())
+        .isEqualTo(
+            new RebalanceErrorResponse(
+                RebalanceErrorCode.CONFIGURATION_CHANGE_IN_PROGRESS,
+                "Cannot start a rebalance while a cluster configuration change is in progress"));
   }
 
   @Test

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class SequentialRebalanceRunnerTest {
+
+  private static final String GROUP = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+  private static final MemberId MEMBER_2 = MemberId.from("2");
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final Map<String, Map<Integer, MemberId>> leaders = new HashMap<>();
+  private final Set<String> unavailableGroups = new HashSet<>();
+  private final Map<String, Integer> groupLookups = new HashMap<>();
+  private final PartitionLeaders partitionLeaders =
+      physicalTenantId -> {
+        groupLookups.merge(physicalTenantId, 1, Integer::sum);
+        if (unavailableGroups.contains(physicalTenantId)) {
+          throw new IllegalStateException(
+              "Topology for physical tenant %s is unavailable".formatted(physicalTenantId));
+        }
+        final var groupLeaders = leaders.getOrDefault(physicalTenantId, Map.of());
+        return partitionId -> Optional.ofNullable(groupLeaders.get(partitionId));
+      };
+
+  @Test
+  void shouldPlanATransferTowardsTheHighestPriorityReplica() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+
+    // when
+    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    assertThat(rebalance.partitions())
+        .containsExactly(PartitionRebalance.pending(GROUP, 1, MEMBER_1, MEMBER_2));
+  }
+
+  @Test
+  void shouldPlanNoTransferForAPartitionAlreadyLedByItsDesiredLeader() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_2);
+
+    // when
+    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome())
+        .isEqualTo(PartitionRebalanceOutcome.ALREADY_LEADER);
+  }
+
+  @Test
+  void shouldPlanATransferForAPartitionWithNoLeaderAtAll() {
+    // given / when
+    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    assertThat(rebalance.partition(0).currentLeader()).isNull();
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.PENDING);
+  }
+
+  @Test
+  void shouldPlanAPendingEntryWithNoCurrentLeaderWhenTheKnownTopologyHasNoLeaderForThePartition() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+
+    // when
+    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    assertThat(rebalance.partition(0).currentLeader()).isNull();
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.PENDING);
+  }
+
+  @Test
+  void shouldFailPlanningWhenTheGroupTopologyIsUnavailable() {
+    // given
+    unavailableGroups.add(GROUP);
+
+    // when / then
+    assertThatThrownBy(() -> run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2))))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldObtainTheGroupTopologyOnceForAllOfItsPartitions() {
+    // given
+    final var configuration =
+        configurationOf(
+            Map.of(
+                GROUP,
+                Map.of(
+                    MEMBER_1,
+                    Map.of(
+                        1, active(1),
+                        2, active(1),
+                        3, active(1)))));
+
+    // when
+    run(configuration);
+
+    // then
+    assertThat(groupLookups).containsEntry(GROUP, 1);
+  }
+
+  @Test
+  void shouldPlanATransferWithNoOutcomeYet() {
+    // given / when
+    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    assertThat(rebalance.partition(0).outcome()).isNull();
+  }
+
+  @Test
+  void shouldPlanEveryPartitionOfTheConfigurationInOrder() {
+    // given
+    final var configuration =
+        configurationOf(
+            Map.of(
+                GROUP,
+                Map.of(
+                    MEMBER_1,
+                    Map.of(
+                        3, active(1),
+                        1, active(1),
+                        2, active(1)))));
+
+    // when
+    final var rebalance = run(configuration);
+
+    // then
+    assertThat(rebalance.partitions())
+        .map(PartitionRebalance::partitionId)
+        .containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void shouldPlanEveryPhysicalTenantsPartitionGroupIndependently() {
+    // given
+    leaders.computeIfAbsent("tenant-a", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    leaders.computeIfAbsent("tenant-b", ignored -> new HashMap<>()).put(1, MEMBER_2);
+    final var configuration =
+        configurationOf(
+            Map.of(
+                "tenant-a", Map.of(MEMBER_1, Map.of(1, active(1)), MEMBER_2, Map.of(1, active(2))),
+                "tenant-b",
+                    Map.of(MEMBER_1, Map.of(1, active(2)), MEMBER_2, Map.of(1, active(1)))));
+
+    // when
+    final var rebalance = run(configuration);
+
+    // then
+    assertThat(rebalance.partitions())
+        .containsExactlyInAnyOrder(
+            PartitionRebalance.pending("tenant-a", 1, MEMBER_1, MEMBER_2),
+            PartitionRebalance.pending("tenant-b", 1, MEMBER_2, MEMBER_1));
+  }
+
+  @Test
+  void shouldSortThePlanByPhysicalTenantIdThenPartitionId() {
+    // given
+    leaders.computeIfAbsent("tenant-a", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    leaders.computeIfAbsent("tenant-b", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration =
+        configurationOf(
+            Map.of(
+                "tenant-b", Map.of(MEMBER_1, Map.of(2, active(1), 1, active(1))),
+                "tenant-a", Map.of(MEMBER_1, Map.of(1, active(1)))));
+
+    // when
+    final var rebalance = run(configuration);
+
+    // then
+    assertThat(rebalance.partitions())
+        .map(PartitionRebalance::physicalTenantId, PartitionRebalance::partitionId)
+        .containsExactly(tuple("tenant-a", 1), tuple("tenant-b", 1), tuple("tenant-b", 2));
+  }
+
+  private RebalanceRun run(final CurrentClusterConfiguration configuration) {
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    new SequentialRebalanceRunner(executor, partitionLeaders).run(rebalance).join();
+    return rebalance;
+  }
+
+  private PartitionState active(final int priority) {
+    return PartitionState.active(priority, partitionConfig);
+  }
+
+  private CurrentClusterConfiguration groupConfiguration(
+      final String group, final Map<MemberId, Integer> prioritiesForPartitionOne) {
+    final Map<MemberId, Map<Integer, PartitionState>> partitionsPerMember = new HashMap<>();
+    prioritiesForPartitionOne.forEach(
+        (memberId, priority) -> partitionsPerMember.put(memberId, Map.of(1, active(priority))));
+    return configurationOf(Map.of(group, partitionsPerMember));
+  }
+
+  private CurrentClusterConfiguration configurationOf(
+      final Map<String, Map<MemberId, Map<Integer, PartitionState>>> partitionsPerGroup) {
+    final Map<MemberId, BrokerState> globalMembers = new HashMap<>();
+    final Map<String, PartitionGroupConfiguration> groups = new HashMap<>();
+    partitionsPerGroup.forEach(
+        (groupId, membersInGroup) -> {
+          final Map<MemberId, BrokerPartitionState> groupMembers = new HashMap<>();
+          membersInGroup.forEach(
+              (memberId, partitions) -> {
+                globalMembers.putIfAbsent(memberId, BrokerState.initializeAsActive());
+                groupMembers.put(memberId, BrokerPartitionState.initialize(partitions));
+              });
+          groups.put(
+              groupId,
+              new PartitionGroupConfiguration(
+                  PartitionGroupConfiguration.INITIAL_VERSION,
+                  PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+                  groupMembers,
+                  Optional.empty(),
+                  Optional.empty(),
+                  Optional.empty()));
+        });
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            GlobalConfiguration.INITIAL_VERSION,
+            Optional.empty(),
+            globalMembers,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration,
+        groups,
+        PhasedChangeState.empty());
+  }
+}


### PR DESCRIPTION
Builds a fixed plan when a rebalance starts, using the committed cluster configuration and current topology. For each partition, the plan records the current leader, selects the highest-priority replica as the desired leader, and records whether the partition should be transferred or skipped.

Rebalance status now includes the plan and each partition's state. Dry runs complete after planning, without pausing or transferring any partition.

This change does not include execution of the plan.

Closes #60061.

BREAKING CHANGE: re-scopes and renames some enums to be message-scoped rather than prefixed. this doesn't actually affect wire-encoding (still gets encoded to the same int values), but buf doesn't know that the moved enum types are the same. (this is in the unreleased rebalance proto, too)