### PR TITLE
fix: exclude disabled physical tenants from topology and new-tenant placement

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -265,18 +265,10 @@ public final class BrokerTopologyManagerImpl extends Actor
     // present in clusterConfiguration.partitionGroups() — its partitions aren't running on any
     // broker, so it should not appear in gateway routing topology or the /cluster topology
     // response.
-    final Set<String> disabledGroupIds =
-        clusterConfiguration.partitionGroups().entrySet().stream()
-            .filter(entry -> entry.getValue().isDisabled())
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toSet());
-    final Set<String> groupIds =
-        clusterConfiguration.partitionGroups().keySet().stream()
-            .filter(groupId -> !disabledGroupIds.contains(groupId))
-            .collect(Collectors.toSet());
+    final Set<String> activeGroupIds = clusterConfiguration.activePartitionGroups().keySet();
 
     final var allGroups =
-        groupIds.stream()
+        activeGroupIds.stream()
             .collect(
                 Collectors.toMap(
                     physicalTenantId -> physicalTenantId,
@@ -295,7 +287,10 @@ public final class BrokerTopologyManagerImpl extends Actor
     // drop a previously-visible group that just became disabled; leave alone any group not yet
     // reflected in clusterConfiguration.partitionGroups() at all (e.g. mid-bootstrap, membership-
     // driven entries from rebuildGroupTopology)
-    updatedTopologyPerGroup.keySet().removeIf(disabledGroupIds::contains);
+    final Set<String> knownGroupIds = clusterConfiguration.partitionGroups().keySet();
+    updatedTopologyPerGroup
+        .keySet()
+        .removeIf(groupId -> knownGroupIds.contains(groupId) && !activeGroupIds.contains(groupId));
     updatedTopologyPerGroup.putAll(allGroups);
     topologyPerGroup = Map.copyOf(updatedTopologyPerGroup);
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -259,9 +259,21 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   private void applyClusterConfiguration(final CurrentClusterConfiguration clusterConfiguration) {
-    // For each known group, update the configured cluster state and notify listeners if anything
-    // changed.
-    final Set<String> groupIds = clusterConfiguration.partitionGroups().keySet();
+    // For each known, enabled group, update the configured cluster state and notify listeners if
+    // anything changed. A disabled tenant (removed from local static configuration, see
+    // PhysicalTenantAvailabilityInitializer) is deliberately excluded here even though it's still
+    // present in clusterConfiguration.partitionGroups() — its partitions aren't running on any
+    // broker, so it should not appear in gateway routing topology or the /cluster topology
+    // response.
+    final Set<String> disabledGroupIds =
+        clusterConfiguration.partitionGroups().entrySet().stream()
+            .filter(entry -> entry.getValue().isDisabled())
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    final Set<String> groupIds =
+        clusterConfiguration.partitionGroups().keySet().stream()
+            .filter(groupId -> !disabledGroupIds.contains(groupId))
+            .collect(Collectors.toSet());
 
     final var allGroups =
         groupIds.stream()
@@ -280,6 +292,10 @@ public final class BrokerTopologyManagerImpl extends Actor
                     }));
     final Map<String, BrokerClientTopologyImpl> updatedTopologyPerGroup =
         new HashMap<>(topologyPerGroup);
+    // drop a previously-visible group that just became disabled; leave alone any group not yet
+    // reflected in clusterConfiguration.partitionGroups() at all (e.g. mid-bootstrap, membership-
+    // driven entries from rebuildGroupTopology)
+    updatedTopologyPerGroup.keySet().removeIf(disabledGroupIds::contains);
     updatedTopologyPerGroup.putAll(allGroups);
     topologyPerGroup = Map.copyOf(updatedTopologyPerGroup);
   }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -877,6 +877,41 @@ final class BrokerTopologyManagerTest {
   }
 
   @Test
