### PR TITLE
ci: verify the Spring Boot 4 modules against Spring Boot 4.1 on 8.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1180,7 +1180,7 @@ jobs:
     needs: [detect-changes]
     runs-on: gcp-perf-core-8-default
     # The 4.1 entry runs Camunda Process Test integration tests, which start a broker container.
-    timeout-minutes: 30
+    timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1197,6 +1197,9 @@ jobs:
             name: "4.1.x"
             profile: "spring-boot-4.1"
             modules: "clients/camunda-spring-boot-4-starter,testing/camunda-process-test-spring-4"
+            # Modules re-run against the starter jar that build-zeebe installed under the default
+            # Spring Boot pin, rather than against a starter recompiled under the profile.
+            consumer-modules: "testing/camunda-process-test-spring-4"
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1222,6 +1225,22 @@ jobs:
           -pl '${{ matrix.modules }}'
           clean verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Maven Test Build (prebuilt starter)
+        # The step above recompiles the starter under the profile, which proves source
+        # compatibility. A customer instead runs the published jar, compiled against the default
+        # Spring Boot pin, on the newer Spring Boot. Leaving the starter out of -pl resolves it
+        # from the local repository, where build-zeebe installed it under that default pin, so
+        # this run covers binary compatibility too. It only runs 'verify', never 'install', so the
+        # installed jar stays the default-pinned one.
+        if: matrix.consumer-modules != ''
+        run: >
+          ./mvnw -T2 -B --no-snapshot-updates
+          -D skipChecks -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+          -D junitThreadCount=8
+          -P parallel-tests,extract-flaky-tests,${{ matrix.profile }}
+          -pl '${{ matrix.consumer-modules }}'
+          clean verify
+          | tee -a "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs
         id: analyze-test-run
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1179,16 +1179,24 @@ jobs:
     name: "[Spring-Boot-Compatibility] ${{ matrix.name }}"
     needs: [detect-changes]
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 10
+    # The 4.1 entry runs Camunda Process Test integration tests, which start a broker container.
+    timeout-minutes: 30
     permissions: {}  # GITHUB_TOKEN unused in this job
     strategy:
       fail-fast: false
       matrix:
-        group: [ spring-boot-3.5 ]
+        group: [ spring-boot-3.5, spring-boot-4.1 ]
         include:
           - group: spring-boot-3.5
             name: "3.5.x"
             profile: "spring-boot-3.5"
+            modules: "clients/spring-boot-starter-camunda-sdk,testing/camunda-process-test-spring"
+          # The Spring Boot 4 line lives in dedicated modules that pin their own 4.x version, so it
+          # needs a separate module list from the 3.x one above.
+          - group: spring-boot-4.1
+            name: "4.1.x"
+            profile: "spring-boot-4.1"
+            modules: "clients/camunda-spring-boot-4-starter,testing/camunda-process-test-spring-4"
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1211,7 +1219,7 @@ jobs:
           -D skipChecks -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -D junitThreadCount=8
           -P parallel-tests,extract-flaky-tests,${{ matrix.profile }}
-          -pl 'clients/spring-boot-starter-camunda-sdk,testing/camunda-process-test-spring'
+          -pl '${{ matrix.modules }}'
           clean verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1191,6 +1191,7 @@ jobs:
             name: "3.5.x"
             profile: "spring-boot-3.5"
             modules: "clients/spring-boot-starter-camunda-sdk,testing/camunda-process-test-spring"
+            consumer-modules: ""
           # The Spring Boot 4 line lives in dedicated modules that pin their own 4.x version, so it
           # needs a separate module list from the 3.x one above.
           - group: spring-boot-4.1

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -294,4 +294,19 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>spring-boot-4.1</id>
+      <properties>
+        <!-- Tests compatibility against a non-default Spring Boot 4 minor version.
+             Spring Boot 4.1.0 manages Spring Framework 7.0.8 (same as the default 4.0.x
+             pinned above), so version.spring is left unchanged; only the Spring Boot
+             version is overridden here. This profile lives in the module pom (not
+             library-parent) because the module pins version.spring-boot locally, which
+             would shadow a parent-level profile property. -->
+        <version.spring-boot>4.1.0</version.spring-boot>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -57,6 +57,13 @@
         <artifactId>jackson-databind</artifactId>
         <version>3.1.5</version>
       </dependency>
