### PR TITLE
feat: track and detect physical tenant availability

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -325,6 +325,7 @@ public final class ClusterConfigurationManagerService
         .andThen(
             new PartitionGroupExportingStateInitializer(
                 legacyExportingStates, staticConfiguration.localMemberId()))
+        .andThen(new PhysicalTenantAvailabilityInitializer(staticConfiguration))
         .andThen(new PhysicalTenantProvisioningInitializer(staticConfiguration));
   }
 
@@ -356,6 +357,7 @@ public final class ClusterConfigurationManagerService
         .andThen(
             new PartitionGroupExportingStateInitializer(
                 legacyExportingStates, staticConfiguration.localMemberId()))
+        .andThen(new PhysicalTenantAvailabilityInitializer(staticConfiguration))
         .andThen(new PhysicalTenantProvisioningInitializer(staticConfiguration));
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * New-model counterpart of {@link ExporterStateInitializer}, applying the same exporter-state
@@ -60,7 +61,7 @@ public class PartitionGroupExporterStateInitializer
   private CurrentClusterConfiguration updateLocalMemberExporterState(
       final CurrentClusterConfiguration configuration) {
     var updated = configuration;
-    for (final var groupId : configuration.partitionGroups().keySet()) {
+    for (final var groupId : enabledGroupIds(configuration)) {
       if (updated.partitionGroup(groupId).hasMember(localMemberId)) {
         updated =
             updated.updatePartitionGroupConfig(
@@ -78,7 +79,7 @@ public class PartitionGroupExporterStateInitializer
   private CurrentClusterConfiguration updateExporterStateForAllMembers(
       final CurrentClusterConfiguration configuration) {
     var updated = configuration;
-    for (final var groupId : configuration.partitionGroups().keySet()) {
+    for (final var groupId : enabledGroupIds(configuration)) {
       for (final var memberId : updated.partitionGroup(groupId).members().keySet()) {
         updated =
             updated.updatePartitionGroupConfig(
@@ -93,12 +94,26 @@ public class PartitionGroupExporterStateInitializer
     return updated;
   }
 
+  /**
+   * Every partition group to reconcile, excluding a disabled one (removed from local static
+   * configuration after being provisioned, see {@link PhysicalTenantAvailabilityInitializer}) - it
+   * has nothing to reconcile, since it is not running anywhere.
+   */
+  private static Set<String> enabledGroupIds(final CurrentClusterConfiguration configuration) {
+    return configuration.partitionGroups().entrySet().stream()
+        .filter(entry -> !entry.getValue().isDisabled())
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+  }
+
   private BrokerPartitionState updateExporterState(
       final String groupId, final BrokerPartitionState brokerPartitionState) {
     BrokerPartitionState updated = brokerPartitionState;
     if (!configuredExporters.containsKey(groupId)) {
-      // All partition groups should have a configuration. When we support disabling physical
-      // tenants, those groups must be filtered out before this call.
+      // An enabled group must always have a local exporter configuration - this initializer only
+      // reaches enabled groups (see enabledGroupIds), so a missing entry here means the local
+      // configuration is inconsistent with the cluster configuration, not that the tenant is
+      // disabled.
       throw new IllegalStateException(
           "No configuration found for partition group '%s'".formatted(groupId));
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializer.java
@@ -61,7 +61,7 @@ public class PartitionGroupExporterStateInitializer
   private CurrentClusterConfiguration updateLocalMemberExporterState(
       final CurrentClusterConfiguration configuration) {
     var updated = configuration;
-    for (final var groupId : enabledGroupIds(configuration)) {
+    for (final var groupId : reconcilableGroupIds(configuration)) {
       if (updated.partitionGroup(groupId).hasMember(localMemberId)) {
         updated =
             updated.updatePartitionGroupConfig(
@@ -79,7 +79,7 @@ public class PartitionGroupExporterStateInitializer
   private CurrentClusterConfiguration updateExporterStateForAllMembers(
       final CurrentClusterConfiguration configuration) {
     var updated = configuration;
-    for (final var groupId : enabledGroupIds(configuration)) {
+    for (final var groupId : reconcilableGroupIds(configuration)) {
       for (final var memberId : updated.partitionGroup(groupId).members().keySet()) {
         updated =
             updated.updatePartitionGroupConfig(
@@ -95,29 +95,30 @@ public class PartitionGroupExporterStateInitializer
   }
 
   /**
-   * Every partition group to reconcile, excluding a disabled one (removed from local static
-   * configuration after being provisioned, see {@link PhysicalTenantAvailabilityInitializer}) - it
-   * has nothing to reconcile, since it is not running anywhere.
+   * The groups to reconcile: exactly the local broker's own currently-configured physical tenants
+   * (the keys of {@code configuredExporters}) that already have a provisioned group in {@code
+   * configuration.partitionGroups()} - a locally-configured tenant not yet provisioned has nothing
+   * to reconcile yet.
+   *
+   * <p>Deliberately keyed off local configuration rather than each group's persisted {@code
+   * disabled} flag (see {@link PhysicalTenantAvailabilityInitializer}): that flag is only updated
+   * by the coordinator-only availability initializer, so on the very first restart after a tenant
+   * is removed from local configuration, the persisted group is still enabled while {@code
+   * configuredExporters} already lacks it - and the reverse on the first restart after a tenant
+   * reappears, where the persisted group is still disabled while {@code configuredExporters}
+   * already has it again. Local configuration is authoritative for both directions immediately,
+   * with no dependency on the availability initializer having already run - on this node or, since
+   * it never runs at all on a non-coordinator, on any node.
    */
-  private static Set<String> enabledGroupIds(final CurrentClusterConfiguration configuration) {
-    return configuration.partitionGroups().entrySet().stream()
-        .filter(entry -> !entry.getValue().isDisabled())
-        .map(Map.Entry::getKey)
+  private Set<String> reconcilableGroupIds(final CurrentClusterConfiguration configuration) {
+    return configuredExporters.keySet().stream()
+        .filter(configuration.partitionGroups()::containsKey)
         .collect(Collectors.toSet());
   }
 
   private BrokerPartitionState updateExporterState(
       final String groupId, final BrokerPartitionState brokerPartitionState) {
     BrokerPartitionState updated = brokerPartitionState;
-    if (!configuredExporters.containsKey(groupId)) {
-      // An enabled group must always have a local exporter configuration - this initializer only
-      // reaches enabled groups (see enabledGroupIds), so a missing entry here means the local
-      // configuration is inconsistent with the cluster configuration, not that the tenant is
-      // disabled.
-      throw new IllegalStateException(
-          "No configuration found for partition group '%s'".formatted(groupId));
-    }
-
     final Set<String> configuredExportersForGroup = configuredExporters.get(groupId);
     for (final var p : brokerPartitionState.partitions().keySet()) {
       final PartitionState currentPartitionState = brokerPartitionState.partitions().get(p);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantAvailabilityInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantAvailabilityInitializer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Disables a physical tenant on the coordinator once it is no longer present in the local static
+ * configuration, and re-enables it if it reappears — without ever removing its {@link
+ * PartitionGroupConfiguration} or touching its partition assignment, so a re-added tenant resumes
+ * where it left off.
+ *
+ * <p>Runs on every configuration initialization, comparing every existing group in {@link
+ * CurrentClusterConfiguration#partitionGroups()} against the coordinator's own local {@link
+ * StaticConfiguration#partitionIds()}. This mirrors {@link PhysicalTenantProvisioningInitializer}'s
+ * existing reliance on the coordinator's own local configuration as the source of truth for "which
+ * physical tenants are configured" — there is no cross-broker aggregation of this information
+ * anywhere in the system, so a rolling config change can move coordinatorship to a broker with a
+ * different local configuration and flip a tenant's availability accordingly. This is an accepted,
+ * pre-existing class of hazard for this subsystem, not one introduced here.
+ *
+ * <p>Deliberately a separate modifier from {@link PhysicalTenantProvisioningInitializer} rather
+ * than a change to it: the two operate on disjoint key sets (provisioning only ever touches tenant
+ * ids missing from {@code partitionGroups()}; this only ever touches ids present in it) and have
+ * different failure shapes (provisioning can fail an entire batch on a reassignment computation;
+ * toggling a flag cannot fail that way).
+ */
+public class PhysicalTenantAvailabilityInitializer
+    extends ClusterConfigurationModifier.CoordinatorOnly<CurrentClusterConfiguration> {
+
+  private final Set<String> staticTenantIds;
+
+  public PhysicalTenantAvailabilityInitializer(final StaticConfiguration staticConfiguration) {
+    super(staticConfiguration.localMemberId());
+    staticTenantIds =
+        staticConfiguration.partitionIds().stream()
+            .map(PartitionId::group)
+            .collect(Collectors.toSet());
+  }
+
+  @Override
+  public ActorFuture<CurrentClusterConfiguration> modify(
+      final CurrentClusterConfiguration configuration) {
+    var result = configuration;
+    for (final var groupId : configuration.partitionGroups().keySet()) {
+      final boolean isKnownLocally = staticTenantIds.contains(groupId);
+      result =
+          result.updatePartitionGroupConfig(
+              groupId,
+              isKnownLocally
+                  ? PartitionGroupConfiguration::enable
+                  : PartitionGroupConfiguration::disable);
+    }
+    return CompletableActorFuture.completed(result);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateIncarnationNumberApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateIncarnationNumberApplier.java
@@ -41,6 +41,7 @@ public final class UpdateIncarnationNumberApplier
                 group.members(),
                 group.routingState(),
                 group.pendingChanges(),
-                group.lastChange()));
+                group.lastChange(),
+                group.availability()));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -99,6 +99,7 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.dynamic.config.state.TenantAvailability;
 import io.camunda.zeebe.util.Either;
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -1933,7 +1934,8 @@ public class ProtoBufSerializer
         Topology.PartitionGroupConfiguration.newBuilder()
             .setVersion(configuration.version())
             .setIncarnationNumber(configuration.incarnationNumber())
-            .putAllMembers(members);
+            .putAllMembers(members)
+            .setAvailability(encodeTenantAvailability(configuration.availability()));
     configuration
         .routingState()
         .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
@@ -1963,13 +1965,30 @@ public class ProtoBufSerializer
         proto.hasLastChange()
             ? Optional.of(decodeCompletedChange(proto.getLastChange()))
             : Optional.empty();
+    final var availability =
+        proto.hasAvailability()
+            ? decodeTenantAvailability(proto.getAvailability())
+            : TenantAvailability.enabled();
     return new PartitionGroupConfiguration(
         proto.getVersion(),
         proto.getIncarnationNumber(),
         members,
         routingState,
         pendingChanges,
-        lastChange);
+        lastChange,
+        availability);
+  }
+
+  private Topology.TenantAvailability encodeTenantAvailability(
+      final TenantAvailability availability) {
+    return Topology.TenantAvailability.newBuilder()
+        .setVersion(availability.version())
+        .setDisabled(availability.disabled())
+        .build();
+  }
+
+  private TenantAvailability decodeTenantAvailability(final Topology.TenantAvailability proto) {
+    return new TenantAvailability(proto.getVersion(), proto.getDisabled());
   }
 
   private Topology.BrokerState encodeBrokerState(final BrokerState brokerState) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -49,6 +49,8 @@ import org.jspecify.annotations.Nullable;
  * @param routingState routing state scoped to this group, if any
  * @param pendingChanges the ongoing change plan for this group, if any
  * @param lastChange the last completed change plan for this group, if any
+ * @param availability whether this tenant is currently disabled; carries its own version,
+ *     independent of {@code version} — see {@link TenantAvailability}
  */
 @NullMarked
 public record PartitionGroupConfiguration(
@@ -57,7 +59,8 @@ public record PartitionGroupConfiguration(
     SortedMap<MemberId, BrokerPartitionState> members,
     Optional<RoutingState> routingState,
     Optional<ClusterChangePlan> pendingChanges,
-    Optional<CompletedChange> lastChange) {
+    Optional<CompletedChange> lastChange,
+    TenantAvailability availability) {
 
   public static final long INITIAL_VERSION = 1;
   public static final long INITIAL_INCARNATION_NUMBER = 0;
@@ -67,6 +70,7 @@ public record PartitionGroupConfiguration(
     Objects.requireNonNull(routingState, "routingState must not be null");
     Objects.requireNonNull(pendingChanges, "pendingChanges must not be null");
     Objects.requireNonNull(lastChange, "lastChange must not be null");
+    Objects.requireNonNull(availability, "availability must not be null");
     if (incarnationNumber < 0) {
       throw new IllegalArgumentException("Incarnation number must be >= 0");
     }
@@ -87,7 +91,27 @@ public record PartitionGroupConfiguration(
         ImmutableSortedMap.copyOf(members),
         routingState,
         pendingChanges,
-        lastChange);
+        lastChange,
+        TenantAvailability.enabled());
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public PartitionGroupConfiguration(
+      final long version,
+      final long incarnationNumber,
+      final Map<MemberId, BrokerPartitionState> members,
+      final Optional<RoutingState> routingState,
+      final Optional<ClusterChangePlan> pendingChanges,
+      final Optional<CompletedChange> lastChange,
+      final TenantAvailability availability) {
+    this(
+        version,
+        incarnationNumber,
+        ImmutableSortedMap.copyOf(members),
+        routingState,
+        pendingChanges,
+        lastChange,
+        availability);
   }
 
   /** Creates an empty group configuration at the given version with no members and no changes. */
@@ -128,7 +152,8 @@ public record PartitionGroupConfiguration(
         members,
         routingState,
         Optional.of(ClusterChangePlan.init(newVersion, operations)),
-        lastChange);
+        lastChange,
+        availability);
   }
 
   /**
@@ -158,7 +183,8 @@ public record PartitionGroupConfiguration(
             members,
             routingState,
             Optional.of(pendingChanges.orElseThrow().advance()),
-            lastChange);
+            lastChange,
+            availability);
 
     if (result.hasPendingChanges()) {
       return result;
@@ -178,7 +204,8 @@ public record PartitionGroupConfiguration(
         remainingMembers,
         routingState,
         Optional.empty(),
-        Optional.of(completedChange));
+        Optional.of(completedChange),
+        availability);
   }
 
   /**
@@ -190,14 +217,39 @@ public record PartitionGroupConfiguration(
    * operating mode); {@code pendingChanges} by plan-internal version; {@code routingState} by the
    * higher version; and {@code incarnationNumber} via {@link Math#max}.
    *
+   * <p>{@code availability} is always merged by its own version ({@link
+   * TenantAvailability#merge(TenantAvailability)}), independently of which branch above is taken —
+   * its version is deliberately kept out of {@code version}, so without this it could be silently
+   * overwritten by an unrelated top-level version bump in the whole-record-wins branch.
+   *
    * @param other the configuration to merge with
    * @return the merged configuration
    */
   public PartitionGroupConfiguration merge(final PartitionGroupConfiguration other) {
+    final var mergedAvailability = availability.merge(other.availability);
+
     if (version > other.version) {
-      return this;
+      return this.availability.equals(mergedAvailability)
+          ? this
+          : new PartitionGroupConfiguration(
+              version,
+              incarnationNumber,
+              members,
+              routingState,
+              pendingChanges,
+              lastChange,
+              mergedAvailability);
     } else if (other.version > version) {
-      return other;
+      return other.availability.equals(mergedAvailability)
+          ? other
+          : new PartitionGroupConfiguration(
+              other.version,
+              other.incarnationNumber,
+              other.members,
+              other.routingState,
+              other.pendingChanges,
+              other.lastChange,
+              mergedAvailability);
     }
 
     final var mergedMembers =
@@ -220,7 +272,8 @@ public record PartitionGroupConfiguration(
         mergedMembers,
         mergedRoutingState,
         mergedChanges,
-        lastChange);
+        lastChange,
+        mergedAvailability);
   }
 
   /**
@@ -278,7 +331,45 @@ public record PartitionGroupConfiguration(
         members,
         Optional.of(updatedRoutingState),
         pendingChanges,
-        lastChange);
+        lastChange,
+        availability);
+  }
+
+  public boolean isDisabled() {
+    return availability.disabled();
+  }
+
+  /**
+   * Marks this tenant as disabled, e.g. because it was removed from the local static configuration.
+   * Does not change {@code version} or touch {@code members} — the partition assignment is retained
+   * so the tenant can resume where it left off if re-enabled. Returns {@code this} if already
+   * disabled.
+   */
+  public PartitionGroupConfiguration disable() {
+    return withAvailability(availability.disable());
+  }
+
+  /**
+   * Marks this tenant as enabled again. Does not change {@code version} or touch {@code members}.
+   * Returns {@code this} if already enabled.
+   */
+  public PartitionGroupConfiguration enable() {
+    return withAvailability(availability.enable());
+  }
+
+  private PartitionGroupConfiguration withAvailability(
+      final TenantAvailability updatedAvailability) {
+    if (updatedAvailability.equals(availability)) {
+      return this;
+    }
+    return new PartitionGroupConfiguration(
+        version,
+        incarnationNumber,
+        members,
+        routingState,
+        pendingChanges,
+        lastChange,
+        updatedAvailability);
   }
 
   public boolean hasPendingChanges() {
@@ -334,7 +425,8 @@ public record PartitionGroupConfiguration(
         members,
         routingState,
         Optional.empty(),
-        Optional.of(cancelledChange));
+        Optional.of(cancelledChange),
+        availability);
   }
 
   public boolean hasMember(final MemberId memberId) {
@@ -388,7 +480,13 @@ public record PartitionGroupConfiguration(
   private PartitionGroupConfiguration withMembers(
       final Map<MemberId, BrokerPartitionState> updatedMembers) {
     return new PartitionGroupConfiguration(
-        version, incarnationNumber, updatedMembers, routingState, pendingChanges, lastChange);
+        version,
+        incarnationNumber,
+        updatedMembers,
+        routingState,
+        pendingChanges,
+        lastChange,
+        availability);
   }
 
   public int partitionCount() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/TenantAvailability.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/TenantAvailability.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Whether a physical tenant (a {@link PartitionGroupConfiguration}) is currently disabled — i.e.
+ * removed from every broker's local static configuration, but still retaining its partition
+ * assignment and data so it can resume where it left off if the tenant is reconfigured.
+ *
+ * <p>{@code version} is this sub-record's own version, deliberately independent of the enclosing
+ * {@link PartitionGroupConfiguration#version()}: toggling availability must not bump the group
+ * version, since availability changes are orthogonal to partition-assignment/plan-boundary changes.
+ * Merge is highest-own-version-wins ({@link #merge(TenantAvailability)}), the same pattern as
+ * {@link BrokerPartitionState}, and must be applied independently of whichever branch of {@link
+ * PartitionGroupConfiguration#merge(PartitionGroupConfiguration)} is taken — otherwise an unrelated
+ * bump of the group's top-level version could silently overwrite a more recently toggled value.
+ *
+ * @param version this sub-record's own version, bumped only by {@link #disable()}/{@link #enable()}
+ * @param disabled whether the tenant is currently disabled
+ */
+@NullMarked
+public record TenantAvailability(long version, boolean disabled) {
+
+  public static final long INITIAL_VERSION = 0;
+
+  public static TenantAvailability enabled() {
+    return new TenantAvailability(INITIAL_VERSION, false);
+  }
+
+  /**
+   * Returns a disabled instance with an incremented version, or {@code this} if already disabled.
+   */
+  public TenantAvailability disable() {
+    return disabled ? this : new TenantAvailability(version + 1, true);
+  }
+
+  /**
+   * Returns an enabled instance with an incremented version, or {@code this} if already enabled.
+   */
+  public TenantAvailability enable() {
+    return disabled ? new TenantAvailability(version + 1, false) : this;
+  }
+
+  /**
+   * Returns whichever of this and {@code other} has the higher own version; {@code this} wins ties.
+   */
+  TenantAvailability merge(final TenantAvailability other) {
+    return version >= other.version ? this : other;
+  }
+}

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -43,6 +43,15 @@ message PartitionGroupConfiguration {
   RoutingState routingState = 4;
   ClusterChangePlan pendingChanges = 5;
   CompletedChange lastChange = 6;
+  TenantAvailability availability = 7;
+}
+
+// Whether a physical tenant is currently disabled (removed from local static configuration, but
+// retaining its partition assignment and data). Carries its own version, independent of the
+// enclosing PartitionGroupConfiguration.version.
+message TenantAvailability {
+  int64 version = 1;
+  bool disabled = 2;
 }
 
 // Broker lifecycle state. Holds State and timestamps; no partition assignment.

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
@@ -240,6 +241,101 @@ final class PartitionGroupExporterStateInitializerTest {
                 .get("expA")
                 .state())
         .isEqualTo(State.CONFIG_NOT_FOUND);
+  }
+
+  @Test
+  void shouldSkipADisabledGroup() {
+    // given — tenant-b was removed from local static configuration (see
+    // PhysicalTenantAvailabilityInitializer) after being provisioned, so it is now disabled and has
+    // no entry in the locally-configured exporters map, even though its group still exists
+    final var config = DynamicPartitionConfig.init();
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(
+                "tenant-a", groupWithMember(LOCAL_MEMBER_ID, config),
+                "tenant-b", groupWithMember(LOCAL_MEMBER_ID, config).disable()),
+            PhasedChangeState.empty());
+
+    // when — only tenant-a has a local exporter configuration
+    final var exporters = Map.of("tenant-a", Set.of("expA"));
+    final var result =
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
+            .modify(configuration)
+            .join();
+
+    // then — tenant-a is reconciled normally, tenant-b is left untouched rather than throwing
+    assertThat(
+            result
+                .partitionGroup("tenant-a")
+                .getMember(LOCAL_MEMBER_ID)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .containsKey("expA");
+    assertThat(result.partitionGroup("tenant-b"))
+        .isEqualTo(configuration.partitionGroup("tenant-b"));
+  }
+
+  @Test
+  void shouldSkipADisabledGroupWhenCoordinatorAndPostRestore() {
+    // given — same as above, but on the coordinator's post-restore, all-members reconciliation path
+    final var config = DynamicPartitionConfig.init();
+    final var otherMember = MemberId.from("1");
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(
+                "tenant-a",
+                groupWithMember(LOCAL_MEMBER_ID, config)
+                    .addMember(otherMember, initialPartitionState(config)),
+                "tenant-b",
+                groupWithMember(LOCAL_MEMBER_ID, config).disable()),
+            postRestorePendingState());
+
+    // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"));
+    final var result =
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, true)
+            .modify(configuration)
+            .join();
+
+    // then
+    assertThat(
+            result
+                .partitionGroup("tenant-a")
+                .getMember(LOCAL_MEMBER_ID)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .containsKey("expA");
+    assertThat(result.partitionGroup("tenant-b"))
+        .isEqualTo(configuration.partitionGroup("tenant-b"));
+  }
+
+  @Test
+  void shouldThrowWhenAnEnabledGroupHasNoLocalExporterConfiguration() {
+    // given — tenant-b is enabled (not removed from local static configuration), but is missing
+    // from the locally-configured exporters map - an inconsistency that should never happen and
+    // must not be silently treated the same way as a disabled tenant
+    final var config = DynamicPartitionConfig.init();
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-b", groupWithMember(LOCAL_MEMBER_ID, config)),
+            PhasedChangeState.empty());
+
+    // when / then
+    final var initializer =
+        new PartitionGroupExporterStateInitializer(Map.of(), LOCAL_MEMBER_ID, false);
+    assertThatThrownBy(() -> initializer.modify(configuration))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tenant-b");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.dynamic.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
@@ -244,10 +243,12 @@ final class PartitionGroupExporterStateInitializerTest {
   }
 
   @Test
-  void shouldSkipADisabledGroup() {
+  void shouldSkipAGroupAbsentFromLocalConfiguration() {
     // given — tenant-b was removed from local static configuration (see
-    // PhysicalTenantAvailabilityInitializer) after being provisioned, so it is now disabled and has
-    // no entry in the locally-configured exporters map, even though its group still exists
+    // PhysicalTenantAvailabilityInitializer) after being provisioned, so it has no entry in the
+    // locally-configured exporters map, even though its group still exists and — since this is the
+    // very first restart after the removal, before the coordinator-only availability initializer
+    // has run — is still marked enabled
     final var config = DynamicPartitionConfig.init();
     final var configuration =
         new CurrentClusterConfiguration(
@@ -255,7 +256,7 @@ final class PartitionGroupExporterStateInitializerTest {
             GlobalConfiguration.init(),
             Map.of(
                 "tenant-a", groupWithMember(LOCAL_MEMBER_ID, config),
-                "tenant-b", groupWithMember(LOCAL_MEMBER_ID, config).disable()),
+                "tenant-b", groupWithMember(LOCAL_MEMBER_ID, config)),
             PhasedChangeState.empty());
 
     // when — only tenant-a has a local exporter configuration
@@ -265,7 +266,8 @@ final class PartitionGroupExporterStateInitializerTest {
             .modify(configuration)
             .join();
 
-    // then — tenant-a is reconciled normally, tenant-b is left untouched rather than throwing
+    // then — tenant-a is reconciled normally, tenant-b is left untouched rather than throwing,
+    // regardless of its still-stale disabled flag
     assertThat(
             result
                 .partitionGroup("tenant-a")
@@ -280,7 +282,7 @@ final class PartitionGroupExporterStateInitializerTest {
   }
 
   @Test
-  void shouldSkipADisabledGroupWhenCoordinatorAndPostRestore() {
+  void shouldSkipAGroupAbsentFromLocalConfigurationWhenCoordinatorAndPostRestore() {
     // given — same as above, but on the coordinator's post-restore, all-members reconciliation path
     final var config = DynamicPartitionConfig.init();
     final var otherMember = MemberId.from("1");
@@ -293,7 +295,7 @@ final class PartitionGroupExporterStateInitializerTest {
                 groupWithMember(LOCAL_MEMBER_ID, config)
                     .addMember(otherMember, initialPartitionState(config)),
                 "tenant-b",
-                groupWithMember(LOCAL_MEMBER_ID, config).disable()),
+                groupWithMember(LOCAL_MEMBER_ID, config)),
             postRestorePendingState());
 
     // when
@@ -318,24 +320,60 @@ final class PartitionGroupExporterStateInitializerTest {
   }
 
   @Test
-  void shouldThrowWhenAnEnabledGroupHasNoLocalExporterConfiguration() {
-    // given — tenant-b is enabled (not removed from local static configuration), but is missing
-    // from the locally-configured exporters map - an inconsistency that should never happen and
-    // must not be silently treated the same way as a disabled tenant
+  void shouldReconcileATenantThatReappearedInLocalConfigurationWhileStillMarkedDisabled() {
+    // given — tenant-b reappeared in local static configuration, but this is the very first
+    // restart since then: the coordinator-only PhysicalTenantAvailabilityInitializer has not yet
+    // flipped its persisted flag back, so the group is still marked disabled even though it is now
+    // locally configured again
     final var config = DynamicPartitionConfig.init();
     final var configuration =
         new CurrentClusterConfiguration(
             CurrentClusterConfiguration.INITIAL_VERSION,
             GlobalConfiguration.init(),
-            Map.of("tenant-b", groupWithMember(LOCAL_MEMBER_ID, config)),
+            Map.of("tenant-b", groupWithMember(LOCAL_MEMBER_ID, config).disable()),
             PhasedChangeState.empty());
 
-    // when / then
-    final var initializer =
-        new PartitionGroupExporterStateInitializer(Map.of(), LOCAL_MEMBER_ID, false);
-    assertThatThrownBy(() -> initializer.modify(configuration))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("tenant-b");
+    // when — tenant-b is locally configured again
+    final var exporters = Map.of("tenant-b", Set.of("expA"));
+    final var result =
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
+            .modify(configuration)
+            .join();
+
+    // then — reconciled normally despite the still-stale disabled flag
+    assertThat(
+            result
+                .partitionGroup("tenant-b")
+                .getMember(LOCAL_MEMBER_ID)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters())
+        .containsKey("expA");
+  }
+
+  @Test
+  void shouldSkipALocallyConfiguredTenantNotYetProvisioned() {
+    // given — tenant-b is locally configured (has a local exporter configuration), but has not
+    // been provisioned into the cluster configuration yet - PhysicalTenantProvisioningInitializer's
+    // job, not this one's
+    final var config = DynamicPartitionConfig.init();
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", groupWithMember(LOCAL_MEMBER_ID, config)),
+            PhasedChangeState.empty());
+
+    // when
+    final var exporters = Map.of("tenant-a", Set.of("expA"), "tenant-b", Set.of("expA"));
+    final var result =
+        new PartitionGroupExporterStateInitializer(exporters, LOCAL_MEMBER_ID, false)
+            .modify(configuration)
+            .join();
+
+    // then — no error, and no group was created for tenant-b
+    assertThat(result.partitionGroups()).containsOnlyKeys("tenant-a");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantAvailabilityInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantAvailabilityInitializerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+final class PhysicalTenantAvailabilityInitializerTest {
+
+  private static final MemberId LOCAL_MEMBER_ID = MemberId.from("0");
+
+  private final DynamicPartitionConfig partitionConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  @Test
+  void shouldDisableATenantRemovedFromLocalStaticConfiguration() {
+    // given — tenantA is still in the topology, but the local static configuration only lists
+    // tenantB
+    final var existing =
+        Set.of(
+            partition("tenantA", 1, Set.of(member(0))), partition("tenantB", 1, Set.of(member(0))));
+    final var configuration = configurationWith(existing);
+    final var staticConfiguration = staticConfigWith(List.of(tenantPartitionIds("tenantB", 1)));
+    final var initializer = new PhysicalTenantAvailabilityInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then
+    assertThat(result.partitionGroup("tenantA").isDisabled()).isTrue();
+    assertThat(result.partitionGroup("tenantB").isDisabled()).isFalse();
+  }
+
+  @Test
+  void shouldRetainPartitionAssignmentWhileDisabling() {
+    // given
+    final var existing = Set.of(partition("tenantA", 1, Set.of(member(0), member(1))));
+    final var configuration = configurationWith(existing);
+    final var staticConfiguration = staticConfigWith(List.of());
+    final var initializer = new PhysicalTenantAvailabilityInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — members/partitions are untouched, only availability changed
+    assertThat(result.partitionGroup("tenantA").isDisabled()).isTrue();
+    assertThat(result.partitionGroup("tenantA").members())
+        .isEqualTo(configuration.partitionGroup("tenantA").members());
+    assertThat(result.partitionGroup("tenantA").version())
+        .isEqualTo(configuration.partitionGroup("tenantA").version());
+  }
+
+  @Test
+  void shouldReEnableATenantThatReappearsInLocalStaticConfiguration() {
+    // given — tenantA was previously disabled, but is now back in the local static configuration
+    final var existing = Set.of(partition("tenantA", 1, Set.of(member(0))));
+    final var disabledConfiguration =
+        configurationWith(existing)
+            .updatePartitionGroupConfig("tenantA", PartitionGroupConfiguration::disable);
+    final var staticConfiguration = staticConfigWith(List.of(tenantPartitionIds("tenantA", 1)));
+    final var initializer = new PhysicalTenantAvailabilityInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(disabledConfiguration).join();
+
+    // then
+    assertThat(result.partitionGroup("tenantA").isDisabled()).isFalse();
+  }
+
+  @Test
+  void shouldNotChangeAnythingWhenEveryGroupMatchesLocalStaticConfiguration() {
+    // given
+    final var existing = Set.of(partition("tenantA", 1, Set.of(member(0))));
+    final var configuration = configurationWith(existing);
+    final var staticConfiguration = staticConfigWith(List.of(tenantPartitionIds("tenantA", 1)));
+    final var initializer = new PhysicalTenantAvailabilityInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then
+    assertThat(result).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldLeaveANotYetProvisionedTenantAlone() {
+    // given — the local static configuration lists tenantB, but it has no group yet (provisioning's
+    // job, not this initializer's)
+    final var existing = Set.of(partition("tenantA", 1, Set.of(member(0))));
+    final var configuration = configurationWith(existing);
+    final var staticConfiguration =
+        staticConfigWith(
+            List.of(tenantPartitionIds("tenantA", 1), tenantPartitionIds("tenantB", 1)));
+    final var initializer = new PhysicalTenantAvailabilityInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — no group was created for tenantB, and tenantA is untouched (still enabled)
+    assertThat(result.partitionGroups()).containsOnlyKeys("tenantA");
+    assertThat(result.partitionGroup("tenantA").isDisabled()).isFalse();
+  }
+
+  private StaticConfiguration staticConfigWith(final List<List<PartitionId>> tenantPartitionIds) {
+    final List<PartitionId> allPartitionIds =
+        tenantPartitionIds.stream().flatMap(List::stream).toList();
+    final var tenantConfigs =
+        tenantPartitionIds.stream()
+            .map(list -> list.get(0).group())
+            .collect(Collectors.toMap(Function.identity(), group -> partitionConfig));
+    return new StaticConfiguration(
+        new RoundRobinPartitionDistributor(),
+        Set.of(member(0), member(1), member(2)),
+        LOCAL_MEMBER_ID,
+        allPartitionIds,
+        1,
+        tenantConfigs,
+        "clusterId");
+  }
+
+  private List<PartitionId> tenantPartitionIds(final String tenantId, final int count) {
+    return IntStream.rangeClosed(1, count)
+        .mapToObj(number -> new PartitionId(tenantId, number))
+        .toList();
+  }
+
+  private CurrentClusterConfiguration configurationWith(final Set<PartitionMetadata> existing) {
+    final Set<MemberId> members = new HashSet<>();
+    existing.forEach(metadata -> members.addAll(metadata.members()));
+    for (int i = 0; i < 3; i++) {
+      members.add(member(i));
+    }
+    final var tenantConfigs =
+        existing.stream()
+            .map(p -> p.id().group())
+            .distinct()
+            .collect(Collectors.toMap(Function.identity(), group -> partitionConfig));
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        members, existing, tenantConfigs, "clusterId");
+  }
+
+  private PartitionMetadata partition(
+      final String group, final int number, final Set<MemberId> members) {
+    final Map<MemberId, Integer> priorities = new HashMap<>();
+    final var sortedMembers = members.stream().sorted().toList();
+    for (int i = 0; i < sortedMembers.size(); i++) {
+      priorities.put(sortedMembers.get(i), sortedMembers.size() - i);
+    }
+    final var primary = sortedMembers.get(0);
+    return new PartitionMetadata(
+        new PartitionId(group, number), members, priorities, priorities.get(primary), primary);
+  }
+
+  private MemberId member(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -152,6 +152,95 @@ class PartitionGroupConfigurationTest {
       // then — the mode rides the winning (higher-version) broker state
       assertThat(merged.members().get(MEMBER_0).mode()).isEqualTo(Mode.RECOVERING);
     }
+
+    @Test
+    void shouldMergeAvailabilityByItsOwnVersionWhenConfigVersionsAreEqual() {
+      // given — same config version, but the right side was disabled more recently
+      final var left = group(3, Map.of()).disable(); // availability version 1, disabled
+      final var right = group(3, Map.of()).disable().enable(); // availability version 2, enabled
+
+      // when / then — availability's own version decides, independent of member/config state
+      assertThat(left.merge(right).isDisabled()).isFalse();
+      assertThat(right.merge(left).isDisabled()).isFalse();
+    }
+
+    @Test
+    void shouldPreserveHigherVersionedAvailabilityAcrossAWholeRecordVersionMismatch() {
+      // given — the lower config-version side was disabled more recently than the higher side ever
+      // toggled its own availability; a plain top-level-version-wins merge would otherwise silently
+      // drop the more recent disable when the higher-config-version side wins wholesale
+      final var lower = group(1, Map.of()).disable();
+      final var higher = group(2, Map.of());
+
+      // when / then — the higher config version wins for everything else, but the more recently
+      // toggled availability (owned independently of the top-level version) survives
+      assertThat(lower.merge(higher))
+          .usingRecursiveComparison()
+          .ignoringFields("availability")
+          .isEqualTo(higher);
+      assertThat(lower.merge(higher).isDisabled()).isTrue();
+      assertThat(higher.merge(lower).isDisabled()).isTrue();
+    }
+  }
+
+  @Nested
+  class Availability {
+
+    @Test
+    void shouldBeEnabledByDefault() {
+      // given
+      final var config = group(1, Map.of());
+
+      // when / then
+      assertThat(config.isDisabled()).isFalse();
+    }
+
+    @Test
+    void shouldDisableWithoutChangingGroupVersionOrMembers() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
+
+      // when
+      final var disabled = config.disable();
+
+      // then
+      assertThat(disabled.isDisabled()).isTrue();
+      assertThat(disabled.version()).isEqualTo(config.version());
+      assertThat(disabled.members()).isEqualTo(config.members());
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenAlreadyDisabled() {
+      // given
+      final var disabled = group(1, Map.of()).disable();
+
+      // when / then
+      assertThat(disabled.disable()).isSameAs(disabled);
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenAlreadyEnabled() {
+      // given
+      final var config = group(1, Map.of());
+
+      // when / then
+      assertThat(config.enable()).isSameAs(config);
+    }
+
+    @Test
+    void shouldReEnableWithoutChangingGroupVersionOrMembers() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
+      final var disabled = config.disable();
+
+      // when
+      final var reEnabled = disabled.enable();
+
+      // then
+      assertThat(reEnabled.isDisabled()).isFalse();
+      assertThat(reEnabled.version()).isEqualTo(config.version());
+      assertThat(reEnabled.members()).isEqualTo(config.members());
+    }
   }
 
   @Nested

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/TenantAvailabilityTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/TenantAvailabilityTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TenantAvailabilityTest {
+
+  @Nested
+  class Toggling {
+
+    @Test
+    void shouldBeEnabledInitially() {
+      assertThat(TenantAvailability.enabled().disabled()).isFalse();
+    }
+
+    @Test
+    void shouldIncrementVersionOnDisable() {
+      // given
+      final var enabled = TenantAvailability.enabled();
+
+      // when
+      final var disabled = enabled.disable();
+
+      // then
+      assertThat(disabled.disabled()).isTrue();
+      assertThat(disabled.version()).isEqualTo(enabled.version() + 1);
+    }
+
+    @Test
+    void shouldIncrementVersionOnEnable() {
+      // given
+      final var disabled = TenantAvailability.enabled().disable();
+
+      // when
+      final var enabled = disabled.enable();
+
+      // then
+      assertThat(enabled.disabled()).isFalse();
+      assertThat(enabled.version()).isEqualTo(disabled.version() + 1);
+    }
+
+    @Test
+    void shouldNotChangeVersionWhenDisablingAnAlreadyDisabledInstance() {
+      // given
+      final var disabled = TenantAvailability.enabled().disable();
+
+      // when
+      final var stillDisabled = disabled.disable();
+
+      // then
+      assertThat(stillDisabled).isEqualTo(disabled);
+    }
+
+    @Test
+    void shouldNotChangeVersionWhenEnablingAnAlreadyEnabledInstance() {
+      // given
+      final var enabled = TenantAvailability.enabled();
+
+      // when
+      final var stillEnabled = enabled.enable();
+
+      // then
+      assertThat(stillEnabled).isEqualTo(enabled);
+    }
+  }
+
+  @Nested
+  class Merge {
+
+    @Test
+    void shouldKeepHigherVersionRegardlessOfSide() {
+      // given
+      final var lower = TenantAvailability.enabled(); // version 0
+      final var higher = lower.disable(); // version 1
+
+      // when / then
+      assertThat(lower.merge(higher)).isEqualTo(higher);
+      assertThat(higher.merge(lower)).isEqualTo(higher);
+    }
+
+    @Test
+    void shouldPreferThisOnEqualVersion() {
+      // given — two independently constructed instances at the same version and value
+      final var a = TenantAvailability.enabled();
+      final var b = TenantAvailability.enabled();
+
+      // when / then
+      assertThat(a.merge(b)).isEqualTo(a);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.dynamic.config.state.TenantAvailability;
 import io.camunda.zeebe.util.ReflectUtil;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -244,11 +245,26 @@ public final class ClusterTopologyDomain extends DomainContextBase {
     final var pendingChanges =
         Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
     final var lastChange = Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
+    final var availability = tenantAvailabilities();
     return Combinators.combine(
-            version, incarnationNumber, members, routingState, pendingChanges, lastChange)
+            version,
+            incarnationNumber,
+            members,
+            routingState,
+            pendingChanges,
+            lastChange,
+            availability)
         .as(
-            (v, inc, m, routing, pending, last) ->
-                new PartitionGroupConfiguration(v, inc, m, routing, pending, last));
+            (v, inc, m, routing, pending, last, tenantAvailability) ->
+                new PartitionGroupConfiguration(
+                    v, inc, m, routing, pending, last, tenantAvailability));
+  }
+
+  @Provide
+  Arbitrary<TenantAvailability> tenantAvailabilities() {
+    final var version = Arbitraries.longs().greaterOrEqual(0);
+    final var disabled = Arbitraries.of(true, false);
+    return Combinators.combine(version, disabled).as(TenantAvailability::new);
   }
 
   @Provide


### PR DESCRIPTION
## Summary
- Adds a persisted, versioned `TenantAvailability` flag on `PartitionGroupConfiguration`, so a physical tenant's disabled/enabled state can be tracked independently of the group's own partition-assignment version, without ever deleting its data or broker assignment.
- Adds `PhysicalTenantAvailabilityInitializer`, which automatically disables a physical tenant once it disappears from the coordinator's local static configuration, and re-enables it if it reappears.
- Wires the new initializer into `ClusterConfigurationManagerService`'s coordinator and non-coordinator initializer chains, ahead of `PhysicalTenantProvisioningInitializer`.

This is the first of three PRs breaking down #60070 ("Disable physical tenants removed from configuration"): it lays the state/detection foundation. Follow-up PRs will make cluster-wide operations, routing topology, and new-tenant placement actually respect this flag.

## Related issue
part of #60070
