### PR TITLE
fix: activate jobs with secret values up to the free message size

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -274,7 +274,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     }
     responseValue.copyFrom(value);
     jobSecretInjector
-        .injectSecretValues(responseValue, value)
+        .injectSecretValues(
+            responseValue, value, record.getLength(), stateWriter::canWriteEventOfLength)
         .ifPresent(this::raiseIncidentForDroppedJob);
     return responseValue;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,21 +147,34 @@ public final class JobSecretInjector {
    * last reset (the engine processor is single-threaded, so the collection of a command always
    * completes before its injection) and resets this injector for the next activation command.
    *
-   * <p>The collector sized the batch against the max message size with {@link
-   * EngineConfiguration#BATCH_SIZE_CALCULATION_BUFFER} bytes of slack, which the injected values
-   * may consume. The first job whose values would grow the response further is dropped together
-   * with every job after it, from the response batch and the to-be-activated batch alike (both must
-   * still contain the same jobs), so the dropped jobs stay activatable and the next activation,
-   * with a fresh budget, picks them up right away. A job whose injection fails is dropped the same
-   * way; its failure details are only logged, so no secret-related data can end up in persisted
-   * records. Must run before the ACTIVATED event is appended. Returns the dropped job the caller
-   * must raise an incident for: a job whose injection failed, or a job whose values can never fit
-   * any batch.
+   * <p>The injected values ride the activation response only, which must stay under the max message
+   * size like the appended event. The collector already sized the appended event (with the
+   * placeholders) against that limit, keeping {@link
+   * EngineConfiguration#BATCH_SIZE_CALCULATION_BUFFER} bytes of slack as a margin for the framing
+   * metadata it cannot measure. Here each job's value growth is measured against the real remaining
+   * space up to that limit, not against the margin: {@code baseLength} is the size the batch
+   * already occupies, and {@code canWriteEventOfLength} is the same predicate the collector used. A
+   * job is kept only while {@code baseLength + accumulatedGrowth + growth + margin} still fits; the
+   * first job whose values would push the response past that is dropped together with every job
+   * after it, from the response batch and the to-be-activated batch alike (both must still contain
+   * the same jobs), so the dropped jobs stay activatable and the next activation, with a fresh
+   * batch, picks them up right away. A job whose injection fails is dropped the same way; its
+   * failure details are only logged, so no secret-related data can end up in persisted records.
+   * Must run before the ACTIVATED event is appended. Returns the dropped job the caller must raise
+   * an incident for: a job whose injection failed, or a job whose values can never fit any batch.
+   *
+   * @param baseLength the length the batch already occupies before any value is injected, i.e. the
+   *     length of the collected activation command; the injected growth is measured on top of it
+   * @param canWriteEventOfLength returns whether a record of the given length still fits the max
+   *     message size, the same proxy the collector uses to size the appended event
    */
   public Optional<DroppedJob> injectSecretValues(
-      final JobBatchRecord responseBatch, final JobBatchRecord activatedBatch) {
+      final JobBatchRecord responseBatch,
+      final JobBatchRecord activatedBatch,
+      final int baseLength,
+      final Predicate<Integer> canWriteEventOfLength) {
     try {
-      int remainingGrowth = EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
+      int accumulatedGrowth = 0;
       for (final JobWithCachedSecrets jobWithSecrets : jobsWithCachedSecrets) {
         final byte[] injected;
         try {
@@ -175,9 +189,11 @@ public final class JobSecretInjector {
           continue;
         }
         final int growth = injected.length - jobWithSecrets.job().getVariablesBuffer().capacity();
-        if (growth > remainingGrowth) {
+        final int occupiedLength = baseLength + accumulatedGrowth;
+        if (!canWriteEventOfLength.test(
+            occupiedLength + growth + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER)) {
           return dropJobsThatNoLongerFit(
-              responseBatch, activatedBatch, jobWithSecrets.index(), growth, remainingGrowth);
+              responseBatch, activatedBatch, jobWithSecrets.index(), growth, occupiedLength);
         }
         // the registered job belongs to the to-be-activated batch; the response element at the
         // same index carries the same variables until they are replaced here
@@ -185,7 +201,7 @@ public final class JobSecretInjector {
             .jobs()
             .get(jobWithSecrets.index())
             .setVariables(BufferUtil.wrapArray(injected));
-        remainingGrowth -= growth;
+        accumulatedGrowth += growth;
       }
       return Optional.empty();
     } finally {
@@ -218,7 +234,7 @@ public final class JobSecretInjector {
   /**
    * Drops the job at the given index and every job after it from both batches, so none of them are
    * activated and all stay activatable, and marks both batches as truncated so the client polls for
-   * the dropped jobs right away. A job dropped as the first of the batch had the full growth budget
+   * the dropped jobs right away. A job dropped as the first of the batch had the whole message size
    * to itself, so its values can never fit any batch: it is returned so the caller can raise an
    * incident for it, just like for a job that is too large to activate without secrets.
    */
@@ -227,17 +243,17 @@ public final class JobSecretInjector {
       final JobBatchRecord activatedBatch,
       final int index,
       final int growth,
-      final int remainingGrowth) {
+      final int occupiedLength) {
     final RemovedJob removed = dropJobsFromIndex(responseBatch, activatedBatch, index);
     LOGGER.warn(
         "Not activating the job with key {} of type '{}' and the jobs after it in the batch: "
-            + "injecting the job's secret values would grow the activation batch by {} bytes but "
-            + "only {} bytes remain before the response could exceed the max message size. The "
+            + "injecting the job's secret values would grow the activation batch by {} bytes on top "
+            + "of the {} bytes it already occupies, which would exceed the max message size. The "
             + "dropped jobs stay activatable",
         removed.jobKey(),
         removed.job().getType(),
         growth,
-        remainingGrowth);
+        occupiedLength);
     return index == 0
         ? Optional.of(new OversizedJob(removed.jobKey(), removed.job(), growth))
         : Optional.empty();
@@ -267,7 +283,7 @@ public final class JobSecretInjector {
 
   /**
    * A job dropped from the batch whose secret values can never fit: injecting them would grow the
-   * batch by {@code growth} bytes, more than the whole budget any activation batch has to spare.
+   * batch by {@code growth} bytes, past the max message size even in an otherwise empty batch.
    */
   public record OversizedJob(long jobKey, JobRecord job, int growth) implements DroppedJob {}
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -246,7 +246,8 @@ final class JobBatchCollectorTest {
     assertThat(secretInjector.hasSecretsToInject()).isTrue();
     final var response = new JobBatchRecord();
     response.copyFrom(record.getValue());
-    secretInjector.injectSecretValues(response, record.getValue());
+    secretInjector.injectSecretValues(
+        response, record.getValue(), record.getValue().getLength(), length -> true);
     assertThat(response.jobs().iterator().next().getVariables()).containsEntry("auth", "resolved");
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
@@ -45,6 +45,10 @@ public final class JobSecretActivationInjectionTest {
   private static final String TASK_ID = "task";
   private static final String JOB_TYPE = "task-type";
 
+  // The default max fragment size of the test log stream, which caps both the appended event and
+  // the activation response (see LogStreamBuilderImpl). The size checks are proxied against it.
+  private static final int MAX_MESSAGE_SIZE = 4 * 1024 * 1024;
+
   @Rule public final EngineRule engine;
 
   @Rule
@@ -263,10 +267,41 @@ public final class JobSecretActivationInjectionTest {
   }
 
   @Test
+  public void shouldActivateSingleJobWithSecretValueLargerThanCalculationBuffer() {
+    // given - a single job whose injected secret value is larger than the batch calculation
+    // buffer but still well within the message size; before the fix the buffer was misused as the
+    // whole growth budget, so this job was wrongly dropped
+    final var value = "x".repeat(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER * 2);
+    secretActivation.putSecret("token", value);
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    createInstanceAndAwaitJob();
+
+    // when
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - the job is activated normally, the batch is not truncated, and no incident is raised
+    assertThat(activated.getValue().getJobs()).hasSize(1);
+    assertThat(activated.getValue().isTruncated()).isFalse();
+    final var response = secretActivation.awaitActivationResponse();
+    assertThat(response.getJobs()).hasSize(1);
+    assertThat(response.getJobs().get(0).getVariables())
+        .containsEntry("authorization", "Bearer " + value);
+
+    // and - no exported record (state, log) leaks the resolved secret value, and no message-size
+    // incident is raised for a job that fits the message size
+    final var records = RecordingExporter.getRecords();
+    assertThat(records).noneMatch(record -> record.toString().contains(value));
+    assertThat(records)
+        .as("no incident is raised for a job that fits the message size")
+        .noneMatch(record -> record.getValueType() == ValueType.INCIDENT);
+  }
+
+  @Test
   public void shouldDropJobExceedingMessageSizeBudgetAndHandItOutOnNextActivation() {
-    // given - two jobs referencing the same secret; the injected value fits the batch growth
-    // budget once, but not twice
-    final var value = "x".repeat(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER / 2 + 1000);
+    // given - two jobs referencing the same secret; the injected value fits the free message size
+    // once, but two of them together would push the response past it
+    final var value = "x".repeat(2 * MAX_MESSAGE_SIZE / 3);
     secretActivation.putSecret("token", value);
     deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
     createInstanceAndAwaitJob();
@@ -307,9 +342,9 @@ public final class JobSecretActivationInjectionTest {
 
   @Test
   public void shouldRaiseIncidentWhenSecretValueCanNeverFitMessageSizeBudget() {
-    // given - the injected value alone exceeds the whole batch growth budget, so no activation
-    // batch could ever carry this job
-    final var value = "x".repeat(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER + 1000);
+    // given - the injected value alone exceeds the whole message size, so no activation batch
+    // could ever carry this job
+    final var value = "x".repeat(MAX_MESSAGE_SIZE);
     secretActivation.putSecret("token", value);
     deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
     final long processInstanceKey = createInstanceAndAwaitJob();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -174,7 +174,7 @@ final class JobSecretInjectorTest {
 
       // and - the collected secret job gets its cached value injected
       final var response = copyOf(batch);
-      injector.injectSecretValues(response, batch);
+      injector.injectSecretValues(response, batch, batch.getLength(), length -> true);
       assertThat(variablesOf(response, 0)).isEqualTo(Map.of("auth", "resolved"));
     }
 
@@ -193,7 +193,7 @@ final class JobSecretInjectorTest {
       // then - both jobs are collected and get their cached values injected
       assertThat(jobKeysOf(batch)).containsExactly(100L, 101L);
       final var response = copyOf(batch);
-      injector.injectSecretValues(response, batch);
+      injector.injectSecretValues(response, batch, batch.getLength(), length -> true);
       assertThat(variablesOfAllJobs(response))
           .containsExactly(Map.of("auth", "t"), Map.of("key", "k"));
     }
@@ -327,7 +327,7 @@ final class JobSecretInjectorTest {
       // then - the job is collected and the value of the named store is injected
       assertThat(jobKeysOf(batch)).containsExactly(100L);
       final var response = copyOf(batch);
-      injector.injectSecretValues(response, batch);
+      injector.injectSecretValues(response, batch, batch.getLength(), length -> true);
       assertThat(variablesOf(response, 0)).isEqualTo(Map.of("auth", "resolved"));
     }
 
@@ -966,6 +966,11 @@ final class JobSecretInjectorTest {
     /**
      * Mirrors the processor flow: register the jobs of the to-be-activated batch like the
      * collector, then inject the prepared values into the response.
+     *
+     * <p>Sizes the message-size limit at the batch length plus twice the calculation buffer, so the
+     * effective growth the first job may add before it is dropped is exactly one {@link
+     * EngineConfiguration#BATCH_SIZE_CALCULATION_BUFFER} (the injector keeps one buffer as the
+     * framing margin on top of the growth), matching what these drop tests exercise.
      */
     private static Optional<DroppedJob> inject(
         final JobBatchRecord response,
@@ -978,7 +983,10 @@ final class JobSecretInjectorTest {
         injector.registerForInjection(injector.checkSecrets(job), index, job);
         index++;
       }
-      return injector.injectSecretValues(response, activated);
+      final int baseLength = activated.getLength();
+      final int maxMessageSize = baseLength + 2 * EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
+      return injector.injectSecretValues(
+          response, activated, baseLength, length -> length <= maxMessageSize);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
@@ -92,10 +92,11 @@ import org.junit.jupiter.api.Test;
 final class SecretResolutionJobActivationIT {
 
   /**
-   * Larger than the growth an activation batch has to spare, which is {@code
-   * EngineConfiguration#BATCH_SIZE_CALCULATION_BUFFER} (8 KB) rather than the whole message size.
+   * Larger than the broker's default max message size, which is what an activation batch has to
+   * spare since the injector now measures growth against it rather than against {@code
+   * EngineConfiguration#BATCH_SIZE_CALCULATION_BUFFER}.
    */
-  private static final int OVERSIZED_SECRET_LENGTH = 16 * 1024;
+  private static final int OVERSIZED_SECRET_LENGTH = 4 * 1024 * 1024;
 
   /**
    * More than the 100 jobs one reactivation command carries, so the chain has to follow up, and


### PR DESCRIPTION
## Description

Injecting resolved secret values into a long-poll activation batch could grow the response by at most `BATCH_SIZE_CALCULATION_BUFFER` (8 KB), regardless of how much of the 4 MB message size was actually free. A job whose secret values grew the batch by more was dropped and raised a `MESSAGE_SIZE_EXCEEDED` incident even when the batch carried a single small job and nearly the whole message size was unused — roughly 500x stricter than necessary.

**Root cause:** the collector sizes the batch while the variables still hold the `camunda.secrets.<name>` placeholders and keeps the 8 KB buffer as a safety margin for the framing metadata it cannot measure. The growth from replacing placeholders with real values is only known later, when the response copy is built, and at that point the injector no longer knew the actual free space — so it reused the 8 KB constant as its entire growth budget. That constant is a *margin on top of a measured length* everywhere else; the injection was the only place spending it as an allowance, which also spent the framing margin twice.

**Fix (Option A from the issue):** give the injector the real remaining space — the collected command length plus the `canWriteEventOfLength` predicate the collector already uses. It tracks a running accumulated growth and keeps a job only while `base + accumulated + growth + margin` still fits the message size. The buffer returns to being a margin, counted separately from the growth. A job dropped as the first of the batch now genuinely does not fit the message size, so the incident message that names the message size is finally accurate.

Only the long poll was affected; the job push path performs no size check, so a streaming worker already received the same job.

## Changes

- `JobSecretInjector.injectSecretValues` measures value growth against the real free message size instead of the 8 KB constant.
- `JobBatchActivateProcessor` passes `record.getLength()` and `stateWriter::canWriteEventOfLength`.
- Tests: resized the two limit tests against the 4 MB message size, added a regression test that a single job with a >8 KB secret value is now activated normally, and updated the direct `injectSecretValues` call sites to the new signature.

Closes #60060