### PR TITLE
feat: add filter & sort by agentDefinitionKey for agent instance search

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -334,6 +334,7 @@
             <typeMapping>ResourceKey=String</typeMapping>
             <typeMapping>ScopeKey=String</typeMapping>
             <!-- map specific filter properties to basic filter types -->
+            <typeMapping>AgentDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>AuditLogEntityKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>AuditLogKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>DecisionDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceFilter.java
@@ -43,6 +43,23 @@ public interface AgentInstanceFilter extends SearchRequestFilter {
   AgentInstanceFilter agentInstanceKey(Consumer<BasicLongProperty> fn);
 
   /**
+   * Filter agent instances by the key of the agent definition they are an instance of.
+   *
+   * @param value the agent definition key
+   * @return the updated filter
+   */
+  AgentInstanceFilter agentDefinitionKey(long value);
+
+  /**
+   * Filter agent instances by the key of the agent definition they are an instance of using a
+   * {@link BasicLongProperty} consumer.
+   *
+   * @param fn the agent definition key filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter agentDefinitionKey(Consumer<BasicLongProperty> fn);
+
+  /**
    * Filter agent instances by their current status.
    *
    * @param value the status to match

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceSort.java
@@ -21,6 +21,8 @@ public interface AgentInstanceSort extends SearchRequestSort<AgentInstanceSort> 
 
   AgentInstanceSort agentInstanceKey();
 
+  AgentInstanceSort agentDefinitionKey();
+
   AgentInstanceSort status();
 
   AgentInstanceSort elementId();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceFilterImpl.java
@@ -62,6 +62,19 @@ public class AgentInstanceFilterImpl
   }
 
   @Override
+  public AgentInstanceFilter agentDefinitionKey(final long value) {
+    return agentDefinitionKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter agentDefinitionKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setAgentDefinitionKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public AgentInstanceFilter status(final AgentInstanceStatus value) {
     return status(f -> f.eq(value));
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceSortImpl.java
@@ -32,6 +32,11 @@ public class AgentInstanceSortImpl extends SearchRequestSortBase<AgentInstanceSo
   }
 
   @Override
+  public AgentInstanceSort agentDefinitionKey() {
+    return field("agentDefinitionKey");
+  }
+
+  @Override
   public AgentInstanceSort status() {
     return field("status");
   }

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
@@ -86,6 +86,17 @@ class SearchAgentInstanceTest extends ClientRestTest {
   }
 
   @Test
+  void shouldSearchAgentInstancesWithAgentDefinitionKeyFilter() {
+    // when
+    client.newAgentInstanceSearchRequest().filter(f -> f.agentDefinitionKey(4321L)).send().join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getFilter().getAgentDefinitionKey().get$Eq()).isEqualTo("4321");
+  }
+
+  @Test
   void shouldSearchAgentInstancesWithProcessInstanceKeyFilter() {
     // when
     client.newAgentInstanceSearchRequest().filter(f -> f.processInstanceKey(9000L)).send().join();

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
@@ -165,7 +165,9 @@ class SearchAgentInstanceTest extends ClientRestTest {
                     .completionDate()
                     .asc()
                     .status()
-                    .asc())
+                    .asc()
+                    .agentDefinitionKey()
+                    .desc())
         .send()
         .join();
 
@@ -183,7 +185,10 @@ class SearchAgentInstanceTest extends ClientRestTest {
                 AgentInstanceSearchQuerySortRequest.FieldEnum.LAST_UPDATED_DATE,
                 SortOrderEnum.DESC),
             tuple(AgentInstanceSearchQuerySortRequest.FieldEnum.COMPLETION_DATE, SortOrderEnum.ASC),
-            tuple(AgentInstanceSearchQuerySortRequest.FieldEnum.STATUS, SortOrderEnum.ASC));
+            tuple(AgentInstanceSearchQuerySortRequest.FieldEnum.STATUS, SortOrderEnum.ASC),
+            tuple(
+                AgentInstanceSearchQuerySortRequest.FieldEnum.AGENT_DEFINITION_KEY,
+                SortOrderEnum.DESC));
   }
 
   @Test

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -230,6 +230,19 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="create_agent_instance_ad_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_INSTANCE_AD_KEY"
+          tableName="${prefix}AGENT_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_INSTANCE"
+      indexName="${prefix}IDX_AGENT_INSTANCE_AD_KEY">
+      <column name="AGENT_DEFINITION_KEY"/>
+    </createIndex>
+  </changeSet>
+
   <changeSet id="create_agent_instance_element_id_index" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentInstanceSearchColumn.java
@@ -11,6 +11,7 @@ import io.camunda.search.entities.AgentInstanceEntity;
 
 public enum AgentInstanceSearchColumn implements SearchColumn<AgentInstanceEntity> {
   AGENT_INSTANCE_KEY("agentInstanceKey"),
+  AGENT_DEFINITION_KEY("agentDefinitionKey"),
   STATUS("status"),
   ELEMENT_ID("elementId"),
   PROCESS_INSTANCE_KEY("processInstanceKey"),

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -265,6 +265,12 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
+      <if test="filter.agentDefinitionKeyOperations != null and !filter.agentDefinitionKeyOperations.isEmpty()">
+        <foreach collection="filter.agentDefinitionKeyOperations" item="operation">
+          AND ai.AGENT_DEFINITION_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
       <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
         <foreach collection="filter.processInstanceKeyOperations" item="operation">
           AND ai.PROCESS_INSTANCE_KEY

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReaderTest.java
@@ -159,6 +159,23 @@ class AgentInstanceDbReaderTest {
   }
 
   @Test
+  void shouldPassAgentDefinitionKeyFilterToMapper() {
+    when(agentInstanceMapper.count(any())).thenReturn(1L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentInstanceDbReader.search(
+        AgentInstanceQuery.of(b -> b.filter(f -> f.agentDefinitionKeys(300L))),
+        ResourceAccessChecks.disabled());
+
+    verify(agentInstanceMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().agentDefinitionKeyOperations().stream()
+                        .anyMatch(op -> op.value().equals(300L))));
+  }
+
+  @Test
   void shouldPassStatusFilterToMapper() {
     when(agentInstanceMapper.count(any())).thenReturn(1L);
     when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L)));

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1573,6 +1573,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getAgentInstanceKey())
           .map(mapToKeyOperations("agentInstanceKey", validationErrors))
           .ifPresent(builder::agentInstanceKeyOperations);
+      ofNullable(filter.getAgentDefinitionKey())
+          .map(mapToKeyOperations("agentDefinitionKey", validationErrors))
+          .ifPresent(builder::agentDefinitionKeyOperations);
       ofNullable(filter.getStatus())
           .map(mapToStringOperations())
           .ifPresent(builder::statusOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -1060,6 +1060,7 @@ public class SearchQuerySortRequestMapper {
     } else {
       switch (field) {
         case AGENT_INSTANCE_KEY -> builder.agentInstanceKey();
+        case AGENT_DEFINITION_KEY -> builder.agentDefinitionKey();
         case STATUS -> builder.status();
         case ELEMENT_ID -> builder.elementId();
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -45,6 +45,10 @@ public class AgentInstanceSearchIT {
   private static String processDefinitionId;
   private static long processDefinitionKey2;
   private static String processDefinitionId2;
+  // agentDefinitionKey is derived from (processDefinitionKey, elementId): ai1 and ai2 share
+  // process definition 1's element, so they share one key; ai3 has a distinct one from pd2.
+  private static long agentDefinitionKey1;
+  private static long agentDefinitionKey3;
 
   @BeforeAll
   static void setup() {
@@ -171,6 +175,20 @@ public class AgentInstanceSearchIT {
         camundaClient, agentInstanceKey1, AgentInstanceStatus.THINKING);
     waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey2);
     waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey3);
+
+    // Capture the engine-assigned agent definition keys for filter/sort assertions.
+    agentDefinitionKey1 = fetchAgentDefinitionKey(agentInstanceKey1);
+    agentDefinitionKey3 = fetchAgentDefinitionKey(agentInstanceKey3);
+  }
+
+  private static long fetchAgentDefinitionKey(final long agentInstanceKey) {
+    return camundaClient
+        .newAgentInstanceSearchRequest()
+        .filter(f -> f.agentInstanceKey(agentInstanceKey))
+        .execute()
+        .items()
+        .getFirst()
+        .getAgentDefinitionKey();
   }
 
   @Test
@@ -270,6 +288,60 @@ public class AgentInstanceSearchIT {
   }
 
   @Test
+  void shouldFilterByAgentDefinitionKey() {
+    // when — ai1 and ai2 share pd1's agent definition
+    final var response1 =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.agentDefinitionKey(agentDefinitionKey1))
+            .execute();
+
+    // then
+    assertThat(response1.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactlyInAnyOrder(agentInstanceKey1, agentInstanceKey2);
+
+    // when — ai3 has pd2's distinct agent definition
+    final var response2 =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.agentDefinitionKey(agentDefinitionKey3))
+            .execute();
+
+    // then
+    assertThat(response2.items())
+        .singleElement()
+        .satisfies(ai -> assertThat(ai.getAgentInstanceKey()).isEqualTo(agentInstanceKey3));
+  }
+
+  @Test
+  void shouldFilterByAgentDefinitionKeyWithAdvancedOperators() {
+    // when — in matches both agent definitions, so it returns all three instances
+    final var inResponse =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.agentDefinitionKey(b -> b.in(agentDefinitionKey1, agentDefinitionKey3)))
+            .execute();
+
+    // then
+    assertThat(inResponse.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactlyInAnyOrder(agentInstanceKey1, agentInstanceKey2, agentInstanceKey3);
+
+    // when — every agent instance is derived from an agent definition, so exists(true) matches all
+    final var existsResponse =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.agentDefinitionKey(b -> b.exists(true)))
+            .execute();
+
+    // then
+    assertThat(existsResponse.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactlyInAnyOrder(agentInstanceKey1, agentInstanceKey2, agentInstanceKey3);
+  }
+
+  @Test
   void shouldFilterByProcessDefinitionId() {
     // when — pd1 has 2 agent instances
     final var responsePd1 =
@@ -357,6 +429,19 @@ public class AgentInstanceSearchIT {
 
     // then — keys must be in ascending order; this is the canonical stable pagination tiebreaker
     assertThat(response.items()).extracting(AgentInstance::getAgentInstanceKey).isSorted();
+  }
+
+  @Test
+  void shouldSortByAgentDefinitionKeyAscending() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .sort(s -> s.agentDefinitionKey().asc())
+            .execute();
+
+    // then — all three agent instances ordered by their agent definition key
+    assertThat(response.items()).extracting(AgentInstance::getAgentDefinitionKey).isSorted();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
@@ -17,6 +17,7 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -43,6 +44,76 @@ public class AgentInstanceFilterIT {
 
     assertThat(result.total()).isEqualTo(1);
     assertThat(result.items().getFirst().agentInstanceKey()).isEqualTo(model.agentInstanceKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByAgentDefinitionKey(final CamundaRdbmsTestApplication testApplication) {
+    final long agentDefinitionKey = nextKey();
+    final var model =
+        createAndSaveRandomAgentInstance(
+            testApplication, b -> b.agentDefinitionKey(agentDefinitionKey));
+    createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder().agentDefinitionKeys(agentDefinitionKey).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentInstanceKey()).isEqualTo(model.agentInstanceKey());
+    assertThat(result.items().getFirst().agentDefinitionKey()).isEqualTo(agentDefinitionKey);
+  }
+
+  @TestTemplate
+  public void shouldFilterByAgentDefinitionKeyIn(
+      final CamundaRdbmsTestApplication testApplication) {
+    final long agentDefinitionKey1 = nextKey();
+    final long agentDefinitionKey2 = nextKey();
+    createAndSaveRandomAgentInstance(
+        testApplication, b -> b.agentDefinitionKey(agentDefinitionKey1));
+    createAndSaveRandomAgentInstance(
+        testApplication, b -> b.agentDefinitionKey(agentDefinitionKey2));
+    createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder()
+                .agentDefinitionKeyOperations(
+                    Operation.in(agentDefinitionKey1, agentDefinitionKey2))
+                .build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items())
+        .extracting(AgentInstanceEntity::agentDefinitionKey)
+        .containsExactlyInAnyOrder(agentDefinitionKey1, agentDefinitionKey2);
+  }
+
+  @TestTemplate
+  public void shouldFilterByAgentDefinitionKeyExists(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String procDefId = "agent-def-exists-" + nextStringId();
+    createAndSaveRandomAgentInstance(testApplication, b -> b.processDefinitionId(procDefId));
+    createAndSaveRandomAgentInstance(testApplication, b -> b.processDefinitionId(procDefId));
+
+    // every agent instance is derived from an agent definition, so its key is always populated
+    final var existing =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder()
+                .processDefinitionIds(procDefId)
+                .agentDefinitionKeyOperations(Operation.exists(true))
+                .build());
+    assertThat(existing.total()).isEqualTo(2);
+
+    final var missing =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder()
+                .processDefinitionIds(procDefId)
+                .agentDefinitionKeyOperations(Operation.exists(false))
+                .build());
+    assertThat(missing.total()).isEqualTo(0);
   }
 
   @TestTemplate

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
@@ -88,6 +88,23 @@ public class AgentInstanceSortIT {
   }
 
   @TestTemplate
+  public void shouldSortByAgentDefinitionKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.agentDefinitionKey().asc(),
+        Comparator.comparingLong(AgentInstanceEntity::agentDefinitionKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByAgentDefinitionKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.agentDefinitionKey().desc(),
+        Comparator.comparingLong(AgentInstanceEntity::agentDefinitionKey).reversed());
+  }
+
+  @TestTemplate
   public void shouldSortByAgentInstanceKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformer.java
@@ -15,6 +15,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperatio
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.ROOT_PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.AGENT_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.CREATION_DATE;
@@ -44,6 +45,7 @@ public class AgentInstanceFilterTransformer extends IndexFilterTransformer<Agent
   public SearchQuery toSearchQuery(final AgentInstanceFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     queries.addAll(longOperations(KEY, filter.agentInstanceKeyOperations()));
+    queries.addAll(longOperations(AGENT_DEFINITION_KEY, filter.agentDefinitionKeyOperations()));
     queries.addAll(longOperations(ELEMENT_INSTANCE_KEYS, filter.elementInstanceKeyOperations()));
     queries.addAll(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
     queries.addAll(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.sort;
 
 import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.ROOT_PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.AGENT_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.CREATION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_ID;
@@ -24,6 +25,7 @@ public class AgentInstanceFieldSortingTransformer implements FieldSortingTransfo
   public String apply(final String domainField) {
     return switch (domainField) {
       case "agentInstanceKey" -> KEY; // ES/OS stores the key as "key", not "agentInstanceKey"
+      case "agentDefinitionKey" -> AGENT_DEFINITION_KEY;
       case "status" -> STATUS;
       case "elementId" -> ELEMENT_ID;
       case "processInstanceKey" -> PROCESS_INSTANCE_KEY;

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformerTest.java
@@ -34,6 +34,21 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  void shouldQueryByAgentDefinitionKey() {
+    final var filter = FilterBuilders.agentInstance(f -> f.agentDefinitionKeys(500L));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("agentDefinitionKey");
+              assertThat(t.value().longValue()).isEqualTo(500L);
+            });
+  }
+
+  @Test
   void shouldQueryByElementInstanceKey() {
     final var filter = FilterBuilders.agentInstance(f -> f.elementInstanceKeys(1L));
 
@@ -240,6 +255,7 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
         FilterBuilders.agentInstance(
             f ->
                 f.agentInstanceKeys(100L)
+                    .agentDefinitionKeys(500L)
                     .elementInstanceKeys(1L)
                     .processInstanceKeys(200L)
                     .rootProcessInstanceKeys(300L)
@@ -260,6 +276,6 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
     final var searchRequest = transformQuery(filter);
 
     assertThat(searchRequest.queryOption()).isInstanceOf(SearchBoolQuery.class);
-    assertThat(((SearchBoolQuery) searchRequest.queryOption()).must()).hasSize(14);
+    assertThat(((SearchBoolQuery) searchRequest.queryOption()).must()).hasSize(15);
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformerTest.java
@@ -30,6 +30,10 @@ public class AgentInstanceFieldSortingTransformerTest extends AbstractSortTransf
     return Stream.of(
         new TestArguments(
             AgentInstanceTemplate.KEY, SortOrder.DESC, s -> s.agentInstanceKey().desc()),
+        new TestArguments(
+            AgentInstanceTemplate.AGENT_DEFINITION_KEY,
+            SortOrder.ASC,
+            s -> s.agentDefinitionKey().asc()),
         new TestArguments(AgentInstanceTemplate.STATUS, SortOrder.ASC, s -> s.status().asc()),
         new TestArguments(
             AgentInstanceTemplate.ELEMENT_ID, SortOrder.ASC, s -> s.elementId().asc()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 
 public record AgentInstanceFilter(
     List<Operation<Long>> agentInstanceKeyOperations,
+    List<Operation<Long>> agentDefinitionKeyOperations,
     List<Operation<Long>> elementInstanceKeyOperations,
     List<Operation<Long>> processInstanceKeyOperations,
     List<Operation<Long>> rootProcessInstanceKeyOperations,
@@ -43,6 +44,7 @@ public record AgentInstanceFilter(
   public static final class Builder implements ObjectBuilder<AgentInstanceFilter> {
 
     private List<Operation<Long>> agentInstanceKeyOperations;
+    private List<Operation<Long>> agentDefinitionKeyOperations;
     private List<Operation<Long>> elementInstanceKeyOperations;
     private List<Operation<Long>> processInstanceKeyOperations;
     private List<Operation<Long>> rootProcessInstanceKeyOperations;
@@ -70,6 +72,21 @@ public record AgentInstanceFilter(
 
     public Builder agentInstanceKeys(final Long value, final Long... values) {
       return agentInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder agentDefinitionKeyOperations(final List<Operation<Long>> operations) {
+      agentDefinitionKeyOperations = addValuesToList(agentDefinitionKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder agentDefinitionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return agentDefinitionKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder agentDefinitionKeys(final Long value, final Long... values) {
+      return agentDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder elementInstanceKeyOperations(final List<Operation<Long>> operations) {
@@ -261,6 +278,7 @@ public record AgentInstanceFilter(
     public AgentInstanceFilter build() {
       return new AgentInstanceFilter(
           Objects.requireNonNullElse(agentInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(agentDefinitionKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(elementInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(rootProcessInstanceKeyOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceSort.java
@@ -31,6 +31,11 @@ public record AgentInstanceSort(List<FieldSorting> orderings) implements SortOpt
       return this;
     }
 
+    public Builder agentDefinitionKey() {
+      currentOrdering = new FieldSorting("agentDefinitionKey", null);
+      return this;
+    }
+
     public Builder status() {
       currentOrdering = new FieldSorting("status", null);
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -323,6 +323,7 @@ components:
           type: string
           enum:
             - agentInstanceKey
+            - agentDefinitionKey
             - status
             - elementId
             - processInstanceKey

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -360,6 +360,10 @@ components:
           description: The unique key of the agent instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentInstanceKeyFilterProperty'
+        agentDefinitionKey:
+          description: The key of the agent definition this agent instance is an instance of.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/AgentDefinitionKeyFilterProperty'
         status:
           description: The current status of the agent instance.
           allOf:
@@ -462,7 +466,7 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentInstanceKey'
         agentDefinitionKey:
-          description: The key of the agent definition this agent instance runs on.
+          description: The key of the agent definition this agent instance is an instance of.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentDefinitionKey'
         status:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -30,8 +30,12 @@ import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -327,6 +331,54 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
                             .build())
                     .build()),
             any());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAgentDefinitionKeyFilterOperations")
+  void shouldSearchAgentInstancesWithAgentDefinitionKeyFilter(
+      final String filterString, final AgentInstanceFilter filter) {
+    // given
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(AGENT_INSTANCE_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": %s
+            }
+            """
+                .formatted(filterString))
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentInstanceServices)
+        .search(eq(new AgentInstanceQuery.Builder().filter(filter).build()), any());
+  }
+
+  private static Stream<Arguments> provideAgentDefinitionKeyFilterOperations() {
+    final var streamBuilder = Stream.<Arguments>builder();
+    keyOperationTestCases(
+        streamBuilder,
+        "agentDefinitionKey",
+        ops -> new AgentInstanceFilter.Builder().agentDefinitionKeyOperations(ops).build());
+    return streamBuilder.build();
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -23,6 +23,7 @@ import io.camunda.search.filter.AgentInstanceFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.exception.ErrorMapper;
@@ -427,6 +428,49 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
                             .processDefinitionVersionOperations(List.of(Operation.eq(1)))
                             .versionTagOperations(List.of(Operation.eq("v1")))
                             .build())
+                    .build()),
+            any());
+  }
+
+  @Test
+  void shouldSortAgentInstancesByAgentDefinitionKey() {
+    // given
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(AGENT_INSTANCE_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "sort": [
+                { "field": "agentDefinitionKey", "order": "ASC" }
+              ]
+            }
+            """)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentInstanceServices)
+        .search(
+            eq(
+                new AgentInstanceQuery.Builder()
+                    .sort(AgentInstanceSort.of(s -> s.agentDefinitionKey().asc()))
                     .build()),
             any());
   }


### PR DESCRIPTION
## Description

Adds support for filtering and sorting agent instances by `agentDefinitionKey` across the full search stack — enabling "runs of this exact agent definition" queries and instance-level drill-down from a definition.

### Changes

- **API (OpenAPI):** Added `agentDefinitionKey` as a filterable field and sortable enum value in `agent-instances.yaml`.
- **Search domain:** Extended `AgentInstanceFilter` with `agentDefinitionKeyOperations` and `AgentInstanceSort` with an `agentDefinitionKey()` ordering.
- **Query transformers:** Wired `agentDefinitionKey` into `AgentInstanceFilterTransformer` and `AgentInstanceFieldSortingTransformer` for Elasticsearch/OpenSearch.
- **RDBMS:** Added `AGENT_DEFINITION_KEY` to `AgentInstanceSearchColumn`, updated the MyBatis mapper with the filter condition, and added a Liquibase changeset to create an index on `AGENT_DEFINITION_KEY`.
- **Gateway (HTTP mapping):** Mapped the new filter property through `SearchQueryFilterMapper` and added the sort field to `SearchQuerySortRequestMapper`.
- **Java client:** Added `agentDefinitionKey(long)` / `agentDefinitionKey(Consumer<BasicLongProperty>)` to `AgentInstanceFilter` and `agentDefinitionKey()` to `AgentInstanceSort`, with corresponding implementations and type mappings.
- **Tests:** Unit, integration, and acceptance tests covering filter and sort by `agentDefinitionKey` across all layers (client, REST controller, RDBMS, and end-to-end).

## Related issues

Closes #59092