### PR TITLE
fix: retry and dedupe Helm chart downloads in golden file tests

### DIFF
--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -123,7 +123,7 @@ while [[ $# -gt 0 ]]; do
       dest="$LOAD_TEST_CHART_CACHE_DIR/$camunda_platform_helm_chart_version/camunda-platform"
       if [[ ! -d "$dest" ]]; then
         echo "Pre-pulling camunda-platform $camunda_platform_helm_chart_version for $target_version..."
-        retry_with_backoff helm pull camunda/camunda-platform \
+        RETRY_CLEANUP_CMD="rm -rf \"$dest\"" retry_with_backoff helm pull camunda/camunda-platform \
             --untar --untardir "$LOAD_TEST_CHART_CACHE_DIR/$camunda_platform_helm_chart_version" \
             --version "$camunda_platform_helm_chart_version"
       fi
@@ -368,8 +368,6 @@ if [[ "${LOAD_TEST_SKIP_REPO_UPDATE:-false}" != "true" ]]; then
   retry_with_backoff helm repo update
 fi
 
-# The directory where local Helm Charts will be stored in. Already exists:
-# the always-copied charts/ tree scaffolded earlier in this script creates it.
 CHARTS_DIR="charts"
 
 # If LOAD_TEST_CHART_CACHE_DIR points at a pre-warmed cache (populated once,
@@ -378,29 +376,24 @@ CHARTS_DIR="charts"
 platform_cache_src="${LOAD_TEST_CHART_CACHE_DIR:-}/${camunda_platform_helm_chart_version}/camunda-platform"
 if [[ -n "${LOAD_TEST_CHART_CACHE_DIR:-}" && -d "$platform_cache_src" ]]; then
   echo "Using pre-warmed camunda-platform $camunda_platform_helm_chart_version chart from cache..."
+  rm -rf "$CHARTS_DIR/camunda-platform"
   cp -r "$platform_cache_src" "$CHARTS_DIR/camunda-platform"
 else
   echo "Pulling Camunda Platform Helm Chart: $camunda_platform_helm_chart_version"
-  retry_with_backoff helm pull camunda/camunda-platform \
+  RETRY_CLEANUP_CMD="rm -rf \"$CHARTS_DIR/camunda-platform\"" retry_with_backoff helm pull camunda/camunda-platform \
       --untar --untardir "$CHARTS_DIR" \
       --version "$camunda_platform_helm_chart_version"
 fi
 
-# Skip re-resolving load-test-setup's dependencies when the charts/ copy
-# already carries them, freshly resolved (not just present: a stale leftover
-# from an unrelated manual session must not be mistaken for a valid resolve
-# after a Chart.lock bump). In CI this is true because the harness resolves
-# the shared source tree once before copying it into every scenario; on a
-# manual run it's naturally false, so this falls through to today's behavior.
-subchart_deps_dir="$CHARTS_DIR/load-test-setup/charts"
-lockfile="$CHARTS_DIR/load-test-setup/Chart.lock"
-deps_already_resolved=false
-if [[ -d "$subchart_deps_dir" ]] && [[ -n "$(ls -A "$subchart_deps_dir" 2>/dev/null)" ]] \
-   && [[ -z "$(find "$subchart_deps_dir" -type f ! -newer "$lockfile" -print -quit)" ]]; then
-  deps_already_resolved=true
-fi
-if [[ "$deps_already_resolved" == "true" ]]; then
-  echo "load-test-setup subchart dependencies already resolved; skipping helm dependency update."
+# If LOAD_TEST_CHART_CACHE_DIR points at pre-resolved load-test-setup
+# dependencies (warmed once against a scratch copy, before this script runs
+# many times in parallel), reuse them instead of resolving over the network
+# again. Unset by default, so a manual invocation always resolves fresh.
+deps_cache_src="${LOAD_TEST_CHART_CACHE_DIR:-}/load-test-setup-deps"
+if [[ -n "${LOAD_TEST_CHART_CACHE_DIR:-}" && -d "$deps_cache_src" ]]; then
+  echo "Using pre-warmed load-test-setup subchart dependencies from cache..."
+  rm -rf "$CHARTS_DIR/load-test-setup/charts"
+  cp -r "$deps_cache_src" "$CHARTS_DIR/load-test-setup/charts"
 else
   echo "Resolving load-test-setup subchart dependencies..."
   retry_with_backoff helm dependency update "$CHARTS_DIR/load-test-setup"

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -9,8 +9,7 @@ ROOT_DIR="$SCRIPT_DIR"
 
 AVAILABLE_VERSIONS=(main stable-87 stable-88 stable-89)
 
-# Internal plumbing hook for the golden-file test harness (like GIT_AUTHOR,
-# undocumented in usage()): lets callers enumerate versions without
+# Internal plumbing hook for the golden-file test harness: lets callers enumerate versions without
 # duplicating AVAILABLE_VERSIONS.
 if [[ " $* " == *" --list-versions "* ]]; then
   echo "${AVAILABLE_VERSIONS[*]}"
@@ -110,7 +109,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --warm-platform-chart-cache)
       # Internal plumbing hook for the golden-file test harness's chart
-      # pre-warm step (like GIT_AUTHOR, undocumented in usage()): pulls the
+      # pre-warm step: pulls the
       # camunda-platform version resolved above for -t/--target-version into
       # LOAD_TEST_CHART_CACHE_DIR (if not already there) and exits before the
       # namespace argument is required. Reuses the same version resolution

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -9,6 +9,14 @@ ROOT_DIR="$SCRIPT_DIR"
 
 AVAILABLE_VERSIONS=(main stable-87 stable-88 stable-89)
 
+# Internal plumbing hook for the golden-file test harness (like GIT_AUTHOR,
+# undocumented in usage()): lets callers enumerate versions without
+# duplicating AVAILABLE_VERSIONS.
+if [[ " $* " == *" --list-versions "* ]]; then
+  echo "${AVAILABLE_VERSIONS[*]}"
+  exit 0
+fi
+
 # Pre-scan argv for --target-version/-t so the version config (and its
 # allowed storage list) is known before any usage/help text needs printing.
 target_version="main"
@@ -100,12 +108,25 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
-    --print-platform-chart-version)
+    --warm-platform-chart-cache)
       # Internal plumbing hook for the golden-file test harness's chart
