### PR TITLE
fix: stop secret-cache warmup from firing the job-lease collision warning

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -552,7 +552,15 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
   public enum JobAction {
     CREATED("created"),
     ACTIVATED("activated"),
-    SKIPPED("skipped"),
+    /**
+     * A leased job skipped by an activation requested without a lease. Operators watch this as the
+     * lease-collision signal, so the label stays {@code "skipped"} even though the constant is not:
+     * panel 13 of {@code monitor/grafana/zeebe.json} keys its orange row highlight on {@code
+     * action="skipped"}. Renaming the label means changing that dashboard in the same PR.
+     */
+    SKIPPED_LEASED("skipped"),
+    /** A job skipped because one of its secret references is not cached yet. */
+    SKIPPED_UNCACHED_SECRET("skipped uncached secret"),
     TIMED_OUT("timed out"),
     COMPLETED("completed"),
     FAILED("failed"),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -260,7 +260,7 @@ public class BpmnJobActivationBehavior {
       parked = true;
     }
     if (parked) {
-      jobMetrics.countJobEvent(JobAction.SKIPPED, jobKind, jobType);
+      jobMetrics.countJobEvent(JobAction.SKIPPED_UNCACHED_SECRET, jobKind, jobType);
     } else {
       notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -117,7 +117,8 @@ final class JobBatchCollector {
 
           if (!value.isWithLease() && !jobRecord.getLeaseToken().isEmpty()) {
             // Skip leased jobs so an unleased activation cannot break the lease's exclusivity
-            jobMetrics.countJobEvent(JobAction.SKIPPED, jobRecord.getJobKind(), value.getType());
+            jobMetrics.countJobEvent(
+                JobAction.SKIPPED_LEASED, jobRecord.getJobKind(), value.getType());
             return true;
           }
 
@@ -127,7 +128,8 @@ final class JobBatchCollector {
             // jobs behind them can still be activated, and register them so the processor can
             // request the background resolution of their non-cached references and park them
             jobSecretInjector.registerForResolution(secretCheckResult, key);
-            jobMetrics.countJobEvent(JobAction.SKIPPED, jobRecord.getJobKind(), value.getType());
+            jobMetrics.countJobEvent(
+                JobAction.SKIPPED_UNCACHED_SECRET, jobRecord.getJobKind(), value.getType());
             skippedUncachedSecretJobs.increment();
             if (skippedUncachedSecretJobs.value
                 >= EngineConfiguration.MAX_UNCACHED_SECRET_JOBS_SKIPPED_PER_ACTIVATION) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/EngineMetricsDocTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/EngineMetricsDocTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The doc enum is the documentation for these meters, so it is worth asserting on. Renaming a meter
+ * or a tag value silently breaks every dashboard and alert built on it, and there is no repo-wide
+ * check for that.
+ */
+final class EngineMetricsDocTest {
+
+  @Test
+  void shouldPinTheJobActionLabelsDashboardsKeyOn() {
+    // given — the tag values dashboards query zeebe_job_events_total{action=...} by
+    final var expectedLabels =
+        Map.ofEntries(
+            Map.entry(JobAction.CREATED, "created"),
+            Map.entry(JobAction.ACTIVATED, "activated"),
+            // the constant is named for the lease skip it reports, but the label stays "skipped":
+            // panel 13 of monitor/grafana/zeebe.json highlights that row orange to warn operators
+            // about unleased workers colliding with leased jobs
+            Map.entry(JobAction.SKIPPED_LEASED, "skipped"),
+            Map.entry(JobAction.SKIPPED_UNCACHED_SECRET, "skipped uncached secret"),
+            Map.entry(JobAction.TIMED_OUT, "timed out"),
+            Map.entry(JobAction.COMPLETED, "completed"),
+            Map.entry(JobAction.FAILED, "failed"),
+            Map.entry(JobAction.CANCELED, "canceled"),
+            Map.entry(JobAction.ERROR_THROWN, "error thrown"),
+            Map.entry(JobAction.WORKERS_NOTIFIED, "workers notified"),
+            Map.entry(JobAction.PUSHED, "pushed"));
+
+    // when
+    final var actualLabels =
+        Stream.of(JobAction.values())
+            .collect(Collectors.toMap(Function.identity(), JobAction::getLabel));
+
+    // then — asserting on the whole domain rather than value by value, so a new action fails here
+    // and its public tag becomes a decision instead of a side effect of the constant's name
+    assertThat(actualLabels).containsExactlyInAnyOrderEntriesOf(expectedLabels);
+  }
+
+  @Test
+  void shouldGiveEveryJobActionItsOwnLabel() {
+    // given/when
+    final var labels = Stream.of(JobAction.values()).map(JobAction::getLabel).toList();
+
+    // then — two actions sharing a label merge their causes into one series, and an operator
+    // watching that series can no longer tell which one moved
+    assertThat(labels).doesNotHaveDuplicates();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobProcessingMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobProcessingMetricsTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeThat;
 
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -76,14 +77,12 @@ public class JobProcessingMetricsTest {
 
   @Test
   public void allCountsStartAtNull() {
-    assertThat(findJobCounter("created", JOB_TYPE, scenario.jobKind)).isEmpty();
-    assertThat(findJobCounter("activated", JOB_TYPE, scenario.jobKind)).isEmpty();
-    assertThat(findJobCounter("skipped", JOB_TYPE, scenario.jobKind)).isEmpty();
-    assertThat(findJobCounter("timed out", JOB_TYPE, scenario.jobKind)).isEmpty();
-    assertThat(findJobCounter("completed", JOB_TYPE, scenario.jobKind)).isEmpty();
-    assertThat(findJobCounter("failed", JOB_TYPE, scenario.jobKind)).isEmpty();
-    assertThat(findJobCounter("canceled", JOB_TYPE, scenario.jobKind)).isEmpty();
-    assertThat(findJobCounter("error thrown", JOB_TYPE, scenario.jobKind)).isEmpty();
+    // derived from the enum rather than listed, so an action added later is covered without an
+    // edit here — the hand-maintained list had already gone stale on "workers notified" and
+    // "pushed". EngineMetricsDocTest pins which label each action emits
+    for (final var action : JobAction.values()) {
+      assertThat(findJobCounter(action.getLabel(), JOB_TYPE, scenario.jobKind)).isEmpty();
+    }
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -188,6 +188,22 @@ final class JobBatchCollectorTest {
   }
 
   @Test
+  void shouldCountLeaseSkipOnTheActionOperatorsWatch() {
+    // given - a leased job, and an activation that did not ask for a lease
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    createLeasedJob(state.getKeyGenerator().nextKey());
+
+    // when
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+
+    // then - panel 13 of monitor/grafana/zeebe.json highlights this emission orange to warn about
+    // unleased workers colliding with leased jobs, so it has to stay on the lease-skip action
+    JobBatchRecordValueAssert.assertThat(record.getValue()).hasNoJobKeys();
+    verify(jobMetrics).countJobEvent(JobAction.SKIPPED_LEASED, JobKind.BPMN_ELEMENT, JOB_TYPE);
+    verify(jobMetrics, never()).countJobEvent(eq(JobAction.SKIPPED_UNCACHED_SECRET), any(), any());
+  }
+
+  @Test
   void shouldStopCollectingWhenSkippedUncachedSecretJobsReachLimit() {
     // given - a plain job, one more uncached-secret job than the skip limit, and a plain job
     // behind them
@@ -762,6 +778,23 @@ final class JobBatchCollectorTest {
       final long variableScopeKey, final Map<String, String> variables) {
     setVariables(variableScopeKey, variables);
     createJob(variableScopeKey);
+  }
+
+  private Job createLeasedJob(final long variableScopeKey) {
+    final var jobRecord =
+        new JobRecord()
+            .setBpmnProcessId("process")
+            .setElementId("element")
+            .setElementInstanceKey(variableScopeKey)
+            .setType(JOB_TYPE)
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            // the job stays activatable while holding a token, which is the state an unleased
+            // activation has to skip over
+            .setLeaseToken("lease-token");
+    final long jobKey = state.getKeyGenerator().nextKey();
+
+    state.getJobState().create(jobKey, jobRecord);
+    return new Job(jobKey, jobRecord);
   }
 
   private Job createJobWithSecretReference(final long variableScopeKey, final String secretName) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -9,7 +9,10 @@ package io.camunda.zeebe.engine.processing.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.secretstore.InMemorySecretCache;
@@ -24,6 +27,7 @@ import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.core.authz.TenantAccess;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
@@ -74,6 +78,7 @@ final class JobBatchCollectorTest {
   private final RecordLengthEvaluator lengthEvaluator = new RecordLengthEvaluator();
   private final ControllableStreamClock clock =
       new ControllableStreamClockImpl(InstantSource.system());
+  private final JobProcessingMetrics jobMetrics = mock(JobProcessingMetrics.class);
   private final InMemorySecretCache secretCache = new InMemorySecretCache();
   private final JobSecretInjector secretInjector =
       new JobSecretInjector(
@@ -93,13 +98,7 @@ final class JobBatchCollectorTest {
     // are never invoked by the collector — pass nulls to satisfy the CslAuthorizationCheck ctor.
     final var cslCheck = new CslAuthorizationCheck(null, null, securityConfig);
     collector =
-        new JobBatchCollector(
-            state,
-            lengthEvaluator,
-            cslCheck,
-            clock,
-            mock(JobProcessingMetrics.class),
-            secretInjector);
+        new JobBatchCollector(state, lengthEvaluator, cslCheck, clock, jobMetrics, secretInjector);
   }
 
   @Test
@@ -149,7 +148,7 @@ final class JobBatchCollectorTest {
     final var securityConfig = EngineSecurityConfigurations.defaultConfig();
     final var cslCheck = new CslAuthorizationCheck(authzService, claimsConverter, securityConfig);
     return new JobBatchCollector(
-        state, lengthEvaluator, cslCheck, clock, mock(JobProcessingMetrics.class), secretInjector);
+        state, lengthEvaluator, cslCheck, clock, jobMetrics, secretInjector);
   }
 
   @Test
@@ -171,6 +170,21 @@ final class JobBatchCollectorTest {
     JobBatchRecordValueAssert.assertThat(record.getValue())
         .hasOnlyJobKeys(plainJob.key)
         .isNotTruncated();
+  }
+
+  @Test
+  void shouldCountUncachedSecretSkipOnItsOwnAction() {
+    // given - a job with an uncached secret reference
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    createJobWithSecretReference(state.getKeyGenerator().nextKey(), "uncached");
+
+    // when
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+
+    // then - the skip is reported on its own action, not on the lease-skip signal operators watch
+    verify(jobMetrics)
+        .countJobEvent(JobAction.SKIPPED_UNCACHED_SECRET, JobKind.BPMN_ELEMENT, JOB_TYPE);
+    verify(jobMetrics, never()).countJobEvent(eq(JobAction.SKIPPED_LEASED), any(), any());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretPushInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretPushInjectionTest.java
@@ -34,12 +34,14 @@ import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.ResolutionState;
 import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.micrometer.core.instrument.Counter;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -172,6 +174,13 @@ public final class JobSecretPushInjectionTest {
     assertThat(jobStream.getActivatedJobs()).isEmpty();
     assertThat(RecordingExporter.getRecords())
         .noneMatch(record -> record.getIntent() == JobBatchIntent.ACTIVATED);
+
+    // and - the skip is reported on its own action. Panel 13 of monitor/grafana/zeebe.json
+    // highlights action="skipped" orange to warn operators about unleased workers colliding with
+    // leased jobs, so an ordinary secret-cache miss must not land there
+    assertThat(findJobCounter("skipped uncached secret"))
+        .hasValueSatisfying(counter -> assertThat(counter.count()).isOne());
+    assertThat(findJobCounter("skipped")).isEmpty();
   }
 
   @Test
@@ -575,6 +584,18 @@ public final class JobSecretPushInjectionTest {
 
   private State jobState(final long jobKey) {
     return engine.getProcessingState().getJobState().getState(jobKey);
+  }
+
+  private Optional<Counter> findJobCounter(final String action) {
+    return Optional.ofNullable(
+        engine
+            .getMeterRegistry()
+            .find("zeebe.job.events.total")
+            .tag("action", action)
+            .tag("partition", "1")
+            .tag("type", JOB_TYPE)
+            .tag("job_kind", JobKind.BPMN_ELEMENT.name())
+            .counter());
   }
 
   private void deploy(final Consumer<ServiceTaskBuilder> modifier) {


### PR DESCRIPTION


Jobs skipped because their secret references are not cached yet counted JobAction.SKIPPED on both the polling and the push path. That action is the job-lease collision signal, and panel 13 of monitor/grafana/zeebe.json highlights its row orange, so ordinary secret-cache warmup looked to operators like unleased workers colliding with leased jobs. Both paths now report a distinct SKIPPED_UNCACHED_SECRET, and the lease action is renamed SKIPPED_LEASED so the next skip added has to pick an action rather than inherit one from a generic name; its label stays "skipped", leaving the emitted metric and every dashboard built on it unchanged.

## Description

`zeebe_job_events_total{action="skipped"}` is the job-lease collision signal. Panel 13 of `monitor/grafana/zeebe.json` highlights that row orange so operators notice unleased workers colliding with leased jobs. Jobs skipped because their secret references are not cached yet were counted on the same action, on both the polling path (`JobBatchCollector`) and the push path (`BpmnJobActivationBehavior`). Result: ordinary secret-cache warmup turned the lease-collision warning orange on any cluster using secret references, and operators could only tell the two apart by correlating other series.

Both paths now report a distinct `SKIPPED_UNCACHED_SECRET`. The lease action is renamed `SKIPPED_LEASED` so a future skip has to pick an action rather than inherit one from a generic name, since sharing the action is what caused this. Its label stays `"skipped"`, so the emitted metric and every dashboard built on it are unchanged, and no dashboard deploy is needed for the fix to take effect.


**Alternatives considered:**

A `reason` label (`lease` / `uncached_secret`) on the shared counter, as the issue suggests. On its own it does not fix the false warning, because `action="skipped"` would still aggregate both causes. Panel 13 would need to split or filter by `reason`, and operators keep seeing orange until that dashboard change ships. The two compose, so a `reason` label can still be added later if needed

**Notes:**

- Breaking in the narrow sense that anything alerting on `action="skipped"` stops counting secret skips, which is the point. No in-repo dashboard filters on `skipped` for this metric.
- No backport: both offending commits are 8.10-only, not on any `stable/*`.
- `EngineMetricsDocTest` pins the label each action emits, so a new action's public tag becomes a decision instead of a side effect of the constant's name.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59794
