### PR TITLE
ci: reduce daily load test Elasticsearch disk size to 64Gi

### DIFF
--- a/.github/scripts/load-test-install-camunda-platform.sh
+++ b/.github/scripts/load-test-install-camunda-platform.sh
@@ -34,6 +34,7 @@
 #   --connectors-tag TAG          Explicit Connectors image tag
 #   --load-test-load VALUE        Extra --set args for the load-tester Helm chart
 #   --platform-helm-values VALUE  Extra --set args for the platform Helm chart
+#   --load-test-setup-helm-values VALUE  Extra --set args for the load-test-setup Helm chart
 #   --scenario SCENARIO           Workload scenario to run
 
 set -euo pipefail
@@ -59,6 +60,7 @@ identity_tag=""
 connectors_tag=""
 load_test_load=""
 platform_helm_values=""
+load_test_setup_helm_values=""
 scenario=""
 
 while [[ $# -gt 0 ]]; do
@@ -69,6 +71,7 @@ while [[ $# -gt 0 ]]; do
     --connectors-tag) connectors_tag="$2"; shift 2 ;;
     --load-test-load) load_test_load="$2"; shift 2 ;;
     --platform-helm-values) platform_helm_values="$2"; shift 2 ;;
+    --load-test-setup-helm-values) load_test_setup_helm_values="$2"; shift 2 ;;
     --scenario) scenario="$2"; shift 2 ;;
     *) echo "::error::Unknown argument: $1" >&2; exit 1 ;;
   esac
@@ -99,7 +102,7 @@ additional_platform_config="--set orchestration.image.registry=${image_registry}
   --set orchestration.image.repository=${camunda_repo} \
   --set orchestration.image.tag=${image_tag}"
 
-additional_load_test_setup_configuration=""
+additional_load_test_setup_configuration="${load_test_setup_helm_values}"
 
 # Append optimize image config: optimize-tag wins if set, otherwise custom builds use internal registry
 if [[ "${enable_optimize}" == "true" ]]; then
@@ -135,7 +138,7 @@ fi
 # is assuming to be always published by the dedicated CI running on
 # the main branch.
 if [[ "${metrics_exporter_built}" == "true" ]]; then
-  additional_load_test_setup_configuration+="--set metricsExporter.image.tag=${image_tag}"
+  additional_load_test_setup_configuration+=" --set metricsExporter.image.tag=${image_tag}"
 fi
 
 make "${install_target}" \

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -84,6 +84,9 @@ jobs:
       ttl: 1
       scenario: max
       build-frontend: true
+      # Daily runs are short-lived (soak for ~3h then delete), so they don't need
+      # the default disk size sized for longer-running/manual load tests.
+      load-test-setup-helm-values: --set elasticsearch.storage.requests=64Gi
 
   setup-max-rest-load-test:
     name: Setup max REST load test
@@ -97,6 +100,7 @@ jobs:
       scenario: max
       build-frontend: true
       load-test-load: --set global.preferRest.enabled=true
+      load-test-setup-helm-values: --set elasticsearch.storage.requests=64Gi
 
   # Wait 15 minutes after setup succeeds before profiling starts, mirroring the
   # warmup convention the rest of the load-test flow already uses (see

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -66,6 +66,11 @@ on:
         type: string
         default: ""
         required: false
+      load-test-setup-helm-values:
+        description: 'Additional Helm values for the load-test-setup chart (e.g. --set elasticsearch.storage.requests=64Gi)'
+        type: string
+        default: ""
+        required: false
       stable-vms:
         description: 'Deploy to non-spot VMs (more stable, higher cost)'
         type: boolean
@@ -166,6 +171,11 @@ on:
         type: string
         default: ""
         required: false
+      load-test-setup-helm-values:
+        description: 'Allows to specify additional values/configurations for the load-test-setup Helm chart, which deploys the secondary storage and supporting infra. For example, the Elasticsearch disk size can be reduced. Allows arbitrary helm arguments, like --set elasticsearch.storage.requests=64Gi'
+        type: string
+        default: ""
+        required: false
       publish:
         description: 'Where to publish the results, can be "slack" or "comment"'
         default: ""
@@ -256,6 +266,7 @@ env:
   IDENTITY_TAG: ${{ inputs.identity-tag }}
   IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
   LOAD_TEST_LOAD: ${{ inputs.load-test-load }}
+  LOAD_TEST_SETUP_HELM_VALUES: ${{ inputs.load-test-setup-helm-values }}
   NAME: ${{ inputs.name }}
   OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
   ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