-      # pre-warm step (like GIT_AUTHOR, undocumented in usage()) — prints the
-      # version resolved above for -t/--target-version and exits before the
-      # namespace argument is required.
-      echo "$camunda_platform_helm_chart_version"
+      # pre-warm step (like GIT_AUTHOR, undocumented in usage()): pulls the
+      # camunda-platform version resolved above for -t/--target-version into
+      # LOAD_TEST_CHART_CACHE_DIR (if not already there) and exits before the
+      # namespace argument is required. Reuses the same version resolution
+      # and cache path convention as the per-scenario pull below, so the two
+      # can never drift apart.
+      if [[ -z "${LOAD_TEST_CHART_CACHE_DIR:-}" ]]; then
+        echo "Error: --warm-platform-chart-cache requires LOAD_TEST_CHART_CACHE_DIR to be set." >&2
+        exit 1
+      fi
+      dest="$LOAD_TEST_CHART_CACHE_DIR/$camunda_platform_helm_chart_version/camunda-platform"
+      if [[ ! -d "$dest" ]]; then
+        echo "Pre-pulling camunda-platform $camunda_platform_helm_chart_version for $target_version..."
+        retry_with_backoff helm pull camunda/camunda-platform \
+            --untar --untardir "$LOAD_TEST_CHART_CACHE_DIR/$camunda_platform_helm_chart_version" \
+            --version "$camunda_platform_helm_chart_version"
+      fi
       exit 0
       ;;
     *)
@@ -340,16 +361,16 @@ EOF
 # once before spawning many scenarios; unset by default, so a manual
 # invocation behaves exactly as before, just retried on transient failures.
 if [[ "${LOAD_TEST_SKIP_REPO_UPDATE:-false}" != "true" ]]; then
-  retry_with_backoff 4 5 helm repo add camunda https://helm.camunda.io/ --force-update
+  retry_with_backoff helm repo add camunda https://helm.camunda.io/ --force-update
   if [[ "$secondary_storage" == "opensearch" ]]; then
-    retry_with_backoff 4 5 helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
+    retry_with_backoff helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
   fi
-  retry_with_backoff 4 5 helm repo update
+  retry_with_backoff helm repo update
 fi
 
-# The directory where local Helm Charts will be stored in.
+# The directory where local Helm Charts will be stored in. Already exists:
+# the always-copied charts/ tree scaffolded earlier in this script creates it.
 CHARTS_DIR="charts"
-mkdir -p "$CHARTS_DIR"
 
 # If LOAD_TEST_CHART_CACHE_DIR points at a pre-warmed cache (populated once,
 # per version, before this script runs), reuse it instead of pulling over the
@@ -360,13 +381,13 @@ if [[ -n "${LOAD_TEST_CHART_CACHE_DIR:-}" && -d "$platform_cache_src" ]]; then
   cp -r "$platform_cache_src" "$CHARTS_DIR/camunda-platform"
 else
   echo "Pulling Camunda Platform Helm Chart: $camunda_platform_helm_chart_version"
