### PR TITLE
refactor: split rebalance coordinator lifecycle from dynamic config

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -58,6 +58,7 @@ public final class BrokerStartupProcess {
 
     result.add(new ApiMessagingServiceStep());
     result.add(new RequestIdGeneratorStep());
+    result.add(new RebalanceCoordinatorStep());
     result.add(new GatewayBrokerTransportStep());
 
     if (config.getGateway().isEnable()) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStep.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.rebalance.ProtoBufRebalanceSerializer;
+import io.camunda.zeebe.rebalance.RebalanceCoordinator;
+import io.camunda.zeebe.rebalance.RebalanceRequestServer;
+import io.camunda.zeebe.rebalance.RebalanceRunner;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.startup.StartupStep;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Owns the rebalance actor, coordinator, request server, and their registration as a cluster
+ * configuration update listener. Runs after {@link RequestIdGeneratorStep} so the request id
+ * generator and cluster services are already available, and is stopped before them since startup
+ * steps shut down in reverse order.
+ */
+public class RebalanceCoordinatorStep implements StartupStep<BrokerStartupContext> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RebalanceCoordinatorStep.class);
+
+  private @Nullable Actor rebalanceCoordinatorActor;
+  private @Nullable RebalanceCoordinator rebalanceCoordinator;
+  private @Nullable RebalanceRequestServer rebalanceRequestServer;
+
+  @Override
+  public String getName() {
+    return "Rebalance Coordinator";
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> startup(
+      final BrokerStartupContext brokerStartupContext) {
+    final ActorFuture<BrokerStartupContext> started =
+        brokerStartupContext.getConcurrencyControl().createFuture();
+
+    final var localMember =
+        brokerStartupContext.getClusterServices().getMembershipService().getLocalMember().id();
+    rebalanceCoordinatorActor = Actor.newActor().name("RebalanceCoordinator").build();
+
+    brokerStartupContext
+        .getActorSchedulingService()
+        .submitActor(rebalanceCoordinatorActor)
+        .onComplete(
+            (ok, error) -> {
+              if (error != null) {
+                LOGGER.error("Failed to start the rebalance coordinator actor", error);
+                started.completeExceptionally(error);
+                return;
+              }
+              rebalanceCoordinator =
+                  new RebalanceCoordinator(
+                      localMember,
+                      rebalanceCoordinatorActor,
+                      RebalanceRunner.none(),
+                      () -> brokerStartupContext.getRequestIdGenerator().nextId());
+              rebalanceRequestServer =
+                  new RebalanceRequestServer(
+                      brokerStartupContext.getClusterServices().getCommunicationService(),
+                      new ProtoBufRebalanceSerializer(),
+                      rebalanceCoordinator);
+              rebalanceRequestServer.start();
+              brokerStartupContext
+                  .getClusterConfigurationService()
+                  .addUpdateListener(rebalanceCoordinator);
+              started.complete(brokerStartupContext);
+            });
+
+    return started;
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> shutdown(
+      final BrokerStartupContext brokerStartupContext) {
+    final ActorFuture<BrokerStartupContext> stopped =
+        brokerStartupContext.getConcurrencyControl().createFuture();
+
+    if (rebalanceRequestServer != null) {
+      rebalanceRequestServer.close();
+      rebalanceRequestServer = null;
+    }
+    if (rebalanceCoordinator != null) {
+      brokerStartupContext
+          .getClusterConfigurationService()
+          .removeUpdateListener(rebalanceCoordinator);
+    }
+
+    closeRebalanceCoordinator()
+        .onComplete(
+            (ok, error) -> {
+              rebalanceCoordinator = null;
+              rebalanceCoordinatorActor = null;
+              if (error != null) {
+                stopped.completeExceptionally(error);
+              } else {
+                stopped.complete(brokerStartupContext);
+              }
+            });
+
+    return stopped;
+  }
+
+  private ActorFuture<Void> closeRebalanceCoordinator() {
+    if (rebalanceCoordinatorActor == null) {
+      return CompletableActorFuture.completed(null);
+    }
+    if (rebalanceCoordinator == null) {
+      return rebalanceCoordinatorActor.closeAsync();
+    }
+    return rebalanceCoordinator
+        .shutdown()
+        .andThen(rebalanceCoordinatorActor::closeAsync, Runnable::run);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestValidator;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
@@ -61,6 +62,10 @@ public interface ClusterConfigurationService extends AsyncClosable {
   void registerInconsistentConfigurationListener(InconsistentConfigurationListener listener);
 
   void removeInconsistentConfigurationListener();
+
+  void addUpdateListener(ClusterConfigurationUpdateListener listener);
+
+  void removeUpdateListener(ClusterConfigurationUpdateListener listener);
 
   void registerRequestValidator(
       @Nullable String physicalTenantId, ClusterConfigurationRequestValidator<?, ?> validator);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -26,11 +26,6 @@ import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
-import io.camunda.zeebe.rebalance.ProtoBufRebalanceSerializer;
-import io.camunda.zeebe.rebalance.RebalanceCoordinator;
-import io.camunda.zeebe.rebalance.RebalanceRequestServer;
-import io.camunda.zeebe.rebalance.RebalanceRunner;
-import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
@@ -56,9 +51,6 @@ public class DynamicClusterConfigurationService
   private volatile CurrentClusterConfiguration currentClusterConfiguration;
 
   private ClusterConfigurationManagerService clusterConfigurationManagerService;
-  private RebalanceCoordinator rebalanceCoordinator;
-  private Actor rebalanceCoordinatorActor;
-  private RebalanceRequestServer rebalanceRequestServer;
   private final ClusterChangeExecutor clusterChangeExecutor;
 
   public DynamicClusterConfigurationService(final ClusterChangeExecutor clusterChangeExecutor) {
@@ -139,7 +131,6 @@ public class DynamicClusterConfigurationService
             clusterConfigurationManagerService.addUpdateListener(this);
             registerInconsistentConfigurationListener(
                 inconsistentConfigurationListener(brokerStartupContext));
-            startRebalanceCoordinator(brokerStartupContext);
             clusterConfigurationManagerService
                 .getClusterConfiguration()
                 .onComplete(
@@ -179,6 +170,23 @@ public class DynamicClusterConfigurationService
   public void removeInconsistentConfigurationListener() {
     if (clusterConfigurationManagerService != null) {
       clusterConfigurationManagerService.removeTopologyChangedListener();
+    }
+  }
+
+  @Override
+  public void addUpdateListener(final ClusterConfigurationUpdateListener listener) {
+    if (clusterConfigurationManagerService != null) {
+      clusterConfigurationManagerService.addUpdateListener(listener);
+    } else {
+      throw new IllegalStateException(
+          "Cannot register an update listener before the topology manager is started");
+    }
+  }
+
+  @Override
+  public void removeUpdateListener(final ClusterConfigurationUpdateListener listener) {
+    if (clusterConfigurationManagerService != null) {
+      clusterConfigurationManagerService.removeUpdateListener(listener);
     }
   }
 
@@ -246,31 +254,10 @@ public class DynamicClusterConfigurationService
     partitionDistributionPerPhysicalTenant.clear();
     currentClusterConfiguration = null;
     removeInconsistentConfigurationListener();
-    if (rebalanceRequestServer != null) {
-      rebalanceRequestServer.close();
-    }
-    if (rebalanceCoordinator != null && clusterConfigurationManagerService != null) {
-      clusterConfigurationManagerService.removeUpdateListener(rebalanceCoordinator);
-    }
-    final ActorFuture<Void> rebalanceCoordinatorClosed = closeRebalanceCoordinator();
     if (clusterConfigurationManagerService != null) {
-      return rebalanceCoordinatorClosed.andThen(
-          clusterConfigurationManagerService::closeAsync, Runnable::run);
-    } else {
-      return rebalanceCoordinatorClosed;
+      return clusterConfigurationManagerService.closeAsync();
     }
-  }
-
-  private ActorFuture<Void> closeRebalanceCoordinator() {
-    if (rebalanceCoordinatorActor == null) {
-      return CompletableActorFuture.completed(null);
-    }
-    if (rebalanceCoordinator == null) {
-      return rebalanceCoordinatorActor.closeAsync();
-    }
-    return rebalanceCoordinator
-        .shutdown()
-        .andThen(rebalanceCoordinatorActor::closeAsync, Runnable::run);
+    return CompletableActorFuture.completed(null);
   }
 
   /**
@@ -367,35 +354,6 @@ public class DynamicClusterConfigurationService
         brokerStartupContext.getBrokerConfiguration().getCluster().getConfigManager().gossip(),
         clusterChangeExecutor,
         brokerStartupContext.getMeterRegistry());
-  }
-
-  private void startRebalanceCoordinator(final BrokerStartupContext brokerStartupContext) {
-    final var localMember =
-        brokerStartupContext.getClusterServices().getMembershipService().getLocalMember().id();
-    rebalanceCoordinatorActor = Actor.newActor().name("RebalanceCoordinator").build();
-    brokerStartupContext
-        .getActorSchedulingService()
-        .submitActor(rebalanceCoordinatorActor)
-        .onComplete(
-            (ok, error) -> {
-              if (error != null) {
-                LOGGER.error("Failed to start the rebalance coordinator actor", error);
-                return;
-              }
-              rebalanceCoordinator =
-                  new RebalanceCoordinator(
-                      localMember,
-                      rebalanceCoordinatorActor,
-                      RebalanceRunner.none(),
-                      () -> brokerStartupContext.getRequestIdGenerator().nextId());
-              rebalanceRequestServer =
-                  new RebalanceRequestServer(
-                      brokerStartupContext.getClusterServices().getCommunicationService(),
-                      new ProtoBufRebalanceSerializer(),
-                      rebalanceCoordinator);
-              rebalanceRequestServer.start();
-              clusterConfigurationManagerService.addUpdateListener(rebalanceCoordinator);
-            });
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStepTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
+import io.camunda.zeebe.rebalance.RebalanceCoordinator;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RebalanceCoordinatorStepTest {
+
+  private static final Duration TIME_OUT = Duration.ofSeconds(10);
+
+  private final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
+  private final TestConcurrencyControl spyConcurrencyControl = spy(new TestConcurrencyControl());
+  private final ClusterConfigurationService clusterConfigurationService =
+      mock(ClusterConfigurationService.class);
+
+  private MockBrokerStartupContext testBrokerStartupContext;
+  private ClusterCommunicationService communicationService;
+
+  private final RebalanceCoordinatorStep sut = new RebalanceCoordinatorStep();
+
+  @BeforeEach
+  void setUp() {
+    actorSchedulerRule.before();
+
+    testBrokerStartupContext = new MockBrokerStartupContext();
+    testBrokerStartupContext.setConcurrencyControl(spyConcurrencyControl);
+    testBrokerStartupContext.setActorSchedulingService(actorSchedulerRule.get());
+    testBrokerStartupContext.setClusterConfigurationService(clusterConfigurationService);
+
+    communicationService = testBrokerStartupContext.getClusterServices().getCommunicationService();
+  }
+
+  @AfterEach
+  void tearDown() {
+    actorSchedulerRule.after();
+  }
+
+  @Test
+  void shouldHaveDescriptiveName() {
+    // when
+    final var actual = sut.getName();
+
+    // then
+    assertThat(actual).isSameAs("Rebalance Coordinator");
+  }
+
+  @Nested
+  class StartupBehavior {
+
+    @Test
+    void shouldWaitForActorSubmission() {
+      // given
+      final var actorSchedulingService = mock(ActorSchedulingService.class);
+      final ActorFuture<Void> submitActorFuture = new CompletableActorFuture<>();
+      when(actorSchedulingService.submitActor(any())).thenReturn(submitActorFuture);
+      testBrokerStartupContext.setActorSchedulingService(actorSchedulingService);
+
+      // when
+      final var startupFuture = sut.startup(testBrokerStartupContext);
+
+      // then
+      assertThat(startupFuture.isDone()).isFalse();
+      verify(clusterConfigurationService, never()).addUpdateListener(any());
+
+      // when
+      submitActorFuture.complete(null);
+
+      // then
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+      verify(clusterConfigurationService, timeout(TIME_OUT.toMillis()))
+          .addUpdateListener(any(RebalanceCoordinator.class));
+    }
+
+    @Test
+    void shouldFailStartupWhenActorSubmissionFails() {
+      // given
+      final var actorSchedulingService = mock(ActorSchedulingService.class);
+      final var expectedError = new RuntimeException("expected failure");
+      final ActorFuture<Void> submitActorFuture = new CompletableActorFuture<>();
+      submitActorFuture.completeExceptionally(expectedError);
+      when(actorSchedulingService.submitActor(any())).thenReturn(submitActorFuture);
+      testBrokerStartupContext.setActorSchedulingService(actorSchedulingService);
+
+      // when
+      final var startupFuture = sut.startup(testBrokerStartupContext);
+
+      // then
+      assertThat(startupFuture).failsWithin(TIME_OUT);
+      verify(clusterConfigurationService, never()).addUpdateListener(any());
+      verifyNoInteractions(communicationService);
+    }
+
+    @Test
+    void shouldRegisterHandlersAndListenerOnSuccessfulStartup() {
+      // when
+      final var startupFuture = sut.startup(testBrokerStartupContext);
+
+      // then
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+      verify(clusterConfigurationService, timeout(TIME_OUT.toMillis()))
+          .addUpdateListener(any(RebalanceCoordinator.class));
+      verify(communicationService, timeout(TIME_OUT.toMillis()).times(3))
+          .replyTo(any(), any(), any(), any());
+    }
+  }
+
+  @Nested
+  class ShutdownBehavior {
+
+    @Test
+    void shouldBeSafeAfterPartialStartup() {
+      // when
+      final var shutdownFuture = sut.shutdown(testBrokerStartupContext);
+
+      // then
+      assertThat(shutdownFuture).succeedsWithin(TIME_OUT);
+      verifyNoInteractions(clusterConfigurationService);
+      verifyNoInteractions(communicationService);
+    }
+
+    @Test
+    void shouldCloseHandlersRemoveListenerAbandonCoordinatorAndCloseActor() {
+      // given
+      final var startupFuture = sut.startup(testBrokerStartupContext);
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+
+      final ArgumentCaptor<RebalanceCoordinator> coordinatorCaptor =
+          ArgumentCaptor.forClass(RebalanceCoordinator.class);
+      verify(clusterConfigurationService, timeout(TIME_OUT.toMillis()))
+          .addUpdateListener(coordinatorCaptor.capture());
+      final var registeredCoordinator = coordinatorCaptor.getValue();
+
+      // when
+      final var shutdownFuture = sut.shutdown(testBrokerStartupContext);
+
+      // then
+      assertThat(shutdownFuture).succeedsWithin(TIME_OUT);
+      verify(communicationService, times(3)).unsubscribe(any());
+      verify(clusterConfigurationService).removeUpdateListener(registeredCoordinator);
+    }
+
+    @Test
+    void shouldCompleteWithoutWaitingForAbandonedRunner() {
+      // given
+      final var startupFuture = sut.startup(testBrokerStartupContext);
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+
+      // when
+      final var shutdownFuture = sut.shutdown(testBrokerStartupContext);
+
+      // then
+      assertThat(shutdownFuture).succeedsWithin(Duration.ofSeconds(2));
+    }
+
+    @Test
+    void shouldBeSafeToShutdownTwice() {
+      // given
+      final var startupFuture = sut.startup(testBrokerStartupContext);
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+      assertThat(sut.shutdown(testBrokerStartupContext)).succeedsWithin(TIME_OUT);
+
+      // when
+      final var secondShutdownFuture = sut.shutdown(testBrokerStartupContext);
+
+      // then
+      assertThat(secondShutdownFuture).succeedsWithin(TIME_OUT);
+    }
+  }
+}


### PR DESCRIPTION
Currently the lifecycle of the rebalance coordinator is managed by the same StartupStep implementation as the dynamic config coordinator. That's an artifact of earlier drafts which coupled them more tightly overall, and it's an unnecessary confounding of the two features.

Closes #60096.