### PR TITLE
fix initialization for physical tenants

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
@@ -40,9 +40,10 @@ import org.springframework.core.env.Environment;
  *
  * <p>Enforcement is <em>key inspection</em> over the declared {@code physical-tenants.<id>.*} keys
  * — the same walk {@link PhysicalTenantResolver#discover(Environment)} does. The one value it binds
- * is the tenant's effective {@code security.authorization.enabled} (per-tenant override, else root,
- * else the default), which determines whether the tenant is exempt. A tenant with authorization
- * enabled that declares no key at or under {@code security.initialization} fails resolution.
+ * is the tenant's effective {@code security.authorizations.enabled} (per-tenant override, else
+ * root, else the default), which determines whether the tenant is exempt. A non-default tenant with
+ * authorization enabled that declares no key at or under {@code security.initialization} fails
+ * resolution.
  */
 @NullMarked
 final class PhysicalTenantRequiredOverrideValidation {
@@ -54,6 +55,12 @@ final class PhysicalTenantRequiredOverrideValidation {
    */
   private static final ConfigurationPropertyName REQUIRED_INITIALIZATION =
       ConfigurationPropertyName.of("security.initialization");
+
+  /**
+   * Relative name of the authorization toggle the runtime enforces. The root and per-tenant keys
+   * are both built from it, so the two cannot drift apart.
+   */
+  private static final String AUTHORIZATIONS_ENABLED = "security.authorizations.enabled";
 
   private PhysicalTenantRequiredOverrideValidation() {}
 
@@ -89,8 +96,11 @@ final class PhysicalTenantRequiredOverrideValidation {
               + "for that tenant; it may not be "
               + "inherited from the root (the '"
               + PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID
-              + "' tenant keeps the top-level 'camunda.security.initialization'). Physical tenants "
-              + "missing a required initialization block: "
+              + "' tenant keeps the top-level 'camunda.security.initialization'). To exempt a "
+              + "tenant instead, disable authorization for it with "
+              + "'camunda.physical-tenants.<id>."
+              + AUTHORIZATIONS_ENABLED
+              + "'. Physical tenants missing a required initialization block: "
               + missing);
     }
   }