-  retry_with_backoff 4 5 helm pull camunda/camunda-platform \
+  retry_with_backoff helm pull camunda/camunda-platform \
       --untar --untardir "$CHARTS_DIR" \
       --version "$camunda_platform_helm_chart_version"
 fi
 
 # Skip re-resolving load-test-setup's dependencies when the charts/ copy
-# already carries them, freshly resolved (not just present — a stale leftover
+# already carries them, freshly resolved (not just present: a stale leftover
 # from an unrelated manual session must not be mistaken for a valid resolve
 # after a Chart.lock bump). In CI this is true because the harness resolves
 # the shared source tree once before copying it into every scenario; on a
@@ -382,7 +403,7 @@ if [[ "$deps_already_resolved" == "true" ]]; then
   echo "load-test-setup subchart dependencies already resolved; skipping helm dependency update."
 else
   echo "Resolving load-test-setup subchart dependencies..."
-  retry_with_backoff 4 5 helm dependency update "$CHARTS_DIR/load-test-setup"
+  retry_with_backoff helm dependency update "$CHARTS_DIR/load-test-setup"
 fi
 
 echo

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -100,6 +100,14 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
+    --print-platform-chart-version)
+      # Internal plumbing hook for the golden-file test harness's chart
+      # pre-warm step (like GIT_AUTHOR, undocumented in usage()) — prints the
+      # version resolved above for -t/--target-version and exits before the
+      # namespace argument is required.
+      echo "$camunda_platform_helm_chart_version"
+      exit 0
+      ;;
     *)
       remaining_args+=("$1")
       shift
@@ -327,23 +335,55 @@ postgresql:
 EOF
 } > load-test-setup-values.yaml
 
-# Add/update helm repositories
-helm repo add camunda https://helm.camunda.io/ --force-update
-if [[ "$secondary_storage" == "opensearch" ]]; then
-  helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
+# Add/update helm repositories. Skippable via LOAD_TEST_SKIP_REPO_UPDATE for
+# callers (the golden-file test harness) that already primed the repo index
+# once before spawning many scenarios; unset by default, so a manual
+# invocation behaves exactly as before, just retried on transient failures.
+if [[ "${LOAD_TEST_SKIP_REPO_UPDATE:-false}" != "true" ]]; then
+  retry_with_backoff 4 5 helm repo add camunda https://helm.camunda.io/ --force-update
+  if [[ "$secondary_storage" == "opensearch" ]]; then
+    retry_with_backoff 4 5 helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
+  fi
+  retry_with_backoff 4 5 helm repo update
 fi
-helm repo update
 
 # The directory where local Helm Charts will be stored in.
 CHARTS_DIR="charts"
+mkdir -p "$CHARTS_DIR"
 
-echo "Pulling Camunda Platform Helm Chart: $camunda_platform_helm_chart_version"
-helm pull camunda/camunda-platform \
-    --untar --untardir "$CHARTS_DIR" \
-    --version "$camunda_platform_helm_chart_version"
+# If LOAD_TEST_CHART_CACHE_DIR points at a pre-warmed cache (populated once,
+# per version, before this script runs), reuse it instead of pulling over the
+# network again. Unset by default, so a manual invocation always pulls fresh.
+platform_cache_src="${LOAD_TEST_CHART_CACHE_DIR:-}/${camunda_platform_helm_chart_version}/camunda-platform"
+if [[ -n "${LOAD_TEST_CHART_CACHE_DIR:-}" && -d "$platform_cache_src" ]]; then
+  echo "Using pre-warmed camunda-platform $camunda_platform_helm_chart_version chart from cache..."
+  cp -r "$platform_cache_src" "$CHARTS_DIR/camunda-platform"
+else
+  echo "Pulling Camunda Platform Helm Chart: $camunda_platform_helm_chart_version"
+  retry_with_backoff 4 5 helm pull camunda/camunda-platform \
+      --untar --untardir "$CHARTS_DIR" \
+      --version "$camunda_platform_helm_chart_version"
+fi
 
