### PR TITLE
Load tests: reduce secondary storage disk capacity

### DIFF
--- a/load-tests/setup/charts/load-test-setup/values.yaml
+++ b/load-tests/setup/charts/load-test-setup/values.yaml
@@ -125,7 +125,7 @@ elasticsearch:
     # -- Kubernetes StorageClass for the PersistentVolumeClaim.
     storageClassName: benchmark-ssd-zonal-v1
     # -- Storage capacity requested per Elasticsearch node.
-    requests: 512Gi
+    requests: 160Gi
 
   # -- Node selector labels for Elasticsearch pod scheduling.
   # The top-level `topologyZone` value is also applied as `topology.kubernetes.io/zone`.
@@ -304,7 +304,7 @@ opensearch:
 
   persistence:
     enabled: true
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   nodeSelector:
@@ -394,7 +394,7 @@ postgresql:
 
   # -- Persistent storage configuration for the PostgreSQL cluster.
   storage:
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   # -- The PostgreSQL database and user used by Camunda to connect to this cluster.

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "512Gi"
+          storage: "160Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "512Gi"
+          storage: "160Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "512Gi"
+          storage: "160Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "512Gi"
+          storage: "160Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "512Gi"
+          storage: "160Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "512Gi"
+          storage: "160Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 512Gi
+    size: 160Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 512Gi
+            storage: 160Gi
 
   http:
     tls:


### PR DESCRIPTION
## Description

 - With the improvements and configuration of Optimize, we no longer need such big disks for the secondary storage.
 - This has been validated and verified via https://github.com/camunda/camunda/issues/59330
 - [Endurance tests](https://github.com/camunda/camunda/issues/59330#issuecomment-5277785871) and [stress tests](https://github.com/camunda/camunda/issues/59330#issuecomment-5278847049) have been executed
 - Conclusion posted [here](https://github.com/camunda/camunda/issues/59330#issuecomment-5278872646), validation for different [secondary storages and versions ](https://github.com/camunda/camunda/issues/59330#issuecomment-5279866000)
 - We are able to reduce the disk capacity by a factor of three, reducing costs for our load tests as well




<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to https://github.com/camunda/camunda/issues/59330
