### PR TITLE
Restore response alignments

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -472,17 +472,75 @@ components:
 
     ClusterRestoreOperation:
       description: >-
-        A single operation that is part of a restore. Which of the optional properties are reported
-        depends on the operation: partition operations carry `partitionId`, the operation that
-        restores a partition also carries the `backupIds` it restores from, and the operations that
-        return the broker to processing carry `mode`.
+        A single operation that is part of a restore. Every operation names the broker that applies
+        it; the rest of its properties depend on what the operation does, so it is reported as one
+        of the variants below, distinguished by `operation`. A property a variant does not declare
+        is absent from the response rather than reported as null.
+      discriminator:
+        propertyName: operation
+        mapping:
+          PartitionPreRestoreOperation: '#/components/schemas/ClusterRestorePartitionOperation'
+          PartitionRestoreOperation: '#/components/schemas/ClusterRestorePartitionRestoreOperation'
+          ModeChangeOperation: '#/components/schemas/ClusterRestoreModeChangeOperation'
+          AwaitModeChangeOperation: '#/components/schemas/ClusterRestoreAwaitModeChangeOperation'
+          UpdateIncarnationNumberOperation: '#/components/schemas/ClusterRestoreBrokerOperation'
+      oneOf:
+        - $ref: '#/components/schemas/ClusterRestoreBrokerOperation'
+        - $ref: '#/components/schemas/ClusterRestorePartitionOperation'
+        - $ref: '#/components/schemas/ClusterRestorePartitionRestoreOperation'
+        - $ref: '#/components/schemas/ClusterRestoreModeChangeOperation'
+        - $ref: '#/components/schemas/ClusterRestoreAwaitModeChangeOperation'
+
+    ClusterRestoreBrokerOperation:
+      description: >-
+        A restore operation that applies to a broker as a whole, such as the one that updates its
+        incarnation number.
+      type: object
+      required:
+        - operation
+        - brokerId
+      properties:
+        operation:
+          description: The type of the operation.
+          type: string
+          example: UpdateIncarnationNumberOperation
+        brokerId:
+          description: The ID of the broker that applies the operation, including its zone if it belongs to one.
+          type: string
+          example: "1"
+
+    ClusterRestorePartitionOperation:
+      description: >-
+        A restore operation that targets a single partition without restoring it, such as the one
+        that prepares the partition for its restore.
+      type: object
+      required:
+        - operation
+        - brokerId
+        - partitionId
+      properties:
+        operation:
+          description: The type of the operation.
+          type: string
+          example: PartitionPreRestoreOperation
+        brokerId:
+          description: The ID of the broker that applies the operation, including its zone if it belongs to one.
+          type: string
+          example: "1"
+        partitionId:
+          description: The partition the operation applies to.
+          type: integer
+          format: int32
+          example: 1
+
+    ClusterRestorePartitionRestoreOperation:
+      description: The operation that restores a single partition from the backups resolved for it.
       type: object
       required:
         - operation
         - brokerId
         - partitionId
         - backupIds
-        - mode
       properties:
         operation:
           description: The type of the operation.
@@ -493,24 +551,58 @@ components:
           type: string
           example: "1"
         partitionId:
-          description: The partition the operation applies to; null for operations that are not partition scoped.
+          description: The partition the operation restores.
           type: integer
           format: int32
-          nullable: true
           example: 1
         backupIds:
-          description: >-
-            The IDs of the backups the partition is restored from; empty for every operation other
-            than the one that restores a partition.
+          description: The IDs of the backups the partition is restored from.
           type: array
           items:
             type: integer
             format: int64
           example: [ 100, 101 ]
-        mode:
-          description: The target mode of the operation, if applicable.
+
+    ClusterRestoreModeChangeOperation:
+      description: The operation that transitions a broker to a mode once its partitions are restored.
+      type: object
+      required:
+        - operation
+        - brokerId
+        - mode
+      properties:
+        operation:
+          description: The type of the operation.
           type: string
-          nullable: true
+          example: ModeChangeOperation
+        brokerId:
+          description: The ID of the broker that applies the operation, including its zone if it belongs to one.
+          type: string
+          example: "1"
+        mode:
+          description: The mode the broker is transitioned to.
+          type: string
+          example: PROCESSING
+
+    ClusterRestoreAwaitModeChangeOperation:
+      description: The operation that awaits the transition of a broker to a mode.
+      type: object
+      required:
+        - operation
+        - brokerId
+        - mode
+      properties:
+        operation:
+          description: The type of the operation.
+          type: string
+          example: AwaitModeChangeOperation
+        brokerId:
+          description: The ID of the broker that applies the operation, including its zone if it belongs to one.
+          type: string
+          example: "1"
+        mode:
+          description: The mode the broker is awaited to have transitioned to.
+          type: string
           example: PROCESSING
 
     RestoreRequest:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
@@ -12,7 +12,12 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
 import io.camunda.gateway.protocol.model.ClusterModeChangePlannedChange;
 import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
+import io.camunda.gateway.protocol.model.ClusterRestoreAwaitModeChangeOperation;
+import io.camunda.gateway.protocol.model.ClusterRestoreBrokerOperation;
+import io.camunda.gateway.protocol.model.ClusterRestoreModeChangeOperation;
 import io.camunda.gateway.protocol.model.ClusterRestoreOperation;
