### PR TITLE
fix: keep diagram element selected after instance selection

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -39,9 +39,27 @@ import {
 import {mockSearchAgentInstances} from 'modules/mocks/api/v2/agentInstances/searchAgentInstances';
 import {mockAgentInstance} from 'modules/mocks/mockAgentInstance';
 import {mockSearchAgentInstanceHistory} from 'modules/mocks/api/v2/agentInstances/searchAgentInstanceHistory';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 
 const PROCESS_INSTANCE_ID = '111222333';
 const PROCESS_DEFINITION_KEY = '444555666';
+
+const ElementSelectionUpdater: React.FC = () => {
+  const {selectElement} = useProcessInstanceElementSelectActions();
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        selectElement({
+          elementId: 'Task_1',
+        })
+      }
+    >
+      Select element
+    </button>
+  );
+};
 
 const CALL_ACTIVITY_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
@@ -274,7 +292,12 @@ function getWrapper(initialSearchParams?: string) {
           children: [
             {
               path: Paths.processInstanceDetails({isRelative: true}),
-              element: children,
+              element: (
+                <>
+                  <ElementSelectionUpdater />
+                  {children}
+                </>
+              ),
             },
           ],
         },
@@ -334,7 +357,9 @@ describe('<DetailsTab />', () => {
       wrapper: getWrapper(),
     });
 
-    expect(await screen.findByTestId('details-tab')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('region', {name: 'Details'}),
+    ).toBeInTheDocument();
     expect(await screen.findByTestId('waiting-status')).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -359,6 +384,54 @@ describe('<DetailsTab />', () => {
         'To view the details, select a single element instance in the instance history.',
       ),
     ).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'Details'})).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', {name: 'Element Instance'}),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('should preserve the details container and presentation when selecting an element from its instance', async () => {
