### PR TITLE
test: unskip 2 API test(s) referencing closed bugs (stable/8.8)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -53,11 +53,11 @@ test.describe.parallel('Search Authorization API', () => {
     description: string;
   };
   let roleAuthorizationKey: string;
-  let userForRoleAuthorization: { 
+  let userForRoleAuthorization: {
     username: string;
-    name: string; 
+    name: string;
     email: string;
-    password: string; 
+    password: string;
   };
 
   let originalMappingRule: {
@@ -444,7 +444,9 @@ test.describe.parallel('Search Authorization API', () => {
     });
   });
 
-  test('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({request}) => {
+  test('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({
+    request,
+  }) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -444,8 +444,7 @@ test.describe.parallel('Search Authorization API', () => {
     });
   });
 
-  // Skiped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({request}) => {
+  test('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -15,6 +15,7 @@ import {
   encode,
   assertStatusCode,
   isForwardCompat,
+  assertInvalidArgument,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {cleanupUsers} from '../../../../utils/usersCleanup';
@@ -444,7 +445,7 @@ test.describe.parallel('Search Authorization API', () => {
     });
   });
 
-  test('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({
+  test('Search Authorization - Negative pagination values - 400 Invalid Argument', async ({
     request,
   }) => {
     await expect(async () => {
@@ -454,7 +455,11 @@ test.describe.parallel('Search Authorization API', () => {
           page: {from: -1, limit: -1},
         },
       });
-      await assertBadRequest(res, /page\.(from|limit)/i);
+      await assertInvalidArgument(
+        res,
+        400,
+        "The value for page.limit is '-1' but must be a non-negative number. The value for page.from is '-1' but must be a non-negative number.",
+      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
@@ -18,6 +18,7 @@ import {
   assertUnauthorizedRequest,
   encode,
   isForwardCompat,
+  assertInvalidArgument,
 } from '../../../../utils/http';
 import {
   CORRELATE_MESSAGE,
@@ -473,7 +474,11 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
           },
         },
       );
-      await assertBadRequest(res, /page\.(from|limit)/i);
+      await assertInvalidArgument(
+        res,
+        400,
+        "The value for page.limit is '-5' but must be a non-negative number.",
+      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
@@ -458,8 +458,7 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
     });
   });
 
-  // Skiped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Message Subscriptions - Negative pagination - 400 Bad Request', async ({
+  test('Search Message Subscriptions - Negative pagination - 400 Bad Request', async ({
     request,
   }) => {
     await expect(async () => {


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/31787153422) on 2026-08-14.

**2** test(s) in `stable/8.8` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#39372](https://github.com/camunda/camunda/issues/39372) No validation of page limit attribute in Search Request — closed 2026-03-09

### Files Changed (2)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)

### On-demand E2E

<!--ONDEMAND_RUN-->

### Checklist

- [x] On-demand test run passes on this branch - [was all green](https://github.com/camunda/camunda/actions/runs/32034212088)
- [x] No regressions in adjacent tests