@@ -300,6 +311,7 @@ jobs:
           | Orchestration tag | \`${ORCHESTRATION_TAG:-—}\` |
           | Load test load | \`${LOAD_TEST_LOAD:-—}\` |
           | Platform Helm values | \`${PLATFORM_HELM_VALUES:-—}\` |
+          | Load test setup Helm values | \`${LOAD_TEST_SETUP_HELM_VALUES:-—}\` |
           | TTL (days) | \`${TTL}\` |
           | Stable VMs | \`${STABLE_VMS}\` |
           | Enable Optimize | \`${ENABLE_OPTIMIZE}\` |
@@ -604,6 +616,7 @@ jobs:
             --connectors-tag "${CONNECTORS_TAG}" \
             --load-test-load "${LOAD_TEST_LOAD}" \
             --platform-helm-values "${PLATFORM_HELM_VALUES}" \
+            --load-test-setup-helm-values "${LOAD_TEST_SETUP_HELM_VALUES}" \
             --scenario "${SCENARIO}"
 
       - name: Annotate namespace with workflow run URL

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -400,6 +400,7 @@ In practice, most ad-hoc runs only need a test `name`, a Git `ref`, a built-in `
 * Specification of an existing Docker image to use — making it possible to reuse existing images.
 * Specification of platform chart overrides via `platform-helm-values` — for example orchestration sizing, env vars, and image-related settings.
 * Specification of load test chart overrides via `load-test-load` — for example starter rate, worker replicas, and BPMN/payload paths.
+* Specification of load-test-setup chart overrides via `load-test-setup-helm-values` — for example secondary storage disk size.
 
 ![load-test-gha](docs/assets/load-test-gha.png)
 
@@ -410,6 +411,7 @@ Use the workflow inputs as follows:
 - `scenario`: picks the base workload profile to run.
 - `platform-helm-values`: passes extra flags to the [Camunda Platform Helm Chart](https://github.com/camunda/camunda-platform-helm).
 - `load-test-load`: passes extra flags to the [Camunda load test Helm Chart](https://github.com/camunda/camunda-load-tests-helm).
+- `load-test-setup-helm-values`: passes extra flags to the local [`load-test-setup` chart](setup/charts/load-test-setup) that provisions secondary storage and supporting infra (e.g. Elasticsearch/OpenSearch/PostgreSQL, chaos-killer, metrics-exporter).
 
 If you need custom tuning, start with the closest `scenario` and then add targeted overrides in the Helm inputs.
 
@@ -474,6 +476,12 @@ Use the following values directly in the workflow form:
 
      ```text
      --set-string 'starter.bpmnXmlPath=bpmn/typical_process.bpmn' --set 'starter.rate=50'
+     ```
+6. **Reduce the Elasticsearch disk size for a short-lived run**
+   - `load-test-setup-helm-values`:
+
+     ```text
+     --set elasticsearch.storage.requests=64Gi
      ```
 
 ##### Creating load test for old versions


### PR DESCRIPTION
## Description

[#60083](https://github.com/camunda/camunda/pull/60083) reduced the default secondary storage disk size for the `load-test-setup` chart from 512Gi to 160Gi. That default is still sized for longer-running or manual load tests. The daily load test soaks for only ~3 hours before its namespace is deleted, so it never approaches 160Gi of Elasticsearch usage, but until now there was no way to configure the `load-test-setup` chart from the reusable load test workflow.

This PR:

- Adds a `load-test-setup-helm-values` input to `camunda-load-test.yml` (both `workflow_dispatch` and `workflow_call`), following the existing `platform-helm-values` / `load-test-load` pattern. It threads through `load-test-install-camunda-platform.sh` into `additional_load_test_setup_configuration`, which already flows into the `helm upgrade load-test-setup` call in `common.mk` - no Makefile changes needed.
- Uses the new input in `camunda-daily-load-tests.yml` to set `--set elasticsearch.storage.requests=64Gi` for both the gRPC and REST daily setup jobs.
- Documents the new input in `load-tests/README.md`.

## Background

 - This has been validated and verified via https://github.com/camunda/camunda/issues/59330
 - [Endurance tests](https://github.com/camunda/camunda/issues/59330#issuecomment-5277785871) and [stress tests](https://github.com/camunda/camunda/issues/59330#issuecomment-5278847049) have been executed
 - Conclusion posted [here](https://github.com/camunda/camunda/issues/59330#issuecomment-5278872646), validation for different [secondary storages and versions ](https://github.com/camunda/camunda/issues/59330#issuecomment-5279866000)
 - We are able to reduce the disk capacity for endurance tests by a factor of three and for daily load tests by a factor of eight, reducing costs for our load tests as well

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)). Not needed here: this only touches the main-branch reusable load test workflow and script, not a stable-branch wrapper.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. Not applicable: no E2E test suite changes.

## Related issues

closes #59330, follow-up to #60083