-echo "Resolving load-test-setup subchart dependencies..."
-helm dependency update "$CHARTS_DIR/load-test-setup"
+# Skip re-resolving load-test-setup's dependencies when the charts/ copy
+# already carries them, freshly resolved (not just present — a stale leftover
+# from an unrelated manual session must not be mistaken for a valid resolve
+# after a Chart.lock bump). In CI this is true because the harness resolves
+# the shared source tree once before copying it into every scenario; on a
+# manual run it's naturally false, so this falls through to today's behavior.
+subchart_deps_dir="$CHARTS_DIR/load-test-setup/charts"
+lockfile="$CHARTS_DIR/load-test-setup/Chart.lock"
+deps_already_resolved=false
+if [[ -d "$subchart_deps_dir" ]] && [[ -n "$(ls -A "$subchart_deps_dir" 2>/dev/null)" ]] \
+   && [[ -z "$(find "$subchart_deps_dir" -type f ! -newer "$lockfile" -print -quit)" ]]; then
+  deps_already_resolved=true
+fi
+if [[ "$deps_already_resolved" == "true" ]]; then
+  echo "load-test-setup subchart dependencies already resolved; skipping helm dependency update."
+else
+  echo "Resolving load-test-setup subchart dependencies..."
+  retry_with_backoff 4 5 helm dependency update "$CHARTS_DIR/load-test-setup"
+fi
 
 echo
 echo "Scaffolding complete. Next steps:"

--- a/load-tests/setup/test/Makefile
+++ b/load-tests/setup/test/Makefile
@@ -50,7 +50,12 @@ endif
 # Renovate version bump can never see a stale cache; test/update-golden
 # remove it once go test finishes (see below).
 ifneq ($(filter test update-golden warm-chart-cache,$(MAKECMDGOALS)),)
-export LOAD_TEST_CHART_CACHE_DIR := $(shell mktemp -d)
+# An explicit template (rather than bare `mktemp -d`) is required by BSD/macOS
+# mktemp and also accepted by GNU mktemp, so this works on both.
+export LOAD_TEST_CHART_CACHE_DIR := $(shell mktemp -d "$${TMPDIR:-/tmp}/load-test-chart-cache.XXXXXXXXXX")
+ifeq ($(LOAD_TEST_CHART_CACHE_DIR),)
+$(error mktemp -d failed to create LOAD_TEST_CHART_CACHE_DIR)
+endif
 # helm-repos (below) already primes the repo index once for the whole run;
 # scenarios don't each need to repeat it themselves.
 export LOAD_TEST_SKIP_REPO_UPDATE := true

--- a/load-tests/setup/test/Makefile
+++ b/load-tests/setup/test/Makefile
@@ -7,16 +7,23 @@
 #
 # Requires: go, helm, git, and network access (charts are cloned and pulled).
 
-.PHONY: help build helm-repos test update-golden clean
+# Recipes below `source ../utils.sh` for retry_with_backoff, which uses
+# bash-only syntax ([[ ]], (( )), until).
+SHELL := /bin/bash
+
+.PHONY: help build helm-repos warm-chart-cache test update-golden clean
 
 help:
 	@echo "Targets:"
-	@echo "  build          Compile the test package"
-	@echo "  helm-repos     Add/update the Helm repositories the charts need"
-	@echo "  test           Run the golden file tests (verify mode)"
-	@echo "  update-golden  Regenerate golden files after an intentional change,"
-	@echo "                 then review 'git diff golden/' before committing"
-	@echo "  clean          Remove leftover scaffolded namespace directories"
+	@echo "  build            Compile the test package"
+	@echo "  helm-repos       Add/update the Helm repositories the charts need"
+	@echo "  warm-chart-cache Pre-resolve/pull chart dependencies once, so the"
+	@echo "                   parallel scenarios below reuse them instead of"
+	@echo "                   each re-fetching the same charts over the network"
+	@echo "  test             Run the golden file tests (verify mode)"
+	@echo "  update-golden    Regenerate golden files after an intentional change,"
+	@echo "                   then review 'git diff golden/' before committing"
+	@echo "  clean            Remove leftover scaffolded namespace directories"
 	@echo ""
 	@echo "Scope test/update-golden to one setup version with PATTERN=, e.g.:"
 	@echo "  make update-golden PATTERN=stable-89"
@@ -34,19 +41,51 @@ ifneq ($(PATTERN),)
 run_filter := -run '.*$(PATTERN).*'
 endif
 
+# Ephemeral, single-`make`-invocation chart cache consumed by newLoadTest.sh
+# (via LOAD_TEST_CHART_CACHE_DIR, see warm-chart-cache below). `:=` evaluates
+# `mktemp -d` once at parse time so every recipe in this invocation shares the
+# same path. A fresh temp dir every invocation means it can never survive
+# across runs, so a Renovate version bump can never see a stale cache.
+export LOAD_TEST_CHART_CACHE_DIR := $(shell mktemp -d)
+# helm-repos already primes the repo index once below; scenarios don't need
+# to repeat it 46 times.
+export LOAD_TEST_SKIP_REPO_UPDATE := true
+
 build:
 	go build ./...
 
 helm-repos:
-	helm repo add camunda https://helm.camunda.io/ --force-update
-	helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update
-	helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
-	helm repo update
+	source ../utils.sh; \
+	retry_with_backoff 4 5 helm repo add camunda https://helm.camunda.io/ --force-update; \
+	retry_with_backoff 4 5 helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update; \
+	retry_with_backoff 4 5 helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update; \
+	retry_with_backoff 4 5 helm repo update
 
-test: helm-repos
+# Resolves load-test-setup's Chart.lock deps ONCE (instead of once per
+# scenario) by running against the shared source chart, which newLoadTest.sh
+# copies wholesale into every scenario's namespace dir. Pre-pulls each unique
+# camunda-platform chart version ONCE into LOAD_TEST_CHART_CACHE_DIR. Runs
+# entirely sequentially, before the parallel go test phase, so there is no
+# read/write race: every scenario only ever reads this tree afterwards.
+warm-chart-cache: helm-repos
+	set -e; \
+	source ../utils.sh; \
+	echo "Pre-resolving load-test-setup chart dependencies..."; \
+	retry_with_backoff 4 5 helm dependency update ../charts/load-test-setup; \
+	for v in main stable-87 stable-88 stable-89; do \
+	  version=$$(../newLoadTest.sh -t $$v --print-platform-chart-version); \
+	  dest="$(LOAD_TEST_CHART_CACHE_DIR)/$$version/camunda-platform"; \
+	  if [ ! -d "$$dest" ]; then \
+	    echo "Pre-pulling camunda-platform $$version..."; \
+	    retry_with_backoff 4 5 helm pull camunda/camunda-platform \
+	      --untar --untardir "$(LOAD_TEST_CHART_CACHE_DIR)/$$version" --version "$$version"; \
+	  fi; \
+	done
+
+test: warm-chart-cache
 	go test -v -timeout 50m -parallel $(PARALLEL) $(run_filter) ./...
 
-update-golden: helm-repos
+update-golden: warm-chart-cache
 	go test -v -timeout 50m -parallel $(PARALLEL) $(run_filter) -update-golden ./...
 
 clean:

--- a/load-tests/setup/test/Makefile
+++ b/load-tests/setup/test/Makefile
@@ -7,8 +7,6 @@
 #
 # Requires: go, helm, git, and network access (charts are cloned and pulled).
 
-# Recipes below `source ../utils.sh` for retry_with_backoff, which uses
-# bash-only syntax ([[ ]], (( )), until).
 SHELL := /bin/bash
 
 .PHONY: help build helm-repos warm-chart-cache test update-golden clean
@@ -47,8 +45,8 @@ endif
 # same path. A fresh temp dir every invocation means it can never survive
 # across runs, so a Renovate version bump can never see a stale cache.
 export LOAD_TEST_CHART_CACHE_DIR := $(shell mktemp -d)
-# helm-repos already primes the repo index once below; scenarios don't need
-# to repeat it 46 times.
+# helm-repos (below) already primes the repo index once for the whole run;
+# scenarios don't each need to repeat it themselves.
 export LOAD_TEST_SKIP_REPO_UPDATE := true
 
 build:
@@ -56,37 +54,33 @@ build:
 
 helm-repos:
 	source ../utils.sh; \
-	retry_with_backoff 4 5 helm repo add camunda https://helm.camunda.io/ --force-update; \
-	retry_with_backoff 4 5 helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update; \
-	retry_with_backoff 4 5 helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update; \
-	retry_with_backoff 4 5 helm repo update
+	retry_with_backoff helm repo add camunda https://helm.camunda.io/ --force-update; \
+	retry_with_backoff helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update; \
+	retry_with_backoff helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update; \
+	retry_with_backoff helm repo update
 
 # Resolves load-test-setup's Chart.lock deps ONCE (instead of once per
 # scenario) by running against the shared source chart, which newLoadTest.sh
 # copies wholesale into every scenario's namespace dir. Pre-pulls each unique
-# camunda-platform chart version ONCE into LOAD_TEST_CHART_CACHE_DIR. Runs
-# entirely sequentially, before the parallel go test phase, so there is no
-# read/write race: every scenario only ever reads this tree afterwards.
+# camunda-platform chart version ONCE into LOAD_TEST_CHART_CACHE_DIR via
+# newLoadTest.sh's own --warm-platform-chart-cache (so the version-to-chart
+# mapping and cache path convention live in one place, not duplicated here).
+# Runs entirely sequentially, before the parallel go test phase, so there is
+# no read/write race: every scenario only ever reads this tree afterwards.
 warm-chart-cache: helm-repos
 	set -e; \
 	source ../utils.sh; \
 	echo "Pre-resolving load-test-setup chart dependencies..."; \
