### PR TITLE
feat: scope partition-count scaling to a physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -283,7 +283,9 @@ public class ClusterEndpoint {
   public ResponseEntity<?> updateClusterConfiguration(
       @RequestParam(defaultValue = "false") final boolean dryRun,
       @RequestParam(defaultValue = "false") final boolean force,
-      @RequestBody final ClusterConfigPatchRequest request) {
+      @RequestBody final ClusterConfigPatchRequest request,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
+    final Optional<String> tenant = Optional.ofNullable(physicalTenant).filter(s -> !s.isBlank());
     try {
       final var brokers = request.getBrokers();
       final var partitions = request.getPartitions();
@@ -314,11 +316,13 @@ public class ClusterEndpoint {
                 newPartitionCount,
                 newReplicationFactor,
                 Optional.ofNullable(request.getBrokers().getZone()).filter(z -> !z.isBlank()),
+                tenant,
                 dryRun);
         return ClusterApiUtils.mapOperationResponse(
             requestSender.scaleCluster(scaleRequest).join());
       } else {
-        return patchCluster(dryRun, request, brokers, newPartitionCount, newReplicationFactor);
+        return patchCluster(
+            dryRun, request, brokers, newPartitionCount, newReplicationFactor, tenant);
       }
 
     } catch (final Exception error) {
@@ -331,7 +335,8 @@ public class ClusterEndpoint {
       final ClusterConfigPatchRequest request,
       final ClusterConfigPatchRequestBrokers brokers,
       final Optional<Integer> newPartitionCount,
-      final Optional<Integer> newReplicationFactor) {
+      final Optional<Integer> newReplicationFactor,
+      final Optional<String> physicalTenant) {
     final Set<MemberId> brokersToAdd =
         brokers != null
             ? request.getBrokers().getAdd().stream()
@@ -348,7 +353,12 @@ public class ClusterEndpoint {
             : Set.of();
     final var patchRequest =
         new ClusterPatchRequest(
-            brokersToAdd, brokersToRemove, newPartitionCount, newReplicationFactor, dryRun);
+            brokersToAdd,
+            brokersToRemove,
+            newPartitionCount,
+            newReplicationFactor,
+            physicalTenant,
+            dryRun);
     return ClusterApiUtils.mapOperationResponse(requestSender.patchCluster(patchRequest).join());
   }
 

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -173,6 +173,16 @@ paths:
       description: Reconfigure cluster by adding or removing brokers, adding more partitions, or
                    changing the replicationFactor. Note that adding partitions is an experimental
                    feature and not fully supported.
+                   Only the partition count can be scoped to a physical tenant, with the
+                   physicalTenant parameter; without it, the partition count of the default
+                   physical tenant is changed. Partitions are distributed across brokers
+                   considering every physical tenant's partitions at once, so that scaling one
+                   tenant does not overload brokers already busy with another tenant's partitions;
+                   as a consequence, it can also relocate partitions of the tenants that are not
+                   being scaled.
+                   The broker count (or the brokers to add/remove) changes cluster membership, and
+                   the replication factor is a cluster-wide setting; neither has a tenant to scope it
+                   to, so neither may be combined with physicalTenant.
       requestBody:
         required: true
         content:
@@ -182,11 +192,14 @@ paths:
       parameters:
         - $ref: '#/components/parameters/DryRunParameter'
         - $ref: '#/components/parameters/ForceParameter'
+        - $ref: '#/components/parameters/PhysicalTenantParameter'
       responses:
         '202':
           $ref: "#/components/responses/ClusterConfigPatchResponse"
         '400':
           $ref: 'components.yaml#/responses/InvalidRequest'
+        '404':
+          $ref: 'components.yaml#/responses/NotFound'
         '409':
           $ref: 'components.yaml#/responses/ConcurrentChangeError'
         '500':

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
@@ -28,6 +29,8 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.ConfigurationChange;
 import io.camunda.zeebe.management.cluster.GetConfigurationChangesResponse;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
@@ -40,6 +43,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -413,6 +417,83 @@ final class ClusterEndpointTest {
       assertThat(body).isNotNull();
       assertThat(body.getChanges()).extracting(ConfigurationChange::getId).containsExactly(2L);
       verify(sender).getTopology();
+    }
+  }
+
+  @Nested
+  class PatchClusterEndpoint {
+
+    @Test
+    void shouldScaleTheGivenPhysicalTenant() {
+      // given
+      final var sender = senderAcceptingPatch();
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      endpoint.updateClusterConfiguration(false, false, partitionCountRequest(3), "tenant-a");
+
+      // then
+      verify(sender)
+          .patchCluster(
+              new ClusterPatchRequest(
+                  Set.of(),
+                  Set.of(),
+                  Optional.of(3),
+                  Optional.empty(),
+                  Optional.of("tenant-a"),
+                  false));
+    }
+
+    @Test
+    void shouldScaleTheDefaultPhysicalTenantWhenParameterIsAbsent() {
+      // given
+      final var sender = senderAcceptingPatch();
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      endpoint.updateClusterConfiguration(false, false, partitionCountRequest(3), null);
+
+      // then — an absent tenant is not passed on at all, which the transformer reads as the
+      // default tenant
+      verify(sender)
+          .patchCluster(
+              new ClusterPatchRequest(
+                  Set.of(), Set.of(), Optional.of(3), Optional.empty(), Optional.empty(), false));
+    }
+
+    @Test
+    void shouldTreatABlankPhysicalTenantAsAbsent() {
+      // given
+      final var sender = senderAcceptingPatch();
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      endpoint.updateClusterConfiguration(false, false, partitionCountRequest(3), "  ");
+
+      // then
+      verify(sender)
+          .patchCluster(
+              new ClusterPatchRequest(
+                  Set.of(), Set.of(), Optional.of(3), Optional.empty(), Optional.empty(), false));
+    }
+
+    private ClusterConfigPatchRequest partitionCountRequest(final int count) {
+      return new ClusterConfigPatchRequest()
+          .partitions(new ClusterConfigPatchRequestPartitions().count(count));
+    }
+
+    private ClusterConfigurationManagementRequestSender senderAcceptingPatch() {
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      when(sender.patchCluster(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  Either.right(
+                      new ClusterConfigurationChangeResponse(
+                          1L,
+                          new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                              Map.of(), Map.of(), List.of()),
+                          null))));
+      return sender;
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.dynamic.config;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
@@ -114,7 +113,7 @@ public class PhysicalTenantProvisioningInitializer
    */
   private CurrentClusterConfiguration provisionTenants(
       final CurrentClusterConfiguration configuration, final List<String> newTenantIds) {
-    final Set<MemberId> targetMembers = liveMembers(configuration);
+    final Set<MemberId> targetMembers = configuration.liveMembers();
     final var existingPartitionIds =
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(configuration).values().stream()
             .flatMap(Set::stream)
@@ -148,24 +147,6 @@ public class PhysicalTenantProvisioningInitializer
       result = addGroupAndStartChange(result, newTenantId, tenantOperations);
     }
     return result;
-  }
-
-  /**
-   * The members eligible to host a new tenant's partitions: every broker known to the cluster
-   * except those in {@link BrokerState.State#LEFT} or {@link BrokerState.State#UNINITIALIZED} —
-   * mirroring {@link CurrentClusterConfiguration#clusterSize()}'s definition of "live". Using the
-   * raw {@code globalConfiguration().members().keySet()} instead would let a decommissioned or
-   * not-yet-joined broker be selected as a target, stalling provisioning once its bootstrap/join
-   * operation can never complete.
-   */
-  private static Set<MemberId> liveMembers(final CurrentClusterConfiguration configuration) {
-    return configuration.globalConfiguration().members().entrySet().stream()
-        .filter(
-            entry ->
-                entry.getValue().state() != BrokerState.State.LEFT
-                    && entry.getValue().state() != BrokerState.State.UNINITIALIZED)
-        .map(Map.Entry::getKey)
-        .collect(Collectors.toSet());
   }
 
   private Set<PartitionMetadata> getTargetDistribution(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -69,13 +69,20 @@ public sealed interface ClusterConfigurationManagementRequest {
    * @param brokerCount the target number of brokers. On a plain (non-zone-aware) cluster this is
    *     the total cluster size; when {@code zone} is set it is the target broker count <em>within
    *     that zone</em>, leaving the other zones untouched. Empty leaves the broker count unchanged.
-   * @param newPartitionCount the target number of partitions, or empty to leave it unchanged.
-   *     Partitions can only be scaled up.
+   *     Targets cluster membership, which has no tenant dimension, so it must not be combined with
+   *     {@code physicalTenantId}.
+   * @param newPartitionCount the target number of partitions of a single physical tenant — the one
+   *     named by {@code physicalTenantId}, or the default tenant when none is named — or empty to
+   *     leave it unchanged. Partitions can only be scaled up.
    * @param newReplicationFactor the target replication factor, or empty to leave it unchanged. When
    *     {@code zone} is set it must not be set. To change replication factor in zone aware clusters
-   *     use {@link UpdatePartitionDistributorConfigRequest}
+   *     use {@link UpdatePartitionDistributorConfigRequest}. A cluster-wide setting, so it has no
+   *     tenant to scope it to and must not be combined with {@code physicalTenantId}.
    * @param zone the zone to scale, or empty to scale a plain cluster. Required when scaling a
    *     zone-aware cluster and rejected on a plain one.
+   * @param physicalTenantId the physical tenant whose partition group {@code newPartitionCount}
+   *     applies to, or empty for the default physical tenant. Must not be combined with {@code
+   *     brokerCount} or {@code newReplicationFactor}.
    * @param dryRun when true, the resulting plan is computed and returned without being applied.
    */
   record ClusterScaleRequest(
@@ -83,25 +90,59 @@ public sealed interface ClusterConfigurationManagementRequest {
       Optional<Integer> newPartitionCount,
       Optional<Integer> newReplicationFactor,
       Optional<String> zone,
+      Optional<String> physicalTenantId,
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {
+    public ClusterScaleRequest(
+        final Optional<Integer> brokerCount,
+        final Optional<Integer> newPartitionCount,
+        final Optional<Integer> newReplicationFactor,
+        final Optional<String> zone,
+        final boolean dryRun) {
+      this(brokerCount, newPartitionCount, newReplicationFactor, zone, Optional.empty(), dryRun);
+    }
+
     public ClusterScaleRequest {
       zone.ifPresent(assertNonEmpty("zone"));
+      physicalTenantId.ifPresent(assertNonEmpty("physicalTenantId"));
       brokerCount.ifPresent(assertPositive("brokerCount"));
       newPartitionCount.ifPresent(assertPositive("newPartitionCount"));
       newReplicationFactor.ifPresent(assertPositive("newReplicationFactor"));
     }
   }
 
+  /**
+   * @param physicalTenantId the physical tenant whose partition group {@code newPartitionCount}
+   *     applies to, or empty for the default physical tenant. Must not be combined with a non-empty
+   *     {@code membersToAdd}/{@code membersToRemove}, which change cluster membership and have no
+   *     tenant dimension, nor with {@code newReplicationFactor}, which is a cluster-wide setting.
+   */
   record ClusterPatchRequest(
       Set<MemberId> membersToAdd,
       Set<MemberId> membersToRemove,
       Optional<Integer> newPartitionCount,
       Optional<Integer> newReplicationFactor,
+      Optional<String> physicalTenantId,
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {
 
+    public ClusterPatchRequest(
+        final Set<MemberId> membersToAdd,
+        final Set<MemberId> membersToRemove,
+        final Optional<Integer> newPartitionCount,
+        final Optional<Integer> newReplicationFactor,
+        final boolean dryRun) {
+      this(
+          membersToAdd,
+          membersToRemove,
+          newPartitionCount,
+          newReplicationFactor,
+          Optional.empty(),
+          dryRun);
+    }
+
     public ClusterPatchRequest {
+      physicalTenantId.ifPresent(assertNonEmpty("physicalTenantId"));
       newPartitionCount.ifPresent(assertPositive("newPartitionCount"));
       newReplicationFactor.ifPresent(assertPositive("newReplicationFactor"));
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -155,7 +155,8 @@ public final class ClusterConfigurationManagementRequestsHandler
             clusterScaleRequest.brokerCount(),
             clusterScaleRequest.newPartitionCount(),
             clusterScaleRequest.newReplicationFactor(),
-            clusterScaleRequest.zone()));
+            clusterScaleRequest.zone(),
+            clusterScaleRequest.physicalTenantId()));
   }
 
   @Override
@@ -167,7 +168,8 @@ public final class ClusterConfigurationManagementRequestsHandler
             clusterPatchRequest.membersToAdd(),
             clusterPatchRequest.membersToRemove(),
             clusterPatchRequest.newPartitionCount(),
-            clusterPatchRequest.newReplicationFactor()));
+            clusterPatchRequest.newReplicationFactor(),
+            clusterPatchRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -9,9 +9,12 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.HashSet;
 import java.util.List;
@@ -24,16 +27,66 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
   private final Set<MemberId> membersToRemove;
   private final Optional<Integer> newPartitionCount;
   private final Optional<Integer> newReplicationFactor;
+  private final Optional<String> physicalTenantId;
 
   public ClusterPatchRequestTransformer(
       final Set<MemberId> membersToAdd,
       final Set<MemberId> membersToRemove,
       final Optional<Integer> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
+    this(membersToAdd, membersToRemove, newPartitionCount, newReplicationFactor, Optional.empty());
+  }
+
+  public ClusterPatchRequestTransformer(
+      final Set<MemberId> membersToAdd,
+      final Set<MemberId> membersToRemove,
+      final Optional<Integer> newPartitionCount,
+      final Optional<Integer> newReplicationFactor,
+      final Optional<String> physicalTenantId) {
     this.membersToAdd = membersToAdd;
     this.membersToRemove = membersToRemove;
     this.newPartitionCount = newPartitionCount;
     this.newReplicationFactor = newReplicationFactor;
+    this.physicalTenantId = physicalTenantId;
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    final var changesMembership = !membersToAdd.isEmpty() || !membersToRemove.isEmpty();
+    if (physicalTenantId.isPresent()) {
+      if (changesMembership) {
+        return Either.left(
+            new InvalidRequest(
+                "membersToAdd/membersToRemove cannot be combined with physicalTenant: they change "
+                    + "cluster membership, which has no tenant dimension"));
+      }
+      if (newReplicationFactor.isPresent()) {
+        return Either.left(
+            new InvalidRequest(
+                "newReplicationFactor cannot be combined with physicalTenant: the replication "
+                    + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
+      }
+    }
+    if (changesMembership || newReplicationFactor.isPresent() || newPartitionCount.isEmpty()) {
+      // Cluster membership and the replication factor have no tenant dimension, so a request
+      // carrying either is planned exactly the way it always was, against the default group. So is
+      // a request that changes neither those nor the partition count, which has nothing to plan.
+      // That such a change redistributes only the default tenant's partitions, rather than every
+      // tenant's, is a gap that predates physical tenants being scalable at all; closing it needs
+      // global and partition-group phases planned together, tracked in #60192 and #60193.
+      return ConfigurationChangeRequest.super.phases(clusterConfiguration);
+    }
+
+    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    if (!clusterConfiguration.hasPartitionGroup(groupId)) {
+      return Either.left(
+          new NotFound(
+              "Expected to patch physical tenant '%s', but there's no such tenant"
+                  .formatted(groupId)));
+    }
+    return PartitionGroupScalingPhases.phases(
+        groupId, clusterConfiguration, newPartitionCount.get());
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -9,10 +9,13 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
@@ -28,16 +31,71 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
   private final Optional<Integer> newPartitionCount;
   private final Optional<Integer> newReplicationFactor;
   private final Optional<String> zone;
+  private final Optional<String> physicalTenantId;
 
   public ClusterScaleRequestTransformer(
       final Optional<Integer> brokerCount,
       final Optional<Integer> newPartitionCount,
       final Optional<Integer> newReplicationFactor,
       final Optional<String> zone) {
+    this(brokerCount, newPartitionCount, newReplicationFactor, zone, Optional.empty());
+  }
+
+  public ClusterScaleRequestTransformer(
+      final Optional<Integer> brokerCount,
+      final Optional<Integer> newPartitionCount,
+      final Optional<Integer> newReplicationFactor,
+      final Optional<String> zone,
+      final Optional<String> physicalTenantId) {
     this.brokerCount = brokerCount;
     this.newPartitionCount = newPartitionCount;
     this.newReplicationFactor = newReplicationFactor;
     this.zone = zone;
+    this.physicalTenantId = physicalTenantId;
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()) {
+      if (brokerCount.isPresent()) {
+        return Either.left(
+            new InvalidRequest(
+                "brokerCount cannot be combined with physicalTenant: brokerCount changes cluster "
+                    + "membership, which has no tenant dimension"));
+      }
+      if (newReplicationFactor.isPresent()) {
+        return Either.left(
+            new InvalidRequest(
+                "newReplicationFactor cannot be combined with physicalTenant: the replication "
+                    + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
+      }
+    }
+    if (brokerCount.isPresent()
+        || newReplicationFactor.isPresent()
+        || newPartitionCount.isEmpty()) {
+      // Cluster membership and the replication factor have no tenant dimension, so a request
+      // carrying either is planned exactly the way it always was, against the default group. So is
+      // a request that changes neither those nor the partition count, which has nothing to plan.
+      // That such a change redistributes only the default tenant's partitions, rather than every
+      // tenant's, is a gap that predates physical tenants being scalable at all; closing it needs
+      // global and partition-group phases planned together, tracked in #60192 and #60193.
+      return ConfigurationChangeRequest.super.phases(clusterConfiguration);
+    }
+
+    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    if (!clusterConfiguration.hasPartitionGroup(groupId)) {
+      return Either.left(
+          new NotFound(
+              "Expected to scale physical tenant '%s', but there's no such tenant"
+                  .formatted(groupId)));
+    }
+    final var invalidZone = validateZone(clusterConfiguration.toLegacy(groupId));
+    if (invalidZone.isPresent()) {
+      return Either.left(invalidZone.get());
+    }
+    return PartitionGroupScalingPhases.phases(
+        groupId, clusterConfiguration, newPartitionCount.get());
   }
 
   @Override
@@ -47,39 +105,15 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
       // Nothing to change
       return Either.right(List.of());
     }
-    if (zone.isPresent()) {
-      if (newReplicationFactor.isPresent()) {
-        return Either.left(
-            new InvalidRequest(
-                "Change of replication factor is not allowed when zone is set. To change replication factor use `/partition-distribution` endpoint"));
-      }
-      if (!clusterConfiguration.isFullyZoneAware()) {
-        return Either.left(
-            new InvalidRequest(
-                "Scaling operation with zone is only allowed when cluster is zone-aware"));
-      }
-    } else {
-      if (!clusterConfiguration.isUnzoned()) {
-        return Either.left(
-            new InvalidRequest(
-                "Scaling operation without zone is allowed only when no broker is zone-aware"));
-      }
+    final var invalidZone = validateZone(clusterConfiguration);
+    if (invalidZone.isPresent()) {
+      return Either.left(invalidZone.get());
     }
 
     // replicationFactor and partitionCount is validated in the delegated transformer.
     final Set<MemberId> newSetOfMembers;
     if (zone.isPresent()) {
       final var zoneName = zone.get();
-      final var knownZone =
-          clusterConfiguration
-              .partitionDistributorConfig()
-              .filter(ZoneAwareConfig.class::isInstance)
-              .map(ZoneAwareConfig.class::cast)
-              .map(cfg -> cfg.zones().stream().anyMatch(z -> z.name().equals(zoneName)))
-              .orElse(false);
-      if (!knownZone) {
-        return Either.left(new InvalidRequest("Unknown zone '" + zoneName + "'"));
-      }
       newSetOfMembers =
           clusterConfiguration.members().keySet().stream()
               .filter(m -> !m.isInZone(zoneName))
@@ -97,6 +131,46 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
     return new ScaleRequestTransformer(
             newSetOfMembers, newReplicationFactor, newPartitionCount, zone)
         .operations(clusterConfiguration);
+  }
+
+  /**
+   * The zone rules this request has to satisfy, shared by {@link #operations} and the tenant-scoped
+   * {@link #phases} path: a zone may only be named on a zone-aware cluster and must be one the
+   * cluster knows, an unzoned request is only valid while no broker is zoned at all, and the
+   * replication factor of a zone-aware cluster is derived from its zone specs rather than set
+   * directly.
+   *
+   * @return the rejection to answer with, or empty if the request is valid
+   */
+  private Optional<InvalidRequest> validateZone(final ClusterConfiguration clusterConfiguration) {
+    if (zone.isEmpty()) {
+      return clusterConfiguration.isUnzoned()
+          ? Optional.empty()
+          : Optional.of(
+              new InvalidRequest(
+                  "Scaling operation without zone is allowed only when no broker is zone-aware"));
+    }
+    if (newReplicationFactor.isPresent()) {
+      return Optional.of(
+          new InvalidRequest(
+              "Change of replication factor is not allowed when zone is set. To change replication factor use `/partition-distribution` endpoint"));
+    }
+    if (!clusterConfiguration.isFullyZoneAware()) {
+      return Optional.of(
+          new InvalidRequest(
+              "Scaling operation with zone is only allowed when cluster is zone-aware"));
+    }
+    final var zoneName = zone.get();
+    final var knownZone =
+        clusterConfiguration
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .map(ZoneAwareConfig.class::cast)
+            .map(cfg -> cfg.zones().stream().anyMatch(z -> z.name().equals(zoneName)))
+            .orElse(false);
+    return knownZone
+        ? Optional.empty()
+        : Optional.of(new InvalidRequest("Unknown zone '" + zoneName + "'"));
   }
 
   private Set<MemberId> membersInZone(final int count) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.PartitionReassignmentOperationsGenerator;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Plans a partition-count scale-up of one physical tenant's partition group, for {@link
+ * ClusterScaleRequestTransformer} and {@link ClusterPatchRequestTransformer}.
+ *
+ * <p>Partitions are distributed across brokers considering every physical tenant's partitions at
+ * once, not just those of the tenant being scaled: a tenant scaled on its own would be placed as if
+ * the brokers held nothing else, and would pile onto brokers that are already busy with another
+ * tenant's partitions. This is why the change cannot be planned through {@code
+ * ConfigurationChangeRequest#operations(ClusterConfiguration)} — the legacy configuration that
+ * takes projects a single partition group, so a distribution computed from it can only ever see the
+ * partitions of the group being scaled.
+ *
+ * <p>The distribution itself is the cluster's configured {@link
+ * io.camunda.zeebe.dynamic.config.PartitionDistributor} — the same round-robin (or zone-aware) one
+ * {@code PartitionReassignRequestTransformer} already applies, only over every group's partitions
+ * rather than one group's. It computes a placement from scratch, so scaling one tenant can also
+ * relocate partitions of another; a {@code PartitionReassigner} that reaches a comparable balance
+ * while moving fewer existing partitions can replace this one call without changing anything else
+ * here.
+ *
+ * <p>{@link PartitionReassignmentOperationsGenerator} turns the resulting distribution into
+ * operations per group, emitting them only where a partition's placement actually changed.
+ */
+final class PartitionGroupScalingPhases {
+
+  private PartitionGroupScalingPhases() {}
+
+  /**
+   * @param targetGroupId the partition group to scale; must exist in {@code clusterConfiguration}
+   * @param clusterConfiguration the current multi-group configuration
+   * @param newPartitionCount the partition count {@code targetGroupId} should reach
+   * @return a single {@link PartitionGroupParallelPhase} covering every group whose partitions have
+   *     to change, or no phase at all when the group already has {@code newPartitionCount}
+   *     partitions. Left if the target count is below the group's current one — partitions can only
+   *     be scaled up — or if no valid distribution exists for it.
+   */
+  static Either<Exception, List<Phase>> phases(
+      final String targetGroupId,
+      final CurrentClusterConfiguration clusterConfiguration,
+      final int newPartitionCount) {
+    final var distributionByGroup =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration);
+    final var currentPartitionCount =
+        distributionByGroup.getOrDefault(targetGroupId, Set.of()).size();
+
+    if (newPartitionCount < currentPartitionCount) {
+      return Either.left(
+          new InvalidRequest(
+              "New partition count [%d] of physical tenant '%s' must be greater than or equal to its current partition count [%d]"
+                  .formatted(newPartitionCount, targetGroupId, currentPartitionCount)));
+    }
+    if (newPartitionCount == currentPartitionCount) {
+      return Either.right(List.of());
+    }
+
+    final var newPartitionIds =
+        IntStream.rangeClosed(currentPartitionCount + 1, newPartitionCount)
+            .mapToObj(number -> new PartitionId(targetGroupId, number))
+            .toList();
+    final var targetPartitionIds =
+        Stream.concat(
+                distributionByGroup.values().stream()
+                    .flatMap(Set::stream)
+                    .map(PartitionMetadata::id),
+                newPartitionIds.stream())
+            .toList();
+    final var replicationFactor = replicationFactor(distributionByGroup);
+
+    final Map<String, List<PartitionGroupOperation>> operationsByGroup;
+    try {
+      final var targetDistribution =
+          targetDistribution(
+              clusterConfiguration,
+              clusterConfiguration.liveMembers(),
+              targetPartitionIds,
+              replicationFactor);
+      operationsByGroup =
+          new LinkedHashMap<>(
+              PartitionReassignmentOperationsGenerator.generateOperations(
+                  clusterConfiguration, targetDistribution, Map.of()));
+    } catch (final RuntimeException e) {
+      // What the distributor and the generator raise is a rejection of the request, not an internal
+      // failure: too few live brokers for the replication factor, a distributor that cannot place
+      // these partitions, a distribution that would drop one.
+      return Either.left(new InvalidRequest(e));
+    }
+
+    final var newPartitionNumbers =
+        new TreeSet<>(newPartitionIds.stream().map(PartitionId::number).toList());
+    operationsByGroup.put(
+        targetGroupId,
+        withScaleUpOperations(
+            operationsByGroup.getOrDefault(targetGroupId, List.of()),
+            ClusterConfigurationCoordinatorSupplier.from(() -> clusterConfiguration)
+                .getDefaultCoordinator(),
+            newPartitionCount,
+            newPartitionNumbers));
+
+    return Either.right(List.of(new PartitionGroupParallelPhase(operationsByGroup)));
+  }
+
+  private static Set<PartitionMetadata> targetDistribution(
+      final CurrentClusterConfiguration clusterConfiguration,
+      final Set<MemberId> targetMembers,
+      final List<PartitionId> targetPartitionIds,
+      final int replicationFactor) {
+    return clusterConfiguration
+        .globalConfiguration()
+        .partitionDistributorConfig()
+        .map(PartitionDistributorConfig::toDistributor)
+        .orElseGet(RoundRobinPartitionDistributor::new)
+        .distributePartitions(
+            targetMembers, targetPartitionIds.stream().sorted().toList(), replicationFactor);
+  }
+
+  /**
+   * The replication factor every partition should keep. Taken as the minimum currently in use
+   * rather than a configured value, mirroring {@code ClusterConfiguration#minReplicationFactor}:
+   * during a configuration change a partition can temporarily hold more replicas than the cluster
+   * is configured for, and treating that as the target would permanently widen it.
+   */
+  private static int replicationFactor(
+      final Map<String, Set<PartitionMetadata>> distributionByGroup) {
+    return distributionByGroup.values().stream()
+        .flatMap(Set::stream)
+        .mapToInt(metadata -> metadata.members().size())
+        .min()
+        .orElse(1);
+  }
+
+  /**
+   * Wraps the scaled group's partition operations in the three {@code ScaleUpOperation}s that drive
+   * the engine's side of a scale-up: the engine is told the new partition count before any new
+   * partition is bootstrapped, and redistribution and relocation are awaited once they all are.
+   * Mirrors the ordering {@code PartitionReassignRequestTransformer} produces for the legacy
+   * single-group model.
+   *
+   * <p>All three name the cluster configuration coordinator rather than a member of the scaled
+   * group. They do not act on a local partition — they drive the group's engine through a
+   * group-scoped {@code BrokerClient} request — and every broker registers change appliers for
+   * every configured physical tenant, whether or not it holds any of that tenant's partitions.
+   */
+  private static List<PartitionGroupOperation> withScaleUpOperations(
+      final List<PartitionGroupOperation> groupOperations,
+      final MemberId coordinator,
+      final int newPartitionCount,
+      final SortedSet<Integer> newPartitionNumbers) {
+    final var operations = new ArrayList<PartitionGroupOperation>();
+    groupOperations.stream()
+        .filter(operation -> !isForNewPartition(operation, newPartitionNumbers))
+        .forEach(operations::add);
+    operations.add(new StartPartitionScaleUp(coordinator, newPartitionCount));
+    groupOperations.stream()
+        .filter(operation -> isForNewPartition(operation, newPartitionNumbers))
+        .forEach(operations::add);
+    operations.add(
+        new AwaitRedistributionCompletion(coordinator, newPartitionCount, newPartitionNumbers));
+    operations.add(
+        new AwaitRelocationCompletion(coordinator, newPartitionCount, newPartitionNumbers));
+    return operations;
+  }
+
+  private static boolean isForNewPartition(
+      final PartitionGroupOperation operation, final Set<Integer> newPartitionNumbers) {
+    return operation instanceof final PartitionChangeOperation partitionChange
+        && newPartitionNumbers.contains(partitionChange.partitionId());
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1119,6 +1119,7 @@ public class ProtoBufSerializer
     clusterScaleRequest.newReplicationFactor().ifPresent(builder::setNewReplicationFactor);
     clusterScaleRequest.newPartitionCount().ifPresent(builder::setNewPartitionCount);
     clusterScaleRequest.zone().ifPresent(builder::setZone);
+    clusterScaleRequest.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
 
     return builder.build().toByteArray();
   }
@@ -1134,6 +1135,7 @@ public class ProtoBufSerializer
         .forEach(memberId -> builder.addMembersToAdd(memberId.id()));
     clusterPatchRequest.membersToRemove().stream()
         .forEach(memberId -> builder.addMembersToRemove(memberId.id()));
+    clusterPatchRequest.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
 
     return builder.build().toByteArray();
   }
@@ -1386,11 +1388,16 @@ public class ProtoBufSerializer
           clusterScaleRequest.hasZone()
               ? Optional.of(clusterScaleRequest.getZone())
               : Optional.empty();
+      final Optional<String> physicalTenantId =
+          clusterScaleRequest.hasPhysicalTenantId()
+              ? Optional.of(clusterScaleRequest.getPhysicalTenantId())
+              : Optional.empty();
       return new ClusterScaleRequest(
           newClusterSize,
           newPartitionCount,
           newReplicationFactor,
           zone,
+          physicalTenantId,
           clusterScaleRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
@@ -1411,6 +1418,10 @@ public class ProtoBufSerializer
           clusterPatchRequest.hasNewReplicationFactor()
               ? Optional.of(clusterPatchRequest.getNewReplicationFactor())
               : Optional.empty();
+      final Optional<String> physicalTenantId =
+          clusterPatchRequest.hasPhysicalTenantId()
+              ? Optional.of(clusterPatchRequest.getPhysicalTenantId())
+              : Optional.empty();
       return new ClusterPatchRequest(
           clusterPatchRequest.getMembersToAddList().stream()
               .map(MemberId::from)
@@ -1420,6 +1431,7 @@ public class ProtoBufSerializer
               .collect(Collectors.toSet()),
           newPartitionCount,
           newReplicationFactor,
+          physicalTenantId,
           clusterPatchRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -80,13 +80,24 @@ public record CurrentClusterConfiguration(
   }
 
   public int getClusterSize() {
-    return (int)
-        globalConfiguration.members().values().stream()
-            .filter(
-                brokerState ->
-                    brokerState.state() != BrokerState.State.LEFT
-                        && brokerState.state() != BrokerState.State.UNINITIALIZED)
-            .count();
+    return liveMembers().size();
+  }
+
+  /**
+   * The members eligible to host partitions: every broker known to the cluster except those in
+   * {@link BrokerState.State#LEFT} or {@link BrokerState.State#UNINITIALIZED}. Using the raw {@link
+   * #getMembers()} instead would let a decommissioned or not-yet-joined broker be picked as the
+   * target of a partition bootstrap or join, stalling the change once that operation can never
+   * complete.
+   */
+  public Set<MemberId> liveMembers() {
+    return globalConfiguration.members().entrySet().stream()
+        .filter(
+            entry ->
+                entry.getValue().state() != BrokerState.State.LEFT
+                    && entry.getValue().state() != BrokerState.State.UNINITIALIZED)
+        .map(Entry::getKey)
+        .collect(Collectors.toSet());
   }
 
   public Optional<String> clusterId() {

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -47,6 +47,10 @@ message ClusterScaleRequest {
   optional uint32 newReplicationFactor = 3;
   bool dryRun = 4;
   optional string zone = 5;
+  // The physical tenant newPartitionCount applies to; the default tenant if not set. Must not be
+  // set together with newClusterSize, which changes cluster membership, nor with
+  // newReplicationFactor, which is a cluster-wide setting; neither has a tenant dimension.
+  optional string physicalTenantId = 6;
 }
 
 message ClusterPatchRequest {
@@ -55,6 +59,10 @@ message ClusterPatchRequest {
   optional uint32 newPartitionCount = 3;
   optional uint32 newReplicationFactor = 4;
   bool dryRun = 5;
+  // The physical tenant newPartitionCount applies to; the default tenant if not set. Must not be
+  // set together with membersToAdd/membersToRemove, which change cluster membership, nor with
+  // newReplicationFactor, which is a cluster-wide setting; neither has a tenant dimension.
+  optional string physicalTenantId = 6;
 }
 
 message UpdateRoutingStateRequest{

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -335,6 +335,94 @@ final class NewModelManagementApiEndpointsTest {
   }
 
   @Test
+  void shouldApplyScaleClusterToOnlyTheRequestedPhysicalTenant() {
+    // given — both physical tenants start with 1 partition
+    wireTwoPhysicalTenants();
+    seedRoutingState(1, CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_B);
+
+    // when — scale only tenant-b's partition count up to 2
+    handler
+        .scaleCluster(
+            new ClusterScaleRequest(
+                Optional.empty(),
+                Optional.of(2),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(TENANT_B),
+                false))
+        .join();
+
+    // then — only tenant-b's partition count changed; the default group is untouched
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.partitionGroup(TENANT_B).partitionCount()).isEqualTo(2);
+    assertThat(config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).partitionCount())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldApplyScaleClusterToOnlyTheDefaultTenantWhenUnscoped() {
+    // given — both physical tenants start with 1 partition
+    wireTwoPhysicalTenants();
+    seedRoutingState(1, CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_B);
+
+    // when — no physicalTenant parameter is given
+    handler
+        .scaleCluster(
+            new ClusterScaleRequest(
+                Optional.empty(), Optional.of(2), Optional.empty(), Optional.empty(), false))
+        .join();
+
+    // then — only the default tenant's partition count changed
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).partitionCount())
+        .isEqualTo(2);
+    assertThat(config.partitionGroup(TENANT_B).partitionCount()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldApplyPatchClusterToOnlyTheRequestedPhysicalTenant() {
+    // given — both physical tenants start with 1 partition
+    wireTwoPhysicalTenants();
+    seedRoutingState(1, CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_B);
+
+    // when — patch only tenant-b's partition count up to 2
+    handler
+        .patchCluster(
+            new ClusterPatchRequest(
+                Set.of(), Set.of(), Optional.of(2), Optional.empty(), Optional.of(TENANT_B), false))
+        .join();
+
+    // then — only tenant-b's partition count changed; the default group is untouched
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.partitionGroup(TENANT_B).partitionCount()).isEqualTo(2);
+    assertThat(config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).partitionCount())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldApplyPatchClusterToOnlyTheDefaultTenantWhenUnscoped() {
+    // given — both physical tenants start with 1 partition
+    wireTwoPhysicalTenants();
+    seedRoutingState(1, CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_B);
+
+    // when — no physicalTenant parameter is given
+    handler
+        .patchCluster(
+            new ClusterPatchRequest(Set.of(), Set.of(), Optional.of(2), Optional.empty(), false))
+        .join();
+
+    // then — only the default tenant's partition count changed
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).partitionCount())
+        .isEqualTo(2);
+    assertThat(config.partitionGroup(TENANT_B).partitionCount()).isEqualTo(1);
+  }
+
+  @Test
   void shouldPlanForceScaleDown() {
     // given
     wire(fourMemberTwoPartitionCluster());
@@ -598,6 +686,29 @@ final class NewModelManagementApiEndpointsTest {
                             Optional.empty(),
                             Optional.empty())),
                     current.phasedChangeState()))
+        .join();
+  }
+
+  /**
+   * Seeds a routing state on each named group: {@code StartPartitionScaleUpApplier} refuses to
+   * scale up a group whose routing state is not initialized yet, so the scale-up tests need it
+   * seeded on both groups regardless of which one is actually targeted.
+   */
+  private void seedRoutingState(final int partitionCount, final String... groupIds) {
+    manager
+        .updateMultiConfiguration(
+            current -> {
+              var updated = current;
+              for (final var groupId : groupIds) {
+                updated =
+                    updated.updatePartitionGroupConfig(
+                        groupId,
+                        group ->
+                            group.setRoutingState(
+                                RoutingState.initializeWithPartitionCount(partitionCount)));
+              }
+              return updated;
+            })
         .join();
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -15,16 +16,29 @@ import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.RoutingStateInitializer;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import io.camunda.zeebe.util.Either;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -34,6 +48,7 @@ import org.junit.jupiter.api.Test;
 
 final class ClusterPatchRequestTransformerTest {
 
+  private static final String TENANT_B = "tenant-b";
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
   private final MemberId id2 = MemberId.from("2");
@@ -285,5 +300,198 @@ final class ClusterPatchRequestTransformerTest {
         .mapToObj(Integer::toString)
         .map(MemberId::from)
         .collect(Collectors.toSet());
+  }
+
+  // -- physicalTenant scoping (phases()) --
+
+  /**
+   * Three brokers, replication factor 1, and a placement that already follows the cluster-wide
+   * round robin over every tenant's partitions: the default tenant holds partitions 1 and 2 on id0
+   * and id1, and tenant-b, whose partition sorts after both of them, holds its single partition on
+   * id2. Scaling a tenant here therefore has nothing to relocate, which leaves id2 as the broker a
+   * tenant-blind placement would strand.
+   */
+  private CurrentClusterConfiguration twoTenantCluster() {
+    final var defaultGroup =
+        Map.of(
+            id0, Map.of(1, PartitionState.active(1, partitionConfig)),
+            id1, Map.of(2, PartitionState.active(1, partitionConfig)));
+    final var tenantB = Map.of(id2, Map.of(1, PartitionState.active(1, partitionConfig)));
+    final var brokers =
+        Map.of(
+            id0, new BrokerState(1, Instant.EPOCH, BrokerState.State.ACTIVE),
+            id1, new BrokerState(1, Instant.EPOCH, BrokerState.State.ACTIVE),
+            id2, new BrokerState(1, Instant.EPOCH, BrokerState.State.ACTIVE));
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1, Optional.empty(), brokers, Optional.empty(), Optional.empty(), Optional.empty()),
+        Map.of(DEFAULT_GROUP, group(defaultGroup), TENANT_B, group(tenantB)),
+        PhasedChangeState.empty());
+  }
+
+  private PartitionGroupConfiguration group(
+      final Map<MemberId, Map<Integer, PartitionState>> partitionsByMember) {
+    return new PartitionGroupConfiguration(
+        1,
+        0,
+        partitionsByMember.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey, e -> BrokerPartitionState.initialize(e.getValue()))),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupParallelPhase singlePhase(
+      final Either<Exception, List<Phase>> result) {
+    assertThat(result).isRight();
+    Assertions.assertThat(result.get()).hasSize(1);
+    return (PartitionGroupParallelPhase) result.get().get(0);
+  }
+
+  private static List<PartitionBootstrapOperation> bootstraps(
+      final PartitionGroupParallelPhase phase, final String groupId) {
+    return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
+        .filter(PartitionBootstrapOperation.class::isInstance)
+        .map(PartitionBootstrapOperation.class::cast)
+        .toList();
+  }
+
+  @Test
+  void shouldTargetOnlyTheRequestedPhysicalTenantsPartitionGroup() {
+    // given — tenant-b currently has 1 partition; scale it to 2
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.of(2), Optional.empty(), Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — only tenant-b gains a partition, and no other tenant is touched at all
+    final var phase = singlePhase(result);
+    Assertions.assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_B);
+    Assertions.assertThat(bootstraps(phase, TENANT_B))
+        .singleElement()
+        .satisfies(op -> Assertions.assertThat(op.partitionId()).isEqualTo(2));
+  }
+
+  @Test
+  void shouldDistributePartitionsOfEveryPhysicalTenantTogether() {
+    // given — id0 and id1 each hold a partition of the default tenant, id2 one of tenant-b
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.of(2), Optional.empty(), Optional.of(TENANT_B));
+
+    // when — tenant-b gains a second partition
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — the placement continues the round robin across all four partitions instead of
+    // restarting it within tenant-b, so tenant-b's existing partition stays on id2 and only the new
+    // one is placed. Distributing tenant-b's partitions on their own would have moved that one onto
+    // id0 and put the new one on id1, leaving id2 — a broker busy with no other tenant — empty.
+    final var phase = singlePhase(result);
+    Assertions.assertThat(bootstraps(phase, TENANT_B))
+        .singleElement()
+        .satisfies(
+            op -> {
+              Assertions.assertThat(op.partitionId()).isEqualTo(2);
+              Assertions.assertThat(op.memberId()).isEqualTo(id0);
+            });
+    Assertions.assertThat(phase.groupOperations().get(TENANT_B))
+        .noneMatch(PartitionJoinOperation.class::isInstance);
+  }
+
+  @Test
+  void shouldTargetOnlyTheDefaultTenantWhenUnscoped() {
+    // given — no physicalTenant parameter: the partition count is not a cluster-wide dimension, so
+    // it applies to the default tenant, as it did before tenants could be named at all
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.of(3), Optional.empty(), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — only the default tenant gains a partition
+    final var phase = singlePhase(result);
+    Assertions.assertThat(bootstraps(phase, DEFAULT_GROUP))
+        .singleElement()
+        .satisfies(op -> Assertions.assertThat(op.partitionId()).isEqualTo(3));
+    Assertions.assertThat(bootstraps(phase, TENANT_B)).isEmpty();
+  }
+
+  @Test
+  void shouldRejectPartitionCountBelowTheTenantsCurrentCount() {
+    // given — partitions can only be scaled up, and the default tenant already has 2
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.of(1), Optional.empty(), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenantWhenPatching() {
+    // given
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.of(3), Optional.empty(), Optional.of("unknown"));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown");
+  }
+
+  @Test
+  void shouldRejectAddingMembersCombinedWithPhysicalTenant() {
+    // given — membersToAdd changes cluster membership, which has no tenant dimension
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(id3), Set.of(), Optional.empty(), Optional.empty(), Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectRemovingMembersCombinedWithPhysicalTenant() {
+    // given — membersToRemove changes cluster membership, which has no tenant dimension
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(id1), Optional.empty(), Optional.empty(), Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectReplicationFactorCombinedWithPhysicalTenant() {
+    // given — the replication factor is a cluster-wide setting, so it has no tenant dimension
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.empty(), Optional.of(2), Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,16 +15,33 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.util.Either;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,7 +60,11 @@ final class ClusterScaleRequestTransformerTest {
   private static final int ZONE_B_REPLICAS = 1;
   private static final int ZONE_A_PRIORITY = 1000;
   private static final int ZONE_B_PRIORITY = 500;
+  private static final String TENANT_B = "tenant-b";
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final MemberId id2 = MemberId.from("2");
 
   @Property(tries = 10)
   void shouldScaleBrokersWhenPartitionsUnchanged(
@@ -380,5 +402,233 @@ final class ClusterScaleRequestTransformerTest {
     final var members = new HashSet<>(membersInZone(Optional.of(ZONE_A), zoneABrokers));
     members.addAll(membersInZone(Optional.of(ZONE_B), ZONE_B_BROKERS));
     return members;
+  }
+
+  // -- physicalTenant scoping (phases()) --
+
+  /**
+   * Three brokers, replication factor 1, and a placement that already follows the cluster-wide
+   * round robin over every tenant's partitions: the default tenant holds partitions 1 and 2 on id0
+   * and id1, and tenant-b, whose partition sorts after both of them, holds its single partition on
+   * id2. Scaling a tenant here therefore has nothing to relocate, which makes any relocation the
+   * planner does emit meaningful, and leaves id2 as the broker a tenant-blind placement would
+   * strand.
+   */
+  private CurrentClusterConfiguration twoTenantCluster() {
+    final var defaultGroup =
+        Map.of(
+            id0, Map.of(1, PartitionState.active(1, partitionConfig)),
+            id1, Map.of(2, PartitionState.active(1, partitionConfig)));
+    final var tenantB = Map.of(id2, Map.of(1, PartitionState.active(1, partitionConfig)));
+    final var brokers =
+        Map.of(
+            id0, new BrokerState(1, Instant.EPOCH, BrokerState.State.ACTIVE),
+            id1, new BrokerState(1, Instant.EPOCH, BrokerState.State.ACTIVE),
+            id2, new BrokerState(1, Instant.EPOCH, BrokerState.State.ACTIVE));
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1, Optional.empty(), brokers, Optional.empty(), Optional.empty(), Optional.empty()),
+        Map.of(DEFAULT_GROUP, group(defaultGroup), TENANT_B, group(tenantB)),
+        PhasedChangeState.empty());
+  }
+
+  private PartitionGroupConfiguration group(
+      final Map<MemberId, Map<Integer, PartitionState>> partitionsByMember) {
+    return new PartitionGroupConfiguration(
+        1,
+        0,
+        partitionsByMember.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey, e -> BrokerPartitionState.initialize(e.getValue()))),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private ClusterScaleRequestTransformer scaleTransformer(
+      final Optional<Integer> newPartitionCount, final Optional<String> physicalTenantId) {
+    return new ClusterScaleRequestTransformer(
+        Optional.empty(), newPartitionCount, Optional.empty(), Optional.empty(), physicalTenantId);
+  }
+
+  private static PartitionGroupParallelPhase singlePhase(
+      final Either<Exception, List<Phase>> result) {
+    assertThat(result).isRight();
+    Assertions.assertThat(result.get()).hasSize(1);
+    return (PartitionGroupParallelPhase) result.get().get(0);
+  }
+
+  private static List<PartitionBootstrapOperation> bootstraps(
+      final PartitionGroupParallelPhase phase, final String groupId) {
+    return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
+        .filter(PartitionBootstrapOperation.class::isInstance)
+        .map(PartitionBootstrapOperation.class::cast)
+        .toList();
+  }
+
+  @Test
+  void shouldTargetOnlyTheRequestedPhysicalTenantsPartitionGroup() {
+    // given — tenant-b currently has 1 partition; scale it to 2
+    final var transformer = scaleTransformer(Optional.of(2), Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — only tenant-b gains a partition, and no other tenant is touched at all
+    final var phase = singlePhase(result);
+    Assertions.assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_B);
+    Assertions.assertThat(bootstraps(phase, TENANT_B))
+        .singleElement()
+        .satisfies(op -> Assertions.assertThat(op.partitionId()).isEqualTo(2));
+  }
+
+  @Test
+  void shouldDistributePartitionsOfEveryPhysicalTenantTogether() {
+    // given — id0 and id1 each hold a partition of the default tenant, id2 one of tenant-b
+    final var transformer = scaleTransformer(Optional.of(2), Optional.of(TENANT_B));
+
+    // when — tenant-b gains a second partition
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — the placement continues the round robin across all four partitions instead of
+    // restarting it within tenant-b, so tenant-b's existing partition stays on id2 and only the new
+    // one is placed. Distributing tenant-b's partitions on their own would have moved that one onto
+    // id0 and put the new one on id1, leaving id2 — a broker busy with no other tenant — empty.
+    final var phase = singlePhase(result);
+    Assertions.assertThat(bootstraps(phase, TENANT_B))
+        .singleElement()
+        .satisfies(
+            op -> {
+              Assertions.assertThat(op.partitionId()).isEqualTo(2);
+              Assertions.assertThat(op.memberId()).isEqualTo(id0);
+            });
+    Assertions.assertThat(phase.groupOperations().get(TENANT_B))
+        .noneMatch(PartitionJoinOperation.class::isInstance);
+  }
+
+  @Test
+  void shouldRelocateAnotherTenantsPartitionWhenTheDistributionChanges() {
+    // given — the default tenant is scaled from 2 partitions to 3, which shifts every partition
+    // sorting after it — here tenant-b's only one — onto a different broker
+    final var transformer = scaleTransformer(Optional.of(3), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — tenant-b's partition is relocated to id0 as part of the same change. Distributing
+    // every tenant's partitions together is what keeps them balanced; the price is that scaling one
+    // tenant can move another's.
+    final var phase = singlePhase(result);
+    Assertions.assertThat(phase.groupOperations().get(TENANT_B))
+        .filteredOn(PartitionJoinOperation.class::isInstance)
+        .singleElement()
+        .satisfies(
+            op -> {
+              Assertions.assertThat(((PartitionJoinOperation) op).partitionId()).isEqualTo(1);
+              Assertions.assertThat(op.memberId()).isEqualTo(id0);
+            });
+  }
+
+  @Test
+  void shouldRunScaleUpOperationsOnTheClusterConfigurationCoordinator() {
+    // given — tenant-b is served by id2 alone
+    final var transformer = scaleTransformer(Optional.of(2), Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — the scale-up operations name the cluster configuration coordinator, the lowest live
+    // member id, rather than a member picked from the scaled group: they drive that group's engine
+    // through a group-scoped broker request instead of acting on a local partition, and every
+    // broker registers change appliers for every configured physical tenant.
+    final var scaleUpOperations =
+        singlePhase(result).groupOperations().get(TENANT_B).stream()
+            .filter(ScaleUpOperation.class::isInstance)
+            .toList();
+    Assertions.assertThat(scaleUpOperations).isNotEmpty();
+    Assertions.assertThat(scaleUpOperations)
+        .allSatisfy(op -> Assertions.assertThat(op.memberId()).isEqualTo(id0));
+  }
+
+  @Test
+  void shouldTargetOnlyTheDefaultTenantWhenUnscoped() {
+    // given — no physicalTenant parameter: the partition count is not a cluster-wide dimension, so
+    // it applies to the default tenant, as it did before tenants could be named at all
+    final var transformer = scaleTransformer(Optional.of(3), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — only the default tenant gains a partition
+    final var phase = singlePhase(result);
+    Assertions.assertThat(bootstraps(phase, DEFAULT_GROUP))
+        .singleElement()
+        .satisfies(op -> Assertions.assertThat(op.partitionId()).isEqualTo(3));
+    Assertions.assertThat(bootstraps(phase, TENANT_B)).isEmpty();
+  }
+
+  @Test
+  void shouldRejectPartitionCountBelowTheTenantsCurrentCount() {
+    // given — partitions can only be scaled up, and the default tenant already has 2
+    final var transformer = scaleTransformer(Optional.of(1), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenantWhenScaling() {
+    // given
+    final var transformer = scaleTransformer(Optional.of(3), Optional.of("unknown"));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown");
+  }
+
+  @Test
+  void shouldRejectBrokerCountCombinedWithPhysicalTenant() {
+    // given — brokerCount changes cluster membership, which has no tenant dimension
+    final var transformer =
+        new ClusterScaleRequestTransformer(
+            Optional.of(3),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectReplicationFactorCombinedWithPhysicalTenant() {
+    // given — the replication factor is a cluster-wide setting, so it has no tenant dimension
+    final var transformer =
+        new ClusterScaleRequestTransformer(
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(2),
+            Optional.empty(),
+            Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -412,6 +412,26 @@ final class ProtoBufSerializerTest {
   }
 
   @Test
+  void shouldEncodeAndDecodeClusterScaleRequestWithPhysicalTenantId() {
+    // given
+    final var clusterScaleRequest =
+        new ClusterScaleRequest(
+            Optional.empty(),
+            Optional.of(15),
+            Optional.of(4),
+            Optional.empty(),
+            Optional.of("tenant-b"),
+            true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeClusterScaleRequest(clusterScaleRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeClusterScaleRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(clusterScaleRequest);
+  }
+
+  @Test
   void shouldEncodeAndDecodeClusterPatchRequest() {
     // given
     final var clusterPatchRequest =
@@ -421,6 +441,21 @@ final class ProtoBufSerializerTest {
             Optional.of(10),
             Optional.of(4),
             true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeClusterPatchRequest(clusterPatchRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeClusterPatchRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(clusterPatchRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeClusterPatchRequestWithPhysicalTenantId() {
+    // given
+    final var clusterPatchRequest =
+        new ClusterPatchRequest(
+            Set.of(), Set.of(), Optional.of(10), Optional.of(4), Optional.of("tenant-b"), true);
 
     // when
     final var encodedRequest = protoBufSerializer.encodeClusterPatchRequest(clusterPatchRequest);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionScalingIT.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
+import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@code PATCH /actuator/cluster} scopes a partition-count scale-up to a single
+ * physical tenant via the {@code physicalTenant} query parameter (issue #60077), mirroring what
+ * #59994 did for {@code PATCH /actuator/cluster/routing-state} ({@link
+ * PhysicalTenantRoutingStateIT}).
+ *
+ * <p>Unlike the read-only {@link PhysicalTenantClusterEndpointIT}, these tests write, so a fresh
+ * broker is used per test rather than sharing one static instance across the class.
+ *
+ * <p>The default tenant and {@link #TENANT_A} are deliberately given different static partition
+ * counts. A wrong-group write — e.g. the request accidentally scaling the default group instead of
+ * the named one — would otherwise be invisible: if both tenants started at the same partition
+ * count, scaling the wrong one would still leave every observable count looking correct.
+ */
+@ZeebeIntegration
+final class PhysicalTenantPartitionScalingIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int DEFAULT_TENANT_PARTITIONS_COUNT = 1;
+  private static final int TENANT_A_PARTITIONS_COUNT = 2;
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe(purgeAfterEach = false)
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withPtConfig(
+                  TENANT_A,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_A_PARTITIONS_COUNT)));
+
+  private final ClusterActuator actuator = ClusterActuator.of(broker);
+
+  @Test
+  void shouldScaleUpOnlyTheTargetedPhysicalTenant() {
+    // given — the default tenant's partition count before tenant A is scaled
+    awaitPartitionCount(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, DEFAULT_TENANT_PARTITIONS_COUNT);
+    awaitPartitionCount(TENANT_A, TENANT_A_PARTITIONS_COUNT);
+
+    // when — scale only tenant A up by one partition
+    final var targetPartitionCount = TENANT_A_PARTITIONS_COUNT + 1;
+    awaitAccepted(
+        "tenant A accepts a scale-up scoped to it",
+        () -> scalePartitions(targetPartitionCount, TENANT_A));
+
+    // then — tenant A's partition count increased and its new partition really started for it;
+    // the default tenant's is untouched
+    awaitPartitionCount(TENANT_A, targetPartitionCount);
+    awaitTopologyPartitionCount(TENANT_A, targetPartitionCount);
+    assertThat(partitionCount(PhysicalTenantsITHelper.DEFAULT_TENANT_ID))
+        .isEqualTo(DEFAULT_TENANT_PARTITIONS_COUNT);
+    assertTopologyPartitionCount(
+        PhysicalTenantsITHelper.DEFAULT_TENANT_ID, DEFAULT_TENANT_PARTITIONS_COUNT);
+  }
+
+  @Test
+  void shouldScaleUpOnlyTheDefaultPhysicalTenantWhenUnscoped() {
+    // given
+    awaitPartitionCount(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, DEFAULT_TENANT_PARTITIONS_COUNT);
+    awaitPartitionCount(TENANT_A, TENANT_A_PARTITIONS_COUNT);
+
+    // when — no physicalTenant parameter is given
+    final var targetPartitionCount = DEFAULT_TENANT_PARTITIONS_COUNT + 1;
+    awaitAccepted(
+        "the default physical tenant accepts the unscoped scale-up",
+        () -> scalePartitions(targetPartitionCount));
+
+    // then — the default tenant's partition count increased and its new partition really started
+    // for it; tenant A's is untouched
+    awaitPartitionCount(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, targetPartitionCount);
+    awaitTopologyPartitionCount(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, targetPartitionCount);
+    assertThat(partitionCount(TENANT_A)).isEqualTo(TENANT_A_PARTITIONS_COUNT);
+    assertTopologyPartitionCount(TENANT_A, TENANT_A_PARTITIONS_COUNT);
+  }
+
+  private void scalePartitions(final int targetPartitionCount, final String physicalTenant) {
+    actuator.patchCluster(
+        new ClusterConfigPatchRequest()
+            .partitions(new ClusterConfigPatchRequestPartitions().count(targetPartitionCount)),
+        false,
+        false,
+        physicalTenant);
+  }
+
+  private void scalePartitions(final int targetPartitionCount) {
+    actuator.patchCluster(
+        new ClusterConfigPatchRequest()
+            .partitions(new ClusterConfigPatchRequestPartitions().count(targetPartitionCount)),
+        false,
+        false);
+  }
+
+  /**
+   * Retries {@code request} until the cluster accepts it. The request is not an assertion — it
+   * either returns or throws a {@link feign.FeignException} — so it cannot be handed to {@code
+   * untilAsserted}, which only retries on {@link AssertionError}. A retry is needed because the
+   * cluster can still be applying its own initial configuration change when the test starts, and
+   * rejects a scale-up while another change is in progress.
+   */
+  private void awaitAccepted(final String alias, final Runnable request) {
+    await(alias)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              request.run();
+              return true;
+            });
+  }
+
+  /**
+   * Asserts against the client-facing, physical-tenant-scoped topology that {@code
+   * physicalTenantId} really runs {@code expectedCount} partitions, each with a leader. The routing
+   * state {@link #partitionCount(String)} reads only records what the cluster configuration says
+   * the count should be; it is written when the change is planned, before any partition has
+   * actually been bootstrapped for that tenant.
+   */
+  private void awaitTopologyPartitionCount(final String physicalTenantId, final int expectedCount) {
+    try (final var client = TENANTS.newClientBuilder(broker, physicalTenantId).build()) {
+      await("physical tenant '%s' runs %d partitions".formatted(physicalTenantId, expectedCount))
+          .atMost(Duration.ofSeconds(60))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                      .isComplete(1, expectedCount, 1));
+    }
+  }
+
+  /**
+   * The same check as {@link #awaitTopologyPartitionCount}, without waiting for it to become true.
+   */
+  private void assertTopologyPartitionCount(
+      final String physicalTenantId, final int expectedCount) {
+    try (final var client = TENANTS.newClientBuilder(broker, physicalTenantId).build()) {
+      TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+          .isComplete(1, expectedCount, 1);
+    }
+  }
+
+  private void awaitPartitionCount(final String physicalTenantId, final int expectedCount) {
+    await("physical tenant '%s' reports %d partitions".formatted(physicalTenantId, expectedCount))
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertThat(partitionCount(physicalTenantId)).isEqualTo(expectedCount));
+  }
+
+  private int partitionCount(final String physicalTenantId) {
+    final var routing = actuator.getTopology(physicalTenantId).getRouting();
+    assertThat(routing).isNotNull();
+    final var requestHandling = routing.getRequestHandling();
+    assertThat(requestHandling).isInstanceOf(RequestHandlingAllPartitions.class);
+    return ((RequestHandlingAllPartitions) requestHandling).getPartitionCount();
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -355,6 +355,22 @@ public interface ClusterActuator {
       @Param boolean dryRun,
       @Param boolean force);
 
+  /**
+   * Scopes the partition count change carried by {@code request} to a single physical tenant's
+   * partition group instead of the default one; every other physical tenant is left untouched.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     the physical tenant is unknown, and 400 if {@code request} also changes cluster membership
+   *     or the replication factor, neither of which has a tenant dimension
+   */
+  @RequestLine("PATCH ?dryRun={dryRun}&force={force}&physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "accept: application/json"})
+  PlannedOperationsResponse patchCluster(
+      @RequestBody final ClusterConfigPatchRequest request,
+      @Param boolean dryRun,
+      @Param boolean force,
+      @Param final String physicalTenant);
+
   @RequestLine("POST /purge?dryRun={dryRun}")
   @Headers({"Content-Type: application/json"})
   PlannedOperationsResponse purge(@Param boolean dryRun);


### PR DESCRIPTION
Accepts a `physicalTenant` query parameter on `PATCH /actuator/cluster` for both shapes of that request — a `newPartitionCount`/`newReplicationFactor`-only patch (`ClusterPatchRequest`) and a `brokers.count`-based scale (`ClusterScaleRequest`) — scoping the partition count change to that tenant's partition group. `Optional<String> physicalTenantId` is threaded end-to-end, the way `ModeChangeRequest` and the exporter requests already carry one, and `phases()` is overridden.

The partition count is the only dimension with a tenant dimension. Cluster membership (`brokerCount`, `membersToAdd`/`membersToRemove`) and the replication factor are cluster-wide, so combining either with `physicalTenant` is rejected with 400, and a request carrying either is planned exactly as before. An unknown tenant returns 404. Without `physicalTenant` the default tenant is scaled, as before.

Partitions are distributed considering every physical tenant's partitions at once. `operations(ClusterConfiguration)` cannot do that — the legacy configuration it takes projects a single group, so a distribution computed from it sees only the group being scaled and places its partitions as if the brokers held nothing else. `phases()` therefore plans on the multi-group model in the new `PartitionGroupScalingPhases`, handing every group's partitions to the cluster's configured `PartitionDistributor` — the same round-robin (or zone-aware) one `PartitionReassignRequestTransformer` already applies, only cluster-wide — and `PartitionReassignmentOperationsGenerator` turns the result into operations per group. Distribution is computed from scratch, so scaling one tenant can also relocate another's partitions; a `PartitionReassigner` reaching a comparable balance with fewer moves can replace that single call later.

The three `ScaleUpOperation`s name the cluster configuration coordinator rather than a member of the scaled group: they drive the group's engine through a group-scoped `BrokerClient` request instead of acting on a local partition, and every broker registers change appliers for every configured physical tenant regardless of which partitions it holds.

closes #60077
