### PR TITLE
refactor: make each /resources path template live in exactly one place

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-linked-generic-resources.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-linked-generic-resources.spec.ts
@@ -7,18 +7,13 @@
  */
 
 import {APIRequestContext, expect, test} from '@playwright/test';
-import {
-  assertStatusCode,
-  authHeaders,
-  buildUrl,
-  credentials,
-  jsonHeaders,
-} from '../../../../utils/http';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
 import {
   activateJobAndGetHeaders,
   completeJob,
   deployInlineFiles,
   deployInlineResource,
+  getResourceContentBinary,
   parseLinkedResourcesHeader,
   serviceTaskWithLinkedResourcesBpmn,
 } from '@requestHelpers';
@@ -46,11 +41,7 @@ async function fetchResourceContent(
   request: APIRequestContext,
   resourceKey: string,
 ): Promise<string> {
-  const res = await request.get(
-    buildUrl('/resources/{resourceKey}/content/binary', {resourceKey}),
-    // No Accept header — see camunda/camunda#59831.
-    {headers: authHeaders(credentials.accessToken)},
-  );
+  const res = await getResourceContentBinary(request, resourceKey);
   await assertStatusCode(res, 200);
   return res.text();
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-start-subscription-lifecycle.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-start-subscription-lifecycle.spec.ts
@@ -7,12 +7,14 @@
  */
 
 import {test} from '@playwright/test';
-import {buildUrl, jsonHeaders, assertStatusCode} from '../../../../utils/http';
+import {assertStatusCode} from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
 import {deploy} from '../../../../utils/zeebeClient';
 import {
+  deleteResource,
   expectStartSubscriptionPresent,
   expectStartSubscriptionAbsent,
+  RESOURCE_DELETION_ENDPOINT,
 } from '@requestHelpers';
 
 /* eslint-disable playwright/expect-expect */
@@ -31,17 +33,13 @@ test.describe('MCP Start-Subscription Lifecycle API Tests', () => {
       resourceKey,
     );
 
-    const deletion = await request.post(
-      buildUrl('/resources/{resourceKey}/deletion', {resourceKey}),
-      {
-        headers: jsonHeaders(),
-        data: {deleteHistory: true},
-      },
-    );
+    const deletion = await deleteResource(request, resourceKey, {
+      data: {deleteHistory: true},
+    });
     await assertStatusCode(deletion, 200);
     await validateResponse(
       {
-        path: '/resources/{resourceKey}/deletion',
+        path: RESOURCE_DELETION_ENDPOINT,
         method: 'POST',
         status: '200',
       },
@@ -76,19 +74,13 @@ test.describe('MCP Start-Subscription Lifecycle API Tests', () => {
       resourceKeyB,
     );
 
-    const deletion = await request.post(
-      buildUrl('/resources/{resourceKey}/deletion', {
-        resourceKey: resourceKeyA,
-      }),
-      {
-        headers: jsonHeaders(),
-        data: {deleteHistory: true},
-      },
-    );
+    const deletion = await deleteResource(request, resourceKeyA, {
+      data: {deleteHistory: true},
+    });
     await assertStatusCode(deletion, 200);
     await validateResponse(
       {
-        path: '/resources/{resourceKey}/deletion',
+        path: RESOURCE_DELETION_ENDPOINT,
         method: 'POST',
         status: '200',
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-api.spec.ts
@@ -9,20 +9,19 @@
 import {expect, test} from '@playwright/test';
 import {
   assertStatusCode,
-  buildUrl,
-  credentials,
-  defaultHeaders,
   assertUnauthorizedRequest,
-  jsonHeaders,
   assertNotFoundRequest,
   assertBadRequest,
   assertPaginatedRequest,
-  authHeaders,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
 import {
+  deleteResource,
   deployInlineResource,
   deployResourceAndGetMetadata,
+  getResource,
+  getResourceContentBinary,
+  RESOURCE_DELETION_ENDPOINT,
   searchResources,
   uniqueResourceName,
 } from '@requestHelpers';
@@ -40,17 +39,12 @@ test.describe.parallel('Resource Delete API', () => {
     );
     const resourceKey = metadata.resourceKey;
 
-    const res = await request.post(
-      buildUrl('/resources/{resourceKey}/deletion', {resourceKey}),
-      {
-        headers: defaultHeaders(),
-      },
-    );
+    const res = await deleteResource(request, resourceKey);
 
     await assertStatusCode(res, 200);
     await validateResponse(
       {
-        path: '/resources/{resourceKey}/deletion',
+        path: RESOURCE_DELETION_ENDPOINT,
         method: 'POST',
         status: '200',
       },
@@ -67,45 +61,29 @@ test.describe.parallel('Resource Delete API', () => {
       '# System prompt',
     );
     const resourceKey = resource.resourceKey;
-    const contentBinaryUrl = buildUrl(
-      '/resources/{resourceKey}/content/binary',
-      {resourceKey},
-    );
 
     await expect(async () => {
       const searchRes = await searchResources(request, {filter: {resourceKey}});
       await assertPaginatedRequest(searchRes, {itemsLengthEqualTo: 1});
 
-      const contentRes = await request.get(contentBinaryUrl, {
-        headers: authHeaders(credentials.accessToken),
-      });
+      const contentRes = await getResourceContentBinary(request, resourceKey);
       await assertStatusCode(contentRes, 200);
     }).toPass(defaultAssertionOptions);
 
-    const deleteRes = await request.post(
-      buildUrl('/resources/{resourceKey}/deletion', {resourceKey}),
-      {
-        headers: defaultHeaders(),
-      },
-    );
+    const deleteRes = await deleteResource(request, resourceKey);
     await assertStatusCode(deleteRes, 200);
 
     await expect(async () => {
       const searchRes = await searchResources(request, {filter: {resourceKey}});
       await assertPaginatedRequest(searchRes, {itemsLengthEqualTo: 0});
 
-      const getRes = await request.get(
-        buildUrl('/resources/{resourceKey}', {resourceKey}),
-        {headers: defaultHeaders()},
-      );
+      const getRes = await getResource(request, resourceKey);
       await assertNotFoundRequest(
         getRes,
         `Resource with key '${resourceKey}' not found`,
       );
 
-      const contentRes = await request.get(contentBinaryUrl, {
-        headers: authHeaders(credentials.accessToken),
-      });
+      const contentRes = await getResourceContentBinary(request, resourceKey);
       await assertNotFoundRequest(
         contentRes,
         `Resource with key '${resourceKey}' not found`,
@@ -116,14 +94,7 @@ test.describe.parallel('Resource Delete API', () => {
   test('Delete Resource - Not Found 404', async ({request}) => {
     const nonExistentResourceKey = '2251799813733053';
 
-    const res = await request.post(
-      buildUrl('/resources/{resourceKey}/deletion', {
-        resourceKey: nonExistentResourceKey,
-      }),
-      {
-        headers: defaultHeaders(),
-      },
-    );
+    const res = await deleteResource(request, nonExistentResourceKey);
 
     await assertNotFoundRequest(
       res,
@@ -136,14 +107,7 @@ test.describe.parallel('Resource Delete API', () => {
   }) => {
     const invalidResourceKey = 'invalid-string-key';
 
-    const res = await request.post(
-      buildUrl('/resources/{resourceKey}/deletion', {
-        resourceKey: invalidResourceKey,
-      }),
-      {
-        headers: defaultHeaders(),
-      },
-    );
+    const res = await deleteResource(request, invalidResourceKey);
 
     await assertBadRequest(
       res,
@@ -161,15 +125,9 @@ test.describe.parallel('Resource Delete API', () => {
     );
     const resourceKey = metadata.resourceKey;
 
-    const res = await request.post(
-      buildUrl('/resources/{resourceKey}/deletion', {resourceKey}),
-      {
-        headers: jsonHeaders(),
-        data: {
-          operationReference: 'invalid-string-reference',
-        },
-      },
-    );
+    const res = await deleteResource(request, resourceKey, {
+      data: {operationReference: 'invalid-string-reference'},
+    });
 
     await assertBadRequest(
       res,
@@ -185,12 +143,7 @@ test.describe.parallel('Resource Delete API', () => {
     );
     const resourceKey = metadata.resourceKey;
 
-    const res = await request.post(
-      buildUrl('/resources/{resourceKey}/deletion', {resourceKey}),
-      {
-        headers: {},
-      },
-    );
+    const res = await deleteResource(request, resourceKey, {headers: {}});
 
     await assertUnauthorizedRequest(res);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
@@ -22,6 +22,8 @@ import {
 import {
   deployInlineResource,
   deployResourceAndGetMetadata,
+  getResource,
+  RESOURCE_ENDPOINT,
   ResourceMetadata,
   uniqueResourceName,
 } from '@requestHelpers';
@@ -33,7 +35,7 @@ function validateResourceResponse(
 ): void {
   validateResponseShape(
     {
-      path: '/resources/{resourceKey}',
+      path: RESOURCE_ENDPOINT,
       method: 'GET',
       status: '200',
     },
@@ -60,19 +62,12 @@ test.describe.parallel('Resource Get API', () => {
     );
 
     await expect(async () => {
-      const res = await request.get(
-        buildUrl('/resources/{resourceKey}', {
-          resourceKey: metadata.resourceKey,
-        }),
-        {
-          headers: jsonHeaders(),
-        },
-      );
+      const res = await getResource(request, metadata.resourceKey);
 
       await assertStatusCode(res, 200);
       await validateResponse(
         {
-          path: '/resources/{resourceKey}',
+          path: RESOURCE_ENDPOINT,
           method: 'GET',
           status: '200',
         },
@@ -91,19 +86,12 @@ test.describe.parallel('Resource Get API', () => {
     );
 
     await expect(async () => {
-      const res = await request.get(
-        buildUrl('/resources/{resourceKey}', {
-          resourceKey: metadata.resourceKey,
-        }),
-        {
-          headers: jsonHeaders(),
-        },
-      );
+      const res = await getResource(request, metadata.resourceKey);
 
       await assertStatusCode(res, 200);
       await validateResponse(
         {
-          path: '/resources/{resourceKey}',
+          path: RESOURCE_ENDPOINT,
           method: 'GET',
           status: '200',
         },
@@ -135,14 +123,7 @@ test.describe.parallel('Resource Get API', () => {
       await assertStatusCode(definitionRes, 200);
     }).toPass(defaultAssertionOptions);
 
-    const res = await request.get(
-      buildUrl('/resources/{resourceKey}', {
-        resourceKey: processDefinition.resourceKey,
-      }),
-      {
-        headers: jsonHeaders(),
-      },
-    );
+    const res = await getResource(request, processDefinition.resourceKey);
 
     await assertNotFoundRequest(
       res,
@@ -154,14 +135,7 @@ test.describe.parallel('Resource Get API', () => {
   test('Get Resource - Not Found 404', async ({request}) => {
     const nonExistentResourceKey = '2251799813733053';
 
-    const res = await request.get(
-      buildUrl('/resources/{resourceKey}', {
-        resourceKey: nonExistentResourceKey,
-      }),
-      {
-        headers: jsonHeaders(),
-      },
-    );
+    const res = await getResource(request, nonExistentResourceKey);
 
     await assertNotFoundRequest(
       res,
@@ -171,12 +145,7 @@ test.describe.parallel('Resource Get API', () => {
 
   // eslint-disable-next-line playwright/expect-expect
   test('Get Resource - Unauthorized 401', async ({request}) => {
-    const res = await request.get(
-      buildUrl('/resources/{resourceKey}', {resourceKey: 'someKey'}),
-      {
-        headers: {},
-      },
-    );
+    const res = await getResource(request, 'someKey', {headers: {}});
 
     await assertUnauthorizedRequest(res);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-api.spec.ts
@@ -9,8 +9,6 @@
 import {expect, test} from '@playwright/test';
 import {
   assertStatusCode,
-  buildUrl,
-  defaultHeaders,
   assertUnauthorizedRequest,
   assertNotAcceptableRequest,
   assertNotFoundRequest,
@@ -19,6 +17,7 @@ import {getExpectedContent} from '../../../../utils/beans/requestBeans';
 import {
   deployInlineResource,
   deployResourceAndGetMetadata,
+  getResourceContent,
   uniqueResourceName,
 } from '@requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
@@ -34,14 +33,7 @@ test.describe.parallel('Resource Get Content API', () => {
     const expectedContent = getExpectedContent(resourceName);
 
     await expect(async () => {
-      const res = await request.get(
-        buildUrl('/resources/{resourceKey}/content', {
-          resourceKey: metadata.resourceKey,
-        }),
-        {
-          headers: defaultHeaders(),
-        },
-      );
+      const res = await getResourceContent(request, metadata.resourceKey);
 
       await assertStatusCode(res, 200);
       expect(await res.text()).toBe(expectedContent);
@@ -58,14 +50,7 @@ test.describe.parallel('Resource Get Content API', () => {
     );
 
     await expect(async () => {
-      const res = await request.get(
-        buildUrl('/resources/{resourceKey}/content', {
-          resourceKey: resource.resourceKey,
-        }),
-        {
-          headers: defaultHeaders(),
-        },
-      );
+      const res = await getResourceContent(request, resource.resourceKey);
 
       await assertNotAcceptableRequest(
         res,
@@ -80,14 +65,7 @@ test.describe.parallel('Resource Get Content API', () => {
   test('Get Resource Content - Not Found 404', async ({request}) => {
     const nonExistentResourceKey = '2251799813733053';
 
-    const res = await request.get(
-      buildUrl('/resources/{resourceKey}/content', {
-        resourceKey: nonExistentResourceKey,
-      }),
-      {
-        headers: defaultHeaders(),
-      },
-    );
+    const res = await getResourceContent(request, nonExistentResourceKey);
 
     await assertNotFoundRequest(
       res,
@@ -97,14 +75,7 @@ test.describe.parallel('Resource Get Content API', () => {
 
   // eslint-disable-next-line playwright/expect-expect
   test('Get Resource Content - Unauthorized 401', async ({request}) => {
-    const res = await request.get(
-      buildUrl('/resources/{resourceKey}/content', {
-        resourceKey: 'someKey',
-      }),
-      {
-        headers: {},
-      },
-    );
+    const res = await getResourceContent(request, 'someKey', {headers: {}});
 
     await assertUnauthorizedRequest(res);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-binary-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-binary-api.spec.ts
@@ -11,12 +11,10 @@ import {
   assertNotFoundRequest,
   assertStatusCode,
   assertUnauthorizedRequest,
-  authHeaders,
-  buildUrl,
-  credentials,
 } from '../../../../utils/http';
 import {
   deployInlineResource,
+  getResourceContentBinary,
   rpaResourceContent,
   uniqueResourceName,
 } from '@requestHelpers';
@@ -30,18 +28,6 @@ const PNG_BYTES = Buffer.from(
   'base64',
 );
 
-function contentBinaryUrl(resourceKey: string): string {
-  return buildUrl('/resources/{resourceKey}/content/binary', {resourceKey});
-}
-
-// Workaround for bug #59831: https://github.com/camunda/camunda/issues/59831
-// The handler is mapped with the gateway's default JSON produces list, so an
-// explicit `Accept: application/octet-stream` — the media type the API spec
-// documents — is answered with 406. Send no Accept header until that is fixed.
-function binaryHeaders(): Record<string, string> {
-  return authHeaders(credentials.accessToken);
-}
-
 test.describe.parallel('Resource Get Content Binary API', () => {
   test('Get Resource Content Binary - Generic Resource Success 200', async ({
     request,
@@ -54,9 +40,7 @@ test.describe.parallel('Resource Get Content Binary API', () => {
     );
 
     await expect(async () => {
-      const res = await request.get(contentBinaryUrl(resource.resourceKey), {
-        headers: binaryHeaders(),
-      });
+      const res = await getResourceContentBinary(request, resource.resourceKey);
 
       await assertStatusCode(res, 200);
       expect(res.headers()['content-type']).toContain(
@@ -77,9 +61,7 @@ test.describe.parallel('Resource Get Content Binary API', () => {
     );
 
     await expect(async () => {
-      const res = await request.get(contentBinaryUrl(resource.resourceKey), {
-        headers: binaryHeaders(),
-      });
+      const res = await getResourceContentBinary(request, resource.resourceKey);
 
       await assertStatusCode(res, 200);
       expect(await res.text()).toBe(content);
@@ -96,9 +78,7 @@ test.describe.parallel('Resource Get Content Binary API', () => {
     );
 
     await expect(async () => {
-      const res = await request.get(contentBinaryUrl(resource.resourceKey), {
-        headers: binaryHeaders(),
-      });
+      const res = await getResourceContentBinary(request, resource.resourceKey);
 
       await assertStatusCode(res, 200);
       expect(await res.body()).toEqual(PNG_BYTES);
@@ -109,9 +89,7 @@ test.describe.parallel('Resource Get Content Binary API', () => {
   test('Get Resource Content Binary - Not Found 404', async ({request}) => {
     const nonExistentResourceKey = '2251799813733053';
 
-    const res = await request.get(contentBinaryUrl(nonExistentResourceKey), {
-      headers: binaryHeaders(),
-    });
+    const res = await getResourceContentBinary(request, nonExistentResourceKey);
 
     await assertNotFoundRequest(
       res,
@@ -121,7 +99,7 @@ test.describe.parallel('Resource Get Content Binary API', () => {
 
   // eslint-disable-next-line playwright/expect-expect
   test('Get Resource Content Binary - Unauthorized 401', async ({request}) => {
-    const res = await request.get(contentBinaryUrl('someKey'), {
+    const res = await getResourceContentBinary(request, 'someKey', {
       headers: {},
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-search-api.spec.ts
@@ -12,7 +12,6 @@ import {
   assertPaginatedRequest,
   assertUnauthorizedRequest,
   assertStatusCode,
-  buildUrl,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
 import {
@@ -22,6 +21,7 @@ import {
   deployInlineResources,
   deployResourceAndGetMetadata,
   resourceKeysOf,
+  RESOURCE_SEARCH_ENDPOINT,
   rpaResourceContent,
   searchResources,
   uniqueResourceName,
@@ -48,7 +48,7 @@ async function searchAndValidate(
 ) {
   const res = await searchResources(request, body);
   await validateResponse(
-    {path: '/resources/search', method: 'POST', status: '200'},
+    {path: RESOURCE_SEARCH_ENDPOINT, method: 'POST', status: '200'},
     res,
   );
   return res;
@@ -398,10 +398,11 @@ test.describe('Resource Search API', () => {
 
   // eslint-disable-next-line playwright/expect-expect
   test('Search Resources - Unauthorized 401', async ({request}) => {
-    const res = await request.post(buildUrl('/resources/search'), {
-      headers: {'Content-Type': 'application/json'},
-      data: {},
-    });
+    const res = await searchResources(
+      request,
+      {},
+      {headers: {'Content-Type': 'application/json'}},
+    );
 
     await assertUnauthorizedRequest(res);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
@@ -411,19 +411,10 @@ export async function deployInlineResource(
   return resources[0];
 }
 
-export async function searchResources(
-  request: APIRequestContext,
-  body: Record<string, unknown> = {},
-): Promise<APIResponse> {
-  return request.post(buildUrl('/resources/search'), {
-    headers: jsonHeaders(),
-    data: body,
-  });
-}
-
 // The endpoint constants are exported because a spec needs the same literal a
 // second time for `validateResponse({path, ...})`. Reusing the constant keeps
 // the requested path and the validated path from drifting apart.
+export const RESOURCE_SEARCH_ENDPOINT = '/resources/search';
 export const RESOURCE_ENDPOINT = '/resources/{resourceKey}';
 export const RESOURCE_CONTENT_ENDPOINT = '/resources/{resourceKey}/content';
 export const RESOURCE_CONTENT_BINARY_ENDPOINT =
@@ -436,6 +427,17 @@ export const RESOURCE_DELETION_ENDPOINT = '/resources/{resourceKey}/deletion';
 // cases send none.
 interface ResourceRequestOptions {
   headers?: Record<string, string>;
+}
+
+export async function searchResources(
+  request: APIRequestContext,
+  body: Record<string, unknown> = {},
+  options: ResourceRequestOptions = {},
+): Promise<APIResponse> {
+  return request.post(buildUrl(RESOURCE_SEARCH_ENDPOINT), {
+    headers: options.headers ?? jsonHeaders(),
+    data: body,
+  });
 }
 
 export function getResource(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
@@ -484,8 +484,13 @@ export function deleteResource(
   resourceKey: string,
   options: DeleteResourceOptions = {},
 ): Promise<APIResponse> {
+  // A request carrying a body states its own Content-Type rather than leaving
+  // Playwright to infer one; a bodyless delete only declares what it accepts.
+  const headers =
+    options.headers ??
+    (options.data === undefined ? defaultHeaders() : jsonHeaders());
   return request.post(buildUrl(RESOURCE_DELETION_ENDPOINT, {resourceKey}), {
-    headers: options.headers ?? defaultHeaders(),
+    headers,
     ...(options.data === undefined ? {} : {data: options.data}),
   });
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
@@ -9,7 +9,14 @@
 import {APIResponse, expect} from '@playwright/test';
 import {readFileSync} from 'node:fs';
 import {APIRequestContext} from 'playwright-core';
-import {assertStatusCode, buildUrl, defaultHeaders, jsonHeaders} from '../http';
+import {
+  assertStatusCode,
+  authHeaders,
+  buildUrl,
+  credentials,
+  defaultHeaders,
+  jsonHeaders,
+} from '../http';
 import {generateUniqueId} from '../constants';
 
 type DeploymentItem = Record<string, Record<string, unknown> | undefined>;
@@ -411,6 +418,73 @@ export async function searchResources(
   return request.post(buildUrl('/resources/search'), {
     headers: jsonHeaders(),
     data: body,
+  });
+}
+
+// The endpoint constants are exported because a spec needs the same literal a
+// second time for `validateResponse({path, ...})`. Reusing the constant keeps
+// the requested path and the validated path from drifting apart.
+export const RESOURCE_ENDPOINT = '/resources/{resourceKey}';
+export const RESOURCE_CONTENT_ENDPOINT = '/resources/{resourceKey}/content';
+export const RESOURCE_CONTENT_BINARY_ENDPOINT =
+  '/resources/{resourceKey}/content/binary';
+export const RESOURCE_DELETION_ENDPOINT = '/resources/{resourceKey}/deletion';
+
+// Every helper below returns the raw response so callers keep asserting the
+// status themselves — these endpoints are exercised for 200, 400, 401, 404 and
+// 406 alike. `headers` overrides the default, which is how the unauthorized
+// cases send none.
+interface ResourceRequestOptions {
+  headers?: Record<string, string>;
+}
+
+export function getResource(
+  request: APIRequestContext,
+  resourceKey: string,
+  options: ResourceRequestOptions = {},
+): Promise<APIResponse> {
+  return request.get(buildUrl(RESOURCE_ENDPOINT, {resourceKey}), {
+    headers: options.headers ?? defaultHeaders(),
+  });
+}
+
+export function getResourceContent(
+  request: APIRequestContext,
+  resourceKey: string,
+  options: ResourceRequestOptions = {},
+): Promise<APIResponse> {
+  return request.get(buildUrl(RESOURCE_CONTENT_ENDPOINT, {resourceKey}), {
+    headers: options.headers ?? defaultHeaders(),
+  });
+}
+
+// Workaround for bug #59831: https://github.com/camunda/camunda/issues/59831
+// The handler is mapped with the gateway's default JSON produces list, so an
+// explicit `Accept: application/octet-stream` — the media type the API spec
+// documents — is answered with 406. Send no Accept header until that is fixed.
+export function getResourceContentBinary(
+  request: APIRequestContext,
+  resourceKey: string,
+  options: ResourceRequestOptions = {},
+): Promise<APIResponse> {
+  return request.get(
+    buildUrl(RESOURCE_CONTENT_BINARY_ENDPOINT, {resourceKey}),
+    {headers: options.headers ?? authHeaders(credentials.accessToken)},
+  );
+}
+
+interface DeleteResourceOptions extends ResourceRequestOptions {
+  data?: Record<string, unknown>;
+}
+
+export function deleteResource(
+  request: APIRequestContext,
+  resourceKey: string,
+  options: DeleteResourceOptions = {},
+): Promise<APIResponse> {
+  return request.post(buildUrl(RESOURCE_DELETION_ENDPOINT, {resourceKey}), {
+    headers: options.headers ?? defaultHeaders(),
+    ...(options.data === undefined ? {} : {data: options.data}),
   });
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/resourceCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/resourceCleanup.ts
@@ -7,7 +7,7 @@
  */
 
 import {APIRequestContext} from '@playwright/test';
-import {defaultHeaders, buildUrl} from './http';
+import {deleteResource} from './requestHelpers/resource-requestHelpers';
 
 export async function cleanupResources(
   request: APIRequestContext,
@@ -20,10 +20,7 @@ export async function cleanupResources(
   const results = await Promise.allSettled(
     resourceKeys.map(async (resourceKey) => {
       try {
-        const response = await request.post(
-          buildUrl('/resources/{resourceKey}/deletion', {resourceKey}),
-          {headers: defaultHeaders()},
-        );
+        const response = await deleteResource(request, resourceKey);
         if (response.status() === 200) {
           console.log(`Successfully deleted resource: ${resourceKey}`);
           return {resourceKey, status: 'deleted'};


### PR DESCRIPTION
Closes #59879 (sub-issue of #51042)

## Why

`resource-requestHelpers.ts` wrapped only the write and search side of the `/resources` API. The four remaining endpoints had no helper, so every spec that touched them re-declared the path template inline:

| Endpoint | Method | Call sites migrated |
|---|---|---|
| `/resources/{resourceKey}` | GET | `resource-get-api.spec.ts`, `resource-delete-api.spec.ts` |
| `/resources/{resourceKey}/content` | GET | `resource-get-content-api.spec.ts` |
| `/resources/{resourceKey}/content/binary` | GET | `resource-get-content-binary-api.spec.ts`, `resource-delete-api.spec.ts`, `job/job-linked-generic-resources.spec.ts` |
| `/resources/{resourceKey}/deletion` | POST | `resource-delete-api.spec.ts`, `message-subscriptions/mcp-start-subscription-lifecycle.spec.ts`, `utils/resourceCleanup.ts` |

Two consequences, beyond the duplication itself:

- A path rename in `rest-api.yaml` needs a grep across up to four spec files per endpoint, and nothing fails loudly if a site is missed.
- Each literal was written twice per call site — once for `buildUrl`, again as the `path:` argument to `validateResponse` — so a spec could silently validate a response against a different path than it requested.

## What

Three `refactor:` commits.

**1. The four un-wrapped endpoints.** Adds `getResource`, `getResourceContent`, `getResourceContentBinary` and a single-key `deleteResource`. Each owns its path template and exports it as a constant (`RESOURCE_ENDPOINT`, `RESOURCE_CONTENT_ENDPOINT`, `RESOURCE_CONTENT_BINARY_ENDPOINT`, `RESOURCE_DELETION_ENDPOINT`) so the `validateResponse` call reuses the same literal.

- All use `{param}` placeholders with a params object, the form `buildUrl` can guard against a missing path parameter.
- They return the raw `APIResponse` — these endpoints are asserted for 200, 400, 401, 404 and 406 alike — and take a `headers` override, which is how the unauthorized cases send none.
- `getResourceContentBinary` keeps the #59831 workaround verbatim (no `Accept` header, because the gateway answers the documented `Accept: application/octet-stream` with 406). The explanation moves out of the spec-local `binaryHeaders()` and into the helper. That endpoint stays without `validateResponse`, as it is absent from the generated response index — the generator only indexes `application/json` responses (camunda/assert-json-body#6).
- `utils/resourceCleanup.ts` routes its bulk best-effort deletes through `deleteResource`, so the deletion path has one definition rather than one for cleanup plus one per asserting spec.

**2. `/resources/search`.** `searchResources` already wrapped this endpoint, but two sites in `resource-search-api.spec.ts` still carried the literal for the same two reasons: `searchAndValidate` passed `'/resources/search'` inline to `validateResponse`, and the 401 case bypassed the helper entirely because it hard-coded `jsonHeaders()` with no way to omit auth. Exports `RESOURCE_SEARCH_ENDPOINT`, gives `searchResources` the same `headers` override, and routes both through it.

**3. Content-Type on body-carrying deletions** (raised by Copilot). `deleteResource` now picks `jsonHeaders()` when a body is present and `defaultHeaders()` otherwise, instead of leaving Playwright to infer the content type.

Net: 144 insertions, 211 deletions across 9 files. No test added, removed or renamed. `grep "'/resources/"` over `utils/` and `tests/` now returns nothing outside `resource-requestHelpers.ts`.

`v2-stateless-tests/tests/request-validation/resources-validation-api-tests.spec.ts` is intentionally untouched: it is generated.

### One behavioural note for review

Consolidating on one default header set per endpoint normalises the four GET `/resources/{resourceKey}` requests, which previously sent `jsonHeaders()` (`Content-Type: application/json`) and now send `defaultHeaders()` (`Accept: application/json`). A sibling site on that endpoint already sent `defaultHeaders()` and asserts the same 200/404 responses, so the shape was already proven — and all four API jobs of the on-demand run below are green. After commit 3, no other request's headers change.

## Verification

- `npm run lint` (tsc + eslint + TestRail-ID check): 0 errors. `npx prettier --check`: clean.
- On-demand run against this branch and a matching baseline run against `main`: results in the comment below. PR CI only lints this suite, so the on-demand run is the real evidence that the requests still behave.

[TestRail test case suite](https://camunda.testrail.com/index.php?/suites/view/17050)