-	retry_with_backoff 4 5 helm dependency update ../charts/load-test-setup; \
-	for v in main stable-87 stable-88 stable-89; do \
-	  version=$$(../newLoadTest.sh -t $$v --print-platform-chart-version); \
-	  dest="$(LOAD_TEST_CHART_CACHE_DIR)/$$version/camunda-platform"; \
-	  if [ ! -d "$$dest" ]; then \
-	    echo "Pre-pulling camunda-platform $$version..."; \
-	    retry_with_backoff 4 5 helm pull camunda/camunda-platform \
-	      --untar --untardir "$(LOAD_TEST_CHART_CACHE_DIR)/$$version" --version "$$version"; \
-	  fi; \
+	retry_with_backoff helm dependency update ../charts/load-test-setup; \
+	for v in $$(../newLoadTest.sh --list-versions); do \
+	  ../newLoadTest.sh -t $$v --warm-platform-chart-cache; \
 	done
 
 test: warm-chart-cache
-	go test -v -timeout 50m -parallel $(PARALLEL) $(run_filter) ./...
+	go test -v -count=1 -timeout 50m -parallel $(PARALLEL) $(run_filter) ./...
 
 update-golden: warm-chart-cache
-	go test -v -timeout 50m -parallel $(PARALLEL) $(run_filter) -update-golden ./...
+	go test -v -count=1 -timeout 50m -parallel $(PARALLEL) $(run_filter) -update-golden ./...
 
 clean:
 	rm -rf ../c8-golden-*

--- a/load-tests/setup/test/Makefile
+++ b/load-tests/setup/test/Makefile
@@ -39,20 +39,28 @@ ifneq ($(PATTERN),)
 run_filter := -run '.*$(PATTERN).*'
 endif
 
-# Ephemeral, single-`make`-invocation chart cache consumed by newLoadTest.sh
-# (via LOAD_TEST_CHART_CACHE_DIR, see warm-chart-cache below). `:=` evaluates
-# `mktemp -d` once at parse time so every recipe in this invocation shares the
-# same path. A fresh temp dir every invocation means it can never survive
-# across runs, so a Renovate version bump can never see a stale cache.
+# Ephemeral chart cache consumed by newLoadTest.sh (via LOAD_TEST_CHART_CACHE_DIR,
+# see warm-chart-cache below). Gated on $(MAKECMDGOALS) rather than a plain
+# top-level `:=` so `make help`/`build`/`clean` never call `mktemp -d` at all
+# — and gated as a global variable, not a target-specific one, so warm-chart-cache
+# and test/update-golden's own `go test` share the exact same path (a
+# target-specific `:=` on multiple targets evaluates $(shell mktemp -d)
+# separately per target, silently handing each its own temp dir). A fresh
+# temp dir every invocation means it can never survive across runs, so a
+# Renovate version bump can never see a stale cache; test/update-golden
+# remove it once go test finishes (see below).
+ifneq ($(filter test update-golden warm-chart-cache,$(MAKECMDGOALS)),)
 export LOAD_TEST_CHART_CACHE_DIR := $(shell mktemp -d)
 # helm-repos (below) already primes the repo index once for the whole run;
 # scenarios don't each need to repeat it themselves.
 export LOAD_TEST_SKIP_REPO_UPDATE := true
+endif
 
 build:
 	go build ./...
 
 helm-repos:
+	set -e; \
 	source ../utils.sh; \
 	retry_with_backoff helm repo add camunda https://helm.camunda.io/ --force-update; \
 	retry_with_backoff helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update; \
@@ -60,27 +68,37 @@ helm-repos:
 	retry_with_backoff helm repo update
 
 # Resolves load-test-setup's Chart.lock deps ONCE (instead of once per
-# scenario) by running against the shared source chart, which newLoadTest.sh
-# copies wholesale into every scenario's namespace dir. Pre-pulls each unique
-# camunda-platform chart version ONCE into LOAD_TEST_CHART_CACHE_DIR via
-# newLoadTest.sh's own --warm-platform-chart-cache (so the version-to-chart
-# mapping and cache path convention live in one place, not duplicated here).
+# scenario) against a scratch copy under LOAD_TEST_CHART_CACHE_DIR, never the
+# git-tracked source chart, so this never leaves Chart.lock modified in
+# `git status`. Pre-pulls each unique camunda-platform chart version ONCE
+# into LOAD_TEST_CHART_CACHE_DIR via newLoadTest.sh's own
+# --warm-platform-chart-cache (so the version-to-chart mapping and cache path
+# convention live in one place, not duplicated here). Both honor PATTERN so
+# `make test PATTERN=stable-89` only warms what it's actually going to use.
 # Runs entirely sequentially, before the parallel go test phase, so there is
 # no read/write race: every scenario only ever reads this tree afterwards.
 warm-chart-cache: helm-repos
 	set -e; \
 	source ../utils.sh; \
 	echo "Pre-resolving load-test-setup chart dependencies..."; \
