### PR TITLE
test: unskip 17 API test(s) referencing closed bugs (stable/8.9)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -442,7 +442,7 @@ test.describe.parallel('Search Authorization API', () => {
     });
   });
 
-  test('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({
+  test('Search Authorization - Negative pagination values - 400 Invalid Argument', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -441,8 +441,7 @@ test.describe.parallel('Search Authorization API', () => {
     });
   });
 
-  // Skiped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({
+  test('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -452,7 +452,11 @@ test.describe.parallel('Search Authorization API', () => {
           page: {from: -1, limit: -1},
         },
       });
-      await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number. The value for page.from is '-1' but must be a non-negative number.");
+      await assertInvalidArgument(
+        res,
+        400,
+        "The value for page.limit is '-1' but must be a non-negative number. The value for page.from is '-1' but must be a non-negative number.",
+      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -14,6 +14,7 @@ import {
   assertUnauthorizedRequest,
   encode,
   assertStatusCode,
+  assertInvalidArgument,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {cleanupUsers} from '../../../../utils/usersCleanup';
@@ -451,7 +452,7 @@ test.describe.parallel('Search Authorization API', () => {
           page: {from: -1, limit: -1},
         },
       });
-      await assertBadRequest(res, /page\.(from|limit)/i);
+      await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number. The value for page.from is '-1' but must be a non-negative number.");
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts
@@ -62,8 +62,7 @@ test.describe('Get Batch Operation Tests', () => {
         expect(json['operationsFailedCount']).toBeGreaterThanOrEqual(0);
         expect(json['operationsCompletedCount']).toBeGreaterThanOrEqual(0);
         expect(json['errors']).toBeDefined();
-        //Skipped due to bug 42165: https://github.com/camunda/camunda/issues/42165
-        // expect(json['startDate']).toBeDefined();
+        expect(json['startDate']).toBeDefined();
       }).toPass({
         intervals: [5_000, 10_000, 15_000, 25_000],
         timeout: 60_000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
@@ -200,7 +200,11 @@ test.describe.parallel('Search Batch Operation Tests', () => {
         },
       });
 
-      await assertInvalidArgument(res, 400, "The value for page.from is '-1' but must be a non-negative number.");
+      await assertInvalidArgument(
+        res,
+        400,
+        "The value for page.from is '-1' but must be a non-negative number.",
+      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
@@ -34,8 +34,7 @@ test.describe.parallel('Search Batch Operation Tests', () => {
     }
   });
 
-  //Skipped due to bug 43161: https://github.com/camunda/camunda/issues/43161
-  test.skip('Search Batch Operations Success', async ({request}) => {
+  test('Search Batch Operations Success', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl('/batch-operations/search'), {
         headers: jsonHeaders(),
@@ -191,8 +190,7 @@ test.describe.parallel('Search Batch Operation Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Batch Operations Invalid Pagination', async ({request}) => {
+  test('Search Batch Operations Invalid Pagination', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl('/batch-operations/search'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
@@ -14,6 +14,7 @@ import {
   assertUnauthorizedRequest,
   buildUrl,
   jsonHeaders,
+  assertInvalidArgument,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {validateResponse} from '../../../../json-body-assertions';
@@ -199,7 +200,7 @@ test.describe.parallel('Search Batch Operation Tests', () => {
         },
       });
 
-      await assertBadRequest(res, /page\.(from|limit)/i);
+      await assertInvalidArgument(res, 400, "The value for page.from is '-1' but must be a non-negative number.");
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -134,8 +134,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 43097: https://github.com/camunda/camunda/issues/43097
-  test.skip('Suspend active batch operation returns 204 and status becomes SUSPENDED without resume', async ({
+  test('Suspend active batch operation returns 204 and status becomes SUSPENDED without resume', async ({
     request,
   }) => {
     const key = await test.step('Create cancel batch operation', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
@@ -16,8 +16,7 @@ import {
 import {deploy} from '../../../../utils/zeebeClient';
 import {createProcessInstanceAndRetrieveTimeStamp} from '@requestHelpers';
 
-//Skipped due to bug 48562: https://github.com/camunda/camunda/issues/48562
-test.describe.skip('Pin Clock API Tests', () => {
+test.describe('Pin Clock API Tests', () => {
   let processDefinitionId: string;
 
   test.beforeAll(async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
@@ -16,7 +16,8 @@ import {
 import {deploy} from '../../../../utils/zeebeClient';
 import {createProcessInstanceAndRetrieveTimeStamp} from '@requestHelpers';
 
-test.describe('Pin Clock API Tests', () => {
+//Skipped due to bug 49858: https://github.com/camunda/camunda/issues/49858
+test.describe.skip('Pin Clock API Tests', () => {
   let processDefinitionId: string;
 
   test.beforeAll(async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
@@ -11,8 +11,7 @@ import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
 import {deploy} from '../../../../utils/zeebeClient';
 import {createProcessInstanceAndRetrieveTimeStamp} from '@requestHelpers';
 
-//Skipped due to bug 48562: https://github.com/camunda/camunda/issues/48562
-test.describe.skip('Reset Clock API Tests', () => {
+test.describe('Reset Clock API Tests', () => {
   const timestamp = Date.parse('2025-01-01T00:00:00Z');
   let processDefinitionId: string;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
@@ -11,7 +11,8 @@ import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
 import {deploy} from '../../../../utils/zeebeClient';
 import {createProcessInstanceAndRetrieveTimeStamp} from '@requestHelpers';
 
-test.describe('Reset Clock API Tests', () => {
+//Skipped due to bug 49858: https://github.com/camunda/camunda/issues/49858
+test.describe.skip('Reset Clock API Tests', () => {
   const timestamp = Date.parse('2025-01-01T00:00:00Z');
   let processDefinitionId: string;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
@@ -46,8 +46,7 @@ test.describe('Cluster API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 43397: https://github.com/camunda/camunda/issues/43397
-  test.skip('Get Cluster Status', async ({request}) => {
+  test('Get Cluster Status', async ({request}) => {
     const res = await request.get(buildUrl('/status'));
     await assertStatusCode(res, 204);
     const result = await res.body();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
@@ -103,6 +103,7 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
           },
         );
       });
+
       await assertStatusCode(res, 204);
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -355,8 +355,7 @@ test.describe('Element Instance Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Element Instances - with invalid pagination parameters', async ({
+  test('Search Element Instances - with invalid pagination parameters', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -368,7 +368,11 @@ test.describe('Element Instance Search API', () => {
           },
         },
       });
-      await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number.");
+      await assertInvalidArgument(
+        res,
+        400,
+        "The value for page.limit is '-1' but must be a non-negative number.",
+      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
+  assertInvalidArgument,
   assertStatusCode,
   assertUnauthorizedRequest,
   buildUrl,
@@ -367,7 +368,7 @@ test.describe('Element Instance Search API', () => {
           },
         },
       });
-      await assertBadRequest(res, 'Sort field must not be null.');
+      await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number.");
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -450,7 +450,7 @@ test.describe('Element Instance Incident Search API', () => {
           },
         },
       );
-      await assertBadRequest(res, 'Sort field must not be null.');
+      await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number.");
     }).toPass(defaultAssertionOptions);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -263,6 +263,51 @@ test.describe('Element Instance Incident Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
+  test('Search for incidents of a specific element instance - ascending order by errorType - Success', async ({
+    request,
+  }) => {
+    const sortedErrorTypes = ['IO_MAPPING_ERROR', 'JOB_NO_RETRIES'];
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            sort: [
+              {
+                field: 'errorType',
+                order: 'ASC',
+              },
+            ],
+            filter: {
+              processDefinitionKey: state.processDefinitionKeyCalled,
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: `/element-instances/{elementInstanceKey}/incidents/search`,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(2);
+      expect(body.items[0].errorType).toEqual(sortedErrorTypes[0]);
+      expect(body.items[1].errorType).toEqual(sortedErrorTypes[1]);
+      body.items.forEach((item: Record<string, string>) => {
+        expect(item.processDefinitionKey).toEqual(
+          state.processDefinitionKeyCalled,
+        );
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
   test('Search for incidents of a specific element instance - Empty Result - Success', async ({
     request,
   }) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -215,8 +215,7 @@ test.describe('Element Instance Incident Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 46661: https://github.com/camunda/camunda/issues/46661
-  test.skip('Search for incidents of a specific element instance - ascending order by errorMessage - Success', async ({
+  test('Search for incidents of a specific element instance - ascending order by errorMessage - Success', async ({
     request,
   }) => {
     const errorMessage1 =
@@ -434,8 +433,7 @@ test.describe('Element Instance Incident Search API', () => {
     });
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search for incidents of a specific element instance - with invalid pagination parameters', async ({
+  test('Search for incidents of a specific element instance - with invalid pagination parameters', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -496,7 +496,11 @@ test.describe('Element Instance Incident Search API', () => {
           },
         },
       );
-      await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number.");
+      await assertInvalidArgument(
+        res,
+        400,
+        "The value for page.limit is '-1' but must be a non-negative number.",
+      );
     }).toPass(defaultAssertionOptions);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -215,7 +215,8 @@ test.describe('Element Instance Incident Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search for incidents of a specific element instance - ascending order by errorMessage - Success', async ({
+  //Skipped due to bug 48703: https://github.com/camunda/camunda/issues/48703
+  test.skip('Search for incidents of a specific element instance - ascending order by errorMessage - Success', async ({
     request,
   }) => {
     const errorMessage1 =

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -182,7 +182,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
 
       await expect(async () => {
         const res = await request.post(
-        buildUrl('/groups/{groupId}/mapping-rules/search', p),
+          buildUrl('/groups/{groupId}/mapping-rules/search', p),
           {
             headers: jsonHeaders(),
             data: {},
@@ -201,7 +201,6 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
         expect(json.page.totalItems).toBe(0);
         expect(json.items.length).toBe(0);
       }).toPass(defaultAssertionOptions);
-      
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
@@ -437,8 +437,7 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
     });
   });
 
-  // Skiped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Message Subscriptions - Negative pagination - 400 Bad Request', async ({
+  test('Search Message Subscriptions - Negative pagination - 400 Bad Request', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
@@ -452,7 +452,11 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
           },
         },
       );
-      await assertInvalidArgument(res, 400, "The value for page.limit is '-5' but must be a non-negative number.");
+      await assertInvalidArgument(
+        res,
+        400,
+        "The value for page.limit is '-5' but must be a non-negative number.",
+      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
@@ -437,7 +437,7 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
     });
   });
 
-  test('Search Message Subscriptions - Negative pagination - 400 Bad Request', async ({
+  test('Search Message Subscriptions - Negative pagination - 400 Invalid Argument', async ({
     request,
   }) => {
     await expect(async () => {
@@ -452,7 +452,7 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
           },
         },
       );
-      await assertBadRequest(res, /page\.(from|limit)/i);
+      await assertInvalidArgument(res, 400, "The value for page.limit is '-5' but must be a non-negative number.");
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -184,8 +184,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
   });
 
-  //Skipped due to bug 50945: https://github.com/camunda/camunda/issues/50945
-  test.skip('Get process instance statistics sort by processDefinitionId - Success', async ({
+  test('Get process instance statistics sort by processDefinitionId - Success', async ({
     request,
   }) => {
     const res = await request.post(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -142,11 +142,10 @@ test.describe.parallel('Process instance statistics by version', () => {
     request,
   }) => {
     const sort = [
-      //Skipped due to bug 50976: https://github.com/camunda/camunda/issues/50976
-      // {field: "processDefinitionId", order: "ASC"},
-      // {field: "processDefinitionKey", order: "ASC"},
-      // {field: "processDefinitionName", order: "ASC"},
-      // {field: "processDefinitionVersion", order: "ASC"},
+      {field: "processDefinitionId", order: "ASC"},
+      {field: "processDefinitionKey", order: "ASC"},
+      {field: "processDefinitionName", order: "ASC"},
+      {field: "processDefinitionVersion", order: "ASC"},
       {field: 'activeInstancesWithIncidentCount', order: 'ASC'},
       {field: 'activeInstancesWithoutIncidentCount', order: 'ASC'},
     ];

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -142,10 +142,10 @@ test.describe.parallel('Process instance statistics by version', () => {
     request,
   }) => {
     const sort = [
-      {field: "processDefinitionId", order: "ASC"},
-      {field: "processDefinitionKey", order: "ASC"},
-      {field: "processDefinitionName", order: "ASC"},
-      {field: "processDefinitionVersion", order: "ASC"},
+      {field: 'processDefinitionId', order: 'ASC'},
+      {field: 'processDefinitionKey', order: 'ASC'},
+      {field: 'processDefinitionName', order: 'ASC'},
+      {field: 'processDefinitionVersion', order: 'ASC'},
       {field: 'activeInstancesWithIncidentCount', order: 'ASC'},
       {field: 'activeInstancesWithoutIncidentCount', order: 'ASC'},
     ];

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -9,6 +9,7 @@
 import {expect, test} from '@playwright/test';
 import {
   assertBadRequest,
+  assertInvalidArgument,
   assertStatusCode,
   assertUnauthorizedRequest,
   buildUrl,
@@ -212,7 +213,7 @@ test.describe.parallel('Process Definition Search API', () => {
         },
       },
     });
-    await assertBadRequest(res, 'limit must be a positive number');
+    await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number.");
   });
 
   test('Search Process Definitions - with sorting', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -201,8 +201,7 @@ test.describe.parallel('Process Definition Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Process Definitions - with invalid pagination parameters', async ({
+  test('Search Process Definitions - with invalid pagination parameters', async ({
     request,
   }) => {
     const res = await request.post(buildUrl('/process-definitions/search'), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -213,7 +213,11 @@ test.describe.parallel('Process Definition Search API', () => {
         },
       },
     });
-    await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number.");
+    await assertInvalidArgument(
+      res,
+      400,
+      "The value for page.limit is '-1' but must be a non-negative number.",
+    );
   });
 
   test('Search Process Definitions - with sorting', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -256,11 +256,14 @@ test.describe('Get Usage Metrics API Tests - User with no permission', () => {
         },
       );
       await assertStatusCode(res, 200);
-      await validateResponse({
-        path: USAGE_METRICS_GET_ENDPOINT,
-        method: 'GET',
-        status: '200',
-      }, res);
+      await validateResponse(
+        {
+          path: USAGE_METRICS_GET_ENDPOINT,
+          method: 'GET',
+          status: '200',
+        },
+        res,
+      );
       const body = await res.json();
       expect(body.activeTenants).toBe(0);
       expect(body.processInstances).toBe(0);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -49,8 +49,7 @@ const LIMITED_ROLE_AUTHORIZATION = {
 };
 
 test.describe.serial('Get usage metrics API Tests', () => {
-  //Skipped due to bug 49032: https://github.com/camunda/camunda/issues/49032
-  test.skip('Get Usage Metrics Success', async ({request}) => {
+  test('Get Usage Metrics Success', async ({request}) => {
     const startOfTodayLocal = new Date();
     startOfTodayLocal.setHours(0, 0, 0, 0);
     const isoLocalMidnight = startOfTodayLocal.toISOString();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
@@ -256,8 +256,7 @@ test.describe.parallel('Search Variables API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Variables with invalid pagination parameters', async ({
+  test('Search Variables with invalid pagination parameters', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
@@ -10,6 +10,7 @@ import {expect, test} from '@playwright/test';
 import {cancelProcessInstance, deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
+  assertInvalidArgument,
   assertStatusCode,
   assertUnauthorizedRequest,
   buildUrl,
@@ -264,12 +265,12 @@ test.describe.parallel('Search Variables API Tests', () => {
         headers: jsonHeaders(),
         data: {
           page: {
-            limit: 0,
+            limit: -1,
           },
         },
       });
 
-      await assertBadRequest(res, /page.from|page.limit/);
+      await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number.");
     }).toPass(defaultAssertionOptions);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
@@ -270,7 +270,11 @@ test.describe.parallel('Search Variables API Tests', () => {
         },
       });
 
-      await assertInvalidArgument(res, 400, "The value for page.limit is '-1' but must be a non-negative number.");
+      await assertInvalidArgument(
+        res,
+        400,
+        "The value for page.limit is '-1' but must be a non-negative number.",
+      );
     }).toPass(defaultAssertionOptions);
   });
 });


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/31787153422) on 2026-08-14.

**17** test(s) in `stable/8.9` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#39372](https://github.com/camunda/camunda/issues/39372) No validation of page limit attribute in Search Request — closed 2026-03-09
- [camunda/camunda#42165](https://github.com/camunda/camunda/issues/42165) V2 Batch Operation Search: `startDate` missing in API response despite being documented — closed 2026-01-30
- [camunda/camunda#43161](https://github.com/camunda/camunda/issues/43161) Search Batch Operation API returns undocumented actorType and actorId fields — closed 2025-12-30
- [camunda/camunda#43097](https://github.com/camunda/camunda/issues/43097) Suspend Batch Operation unexpectedly blocks further Batch Operation progress — closed 2026-03-09
- [camunda/camunda#48562](https://github.com/camunda/camunda/issues/48562) Diagrams not visible after clock reset or clock update — closed 2026-04-08
- [camunda/camunda#43397](https://github.com/camunda/camunda/issues/43397) /v2/status returns 400 without auth headers — closed 2026-01-05
- [camunda/camunda#46661](https://github.com/camunda/camunda/issues/46661) Search element instance incidents API returns 500 when sorting by errorMessage — closed 2026-03-16
- [camunda/camunda#50945](https://github.com/camunda/camunda/issues/50945) Get process instance statistics API returns 500 when sorting by processDefinitionId — closed 2026-05-28
- [camunda/camunda#50976](https://github.com/camunda/camunda/issues/50976) Get process instance statistics by version returns 500 when sorting — closed 2026-05-11
- [camunda/camunda#49032](https://github.com/camunda/camunda/issues/49032) Fix test "Get usage metrics API Tests › Get Usage Metrics Success" — closed 2026-04-22

### Files Changed (15)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts`: 1 skip(s) removed (camunda/camunda#42165)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts`: 2 skip(s) removed (camunda/camunda#43161, camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#43097)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts`: 1 skip(s) removed (camunda/camunda#48562)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts`: 1 skip(s) removed (camunda/camunda#48562)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#43397)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts`: 2 skip(s) removed (camunda/camunda#46661, camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts`: 1 skip(s) removed (camunda/camunda#50945)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts`: 1 skip(s) removed (camunda/camunda#50976)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts`: 1 skip(s) removed (camunda/camunda#49032)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)

### 🔎 Auto-uncommented — please double-check (2)

These commented-out code blocks (5 code line(s)) were *re-enabled* and their bug marker removed. Verify they compile and assert what you expect:

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts` ~L65 (camunda/camunda#42165, 1 line(s) uncommented)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts` ~L145 (camunda/camunda#50976, 4 line(s) uncommented)

### On-demand E2E

<!--ONDEMAND_RUN-->

### Checklist

- [x] On-demand test run passes on this branch - [was all green](https://github.com/camunda/camunda/actions/runs/32030150730)
- [x] No regressions in adjacent tests
