### PR TITLE
ci: print GITHUB_TOKEN core rate limit in detect-changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
         timeout-minutes: 1
         with:
           persist-credentials: false
+      - name: Check GitHub API rate limit
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api rate_limit | jq 'walk(if type == "object" and has("reset") then .reset = (.reset | todate) else . end)'
       # Detect changes against the base branch
       - name: Detect changes
         uses: ./.github/actions/paths-filter


### PR DESCRIPTION
## Description

- `detect-changes` failed across the CI with `##[error]API rate limit exceeded for installation` from a `dorny/paths-filter` call: https://github.com/camunda/camunda/actions/runs/31687475728/job/94406808736
- Confirmed `dorny/paths-filter` uses the default `GITHUB_TOKEN` (not a camunda-controlled GitHub App), and this org's GHEC contract should put the per-repo core rate limit at 15,000 req/hour
- Before deciding whether/how to monitor this long-term, this PR adds a diagnostic step to `detect-changes` that prints the full `GET /rate_limit` response (that call itself doesn't consume the quota), with every bucket's `reset` epoch formatted as an ISO 8601 string so it's readable in the logs -> this will give us more info for repeat incidents in case they happen (looks less likely)
- `/rate_limit` requests do not count against the rate limit itself :)

Related to INC-7150