### PR TITLE
fix: keep retrying a join while its deadline has budget

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -90,54 +90,67 @@ public final class ReconfigurationHelper {
           final var joining =
               new DefaultRaftMember(
                   raftContext.getCluster().getLocalMember().memberId(), Type.ACTIVE, Instant.now());
-          final var assistingMembers =
+          final var knownAssistingMembers =
               clusterMembers.stream()
                   .filter(memberId -> !memberId.equals(joining.memberId()))
-                  .collect(Collectors.toCollection(LinkedBlockingQueue::new));
-          if (assistingMembers.isEmpty()) {
+                  .toList();
+          if (knownAssistingMembers.isEmpty()) {
             result.completeExceptionally(
                 new IllegalStateException(
                     "Cannot join cluster, because there are no other members in the cluster."));
             return;
           }
-
-          // if single member cluster, we retry with the same member a few times before failing the
-          // join request. This gives the other member a chance to become leader and continue the
-          // reconfiguration process.
-          if (clusterMembers.size() == 1) {
-            final var otherMember = clusterMembers.stream().findFirst().get();
-            assistingMembers.offer(otherMember);
-            assistingMembers.offer(otherMember);
-            assistingMembers.offer(otherMember);
-          }
+          final var assistingMembers = new LinkedBlockingQueue<>(knownAssistingMembers);
           final var deadline = Instant.now().plus(raftContext.getConfigurationChangeTimeout());
-          threadContext.execute(() -> joinWithRetry(joining, assistingMembers, result, deadline));
+          threadContext.execute(
+              () ->
+                  joinWithRetry(
+                      joining, knownAssistingMembers, assistingMembers, result, deadline));
         });
     return result;
   }
 
   /**
-   * Repeatedly tries to join the cluster until it succeeds or there are no more members to try.
-   * When sending a join request to an assisting member fails because the member is currently not
-   * known, or it is known but not ready to receive join request, try again with a different
-   * assisting member.
+   * Repeatedly tries to join the cluster until it succeeds or the deadline passes. When sending a
+   * join request to an assisting member fails because the member is currently not known, or it is
+   * known but not ready to receive join request, try again with a different assisting member. Once
+   * every known member failed, start over with all of them after a delay.
    *
    * <p>Retrying helps in cases where the cluster is in flux and not all members are online and
    * ready.
    *
    * @param joining the new member joining
+   * @param knownAssistingMembers all members that can assist the join, used to refill the queue
    * @param assistingMembers a queue of members that we will send a join request to.
    * @param result a future to complete when joining succeeds or fails
-   * @param deadline until when a member that responded with NO_LEADER is retried
+   * @param deadline until when the join is retried
    */
   private void joinWithRetry(
       final RaftMember joining,
+      final Collection<MemberId> knownAssistingMembers,
       final Queue<MemberId> assistingMembers,
       final CompletableFuture<Void> result,
       final Instant deadline) {
 
     final var receiver = assistingMembers.poll();
     if (receiver == null) {
+      if (Instant.now().isBefore(deadline)) {
+        // Don't fail while the deadline still has budget: the reasons a member fails to accept a
+        // join request are transient, and there may be only a single assisting member - the
+        // production shape when scaling a partition from one to two replicas - so a single
+        // transport error can drain the queue within milliseconds. Refill it and start over after
+        // a delay, giving the cluster time to make progress.
+        LOGGER.debug(
+            "Join request failed on all known members {}, retrying after {}",
+            knownAssistingMembers,
+            raftContext.getElectionTimeout());
+        assistingMembers.addAll(knownAssistingMembers);
+        threadContext.schedule(
+            raftContext.getElectionTimeout(),
+            () ->
+                joinWithRetry(joining, knownAssistingMembers, assistingMembers, result, deadline));
+        return;
+      }
       result.completeExceptionally(
           new IllegalStateException(
               "Sent join request to all known members, but all failed. No more members left."));
@@ -156,7 +169,9 @@ public final class ReconfigurationHelper {
                     || cause instanceof ConnectException) {
                   LOGGER.debug("Join request was not acknowledged, retrying", cause);
                   threadContext.execute(
-                      () -> joinWithRetry(joining, assistingMembers, result, deadline));
+                      () ->
+                          joinWithRetry(
+                              joining, knownAssistingMembers, assistingMembers, result, deadline));
                 } else {
                   LOGGER.error("Join request failed with an unexpected error, not retrying", error);
                   result.completeExceptionally(error);
@@ -182,7 +197,9 @@ public final class ReconfigurationHelper {
                   assistingMembers.offer(receiver);
                   threadContext.schedule(
                       raftContext.getElectionTimeout(),
-                      () -> joinWithRetry(joining, assistingMembers, result, deadline));
+                      () ->
+                          joinWithRetry(
+                              joining, knownAssistingMembers, assistingMembers, result, deadline));
                 } else {
                   LOGGER.error(
                       "Join request failed, not retrying because the join did not complete within {}",
@@ -193,7 +210,9 @@ public final class ReconfigurationHelper {
               } else if (response.error().type() == RaftError.Type.UNAVAILABLE) {
                 LOGGER.debug("Join request failed, retrying", response.error().createException());
                 threadContext.execute(
-                    () -> joinWithRetry(joining, assistingMembers, result, deadline));
+                    () ->
+                        joinWithRetry(
+                            joining, knownAssistingMembers, assistingMembers, result, deadline));
               } else {
                 final var errorAsException = response.error().createException();
                 LOGGER.error("Join request rejected, not retrying", errorAsException);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
@@ -85,6 +85,10 @@ public class RandomizedRaftJoinTest {
       final MemberId member = memberIter.next();
       LOG.info("{} on {}", operation, member);
       operation.run(raftContexts, member);
+      // sample the safety invariant on every step: it records the vote of each member at the term
+      // it is currently in, so a vote that is overwritten between two steps is only observable
+      // while it is still recorded
+      raftContexts.assertAtMostOneVotePerMemberAndTerm();
       if (joinFuture.isCompletedExceptionally()) {
         // retry join
         LOG.info("Join failed. Retrying...");
@@ -122,6 +126,7 @@ public class RandomizedRaftJoinTest {
     assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
     assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
     raftContexts.assertAllMembersAreReady();
+    raftContexts.assertAtMostOneVotePerMemberAndTerm();
   }
 
   private void setUpRaftNodes(final Random random) throws Exception {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -18,6 +18,7 @@ import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.ConfigureRequest;
+import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
@@ -245,6 +246,45 @@ final class ReconfigurationTest {
           .as("m2 can join when retrying after a failed first attempt")
           .succeedsWithin(Duration.ofSeconds(30));
       awaitLeader(m1, retriedM2);
+    }
+
+    /**
+     * A partition that is scaled from one to two replicas has a single assisting member, so one
+     * transport error is enough to leave the join without another member to try. The join must keep
+     * retrying until its deadline passes instead of failing immediately.
+     */
+    @Test
+    void joinShouldSucceedWhenFirstRequestFailsAtTransportLevel(@TempDir final Path tmp) {
+      // given - a single-member cluster, as after the bootstrap of a scaled-up partition
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      m1.bootstrap(id1).join();
+      awaitLeader(m1);
+
+      // m1 is the only member that can assist the join: like RaftPartitionServer, we pass all
+      // members of the partition and the joiner filters itself out
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+
+      // when - the connection fails before the first join request is delivered, and connectivity
+      // returns well within the configuration change timeout
+      final var joinRequests = new AtomicInteger();
+      final var joinerProtocol = (TestRaftServerProtocol) m2.getContext().getProtocol();
+      joinerProtocol.interceptRequest(
+          JoinRequest.class,
+          (final JoinRequest request) -> {
+            if (joinRequests.incrementAndGet() == 1) {
+              return CompletableFuture.failedFuture(new ConnectException());
+            }
+            return CompletableFuture.completedFuture(null);
+          });
+
+      // then - the join still succeeds because it is retried while its deadline has budget left
+      assertThat(m2.join(id1, id2))
+          .as("m2 can join although its first join request failed at the transport level")
+          .succeedsWithin(Duration.ofSeconds(30));
+      assertThat(joinRequests).as("the join request was retried").hasValueGreaterThan(1);
     }
 
     /**

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/VotingTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/VotingTest.java
@@ -18,6 +18,7 @@ import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
+import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
@@ -45,6 +46,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
@@ -76,7 +78,8 @@ final class VotingTest {
     // reachable
     final var id1 = MemberId.from("1");
     final var id2 = MemberId.from("2");
-    final var joiner = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+    final var joiner =
+        createServerWithFastFailingJoin(tmp, StaticClusterMembershipService.of(id2, id1));
     assertThat(joiner.join(id1)).failsWithin(Duration.ofSeconds(10));
     Awaitility.await("Joiner is passive")
         .until(() -> joiner.getContext().getRaftRole().role() == RaftServer.Role.PASSIVE);
@@ -95,7 +98,8 @@ final class VotingTest {
     // given - a passive, configuration-less joiner that voted for candidate A in term 2
     final var id1 = MemberId.from("1");
     final var id2 = MemberId.from("2");
-    final var joiner = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+    final var joiner =
+        createServerWithFastFailingJoin(tmp, StaticClusterMembershipService.of(id2, id1));
     assertThat(joiner.join(id1)).failsWithin(Duration.ofSeconds(10));
     Awaitility.await("Joiner is passive")
         .until(() -> joiner.getContext().getRaftRole().role() == RaftServer.Role.PASSIVE);
@@ -113,7 +117,8 @@ final class VotingTest {
     // when - the joiner restarts
     joiner.shutdown().join();
     servers.remove(joiner);
-    final var restarted = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+    final var restarted =
+        createServerWithFastFailingJoin(tmp, StaticClusterMembershipService.of(id2, id1));
     assertThat(restarted.join(id1)).failsWithin(Duration.ofSeconds(10));
     Awaitility.await("Restarted joiner is passive")
         .until(() -> restarted.getContext().getRaftRole().role() == RaftServer.Role.PASSIVE);
@@ -140,6 +145,41 @@ final class VotingTest {
     // then - member 3 answers instead of rejecting with ILLEGAL_MEMBER_STATE
     assertPoll(candidate.poll(id3, pollRequest(candidateId, term)), true);
     assertVote(candidate.vote(id3, voteRequest(candidateId, term)), true);
+  }
+
+  @Test
+  void inactiveMemberRejectsPollAndVote(@TempDir final Path tmp) {
+    // given - a cluster [1A, 2A, 3A] whose leader left, which leaves it INACTIVE. Demoting a
+    // member cannot produce an INACTIVE member: it is no replication target, so it never receives
+    // the configuration that demotes it. The leaving member has to be the leader for the same
+    // reason - it steps down to inactive when it sees its own removal commit, which a removed
+    // follower may never learn because the leader stops replicating to it at that point.
+    final var id1 = MemberId.from("1");
+    final var id2 = MemberId.from("2");
+    final var id3 = MemberId.from("3");
+
+    final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2, id3));
+    final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1, id3));
+    final var m3 = createServer(tmp, StaticClusterMembershipService.of(id3, id1, id2));
+    CompletableFuture.allOf(
+            m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
+        .join();
+    awaitLeader(m1, m2, m3);
+    final var leaver = getLeaderServer(List.of(m1, m2, m3)).orElseThrow();
+    final var leaverId = leaver.cluster().getLocalMember().memberId();
+    leaver.leave().join();
+    Awaitility.await("The member that left is inactive")
+        .until(() -> leaver.getContext().getRaftRole().role() == RaftServer.Role.INACTIVE);
+
+    // when - a candidate requests a poll and a vote in a new term with an up-to-date log
+    final var candidateId = MemberId.from("99");
+    final var candidate = protocolFactory.newServerProtocol(candidateId);
+    final var term = leaver.getContext().getTerm() + 1;
+
+    // then - both are rejected: a member that is no longer part of the cluster must not vote, even
+    // though members that are in the configuration vote without checking membership
+    assertRejected(candidate.poll(leaverId, pollRequest(candidateId, term)));
+    assertRejected(candidate.vote(leaverId, voteRequest(candidateId, term)));
   }
 
   @ParameterizedTest
@@ -298,6 +338,16 @@ final class VotingTest {
             });
   }
 
+  private <T extends RaftResponse> void assertRejected(final CompletableFuture<T> response) {
+    assertThat(response)
+        .succeedsWithin(Duration.ofSeconds(5))
+        .satisfies(
+            rejection -> {
+              assertThat(rejection.status()).isEqualTo(Status.ERROR);
+              assertThat(rejection.error().type()).isEqualTo(RaftError.Type.UNAVAILABLE);
+            });
+  }
+
   private void assertVote(final CompletableFuture<VoteResponse> response, final boolean voted) {
     assertThat(response)
         .succeedsWithin(Duration.ofSeconds(5))
@@ -350,6 +400,25 @@ final class VotingTest {
 
   private RaftServer createServer(
       final Path dir, final ClusterMembershipService membershipService) {
+    return createServer(dir, membershipService, config -> {});
+  }
+
+  /**
+   * Creates a server for the tests that join a member which does not exist. Such a join is retried
+   * until the configuration change timeout passes, so shorten it to keep those tests quick.
+   */
+  private RaftServer createServerWithFastFailingJoin(
+      final Path dir, final ClusterMembershipService membershipService) {
+    return createServer(
+        dir,
+        membershipService,
+        config -> config.setConfigurationChangeTimeout(Duration.ofSeconds(1)));
+  }
+
+  private RaftServer createServer(
+      final Path dir,
+      final ClusterMembershipService membershipService,
+      final Consumer<RaftPartitionConfig> configCustomizer) {
     final var memberId = membershipService.getLocalMember().id();
     final var protocol = protocolFactory.newServerProtocol(memberId);
     protocols.put(memberId, protocol);
@@ -359,15 +428,17 @@ final class VotingTest {
             .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
             .withMaxSegmentSize(1024 * 10)
             .build();
+    final var partitionConfig =
+        new RaftPartitionConfig()
+            .setElectionTimeout(Duration.ofMillis(500))
+            .setHeartbeatInterval(Duration.ofMillis(100));
+    configCustomizer.accept(partitionConfig);
     final var server =
         RaftServer.builder(memberId)
             .withMembershipService(membershipService)
             .withProtocol(protocol)
             .withStorage(storage)
-            .withPartitionConfig(
-                new RaftPartitionConfig()
-                    .setElectionTimeout(Duration.ofMillis(500))
-                    .setHeartbeatInterval(Duration.ofMillis(100)))
+            .withPartitionConfig(partitionConfig)
             .withMeterRegistry(meterRegistry)
             .build();
     servers.add(server);


### PR DESCRIPTION
A join no longer gives up while its own deadline still has time left.

`ReconfigurationHelper#joinWithRetry` polls a queue of assisting members and fails the join as soon as that queue is empty. The retry deadline derived from `configurationChangeTimeout` was only consulted on the `NO_LEADER` and `CONFIGURATION_ERROR` branches, which re-offer the member they just tried; the transport branch — `NoSuchMemberException`, `NoRemoteHandler`, `TimeoutException`, `ConnectException` — and the `UNAVAILABLE` branch consume a member without re-offering it. When there is only one assisting member, which is the shape of a partition being scaled from one to two replicas because `RaftPartitionServer#join` passes all partition members and the joiner filters itself out, a single transport error drains the queue and the join fails within milliseconds with "Sent join request to all known members, but all failed" — the message from the incident in #56808 — without the deadline ever being read. `NoRemoteHandler` is not hypothetical there: it is what the stranded leader logs toward the joiner, and the reported trigger was first-connection latency in a service mesh.

That matters beyond the wasted budget: when the join fails, `PartitionManagerImpl` tears the joiner's Raft server down, unregistering its messaging handlers until the next cluster-configuration retry cycle roughly a minute later. The heal for a stuck joint configuration depends on a stranded leader reaching the joiner inside that window, so collapsing a ten-second window to milliseconds makes the heal materially less likely to engage.

The fix sits at [the drain point](https://github.com/camunda/camunda/blob/20ddaf09bdb20e0729f927dca17d09a8ba992f21/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java#L138-L160) rather than in each branch, so it covers every way the queue can empty: if the deadline has not passed, the queue is refilled with the known assisting members and retried after one election timeout, and the join only fails once the deadline passed. Falling through to the next queued member on a transport error stays immediate, so nothing gets slower while alternatives remain. The now-superseded single-member provision, which offered the same member three extra times and whose comment promised behaviour it no longer had, is removed.

The first commit is the regression test and fails without the fix. Two unrelated test gaps in the same area are closed in their own commits: that an `INACTIVE` member rejects polls and votes, which #57388 states as a correctness property and nothing covered, and sampling the at-most-one-vote-per-member-and-term invariant after every operation of the randomized join walk, which previously asserted liveness only and only after the walk had finished.

One known limitation, pre-existing and not addressed here: `threadContext.schedule` throws after the context is closed, which escapes `joinWithRetry` and leaves the join future uncompleted, and nothing in the join path applies a timeout. The `NO_LEADER` branch already had that shape; this change makes it reachable for any failing join, so a shutdown can now wait up to `configurationChangeTimeout` on a join that is failing at the transport level.

relates to #56808, part of #57386