-	retry_with_backoff helm dependency update ../charts/load-test-setup; \
+	rm -rf "$(LOAD_TEST_CHART_CACHE_DIR)/load-test-setup-scratch" "$(LOAD_TEST_CHART_CACHE_DIR)/load-test-setup-deps"; \
+	cp -r ../charts/load-test-setup "$(LOAD_TEST_CHART_CACHE_DIR)/load-test-setup-scratch"; \
+	retry_with_backoff helm dependency update "$(LOAD_TEST_CHART_CACHE_DIR)/load-test-setup-scratch"; \
+	mv "$(LOAD_TEST_CHART_CACHE_DIR)/load-test-setup-scratch/charts" "$(LOAD_TEST_CHART_CACHE_DIR)/load-test-setup-deps"; \
 	for v in $$(../newLoadTest.sh --list-versions); do \
-	  ../newLoadTest.sh -t $$v --warm-platform-chart-cache; \
+	  case "$$v" in \
+	    *$(PATTERN)*) ../newLoadTest.sh -t $$v --warm-platform-chart-cache ;; \
+	    *) echo "Skipping $$v pre-pull (doesn't match PATTERN=$(PATTERN))" ;; \
+	  esac; \
 	done
 
 test: warm-chart-cache
-	go test -v -count=1 -timeout 50m -parallel $(PARALLEL) $(run_filter) ./...
+	go test -v -count=1 -timeout 50m -parallel $(PARALLEL) $(run_filter) ./...; \
+	status=$$?; rm -rf "$(LOAD_TEST_CHART_CACHE_DIR)"; exit $$status
 
 update-golden: warm-chart-cache
-	go test -v -count=1 -timeout 50m -parallel $(PARALLEL) $(run_filter) -update-golden ./...
+	go test -v -count=1 -timeout 50m -parallel $(PARALLEL) $(run_filter) -update-golden ./...; \
+	status=$$?; rm -rf "$(LOAD_TEST_CHART_CACHE_DIR)"; exit $$status
 
 clean:
 	rm -rf ../c8-golden-*

