### PR TITLE
test: unskip 4 E2E test(s) referencing closed bugs (stable/8.9)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -148,8 +148,7 @@ test.describe('Dashboard', () => {
     });
   });
 
-  //Skipped due to bug 45129: https://github.com/camunda/camunda/issues/45129
-  test.skip('Navigate to processes view (same truncated error message)', async ({
+  test('Navigate to processes view (same truncated error message)', async ({
     operateDashboardPage,
     operateProcessInstancePage,
   }) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -160,6 +160,7 @@ test.describe('Dashboard', () => {
       ).toBeVisible();
 
       await operateDashboardPage.clickViewInstanceLink();
+      await operateProcessInstancePage.clickVariablesTab();
       await expect(
         operateProcessInstancePage.variableCellByName(/incident type a/i),
       ).toBeVisible();
@@ -173,6 +174,7 @@ test.describe('Dashboard', () => {
       ).toBeVisible();
 
       await operateDashboardPage.clickViewInstanceLink();
+      await operateProcessInstancePage.clickVariablesTab();
       await expect(
         operateProcessInstancePage.variableCellByName(/incident type b/i),
       ).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -106,6 +106,7 @@ test.describe('Operations', () => {
     });
 
     await test.step('Validate canceled instance details', async () => {
+      await operateFiltersPanelPage.clickCanceledInstancesCheckbox();
       const instanceRow = operateProcessesPage.getInstanceRow(0);
 
       await expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -65,9 +65,8 @@ test.describe('Operations', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
   // !Note: assert the code after the bug is fixed as it was dicoverd during the test implementation
-  test.skip('Retry and cancel single instance', async ({
+  test('Retry and cancel single instance', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -80,8 +80,7 @@ test.describe('Process Instances Filters', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  //Skipped due to bug 45156: https://github.com/camunda/camunda/issues/45156
-  test.skip('Interaction between diagram and filters', async ({
+  test('Interaction between diagram and filters', async ({
     operateProcessesPage,
     operateFiltersPanelPage,
     page,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -113,8 +113,7 @@ test.describe('task panel page', () => {
     }).toPass({timeout: 5000});
   });
 
-  //Skipped due to bug 44583: https://github.com/camunda/camunda/issues/44583
-  test.skip('scrolling', async ({page, taskPanelPageV1}) => {
+  test('scrolling', async ({page, taskPanelPageV1}) => {
     // TODO: This test fails in V2 mode - investigate if this is expected behavior or a bug
     // V2 mode may have different scrolling/pagination behavior that affects task count expectations
     test.slow();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -36,7 +36,10 @@ test.beforeAll(async ({request}) => {
   await sleep(500);
 });
 
-test.describe('task panel page', () => {
+// Serial: `scrolling` needs `usertask_to_be_assigned` completed by the test before
+// it. A retry re-runs `beforeAll`, which recreates that task as open, so the group
+// has to be retried as a whole for the retry to reach the same starting state.
+test.describe.serial('task panel page', () => {
   test.beforeEach(async ({page, loginPage}) => {
     await navigateToApp(page, 'tasklist');
     await loginPage.login('demo', 'demo');
@@ -148,10 +151,13 @@ test.describe('task panel page', () => {
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
+    // The list keeps a sliding window of 4 pages x 50 tasks, so this scroll evicts
+    // page 1 and leaves pages 2-5. Page 5 holds only the 2 remaining tasks (the last
+    // usertask_for_scrolling_2 and usertask_for_scrolling_3), hence 151 and not 199.
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(0);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(151);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(1);
 
     await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/31787153422) on 2026-08-14.

**4** test(s) in `stable/8.9` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#45129](https://github.com/camunda/camunda/issues/45129) incidentErrorHashCode filter param is ignored on process instances search endpoint — closed 2026-05-12
- [camunda/camunda#42375](https://github.com/camunda/camunda/issues/42375) Cancel operation is not added to operations panel when triggered for single instance — closed 2026-03-24
- [camunda/camunda#45156](https://github.com/camunda/camunda/issues/45156) Operate – Incorrect process instances count when selecting flow node without active token — closed 2026-05-29
- [camunda/camunda#44583](https://github.com/camunda/camunda/issues/44583) Scrolling gets stuck in Tasklist v1 with large process list and search returns 500 error — closed 2026-05-20

### Files Changed (4)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts`: 1 skip(s) removed (camunda/camunda#45129)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts`: 1 skip(s) removed (camunda/camunda#42375)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts`: 1 skip(s) removed (camunda/camunda#45156)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts`: 1 skip(s) removed (camunda/camunda#44583)

### On-demand E2E

<!--ONDEMAND_RUN-->

### Checklist

- [x] On-demand test run passes on this branch - [was all green](https://github.com/camunda/camunda/actions/runs/32131519059)
- [x] No regressions in adjacent tests