+      <!-- Override the parent's version.httpclient5 (5.4.4) pin, which the vulnerability gate
+      flags for GHSA-hjcp-jmpx-g3qm. Scoped to this module only, matching the pattern above. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>5.6.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -289,6 +289,18 @@
 
   <profiles>
     <profile>
+      <id>spring-boot-4.1</id>
+      <properties>
+        <!-- Tests compatibility against a non-default Spring Boot 4 minor version.
+             Spring Boot 4.1.0 manages Spring Framework 7.0.8 (same as the default 4.0.x
+             pinned above), so version.spring is left unchanged; only the Spring Boot
+             version is overridden here. This profile lives in the module pom (not
+             library-parent) because the module pins version.spring-boot locally, which
+             would shadow a parent-level profile property. -->
+        <version.spring-boot>4.1.0</version.spring-boot>
+      </properties>
+    </profile>
+    <profile>
       <id>central-sonatype-publish</id>
       <!--
         This profile is typically activated during release builds refer to


### PR DESCRIPTION
## Description

Verifies that `camunda-spring-boot-4-starter` and `camunda-process-test-spring-4` on the 8.7 line
work with Spring Boot 4.1.x, which a customer under an extended support agreement requires.

**No production code changes were needed.** The default Spring Boot pin stays at 4.0.7, so
existing 4.0.x consumers keep working. A
`spring-boot-4.1` profile adds a second tested axis, and the `spring-boot-compatibility-tests` job
now runs both Spring Boot 4 modules under it, then re-runs the integration tests against the
starter jar built under the default pin.

This mirrors the approach already used on 8.8 (shipped in 8.8.30+), adapted to the 8.7 module
layout: 8.7 has `testing/camunda-process-test-spring-4` rather than `-spring-boot-4`, and it already
has a `spring-boot-compatibility-tests` job whose matrix is extended here rather than duplicated.

Bumping the default pin to 4.1 was deliberately rejected: it would risk compiling against a
4.1-only API and breaking every consumer still on 4.0.x, which is the wrong trade on a branch under
extended support.

### Result

Both modules are green against Spring Boot 4.1.0:

- `camunda-spring-boot-4-starter`: 337 tests, 0 failures, identical to the 4.0.7 baseline.
- `camunda-process-test-spring-4`: 9 unit tests plus 3 integration tests that boot a real Spring
  context and a broker container.

The job runs those integration tests twice. First against a starter recompiled under the 4.1
profile, which covers source compatibility. Then against the starter jar that `build-zeebe`
installed under the default 4.0.x pin, which is the jar a customer resolves from Maven Central.
The second run is the customer-shaped one, because a changed Spring Boot signature would only
surface against a prebuilt jar, never against a recompile.

### One thing worth knowing

Spring Boot 4.1 added Spring gRPC, so its BOM now manages `grpc-java` and `protobuf-java`, neither of
which 4.0.7 managed at all. Since `library-parent` re-imports `spring-boot-dependencies` at a nearer
level than `zeebe-parent` imports `grpc-bom`, the Spring pin wins under 4.1 and the shaded client
moves grpc 1.76.3 to 1.80.0 and protobuf 4.31.1 to 4.34.2. That combination is green, and it is what
a customer on Spring Boot 4.1 actually resolves, but it is precisely why the CI entry matters: a
future Spring Boot minor can shift these pins again without any change on our side.

Note that only 4.1.0 is published on Maven Central today, so "4.1.x" is verified at 4.1.0.

The remaining acceptance criterion on the issue is the docs PR adding 4.1.x to the 8.7
version-compatibility table.

## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to #60069



