### PR TITLE
refactor: accept empty tenant param as cluster-wide op for cluster admin operations for recovery

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryController.java
@@ -56,16 +56,16 @@ public final class ClusterRecoveryController {
       @RequestParam final Mode mode,
       @RequestParam(required = false) final @Nullable String physicalTenantId,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
-    rejectBlankPhysicalTenantId(physicalTenantId);
+    final var targetPhysicalTenantId = targetPhysicalTenant(physicalTenantId);
     LOG.debug(
         "Requested cluster mode change to {} for {}",
         mode,
-        physicalTenantId == null ? "all tenants" : physicalTenantId);
+        targetPhysicalTenantId == null ? "all tenants" : targetPhysicalTenantId);
     return RequestExecutor.executeServiceMethod(
         () ->
             serviceRegistry
                 .clusterRecoveryServices()
-                .changeMode(physicalTenantId, mode, dryRun)
+                .changeMode(targetPhysicalTenantId, mode, dryRun)
                 .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
         ClusterModeChangeMapper::toClusterModeChangeResponse,
         HttpStatus.OK);
@@ -76,16 +76,16 @@ public final class ClusterRecoveryController {
       @RequestParam(required = false) final @Nullable String physicalTenantId,
       @RequestBody final io.camunda.gateway.protocol.model.ClusterRestoreRequest restoreRequest,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
-    rejectBlankPhysicalTenantId(physicalTenantId);
+    final var targetPhysicalTenantId = targetPhysicalTenant(physicalTenantId);
     LOG.info(
         "Requested restore for {}: {}",
-        physicalTenantId == null ? "all tenants" : physicalTenantId,
+        targetPhysicalTenantId == null ? "all tenants" : targetPhysicalTenantId,
         restoreRequest);
     final var overrides = restoreRequest.getOverrides();
-    if (physicalTenantId != null && overrides != null && !overrides.isEmpty()) {
+    if (targetPhysicalTenantId != null && overrides != null && !overrides.isEmpty()) {
       throw new ServiceException(
           "Expected to restore physical tenant '%s', but the request also carries overrides for "
-                  .formatted(physicalTenantId)
+                  .formatted(targetPhysicalTenantId)
               + "other physical tenants. Overrides are only allowed for a cluster-wide restore.",
           Status.INVALID_ARGUMENT);
     }
@@ -103,17 +103,22 @@ public final class ClusterRecoveryController {
             serviceRegistry
                 .clusterRecoveryServices()
                 .restore(
-                    Optional.ofNullable(physicalTenantId), parameters, overrideParameters, dryRun)
+                    Optional.ofNullable(targetPhysicalTenantId),
+                    parameters,
+                    overrideParameters,
+                    dryRun)
                 .thenApply(ClusterModeChangeMapper::unwrapOrThrow),
         ClusterModeChangeMapper::toClusterRestoreResponse,
         HttpStatus.ACCEPTED);
   }
 
-  private static void rejectBlankPhysicalTenantId(final @Nullable String physicalTenantId) {
-    if (physicalTenantId != null && physicalTenantId.isBlank()) {
-      throw new ServiceException(
-          "Expected physicalTenantId to identify a physical tenant, but it was empty.",
-          Status.INVALID_ARGUMENT);
-    }
+  /**
+   * Resolves which physical tenant an operation targets: the named tenant, or {@code null} when the
+   * request names none and the operation therefore spans every physical tenant of the cluster. A
+   * blank id names no tenant, so it is cluster-wide as well rather than a request the cluster-admin
+   * API rejects.
+   */
+  private static @Nullable String targetPhysicalTenant(final @Nullable String physicalTenantId) {
+    return physicalTenantId == null || physicalTenantId.isBlank() ? null : physicalTenantId;
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -182,23 +182,32 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldRejectABlankPhysicalTenantAsAMalformedRequest() {
-    // when / then
+  void shouldChangeModeOfEveryPhysicalTenantWhenTheGivenTenantIsBlank() {
+    // given
+    when(clusterRecoveryServices.changeMode(
+            Mockito.isNull(), Mockito.eq(Mode.RECOVERING), Mockito.eq(false)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(plannedChange(8L, "tenant-b", "default"))));
+
+    // when / then — a blank id names no tenant, so the operation spans the cluster instead of being
+    // rejected
     webClient
         .patch()
         .uri(MODE_URL + "?mode=RECOVERING&physicalTenantId=")
         .exchange()
         .expectStatus()
-        .isBadRequest();
+        .isOk();
 
-    Mockito.verify(clusterRecoveryServices, Mockito.never())
-        .changeMode(Mockito.any(), Mockito.any(), Mockito.anyBoolean());
+    Mockito.verify(clusterRecoveryServices).changeMode(null, Mode.RECOVERING, false);
   }
 
   @Test
-  void shouldRejectABlankPhysicalTenantOnARestoreAsAMalformedRequest() {
-    // when / then — the parameter both operations share is rejected the same way, rather than a
-    // restore being scoped to an empty physical tenant id
+  void shouldRestoreEveryPhysicalTenantWhenTheGivenTenantIsBlank() {
+    // given
+    givenRestoreAccepted(9L);
+
+    // when / then — the parameter both operations share resolves the same way
     webClient
         .post()
         .uri(RESTORE_URL + "?physicalTenantId=")
@@ -206,10 +215,11 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
         .bodyValue("{\"backupIds\": [ 55 ]}")
         .exchange()
         .expectStatus()
-        .isBadRequest();
+        .isAccepted();
 
-    Mockito.verify(clusterRecoveryServices, Mockito.never())
-        .restore(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
+    Mockito.verify(clusterRecoveryServices)
+        .restore(
+            Optional.empty(), new RestoreParameters(List.of(55L), null, null), Map.of(), false);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

For the ClusterRecoveryController, map a possible empty tenant to a cluster-wide operation

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
