### PR TITLE
deps: bump hardened and public base image digests (stable/optimize-8.7)

### DIFF
--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -4,13 +4,13 @@
 # see https://docs.docker.com/build/buildkit/#getting-started
 
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:56a15823bfdee9bf1bf166488f835d01f93b44aa7d3cf44127f1016462889269"
+ARG BASE_DIGEST="sha256:a99ec526ee35aff020694da8a4067cacda5e19a0958e0f106521eb5d120f3ac7"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
 ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:420374e45e8e9dce3057e768c87a3e8ba58e815049511d8df95ca88a041ec82b"
+ARG BASE_DIGEST_PUBLIC="sha256:ca397720325ceefe39ce397f186759fc87d9efafb2dc4ce53315980844c2f4f2"
 ARG BASE="hardened"
 
 # set to "build" to build camunda from scratch instead of using a distball

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:56a15823bfdee9bf1bf166488f835d01f93b44aa7d3cf44127f1016462889269"
+ARG BASE_DIGEST="sha256:a99ec526ee35aff020694da8a4067cacda5e19a0958e0f106521eb5d120f3ac7"
 ARG WAITFORIT_CHECKSUM="b7a04f38de1e51e7455ecf63151c8c7e405bd2d45a2d4e16f6419db737a125d6"
 
 # If you don't have access to Minimus hardened base images, you can use public


### PR DESCRIPTION
## Description

Bumps the pinned `openjre-base-compat:21-dev` digest in `camunda.Dockerfile` and `optimize.Dockerfile`, and the `eclipse-temurin:21-jre-noble` public fallback digest in `camunda.Dockerfile`, to the latest available builds.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

none