@@ -101,20 +111,23 @@ final class PhysicalTenantRequiredOverrideValidation {
   }
 
   /**
-   * Resolves the effective {@code authorization.enabled} for a tenant: the per-tenant override if
+   * Resolves the effective {@code authorizations.enabled} for a tenant: the per-tenant override if
    * declared, otherwise the root value, otherwise the default ({@code true}). This is the only
    * value read by this validation; the rest is pure key inspection.
+   *
+   * <p>Unbound and blank values resolve to {@code true} so that an unreadable toggle requires an
+   * initialization block rather than silently exempting the tenant.
    */
   private static boolean authorizationEnabledFor(final Binder binder, final String tenantId) {
     final var perTenant =
         binder.bind(
-            Camunda.PREFIX + ".physical-tenants." + tenantId + ".security.authorization.enabled",
+            Camunda.PREFIX + ".physical-tenants." + tenantId + "." + AUTHORIZATIONS_ENABLED,
             Bindable.of(Boolean.class));
     if (perTenant.isBound()) {
       return perTenant.get();
     }
     return binder
-        .bind(Camunda.PREFIX + ".security.authorization.enabled", Bindable.of(Boolean.class))
+        .bind(Camunda.PREFIX + "." + AUTHORIZATIONS_ENABLED, Bindable.of(Boolean.class))
         .orElse(true);
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidationTest.java
@@ -143,24 +143,12 @@ class PhysicalTenantRequiredOverrideValidationTest {
   }
 
   @Test
-  void shouldNotRequireInitializationWhenTenantAuthorizationDisabled() {
-    // given a non-default tenant with authorization disabled and no initialization block
-    final MockEnvironment environment =
-        environmentWith(
-            Map.of("camunda.physical-tenants.tenanta.security.authorization.enabled", false));
-
-    // when / then the initialization block is not required for an authz-disabled tenant
-    assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
-        .doesNotThrowAnyException();
-  }
-
-  @Test
   void shouldNotRequireInitializationWhenRootAuthorizationDisabled() {
     // given root authorization disabled and a tenant that does not override it or declare init
     final MockEnvironment environment =
         environmentWith(
             Map.of(
-                "camunda.security.authorization.enabled",
+                "camunda.security.authorizations.enabled",
                 false,
                 "camunda.physical-tenants.tenanta.cluster.partition-count",
                 3));
@@ -171,27 +159,13 @@ class PhysicalTenantRequiredOverrideValidationTest {
   }
 
   @Test
-  void shouldRequireInitializationWhenTenantAuthorizationEnabledExplicitly() {
-    // given a tenant that explicitly enables authorization but declares no initialization block
-    final MockEnvironment environment =
-        environmentWith(
-            Map.of("camunda.physical-tenants.tenanta.security.authorization.enabled", true));
-
-    // when / then initialization is still required, and the offending tenant is named
-    assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
-        .withMessageContaining("camunda.physical-tenants.<id>.security.initialization")
-        .withMessageContaining("tenanta");
-  }
-
-  @Test
   void shouldOnlyExemptTenantsWithAuthorizationDisabled() {
     // given one authz-disabled tenant and one authz-enabled tenant, neither with init
     final MockEnvironment environment =
         environmentWith(
             Map.of(
-                "camunda.physical-tenants.tenanta.security.authorization.enabled", false,
-                "camunda.physical-tenants.tenantb.security.authorization.enabled", true));
+                "camunda.physical-tenants.tenanta.security.authorizations.enabled", false,
+                "camunda.physical-tenants.tenantb.security.authorizations.enabled", true));
 
     // when / then only the authz-enabled tenant is reported as missing initialization
     assertThatExceptionOfType(UnifiedConfigurationException.class)
@@ -202,11 +176,11 @@ class PhysicalTenantRequiredOverrideValidationTest {
 
   @Test
   void shouldRequireInitializationWhenAuthorizationValueIsBlank() {
-    // given a non-default tenant whose authorization.enabled is present but blank (YAML
+    // given a non-default tenant whose authorizations.enabled is present but blank (YAML
     // 'enabled:'), with no initialization block and no root override
     final MockEnvironment environment =
         environmentWith(
-            Map.of("camunda.physical-tenants.tenanta.security.authorization.enabled", ""));
+            Map.of("camunda.physical-tenants.tenanta.security.authorizations.enabled", ""));
 
     // when / then Spring binds a blank value to "unbound", so authorization resolves to the
     // default (enabled) and initialization is still required — a clear configuration error,
@@ -215,5 +189,36 @@ class PhysicalTenantRequiredOverrideValidationTest {
         .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
         .withMessageContaining("camunda.physical-tenants.<id>.security.initialization")
         .withMessageContaining("tenanta");
+  }
+
+  @Test
+  void shouldPreferTenantAuthorizationsOverrideOverDisabledRoot() {
+    // given authorization disabled at root but re-enabled by the tenant, with no initialization
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authorizations.enabled", false,
+                "camunda.physical-tenants.tenanta.security.authorizations.enabled", true));
+
+    // when / then the per-tenant override wins, so the tenant must declare its own block
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .withMessageContaining("camunda.physical-tenants.<id>.security.initialization")
+        .withMessageContaining("tenanta");
+  }
+
+  @Test
+  void shouldPreferTenantAuthorizationsOverrideOverEnabledRoot() {
+    // given authorization enabled at root but disabled by the tenant, with no initialization
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authorizations.enabled", true,
+                "camunda.physical-tenants.tenanta.security.authorizations.enabled", false));
+
+    // when / then the per-tenant opt-out wins: an authz-disabled tenant seeds no identity, so
+    // there is nothing for it to inherit from the root and no block is required
+    assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .doesNotThrowAnyException();
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -326,8 +326,8 @@ class SearchEngineSchemaInitializerTest {
                       "elasticsearch",
                       "camunda.physical-tenants.tenantb.data.secondary-storage.type",
                       "elasticsearch",
-                      "camunda.physical-tenants.tenantb.security.authorization.enabled",
-                      "false",
+                      "camunda.physical-tenants.tenantb.security.initialization.default-roles.admin.users[0]",
+                      "tenantb-admin",
                       "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
                       "tenantb")));
       final Camunda camunda = new Camunda();

--- a/dist/src/test/java/io/camunda/application/commons/security/PhysicalTenantSecurityPropertiesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/PhysicalTenantSecurityPropertiesConfigurationTest.java
@@ -8,9 +8,11 @@
 package io.camunda.application.commons.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
@@ -112,6 +114,23 @@ class PhysicalTenantSecurityPropertiesConfigurationTest {
                 .getAuthorizations()
                 .isEnabled())
         .isTrue();
+  }
+
+  @Test
+  void shouldFailResolutionWhenAuthorizationsEnabledTenantOmitsInitialization() {
+    // given a tenant with authorization enabled and no initialization block of its own
+    // (the tenant id is deliberately not passed to setProperties, so none is stamped)
+    setProperties(
+        Map.of(
+            "camunda.physical-tenants.tenanta.security.authorizations.enabled", "true",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"));
+
+    // when / then resolution fails rather than letting the tenant inherit the root's identity
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(this::resolve)
+        .withMessageContaining("camunda.physical-tenants.<id>.security.initialization")
+        .withMessageContaining("tenanta");
   }
 
   private PhysicalTenantSecurityProperties resolve() {


### PR DESCRIPTION
`PhysicalTenantRequiredOverrideValidation` decided whether a physical tenant is exempt from declaring its own `security.initialization` block by reading `camunda.security.authorization.enabled `(singular). The runtime authorization check that this validation exists to guard against instead reads `camunda.security.authorizations.enabled` (plural). The two keys are unrelated, so a tenant could satisfy the validation while authorization was still enabled at runtime, silently inheriting the root's identity setup instead of failing fast.

**Solution**
Point both the per-tenant override and the root fallback at the plural key the runtime actually enforces, via a shared constant so the two cannot drift apart again. 

closes https://github.com/camunda/camunda/issues/59949
