### PR TITLE
Export agent definitions to RDBMS

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -289,6 +289,105 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="create_agent_definition_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}AGENT_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}AGENT_DEFINITION">
+      <column name="AGENT_DEFINITION_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="AGENT_TYPE" type="VARCHAR(50)"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ELEMENT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_VERSION" type="SMALLINT"/>
+      <column name="PROCESS_DEFINITION_VERSION_TAG" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_agent_definition_tenant_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_DEFINITION_TENANT_ID"
+          tableName="${prefix}AGENT_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_DEFINITION"
+      indexName="${prefix}IDX_AGENT_DEFINITION_TENANT_ID">
+      <column name="TENANT_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_definition_pd_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_DEFINITION_PD_KEY"
+          tableName="${prefix}AGENT_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_DEFINITION"
+      indexName="${prefix}IDX_AGENT_DEFINITION_PD_KEY">
+      <column name="PROCESS_DEFINITION_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_definition_pd_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_DEFINITION_PD_ID"
+          tableName="${prefix}AGENT_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_DEFINITION"
+      indexName="${prefix}IDX_AGENT_DEFINITION_PD_ID">
+      <column name="PROCESS_DEFINITION_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_definition_element_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_DEFINITION_ELEMENT_ID"
+          tableName="${prefix}AGENT_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_DEFINITION"
+      indexName="${prefix}IDX_AGENT_DEFINITION_ELEMENT_ID">
+      <column name="ELEMENT_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_definition_pd_version_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_DEFINITION_PD_VERSION"
+          tableName="${prefix}AGENT_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_DEFINITION"
+      indexName="${prefix}IDX_AGENT_DEFINITION_PD_VERSION">
+      <column name="PROCESS_DEFINITION_VERSION"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_definition_pd_version_tag_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_DEFINITION_PD_VERSION_TAG"
+          tableName="${prefix}AGENT_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_DEFINITION"
+      indexName="${prefix}IDX_AGENT_DEFINITION_PD_VERSION_TAG">
+      <column name="PROCESS_DEFINITION_VERSION_TAG"/>
+    </createIndex>
+  </changeSet>
+
   <changeSet id="create_wait_state_table" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -27,6 +27,7 @@ public final class RdbmsTableNames {
           "AGENT_INSTANCE_ELEMENT_INSTANCE",
           "AGENT_INSTANCE",
           "AGENT_HISTORY",
+          "AGENT_DEFINITION",
           "AUDIT_LOG",
           "AUTHORIZATIONS",
           "BATCH_OPERATION_ITEM",

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -33,6 +33,7 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.sql.WaitStateMapper;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.service.AgentDefinitionWriter;
 import io.camunda.db.rdbms.write.service.AgentHistoryWriter;
 import io.camunda.db.rdbms.write.service.AgentInstanceWriter;
 import io.camunda.db.rdbms.write.service.AuditLogWriter;
@@ -190,6 +191,7 @@ public class RdbmsWriters implements AutoCloseable {
         new HistoryDeletionWriter(executionQueue, historyDeletionMapper));
     writers.put(GlobalListenerWriter.class, new GlobalListenerWriter(executionQueue));
     writers.put(DeployedResourceWriter.class, new DeployedResourceWriter(executionQueue));
+    writers.put(AgentDefinitionWriter.class, new AgentDefinitionWriter(executionQueue));
     writers.put(
         AgentHistoryWriter.class,
         new AgentHistoryWriter(executionQueue, agentHistoryMapper, vendorDatabaseProperties));
@@ -317,6 +319,10 @@ public class RdbmsWriters implements AutoCloseable {
 
   public DeployedResourceWriter getResourceWriter() {
     return getWriter(DeployedResourceWriter.class);
+  }
+
+  public AgentDefinitionWriter getAgentDefinitionWriter() {
+    return getWriter(AgentDefinitionWriter.class);
   }
 
   public AgentHistoryWriter getAgentHistoryWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentDefinitionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentDefinitionDbModel.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.util.ObjectBuilder;
+
+public record AgentDefinitionDbModel(
+    Long agentDefinitionKey,
+    AgentType agentType,
+    String name,
+    String elementId,
+    String processDefinitionId,
+    Long processDefinitionKey,
+    int processDefinitionVersion,
+    String processDefinitionVersionTag,
+    String tenantId) {
+
+  // create a builder for this record extending ObjectBuilder
+  public static class AgentDefinitionDbModelBuilder
+      implements ObjectBuilder<AgentDefinitionDbModel> {
+
+    private Long agentDefinitionKey;
+    private AgentType agentType;
+    private String name;
+    private String elementId;
+    private String processDefinitionId;
+    private Long processDefinitionKey;
+    private int processDefinitionVersion;
+    private String processDefinitionVersionTag;
+    private String tenantId;
+
+    public AgentDefinitionDbModelBuilder agentDefinitionKey(final Long agentDefinitionKey) {
+      this.agentDefinitionKey = agentDefinitionKey;
+      return this;
+    }
+
+    public AgentDefinitionDbModelBuilder agentType(final AgentType agentType) {
+      this.agentType = agentType;
+      return this;
+    }
+
+    public AgentDefinitionDbModelBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public AgentDefinitionDbModelBuilder elementId(final String elementId) {
+      this.elementId = elementId;
+      return this;
+    }
+
+    public AgentDefinitionDbModelBuilder processDefinitionId(final String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
+      return this;
+    }
+
+    public AgentDefinitionDbModelBuilder processDefinitionKey(final Long processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public AgentDefinitionDbModelBuilder processDefinitionVersion(
+        final int processDefinitionVersion) {
+      this.processDefinitionVersion = processDefinitionVersion;
+      return this;
+    }
+
+    public AgentDefinitionDbModelBuilder processDefinitionVersionTag(
+        final String processDefinitionVersionTag) {
+      this.processDefinitionVersionTag = processDefinitionVersionTag;
+      return this;
+    }
+
+    public AgentDefinitionDbModelBuilder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    @Override
+    public AgentDefinitionDbModel build() {
+      return new AgentDefinitionDbModel(
+          agentDefinitionKey,
+          agentType,
+          name,
+          elementId,
+          processDefinitionId,
+          processDefinitionKey,
+          processDefinitionVersion,
+          processDefinitionVersionTag,
+          tenantId);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -15,6 +15,7 @@ public enum ContextType {
   // INSERT-before-UPDATE ordering within a batch is guaranteed by optimizeQueueOrder's
   // WriteStatementType sort, so no explicit preservation is needed here
   AGENT_HISTORY(false),
+  AGENT_DEFINITION(false),
   AUDIT_LOG(false),
   AUTHORIZATION(true),
   BATCH_OPERATION(false),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+
+public class AgentDefinitionWriter implements RdbmsWriter {
+
+  private final ExecutionQueue executionQueue;
+
+  public AgentDefinitionWriter(final ExecutionQueue executionQueue) {
+    this.executionQueue = executionQueue;
+  }
+
+  public void create(final AgentDefinitionDbModel agentDefinition) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.AGENT_DEFINITION,
+            WriteStatementType.INSERT,
+            agentDefinition.agentDefinitionKey(),
+            "io.camunda.db.rdbms.sql.AgentDefinitionMapper.insert",
+            agentDefinition));
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/AgentDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentDefinitionMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.db.rdbms.sql.AgentDefinitionMapper">
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel">
+    INSERT INTO ${prefix}AGENT_DEFINITION (
+      AGENT_DEFINITION_KEY,
+      AGENT_TYPE,
+      NAME,
+      ELEMENT_ID,
+      PROCESS_DEFINITION_ID,
+      PROCESS_DEFINITION_KEY,
+      PROCESS_DEFINITION_VERSION,
+      PROCESS_DEFINITION_VERSION_TAG,
+      TENANT_ID
+    )
+    VALUES (
+      #{agentDefinitionKey},
+      #{agentType},
+      #{name},
+      #{elementId},
+      #{processDefinitionId},
+      #{processDefinitionKey},
+      #{processDefinitionVersion},
+      #{processDefinitionVersionTag},
+      #{tenantId}
+    )
+  </insert>
+
+</mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel.AgentDefinitionDbModelBuilder;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import org.junit.jupiter.api.Test;
+
+class AgentDefinitionWriterTest {
+
+  private final ExecutionQueue executionQueue = mock(ExecutionQueue.class);
+  private final AgentDefinitionWriter writer = new AgentDefinitionWriter(executionQueue);
+
+  @Test
+  void shouldCreateAgentDefinition() {
+    // given
+    final var model =
+        new AgentDefinitionDbModelBuilder()
+            .agentDefinitionKey(1L)
+            .agentType(AgentType.AI_AGENT_TASK)
+            .name("name")
+            .elementId("element-id")
+            .processDefinitionId("process-definition-id")
+            .processDefinitionKey(2L)
+            .processDefinitionVersion(3)
+            .processDefinitionVersionTag("version-tag")
+            .tenantId("tenant-id")
+            .build();
+
+    // when
+    writer.create(model);
+
+    // then
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.AGENT_DEFINITION,
+                    WriteStatementType.INSERT,
+                    1L,
+                    "io.camunda.db.rdbms.sql.AgentDefinitionMapper.insert",
+                    model)));
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
@@ -57,8 +57,10 @@ class RdbmsDbModelCoverageArchTest {
           // UsageMetricIT
           "UsageMetricTUTenantStatisticsDbModel", // TU tenant statistics variant; covered by
           // UsageMetricIT
-          "ClusterVariableMetadataDbModel"); // metadata sub-entity of ClusterVariable; covered by
-  // ClusterVariableIT
+          "ClusterVariableMetadataDbModel", // metadata sub-entity of ClusterVariable; covered by
+          // ClusterVariableIT
+          "AgentDefinitionDbModel"); // no read/search API yet (issue #59072 is write-only);
+  // add AgentDefinitionIT once #59079 implements AgentDefinitionDbReader#search()
 
   // IT class simple names scanned from test-jars once at class-load time.
   static final Set<String> IT_SIMPLE_NAMES =

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
@@ -55,6 +55,8 @@ class RdbmsDbModelSortITCoverageArchTest {
           "TenantMemberDbModel", // member sub-entity; no TenantMemberSortIT
           "RoleMemberDbModel", // member sub-entity; no RoleMemberSortIT
           "ClusterVariableMetadataDbModel", // metadata sub-entity; covered by ClusterVariableIT
+          "AgentDefinitionDbModel", // no read/search API yet (issue #59072 is write-only); add
+          // AgentDefinitionSortIT once #59079 implements AgentDefinitionDbReader#search()
           "ProcessDefinitionVariableNameLookupDbModel", // variable-name cache; has an IT but no
           // sort fields
           "BatchOperationErrorDbModel", // error sub-entity of BatchOperation; no sort fields

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.HistoryDeletionService;
 import io.camunda.exporter.rdbms.RdbmsExporter.Builder;
 import io.camunda.exporter.rdbms.cache.RdbmsCacheRegistry;
+import io.camunda.exporter.rdbms.handlers.AgentDefinitionExportHandler;
 import io.camunda.exporter.rdbms.handlers.AgentHistoryExportHandler;
 import io.camunda.exporter.rdbms.handlers.AgentInstanceExportHandler;
 import io.camunda.exporter.rdbms.handlers.AuditLogExportHandler;
@@ -257,6 +258,9 @@ public class RdbmsExporterWrapper implements Exporter {
           new GlobalListenerExportHandler(rdbmsWriters.getGlobalListenerWriter()));
       builder.withHandler(
           ValueType.RESOURCE, new ResourceExportHandler(rdbmsWriters.getResourceWriter()));
+      builder.withHandler(
+          ValueType.AGENT_DEFINITION,
+          new AgentDefinitionExportHandler(rdbmsWriters.getAgentDefinitionWriter()));
     }
 
     builder.withHandler(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentDefinitionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentDefinitionExportHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel.AgentDefinitionDbModelBuilder;
+import io.camunda.db.rdbms.write.service.AgentDefinitionWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.exporter.rdbms.utils.ExportUtil;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionRecordValue;
+import java.util.Set;
+
+/**
+ * Exports {@code AgentDefinition:CREATED} records. The engine replicates {@code
+ * AgentDefinition:CREATED} with the same key to every partition, the same way {@code
+ * Process:CREATED} and {@code Decision:CREATED} are, so this handler is only registered on {@code
+ * RdbmsExporterWrapper#PROCESS_DEFINITION_PARTITION} to avoid every partition's exporter inserting
+ * the same {@code AGENT_DEFINITION_KEY} row into the shared RDBMS table.
+ */
+public class AgentDefinitionExportHandler
+    implements RdbmsExportHandler<AgentDefinitionRecordValue> {
+
+  private static final Set<AgentDefinitionIntent> EXPORTABLE_INTENTS =
+      Set.of(AgentDefinitionIntent.CREATED);
+
+  private final AgentDefinitionWriter writer;
+
+  public AgentDefinitionExportHandler(final AgentDefinitionWriter writer) {
+    this.writer = writer;
+  }
+
+  @Override
+  public boolean canExport(final Record<AgentDefinitionRecordValue> record) {
+    return record.getValueType() == ValueType.AGENT_DEFINITION
+        && record.getIntent() instanceof final AgentDefinitionIntent intent
+        && EXPORTABLE_INTENTS.contains(intent);
+  }
+
+  @Override
+  public void export(final Record<AgentDefinitionRecordValue> record) {
+    writer.create(map(record.getValue()));
+  }
+
+  private AgentDefinitionDbModel map(final AgentDefinitionRecordValue value) {
+    return new AgentDefinitionDbModelBuilder()
+        .agentDefinitionKey(value.getAgentDefinitionKey())
+        .agentType(mapAgentType(value.getAgentType()))
+        .name(value.getName())
+        .elementId(value.getElementId())
+        .processDefinitionId(value.getBpmnProcessId())
+        .processDefinitionKey(value.getProcessDefinitionKey())
+        .processDefinitionVersion(value.getProcessDefinitionVersion())
+        .processDefinitionVersionTag(ExportUtil.emptyToNull(value.getProcessDefinitionVersionTag()))
+        .tenantId(value.getTenantId())
+        .build();
+  }
+
+  /** Maps the protocol {@code AgentDefinitionType} to the search-side {@link AgentType}. */
+  private static AgentType mapAgentType(
+      final io.camunda.zeebe.protocol.record.value.AgentDefinitionType protocolAgentType) {
+    return switch (protocolAgentType) {
+      case AI_AGENT_SUB_PROCESS -> AgentType.AI_AGENT_SUB_PROCESS;
+      case AI_AGENT_TASK -> AgentType.AI_AGENT_TASK;
+      case EXTERNAL_AGENT -> AgentType.EXTERNAL_AGENT;
+      case UNSPECIFIED ->
+          throw new IllegalStateException(
+              "Received unexpected AgentDefinitionType.UNSPECIFIED; the broker must never emit "
+                  + "this value. If a new AgentDefinitionType was intentionally added, extend "
+                  + AgentType.class.getName()
+                  + " and this mapping accordingly.");
+    };
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -281,6 +281,9 @@ class RdbmsExporterWrapperTest {
     assertThat(registeredHandlers)
         .as("Should register GLOBAL_LISTENER handler on partition 1")
         .containsKey(ValueType.GLOBAL_LISTENER);
+    assertThat(registeredHandlers)
+        .as("Should register AGENT_DEFINITION handler on partition 1")
+        .containsKey(ValueType.AGENT_DEFINITION);
   }
 
   @Test
@@ -349,6 +352,9 @@ class RdbmsExporterWrapperTest {
     assertThat(registeredHandlers)
         .as("Should not register GLOBAL_LISTENER handler on partition 1")
         .doesNotContainKey(ValueType.GLOBAL_LISTENER);
+    assertThat(registeredHandlers)
+        .as("Should not register AGENT_DEFINITION handler on partition 2")
+        .doesNotContainKey(ValueType.AGENT_DEFINITION);
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentDefinitionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentDefinitionExportHandlerTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
+import io.camunda.db.rdbms.write.service.AgentDefinitionWriter;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentDefinitionType;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentDefinitionRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgentDefinitionExportHandlerTest {
+
+  private static final Set<AgentDefinitionIntent> EXPORTABLE_INTENTS =
+      EnumSet.of(AgentDefinitionIntent.CREATED);
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Mock private AgentDefinitionWriter writer;
+  @Captor private ArgumentCaptor<AgentDefinitionDbModel> modelCaptor;
+
+  private AgentDefinitionExportHandler handler;
+
+  static Stream<AgentDefinitionIntent> exportableIntents() {
+    return EXPORTABLE_INTENTS.stream();
+  }
+
+  static Stream<AgentDefinitionIntent> nonExportableIntents() {
+    return Stream.of(AgentDefinitionIntent.values())
+        .filter(Predicate.not(EXPORTABLE_INTENTS::contains));
+  }
+
+  @BeforeEach
+  void setUp() {
+    handler = new AgentDefinitionExportHandler(writer);
+  }
+
+  @ParameterizedTest(name = "Should export record with intent: {0}")
+  @MethodSource("exportableIntents")
+  void shouldExportRecord(final AgentDefinitionIntent intent) {
+    // given
+    final Record<AgentDefinitionRecordValue> record =
+        factory.generateRecord(ValueType.AGENT_DEFINITION, r -> r.withIntent(intent));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @ParameterizedTest(name = "Should not export record with unsupported intent: {0}")
+  @MethodSource("nonExportableIntents")
+  void shouldNotExportRecord(final AgentDefinitionIntent intent) {
+    // given
+    final Record<AgentDefinitionRecordValue> record =
+        factory.generateRecord(ValueType.AGENT_DEFINITION, r -> r.withIntent(intent));
+
+    // when / then
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldCallCreateOnCreatedIntent() {
+    // given
+    final var recordValue = buildRecordValue(123L);
+    final Record<AgentDefinitionRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_DEFINITION,
+            r -> r.withIntent(AgentDefinitionIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final AgentDefinitionDbModel model = modelCaptor.getValue();
+    assertThat(model.agentDefinitionKey()).isEqualTo(123L);
+    assertThat(model.agentType()).isEqualTo(AgentType.AI_AGENT_TASK);
+    assertThat(model.name()).isEqualTo("agentName");
+    assertThat(model.elementId()).isEqualTo("elementId");
+    assertThat(model.processDefinitionId()).isEqualTo("bpmnProcessId");
+    assertThat(model.processDefinitionKey()).isEqualTo(456L);
+    assertThat(model.processDefinitionVersion()).isEqualTo(2);
+    assertThat(model.processDefinitionVersionTag()).isEqualTo("versionTag");
+    assertThat(model.tenantId()).isEqualTo("tenantId");
+  }
+
+  @Test
+  void shouldMapEmptyProcessDefinitionVersionTagToNull() {
+    // given
+    final var recordValue =
+        ImmutableAgentDefinitionRecordValue.builder()
+            .from(buildRecordValue(123L))
+            .withProcessDefinitionVersionTag("")
+            .build();
+    final Record<AgentDefinitionRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_DEFINITION,
+            r -> r.withIntent(AgentDefinitionIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    assertThat(modelCaptor.getValue().processDefinitionVersionTag()).isNull();
+  }
+
+  @ParameterizedTest(name = "[{index}] Should map protocol agent type ''{0}'' to model agent type")
+  @EnumSource(
+      value = AgentDefinitionType.class,
+      // The broker should never emit UNSPECIFIED;
+      // all other protocol agent types must map to an explicit AgentType.
+      names = {"UNSPECIFIED"},
+      mode = Mode.EXCLUDE)
+  void shouldMapAllProtocolAgentTypes(final AgentDefinitionType protocolAgentType) {
+    // given
+    final var recordValue =
+        ImmutableAgentDefinitionRecordValue.builder()
+            .from(buildRecordValue(123L))
+            .withAgentType(protocolAgentType)
+            .build();
+    final Record<AgentDefinitionRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_DEFINITION,
+            r -> r.withIntent(AgentDefinitionIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    assertThat(modelCaptor.getValue().agentType())
+        .as(
+            """
+            Protocol agent type '%s' has no explicit mapping in \
+            'AgentDefinitionExportHandler.mapAgentType()' — add '%s' to '%s' and handle it \
+            explicitly in the switch.\
+            """,
+            protocolAgentType, protocolAgentType, AgentType.class.getName())
+        .isNotNull()
+        .extracting(Enum::name)
+        .isEqualTo(protocolAgentType.name());
+  }
+
+  @Test
+  void shouldThrowWhenProtocolAgentTypeIsUnspecified() {
+    // given — UNSPECIFIED is not explicitly mapped and must never be emitted by the broker
+    final var recordValue =
+        ImmutableAgentDefinitionRecordValue.builder()
+            .from(buildRecordValue(123L))
+            .withAgentType(AgentDefinitionType.UNSPECIFIED)
+            .build();
+    final Record<AgentDefinitionRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_DEFINITION,
+            r -> r.withIntent(AgentDefinitionIntent.CREATED).withValue(recordValue));
+
+    // when / then
+    assertThatThrownBy(() -> handler.export(record))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("UNSPECIFIED");
+  }
+
+  private AgentDefinitionRecordValue buildRecordValue(final long agentDefinitionKey) {
+    return ImmutableAgentDefinitionRecordValue.builder()
+        .from(factory.generateObject(AgentDefinitionRecordValue.class))
+        .withAgentDefinitionKey(agentDefinitionKey)
+        .withAgentType(AgentDefinitionType.AI_AGENT_TASK)
+        .withName("agentName")
+        .withElementId("elementId")
+        .withBpmnProcessId("bpmnProcessId")
+        .withProcessDefinitionKey(456L)
+        .withProcessDefinitionVersion(2)
+        .withProcessDefinitionVersionTag("versionTag")
+        .withTenantId("tenantId")
+        .build();
+  }
+}


### PR DESCRIPTION
## Description

Zeebe now emits `AgentDefinitionRecordValue` records for AI agent definitions declared in deployed BPMN processes. The ES/OS Camunda exporter already persists these into a secondary-storage index (#59071, merged in #59904), but the RDBMS exporter has no equivalent write path, so a Camunda 8 deployment configured to use the RDBMS exporter silently drops `AgentDefinition` data. This PR adds that missing write path, giving RDBMS deployments the same `AgentDefinition` persistence capability ES/OS already has.

### What changed and why

1. **`feat: add AGENT_DEFINITION table to RDBMS schema`** — adds the `AGENT_DEFINITION` table to `8.10.0.xml` with one column per field of the `search-domain` `AgentDefinitionEntity`/`AgentDefinitionFilter`/`AgentDefinitionSort` contract (#59078), plus indexes matching the subset-of-filterable-columns pattern already used for `DECISION_DEFINITION`/`FORM`. `AGENT_DEFINITION` is registered in `RdbmsTableNames.TABLE_NAMES`.
2. **`feat: write AGENT_DEFINITION rows through AgentDefinitionWriter`** — adds `AgentDefinitionDbModel`, `AgentDefinitionMapper.xml` (insert-only, no Java mapper interface needed since nothing calls it directly), and `AgentDefinitionWriter`, wired into `RdbmsWriters` and `ContextType`.
3. **`feat: export AgentDefinition:CREATED records to RDBMS`** — adds `AgentDefinitionExportHandler`, handling only the `CREATED` intent (matching the ES/OS `AgentDefinitionHandler`, since agent definitions are immutable historic data). Registered in `RdbmsExporterWrapper` inside the `PROCESS_DEFINITION_PARTITION`-gated block, because `AgentDefinition:CREATED` is replicated with the same key to every partition — without this gating, every partition's exporter would attempt to `INSERT` the same primary key.
4. **`test: exclude AgentDefinitionDbModel from RDBMS IT/SortIT ArchUnit coverage`** — excludes `AgentDefinitionDbModel` from `RdbmsDbModelCoverageArchTest`/`RdbmsDbModelSortITCoverageArchTest`, since there's no reader/search API yet to exercise an IT/SortIT against (see "Out of scope" below).

### Note on the AGENT_INSTANCE → AGENT_DEFINITION relationship

`AGENT_INSTANCE.AGENT_DEFINITION_KEY` conceptually references `AGENT_DEFINITION.AGENT_DEFINITION_KEY`, but this PR deliberately does **not** add a DB-level foreign key for it. `AgentDefinition:CREATED` is only exported by the exporter on `PROCESS_DEFINITION_PARTITION`, while `AgentInstance` records are written independently by every partition's own exporter queue, with no cross-partition ordering guarantee between the two. A partition could flush an `AGENT_INSTANCE` row before partition 1 has committed the corresponding `AGENT_DEFINITION` row, which would violate a real FK constraint and repeatedly block that partition's exporter. Enforcing the relationship at the DB level would require making `AgentDefinition` writes idempotent/ordered across partitions first, which is out of scope here. The column stays a plain, unconstrained `BIGINT`.

### What this enables

- RDBMS-backed Camunda 8 deployments now persist `AgentDefinition` data emitted by the broker, at parity with the ES/OS exporter.

### Out of scope

- Read/search API for `AGENT_DEFINITION` (`AgentDefinitionDbReader#search()` still throws `UnsupportedOperationException`) — tracked separately in #59079.
- A DB-level foreign key from `AGENT_INSTANCE` to `AGENT_DEFINITION` (see note above).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #59072