--- a/load-tests/setup/utils.sh
+++ b/load-tests/setup/utils.sh
@@ -80,7 +80,10 @@ function hashmod_zone() {
 # against transient network blips (e.g. a "Get ...: EOF" on a Helm chart
 # download) without masking real failures.
 # Tuning: set RETRY_MAX_ATTEMPTS/RETRY_BASE_DELAY_SECONDS in the environment;
-# defaults below apply when unset.
+# defaults below apply when unset. Set RETRY_CLEANUP_CMD to a shell command
+# that undoes a failed attempt's partial state before the next one starts
+# (e.g. `helm pull --untar` refuses to run again if its target directory is
+# already there from a killed-mid-extraction previous attempt).
 # Usage: retry_with_backoff <command...>
 retry_with_backoff() {
   local max_attempts="${RETRY_MAX_ATTEMPTS:-4}"
@@ -93,6 +96,7 @@ retry_with_backoff() {
       return "$status"
     fi
     echo "Attempt ${attempt}/${max_attempts} failed (exit ${status}); retrying in ${delay}s: $*" >&2
+    [[ -n "${RETRY_CLEANUP_CMD:-}" ]] && eval "$RETRY_CLEANUP_CMD"
     sleep "$delay"
     delay=$(( delay * 2 ))
     ((attempt++))

--- a/load-tests/setup/utils.sh
+++ b/load-tests/setup/utils.sh
@@ -72,6 +72,31 @@ function hashmod_zone() {
     echo "$zone"
 }
 
+# Retry a command with exponential backoff. Only the invoked command's own
+# exit status is inspected — stdout/stderr of every attempt are shown live,
+# and on final failure the real exit code from the last attempt is returned
+# unchanged, so a permanent/logical error (bad chart name, malformed values)
+# still fails clearly, it's just tried max_attempts times first. Guards
+# against transient network blips (e.g. a "Get ...: EOF" on a Helm chart
+# download) without masking real failures.
+# Usage: retry_with_backoff <max_attempts> <base_delay_seconds> <command...>
+retry_with_backoff() {
+  local max_attempts="$1"; shift
+  local delay="$1"; shift
+  local attempt=1
+  until "$@"; do
+    local status=$?
+    if (( attempt >= max_attempts )); then
+      echo "Command failed after ${attempt} attempt(s), giving up: $*" >&2
+      return "$status"
+    fi
+    echo "Attempt ${attempt}/${max_attempts} failed (exit ${status}); retrying in ${delay}s: $*" >&2
+    sleep "$delay"
+    delay=$(( delay * 2 ))
+    ((attempt++))
+  done
+}
+
 # Check whether a value is present in a list (pass the list as trailing args).
 # Usage: if contains "$value" "${some_array[@]}"; then ...
 contains() {

--- a/load-tests/setup/utils.sh
+++ b/load-tests/setup/utils.sh
@@ -73,16 +73,18 @@ function hashmod_zone() {
 }
 
 # Retry a command with exponential backoff. Only the invoked command's own
-# exit status is inspected — stdout/stderr of every attempt are shown live,
+# exit status is inspected (stdout/stderr of every attempt are shown live),
 # and on final failure the real exit code from the last attempt is returned
 # unchanged, so a permanent/logical error (bad chart name, malformed values)
 # still fails clearly, it's just tried max_attempts times first. Guards
 # against transient network blips (e.g. a "Get ...: EOF" on a Helm chart
 # download) without masking real failures.
-# Usage: retry_with_backoff <max_attempts> <base_delay_seconds> <command...>
+# Tuning: set RETRY_MAX_ATTEMPTS/RETRY_BASE_DELAY_SECONDS in the environment;
+# defaults below apply when unset.
+# Usage: retry_with_backoff <command...>
 retry_with_backoff() {
-  local max_attempts="$1"; shift
-  local delay="$1"; shift
+  local max_attempts="${RETRY_MAX_ATTEMPTS:-4}"
+  local delay="${RETRY_BASE_DELAY_SECONDS:-5}"
   local attempt=1
   until "$@"; do
     local status=$?


### PR DESCRIPTION
## Description

The `Load Test / Golden File Tests` CI job runs 46 golden-file scenarios in parallel, each independently re-downloading the same Helm chart tarballs (`camunda-platform`, `opensearch`, `camunda-load-tests`) via `newLoadTest.sh`, with no retry (`set -eo pipefail`) and no shared cache. A single transient network blip on any one of the ~46 redundant downloads fails the whole job - see the failing run in the linked issue.

This adds two additive, backward-compatible fixes:

- `retry_with_backoff` (`utils.sh`) wraps every `helm` network call in `newLoadTest.sh` with exponential backoff (tunable via `RETRY_MAX_ATTEMPTS`/`RETRY_BASE_DELAY_SECONDS`), scoped to just those calls so a transient blip doesn't cost re-running all 46 scenarios. An optional `RETRY_CLEANUP_CMD` hook clears a failed attempt's partial state before the next one, since `helm pull --untar` refuses to run again if its target directory is already there from a killed-mid-extraction attempt (confirmed empirically).
- A one-time chart cache, populated sequentially by a new `warm-chart-cache` Makefile target before the parallel test phase starts: `load-test-setup`'s dependencies are resolved once against a scratch copy under a temp cache dir (never the git-tracked source chart, which would otherwise get its `Chart.lock` rewritten on every run), and each unique `camunda-platform` version is pre-pulled once. `newLoadTest.sh` reuses the cached artifacts instead of its own per-scenario fetch when the cache dir is set - cutting up to 46 redundant downloads down to 1 (or 4, for the per-version platform chart). Both steps honor `PATTERN=` so a version-scoped run doesn't warm versions it won't use.

Neither `helm dependency update` nor `helm dependency build` skip the network fetch when a matching chart archive already exists locally (verified empirically), so this doesn't lean on Helm's own caching - the cache-hit checks are explicit (cache-dir/subpath existence), not inferred from file timestamps.

Both new env vars default to unset/false, so `newLoadTest.sh`'s other role as a manual, real-cluster setup script used directly by engineers is unaffected. `go test` also gets `-count=1`: without it, an unchanged Go source tree lets a stale cached PASS mask a real failure in `newLoadTest.sh`/chart values, which matters here since this job's own trigger is "load-tests/setup/** changed" while the `.go` test files themselves often don't (e.g. a Renovate chart-version bump).

Verified with full `make test` runs after each change (all scenarios pass, golden files unchanged), plus targeted checks that `make -n test`/`make -n help` produce one consistent cache path and no path at all respectively, and that `load-tests/setup/charts/` stays untouched in `git status` for the duration of a run.

Reviewed by GitHub Copilot; findings addressed or replied to inline.

## Checklist

- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

Not backported: per `.github/instructions/load-tests.instructions.md`, changes under `load-tests/setup/**` are never backported - the versioned setup folders on `main` are the only copy.


## Related issues

closes #60085