+    mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
+    mockSearchElementInstances().withSuccess(
+      searchResult(
+        [
+          mockElementInstance,
+          {...mockElementInstance, elementInstanceKey: '987654321'},
+        ],
+        2,
+      ),
+    );
+    mockSearchAgentInstances().withSuccess(searchResult([]));
+
+    const {user} = render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    const detailsTab = await screen.findByRole('region', {name: 'Details'});
+    expect(await screen.findByText('123456789')).toBeInTheDocument();
+    detailsTab.scrollTop = 120;
+
+    await user.click(screen.getByRole('button', {name: 'Select element'}));
+
+    expect(
+      await screen.findByText(
+        'To view the details, select a single element instance in the instance history.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'Details'})).toBe(detailsTab);
+    expect(detailsTab.scrollTop).toBe(120);
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', {name: 'Element Instance'}),
+      ).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Select element'}));
+
+    expect(screen.getByRole('region', {name: 'Details'})).toBe(detailsTab);
+    expect(detailsTab.scrollTop).toBe(120);
   });
 
   it('should render agent-details and a multi-instance message when multiple element instances are activated', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -528,7 +528,7 @@ const DetailsTab: React.FC = () => {
     // The process scope only surfaces the process-level wait state status
     // (the Details tab is only shown when such a wait state exists).
     return (
-      <Container data-testid="details-tab">
+      <Container>
         <WaitingStatus waitStates={waitStates} />
       </Container>
     );
@@ -544,20 +544,22 @@ const DetailsTab: React.FC = () => {
     !showAgentInstance
   ) {
     return (
-      <EmptyMessageContainer>
-        <EmptyMessage
-          message={
-            hasMultipleInstances
-              ? 'To view the details, select a single element instance in the instance history.'
-              : 'There is no element selected.'
-          }
-        />
-      </EmptyMessageContainer>
+      <Container $isEmpty>
+        <EmptyMessageContainer>
+          <EmptyMessage
+            message={
+              hasMultipleInstances
+                ? 'To view the details, select a single element instance in the instance history.'
+                : 'There is no element selected.'
+            }
+          />
+        </EmptyMessageContainer>
+      </Container>
     );
   }
 
   return (
-    <Container data-testid="details-tab">
+    <Container>
       {resolvedElementType === 'USER_TASK' &&
         !isCamundaUserTask(businessObject) && (
           <Callout

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/styled.ts
@@ -13,15 +13,21 @@ const EmptyMessageContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  flex: 1;
 `;
 
-const Container = styled.div`
+const Container = styled.div.attrs({
+  role: 'region',
+  'aria-label': 'Details',
+})<{$isEmpty?: boolean}>`
   display: flex;
   flex-direction: column;
-  gap: var(--cds-spacing-05);
-  padding-inline: var(--cds-spacing-05);
-  padding-block-end: var(--cds-spacing-05);
+  height: 100%;
+  min-height: 0;
+  gap: ${({$isEmpty}) => ($isEmpty ? 0 : 'var(--cds-spacing-05)')};
+  padding-inline: ${({$isEmpty}) => ($isEmpty ? 0 : 'var(--cds-spacing-05)')};
+  padding-block-end: ${({$isEmpty}) =>
+    $isEmpty ? 0 : 'var(--cds-spacing-05)'};
   overflow-y: auto;
 
   & > * {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -12,7 +12,7 @@ import {
   screen,
   waitFor,
 } from 'modules/testing-library';
-import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {MemoryRouter, Route, Routes, useLocation} from 'react-router-dom';
 import {TopPanel} from './index';
 import {modificationsStore} from 'modules/stores/modifications';
 import {searchResult} from 'modules/testUtils';
@@ -136,7 +136,18 @@ const mockElementInstance: ElementInstance = {
   tenantId: '<default>',
 };
 
-const getWrapper = (searchParams?: Record<string, string>) => {
+const LocationSpy: React.FC<{onLocationChange: (search: string) => void}> = ({
+  onLocationChange,
+}) => {
+  const location = useLocation();
+  onLocationChange(location.search);
+  return null;
+};
+
+const getWrapper = (
+  searchParams?: Record<string, string>,
+  onLocationChange?: (search: string) => void,
+) => {
   let initialPath = Paths.processInstance('1');
   if (searchParams) {
     const search = new URLSearchParams(searchParams).toString();
@@ -154,6 +165,9 @@ const getWrapper = (searchParams?: Record<string, string>) => {
                 element={
                   <>
                     <SearchParamsUpdater />
+                    {onLocationChange && (
+                      <LocationSpy onLocationChange={onLocationChange} />
+                    )}
                     {children}
                   </>
                 }
@@ -332,6 +346,189 @@ describe('TopPanel', () => {
         /Move selected instance in this element to another target/,
       ),
     ).toBeInTheDocument();
+  });
+
+  it('should keep the clicked element selected and reset its instance selection', async () => {
+    const elementId = 'multi-instance-subprocess';
+    const elementInstanceKey = '2251799813699889';
+    let currentSearch = '';
+    const elementInstance = {
+      ...mockElementInstance,
+      elementId,
+      elementName: 'Multi Instance Subprocess',
+      type: 'MULTI_INSTANCE_BODY' as const,
+    };
+
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId,
+          active: 1,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    });
+    mockFetchElementInstance(elementInstanceKey).withSuccess(elementInstance);
+
+    const {user} = render(<TopPanel />, {
+      wrapper: getWrapper(
+        {
+          elementId,
+          isMultiInstanceBody: 'true',
+        },
+        (search) => {
+          currentSearch = search;
+        },
+      ),
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('diagram-spinner'),
+    );
+
+    await user.click(await screen.findByTestId(elementId));
+
+    expect(currentSearch).toContain(`elementId=${elementId}`);
+    expect(currentSearch).not.toContain('elementInstanceKey=');
+    expect(currentSearch).toContain('isMultiInstanceBody=true');
+
+    updateSearchParams({
+      elementId,
+      elementInstanceKey,
+      isMultiInstanceBody: 'true',
+    });
+
+    await waitFor(() => {
+      expect(currentSearch).toContain(
+        `elementInstanceKey=${elementInstanceKey}`,
+      );
+    });
+
+    await user.click(screen.getByTestId('diagram-canvas'));
+
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+
+    mockSearchElementInstances().withSuccess(
+      searchResult([
+        elementInstance,
+        {...elementInstance, elementInstanceKey: '2251799813699890'},
+      ]),
+    );
+    updateSearchParams({
+      elementId,
+      elementInstanceKey,
+    });
+
+    await waitFor(() => {
+      expect(currentSearch).toContain(
+        `elementInstanceKey=${elementInstanceKey}`,
+      );
+    });
+    expect(currentSearch).toContain(`elementId=${elementId}`);
+    expect(currentSearch).not.toContain('isMultiInstanceBody=');
+
+    await user.click(await screen.findByTestId(elementId));
+
+    await waitFor(() => {
+      expect(currentSearch).not.toContain('elementInstanceKey=');
+    });
+    expect(currentSearch).toContain(`elementId=${elementId}`);
+    expect(currentSearch).toContain('isMultiInstanceBody=true');
+  });
+
+  it('should select the anchor element from an anchored instance selection', async () => {
+    const elementInstanceKey = '2251799813699889';
+    let currentSearch = '';
+
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: 'user-task-1',
+          active: 1,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    });
+    mockFetchElementInstance(elementInstanceKey).withSuccess({
+      ...mockElementInstance,
+      elementInstanceKey,
+      elementId: 'multi-instance-subprocess',
+      type: 'AD_HOC_SUB_PROCESS_INNER_INSTANCE',
+    });
+
+    const {user} = render(<TopPanel />, {
+      wrapper: getWrapper(
+        {
+          elementId: 'multi-instance-subprocess',
+          elementInstanceKey,
+          anchorElementId: 'user-task-1',
+        },
+        (search) => {
+          currentSearch = search;
+        },
+      ),
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('diagram-spinner'),
+    );
+    await user.click(await screen.findByTestId('user-task-1'));
+
+    await waitFor(() => {
+      expect(currentSearch).toContain('elementId=user-task-1');
+    });
+    expect(currentSearch).not.toContain('elementInstanceKey=');
+    expect(currentSearch).not.toContain('anchorElementId=');
+    expect(currentSearch).not.toContain('isMultiInstanceBody=');
+  });
+
+  it('should preserve repeated-click behavior in modification mode', async () => {
+    const elementInstanceKey = '2251799813699889';
+    const elementId = 'multi-instance-subprocess';
+    let currentSearch = '';
+
+    mockFetchElementInstance(elementInstanceKey).withSuccess({
+      ...mockElementInstance,
+      elementId,
+      type: 'MULTI_INSTANCE_BODY',
+    });
+    mockFetchElementInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId,
+          active: 1,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    });
+    modificationsStore.enableModificationMode();
+
+    const {user} = render(<TopPanel />, {
+      wrapper: getWrapper(
+        {
+          elementId,
+          elementInstanceKey,
+        },
+        (search) => {
+          currentSearch = search;
+        },
+      ),
+    });
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('diagram-spinner'),
+    );
+    await user.click(await screen.findByTestId(elementId));
+
+    expect(currentSearch).toBe('');
   });
 
   it('should display move token banner in moving mode', async () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -39,6 +39,7 @@ import {isRequestError} from 'modules/request';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {useDrillDownNavigation} from 'modules/hooks/useDrilldownNavigation';
 import {getAncestorScopeType} from 'modules/utils/processInstanceDetailsDiagram';
+import {isMultiInstance as isMultiInstanceElement} from 'modules/bpmn-js/utils/isMultiInstance';
 
 const TopPanel: React.FC = observer(() => {
   const {
@@ -198,6 +199,65 @@ const TopPanel: React.FC = observer(() => {
     return 'content';
   };
 
+  const handleElementSelection = (
+    elementId?: string,
+    isMultiInstance?: boolean,
+    clickedElementId?: string,
+  ) => {
+    if (modificationsStore.state.status === 'moving-token' && businessObjects) {
+      const ancestorScopeType = getAncestorScopeType(
+        businessObjects,
+        sourceElementIdForMoveOperation ?? '',
+        elementId ?? '',
+        totalRunningInstancesByElement,
+      );
+
+      clearSelection();
+      finishMovingToken(
+        affectedTokenCount,
+        visibleAffectedTokenCount,
+        businessObjects,
+        processInstance?.processDefinitionId,
+        elementId,
+        ancestorScopeType,
+      );
+      return;
+    }
+
+    if (modificationsStore.state.status === 'adding-token') {
+      return;
+    }
+
+    if (elementId !== undefined) {
+      selectElement({
+        elementId,
+        isMultiInstanceBody: isMultiInstance,
+      });
+      return;
+    }
+
+    if (
+      selectedElementId !== null &&
+      clickedElementId !== undefined &&
+      selectedElementIds?.includes(clickedElementId)
+    ) {
+      if (isModificationModeEnabled) {
+        clearSelection();
+        return;
+      }
+
+      selectElement({
+        elementId: clickedElementId,
+        isMultiInstanceBody: isMultiInstanceElement(
+          businessObjects?.[clickedElementId],
+        ),
+      });
+      return;
+    }
+
+    clearSelection();
+  };
+
   return (
     <Container>
       {modificationsStore.state.status === 'moving-token' &&
@@ -239,37 +299,7 @@ const TopPanel: React.FC = observer(() => {
                     clearSelection();
                   }
                 }}
-                onElementSelection={(elementId, isMultiInstance) => {
-                  if (modificationsStore.state.status === 'moving-token') {
-                    const ancestorScopeType = getAncestorScopeType(
-                      businessObjects,
-                      sourceElementIdForMoveOperation ?? '',
-                      elementId ?? '',
-                      totalRunningInstancesByElement,
-                    );
-
-                    clearSelection();
-                    finishMovingToken(
-                      affectedTokenCount,
-                      visibleAffectedTokenCount,
-                      businessObjects,
-                      processInstance?.processDefinitionId,
-                      elementId,
-                      ancestorScopeType,
-                    );
-                  } else {
-                    if (modificationsStore.state.status !== 'adding-token') {
-                      if (elementId !== undefined) {
-                        selectElement({
-                          elementId,
-                          isMultiInstanceBody: isMultiInstance,
-                        });
-                      } else {
-                        clearSelection();
-                      }
-                    }
-                  }
-                }}
+                onElementSelection={handleElementSelection}
                 overlaysData={overlaysData}
                 selectedElementOverlay={
                   isModificationModeEnabled && <ModificationDropdown />

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import {observer} from 'mobx-react';
 import {useProcessInstancePageParams} from '../useProcessInstancePageParams';
 import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
@@ -199,64 +199,82 @@ const TopPanel: React.FC = observer(() => {
     return 'content';
   };
 
-  const handleElementSelection = (
-    elementId?: string,
-    isMultiInstance?: boolean,
-    clickedElementId?: string,
-  ) => {
-    if (modificationsStore.state.status === 'moving-token' && businessObjects) {
-      const ancestorScopeType = getAncestorScopeType(
-        businessObjects,
-        sourceElementIdForMoveOperation ?? '',
-        elementId ?? '',
-        totalRunningInstancesByElement,
-      );
+  const handleElementSelection = useCallback(
+    (
+      elementId?: string,
+      isMultiInstance?: boolean,
+      clickedElementId?: string,
+    ) => {
+      if (
+        modificationsStore.state.status === 'moving-token' &&
+        businessObjects
+      ) {
+        const ancestorScopeType = getAncestorScopeType(
+          businessObjects,
+          sourceElementIdForMoveOperation ?? '',
+          elementId ?? '',
+          totalRunningInstancesByElement,
+        );
 
-      clearSelection();
-      finishMovingToken(
-        affectedTokenCount,
-        visibleAffectedTokenCount,
-        businessObjects,
-        processInstance?.processDefinitionId,
-        elementId,
-        ancestorScopeType,
-      );
-      return;
-    }
-
-    if (modificationsStore.state.status === 'adding-token') {
-      return;
-    }
-
-    if (elementId !== undefined) {
-      selectElement({
-        elementId,
-        isMultiInstanceBody: isMultiInstance,
-      });
-      return;
-    }
-
-    if (
-      selectedElementId !== null &&
-      clickedElementId !== undefined &&
-      selectedElementIds?.includes(clickedElementId)
-    ) {
-      if (isModificationModeEnabled) {
         clearSelection();
+        finishMovingToken(
+          affectedTokenCount,
+          visibleAffectedTokenCount,
+          businessObjects,
+          processInstance?.processDefinitionId,
+          elementId,
+          ancestorScopeType,
+        );
         return;
       }
 
-      selectElement({
-        elementId: clickedElementId,
-        isMultiInstanceBody: isMultiInstanceElement(
-          businessObjects?.[clickedElementId],
-        ),
-      });
-      return;
-    }
+      if (modificationsStore.state.status === 'adding-token') {
+        return;
+      }
 
-    clearSelection();
-  };
+      if (elementId !== undefined) {
+        selectElement({
+          elementId,
+          isMultiInstanceBody: isMultiInstance,
+        });
+        return;
+      }
+
+      if (
+        selectedElementId !== null &&
+        clickedElementId !== undefined &&
+        selectedElementIds?.includes(clickedElementId)
+      ) {
+        if (isModificationModeEnabled) {
+          clearSelection();
+          return;
+        }
+
+        selectElement({
+          elementId: clickedElementId,
+          isMultiInstanceBody: isMultiInstanceElement(
+            businessObjects?.[clickedElementId],
+          ),
+        });
+        return;
+      }
+
+      clearSelection();
+    },
+    [
+      affectedTokenCount,
+      businessObjects,
+      clearSelection,
+      isModificationModeEnabled,
+      processInstance?.processDefinitionId,
+      selectedElementId,
+      selectedElementIds,
+      selectElement,
+      sourceElementIdForMoveOperation,
+      totalRunningInstancesByElement,
+      visibleAffectedTokenCount,
+    ],
+  );
 
   return (
     <Container>

--- a/operate/client/src/__mocks__/bpmn-js/lib/NavigatedViewer.ts
+++ b/operate/client/src/__mocks__/bpmn-js/lib/NavigatedViewer.ts
@@ -49,6 +49,15 @@ const createMockFlowNode = (id: string) => ({
   },
 });
 
+const createMockRoot = () => ({
+  id: 'mock-root',
+  type: 'bpmn:Process',
+  businessObject: {
+    id: 'mock-root',
+    $instanceOf: () => false,
+  },
+});
+
 const createMockedModules = (container: HTMLElement) => ({
   canvas: {
     zoom: vi.fn(),
@@ -113,6 +122,13 @@ class Viewer {
     this.container = container;
     this.bpmnRenderer = bpmnRenderer;
     this.modules = createMockedModules(container);
+    this.container.addEventListener('click', (event) => {
+      if (event.target === this.container) {
+        this.modules.eventBus.emit('element.click', {
+          element: createMockRoot(),
+        });
+      }
+    });
   }
 
   importDefinitions = vi.fn(() => Promise.resolve({}));

--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -28,6 +28,7 @@ import type {OverlayData} from './overlayTypes';
 type OnElementSelection = (
   elementId?: string,
   isMultiInstance?: boolean,
+  clickedElementId?: string,
 ) => void;
 
 type OnElementDoubleClick = (elementId: string) => void;
@@ -444,7 +445,7 @@ class BpmnJS {
         isMultiInstance(element.businessObject),
       );
     } else if (this.#selectedElementIds !== undefined) {
-      this.onElementSelection?.(undefined);
+      this.onElementSelection?.(undefined, undefined, element.id);
     }
   };
 


### PR DESCRIPTION
## Description

Selecting an element instance also highlights its element in the diagram. Clicking that highlighted element was indistinguishable from clicking the diagram background, so Operate cleared the selection and remounted the Details content.

This change distinguishes those interactions: clicking the highlighted element keeps it selected, resets Instance History to all instances of that element, and refreshes Details without replacing its scroll container. The resulting empty state is identical regardless of how the element was selected. Background clicks continue to clear the selection.

## Related issues

Closes #59885
