### PR TITLE
test: restore Operate history panel test coverage on stable/8.8

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/modificationPlaceholders.test.tsx
@@ -37,8 +37,7 @@ import {
 import {mockNestedSubProcessBusinessObjects} from 'modules/mocks/mockNestedSubProcessBusinessObjects';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 
-// TODO: https://github.com/camunda/camunda/issues/59641
-describe.todo('FlowNodeInstancesTree - Modification placeholders', () => {
+describe('FlowNodeInstancesTree - Modification placeholders', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       multiInstanceProcessInstance,
@@ -51,6 +50,12 @@ describe.todo('FlowNodeInstancesTree - Modification placeholders', () => {
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [],
     });
+  });
+
+  afterEach(() => {
+    modificationsStore.reset();
+    flowNodeInstanceStore.reset();
+    processInstanceDetailsStore.reset();
   });
 
   it('should create new parent scopes for a new palceholder if there are no running scopes', async () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/nestedSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/nestedSubprocess.test.tsx
@@ -27,8 +27,7 @@ import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstanc
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 
-// TODO: https://github.com/camunda/camunda/issues/59641
-describe.todo('FlowNodeInstancesTree - Nested Subprocesses', () => {
+describe('FlowNodeInstancesTree - Nested Subprocesses', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       nestedSubProcessesInstance,
@@ -56,6 +55,7 @@ describe.todo('FlowNodeInstancesTree - Nested Subprocesses', () => {
   });
 
   afterEach(() => {
+    modificationsStore.reset();
     flowNodeInstanceStore.reset();
     processInstanceDetailsStore.reset();
     flowNodeInstanceStore.reset();


### PR DESCRIPTION
## Summary

Restores the two Operate FE unit tests quarantined via `describe.todo` — they were causing a vitest heap OOM in the single-worker `fe-unit-tests` job.

Root cause: `modificationsStore` (global MobX singleton) was never reset after these tests ran, so leftover modification entries persisted into whichever test ran next in the same worker process. Adding the missing `modificationsStore.reset()` alongside the existing store resets in `afterEach` fixes it.

## Test plan

- [x] 3x full single-worker suite runs (`--no-file-parallelism --maxWorkers 1`), CI-exact flags — clean, no OOM, no new failures
- [x] Full 6-shard sweep matching the CI matrix — clean
- [x] Confirmed both restored test files pass their own assertions, not just "doesn't crash"

Issue: #59641