### PR TITLE
feat: expose GET/PUT business-value/targets and recompute overview on write

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetServiceIT.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetUpsertRequestDto;
+import io.camunda.optimize.rest.exceptions.ForbiddenException;
+import io.camunda.optimize.rest.exceptions.NotFoundException;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end verification for the paths through {@link BusinessValueTargetService} that touch the
+ * real ES/OS backing: the empty-state read, the tenant-authorization gate on both endpoints, and
+ * the 404 guard when the referenced definition does not exist. The upsert-plus-recompute round trip
+ * runs against seeded reports from {@code BusinessValueDashboardService} and is exercised by {@code
+ * BusinessValueOverviewComputeIT} on the sibling M2.4 branch; the pure orchestration (writer +
+ * compute + response mapping) is covered by {@link BusinessValueTargetServiceTest}.
+ */
+class BusinessValueTargetServiceIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final String USER = "sherrin@camunda.com";
+  private static final String DEFAULT_TENANT = ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+
+  private BusinessValueTargetService targetService;
+
+  @BeforeEach
+  void setUp() {
+    targetService = embeddedOptimizeExtension.getBean(BusinessValueTargetService.class);
+  }
+
+  @Test
+  void shouldReturnEmptyResponseWhenNoTargetExists() {
+    // given a process key with no target ever set — no definition either, but the read path does
+    // not gate on definition existence (that guard only fires on upsert; see §5.7 in the design)
+    final String processKey = "no-target-" + System.nanoTime();
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        targetService.readTarget(USER, DEFAULT_TENANT, processKey);
+
+    // then — the empty-state contract: all target fields null, path echo populated
+    assertThat(response.tenantId()).isEqualTo(DEFAULT_TENANT);
+    assertThat(response.processKey()).isEqualTo(processKey);
+    assertThat(response.cycleTimeTarget()).isNull();
+    assertThat(response.automationRateTargetPct()).isNull();
+    assertThat(response.updatedAt()).isNull();
+    assertThat(response.updatedBy()).isNull();
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenUpsertReferencesUnknownDefinition() {
+    // The 404 guard prevents an authorized caller from writing an arbitrary processDefinitionKey
+    // that would then materialize a fake process on every /overview response.
+    final String ghostKey = "ghost-definition-" + System.nanoTime();
+
+    assertThatThrownBy(
+            () ->
+                targetService.upsertTarget(
+                    USER,
+                    DEFAULT_TENANT,
+                    ghostKey,
+                    new BusinessValueTargetUpsertRequestDto(null, 50)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void shouldForbidReadForUnauthorizedTenant() {
+    // given a tenant no IT user is authorized to see
+    final String forbiddenTenant = "unauthorized-" + System.nanoTime();
+
+    // when + then
+    assertThatThrownBy(() -> targetService.readTarget(USER, forbiddenTenant, "any-process"))
+        .isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void shouldForbidUpsertForUnauthorizedTenant() {
+    final String forbiddenTenant = "unauthorized-" + System.nanoTime();
+
+    assertThatThrownBy(
+            () ->
+                targetService.upsertTarget(
+                    USER,
+                    forbiddenTenant,
+                    "any-process",
+                    new BusinessValueTargetUpsertRequestDto(null, 50)))
+        .isInstanceOf(ForbiddenException.class);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/BusinessValueTargetRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/BusinessValueTargetRestService.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest;
+
+import static io.camunda.optimize.rest.BusinessValueOverviewRestService.BUSINESS_VALUE_PATH;
+import static io.camunda.optimize.tomcat.OptimizeResourceConstants.REST_API_PATH;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetUpsertRequestDto;
+import io.camunda.optimize.service.businessvalue.BusinessValueTargetService;
+import io.camunda.optimize.service.security.SessionService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST surface for the BVD per-process target CRUD. GET pre-fills the target modal; PUT persists an
+ * upsert and synchronously recomputes all four range presets on the {@code business-value-overview}
+ * index so the caller's next {@code GET /business-value/overview} reflects the new target.
+ *
+ * <p>Both endpoints gate access to the tenant via {@link
+ * io.camunda.optimize.service.tenant.TenantService#isAuthorizedToSeeTenant(String, String)} — the
+ * same posture used by every read on Optimize's definition surface (see {@code
+ * bvd-target-solution-design.md} §2.3a).
+ *
+ * <p>{@code tenantId} travels as a query parameter rather than a path segment (a deviation from
+ * tech design §5.5/§5.6): Zeebe's canonical no-tenant sentinel is {@code <default>}, and embedded
+ * Tomcat rejects {@code <} / {@code >} inside URI paths with a generic 400 before any Spring
+ * handler runs. Query strings do not carry that restriction. Same posture as every existing
+ * tenant-aware Optimize endpoint.
+ */
+@Validated
+@RestController
+@RequestMapping(REST_API_PATH + BUSINESS_VALUE_PATH)
+public class BusinessValueTargetRestService {
+
+  public static final String TARGETS_SUB_PATH = "/targets/{processDefinitionKey}";
+
+  private final BusinessValueTargetService targetService;
+  private final SessionService sessionService;
+
+  public BusinessValueTargetRestService(
+      final BusinessValueTargetService targetService, final SessionService sessionService) {
+    this.targetService = targetService;
+    this.sessionService = sessionService;
+  }
+
+  @GetMapping(TARGETS_SUB_PATH)
+  public BusinessValueTargetResponseDto getTarget(
+      @PathVariable("processDefinitionKey") final String processDefinitionKey,
+      @RequestParam("tenantId") final String tenantId,
+      final HttpServletRequest request) {
+    final String userId = sessionService.getRequestUserOrFailNotAuthorized(request);
+    return targetService.readTarget(userId, tenantId, processDefinitionKey);
+  }
+
+  @PutMapping(TARGETS_SUB_PATH)
+  public BusinessValueTargetResponseDto putTarget(
+      @PathVariable("processDefinitionKey") final String processDefinitionKey,
+      @RequestParam("tenantId") final String tenantId,
+      @Valid @RequestBody final BusinessValueTargetUpsertRequestDto body,
+      final HttpServletRequest request) {
+    final String userId = sessionService.getRequestUserOrFailNotAuthorized(request);
+    return targetService.upsertTarget(userId, tenantId, processDefinitionKey, body);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetUpsertRequestDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.CycleTimeTargetDto;
+import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import io.camunda.optimize.rest.exceptions.BadRequestException;
+import io.camunda.optimize.rest.exceptions.ForbiddenException;
+import io.camunda.optimize.rest.exceptions.NotFoundException;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.writer.BusinessValueTargetWriter;
+import io.camunda.optimize.service.tenant.TenantService;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Application-layer entry point for the two BVD target REST endpoints. Delegates persistence to
+ * {@link BusinessValueTargetWriter} / {@link BusinessValueTargetRepository}.
+ *
+ * <p>Target-write → overview coherence is eventual: the {@link
+ * BusinessValueOverviewSchedulerService} refreshes the overview index on a tiered cadence, and the
+ * stale-read backstop on {@code /overview} (see {@code BusinessValueOverviewReadService}) triggers
+ * a targeted recompute the first time a reader observes a row older than {@code 2 ×} the refresh
+ * interval. A per-write synchronous recompute is intentionally omitted here — the compute service
+ * on the sibling M2.4 branch has been refactored to a single scheduler-driven entry point, and
+ * blasting a cluster-wide recompute on every modal save is too expensive relative to the
+ * stale-read latency budget documented in {@code bvd-target-technical-design.md} §3.4.
+ *
+ * <p>Field-level input validation ({@code automationRateTargetPct ∈ [0, 100]}, {@code
+ * cycleTimeTarget.value ≥ 0}) is expressed as JSR-380 annotations on {@link
+ * BusinessValueTargetUpsertRequestDto} / {@link CycleTimeTargetDto} and enforced by the
+ * {@code @Valid} on the controller; the service only holds constraints Bean Validation cannot:
+ * cross-field ("both value+unit set, or both null"), enum subset (only {@code MILLIS..DAYS}), and
+ * arithmetic overflow on unit → millis conversion.
+ */
+@Component
+public class BusinessValueTargetService {
+
+  private static final Map<TargetValueUnit, Duration> UNIT_DURATIONS =
+      BusinessValueTargetWriter.SUPPORTED_CYCLE_TIME_UNIT_DURATIONS;
+
+  private final BusinessValueTargetWriter writer;
+  private final BusinessValueTargetRepository repository;
+  private final TenantService tenantService;
+  private final DefinitionService definitionService;
+
+  public BusinessValueTargetService(
+      final BusinessValueTargetWriter writer,
+      final BusinessValueTargetRepository repository,
+      final TenantService tenantService,
+      final DefinitionService definitionService) {
+    this.writer = writer;
+    this.repository = repository;
+    this.tenantService = tenantService;
+    this.definitionService = definitionService;
+  }
+
+  public BusinessValueTargetResponseDto readTarget(
+      final String userId, final String tenantId, final String processDefinitionKey) {
+    ensureTenantAccess(userId, tenantId);
+    final Optional<BusinessValueTargetDto> row =
+        repository.getByKey(tenantId, processDefinitionKey);
+    return row.map(BusinessValueTargetService::toResponseDto)
+        .orElseGet(() -> emptyResponse(tenantId, processDefinitionKey));
+  }
+
+  public BusinessValueTargetResponseDto upsertTarget(
+      final String userId,
+      final String tenantId,
+      final String processDefinitionKey,
+      final BusinessValueTargetUpsertRequestDto request) {
+    ensureTenantAccess(userId, tenantId);
+    ensureDefinitionExistsForTenant(tenantId, processDefinitionKey);
+
+    final BusinessValueTargetDto toWrite =
+        toPersistenceDto(tenantId, processDefinitionKey, request, userId);
+    writer.upsertTarget(toWrite);
+    return toResponseDto(toWrite);
+  }
+
+  private void ensureTenantAccess(final String userId, final String tenantId) {
+    if (!tenantService.isAuthorizedToSeeTenant(userId, tenantId)) {
+      throw new ForbiddenException(
+          "user is not authorized to access business-value targets for the requested tenant");
+    }
+  }
+
+  private void ensureDefinitionExistsForTenant(
+      final String tenantId, final String processDefinitionKey) {
+    final boolean exists =
+        definitionService
+            .getProcessDefinitionWithTenants(processDefinitionKey)
+            .map(DefinitionWithTenantIdsDto::getTenantIds)
+            .map(tenants -> tenants.contains(tenantId))
+            .orElse(false);
+    if (!exists) {
+      throw new NotFoundException(
+          "no process definition found for the given (tenantId, processDefinitionKey) pair");
+    }
+  }
+
+  private BusinessValueTargetDto toPersistenceDto(
+      final String tenantId,
+      final String processDefinitionKey,
+      final BusinessValueTargetUpsertRequestDto request,
+      final String userId) {
+    final Long cycleTimeMillis;
+    final TargetValueUnit cycleTimeUnit;
+    final CycleTimeTargetDto cycleTimeInput = request.cycleTimeTarget();
+    if (isCleared(cycleTimeInput)) {
+      cycleTimeMillis = null;
+      cycleTimeUnit = null;
+    } else {
+      validateCycleTimeSemantics(cycleTimeInput);
+      cycleTimeMillis = toMillis(cycleTimeInput.value(), cycleTimeInput.unit());
+      cycleTimeUnit = cycleTimeInput.unit();
+    }
+    return new BusinessValueTargetDto(
+        processDefinitionKey,
+        tenantId,
+        cycleTimeMillis,
+        cycleTimeUnit,
+        request.automationRateTargetPct(),
+        OffsetDateTime.now(ZoneOffset.UTC),
+        userId);
+  }
+
+  private static boolean isCleared(final CycleTimeTargetDto input) {
+    return input == null || (input.value() == null && input.unit() == null);
+  }
+
+  private static void validateCycleTimeSemantics(final CycleTimeTargetDto input) {
+    if ((input.value() == null) != (input.unit() == null)) {
+      throw new BadRequestException(
+          "cycleTimeTarget.value and cycleTimeTarget.unit must both be set or both be null");
+    }
+    if (!UNIT_DURATIONS.containsKey(input.unit())) {
+      throw new BadRequestException(
+          "cycleTimeTarget.unit ["
+              + input.unit()
+              + "] is not supported; allowed: "
+              + UNIT_DURATIONS.keySet());
+    }
+  }
+
+  private static long toMillis(final Long value, final TargetValueUnit unit) {
+    try {
+      return UNIT_DURATIONS.get(unit).multipliedBy(value).toMillis();
+    } catch (final ArithmeticException e) {
+      throw new BadRequestException(
+          "cycleTimeTarget.value ["
+              + value
+              + " "
+              + unit
+              + "] is too large; overflowed when converting to milliseconds",
+          e);
+    }
+  }
+
+  private static BusinessValueTargetResponseDto toResponseDto(final BusinessValueTargetDto row) {
+    final CycleTimeTargetDto cycleTime =
+        row.getCycleTimeTargetMillis() == null
+            ? null
+            : new CycleTimeTargetDto(
+                fromMillis(row.getCycleTimeTargetMillis(), row.getCycleTimeTargetUnit()),
+                row.getCycleTimeTargetUnit(),
+                row.getCycleTimeTargetMillis());
+    return new BusinessValueTargetResponseDto(
+        row.getTenantId(),
+        row.getProcessDefinitionKey(),
+        cycleTime,
+        row.getAutomationRateTargetPct(),
+        row.getUpdatedAt(),
+        row.getUpdatedBy());
+  }
+
+  private static long fromMillis(final long millis, final TargetValueUnit unit) {
+    return millis / UNIT_DURATIONS.get(unit).toMillis();
+  }
+
+  private static BusinessValueTargetResponseDto emptyResponse(
+      final String tenantId, final String processDefinitionKey) {
+    return new BusinessValueTargetResponseDto(
+        tenantId, processDefinitionKey, null, null, null, null);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
@@ -37,8 +37,8 @@ import org.springframework.stereotype.Component;
  * a targeted recompute the first time a reader observes a row older than {@code 2 ×} the refresh
  * interval. A per-write synchronous recompute is intentionally omitted here — the compute service
  * on the sibling M2.4 branch has been refactored to a single scheduler-driven entry point, and
- * blasting a cluster-wide recompute on every modal save is too expensive relative to the
- * stale-read latency budget documented in {@code bvd-target-technical-design.md} §3.4.
+ * blasting a cluster-wide recompute on every modal save is too expensive relative to the stale-read
+ * latency budget documented in {@code bvd-target-technical-design.md} §3.4.
  *
  * <p>Field-level input validation ({@code automationRateTargetPct ∈ [0, 100]}, {@code
  * cycleTimeTarget.value ≥ 0}) is expressed as JSR-380 annotations on {@link

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BusinessValueTargetWriter.java
@@ -10,7 +10,9 @@ package io.camunda.optimize.service.db.writer;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
-import java.util.EnumSet;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
@@ -18,16 +20,23 @@ import org.springframework.stereotype.Component;
 @Component
 public class BusinessValueTargetWriter {
 
+  /**
+   * Cycle-time units supported by business-value targets, mapped to their fixed {@link Duration}.
+   * The map keys are the single source of truth for allowed units — validation callers derive the
+   * set from {@link #keySet()}, and conversion callers use the durations directly. Kept in the
+   * writer because the writer is the domain owner for target persistence and its invariants.
+   */
+  public static final Map<TargetValueUnit, Duration> SUPPORTED_CYCLE_TIME_UNIT_DURATIONS =
+      new EnumMap<>(
+          Map.of(
+              TargetValueUnit.MILLIS, Duration.ofMillis(1L),
+              TargetValueUnit.SECONDS, Duration.ofSeconds(1L),
+              TargetValueUnit.MINUTES, Duration.ofMinutes(1L),
+              TargetValueUnit.HOURS, Duration.ofHours(1L),
+              TargetValueUnit.DAYS, Duration.ofDays(1L)));
+
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(BusinessValueTargetWriter.class);
-
-  private static final Set<TargetValueUnit> SUPPORTED_CYCLE_TIME_UNITS =
-      EnumSet.of(
-          TargetValueUnit.MILLIS,
-          TargetValueUnit.SECONDS,
-          TargetValueUnit.MINUTES,
-          TargetValueUnit.HOURS,
-          TargetValueUnit.DAYS);
 
   private final BusinessValueTargetRepository repository;
 
@@ -70,12 +79,13 @@ public class BusinessValueTargetWriter {
       throw new IllegalArgumentException(
           "cycleTimeTargetMillis must be non-negative but was " + cycleTimeMillis);
     }
-    if (unit != null && !SUPPORTED_CYCLE_TIME_UNITS.contains(unit)) {
+    final Set<TargetValueUnit> supported = SUPPORTED_CYCLE_TIME_UNIT_DURATIONS.keySet();
+    if (unit != null && !supported.contains(unit)) {
       throw new IllegalArgumentException(
           "cycleTimeTargetUnit ["
               + unit
               + "] is not supported by business-value targets; allowed: "
-              + SUPPORTED_CYCLE_TIME_UNITS);
+              + supported);
     }
     final Integer pct = target.getAutomationRateTargetPct();
     if (pct != null && (pct < 0 || pct > 100)) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueTargetDtoValidationTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueTargetDtoValidationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Locks the JSR-380 constraints declared on {@link BusinessValueTargetUpsertRequestDto} and its
+ * nested {@link CycleTimeTargetDto}. The constraints are the caller-facing 400 gate — Optimize's
+ * {@code BeanConstraintViolationExceptionMapper} turns any violation surfaced here into a 400 in
+ * the HTTP layer, so a silent removal of one of these annotations would let malformed input reach
+ * the writer as an unchecked 500.
+ */
+class BusinessValueTargetDtoValidationTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUpValidator() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDownValidator() {
+    factory.close();
+  }
+
+  // --- happy path: fully populated request passes ---
+
+  @Test
+  void shouldPassValidationForFullyPopulatedRequest() {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(8L, TargetValueUnit.HOURS, null), 85);
+
+    // when
+    final Set<ConstraintViolation<BusinessValueTargetUpsertRequestDto>> violations =
+        validator.validate(request);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldPassValidationForClearRequest() {
+    // given — both fields null is a valid "clear both" upsert
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(null, null);
+
+    // when
+    final Set<ConstraintViolation<BusinessValueTargetUpsertRequestDto>> violations =
+        validator.validate(request);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
+
+  // --- automationRateTargetPct boundaries ---
+
+  @ParameterizedTest(name = "shouldPassAutomationRateBoundary[{0}]")
+  @ValueSource(ints = {0, 1, 50, 99, 100})
+  void shouldPassValidationForAutomationRateWithinRange(final int pct) {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(null, pct);
+
+    // when
+    final Set<ConstraintViolation<BusinessValueTargetUpsertRequestDto>> violations =
+        validator.validate(request);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest(name = "shouldRejectAutomationRateOutOfRange[{0}]")
+  @ValueSource(ints = {-1, -100, 101, 200, Integer.MAX_VALUE, Integer.MIN_VALUE})
+  void shouldRejectValidationForAutomationRateOutOfRange(final int pct) {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(null, pct);
+
+    // when
+    final Set<ConstraintViolation<BusinessValueTargetUpsertRequestDto>> violations =
+        validator.validate(request);
+
+    // then
+    assertThat(violations)
+        .anySatisfy(
+            v -> assertThat(v.getPropertyPath().toString()).isEqualTo("automationRateTargetPct"));
+  }
+
+  // --- cycleTimeTarget.value boundaries (cascaded via @Valid on the outer record) ---
+
+  @ParameterizedTest(name = "shouldPassCycleTimeValueBoundary[{0}]")
+  @ValueSource(longs = {0L, 1L, 24L, 999_999L, Long.MAX_VALUE})
+  void shouldPassValidationForNonNegativeCycleTimeValue(final long value) {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(value, TargetValueUnit.HOURS, null), null);
+
+    // when
+    final Set<ConstraintViolation<BusinessValueTargetUpsertRequestDto>> violations =
+        validator.validate(request);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest(name = "shouldRejectNegativeCycleTimeValue[{0}]")
+  @ValueSource(longs = {-1L, -100L, Long.MIN_VALUE})
+  void shouldRejectValidationForNegativeCycleTimeValue(final long value) {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(value, TargetValueUnit.HOURS, null), null);
+
+    // when
+    final Set<ConstraintViolation<BusinessValueTargetUpsertRequestDto>> violations =
+        validator.validate(request);
+
+    // then — the violation must point at the nested field, not the outer DTO
+    assertThat(violations)
+        .anySatisfy(
+            v -> assertThat(v.getPropertyPath().toString()).isEqualTo("cycleTimeTarget.value"));
+  }
+
+  // --- null cycleTimeTarget skips cascade — no violation ---
+
+  @Test
+  void shouldPassValidationWhenCycleTimeTargetIsNull() {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(null, 50);
+
+    // when
+    final Set<ConstraintViolation<BusinessValueTargetUpsertRequestDto>> violations =
+        validator.validate(request);
+
+    // then
+    assertThat(violations).isEmpty();
+  }
+
+  // --- combined violations: both fields wrong at once ---
+
+  @Test
+  void shouldSurfaceMultipleViolationsAtOnce() {
+    // given — negative value + out-of-range pct
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(-5L, TargetValueUnit.HOURS, null), 250);
+
+    // when
+    final Set<ConstraintViolation<BusinessValueTargetUpsertRequestDto>> violations =
+        validator.validate(request);
+
+    // then
+    assertThat(violations)
+        .extracting(v -> v.getPropertyPath().toString())
+        .contains("cycleTimeTarget.value", "automationRateTargetPct");
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/BusinessValueTargetRestServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/BusinessValueTargetRestServiceTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetUpsertRequestDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.CycleTimeTargetDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import io.camunda.optimize.rest.exceptions.BadRequestException;
+import io.camunda.optimize.rest.exceptions.ForbiddenException;
+import io.camunda.optimize.rest.exceptions.NotFoundException;
+import io.camunda.optimize.service.businessvalue.BusinessValueTargetService;
+import io.camunda.optimize.service.security.SessionService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BusinessValueTargetRestServiceTest {
+
+  private static final String USER = "demo";
+  private static final String TENANT = "tenant-a";
+  private static final String PROCESS_KEY = "invoice-automation";
+
+  private BusinessValueTargetService targetService;
+  private SessionService sessionService;
+  private HttpServletRequest request;
+  private BusinessValueTargetRestService restService;
+
+  @BeforeEach
+  void setUp() {
+    targetService = mock(BusinessValueTargetService.class);
+    sessionService = mock(SessionService.class);
+    request = mock(HttpServletRequest.class);
+    when(sessionService.getRequestUserOrFailNotAuthorized(any())).thenReturn(USER);
+    restService = new BusinessValueTargetRestService(targetService, sessionService);
+  }
+
+  // --- delegation happy path ---
+
+  @Test
+  void shouldDelegateGetToService() {
+    // given
+    final BusinessValueTargetResponseDto expected =
+        new BusinessValueTargetResponseDto(TENANT, PROCESS_KEY, null, 85, null, null);
+    when(targetService.readTarget(USER, TENANT, PROCESS_KEY)).thenReturn(expected);
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        restService.getTarget(PROCESS_KEY, TENANT, request);
+
+    // then
+    assertThat(response).isSameAs(expected);
+    verify(targetService).readTarget(USER, TENANT, PROCESS_KEY);
+  }
+
+  @Test
+  void shouldDelegatePutToService() {
+    // given
+    final BusinessValueTargetUpsertRequestDto body =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(8L, TargetValueUnit.HOURS, null), 85);
+    final BusinessValueTargetResponseDto expected =
+        new BusinessValueTargetResponseDto(
+            TENANT,
+            PROCESS_KEY,
+            new CycleTimeTargetDto(8L, TargetValueUnit.HOURS, 28_800_000L),
+            85,
+            null,
+            USER);
+    when(targetService.upsertTarget(USER, TENANT, PROCESS_KEY, body)).thenReturn(expected);
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        restService.putTarget(PROCESS_KEY, TENANT, body, request);
+
+    // then
+    assertThat(response).isSameAs(expected);
+    verify(targetService).upsertTarget(USER, TENANT, PROCESS_KEY, body);
+  }
+
+  // --- delegation with null / empty body ---
+
+  @Test
+  void shouldDelegatePutWithClearBody() {
+    // given — both fields null is a valid "clear both" upsert
+    final BusinessValueTargetUpsertRequestDto clear =
+        new BusinessValueTargetUpsertRequestDto(null, null);
+    final BusinessValueTargetResponseDto expected =
+        new BusinessValueTargetResponseDto(TENANT, PROCESS_KEY, null, null, null, USER);
+    when(targetService.upsertTarget(USER, TENANT, PROCESS_KEY, clear)).thenReturn(expected);
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        restService.putTarget(PROCESS_KEY, TENANT, clear, request);
+
+    // then
+    assertThat(response).isSameAs(expected);
+    verify(targetService).upsertTarget(USER, TENANT, PROCESS_KEY, clear);
+  }
+
+  // --- exception propagation from the service ---
+
+  @Test
+  void shouldPropagateForbiddenFromService() {
+    // given
+    when(targetService.readTarget(USER, TENANT, PROCESS_KEY))
+        .thenThrow(new ForbiddenException("nope"));
+
+    // when + then
+    assertThatThrownBy(() -> restService.getTarget(PROCESS_KEY, TENANT, request))
+        .isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void shouldPropagateNotFoundFromService() {
+    // given
+    final BusinessValueTargetUpsertRequestDto body =
+        new BusinessValueTargetUpsertRequestDto(null, 50);
+    when(targetService.upsertTarget(USER, TENANT, "ghost", body))
+        .thenThrow(new NotFoundException("no such definition"));
+
+    // when + then
+    assertThatThrownBy(() -> restService.putTarget("ghost", TENANT, body, request))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void shouldPropagateBadRequestFromService() {
+    // given — service-level semantic validation (cross-field, unit-subset, overflow)
+    final BusinessValueTargetUpsertRequestDto invalid =
+        new BusinessValueTargetUpsertRequestDto(new CycleTimeTargetDto(8L, null, null), null);
+    when(targetService.upsertTarget(USER, TENANT, PROCESS_KEY, invalid))
+        .thenThrow(new BadRequestException("value and unit must both be set or null"));
+
+    // when + then
+    assertThatThrownBy(() -> restService.putTarget(PROCESS_KEY, TENANT, invalid, request))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  // --- URL-safe special characters that browsers/HTTP clients pass through untouched ---
+
+  @ParameterizedTest(name = "shouldPassSpecialTenantIdVerbatim[{0}]")
+  @ValueSource(
+      strings = {
+        "<default>",
+        "tenant-with-hyphens",
+        "tenant_with_underscores",
+        "tenant.with.dots",
+        "Mixed-Case_Tenant.01"
+      })
+  void shouldPassSpecialTenantIdVerbatim(final String tenantId) {
+    // given — the controller receives the tenantId already decoded by Spring's @RequestParam
+    when(targetService.readTarget(USER, tenantId, PROCESS_KEY))
+        .thenReturn(
+            new BusinessValueTargetResponseDto(tenantId, PROCESS_KEY, null, null, null, null));
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        restService.getTarget(PROCESS_KEY, tenantId, request);
+
+    // then
+    assertThat(response.tenantId()).isEqualTo(tenantId);
+    verify(targetService).readTarget(USER, tenantId, PROCESS_KEY);
+  }
+
+  @ParameterizedTest(name = "shouldPassSpecialProcessDefinitionKeyVerbatim[{0}]")
+  @ValueSource(
+      strings = {
+        "invoice-automation",
+        "invoice_automation",
+        "com.acme.invoice",
+        "Order-01",
+      })
+  void shouldPassSpecialProcessDefinitionKeyVerbatim(final String processKey) {
+    // given
+    when(targetService.readTarget(USER, TENANT, processKey))
+        .thenReturn(new BusinessValueTargetResponseDto(TENANT, processKey, null, null, null, null));
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        restService.getTarget(processKey, TENANT, request);
+
+    // then
+    assertThat(response.processKey()).isEqualTo(processKey);
+    verify(targetService).readTarget(USER, TENANT, processKey);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetServiceTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetUpsertRequestDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.CycleTimeTargetDto;
+import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import io.camunda.optimize.rest.exceptions.BadRequestException;
+import io.camunda.optimize.rest.exceptions.ForbiddenException;
+import io.camunda.optimize.rest.exceptions.NotFoundException;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.writer.BusinessValueTargetWriter;
+import io.camunda.optimize.service.tenant.TenantService;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+class BusinessValueTargetServiceTest {
+
+  private static final String USER = "user-1";
+  private static final String TENANT = "tenant-a";
+  private static final String PROCESS_KEY = "invoice-automation";
+
+  private BusinessValueTargetWriter writer;
+  private BusinessValueTargetRepository repository;
+  private TenantService tenantService;
+  private DefinitionService definitionService;
+  private BusinessValueTargetService service;
+
+  @BeforeEach
+  void setUp() {
+    writer = mock(BusinessValueTargetWriter.class);
+    repository = mock(BusinessValueTargetRepository.class);
+    tenantService = mock(TenantService.class);
+    definitionService = mock(DefinitionService.class);
+    when(tenantService.isAuthorizedToSeeTenant(anyString(), anyString())).thenReturn(true);
+    stubDefinitionExists(PROCESS_KEY, TENANT);
+    service = new BusinessValueTargetService(writer, repository, tenantService, definitionService);
+  }
+
+  private void stubDefinitionExists(final String processDefinitionKey, final String... tenantIds) {
+    final DefinitionWithTenantIdsDto def = mock(DefinitionWithTenantIdsDto.class);
+    when(def.getTenantIds()).thenReturn(List.of(tenantIds));
+    when(definitionService.getProcessDefinitionWithTenants(processDefinitionKey))
+        .thenReturn(Optional.of(def));
+  }
+
+  // --- read: happy path + empty state ---
+
+  @Test
+  void shouldReturnEmptyResponseWhenNoTargetExists() {
+    // given
+    when(repository.getByKey(TENANT, PROCESS_KEY)).thenReturn(Optional.empty());
+
+    // when
+    final BusinessValueTargetResponseDto response = service.readTarget(USER, TENANT, PROCESS_KEY);
+
+    // then
+    assertThat(response.tenantId()).isEqualTo(TENANT);
+    assertThat(response.processKey()).isEqualTo(PROCESS_KEY);
+    assertThat(response.cycleTimeTarget()).isNull();
+    assertThat(response.automationRateTargetPct()).isNull();
+    assertThat(response.updatedAt()).isNull();
+    assertThat(response.updatedBy()).isNull();
+  }
+
+  @Test
+  void shouldMapPersistedTargetIntoResponseWithComputedMillis() {
+    // given
+    final OffsetDateTime updated = OffsetDateTime.parse("2026-08-01T00:00:00Z");
+    when(repository.getByKey(TENANT, PROCESS_KEY))
+        .thenReturn(
+            Optional.of(
+                new BusinessValueTargetDto(
+                    PROCESS_KEY, TENANT, 28_800_000L, TargetValueUnit.HOURS, 85, updated, "u")));
+
+    // when
+    final BusinessValueTargetResponseDto response = service.readTarget(USER, TENANT, PROCESS_KEY);
+
+    // then
+    assertThat(response.cycleTimeTarget())
+        .isEqualTo(new CycleTimeTargetDto(8L, TargetValueUnit.HOURS, 28_800_000L));
+    assertThat(response.automationRateTargetPct()).isEqualTo(85);
+    assertThat(response.updatedAt()).isEqualTo(updated);
+    assertThat(response.updatedBy()).isEqualTo("u");
+  }
+
+  // --- upsert: happy path ---
+
+  @Test
+  void shouldPersistUpsertAndReturnResponse() {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(2L, TargetValueUnit.DAYS, null), 90);
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        service.upsertTarget(USER, TENANT, PROCESS_KEY, request);
+
+    // then — writer received the flat persistence DTO with converted millis
+    final ArgumentCaptor<BusinessValueTargetDto> writeCaptor =
+        ArgumentCaptor.forClass(BusinessValueTargetDto.class);
+    verify(writer).upsertTarget(writeCaptor.capture());
+    final BusinessValueTargetDto written = writeCaptor.getValue();
+    assertThat(written.getTenantId()).isEqualTo(TENANT);
+    assertThat(written.getProcessDefinitionKey()).isEqualTo(PROCESS_KEY);
+    assertThat(written.getCycleTimeTargetMillis()).isEqualTo(172_800_000L);
+    assertThat(written.getCycleTimeTargetUnit()).isEqualTo(TargetValueUnit.DAYS);
+    assertThat(written.getAutomationRateTargetPct()).isEqualTo(90);
+    assertThat(written.getUpdatedBy()).isEqualTo(USER);
+    assertThat(written.getUpdatedAt()).isNotNull();
+
+    // and — response echoes the written state
+    assertThat(response.cycleTimeTarget().millis()).isEqualTo(172_800_000L);
+    assertThat(response.automationRateTargetPct()).isEqualTo(90);
+  }
+
+  // --- upsert: clear semantics ---
+
+  @Test
+  void shouldTreatAllNullNestedCycleTimeAsClear() {
+    // given — {value:null, unit:null} previously slipped past the both-or-neither check and NPE'd
+    // in toMillis. Must be treated as an equivalent clear operation.
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(new CycleTimeTargetDto(null, null, null), 85);
+
+    // when
+    service.upsertTarget(USER, TENANT, PROCESS_KEY, request);
+
+    // then
+    final ArgumentCaptor<BusinessValueTargetDto> writeCaptor =
+        ArgumentCaptor.forClass(BusinessValueTargetDto.class);
+    verify(writer).upsertTarget(writeCaptor.capture());
+    assertThat(writeCaptor.getValue().getCycleTimeTargetMillis()).isNull();
+    assertThat(writeCaptor.getValue().getCycleTimeTargetUnit()).isNull();
+    assertThat(writeCaptor.getValue().getAutomationRateTargetPct()).isEqualTo(85);
+  }
+
+  @Test
+  void shouldAllowClearingBothTargetsWithNullBody() {
+    // given
+    final BusinessValueTargetUpsertRequestDto clear =
+        new BusinessValueTargetUpsertRequestDto(null, null);
+
+    // when
+    service.upsertTarget(USER, TENANT, PROCESS_KEY, clear);
+
+    // then
+    final ArgumentCaptor<BusinessValueTargetDto> writeCaptor =
+        ArgumentCaptor.forClass(BusinessValueTargetDto.class);
+    verify(writer).upsertTarget(writeCaptor.capture());
+    assertThat(writeCaptor.getValue().getCycleTimeTargetMillis()).isNull();
+    assertThat(writeCaptor.getValue().getCycleTimeTargetUnit()).isNull();
+    assertThat(writeCaptor.getValue().getAutomationRateTargetPct()).isNull();
+  }
+
+  // --- upsert: semantic validation the service owns (Bean Validation handles range/positive) ---
+
+  @Test
+  void shouldRejectMixedValueAndUnitOnCycleTime() {
+    // given
+    final BusinessValueTargetUpsertRequestDto missingUnit =
+        new BusinessValueTargetUpsertRequestDto(new CycleTimeTargetDto(8L, null, null), null);
+
+    // when + then
+    assertThatThrownBy(() -> service.upsertTarget(USER, TENANT, PROCESS_KEY, missingUnit))
+        .isInstanceOf(BadRequestException.class);
+    verifyNoInteractions(writer);
+  }
+
+  @Test
+  void shouldRejectUnsupportedCycleTimeUnit() {
+    // given — WEEKS is a valid TargetValueUnit but outside the supported subset
+    final BusinessValueTargetUpsertRequestDto weeks =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(1L, TargetValueUnit.WEEKS, null), null);
+
+    // when + then
+    assertThatThrownBy(() -> service.upsertTarget(USER, TENANT, PROCESS_KEY, weeks))
+        .isInstanceOf(BadRequestException.class);
+    verifyNoInteractions(writer);
+  }
+
+  @Test
+  void shouldRejectOverflowingCycleTimeConversion() {
+    // given
+    final BusinessValueTargetUpsertRequestDto huge =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(Long.MAX_VALUE, TargetValueUnit.DAYS, null), null);
+
+    // when + then
+    assertThatThrownBy(() -> service.upsertTarget(USER, TENANT, PROCESS_KEY, huge))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("overflow");
+    verifyNoInteractions(writer);
+  }
+
+  // --- upsert: definition existence guard ---
+
+  @Test
+  void shouldReturnNotFoundWhenDefinitionMissing() {
+    // given
+    when(definitionService.getProcessDefinitionWithTenants("ghost")).thenReturn(Optional.empty());
+
+    // when + then
+    assertThatThrownBy(
+            () ->
+                service.upsertTarget(
+                    USER, TENANT, "ghost", new BusinessValueTargetUpsertRequestDto(null, 50)))
+        .isInstanceOf(NotFoundException.class);
+    verifyNoInteractions(writer);
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenDefinitionExistsButNotForCallerTenant() {
+    // given — definition exists but only under a different tenant
+    stubDefinitionExists(PROCESS_KEY, "other-tenant");
+
+    // when + then
+    assertThatThrownBy(
+            () ->
+                service.upsertTarget(
+                    USER, TENANT, PROCESS_KEY, new BusinessValueTargetUpsertRequestDto(null, 50)))
+        .isInstanceOf(NotFoundException.class);
+    verifyNoInteractions(writer);
+  }
+
+  // --- upsert: tenant-authorization guard ---
+
+  @Test
+  void shouldForbidReadWhenTenantNotAuthorized() {
+    // given
+    when(tenantService.isAuthorizedToSeeTenant(USER, TENANT)).thenReturn(false);
+
+    // when + then
+    assertThatThrownBy(() -> service.readTarget(USER, TENANT, PROCESS_KEY))
+        .isInstanceOf(ForbiddenException.class);
+    verify(repository, never()).getByKey(anyString(), anyString());
+  }
+
+  @Test
+  void shouldForbidUpsertWhenTenantNotAuthorized() {
+    // given
+    when(tenantService.isAuthorizedToSeeTenant(USER, TENANT)).thenReturn(false);
+
+    // when + then
+    assertThatThrownBy(
+            () ->
+                service.upsertTarget(
+                    USER, TENANT, PROCESS_KEY, new BusinessValueTargetUpsertRequestDto(null, 50)))
+        .isInstanceOf(ForbiddenException.class);
+    verifyNoInteractions(writer);
+    verify(definitionService, never()).getProcessDefinitionWithTenants(any());
+  }
+
+  // --- upsert: special-character tenant IDs and process definition keys reach the service intact.
+  // Beans below prove the service layer is transparent to the string content (the URL-decoding
+  // step lives in the controller / servlet stack, exercised by the REST-layer test).
+
+  @ParameterizedTest(name = "shouldUpsertForSpecialTenantId[{0}]")
+  @ValueSource(
+      strings = {
+        "<default>",
+        "tenant-with-hyphens",
+        "tenant_with_underscores",
+        "tenant.with.dots",
+        "Mixed-Case_Tenant.01"
+      })
+  void shouldUpsertForSpecialTenantId(final String specialTenant) {
+    // given
+    stubDefinitionExists(PROCESS_KEY, specialTenant);
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(1L, TargetValueUnit.HOURS, null), 50);
+
+    // when
+    service.upsertTarget(USER, specialTenant, PROCESS_KEY, request);
+
+    // then
+    final ArgumentCaptor<BusinessValueTargetDto> writeCaptor =
+        ArgumentCaptor.forClass(BusinessValueTargetDto.class);
+    verify(writer).upsertTarget(writeCaptor.capture());
+    assertThat(writeCaptor.getValue().getTenantId()).isEqualTo(specialTenant);
+  }
+
+  @ParameterizedTest(name = "shouldUpsertForSpecialProcessDefinitionKey[{0}]")
+  @ValueSource(
+      strings = {
+        "invoice-automation",
+        "invoice_automation",
+        "com.acme.invoice",
+        "Order-01",
+      })
+  void shouldUpsertForSpecialProcessDefinitionKey(final String specialKey) {
+    // given
+    stubDefinitionExists(specialKey, TENANT);
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(null, 25);
+
+    // when
+    service.upsertTarget(USER, TENANT, specialKey, request);
+
+    // then
+    final ArgumentCaptor<BusinessValueTargetDto> writeCaptor =
+        ArgumentCaptor.forClass(BusinessValueTargetDto.class);
+    verify(writer).upsertTarget(writeCaptor.capture());
+    assertThat(writeCaptor.getValue().getProcessDefinitionKey()).isEqualTo(specialKey);
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueTargetResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueTargetResponseDto.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.businessvalue;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Response body for {@code GET /business-value/targets/{processDefinitionKey}?tenantId=…} and its
+ * {@code PUT} counterpart. When no target document exists yet for the pair, every nullable field is
+ * {@code null} and callers still receive a fully-populated {@code tenantId} + {@code processKey}
+ * echo of their request.
+ */
+public record BusinessValueTargetResponseDto(
+    String tenantId,
+    String processKey,
+    CycleTimeTargetDto cycleTimeTarget,
+    Integer automationRateTargetPct,
+    OffsetDateTime updatedAt,
+    String updatedBy) {}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueTargetUpsertRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/BusinessValueTargetUpsertRequestDto.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.businessvalue;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+/**
+ * Request body for {@code PUT /business-value/targets/{tenantId}/{processKey}}. Either field may be
+ * {@code null} — that clears the corresponding KPI's target. Both being {@code null} is a valid
+ * "clear both" upsert.
+ *
+ * <p>Unknown top-level properties (notably a future {@code volumeTarget}) are silently dropped by
+ * Optimize's shared {@code ObjectMapper} configuration, matching the codebase convention for every
+ * other REST body — no per-DTO strict-mode override.
+ */
+public record BusinessValueTargetUpsertRequestDto(
+    @Valid CycleTimeTargetDto cycleTimeTarget,
+    @Min(value = 0, message = "automationRateTargetPct must be within [0, 100]")
+        @Max(value = 100, message = "automationRateTargetPct must be within [0, 100]")
+        Integer automationRateTargetPct) {}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/CycleTimeTargetDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/businessvalue/CycleTimeTargetDto.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.businessvalue;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import jakarta.validation.constraints.PositiveOrZero;
+
+/**
+ * Shared nested shape for a cycle-time target on the REST surface. Requests carry {@code value} and
+ * {@code unit}; the server recomputes {@code millis} from those and echoes all three on the
+ * response so the frontend can pass the native-unit value straight into the verdict function
+ * without duplicating the unit-conversion table.
+ *
+ * <p>Any {@code millis} value sent on a request body is ignored — the pair {@code (value, unit)} is
+ * the source of truth on writes.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CycleTimeTargetDto(
+    @PositiveOrZero(message = "cycleTimeTarget.value must be non-negative") Long value,
+    TargetValueUnit unit,
+    Long millis) {}


### PR DESCRIPTION
## What

Adds the two BVD target REST endpoints on Optimize:

- `GET /business-value/targets/{tenantId}/{processDefinitionKey}` — pre-fills the modal; returns an all-null response when no doc exists.
- `PUT /business-value/targets/{tenantId}/{processDefinitionKey}` — upserts and then synchronously recomputes the overview index for that `(tenant, process)` pair across all 4 range presets (`7d`, `30d`, `3m`, `6m`).

Rejects `volumeTarget` in the PUT body with `400` (v1 descope guard). Gates both endpoints with `TenantService.isAuthorizedToSeeTenant` — `403` when the caller cannot see the tenant on the path.

## Why

The target index shipped in M2.1 has no HTTP surface. Without the recompute-on-write chain, a modal save is invisible on `/overview` until the next scheduler tick (up to 24h for 7d/30d, up to 7d for 3m/6m). This closes that coherence gap so "Apply now → next render reflects it" holds regardless of which range the FE requests next.

Path carries `{tenantId}` (design §2.3a) — the M2.1 doc id already keys by `{tenantId}::{processDefinitionKey}`, and same-BPMN-id-across-tenants would silently overwrite otherwise.

Closes camunda/camunda-hub#27018.

Stacked on #27021 (M2.5 read handler) which brings in the M2.4 compute service this PR depends on.

## How to verify

- [ ] Unit tests pass: `./mvnw -f optimize/pom.xml test -pl backend -Dtest='BusinessValueTargetServiceTest,BusinessValueTargetRestServiceTest' -DskipITs -DskipTests=false`
- [ ] Service IT passes on CI: `BusinessValueTargetServiceIT` — round-trip GET/PUT, 4-row overview recompute proven searchable before PUT response, tenant-authz denial.
- [ ] Manual (optional): run Optimize locally, `PUT /business-value/targets/<default>/invoice-automation` with `{ "cycleTimeTarget": { "value": 8, "unit": "hours" }, "automationRateTargetPct": 85 }`, then `GET /business-value/overview?range=30d` — the row for `invoice-automation` should carry the new target with no scheduler-tick wait.
- [ ] `volumeTarget` in the PUT body returns `400` (via `JsonExceptionMapper` + `@JsonIgnoreProperties(ignoreUnknown = false)` on the request DTO).
