### PR TITLE
feat: physical-tenant-aware exporters actuator endpoint

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -1101,6 +1101,36 @@ final class ClusterApiUtils {
     return config;
   }
 
+  /**
+   * Aggregates the exporter state of every physical tenant, or of {@code physicalTenant} alone when
+   * given. Exporter configuration is per physical tenant, so an exporter id may exist in some
+   * tenants only and the same id can be in different states in each of them; each tenant is
+   * therefore aggregated on its own and reported as its own entry, tagged with {@code
+   * physicalTenant}, rather than reduced across tenants into one status that belongs to none of
+   * them. Entries are grouped by tenant, tenants in ascending id order.
+   *
+   * <p>The tag is omitted for an unscoped request against a single-tenant cluster, so a caller that
+   * predates physical tenants keeps exactly the response it always had. Every other shape carries
+   * it — without it an unscoped multi-tenant response would list the same exporter id repeatedly
+   * with no way to tell the entries apart, and a scoped response repeating the requested id is the
+   * same trade-off {@code GET /cluster?physicalTenant=} already makes for {@code physicalTenants}.
+   */
+  static List<ExporterStatus> aggregateExporterState(
+      final CurrentClusterConfiguration configuration, final @Nullable String physicalTenant) {
+    final List<String> tenantsInView =
+        physicalTenant == null
+            ? configuration.partitionGroups().keySet().stream().sorted().toList()
+            : List.of(physicalTenant);
+    final boolean tagWithPhysicalTenant = physicalTenant != null || tenantsInView.size() > 1;
+
+    return tenantsInView.stream()
+        .flatMap(
+            tenant ->
+                aggregateExporterState(configuration.toLegacy(tenant)).stream()
+                    .map(status -> tagWithPhysicalTenant ? status.physicalTenant(tenant) : status))
+        .toList();
+  }
+
   static List<ExporterStatus> aggregateExporterState(
       final ClusterConfiguration clusterConfiguration) {
     // Map of ExporterId => List of ExporterState (each item corresponds to a partition)

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -1109,11 +1109,10 @@ final class ClusterApiUtils {
    * physicalTenant}, rather than reduced across tenants into one status that belongs to none of
    * them. Entries are grouped by tenant, tenants in ascending id order.
    *
-   * <p>The tag is omitted for an unscoped request against a single-tenant cluster, so a caller that
-   * predates physical tenants keeps exactly the response it always had. Every other shape carries
-   * it — without it an unscoped multi-tenant response would list the same exporter id repeatedly
-   * with no way to tell the entries apart, and a scoped response repeating the requested id is the
-   * same trade-off {@code GET /cluster?physicalTenant=} already makes for {@code physicalTenants}.
+   * <p>Every entry carries the tag, including a single-tenant cluster's — where it reads {@code
+   * default} — so the field means the same thing in every response instead of being present only
+   * when a caller could have deduced it anyway. This stays backwards compatible because the field
+   * is not required: a client that predates physical tenants ignores it.
    */
   static List<ExporterStatus> aggregateExporterState(
       final CurrentClusterConfiguration configuration, final @Nullable String physicalTenant) {
@@ -1121,13 +1120,12 @@ final class ClusterApiUtils {
         physicalTenant == null
             ? configuration.partitionGroups().keySet().stream().sorted().toList()
             : List.of(physicalTenant);
-    final boolean tagWithPhysicalTenant = physicalTenant != null || tenantsInView.size() > 1;
 
     return tenantsInView.stream()
         .flatMap(
             tenant ->
                 aggregateExporterState(configuration.toLegacy(tenant)).stream()
-                    .map(status -> tagWithPhysicalTenant ? status.physicalTenant(tenant) : status))
+                    .map(status -> status.physicalTenant(tenant)))
         .toList();
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.ResponseEntity;
@@ -39,38 +40,56 @@ public class ExportersEndpoint {
     this.requestSender = requestSender;
   }
 
+  /**
+   * Disables an exporter. Without a {@code physicalTenant} query parameter, the exporter is
+   * disabled in every physical tenant that has it configured, keeping the whole-cluster meaning the
+   * operation always had. With the parameter, only the given physical tenant is affected.
+   */
   @PostMapping(path = "/{exporterId}/disable")
   public CompletableFuture<ResponseEntity<?>> disableExporter(
       @PathVariable("exporterId") final String exporterId,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
 
     return requestSender
-        .disableExporter(new ExporterDisableRequest(exporterId, Optional.empty(), dryRun))
+        .disableExporter(new ExporterDisableRequest(exporterId, nonBlank(physicalTenant), dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }
 
+  /**
+   * Enables an exporter. Without a {@code physicalTenant} query parameter, the exporter is enabled
+   * in every physical tenant, keeping the whole-cluster meaning the operation always had. With the
+   * parameter, only the given physical tenant is affected.
+   */
   @PostMapping(path = "/{exporterId}/enable")
   public CompletableFuture<ResponseEntity<?>> enableExporter(
       @PathVariable("exporterId") final String exporterId,
       @RequestBody(required = false) final InitializationInfo initializeInfo,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
     return requestSender
         .enableExporter(
             new ExporterEnableRequest(
                 exporterId,
                 Optional.ofNullable(initializeInfo).map(InitializationInfo::initializeFrom),
-                Optional.empty(),
+                nonBlank(physicalTenant),
                 dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }
 
+  /**
+   * Deletes an exporter. Without a {@code physicalTenant} query parameter, the exporter is deleted
+   * from every physical tenant that has it configured, keeping the whole-cluster meaning the
+   * operation always had. With the parameter, only the given physical tenant is affected.
+   */
   @DeleteMapping(path = "/{exporterId}")
   public CompletableFuture<ResponseEntity<?>> deleteExporter(
       @PathVariable("exporterId") final String exporterId,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
 
     return requestSender
-        .deleteExporter(new ExporterDeleteRequest(exporterId, Optional.empty(), dryRun))
+        .deleteExporter(new ExporterDeleteRequest(exporterId, nonBlank(physicalTenant), dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }
 
@@ -93,6 +112,10 @@ public class ExportersEndpoint {
     }
 
     return ResponseEntity.status(200).body(ClusterApiUtils.aggregateExporterState(response.get()));
+  }
+
+  private static Optional<String> nonBlank(final @Nullable String value) {
+    return Optional.ofNullable(value).filter(s -> !s.isBlank());
   }
 
   private record InitializationInfo(String initializeFrom) {}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
@@ -93,16 +93,25 @@ public class ExportersEndpoint {
         .handle(ClusterApiUtils::mapOperationResponse);
   }
 
+  /**
+   * Lists the exporters of every physical tenant, grouped by tenant, or of the one named by the
+   * {@code physicalTenant} query parameter. Each entry carries the tenant it belongs to, except for
+   * an unscoped request against a single-tenant cluster, which keeps the response shape that
+   * predates physical tenants — see {@link ClusterApiUtils#aggregateExporterState}.
+   */
   @GetMapping(produces = "application/json")
-  public CompletableFuture<ResponseEntity<?>> listExporters() {
+  public CompletableFuture<ResponseEntity<?>> listExporters(
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
+    final var tenant = nonBlank(physicalTenant);
     return requestSender
         .getTopology()
-        .thenApply(result -> result.map(CurrentClusterConfiguration::toLegacyDefault))
-        .handle(this::mapQueryResponse);
+        .handle((response, throwable) -> mapQueryResponse(tenant, response, throwable));
   }
 
   private ResponseEntity<?> mapQueryResponse(
-      final Either<ErrorResponse, ClusterConfiguration> response, final Throwable throwable) {
+      final Optional<String> physicalTenant,
+      final Either<ErrorResponse, CurrentClusterConfiguration> response,
+      final Throwable throwable) {
     if (throwable != null) {
       return ClusterApiUtils.mapError(throwable);
     }
@@ -111,7 +120,21 @@ public class ExportersEndpoint {
       return ClusterApiUtils.mapErrorResponse(response.getLeft());
     }
 
-    return ResponseEntity.status(200).body(ClusterApiUtils.aggregateExporterState(response.get()));
+    final var configuration = response.get();
+    // an uninitialized configuration has no partition groups yet (broker startup, or right after a
+    // restore), so absence there means "not bootstrapped", not "unknown tenant" - reporting an
+    // empty exporter list is then more truthful than a 404 on a tenant that is merely not up yet.
+    if (physicalTenant.isPresent()
+        && !configuration.isUninitialized()
+        && !configuration.hasPartitionGroup(physicalTenant.get())) {
+      return ClusterApiUtils.mapErrorResponse(
+          new ErrorResponse(
+              ErrorCode.NOT_FOUND,
+              "Physical tenant '" + physicalTenant.get() + "' does not exist"));
+    }
+
+    return ResponseEntity.status(200)
+        .body(ClusterApiUtils.aggregateExporterState(configuration, physicalTenant.orElse(null)));
   }
 
   private static Optional<String> nonBlank(final @Nullable String value) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -95,9 +95,8 @@ public class ExportersEndpoint {
 
   /**
    * Lists the exporters of every physical tenant, grouped by tenant, or of the one named by the
-   * {@code physicalTenant} query parameter. Each entry carries the tenant it belongs to, except for
-   * an unscoped request against a single-tenant cluster, which keeps the response shape that
-   * predates physical tenants — see {@link ClusterApiUtils#aggregateExporterState}.
+   * {@code physicalTenant} query parameter. Each entry names the tenant it belongs to — see {@link
+   * ClusterApiUtils#aggregateExporterState}.
    */
   @GetMapping(produces = "application/json")
   public CompletableFuture<ResponseEntity<?>> listExporters(

--- a/dist/src/main/resources/api/cluster/exporter-api.yaml
+++ b/dist/src/main/resources/api/cluster/exporter-api.yaml
@@ -18,9 +18,13 @@ paths:
   /{exporterId}/disable:
     post:
       summary: Disable an exporter
-      description: Disable the exporter with the given exporterId. After the exporter is disabled, the records are not exported to this exporter anymore.
+      description: >
+        Disable the exporter with the given exporterId. After the exporter is disabled, the records are not exported to this exporter anymore.
+        Without the physicalTenant parameter the exporter is disabled in every physical tenant that has it configured;
+        with it, only the given physical tenant is affected.
       parameters:
         - $ref: '#/components/parameters/ExporterId'
+        - $ref: '#/components/parameters/PhysicalTenantParameter'
       responses:
         '202':
           $ref: "#/components/responses/ExporterOperationResponse"
@@ -37,10 +41,14 @@ paths:
 
   /{exporterId}/enable:
     summary: Enable an exporter
-    description: Enable the exporter with the given exporterId. After the exporter is enabled, the records are exported to this exporter.
+    description: >
+      Enable the exporter with the given exporterId. After the exporter is enabled, the records are exported to this exporter.
+      Without the physicalTenant parameter the exporter is enabled in every physical tenant;
+      with it, only the given physical tenant is affected.
     post:
       parameters:
         - $ref: '#/components/parameters/ExporterId'
+        - $ref: '#/components/parameters/PhysicalTenantParameter'
       requestBody:
         required: false
         content:
@@ -64,9 +72,13 @@ paths:
   /{exporterId}:
     delete:
       summary: Delete an exporter
-      description: Delete the exporter with the given exporterId. This will remove the exporter configuration and stop all export operations for this exporter.
+      description: >
+        Delete the exporter with the given exporterId. This will remove the exporter configuration and stop all export operations for this exporter.
+        Without the physicalTenant parameter the exporter is deleted from every physical tenant that has it configured;
+        with it, only the given physical tenant is affected.
       parameters:
         - $ref: '#/components/parameters/ExporterId'
+        - $ref: '#/components/parameters/PhysicalTenantParameter'
       responses:
         '202':
           $ref: "#/components/responses/ExporterOperationResponse"
@@ -101,6 +113,15 @@ components:
       description: Id of the exporter
       schema:
         $ref: 'components.yaml#/schemas/ExporterId'
+
+    PhysicalTenantParameter:
+      name: physicalTenant
+      description: Id of the physical tenant to target. If not specified, the operation applies to all physical tenants.
+      in: query
+      style: form
+      required: false
+      schema:
+        $ref: 'components.yaml#/schemas/PhysicalTenantId'
 
   responses:
     ExporterOperationResponse:

--- a/dist/src/main/resources/api/cluster/exporter-api.yaml
+++ b/dist/src/main/resources/api/cluster/exporter-api.yaml
@@ -100,8 +100,8 @@ paths:
         List all exporters and their status whether they are enabled or disabled.
         Exporters are configured per physical tenant, so the same exporter id may exist in some
         tenants only and may be in a different state in each of them. Without the physicalTenant
-        parameter every physical tenant is listed, grouped by tenant and each entry tagged with the
-        tenant it belongs to; with it, only the given physical tenant is listed.
+        parameter every physical tenant is listed, grouped by tenant; with it, only the given
+        physical tenant is listed. Every entry names the physical tenant it belongs to either way.
       parameters:
         - $ref: '#/components/parameters/PhysicalTenantParameter'
       responses:
@@ -169,8 +169,9 @@ components:
           example: "ENABLED"
         physicalTenant:
           description: >
-            The physical tenant this status belongs to. Absent only for an unscoped request against
-            a single-tenant cluster, which keeps the response shape that predates physical tenants.
+            The physical tenant this status belongs to. Always present, including on a single-tenant
+            cluster, where it reads "default". Not required, so a client that predates physical
+            tenants can ignore it.
           allOf:
             - $ref: 'components.yaml#/schemas/PhysicalTenantId'
 

--- a/dist/src/main/resources/api/cluster/exporter-api.yaml
+++ b/dist/src/main/resources/api/cluster/exporter-api.yaml
@@ -96,7 +96,14 @@ paths:
   /:
     get:
       summary: List all exporters
-      description: List all exporters and their status whether they are enabled or disabled.
+      description: >
+        List all exporters and their status whether they are enabled or disabled.
+        Exporters are configured per physical tenant, so the same exporter id may exist in some
+        tenants only and may be in a different state in each of them. Without the physicalTenant
+        parameter every physical tenant is listed, grouped by tenant and each entry tagged with the
+        tenant it belongs to; with it, only the given physical tenant is listed.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantParameter'
       responses:
         '200':
           description: "List of exporters"
@@ -104,6 +111,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ExporterList"
+        '404':
+          description: "The requested physical tenant does not exist"
+          content:
+            application/json:
+              schema:
+                $ref: 'components.yaml#/schemas/Error'
 components:
   parameters:
     ExporterId:
@@ -154,6 +167,12 @@ components:
             - CONFIG_NOT_FOUND
           description: Status of the exporter
           example: "ENABLED"
+        physicalTenant:
+          description: >
+            The physical tenant this status belongs to. Absent only for an unscoped request against
+            a single-tenant cluster, which keeps the response shape that predates physical tenants.
+          allOf:
+            - $ref: 'components.yaml#/schemas/PhysicalTenantId'
 
     EnableExporterRequest:
       type: object

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -87,14 +87,17 @@ import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
 import io.camunda.zeebe.util.Either;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -113,6 +116,85 @@ final class ClusterApiUtilsTest {
 
     // then
     assertThat(result).containsExactlyInAnyOrderElementsOf(param.expectedResult());
+  }
+
+  @Test
+  void shouldOmitPhysicalTenantWhenAggregatingUnscopedForSingleTenant() {
+    // given
+    final var configuration =
+        configWithExporters(Map.of("tenant-a", Map.of("exporter-1", State.ENABLED)));
+
+    // when
+    final var result = ClusterApiUtils.aggregateExporterState(configuration, null);
+
+    // then — the response a caller that predates physical tenants always got
+    assertThat(result)
+        .containsExactly(new ExporterStatus().exporterId("exporter-1").status(StatusEnum.ENABLED));
+  }
+
+  @Test
+  void shouldAggregateEachPhysicalTenantOnItsOwnWhenAggregatingUnscoped() {
+    // given — the same exporter id is enabled in one tenant and disabled in the other, and each
+    // tenant has an exporter the other does not
+    final var configuration =
+        configWithExporters(
+            Map.of(
+                "tenant-b",
+                Map.of("shared", State.DISABLED, "only-in-b", State.ENABLED),
+                "tenant-a",
+                Map.of("shared", State.ENABLED, "only-in-a", State.DISABLED)));
+
+    // when
+    final var result = ClusterApiUtils.aggregateExporterState(configuration, null);
+
+    // then — grouped by tenant, tenants in ascending id order
+    assertThat(result)
+        .extracting(
+            ExporterStatus::getPhysicalTenant,
+            ExporterStatus::getExporterId,
+            ExporterStatus::getStatus)
+        .containsExactlyInAnyOrder(
+            tuple("tenant-a", "shared", StatusEnum.ENABLED),
+            tuple("tenant-a", "only-in-a", StatusEnum.DISABLED),
+            tuple("tenant-b", "shared", StatusEnum.DISABLED),
+            tuple("tenant-b", "only-in-b", StatusEnum.ENABLED));
+    assertThat(result).extracting(ExporterStatus::getPhysicalTenant).isSorted();
+  }
+
+  @Test
+  void shouldAggregateOnlyTheRequestedPhysicalTenant() {
+    // given
+    final var configuration =
+        configWithExporters(
+            Map.of(
+                "tenant-a",
+                Map.of("exporter-1", State.ENABLED),
+                "tenant-b",
+                Map.of("exporter-2", State.ENABLED)));
+
+    // when
+    final var result = ClusterApiUtils.aggregateExporterState(configuration, "tenant-b");
+
+    // then
+    assertThat(result)
+        .containsExactly(
+            new ExporterStatus()
+                .exporterId("exporter-2")
+                .status(StatusEnum.ENABLED)
+                .physicalTenant("tenant-b"));
+  }
+
+  @Test
+  void shouldAggregateNothingForAPhysicalTenantWithoutExporters() {
+    // given
+    final var configuration =
+        configWithExporters(Map.of("tenant-a", Map.of("exporter-1", State.ENABLED)));
+
+    // when
+    final var result = ClusterApiUtils.aggregateExporterState(configuration, "tenant-b");
+
+    // then — an unknown tenant is rejected by the endpoint, so all this needs to do is not fail
+    assertThat(result).isEmpty();
   }
 
   @ParameterizedTest
@@ -949,6 +1031,54 @@ final class ClusterApiUtilsTest {
 
   private static MemberId member(final int id) {
     return MemberId.from(String.valueOf(id));
+  }
+
+  /**
+   * A cluster configuration with one broker holding a single partition per physical tenant, each
+   * partition configured with the given exporters in the given states.
+   */
+  private static CurrentClusterConfiguration configWithExporters(
+      final Map<String, Map<String, State>> exportersPerTenant) {
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                member(1),
+                new io.camunda.zeebe.dynamic.config.state.BrokerState(
+                    0,
+                    Instant.ofEpochSecond(1),
+                    io.camunda.zeebe.dynamic.config.state.BrokerState.State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final Map<String, PartitionGroupConfiguration> groups = new HashMap<>();
+    exportersPerTenant.forEach(
+        (tenant, exporters) -> groups.put(tenant, groupWithExporters(exporters)));
+    return new CurrentClusterConfiguration(
+        1, globalConfiguration, groups, PhasedChangeState.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithExporters(
+      final Map<String, State> exporters) {
+    final var partitionConfig =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                exporters.entrySet().stream()
+                    .collect(
+                        Collectors.toMap(
+                            Entry::getKey,
+                            e -> new ExporterState(0, e.getValue(), Optional.empty())))));
+    return new PartitionGroupConfiguration(
+        1,
+        0,
+        Map.of(
+            member(1),
+            BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, partitionConfig)))),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
   }
 
   private static CurrentClusterConfiguration configWithPhasedChangeState(

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -119,17 +119,22 @@ final class ClusterApiUtilsTest {
   }
 
   @Test
-  void shouldOmitPhysicalTenantWhenAggregatingUnscopedForSingleTenant() {
+  void shouldTagPhysicalTenantWhenAggregatingUnscopedForSingleTenant() {
     // given
     final var configuration =
-        configWithExporters(Map.of("tenant-a", Map.of("exporter-1", State.ENABLED)));
+        configWithExporters(
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, Map.of("exporter-1", State.ENABLED)));
 
     // when
     final var result = ClusterApiUtils.aggregateExporterState(configuration, null);
 
-    // then — the response a caller that predates physical tenants always got
+    // then — the tag is present even though a single-tenant caller could have deduced it
     assertThat(result)
-        .containsExactly(new ExporterStatus().exporterId("exporter-1").status(StatusEnum.ENABLED));
+        .containsExactly(
+            new ExporterStatus()
+                .exporterId("exporter-1")
+                .status(StatusEnum.ENABLED)
+                .physicalTenant(CurrentClusterConfiguration.DEFAULT_GROUP));
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportersEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportersEndpointTest.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
@@ -19,12 +22,30 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.management.cluster.Error;
+import io.camunda.zeebe.management.cluster.ExporterStatus;
 import io.camunda.zeebe.util.Either;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 
 final class ExportersEndpointTest {
 
@@ -126,6 +147,110 @@ final class ExportersEndpointTest {
     // then
     verify(sender)
         .disableExporter(new ExporterDisableRequest("exporter-1", Optional.empty(), false));
+  }
+
+  @Test
+  void shouldListExportersOfEveryPhysicalTenant() {
+    // given
+    final var endpoint =
+        new ExportersEndpoint(
+            senderReportingTopology(
+                configWithExporters(Map.of("tenant-a", "exporter-1", "tenant-b", "exporter-2"))));
+
+    // when
+    final var response = endpoint.listExporters(null).join();
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(exporters(response))
+        .extracting(ExporterStatus::getPhysicalTenant, ExporterStatus::getExporterId)
+        .containsExactly(tuple("tenant-a", "exporter-1"), tuple("tenant-b", "exporter-2"));
+  }
+
+  @Test
+  void shouldListExportersOfOnlyTheGivenPhysicalTenant() {
+    // given
+    final var endpoint =
+        new ExportersEndpoint(
+            senderReportingTopology(
+                configWithExporters(Map.of("tenant-a", "exporter-1", "tenant-b", "exporter-2"))));
+
+    // when
+    final var response = endpoint.listExporters("tenant-b").join();
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(exporters(response))
+        .extracting(ExporterStatus::getPhysicalTenant, ExporterStatus::getExporterId)
+        .containsExactly(tuple("tenant-b", "exporter-2"));
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenant() {
+    // given
+    final var endpoint =
+        new ExportersEndpoint(
+            senderReportingTopology(configWithExporters(Map.of("tenant-a", "exporter-1"))));
+
+    // when
+    final var response = endpoint.listExporters("tenant-c").join();
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(404);
+    assertThat(response.getBody())
+        .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
+        .extracting(Error::getMessage)
+        .isEqualTo("Physical tenant 'tenant-c' does not exist");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<ExporterStatus> exporters(final ResponseEntity<?> response) {
+    return (List<ExporterStatus>) response.getBody();
+  }
+
+  private static ClusterConfigurationManagementRequestSender senderReportingTopology(
+      final CurrentClusterConfiguration configuration) {
+    final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+    when(sender.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(Either.right(configuration)));
+    return sender;
+  }
+
+  /** A configuration with one broker holding one enabled exporter per physical tenant. */
+  private static CurrentClusterConfiguration configWithExporters(
+      final Map<String, String> exporterPerTenant) {
+    final var member = MemberId.from("1");
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(member, new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final Map<String, PartitionGroupConfiguration> groups = new HashMap<>();
+    exporterPerTenant.forEach(
+        (tenant, exporterId) -> {
+          final var partitionConfig =
+              new DynamicPartitionConfig(
+                  new ExportingConfig(
+                      ExportingState.EXPORTING,
+                      Map.of(exporterId, new ExporterState(0, State.ENABLED, Optional.empty()))));
+          groups.put(
+              tenant,
+              new PartitionGroupConfiguration(
+                  1,
+                  0,
+                  Map.of(
+                      member,
+                      BrokerPartitionState.initialize(
+                          Map.of(1, PartitionState.active(1, partitionConfig)))),
+                  Optional.empty(),
+                  Optional.empty(),
+                  Optional.empty()));
+        });
+    return new CurrentClusterConfiguration(
+        1, globalConfiguration, groups, PhasedChangeState.empty());
   }
 
   private static ClusterConfigurationManagementRequestSender senderAcceptingExporterChanges() {

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportersEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportersEndpointTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+final class ExportersEndpointTest {
+
+  @Test
+  void shouldDisableExporterInEveryPhysicalTenantWhenParameterIsAbsent() {
+    // given
+    final var sender = senderAcceptingExporterChanges();
+    final var endpoint = new ExportersEndpoint(sender);
+
+    // when
+    endpoint.disableExporter("exporter-1", false, null).join();
+
+    // then
+    verify(sender)
+        .disableExporter(new ExporterDisableRequest("exporter-1", Optional.empty(), false));
+  }
+
+  @Test
+  void shouldDisableExporterOnlyInTheGivenPhysicalTenant() {
+    // given
+    final var sender = senderAcceptingExporterChanges();
+    final var endpoint = new ExportersEndpoint(sender);
+
+    // when
+    endpoint.disableExporter("exporter-1", true, "tenant-a").join();
+
+    // then
+    verify(sender)
+        .disableExporter(new ExporterDisableRequest("exporter-1", Optional.of("tenant-a"), true));
+  }
+
+  @Test
+  void shouldEnableExporterInEveryPhysicalTenantWhenParameterIsAbsent() {
+    // given
+    final var sender = senderAcceptingExporterChanges();
+    final var endpoint = new ExportersEndpoint(sender);
+
+    // when
+    endpoint.enableExporter("exporter-1", null, false, null).join();
+
+    // then
+    verify(sender)
+        .enableExporter(
+            new ExporterEnableRequest("exporter-1", Optional.empty(), Optional.empty(), false));
+  }
+
+  @Test
+  void shouldEnableExporterOnlyInTheGivenPhysicalTenant() {
+    // given
+    final var sender = senderAcceptingExporterChanges();
+    final var endpoint = new ExportersEndpoint(sender);
+
+    // when
+    endpoint.enableExporter("exporter-1", null, false, "tenant-a").join();
+
+    // then
+    verify(sender)
+        .enableExporter(
+            new ExporterEnableRequest(
+                "exporter-1", Optional.empty(), Optional.of("tenant-a"), false));
+  }
+
+  @Test
+  void shouldDeleteExporterInEveryPhysicalTenantWhenParameterIsAbsent() {
+    // given
+    final var sender = senderAcceptingExporterChanges();
+    final var endpoint = new ExportersEndpoint(sender);
+
+    // when
+    endpoint.deleteExporter("exporter-1", false, null).join();
+
+    // then
+    verify(sender).deleteExporter(new ExporterDeleteRequest("exporter-1", Optional.empty(), false));
+  }
+
+  @Test
+  void shouldDeleteExporterOnlyInTheGivenPhysicalTenant() {
+    // given
+    final var sender = senderAcceptingExporterChanges();
+    final var endpoint = new ExportersEndpoint(sender);
+
+    // when
+    endpoint.deleteExporter("exporter-1", true, "tenant-a").join();
+
+    // then
+    verify(sender)
+        .deleteExporter(new ExporterDeleteRequest("exporter-1", Optional.of("tenant-a"), true));
+  }
+
+  @Test
+  void shouldTreatABlankPhysicalTenantAsAbsent() {
+    // given
+    final var sender = senderAcceptingExporterChanges();
+    final var endpoint = new ExportersEndpoint(sender);
+
+    // when
+    endpoint.disableExporter("exporter-1", false, "  ").join();
+
+    // then
+    verify(sender)
+        .disableExporter(new ExporterDisableRequest("exporter-1", Optional.empty(), false));
+  }
+
+  private static ClusterConfigurationManagementRequestSender senderAcceptingExporterChanges() {
+    final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+    when(sender.disableExporter(any())).thenReturn(acceptedChange());
+    when(sender.enableExporter(any())).thenReturn(acceptedChange());
+    when(sender.deleteExporter(any())).thenReturn(acceptedChange());
+    return sender;
+  }
+
+  private static CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      acceptedChange() {
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new ClusterConfigurationChangeResponse(
+                1L, new LegacyConfigurationChangeResponse(Map.of(), Map.of(), List.of()), null)));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ExportersEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ExportersEndpointIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
@@ -96,7 +97,10 @@ final class ExportersEndpointIT {
         .hasSize(1)
         .first()
         .isEqualTo(
-            new ExporterStatus().exporterId("recordingExporter").status(StatusEnum.DISABLED));
+            new ExporterStatus()
+                .exporterId("recordingExporter")
+                .status(StatusEnum.DISABLED)
+                .physicalTenant(DEFAULT_PHYSICAL_TENANT_ID));
   }
 
   private boolean hasExporterDisabled(final BrokerState b) {
@@ -143,7 +147,11 @@ final class ExportersEndpointIT {
         .describedAs("Exporter is enabled")
         .hasSize(1)
         .first()
-        .isEqualTo(new ExporterStatus().exporterId("recordingExporter").status(StatusEnum.ENABLED));
+        .isEqualTo(
+            new ExporterStatus()
+                .exporterId("recordingExporter")
+                .status(StatusEnum.ENABLED)
+                .physicalTenant(DEFAULT_PHYSICAL_TENANT_ID));
   }
 
   private void waitUntilOperationIsApplied(final PlannedOperationsResponse response) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterDeleteIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterDeleteIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker.RECORDING_EXPORTER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
+import feign.FeignException;
+import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
+import io.camunda.zeebe.qa.util.actuator.ExportersActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that deleting an exporter through the {@code exporters} actuator is scoped by the {@code
+ * physicalTenant} query parameter: the exporter is removed from the named tenant's partition group
+ * only, and omitting the parameter removes it from every tenant.
+ *
+ * <p>Delete needs its own fixture, which is why it is not part of {@link
+ * PhysicalTenantExportersActuatorIT}: an exporter can only be deleted once it is gone from the
+ * application configuration ({@code CONFIG_NOT_FOUND}), which takes a restart with a changed
+ * configuration and therefore a working directory that survives it. Removing the exporter from the
+ * <em>root</em> configuration puts every tenant into that state at once — narrowing a root-declared
+ * exporter out of a single tenant's configuration is not supported yet (<a
+ * href="https://github.com/camunda/camunda/issues/56652">#56652</a>) — which is all this needs:
+ * what is under test is that the delete <em>operation</em> is scoped, not how the precondition was
+ * reached.
+ */
+@Timeout(2 * 60)
+@ZeebeIntegration
+final class PhysicalTenantExporterDeleteIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String DEFAULT_TENANT = PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+
+  // both tenants run broker-only (no secondary storage); declaring tenant A starts a second,
+  // fully isolated partition group for it
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(DEFAULT_TENANT, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  // started by the test rather than the extension: the working directory has to be set from the
+  // injected @TempDir first, so the persisted cluster configuration survives the restart below.
+  // Without it the restarted broker would generate its configuration afresh and the exporter would
+  // simply be absent instead of CONFIG_NOT_FOUND.
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker().withUnauthenticatedAccess().withRecordingExporter(true));
+
+  @TempDir private Path workingDirectory;
+
+  private ExportersActuator actuator;
+
+  @BeforeEach
+  void beforeEach() {
+    broker.withWorkingDirectory(workingDirectory).start();
+    actuator = ExportersActuator.of(broker);
+
+    // a tenant's partition group may need a moment to elect a leader after startup, and the
+    // exporter state is only reported once its partition is up
+    await("every physical tenant reports its exporter as enabled")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(statuses())
+                    .containsExactlyInAnyOrder(
+                        tuple(DEFAULT_TENANT, StatusEnum.ENABLED),
+                        tuple(TENANT_A, StatusEnum.ENABLED)));
+  }
+
+  @Test
+  void shouldDeleteExporterFromTargetedPhysicalTenantOnly() {
+    // given - the exporter gone from the configuration, so both tenants allow deleting it
+    restartWithoutExporter();
+
+    // when
+    actuator.deleteExporter(RECORDING_EXPORTER_ID, TENANT_A);
+
+    // then - tenant A no longer has the exporter at all, while the default tenant still reports it
+    await("only tenant A's exporter is deleted")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () ->
+                assertThat(statuses())
+                    .containsExactly(tuple(DEFAULT_TENANT, StatusEnum.CONFIG_NOT_FOUND)));
+  }
+
+  @Test
+  void shouldDeleteExporterFromEveryPhysicalTenantWhenNoneIsGiven() {
+    // given - the exporter gone from the configuration, so both tenants allow deleting it
+    restartWithoutExporter();
+
+    // when
+    actuator.deleteExporter(RECORDING_EXPORTER_ID);
+
+    // then - the whole-cluster meaning of a delete is kept
+    await("every physical tenant's exporter is deleted")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(() -> assertThat(actuator.getExporters()).isEmpty());
+  }
+
+  @Test
+  void shouldRejectDeletingFromAPhysicalTenantThatStillConfiguresTheExporter() {
+    // given - no restart, so the exporter is still configured and enabled in both tenants
+
+    // when - then
+    assertThatThrownBy(() -> actuator.deleteExporter(RECORDING_EXPORTER_ID, TENANT_A))
+        .isInstanceOf(FeignException.class)
+        .extracting(error -> ((FeignException) error).status())
+        .isEqualTo(400);
+
+    // and - the rejected request left both tenants untouched
+    assertThat(statuses())
+        .containsExactlyInAnyOrder(
+            tuple(DEFAULT_TENANT, StatusEnum.ENABLED), tuple(TENANT_A, StatusEnum.ENABLED));
+  }
+
+  /**
+   * Restarts the broker with the exporter removed from the root configuration, and waits until
+   * every tenant reports it as {@code CONFIG_NOT_FOUND} - the only state a delete is accepted in.
+   */
+  private void restartWithoutExporter() {
+    broker.stop();
+    broker.withRecordingExporter(false);
+    broker.start();
+
+    await("every physical tenant reports the exporter as CONFIG_NOT_FOUND")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(statuses())
+                    .containsExactlyInAnyOrder(
+                        tuple(DEFAULT_TENANT, StatusEnum.CONFIG_NOT_FOUND),
+                        tuple(TENANT_A, StatusEnum.CONFIG_NOT_FOUND)));
+  }
+
+  /** The (physical tenant, status) of every exporter in the cluster. */
+  private List<Tuple> statuses() {
+    return actuator.getExporters().stream()
+        .map(status -> tuple(status.getPhysicalTenant(), status.getStatus()))
+        .toList();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExportersActuatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExportersActuatorIT.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
+import feign.FeignException;
+import io.camunda.zeebe.management.cluster.ExporterStatus;
+import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
+import io.camunda.zeebe.qa.util.actuator.ExportersActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Verifies that the {@code exporters} actuator's {@code physicalTenant} query parameter scopes both
+ * the listing and the mutations to one physical tenant's partition group, while omitting it keeps
+ * the whole-cluster meaning the operations always had.
+ *
+ * <p>The exporter is declared once in the root configuration, so both physical tenants start with
+ * the same exporter id enabled — which is exactly the case the parameter exists for: the same id
+ * can be in a different state in each tenant, so a status that is not attributed to a tenant would
+ * belong to neither.
+ */
+@Timeout(2 * 60)
+@ZeebeIntegration
+final class PhysicalTenantExportersActuatorIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String DEFAULT_TENANT = PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+  private static final String EXPORTER_ID = "recordingExporter";
+
+  // both tenants run broker-only (no secondary storage); declaring tenant A starts a second,
+  // fully isolated partition group for it
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(DEFAULT_TENANT, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker().withUnauthenticatedAccess().withRecordingExporter(true));
+
+  private ExportersActuator actuator;
+
+  @BeforeEach
+  void beforeEach() {
+    actuator = ExportersActuator.of(broker);
+    // a tenant's partition group may need a moment to elect a leader after startup, and the
+    // exporter state is only reported once its partition is up
+    await("every physical tenant reports its exporter")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(actuator.getExporters())
+                    .extracting(ExporterStatus::getPhysicalTenant, ExporterStatus::getExporterId)
+                    .containsExactlyInAnyOrder(
+                        tuple(DEFAULT_TENANT, EXPORTER_ID), tuple(TENANT_A, EXPORTER_ID)));
+  }
+
+  @Test
+  void shouldListExportersOfEveryPhysicalTenant() {
+    // when
+    final var exporters = actuator.getExporters();
+
+    // then - one entry per tenant, each attributed to the tenant it belongs to
+    assertThat(exporters)
+        .extracting(
+            ExporterStatus::getPhysicalTenant,
+            ExporterStatus::getExporterId,
+            ExporterStatus::getStatus)
+        .containsExactlyInAnyOrder(
+            tuple(DEFAULT_TENANT, EXPORTER_ID, StatusEnum.ENABLED),
+            tuple(TENANT_A, EXPORTER_ID, StatusEnum.ENABLED));
+  }
+
+  @Test
+  void shouldListExportersOfOnePhysicalTenantOnly() {
+    // when
+    final var exporters = actuator.getExporters(TENANT_A);
+
+    // then
+    assertThat(exporters)
+        .extracting(ExporterStatus::getPhysicalTenant, ExporterStatus::getExporterId)
+        .containsExactly(tuple(TENANT_A, EXPORTER_ID));
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenant() {
+    // when - then
+    assertThatThrownBy(() -> actuator.getExporters("unknowntenant"))
+        .isInstanceOf(FeignException.NotFound.class);
+  }
+
+  @Test
+  void shouldDisableExporterOnTargetedPhysicalTenantOnly() {
+    // when
+    actuator.disableExporter(EXPORTER_ID, TENANT_A);
+
+    // then - tenant A's exporter is disabled while the default tenant keeps exporting
+    await("only tenant A's exporter is disabled")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () ->
+                assertThat(statuses())
+                    .containsExactlyInAnyOrder(
+                        tuple(DEFAULT_TENANT, StatusEnum.ENABLED),
+                        tuple(TENANT_A, StatusEnum.DISABLED)));
+  }
+
+  @Test
+  void shouldDisableExporterOnEveryPhysicalTenantWhenNoneIsGiven() {
+    // when
+    actuator.disableExporter(EXPORTER_ID);
+
+    // then - the whole-cluster meaning of a disable is kept
+    await("every physical tenant's exporter is disabled")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () ->
+                assertThat(statuses())
+                    .containsExactlyInAnyOrder(
+                        tuple(DEFAULT_TENANT, StatusEnum.DISABLED),
+                        tuple(TENANT_A, StatusEnum.DISABLED)));
+  }
+
+  @Test
+  void shouldEnableExporterOnTargetedPhysicalTenantOnly() {
+    // given - the exporter disabled everywhere
+    actuator.disableExporter(EXPORTER_ID);
+    await("every physical tenant's exporter is disabled")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () ->
+                assertThat(statuses())
+                    .containsExactlyInAnyOrder(
+                        tuple(DEFAULT_TENANT, StatusEnum.DISABLED),
+                        tuple(TENANT_A, StatusEnum.DISABLED)));
+
+    // when
+    actuator.enableExporterForTenant(EXPORTER_ID, TENANT_A);
+
+    // then - only tenant A exports again
+    await("only tenant A's exporter is enabled")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () ->
+                assertThat(statuses())
+                    .containsExactlyInAnyOrder(
+                        tuple(DEFAULT_TENANT, StatusEnum.DISABLED),
+                        tuple(TENANT_A, StatusEnum.ENABLED)));
+  }
+
+  /** The (physical tenant, status) of every exporter in the cluster. */
+  private List<org.assertj.core.groups.Tuple> statuses() {
+    return actuator.getExporters().stream()
+        .map(status -> tuple(status.getPhysicalTenant(), status.getStatus()))
+        .toList();
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
@@ -85,6 +85,17 @@ public interface ExportersActuator {
   PlannedOperationsResponse disableExporter(@Param final String exporterId);
 
   /**
+   * Request to disable an exporter in the given physical tenant only, leaving the other physical
+   * tenants untouched.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /{exporterId}/disable?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse disableExporter(
+      @Param final String exporterId, @Param final String physicalTenant);
+
+  /**
    * Request to enable an exporter
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
@@ -104,6 +115,17 @@ public interface ExportersActuator {
   PlannedOperationsResponse enableExporter(@Param final String exporterId);
 
   /**
+   * Request to enable an exporter in the given physical tenant only, leaving the other physical
+   * tenants untouched.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /{exporterId}/enable?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse enableExporterForTenant(
+      @Param final String exporterId, @Param final String physicalTenant);
+
+  /**
    * Request to delete an exporter
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
@@ -113,13 +135,35 @@ public interface ExportersActuator {
   PlannedOperationsResponse deleteExporter(@Param final String exporterId);
 
   /**
-   * Returns the list of exporters with their status
+   * Request to delete an exporter from the given physical tenant only, leaving the other physical
+   * tenants untouched.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("DELETE /{exporterId}?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse deleteExporter(
+      @Param final String exporterId, @Param final String physicalTenant);
+
+  /**
+   * Returns the list of exporters with their status, for every physical tenant. Each entry carries
+   * the physical tenant it belongs to, unless the cluster has a single physical tenant.
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("GET")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   List<ExporterStatus> getExporters();
+
+  /**
+   * Returns the list of exporters with their status for the given physical tenant only.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     the physical tenant is unknown
+   */
+  @RequestLine("GET ?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  List<ExporterStatus> getExporters(@Param final String physicalTenant);
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   @JsonInclude(Include.NON_EMPTY)

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
@@ -146,8 +146,8 @@ public interface ExportersActuator {
       @Param final String exporterId, @Param final String physicalTenant);
 
   /**
-   * Returns the list of exporters with their status, for every physical tenant. Each entry carries
-   * the physical tenant it belongs to, unless the cluster has a single physical tenant.
+   * Returns the list of exporters with their status, for every physical tenant. Each entry names
+   * the physical tenant it belongs to, {@code default} included.
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The `exporters` actuator gains an optional `physicalTenant` query parameter on all four operations, and its listing now covers every physical tenant instead of only the default one.

- `GET /actuator/exporters` — lists every physical tenant's exporters, grouped by tenant
- `GET /actuator/exporters?physicalTenant=<id>` — lists one tenant's exporters, 404 if unknown
- `POST /actuator/exporters/{id}/enable|disable`, `DELETE /actuator/exporters/{id}` — apply to
  every tenant that defines the exporter id, or to one tenant when the parameter is given

## Related issues

related to #57377
