### PR TITLE
[Backport stable/8.8] R/W backup store timeouts

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Backup.java
+++ b/configuration/src/main/java/io/camunda/configuration/Backup.java
@@ -75,6 +75,22 @@ public class Backup {
    */
   private BackupStoreType store = BackupStoreType.NONE;
 
+  /**
+   * Timeout for reading a response from an already-established connection to the backup store. When
+   * unset, the store client's own default applies.
+   *
+   * <p>Note: This configuration applies to the backup of primary storage.
+   */
+  private Duration readTimeout;
+
+  /**
+   * Timeout for writing a request to an already-established connection to the backup store. When
+   * unset, the store client's own default applies.
+   *
+   * <p>Note: This configuration applies to the backup of primary storage.
+   */
+  private Duration writeTimeout;
+
   /** Configuration for backup store AWS S3 */
   private S3 s3 = new S3();
 
@@ -174,6 +190,22 @@ public class Backup {
     this.store = store;
   }
 
+  public Duration getReadTimeout() {
+    return readTimeout;
+  }
+
+  public void setReadTimeout(final Duration readTimeout) {
+    this.readTimeout = readTimeout;
+  }
+
+  public Duration getWriteTimeout() {
+    return writeTimeout;
+  }
+
+  public void setWriteTimeout(final Duration writeTimeout) {
+    this.writeTimeout = writeTimeout;
+  }
+
   @Override
   public Backup clone() {
     final Backup copy = new Backup();
@@ -181,6 +213,8 @@ public class Backup {
     copy.snapshotTimeout = snapshotTimeout;
     copy.incompleteCheckTimeout = incompleteCheckTimeout;
     copy.store = store;
+    copy.readTimeout = readTimeout;
+    copy.writeTimeout = writeTimeout;
     copy.s3 = s3;
     copy.gcs = gcs;
     copy.filesystem = filesystem;

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -289,6 +289,16 @@ public class BrokerBasedPropertiesOverride {
     final BackupStoreCfg backupStoreCfg = override.getData().getBackup();
     backupStoreCfg.setStore(BackupStoreType.valueOf(backup.getStore().name()));
 
+    if (backup.getReadTimeout() != null && !backup.getReadTimeout().isPositive()) {
+      throw new IllegalArgumentException("BackupStore readTimeout must be positive");
+    }
+    backupStoreCfg.setReadTimeout(backup.getReadTimeout());
+
+    if (backup.getWriteTimeout() != null && !backup.getWriteTimeout().isPositive()) {
+      throw new IllegalArgumentException("BackupStore writeTimeout must be positive");
+    }
+    backupStoreCfg.setWriteTimeout(backup.getWriteTimeout());
+
     populateFromS3(override);
     populateFromGcs(override);
     populateFromAzure(override);

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupBrokerPropertiesTest.java
@@ -8,13 +8,18 @@
 package io.camunda.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -74,6 +79,89 @@ public class DataBackupBrokerPropertiesTest {
     @Test
     void shouldSetStoreFromNew() {
       assertThat(brokerCfg.getData().getBackup().getStore()).isEqualTo(BackupStoreType.AZURE);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.backup.read-timeout=90s",
+        "camunda.data.backup.write-timeout=120s"
+      })
+  class RequestTimeoutConfiguration {
+    final BackupStoreCfg backupCfg;
+
+    RequestTimeoutConfiguration(@Autowired final BrokerBasedProperties brokerCfg) {
+      backupCfg = brokerCfg.getData().getBackup();
+    }
+
+    @Test
+    void shouldSetReadAndWriteTimeoutSeparately() {
+      assertThat(backupCfg.getReadTimeout()).isEqualTo(Duration.ofSeconds(90));
+      assertThat(backupCfg.getWriteTimeout()).isEqualTo(Duration.ofSeconds(120));
+    }
+  }
+
+  @Nested
+  class DefaultRequestTimeoutConfiguration {
+    final BackupStoreCfg backupCfg;
+
+    DefaultRequestTimeoutConfiguration(@Autowired final BrokerBasedProperties brokerCfg) {
+      backupCfg = brokerCfg.getData().getBackup();
+    }
+
+    @Test
+    void shouldLeaveTimeoutsUnsetSoThatStoreDefaultsApply() {
+      assertThat(backupCfg.getReadTimeout()).isNull();
+      assertThat(backupCfg.getWriteTimeout()).isNull();
+    }
+  }
+
+  @Nested
+  class RequestTimeoutStartupValidation {
+
+    @Test
+    void shouldFailToStartWithNegativeReadTimeout() {
+      // given/when/then - application startup should fail
+      assertThatStartupFails("camunda.data.backup.read-timeout", "-10s")
+          .hasMessageContaining("BackupStore readTimeout must be positive");
+    }
+
+    @Test
+    void shouldFailToStartWithNegativeWriteTimeout() {
+      // given/when/then - application startup should fail
+      assertThatStartupFails("camunda.data.backup.write-timeout", "-10s")
+          .hasMessageContaining("BackupStore writeTimeout must be positive");
+    }
+
+    @Test
+    void shouldFailToStartWithZeroReadTimeout() {
+      // given/when/then - application startup should fail
+      assertThatStartupFails("camunda.data.backup.read-timeout", "0s")
+          .hasMessageContaining("BackupStore readTimeout must be positive");
+    }
+
+    @Test
+    void shouldFailToStartWithZeroWriteTimeout() {
+      // given/when/then - application startup should fail
+      assertThatStartupFails("camunda.data.backup.write-timeout", "0s")
+          .hasMessageContaining("BackupStore writeTimeout must be positive");
+    }
+
+    private org.assertj.core.api.AbstractThrowableAssert<?, ? extends Throwable>
+        assertThatStartupFails(final String property, final String value) {
+      final Map<String, Object> properties =
+          Map.of("camunda.data.secondary-storage.type", "rdbms", property, value);
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      return assertThatThrownBy(app::run).hasRootCauseInstanceOf(IllegalArgumentException.class);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupBrokerPropertiesTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -160,6 +161,8 @@ public class DataBackupBrokerPropertiesTest {
               UnifiedConfigurationHelper.class);
       app.setAdditionalProfiles("broker");
       app.setDefaultProperties(properties);
+      // the test classpath contains spring-boot-starter-web but no web server factory
+      app.setWebApplicationType(WebApplicationType.NONE);
 
       return assertThatThrownBy(app::run).hasRootCauseInstanceOf(IllegalArgumentException.class);
     }

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -51,17 +51,29 @@ final class BackupStoreComponent {
   }
 
   private static BackupStore buildS3BackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupStoreCfg.getS3());
+    final var storeConfig =
+        S3BackupStoreConfig.toStoreConfig(
+            backupStoreCfg.getS3(),
+            backupStoreCfg.getReadTimeout(),
+            backupStoreCfg.getWriteTimeout());
     return S3BackupStore.of(storeConfig);
   }
 
   private static BackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var storeConfig = GcsBackupStoreConfig.toStoreConfig(backupStoreCfg.getGcs());
+    final var storeConfig =
+        GcsBackupStoreConfig.toStoreConfig(
+            backupStoreCfg.getGcs(),
+            backupStoreCfg.getReadTimeout(),
+            backupStoreCfg.getWriteTimeout());
     return GcsBackupStore.of(storeConfig);
   }
 
   private static BackupStore buildAzureBackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var storeConfig = AzureBackupStoreConfig.toStoreConfig(backupStoreCfg.getAzure());
+    final var storeConfig =
+        AzureBackupStoreConfig.toStoreConfig(
+            backupStoreCfg.getAzure(),
+            backupStoreCfg.getReadTimeout(),
+            backupStoreCfg.getWriteTimeout());
     return AzureBackupStore.of(storeConfig);
   }
 

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupConfig.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupConfig.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.backup.azure;
 
+import java.time.Duration;
+import java.util.Optional;
+
 public record AzureBackupConfig(
     String endpoint,
     String accountName,
@@ -14,7 +17,9 @@ public record AzureBackupConfig(
     String connectionString,
     String containerName,
     boolean createContainer,
-    SasTokenConfig sasTokenConfig) {
+    SasTokenConfig sasTokenConfig,
+    Optional<Duration> readTimeout,
+    Optional<Duration> writeTimeout) {
 
   public static class Builder {
 
@@ -26,6 +31,8 @@ public record AzureBackupConfig(
     private SasTokenConfig sasToken;
     // maps to the basePath env variable
     private String containerName;
+    private Duration readTimeout;
+    private Duration writeTimeout;
 
     public Builder withEndpoint(final String endpoint) {
       this.endpoint = endpoint;
@@ -62,6 +69,16 @@ public record AzureBackupConfig(
       return this;
     }
 
+    public Builder withReadTimeout(final Duration readTimeout) {
+      this.readTimeout = readTimeout;
+      return this;
+    }
+
+    public Builder withWriteTimeout(final Duration writeTimeout) {
+      this.writeTimeout = writeTimeout;
+      return this;
+    }
+
     public AzureBackupConfig build() {
 
       return new AzureBackupConfig(
@@ -71,7 +88,9 @@ public record AzureBackupConfig(
           conectionString,
           containerName,
           createContainer,
-          sasToken);
+          sasToken,
+          Optional.ofNullable(readTimeout),
+          Optional.ofNullable(writeTimeout));
     }
   }
 }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.azure;
 
+import com.azure.core.http.HttpClient;
+import com.azure.core.util.HttpClientOptions;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
@@ -26,6 +28,7 @@ import io.camunda.zeebe.backup.common.Manifest;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -65,16 +68,18 @@ public final class AzureBackupStore implements BackupStore {
   }
 
   public static BlobServiceClient buildClient(final AzureBackupConfig config) {
+    final var builder = new BlobServiceClientBuilder();
+
+    httpClientOptions(config).map(HttpClient::createDefault).ifPresent(builder::httpClient);
+
     // BlobServiceClientBuilder has their own validations, for building the client
     if (config.sasTokenConfig() != null) {
-      return new BlobServiceClientBuilder()
+      return builder
           .sasToken(config.sasTokenConfig().value())
           .endpoint(config.endpoint())
           .buildClient();
     } else if (config.connectionString() != null) {
-      return new BlobServiceClientBuilder()
-          .connectionString(config.connectionString())
-          .buildClient();
+      return builder.connectionString(config.connectionString()).buildClient();
     } else if (config.accountName() != null || config.accountKey() != null) {
       final var credential =
           new StorageSharedKeyCredential(
@@ -84,14 +89,11 @@ public final class AzureBackupStore implements BackupStore {
               Objects.requireNonNull(
                   config.accountKey(),
                   "Account name is specified but no account key was provided."));
-      return new BlobServiceClientBuilder()
-          .endpoint(config.endpoint())
-          .credential(credential)
-          .buildClient();
+      return builder.endpoint(config.endpoint()).credential(credential).buildClient();
     } else {
       LOG.info(
           "No connection string, sas token or account credentials are configured, using DefaultAzureCredentialBuilder for authentication.");
-      return new BlobServiceClientBuilder()
+      return builder
           .endpoint(config.endpoint())
           .credential(new DefaultAzureCredentialBuilder().build())
           .buildClient();
@@ -275,6 +277,19 @@ public final class AzureBackupStore implements BackupStore {
       }
     }
     return false;
+  }
+
+  static Optional<HttpClientOptions> httpClientOptions(final AzureBackupConfig config) {
+    if (config.readTimeout().isEmpty() && config.writeTimeout().isEmpty()) {
+      return Optional.empty();
+    }
+
+    final var options = new HttpClientOptions();
+    config
+        .readTimeout()
+        .ifPresent(timeout -> options.setResponseTimeout(timeout).setReadTimeout(timeout));
+    config.writeTimeout().ifPresent(options::setWriteTimeout);
+    return Optional.of(options);
   }
 
   public static BackupStore of(final AzureBackupConfig storeConfig) {

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/RequestTimeoutTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/RequestTimeoutTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+
+final class RequestTimeoutTest {
+
+  /**
+   * {@code HttpClientOptions} resolves every timeout it was not given to this azure-core default.
+   */
+  private static final Duration AZURE_DEFAULT_TIMEOUT = Duration.ofSeconds(60);
+
+  @Test
+  void shouldApplyReadTimeoutToResponseAndReadTimeouts() {
+    // given
+    final var readTimeout = Duration.ofSeconds(90);
+
+    // when
+    final var options =
+        AzureBackupStore.httpClientOptions(
+            configWith(builder -> builder.withReadTimeout(readTimeout)));
+
+    // then
+    assertThat(options).isPresent();
+    assertThat(options.get().getResponseTimeout()).isEqualTo(readTimeout);
+    assertThat(options.get().getReadTimeout()).isEqualTo(readTimeout);
+    // an unset write timeout leaves the azure-core default in place
+    assertThat(options.get().getWriteTimeout()).isEqualTo(AZURE_DEFAULT_TIMEOUT);
+  }
+
+  @Test
+  void shouldApplyWriteTimeoutOnly() {
+    // given
+    final var writeTimeout = Duration.ofSeconds(120);
+
+    // when
+    final var options =
+        AzureBackupStore.httpClientOptions(
+            configWith(builder -> builder.withWriteTimeout(writeTimeout)));
+
+    // then
+    assertThat(options).isPresent();
+    assertThat(options.get().getWriteTimeout()).isEqualTo(writeTimeout);
+    // unset read timeouts leave the azure-core defaults in place
+    assertThat(options.get().getResponseTimeout()).isEqualTo(AZURE_DEFAULT_TIMEOUT);
+    assertThat(options.get().getReadTimeout()).isEqualTo(AZURE_DEFAULT_TIMEOUT);
+  }
+
+  @Test
+  void shouldKeepClientDefaultsWhenNoTimeoutIsSet() {
+    // when
+    final var options = AzureBackupStore.httpClientOptions(configWith(builder -> builder));
+
+    // then
+    assertThat(options).isEmpty();
+  }
+
+  private static AzureBackupConfig configWith(
+      final UnaryOperator<AzureBackupConfig.Builder> timeouts) {
+    return timeouts
+        .apply(
+            new AzureBackupConfig.Builder()
+                .withEndpoint("https://localhost")
+                .withContainerName("container"))
+        .build();
+  }
+}

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -156,6 +156,8 @@
             -->
             <ignoredUsedUndeclaredDependency>com.google.auth:*</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>com.google.apis:*</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>com.google.cloud:google-cloud-core-http</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>com.google.http-client:google-http-client</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -12,14 +12,23 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.None;
+import java.time.Duration;
+import java.util.Optional;
 
 public record GcsBackupConfig(
-    String bucketName, String basePath, GcsConnectionConfig connection, int bufferSize) {
+    String bucketName,
+    String basePath,
+    GcsConnectionConfig connection,
+    int bufferSize,
+    Optional<Duration> readTimeout,
+    Optional<Duration> writeTimeout) {
   public GcsBackupConfig(
       final String bucketName,
       final String basePath,
       final GcsConnectionConfig connection,
-      final int bufferSize) {
+      final int bufferSize,
+      final Optional<Duration> readTimeout,
+      final Optional<Duration> writeTimeout) {
     this.bucketName = requireBucketName(bucketName);
     this.basePath = sanitizeBasePath(basePath);
     this.connection = requireNonNull(connection);
@@ -27,6 +36,8 @@ public record GcsBackupConfig(
       throw new ConfigurationException("Expected bufferSize to be > 0, but got " + bufferSize);
     }
     this.bufferSize = bufferSize;
+    this.readTimeout = readTimeout;
+    this.writeTimeout = writeTimeout;
   }
 
   private static String requireBucketName(final String bucketName) {
@@ -67,6 +78,8 @@ public record GcsBackupConfig(
     private String basePath;
     private String host;
     private GcsConnectionConfig.Authentication auth;
+    private Duration readTimeout;
+    private Duration writeTimeout;
     // 2MiB matches the default used by the GCS library's Path-based upload
     private int bufferSize = 2 * 1024 * 1024;
 
@@ -101,9 +114,24 @@ public record GcsBackupConfig(
       return this;
     }
 
+    public Builder withReadTimeout(final Duration readTimeout) {
+      this.readTimeout = readTimeout;
+      return this;
+    }
+
+    public Builder withWriteTimeout(final Duration writeTimeout) {
+      this.writeTimeout = writeTimeout;
+      return this;
+    }
+
     public GcsBackupConfig build() {
       return new GcsBackupConfig(
-          bucketName, basePath, new GcsConnectionConfig(host, auth), bufferSize);
+          bucketName,
+          basePath,
+          new GcsConnectionConfig(host, auth),
+          bufferSize,
+          Optional.ofNullable(readTimeout),
+          Optional.ofNullable(writeTimeout));
     }
   }
 }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
@@ -23,6 +26,7 @@ import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.None;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -168,11 +172,52 @@ public final class GcsBackupStore implements BackupStore {
         executor);
   }
 
+  /**
+   * Transport options capping how long a single request may stall, or empty to leave the
+   * google-http-client defaults in place. Slow storage backends can stall a response past its
+   * default of 20s, or stall a content upload indefinitely, which fails the whole backup.
+   */
+  static Optional<HttpTransportOptions> transportOptions(final GcsBackupConfig config) {
+    if (config.readTimeout().isEmpty() && config.writeTimeout().isEmpty()) {
+      return Optional.empty();
+    }
+
+    final var optionsBuilder = HttpTransportOptions.newBuilder();
+    config.readTimeout().ifPresent(timeout -> optionsBuilder.setReadTimeout(toMillis(timeout)));
+    // HttpTransportOptions has no write timeout, even though the underlying request supports one.
+    return Optional.of(
+        config
+            .writeTimeout()
+            .map(timeout -> writeTimeoutOptions(optionsBuilder, toMillis(timeout)))
+            .orElseGet(optionsBuilder::build));
+  }
+
+  private static HttpTransportOptions writeTimeoutOptions(
+      final HttpTransportOptions.Builder optionsBuilder, final int writeTimeoutMillis) {
+    return new HttpTransportOptions(optionsBuilder) {
+      @Override
+      public HttpRequestInitializer getHttpRequestInitializer(
+          final ServiceOptions<?, ?> serviceOptions) {
+        final var delegate = super.getHttpRequestInitializer(serviceOptions);
+        return request -> {
+          delegate.initialize(request);
+          request.setWriteTimeout(writeTimeoutMillis);
+        };
+      }
+    };
+  }
+
+  private static int toMillis(final Duration timeout) {
+    return Math.toIntExact(timeout.toMillis());
+  }
+
   public static Storage buildClient(final GcsBackupConfig config) {
     final var builder =
         StorageOptions.newBuilder()
             .setHost(config.connection().host())
             .setCredentials(config.connection().auth().credentials());
+
+    transportOptions(config).ifPresent(builder::setTransportOptions);
 
     // Without authentication, we need to set the project ID explicitly
     if (config.connection().auth() instanceof None(final String projectId)) {

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
@@ -7,9 +7,16 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.StorageOptions;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
+import java.io.IOException;
+import java.time.Duration;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 final class ConfigTest {
@@ -105,6 +112,69 @@ final class ConfigTest {
 
     // then
     Assertions.assertThat(config.connection().auth()).isInstanceOf(Auto.class);
+  }
+
+  @Test
+  void shouldUseConfiguredReadTimeoutAsClientReadTimeout() {
+    // given
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withBucketName("test")
+            .withoutAuthentication()
+            .withReadTimeout(Duration.ofSeconds(90))
+            .build();
+
+    // when
+    final var client = GcsBackupStore.buildClient(config);
+
+    // then
+    Assertions.assertThat(client.getOptions().getTransportOptions())
+        .asInstanceOf(InstanceOfAssertFactories.type(HttpTransportOptions.class))
+        .extracting(HttpTransportOptions::getReadTimeout)
+        .isEqualTo(90_000);
+  }
+
+  @Test
+  void shouldApplyConfiguredWriteTimeoutToRequests() throws IOException {
+    // given
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withBucketName("test")
+            .withoutAuthentication()
+            .withWriteTimeout(Duration.ofSeconds(120))
+            .build();
+    final var transportOptions = GcsBackupStore.transportOptions(config).orElseThrow();
+    final var request =
+        new NetHttpTransport()
+            .createRequestFactory()
+            .buildGetRequest(new GenericUrl("http://localhost"));
+
+    // when
+    // the write timeout is not part of HttpTransportOptions, it is applied per request
+    transportOptions
+        .getHttpRequestInitializer(StorageOptions.newBuilder().setProjectId("test").build())
+        .initialize(request);
+
+    // then
+    Assertions.assertThat(request.getWriteTimeout()).isEqualTo(120_000);
+  }
+
+  @Test
+  void shouldKeepClientDefaultsWhenNoTimeoutIsSet() {
+    // given
+    final var config =
+        new GcsBackupConfig.Builder().withBucketName("test").withoutAuthentication().build();
+
+    // when
+    final var client = GcsBackupStore.buildClient(config);
+
+    // then
+    // -1 means the client does not set a read timeout, leaving the google-http-client default
+    Assertions.assertThat(GcsBackupStore.transportOptions(config)).isEmpty();
+    Assertions.assertThat(client.getOptions().getTransportOptions())
+        .asInstanceOf(InstanceOfAssertFactories.type(HttpTransportOptions.class))
+        .extracting(HttpTransportOptions::getReadTimeout)
+        .isEqualTo(-1);
   }
 
   @Test

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -32,6 +32,11 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
  * @param maxConcurrentConnections Maximum number of connections allowed in a connection pool.
  * @param connectionAcquisitionTimeout Timeout for acquiring an already-established connection from
  *     a connection pool to a remote service.
+ * @param readTimeout Timeout for reading a response from an already-established connection. A
+ *     single request exceeding this timeout fails and may be retried, as long as {@code
+ *     apiCallTimeout} is not exhausted. If empty, the AWS SDK default of 30s is used.
+ * @param writeTimeout Timeout for writing a request to an already-established connection, with the
+ *     same retry semantics as {@code readTimeout}. If empty, the AWS SDK default of 30s is used.
  * @see <a
  *     href=https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment>
  *     Automatically determine the Region from the environment</a>
@@ -51,7 +56,9 @@ public record S3BackupConfig(
     Optional<String> basePath,
     Integer maxConcurrentConnections,
     Duration connectionAcquisitionTimeout,
-    boolean supportLegacyMd5) {
+    boolean supportLegacyMd5,
+    Optional<Duration> readTimeout,
+    Optional<Duration> writeTimeout) {
 
   public S3BackupConfig {
     if (bucketName == null || bucketName.isEmpty()) {
@@ -95,6 +102,8 @@ public record S3BackupConfig(
     private Credentials credentials;
     private String basePath;
     private boolean supportLegacyMd5 = false;
+    private Duration readTimeout;
+    private Duration writeTimeout;
 
     /** Default from `SdkHttpConfigurationOption.MAX_CONNECTIONS` */
     private Integer maxConcurrentConnections = 50;
@@ -157,6 +166,16 @@ public record S3BackupConfig(
       return this;
     }
 
+    public Builder withReadTimeout(final Duration readTimeout) {
+      this.readTimeout = readTimeout;
+      return this;
+    }
+
+    public Builder withWriteTimeout(final Duration writeTimeout) {
+      this.writeTimeout = writeTimeout;
+      return this;
+    }
+
     public S3BackupConfig build() {
       return new S3BackupConfig(
           bucketName,
@@ -169,7 +188,9 @@ public record S3BackupConfig(
           Optional.ofNullable(basePath),
           maxConcurrentConnections,
           connectionAcquisitionTimeout,
-          supportLegacyMd5);
+          supportLegacyMd5,
+          Optional.ofNullable(readTimeout),
+          Optional.ofNullable(writeTimeout));
     }
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -398,13 +398,15 @@ public final class S3BackupStore implements BackupStore {
       builder.addPlugin(LegacyMd5Plugin.create());
     }
 
-    builder.httpClient(
+    final var httpClientBuilder =
         NettyNioAsyncHttpClient.builder()
             .maxConcurrency(config.maxConcurrentConnections())
             // We'd rather wait longer for a connection than have a failed backup. This helps in
             // smoothing out spikes when taking a backup.
-            .connectionAcquisitionTimeout(config.connectionAcquisitionTimeout())
-            .build());
+            .connectionAcquisitionTimeout(config.connectionAcquisitionTimeout());
+    config.readTimeout().ifPresent(httpClientBuilder::readTimeout);
+    config.writeTimeout().ifPresent(httpClientBuilder::writeTimeout);
+    builder.httpClient(httpClientBuilder.build());
 
     builder.overrideConfiguration(cfg -> cfg.retryStrategy(RetryMode.ADAPTIVE_V2));
     builder.forcePathStyle(config.forcePathStyleAccess());

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/RequestTimeoutTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/RequestTimeoutTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.UnaryOperator;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * Verifies that a configured read timeout takes effect, using an endpoint that accepts connections
+ * but never answers. Without a configured timeout, the AWS SDK would wait for its default of 30s
+ * per attempt, so the assertions below would not hold.
+ */
+final class RequestTimeoutTest {
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(1);
+
+  private ServerSocket serverSocket;
+  private ExecutorService acceptor;
+  private final List<Socket> acceptedConnections = new ArrayList<>();
+
+  @BeforeEach
+  void startStallingServer() throws IOException {
+    serverSocket = new ServerSocket(0);
+    acceptor = Executors.newSingleThreadExecutor();
+    acceptor.submit(
+        () -> {
+          while (!serverSocket.isClosed()) {
+            // Hold on to the connection so that it stays open without ever writing a response.
+            acceptedConnections.add(serverSocket.accept());
+          }
+          return null;
+        });
+  }
+
+  @AfterEach
+  void stopStallingServer() throws IOException {
+    serverSocket.close();
+    acceptor.shutdownNow();
+    for (final var connection : acceptedConnections) {
+      connection.close();
+    }
+  }
+
+  @Test
+  void shouldFailRequestAfterReadTimeout() {
+    // given
+    final var store = storeWith(builder -> builder.withReadTimeout(READ_TIMEOUT));
+
+    // when
+    final var status = store.getStatus(new BackupIdentifierImpl(1, 1, 1));
+
+    // then
+    assertThat(status)
+        .failsWithin(Duration.ofSeconds(15))
+        .withThrowableOfType(ExecutionException.class)
+        .withStackTraceContaining("Read timed out");
+  }
+
+  private S3BackupStore storeWith(final UnaryOperator<Builder> timeouts) {
+    final var config =
+        timeouts
+            .apply(
+                new Builder()
+                    .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+                    .withEndpoint("http://localhost:%d".formatted(serverSocket.getLocalPort()))
+                    .withRegion(Region.US_EAST_1.id())
+                    .withCredentials("letmein", "letmein1234")
+                    .forcePathStyleAccess(true))
+            .build();
+    return new S3BackupStore(config, S3BackupStore.buildClient(config));
+  }
+}

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/RequestTimeoutTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/RequestTimeoutTest.java
@@ -15,8 +15,8 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,7 +37,7 @@ final class RequestTimeoutTest {
 
   private ServerSocket serverSocket;
   private ExecutorService acceptor;
-  private final List<Socket> acceptedConnections = new ArrayList<>();
+  private final List<Socket> acceptedConnections = new CopyOnWriteArrayList<>();
 
   @BeforeEach
   void startStallingServer() throws IOException {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -384,12 +384,18 @@ public final class SystemContext {
     try {
       switch (backup.getStore()) {
         case NONE -> LOG.warn("No backup store is configured. Backups will not be taken");
-        case S3 -> S3BackupStore.validateConfig(S3BackupStoreConfig.toStoreConfig(backup.getS3()));
+        case S3 ->
+            S3BackupStore.validateConfig(
+                S3BackupStoreConfig.toStoreConfig(
+                    backup.getS3(), backup.getReadTimeout(), backup.getWriteTimeout()));
         case GCS ->
-            GcsBackupStore.validateConfig(GcsBackupStoreConfig.toStoreConfig(backup.getGcs()));
+            GcsBackupStore.validateConfig(
+                GcsBackupStoreConfig.toStoreConfig(
+                    backup.getGcs(), backup.getReadTimeout(), backup.getWriteTimeout()));
         case AZURE ->
             AzureBackupStore.validateConfig(
-                AzureBackupStoreConfig.toStoreConfig(backup.getAzure()));
+                AzureBackupStoreConfig.toStoreConfig(
+                    backup.getAzure(), backup.getReadTimeout(), backup.getWriteTimeout()));
         case FILESYSTEM ->
             FilesystemBackupStore.validateConfig(
                 FilesystemBackupStoreConfig.toStoreConfig(backup.getFilesystem()));

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/AzureBackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/AzureBackupStoreConfig.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.configuration.backup;
 import io.camunda.zeebe.backup.azure.AzureBackupConfig;
 import io.camunda.zeebe.backup.azure.SasTokenConfig;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import java.time.Duration;
 import java.util.Objects;
 
 public class AzureBackupStoreConfig implements ConfigurationEntry {
@@ -81,12 +82,17 @@ public class AzureBackupStoreConfig implements ConfigurationEntry {
     this.sasToken = sasToken;
   }
 
-  public static AzureBackupConfig toStoreConfig(final AzureBackupStoreConfig config) {
+  public static AzureBackupConfig toStoreConfig(
+      final AzureBackupStoreConfig config,
+      final Duration readTimeout,
+      final Duration writeTimeout) {
     // if sas token is enabled, then we don't create the container initially. This is due to the
     // fact that both delegation sas token and service sas token don't have permissions to
     // create/list a container. On the other hand account sas token can be configured to have the
     // permissions to do so.
     return new AzureBackupConfig.Builder()
+        .withReadTimeout(readTimeout)
+        .withWriteTimeout(writeTimeout)
         .withEndpoint(config.getEndpoint())
         .withAccountName(config.getAccountName())
         .withAccountKey(config.getAccountKey())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
@@ -92,11 +92,10 @@ public class BackupStoreCfg implements ConfigurationEntry {
   public String toString() {
     final var timeouts = ", readTimeout=" + readTimeout + ", writeTimeout=" + writeTimeout;
     return switch (store) {
-      case NONE -> "BackupStoreCfg{" + "store=" + store + timeouts + '}';
+      case NONE, FILESYSTEM -> "BackupStoreCfg{" + "store=" + store + timeouts + '}';
       case S3 -> "BackupStoreCfg{" + "store=" + store + ", s3=" + s3 + timeouts + '}';
       case GCS -> "BackupStoreCfg{" + "store=" + store + ", gcs=" + gcs + timeouts + '}';
       case AZURE -> "BackupStoreCfg{" + "store=" + store + ", azure=" + azure + timeouts + '}';
-      case FILESYSTEM -> "BackupStoreCfg{" + "store=" + store + ", azure=" + azure + timeouts + '}';
     };
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.configuration.backup;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import java.time.Duration;
 
 public class BackupStoreCfg implements ConfigurationEntry {
 
@@ -19,6 +20,9 @@ public class BackupStoreCfg implements ConfigurationEntry {
 
   private AzureBackupStoreConfig azure = new AzureBackupStoreConfig();
   private FilesystemBackupStoreConfig filesystem = new FilesystemBackupStoreConfig();
+
+  private Duration readTimeout;
+  private Duration writeTimeout;
 
   public S3BackupStoreConfig getS3() {
     return s3;
@@ -60,6 +64,22 @@ public class BackupStoreCfg implements ConfigurationEntry {
     this.store = store;
   }
 
+  public Duration getReadTimeout() {
+    return readTimeout;
+  }
+
+  public void setReadTimeout(final Duration readTimeout) {
+    this.readTimeout = readTimeout;
+  }
+
+  public Duration getWriteTimeout() {
+    return writeTimeout;
+  }
+
+  public void setWriteTimeout(final Duration writeTimeout) {
+    this.writeTimeout = writeTimeout;
+  }
+
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     s3.init(globalConfig, brokerBase);
@@ -70,12 +90,13 @@ public class BackupStoreCfg implements ConfigurationEntry {
 
   @Override
   public String toString() {
+    final var timeouts = ", readTimeout=" + readTimeout + ", writeTimeout=" + writeTimeout;
     return switch (store) {
-      case NONE -> "BackupStoreCfg{" + "store=" + store + '}';
-      case S3 -> "BackupStoreCfg{" + "store=" + store + ", s3=" + s3 + '}';
-      case GCS -> "BackupStoreCfg{" + "store=" + store + ", gcs=" + gcs + '}';
-      case AZURE -> "BackupStoreCfg{" + "store=" + store + ", azure=" + azure + '}';
-      case FILESYSTEM -> "BackupStoreCfg{" + "store=" + store + ", azure=" + azure + '}';
+      case NONE -> "BackupStoreCfg{" + "store=" + store + timeouts + '}';
+      case S3 -> "BackupStoreCfg{" + "store=" + store + ", s3=" + s3 + timeouts + '}';
+      case GCS -> "BackupStoreCfg{" + "store=" + store + ", gcs=" + gcs + timeouts + '}';
+      case AZURE -> "BackupStoreCfg{" + "store=" + store + ", azure=" + azure + timeouts + '}';
+      case FILESYSTEM -> "BackupStoreCfg{" + "store=" + store + ", azure=" + azure + timeouts + '}';
     };
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.configuration.backup;
 
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import java.time.Duration;
 import java.util.Objects;
 
 public class GcsBackupStoreConfig implements ConfigurationEntry {
@@ -60,9 +61,12 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
     this.bufferSize = bufferSize;
   }
 
-  public static GcsBackupConfig toStoreConfig(GcsBackupStoreConfig config) {
+  public static GcsBackupConfig toStoreConfig(
+      final GcsBackupStoreConfig config, final Duration readTimeout, final Duration writeTimeout) {
     final var storeConfig =
         new GcsBackupConfig.Builder()
+            .withReadTimeout(readTimeout)
+            .withWriteTimeout(writeTimeout)
             .withBucketName(config.getBucketName())
             .withBasePath(config.getBasePath())
             .withHost(config.getHost())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -133,9 +133,12 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     this.supportLegacyMd5 = supportLegacyMd5;
   }
 
-  public static S3BackupConfig toStoreConfig(final S3BackupStoreConfig config) {
+  public static S3BackupConfig toStoreConfig(
+      final S3BackupStoreConfig config, final Duration readTimeout, final Duration writeTimeout) {
     final var builder =
         new Builder()
+            .withReadTimeout(readTimeout)
+            .withWriteTimeout(writeTimeout)
             .withBucketName(config.getBucketName())
             .withEndpoint(config.getEndpoint())
             .withRegion(config.getRegion())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -85,7 +85,9 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final BackupStoreCfg backupCfg,
       final ActorFuture<Void> installed) {
     try {
-      final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupCfg.getS3());
+      final var storeConfig =
+          S3BackupStoreConfig.toStoreConfig(
+              backupCfg.getS3(), backupCfg.getReadTimeout(), backupCfg.getWriteTimeout());
       final var backupStore = S3BackupStore.of(storeConfig);
       context.setBackupStore(backupStore);
       installed.complete(null);
@@ -100,7 +102,9 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final ActorFuture<Void> installed) {
     try {
       final var brokerGcsConfig = backupCfg.getGcs();
-      final var storeGcsConfig = GcsBackupStoreConfig.toStoreConfig(brokerGcsConfig);
+      final var storeGcsConfig =
+          GcsBackupStoreConfig.toStoreConfig(
+              brokerGcsConfig, backupCfg.getReadTimeout(), backupCfg.getWriteTimeout());
       final var gcsStore = GcsBackupStore.of(storeGcsConfig);
       context.setBackupStore(gcsStore);
       installed.complete(null);
@@ -115,7 +119,9 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final ActorFuture<Void> installed) {
     try {
       final var brokerAzureConfig = backupCfg.getAzure();
-      final var storeAzureConfig = AzureBackupStoreConfig.toStoreConfig(brokerAzureConfig);
+      final var storeAzureConfig =
+          AzureBackupStoreConfig.toStoreConfig(
+              brokerAzureConfig, backupCfg.getReadTimeout(), backupCfg.getWriteTimeout());
       final var azureStore = AzureBackupStore.of(storeAzureConfig);
       context.setBackupStore(azureStore);
       installed.complete(null);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
@@ -9,12 +9,19 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.backup.azure.AzureBackupConfig;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 final class BackupStoreCfgTest {
@@ -72,6 +79,59 @@ final class BackupStoreCfgTest {
   }
 
   @Test
+  void shouldLeaveTimeoutsUnsetByDefault() {
+    // given
+    final var env = Map.<String, String>of();
+
+    // when
+    final var backup =
+        withBucketNames(TestConfigReader.readConfig("empty", env).getData().getBackup());
+
+    // then
+    assertThat(backup.getReadTimeout()).isNull();
+    assertThat(backup.getWriteTimeout()).isNull();
+    assertThat(s3StoreConfig(backup))
+        .extracting(S3BackupConfig::readTimeout, S3BackupConfig::writeTimeout)
+        .containsExactly(Optional.empty(), Optional.empty());
+    assertThat(gcsStoreConfig(backup))
+        .extracting(GcsBackupConfig::readTimeout, GcsBackupConfig::writeTimeout)
+        .containsExactly(Optional.empty(), Optional.empty());
+    assertThat(azureStoreConfig(backup))
+        .extracting(AzureBackupConfig::readTimeout, AzureBackupConfig::writeTimeout)
+        .containsExactly(Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  void shouldPassConfiguredTimeoutsToEveryStore() {
+    // given
+    final var env =
+        Map.of(
+            "zeebe.broker.data.backup.readTimeout",
+            "90s",
+            "zeebe.broker.data.backup.writeTimeout",
+            "120s");
+
+    // when
+    final var backup =
+        withBucketNames(TestConfigReader.readConfig("empty", env).getData().getBackup());
+
+    // then
+    final var read = Duration.ofSeconds(90);
+    final var write = Duration.ofSeconds(120);
+    assertThat(backup.getReadTimeout()).isEqualTo(read);
+    assertThat(backup.getWriteTimeout()).isEqualTo(write);
+    assertThat(s3StoreConfig(backup))
+        .extracting(S3BackupConfig::readTimeout, S3BackupConfig::writeTimeout)
+        .containsExactly(Optional.of(read), Optional.of(write));
+    assertThat(gcsStoreConfig(backup))
+        .extracting(GcsBackupConfig::readTimeout, GcsBackupConfig::writeTimeout)
+        .containsExactly(Optional.of(read), Optional.of(write));
+    assertThat(azureStoreConfig(backup))
+        .extracting(AzureBackupConfig::readTimeout, AzureBackupConfig::writeTimeout)
+        .containsExactly(Optional.of(read), Optional.of(write));
+  }
+
+  @Test
   void shouldSetPartialS3Config() {
     // given
     final S3BackupStoreConfig expectedConfig = new S3BackupStoreConfig();
@@ -88,5 +148,27 @@ final class BackupStoreCfgTest {
     // then
     assertThat(backup.getStore()).isEqualTo(BackupStoreType.S3);
     assertThat(backup.getS3()).isEqualTo(expectedConfig);
+  }
+
+  /** The S3 and GCS store configs reject a missing bucket name, which is unset by default. */
+  private static BackupStoreCfg withBucketNames(final BackupStoreCfg backup) {
+    backup.getS3().setBucketName("bucket");
+    backup.getGcs().setBucketName("bucket");
+    return backup;
+  }
+
+  private static S3BackupConfig s3StoreConfig(final BackupStoreCfg backup) {
+    return S3BackupStoreConfig.toStoreConfig(
+        backup.getS3(), backup.getReadTimeout(), backup.getWriteTimeout());
+  }
+
+  private static GcsBackupConfig gcsStoreConfig(final BackupStoreCfg backup) {
+    return GcsBackupStoreConfig.toStoreConfig(
+        backup.getGcs(), backup.getReadTimeout(), backup.getWriteTimeout());
+  }
+
+  private static AzureBackupConfig azureStoreConfig(final BackupStoreCfg backup) {
+    return AzureBackupStoreConfig.toStoreConfig(
+        backup.getAzure(), backup.getReadTimeout(), backup.getWriteTimeout());
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Backport the read/write timeouts for primary storage backup stores to 8.8.

Configuration itself is cherry picked from the same commits, wiring is different due to older version and incomplete unified config structure

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to: #58044
