### PR TITLE
feat: report disabled physical tenant status on GET /actuator/cluster

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -579,6 +579,12 @@ final class ClusterApiUtils {
     for (final var entry : partitionGroups.entrySet()) {
       final var physicalTenantId = entry.getKey();
       final var group = entry.getValue();
+      if (group.isDisabled()) {
+        // not running anywhere - excluded from this broker's partitions/physicalTenants and from
+        // the version/lastUpdated fold below, the same way it is reported as disabled rather than
+        // with routing state in PhysicalTenantInfo (see mapPhysicalTenantInfo).
+        continue;
+      }
       final var brokerPartitionState = group.members().get(memberId);
       if (brokerPartitionState != null) {
         physicalTenants.add(
@@ -808,6 +814,12 @@ final class ClusterApiUtils {
   private static PhysicalTenantInfo mapPhysicalTenantInfo(
       final String groupId, final PartitionGroupConfiguration group) {
     final var info = new PhysicalTenantInfo().id(groupId);
+    if (group.isDisabled()) {
+      // disabled: not running anywhere, so its routing state is not reported - only that it is
+      // disabled. An enabled tenant never sets `disabled`; a populated `routing` already implies
+      // it.
+      return info.disabled(true);
+    }
     group.routingState().ifPresent(routingState -> info.routing(mapRoutingState(routingState)));
     return info;
   }

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -197,11 +197,18 @@ schemas:
 
   PhysicalTenantInfo:
     title: PhysicalTenantInfo
-    description: A physical tenant's own routing state, as reported by `GetTopologyResponse`.
+    description: A physical tenant's own routing state, as reported by `GetTopologyResponse`. A
+      disabled tenant (removed from local static configuration, but retaining its data and
+      partition assignment) only sets `disabled`; `routing` is omitted since the tenant is not
+      running anywhere. An enabled tenant never sets `disabled` - its presence with a populated
+      `routing` already means it is enabled.
     type: object
     properties:
       id:
         $ref: "components.yaml#/schemas/PhysicalTenantId"
+      disabled:
+        type: boolean
+        description: Set only when the physical tenant is disabled.
       routing:
         $ref: "components.yaml#/schemas/RoutingState"
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -579,6 +579,120 @@ final class ClusterApiUtilsTest {
   }
 
   @Test
+  void shouldReportADisabledPhysicalTenantWithoutRoutingOrPartitions() {
+    // given — same two-tenant setup as
+    // shouldPopulatePhysicalTenantsAndOmitLegacyFieldsForTwoTenants,
+    // except tenant-b is disabled: removed from local static configuration, but its partition
+    // assignment and data are still retained in the configuration.
+    final var member1 = member(1);
+    final var member2 = member(2);
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            5,
+            Optional.empty(),
+            Map.of(
+                member1,
+                new io.camunda.zeebe.dynamic.config.state.BrokerState(
+                    0,
+                    Instant.ofEpochSecond(1),
+                    io.camunda.zeebe.dynamic.config.state.BrokerState.State.ACTIVE),
+                member2,
+                new io.camunda.zeebe.dynamic.config.state.BrokerState(
+                    0,
+                    Instant.ofEpochSecond(2),
+                    io.camunda.zeebe.dynamic.config.state.BrokerState.State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var tenantA =
+        new PartitionGroupConfiguration(
+            3,
+            0,
+            Map.of(
+                member1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))),
+            Optional.of(
+                new RoutingState(
+                    2,
+                    new RoutingState.RequestHandling.AllPartitions(1),
+                    new RoutingState.MessageCorrelation.HashMod(1))),
+            Optional.empty(),
+            Optional.empty());
+    final var tenantB =
+        new PartitionGroupConfiguration(
+                4,
+                0,
+                Map.of(
+                    member1,
+                    BrokerPartitionState.initialize(
+                        Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()))),
+                    member2,
+                    BrokerPartitionState.initialize(
+                        Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))),
+                Optional.of(
+                    new RoutingState(
+                        3,
+                        new RoutingState.RequestHandling.AllPartitions(2),
+                        new RoutingState.MessageCorrelation.HashMod(2))),
+                Optional.empty(),
+                Optional.empty())
+            .disable();
+    final var config =
+        new CurrentClusterConfiguration(
+            0,
+            globalConfiguration,
+            Map.of("tenant-a", tenantA, "tenant-b", tenantB),
+            PhasedChangeState.empty());
+
+    // when
+    final var body = ClusterApiUtils.mapClusterTopology(config);
+
+    // then — tenant-b is reported as disabled with no routing state, tenant-a is unaffected and
+    // never explicitly marked enabled
+    assertThat(body.getPhysicalTenants())
+        .extracting(
+            io.camunda.zeebe.management.cluster.PhysicalTenantInfo::getId,
+            io.camunda.zeebe.management.cluster.PhysicalTenantInfo::getDisabled)
+        .containsExactly(tuple("tenant-a", null), tuple("tenant-b", true));
+    final var tenantAInfo =
+        body.getPhysicalTenants().stream()
+            .filter(info -> "tenant-a".equals(info.getId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(tenantAInfo.getRouting()).isNotNull();
+    assertThat(tenantAInfo.getRouting().getVersion()).isEqualTo(2);
+    final var tenantBInfo =
+        body.getPhysicalTenants().stream()
+            .filter(info -> "tenant-b".equals(info.getId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(tenantBInfo.getRouting()).isNull();
+
+    // and — tenant-b's partitions are excluded from every broker's partitions/physicalTenants,
+    // exactly as if it had never been configured; tenant-a is untouched
+    final var broker1 =
+        body.getBrokers().stream()
+            .filter(b -> "1".equals(String.valueOf(b.getId())))
+            .findFirst()
+            .orElseThrow();
+    assertThat(broker1.getPartitions())
+        .extracting(p -> p.getId(), p -> p.getPhysicalTenant())
+        .containsExactly(tuple(1, "tenant-a"));
+    assertThat(broker1.getPhysicalTenants())
+        .extracting(io.camunda.zeebe.management.cluster.PhysicalTenantState::getId)
+        .containsExactly("tenant-a");
+
+    final var broker2 =
+        body.getBrokers().stream()
+            .filter(b -> "2".equals(String.valueOf(b.getId())))
+            .findFirst()
+            .orElseThrow();
+    assertThat(broker2.getPartitions()).isEmpty();
+    assertThat(broker2.getPhysicalTenants()).isEmpty();
+  }
+
+  @Test
   void shouldKeepLegacyUninitializedVersionWhenNoPhysicalTenantsExist() {
     // given — an uninitialized configuration has zero partition groups; it must keep reporting
     // today's sentinel version rather than being (mis-)treated as a multi-tenant response.

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
@@ -13,6 +13,7 @@ import static org.awaitility.Awaitility.await;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
@@ -26,6 +27,7 @@ import java.util.Comparator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -139,6 +141,60 @@ final class PhysicalTenantProvisioningIT {
       TopologyAssert.assertThat(tenantAClient.newTopologyRequest().send().join())
           .isComplete(BROKERS_COUNT, 2, BROKERS_COUNT);
     }
+  }
+
+  @Test
+  void shouldMarkPhysicalTenantDisabledOnActuatorWhenRemovedFromConfigAfterRestart() {
+    // given - tenantB is provisioned by adding it to every broker's configuration and restarting
+    restartCluster(cluster);
+    try (final var tenantBClient =
+        TENANTS_AFTER.newClientBuilder(cluster.availableGateway(), TENANT_B).build()) {
+      await("tenantB's topology is complete after provisioning")
+          .atMost(Duration.ofSeconds(60))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(tenantBClient.newTopologyRequest().send().join())
+                      .isComplete(BROKERS_COUNT, TENANT_B_PARTITIONS_COUNT, BROKERS_COUNT));
+    }
+
+    // when - tenantB is removed from every broker's local static configuration and the cluster is
+    // restarted again
+    cluster.shutdown();
+    cluster.brokers().values().forEach(broker -> broker.removePtConfig(TENANT_B));
+    cluster.start().awaitCompleteTopology();
+
+    // then - the physical-tenant-scoped actuator reports tenantB as disabled, with no routing
+    // state or partitions: it is retained in the configuration, just not running anywhere
+    final var actuator = ClusterActuator.of(cluster.availableGateway());
+    await("tenantB is reported as disabled via the actuator")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var topology = actuator.getTopology(TENANT_B);
+              assertThat(topology.getPhysicalTenants())
+                  .singleElement()
+                  .satisfies(
+                      info -> {
+                        assertThat(info.getId()).isEqualTo(TENANT_B);
+                        assertThat(info.getDisabled()).isTrue();
+                        assertThat(info.getRouting()).isNull();
+                      });
+              assertThat(topology.getBrokers())
+                  .allSatisfy(broker -> assertThat(broker.getPartitions()).isEmpty());
+            });
+
+    // and - tenantA, which is unaffected by tenantB's removal, is never explicitly marked enabled
+    // but still resolves normally with its routing state intact
+    final var tenantAInfo = actuator.getTopology(TENANT_A).getPhysicalTenants();
+    assertThat(tenantAInfo)
+        .singleElement()
+        .satisfies(
+            info -> {
+              assertThat(info.getId()).isEqualTo(TENANT_A);
+              assertThat(info.getDisabled()).isNull();
+              assertThat(info.getRouting()).isNotNull();
+            });
   }
 
   public static Stream<Arguments> restartStrategies() {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -260,6 +260,22 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   /**
+   * Removes a physical tenant declared via {@link #withPtConfig}, so its {@code
+   * camunda.physical-tenants.<tenantId>.*} properties are no longer flattened at the next {@link
+   * #createSpringBuilder()} — simulating a physical tenant being removed from application
+   * configuration. Since those properties are refreshable (see {@link #createSpringBuilder()}),
+   * they are also cleared from any properties already registered from a previous start. Does
+   * nothing if the tenant was never declared.
+   *
+   * @param tenantId the physical tenant id to remove
+   * @return itself for chaining
+   */
+  public T removePtConfig(final String tenantId) {
+    ptConfigs.remove(tenantId);
+    return self();
+  }
+
+  /**
    * Replaces a set of properties that should be re-derived from in-memory builder state on every
    * {@link #start()}. Keys set in a previous call are removed before the new {@code properties} are
    * applied, so fields that disappear between restarts (e.g. an exporter cleared from the unified


### PR DESCRIPTION
## Summary
- Stacked on #60073 (needs that merged/rebased first).
- Adds a `disabled` flag to `PhysicalTenantInfo` in the `GET /actuator/cluster` response: a disabled physical tenant (removed from local static configuration, but retaining its data and partition assignment) is reported with `disabled: true` and no `routing`; an enabled tenant is never explicitly marked - a populated `routing` already means that.
- Excludes a disabled group's partitions and per-broker `physicalTenants` entries from `BrokerState`, since neither reflects anything actually running.
- Adds `TestSpringApplication.removePtConfig` (inverse of `withPtConfig`) and extends `PhysicalTenantProvisioningIT` with a disable-focused test case, verified via the updated actuator.

## Related issue
Part of #60070