+  void shouldExcludeADisabledGroupFromTopology() {
+    // given -- default and tenant1 are both known locally and both configured
+    notifyEvent(createMemberAddedEvent(createBroker(BrokerMemberId.from(0))));
+    notifyEvent(createMemberAddedEvent(createBrokerWithGroup(BrokerMemberId.from(0), "tenant1")));
+
+    final var global = globalConfigWithMember(MemberId.from("1"));
+    final var defaultGroup = singleMemberGroup(MemberId.from("1"), Map.of(1, 1));
+    final var tenant1Group = singleMemberGroup(MemberId.from("1"), Map.of(5, 1));
+    topologyManager.onClusterConfigurationUpdated(
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(DEFAULT_PHYSICAL_TENANT_ID, defaultGroup, "tenant1", tenant1Group),
+            PhasedChangeState.empty()));
+    actorSchedulerRule.workUntilDone();
+    assertThat(topologyManager.getTopology("tenant1").isInitialized()).isTrue();
+    assertThat(topologyManager.getTopology("tenant1").getPartitionsCount()).isEqualTo(1);
+
+    // when -- tenant1 is disabled (removed from local static configuration); its
+    // PartitionGroupConfiguration is still present, just flagged
+    topologyManager.onClusterConfigurationUpdated(
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            global,
+            Map.of(DEFAULT_PHYSICAL_TENANT_ID, defaultGroup, "tenant1", tenant1Group.disable()),
+            PhasedChangeState.empty()));
+    actorSchedulerRule.workUntilDone();
+
+    // then -- tenant1 no longer resolves, as if it were never configured at all; default is
+    // unaffected
+    assertThat(topologyManager.getTopology("tenant1").isInitialized()).isFalse();
+    assertThat(topologyManager.getTopology().getPartitionsCount()).isEqualTo(1);
+  }
+
+  @Test
   void shouldFireIncarnationChangedOncePerGroupWhoseIncarnationNumberChanged() {
     // given -- default and tenant1 are both configured at their initial incarnation number
     notifyEvent(createMemberAddedEvent(createBroker(BrokerMemberId.from(0))));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPara
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -586,9 +587,10 @@ public record CurrentClusterConfiguration(
    * gateway routing topology, nor targeted by cluster-wide operations.
    */
   public Map<String, PartitionGroupConfiguration> activePartitionGroups() {
-    return partitionGroups.entrySet().stream()
-        .filter(entry -> !entry.getValue().isDisabled())
-        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    return Collections.unmodifiableMap(
+        partitionGroups.entrySet().stream()
+            .filter(entry -> !entry.getValue().isDisabled())
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -578,6 +578,20 @@ public record CurrentClusterConfiguration(
   }
 
   /**
+   * The subset of {@link #partitionGroups()} that are not disabled, keyed by physical tenant id. A
+   * disabled group (removed from local static configuration after being provisioned, see {@code
+   * PhysicalTenantAvailabilityInitializer}) is retained in {@link #partitionGroups()} — its data
+   * and partition assignment are not deleted — but excluded here, since it is not running on any
+   * broker: it must not be counted as load when placing a new tenant's partitions, nor shown in
+   * gateway routing topology, nor targeted by cluster-wide operations.
+   */
+  public Map<String, PartitionGroupConfiguration> activePartitionGroups() {
+    return partitionGroups.entrySet().stream()
+        .filter(entry -> !entry.getValue().isDisabled())
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+  }
+
+  /**
    * Returns the desired leader of every partition in the cluster, grouped by partition group id.
    * Partition ids are unique only within a group, so the outer group-id key is required to
    * disambiguate them. See {@link PartitionGroupConfiguration#desiredLeaders()} for how the

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
@@ -125,8 +125,8 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
       final int replicationFactor) {
     // A disabled tenant's partitions are not actually running on any broker, so they must not
     // count as load when deciding where to place a new tenant's partitions — but they still need
-    // to appear in distributionByGroup/currentById (above) and validateNoRemoval (below) so they
-    // are correctly left untouched rather than treated as removed.
+    // to appear in distributionByGroup/currentById so they are correctly left untouched rather
+    // than treated as removed.
     distributionByGroup.entrySet().stream()
         .filter(entry -> activeGroupIds.contains(entry.getKey()))
         .forEach(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
@@ -89,12 +89,19 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
     final List<PartitionId> sortedPartitionIds =
         targetPartitionIds.stream().distinct().sorted().toList();
 
+    final Set<String> disabledGroups =
+        currentConfiguration.partitionGroups().entrySet().stream()
+            .filter(entry -> entry.getValue().isDisabled())
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+
     final Map<MemberId, Integer> replicaCountByMember = new HashMap<>();
     final Map<MemberId, Integer> leaderCountByMember = new HashMap<>();
     final var result =
         generateAssignmentForNewPartitions(
             sortedPartitionIds,
             distributionByGroup,
+            disabledGroups,
             replicaCountByMember,
             leaderCountByMember,
             currentById,
@@ -114,15 +121,20 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
   private static Assignment generateAssignmentForNewPartitions(
       final List<PartitionId> sortedPartitionIds,
       final Map<String, Set<PartitionMetadata>> distributionByGroup,
+      final Set<String> disabledGroups,
       final Map<MemberId, Integer> replicaCountByMember,
       final Map<MemberId, Integer> leaderCountByMember,
       final Map<PartitionId, PartitionMetadata> currentById,
       final List<MemberId> sortedMembers,
       final int replicationFactor) {
-    distributionByGroup
-        .values()
+    // A disabled tenant's partitions are not actually running on any broker, so they must not
+    // count as load when deciding where to place a new tenant's partitions — but they still need
+    // to appear in distributionByGroup/currentById (above) and validateNoRemoval (below) so they
+    // are correctly left untouched rather than treated as removed.
+    distributionByGroup.entrySet().stream()
+        .filter(entry -> !disabledGroups.contains(entry.getKey()))
         .forEach(
-            partitions -> accumulateLoad(partitions, replicaCountByMember, leaderCountByMember));
+            entry -> accumulateLoad(entry.getValue(), replicaCountByMember, leaderCountByMember));
 
     final List<PartitionId> newPartitionIds = new ArrayList<>();
     final Map<PartitionId, Set<MemberId>> newMembersById = new LinkedHashMap<>();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
@@ -89,11 +89,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
     final List<PartitionId> sortedPartitionIds =
         targetPartitionIds.stream().distinct().sorted().toList();
 
-    final Set<String> disabledGroups =
-        currentConfiguration.partitionGroups().entrySet().stream()
-            .filter(entry -> entry.getValue().isDisabled())
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toSet());
+    final Set<String> activeGroupIds = currentConfiguration.activePartitionGroups().keySet();
 
     final Map<MemberId, Integer> replicaCountByMember = new HashMap<>();
     final Map<MemberId, Integer> leaderCountByMember = new HashMap<>();
@@ -101,7 +97,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
         generateAssignmentForNewPartitions(
             sortedPartitionIds,
             distributionByGroup,
-            disabledGroups,
+            activeGroupIds,
             replicaCountByMember,
             leaderCountByMember,
             currentById,
@@ -121,7 +117,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
   private static Assignment generateAssignmentForNewPartitions(
       final List<PartitionId> sortedPartitionIds,
       final Map<String, Set<PartitionMetadata>> distributionByGroup,
-      final Set<String> disabledGroups,
+      final Set<String> activeGroupIds,
       final Map<MemberId, Integer> replicaCountByMember,
       final Map<MemberId, Integer> leaderCountByMember,
       final Map<PartitionId, PartitionMetadata> currentById,
@@ -132,7 +128,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
     // to appear in distributionByGroup/currentById (above) and validateNoRemoval (below) so they
     // are correctly left untouched rather than treated as removed.
     distributionByGroup.entrySet().stream()
-        .filter(entry -> !disabledGroups.contains(entry.getKey()))
+        .filter(entry -> activeGroupIds.contains(entry.getKey()))
         .forEach(
             entry -> accumulateLoad(entry.getValue(), replicaCountByMember, leaderCountByMember));
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -760,6 +760,49 @@ class CurrentClusterConfigurationTest {
   }
 
   @Nested
+  class ActivePartitionGroups {
+
+    @Test
+    void shouldExcludeADisabledGroup() {
+      // given — "a" is enabled, "b" is disabled
+      final var config =
+          config(
+              global(1, Map.of()),
+              Map.of("a", group(1, Map.of()), "b", group(1, Map.of()).disable()),
+              PhasedChangeState.empty());
+
+      // when / then
+      assertThat(config.activePartitionGroups()).containsOnlyKeys("a");
+    }
+
+    @Test
+    void shouldReturnEveryGroupWhenNoneIsDisabled() {
+      // given
+      final var config =
+          config(
+              global(1, Map.of()),
+              Map.of("a", group(1, Map.of()), "b", group(1, Map.of())),
+              PhasedChangeState.empty());
+
+      // when / then
+      assertThat(config.activePartitionGroups()).containsOnlyKeys("a", "b");
+    }
+
+    @Test
+    void shouldReturnEmptyWhenEveryGroupIsDisabled() {
+      // given
+      final var config =
+          config(
+              global(1, Map.of()),
+              Map.of("a", group(1, Map.of()).disable()),
+              PhasedChangeState.empty());
+
+      // when / then
+      assertThat(config.activePartitionGroups()).isEmpty();
+    }
+  }
+
+  @Nested
   class PlanTransitions {
 
     private static GlobalPhase globalPhase() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -100,6 +101,43 @@ final class AdditivePartitionReassignerTest {
     assertThat(assigned).contains(existingTenantB);
     final var placed = findPartition(assigned, NEW_GROUP, 2);
     assertThat(placed.members()).containsExactlyInAnyOrder(member(3), member(2));
+  }
+
+  @Test
+  void shouldNotCountADisabledTenantsPartitionsAsLoadWhenPlacingNewTenantPartitions() {
+    // given — tenantB (enabled) loads member 0 twice; tenantA (about to be disabled) loads member
+    // 1 three times, i.e. more heavily than member 0
+    final var tenantBPartitions =
+        Set.of(
+            PartitionMetadataFixtures.partition(
+                "tenantB-existing", 1, Set.of(member(0)), member(0)),
+            PartitionMetadataFixtures.partition(
+                "tenantB-existing", 2, Set.of(member(0)), member(0)));
+    final var tenantAPartitions =
+        Set.of(
+            PartitionMetadataFixtures.partition("tenantA", 1, Set.of(member(1)), member(1)),
+            PartitionMetadataFixtures.partition("tenantA", 2, Set.of(member(1)), member(1)),
+            PartitionMetadataFixtures.partition("tenantA", 3, Set.of(member(1)), member(1)));
+    final var configuration =
+        configurationWithExistingGroups(
+                Map.of(
+                    "tenantB-existing", tenantBPartitions,
+                    "tenantA", tenantAPartitions))
+            .updatePartitionGroupConfig("tenantA", PartitionGroupConfiguration::disable);
+
+    // when — placing one partition for a brand-new tenant, choosing between members 0 and 1
+    final var targetMembers = Set.of(member(0), member(1));
+    final var targetPartitionIds = new ArrayList<>(sortedPartitionIds("tenantB-existing", 1, 2));
+    targetPartitionIds.addAll(sortedPartitionIds("tenantA", 1, 3));
+    targetPartitionIds.add(new PartitionId(NEW_GROUP, 1));
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 1);
+
+    // then — with tenantA's (disabled) load excluded, member 1 looks less loaded (0) than member 0
+    // (2 from tenantB), so the new partition lands on member 1. Counting tenantA's load would have
+    // placed it on member 0 instead, since member 1 would then look more loaded (3 vs 2).
+    final var placed = findPartition(assigned, NEW_GROUP, 1);
+    assertThat(placed.members()).containsExactly(member(1));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Stacked on #60073 
- Excludes a disabled physical tenant (removed from local static configuration, but retaining its data and partition assignment - see `PhysicalTenantAvailabilityInitializer`) from gateway routing topology and the `/cluster` topology response: `BrokerTopologyManagerImpl` skips a disabled group when applying a new `CurrentClusterConfiguration`, and drops a previously-visible group's entry once it becomes disabled.
- Excludes a disabled tenant's partitions from load accounting in `AdditivePartitionReassigner` when placing a new tenant's partitions, without omitting them from `validateNoRemoval`'s no-removal check (which would incorrectly treat them as being removed and abort the whole provisioning batch).
- Adds `CurrentClusterConfiguration.activePartitionGroups()`, a reusable accessor for the non-disabled subset of `partitionGroups()`, and refactors both of the above to use it instead of reimplementing the filter - more cluster-wide operations are gaining the same requirement and will reuse this.


## Related issue
Part of #60070