+import io.camunda.gateway.protocol.model.ClusterRestorePartitionOperation;
+import io.camunda.gateway.protocol.model.ClusterRestorePartitionRestoreOperation;
 import io.camunda.gateway.protocol.model.ClusterRestorePlannedChange;
 import io.camunda.gateway.protocol.model.ClusterRestoreResponse;
 import io.camunda.service.exception.ServiceException;
@@ -22,7 +27,7 @@ import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
@@ -148,26 +153,45 @@ final class ClusterModeChangeMapper {
 
   /**
    * Reports the operation with the detail a restore plan is reviewed by: which broker applies it,
-   * which partition it targets, and which backups that partition is restored from. Properties that
-   * the operation does not carry are left null.
+   * plus what the operation itself carries — the partition it targets, the backups that partition
+   * is restored from, or the mode the broker is transitioned to. Each kind is reported as its own
+   * variant, so a property the operation does not carry is absent rather than null.
    */
   private static ClusterRestoreOperation toClusterRestoreOperation(
       final ClusterConfigurationChangeOperation operation) {
-    final @Nullable Integer partitionId =
-        operation instanceof final PartitionChangeOperation partitionChange
-            ? partitionChange.partitionId()
-            : null;
-    final List<Long> backupIds =
-        operation instanceof final PartitionRestoreOperation restore
-            ? List.copyOf(restore.backupIds())
-            : List.of();
-    return ClusterRestoreOperation.Builder.create()
-        .operation(operation.getClass().getSimpleName())
-        .brokerId(operation.brokerId())
-        .partitionId(partitionId)
-        .backupIds(backupIds)
-        .mode(modeOf(operation))
-        .build();
+    final var type = operation.getClass().getSimpleName();
+    return switch (operation) {
+      case final PartitionRestoreOperation restore ->
+          ClusterRestorePartitionRestoreOperation.Builder.create()
+              .operation(type)
+              .brokerId(restore.brokerId())
+              .partitionId(restore.partitionId())
+              .backupIds(List.copyOf(restore.backupIds()))
+              .build();
+      case final PartitionPreRestoreOperation preRestore ->
+          ClusterRestorePartitionOperation.Builder.create()
+              .operation(type)
+              .brokerId(preRestore.brokerId())
+              .partitionId(preRestore.partitionId())
+              .build();
+      case final ModeChangeOperation modeChange ->
+          ClusterRestoreModeChangeOperation.Builder.create()
+              .operation(type)
+              .brokerId(modeChange.brokerId())
+              .mode(modeChange.mode().name())
+              .build();
+      case final AwaitModeChangeOperation awaitModeChange ->
+          ClusterRestoreAwaitModeChangeOperation.Builder.create()
+              .operation(type)
+              .brokerId(awaitModeChange.brokerId())
+              .mode(awaitModeChange.mode().name())
+              .build();
+      default ->
+          ClusterRestoreBrokerOperation.Builder.create()
+              .operation(type)
+              .brokerId(operation.brokerId())
+              .build();
+    };
   }
 
   private static @Nullable String modeOf(final ClusterConfigurationChangeOperation operation) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -22,9 +22,11 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
@@ -316,9 +318,9 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReportTheBackupsEveryPlannedPartitionRestoreRestoresFrom() {
+  void shouldReportEachPlannedRestoreOperationWithOnlyThePropertiesItCarries() {
     // given — the plan a restore produces: a partition is pre-restored, restored from its backups,
-    // and the broker is returned to processing
+    // the broker is returned to processing, and its incarnation number is updated
     final var broker = MemberId.from("1");
     when(clusterRecoveryServices.restore(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean()))
@@ -334,9 +336,13 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
                                     new PartitionPreRestoreOperation(broker, 1),
                                     new PartitionRestoreOperation(
                                         broker, 1, new TreeSet<>(List.of(100L, 101L))),
-                                    new ModeChangeOperation(broker, Mode.PROCESSING))))))));
+                                    new ModeChangeOperation(broker, Mode.PROCESSING),
+                                    new AwaitModeChangeOperation(broker, Mode.PROCESSING),
+                                    new UpdateIncarnationNumberOperation(broker))))))));
 
-    // when / then — an operator reviewing the plan can see which backups land on which partition
+    // when / then — an operator reviewing the plan sees which backups land on which partition, and
+    // each operation reports only what it carries: no null partition on a mode change, no empty
+    // backups on an operation that restores nothing
     webClient
         .post()
         .uri(RESTORE_URL + "?dryRun=true")
@@ -357,23 +363,27 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
                     {
                       "operation": "PartitionPreRestoreOperation",
                       "brokerId": "1",
-                      "partitionId": 1,
-                      "backupIds": [ ],
-                      "mode": null
+                      "partitionId": 1
                     },
                     {
                       "operation": "PartitionRestoreOperation",
                       "brokerId": "1",
                       "partitionId": 1,
-                      "backupIds": [ 100, 101 ],
-                      "mode": null
+                      "backupIds": [ 100, 101 ]
                     },
                     {
                       "operation": "ModeChangeOperation",
                       "brokerId": "1",
-                      "partitionId": null,
-                      "backupIds": [ ],
                       "mode": "PROCESSING"
+                    },
+                    {
+                      "operation": "AwaitModeChangeOperation",
+                      "brokerId": "1",
+                      "mode": "PROCESSING"
+                    },
+                    {
+                      "operation": "UpdateIncarnationNumberOperation",
+                      "brokerId": "1"
                     }
                   ]
                 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Proper response mapping for restore procedure. Return mapped distinct operations so as to avoid having `nulls` and empty arrays listed in all responses.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #60053
