### PR TITLE
ci: stop AlwaysGreen from re-dispatching work it has already done

### DIFF
--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -462,6 +462,55 @@ def recent_no_fix_fingerprints(workdir: Path) -> set[str]:
     return out
 
 
+def _e2e_touched_since(suite: str, since: str) -> bool:
+    """True when the e2e repo changed this version's test code after `since`."""
+    for path in (f"tests/{suite}", f"pages/{suite}"):
+        commits = gh_json(
+            [
+                "api",
+                f"repos/{E2E_REPO}/commits?path={path}&since={since}&per_page=5",
+            ],
+            [],
+        )
+        if isinstance(commits, list) and commits:
+            shas = [str(c.get("sha") or "")[:7] for c in commits if isinstance(c, dict)]
+            log(f"e2e {path} changed after the run started: {', '.join(shas)}")
+            return True
+    return False
+
+
+def fixed_upstream_fingerprints(
+    candidates: list[planning.Candidate], since: str
+) -> set[str]:
+    """Fingerprints whose test code was already superseded when triage ran.
+
+    The suite executes the published `@camunda/e2e-test-suite` package, not repo
+    source, so a merged fix keeps failing until the package is published. Every run
+    inside that window dispatched an agent that could only conclude "already fixed,
+    no diff to open" — runs 30887597964 and 31016165246 both did exactly that for
+    e2e PR #2899, which merged 33 minutes after the first of them started.
+
+    Anchored to the failing run's start, which makes it self-limiting: once the fix
+    has landed, a later run that still fails started *after* the commit, nothing
+    matches, and the agent is dispatched normally. It only ever withholds the window
+    between a run beginning and a fix landing mid-flight.
+    """
+    if not since:
+        return set()
+    out: set[str] = set()
+    touched: dict[str, bool] = {}
+    for cand in candidates:
+        for spec, fp in zip(cand.specs, cand.spec_fingerprints):
+            suite = planning.spec_suite(spec.file)
+            if not suite:
+                continue
+            if suite not in touched:
+                touched[suite] = _e2e_touched_since(suite, since)
+            if touched[suite]:
+                out.add(fp)
+    return out
+
+
 def product_bug_fingerprints() -> set[str]:
     issues = gh_json(
         [
@@ -643,6 +692,9 @@ def main() -> int:
             pr_keys = {c.key for c in candidates}
             log("::warning::open fix PR lookup failed; suppressing dispatch this run")
 
+        run = gh_json(["api", f"repos/{REPO}/actions/runs/{args.run_id}"], {})
+        started = run.get("run_started_at") or run.get("created_at") or ""
+
         result = planning.plan_dispatches(
             candidates,
             covered_fingerprints=covered_fingerprints(),
@@ -650,11 +702,11 @@ def main() -> int:
             open_pr_keys=pr_keys,
             product_bug_fingerprints=product_bug_fingerprints(),
             recent_no_fix_fingerprints=recent_no_fix_fingerprints(workdir),
+            fixed_upstream_fingerprints=fixed_upstream_fingerprints(candidates, started),
             max_dispatches=args.max_dispatches,
         )
         result.noise = noise
 
-        run = gh_json(["api", f"repos/{REPO}/actions/runs/{args.run_id}"], {})
         blame = resolve_blame(run.get("head_sha") or "")
 
         payload = serialise(result, blame, args.run_id)

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -24,6 +24,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timedelta, timezone
 from dataclasses import asdict
 from pathlib import Path
 
@@ -36,6 +37,11 @@ FIX_WORKFLOW = os.environ.get("ALWAYSGREEN_FIX_WORKFLOW", "alwaysgreen-fix.yml")
 FIX_LABEL = os.environ.get("ALWAYSGREEN_FIX_LABEL", "alwaysgreen-fix")
 #: Prefix of the per-dispatch-key label the fix workflow stamps on every PR it opens.
 KEY_LABEL_PREFIX = "alwaysgreen-key:"
+#: How long a no-fix verdict keeps its fingerprints out of dispatch.
+NO_FIX_COOLDOWN_DAYS = int(os.environ.get("ALWAYSGREEN_NO_FIX_COOLDOWN_DAYS", "7"))
+#: Cap on artifact downloads while reading past verdicts, so a burst of agent runs
+#: cannot make triage slow.
+NO_FIX_MAX_RUNS = 20
 #: Repos a fix PR can land in, mirroring the fix workflow's own label list.
 FIX_PR_REPOS = [
     REPO,
@@ -316,17 +322,24 @@ def downstream_ci_specs(downstream_id: str) -> list[classify.FailingSpec]:
 
 
 def covered_fingerprints() -> set[str]:
-    prs = gh_json(
-        [
-            "pr", "list", "--repo", REPO,
-            "--search", f"label:{FIX_LABEL} is:open",
-            "--limit", "100", "--json", "number,body",
-        ],
-        [],
-    )
+    """Fingerprints claimed by an open fix PR, in any repo a fix can land in.
+
+    Scoped to every repo in FIX_PR_REPOS, not just the monorepo: most fixes land in
+    the e2e or chart repo, and reading only `REPO` made those coverage blocks
+    invisible here, so their specs stayed dispatchable.
+    """
     out: set[str] = set()
-    for pr in prs if isinstance(prs, list) else []:
-        out |= planning.parse_coverage_block(pr.get("body"))
+    for repo in FIX_PR_REPOS:
+        prs = gh_json(
+            [
+                "pr", "list", "--repo", repo,
+                "--search", f"label:{FIX_LABEL} is:open",
+                "--limit", "100", "--json", "number,body",
+            ],
+            [],
+        )
+        for pr in prs if isinstance(prs, list) else []:
+            out |= planning.parse_coverage_block(pr.get("body"))
     return out
 
 
@@ -392,6 +405,61 @@ def inflight_keys() -> tuple[set[str], bool]:
         if r.get("status") in {"queued", "in_progress"} and "[" in (r.get("name") or "")
     }
     return {k for k in keys if k}, True
+
+
+def recent_no_fix_fingerprints(workdir: Path) -> set[str]:
+    """Fingerprints an agent investigated recently and could not safely fix.
+
+    A verdict with an empty `prs` list opens no PR, so neither a coverage block nor a
+    key label exists to record it, and the identical investigation was dispatched
+    again on the next red run. The agent already uploads its manifest as
+    `alwaysgreen-fix-<run_id>`, so its own artifacts are the record — no issue and no
+    label are created anywhere, and the cooldown expires on its own rather than
+    suppressing a surface indefinitely.
+
+    Runs older than the cooldown are skipped before they are downloaded, and no more
+    than NO_FIX_MAX_RUNS artifacts are fetched per triage run. Fingerprints already
+    encode base_ref and surface, so verdicts from other dispatch keys cannot leak in.
+    """
+    runs = gh_json(
+        [
+            "run", "list", "--repo", REPO, "--workflow", FIX_WORKFLOW,
+            "--status", "completed", "--limit", "50",
+            "--json", "databaseId,createdAt",
+        ],
+        [],
+    )
+    if not isinstance(runs, list):
+        return set()
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=NO_FIX_COOLDOWN_DAYS)
+    out: set[str] = set()
+    fetched = 0
+    for run in runs:
+        if fetched >= NO_FIX_MAX_RUNS:
+            log(f"no-fix lookback capped at {NO_FIX_MAX_RUNS} runs")
+            break
+        created = run.get("createdAt") or ""
+        try:
+            when = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if when < cutoff:
+            continue
+        run_id = run.get("databaseId")
+        dest = workdir / f"verdict-{run_id}"
+        if not download_artifacts(run_id, REPO, f"alwaysgreen-fix-{run_id}", dest):
+            continue
+        fetched += 1
+        metas = read_json_files(dest, "fix-meta.json")
+        fps = read_json_files(dest, "fingerprints.json")
+        claimed = planning.verdict_fingerprints(
+            metas[0] if metas else None, fps[0] if fps else None
+        )
+        if claimed:
+            log(f"run {run_id} recorded no fix for {sorted(claimed)}")
+        out |= claimed
+    return out
 
 
 def product_bug_fingerprints() -> set[str]:
@@ -581,6 +649,7 @@ def main() -> int:
             inflight_keys=keys,
             open_pr_keys=pr_keys,
             product_bug_fingerprints=product_bug_fingerprints(),
+            recent_no_fix_fingerprints=recent_no_fix_fingerprints(workdir),
             max_dispatches=args.max_dispatches,
         )
         result.noise = noise

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -27,12 +27,53 @@ SUPPRESSED_IN_FLIGHT = "agent-already-running"
 SUPPRESSED_PR_COVERED = "open-pr-covers-all-specs"
 SUPPRESSED_PR_OPEN = "open-fix-pr-for-surface"
 SUPPRESSED_PRODUCT_BUG = "tracked-by-open-product-bug"
+SUPPRESSED_RECENT_NO_FIX = "no-fix-verdict-within-cooldown"
 SUPPRESSED_NO_EVIDENCE = "no-failing-specs-extracted"
 SUPPRESSED_CAP = "per-run-cap-reached"
 
 
 def dispatch_key(base_ref: str, surface: str) -> str:
     return f"{base_ref}:{surface}"
+
+
+def dedupe_specs(specs: list[classify.FailingSpec]) -> list[classify.FailingSpec]:
+    """Collapse repeats of the same (file, test_name), keeping the first.
+
+    A SaaS run on 8.8/8.9 publishes one Playwright report per Tasklist generation
+    (`json-report-v1` and `json-report-v2`), and discover concatenates every report
+    it downloads. A spec that fails in both generations therefore arrives twice, which
+    doubles the agent's spec list and the fingerprints it is told to claim — observed
+    on run 31016165246, where two failing tests were dispatched as four.
+    """
+    out: list[classify.FailingSpec] = []
+    seen: set[tuple[str, str]] = set()
+    for spec in specs:
+        identity = (spec.file, spec.test_name)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        out.append(spec)
+    return out
+
+
+def verdict_fingerprints(
+    fix_meta: object, fingerprints: object
+) -> set[str]:
+    """Fingerprints a finished agent run leaves suppressed, from its own artifacts.
+
+    Empty unless the run produced a manifest that opened nothing. A crashed agent
+    (no manifest, or one that will not parse) and a run that opened a PR must both
+    contribute nothing: the first is an infrastructure failure rather than a verdict,
+    and the second is already covered by the PR's own coverage block.
+    """
+    if not isinstance(fix_meta, dict):
+        return set()
+    prs = fix_meta.get("prs")
+    if not isinstance(prs, list) or prs:
+        return set()
+    if not isinstance(fingerprints, list):
+        return set()
+    return {str(fp)[:8] for fp in fingerprints if fp}
 
 
 @dataclass
@@ -95,6 +136,7 @@ def plan_dispatches(
     inflight_keys: set[str],
     open_pr_keys: set[str],
     product_bug_fingerprints: set[str],
+    recent_no_fix_fingerprints: set[str] | None = None,
     max_dispatches: int = 2,
     dispatchable_surfaces: frozenset[str] = classify.DISPATCHABLE_SURFACES,
 ) -> Plan:
@@ -102,10 +144,19 @@ def plan_dispatches(
 
     Checks are ordered cheapest-and-most-decisive first so the summary reports the
     most useful reason when several apply.
+
+    `recent_no_fix_fingerprints` are those an agent investigated inside the cooldown
+    window and could not safely fix. Without them a `not-determined` verdict leaves no
+    state anywhere — no PR, so no coverage block and no key label — and the identical
+    forensic run is dispatched again on the next failure.
     """
     plan = Plan()
+    no_fix = recent_no_fix_fingerprints or set()
 
     for cand in candidates:
+        # Before anything reads .specs or derives fingerprints from them.
+        cand.specs = dedupe_specs(cand.specs)
+
         if cand.surface not in dispatchable_surfaces:
             plan.suppressed.append(
                 Suppression(cand, SUPPRESSED_NOT_DISPATCHABLE, cand.surface)
@@ -135,13 +186,21 @@ def plan_dispatches(
             )
             continue
 
-        # Drop specs an open PR already covers; dispatch only what is left.
+        if fps and all(f in no_fix for f in fps):
+            plan.suppressed.append(
+                Suppression(cand, SUPPRESSED_RECENT_NO_FIX, ",".join(sorted(set(fps))))
+            )
+            continue
+
+        # Drop specs an open PR or a recent no-fix verdict already accounts for;
+        # dispatch only what is left.
         if not cand.job_level:
             remaining = [
                 s
                 for s, fp in zip(cand.specs, cand.spec_fingerprints)
                 if fp not in covered_fingerprints
                 and fp not in product_bug_fingerprints
+                and fp not in no_fix
             ]
             if not remaining:
                 plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_COVERED))

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -28,8 +28,25 @@ SUPPRESSED_PR_COVERED = "open-pr-covers-all-specs"
 SUPPRESSED_PR_OPEN = "open-fix-pr-for-surface"
 SUPPRESSED_PRODUCT_BUG = "tracked-by-open-product-bug"
 SUPPRESSED_RECENT_NO_FIX = "no-fix-verdict-within-cooldown"
+SUPPRESSED_FIXED_UPSTREAM = "fixed-upstream-after-run-started"
+SUPPRESSED_UNSUPPORTED_REF = "base-ref-not-supported-by-fix-agent"
 SUPPRESSED_NO_EVIDENCE = "no-failing-specs-extracted"
 SUPPRESSED_CAP = "per-run-cap-reached"
+
+
+#: Branches the fix agent accepts. Must stay in sync with the `Validate inputs` case
+#: statement in alwaysgreen-fix.yml: dispatching anything else spends a runner only to
+#: fail on the agent's first step, which is what happened to run 31115770750 on
+#: `ci/alwaysgreen-helm-live-check`.
+SUPPORTED_BASE_REFS = frozenset({"main", "stable/8.7", "stable/8.8", "stable/8.9"})
+
+
+def spec_suite(spec_file: str) -> str | None:
+    """The version directory a spec lives in: `tests/SM-8.10/x.spec.ts` -> `SM-8.10`."""
+    parts = (spec_file or "").split("/")
+    if len(parts) >= 3 and parts[0] == "tests" and parts[1]:
+        return parts[1]
+    return None
 
 
 def dispatch_key(base_ref: str, surface: str) -> str:
@@ -137,6 +154,8 @@ def plan_dispatches(
     open_pr_keys: set[str],
     product_bug_fingerprints: set[str],
     recent_no_fix_fingerprints: set[str] | None = None,
+    fixed_upstream_fingerprints: set[str] | None = None,
+    supported_base_refs: frozenset[str] = SUPPORTED_BASE_REFS,
     max_dispatches: int = 2,
     dispatchable_surfaces: frozenset[str] = classify.DISPATCHABLE_SURFACES,
 ) -> Plan:
@@ -149,13 +168,23 @@ def plan_dispatches(
     window and could not safely fix. Without them a `not-determined` verdict leaves no
     state anywhere — no PR, so no coverage block and no key label — and the identical
     forensic run is dispatched again on the next failure.
+
+    `fixed_upstream_fingerprints` are those whose test code changed in the e2e repo
+    after the failing run started, so the run executed source that is already superseded.
     """
     plan = Plan()
     no_fix = recent_no_fix_fingerprints or set()
+    fixed_upstream = fixed_upstream_fingerprints or set()
 
     for cand in candidates:
         # Before anything reads .specs or derives fingerprints from them.
         cand.specs = dedupe_specs(cand.specs)
+
+        if cand.base_ref not in supported_base_refs:
+            plan.suppressed.append(
+                Suppression(cand, SUPPRESSED_UNSUPPORTED_REF, cand.base_ref)
+            )
+            continue
 
         if cand.surface not in dispatchable_surfaces:
             plan.suppressed.append(
@@ -192,8 +221,14 @@ def plan_dispatches(
             )
             continue
 
-        # Drop specs an open PR or a recent no-fix verdict already accounts for;
-        # dispatch only what is left.
+        if fps and all(f in fixed_upstream for f in fps):
+            plan.suppressed.append(
+                Suppression(cand, SUPPRESSED_FIXED_UPSTREAM, ",".join(sorted(set(fps))))
+            )
+            continue
+
+        # Drop specs an open PR, a recent no-fix verdict or an upstream fix already
+        # accounts for; dispatch only what is left.
         if not cand.job_level:
             remaining = [
                 s
@@ -201,6 +236,7 @@ def plan_dispatches(
                 if fp not in covered_fingerprints
                 and fp not in product_bug_fingerprints
                 and fp not in no_fix
+                and fp not in fixed_upstream
             ]
             if not remaining:
                 plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_COVERED))

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -30,6 +30,8 @@ SUPPRESSED_PRODUCT_BUG = "tracked-by-open-product-bug"
 SUPPRESSED_RECENT_NO_FIX = "no-fix-verdict-within-cooldown"
 SUPPRESSED_FIXED_UPSTREAM = "fixed-upstream-after-run-started"
 SUPPRESSED_UNSUPPORTED_REF = "base-ref-not-supported-by-fix-agent"
+#: Every spec was dropped, but by more than one of the sources above.
+SUPPRESSED_ALL_ACCOUNTED = "all-specs-already-accounted-for"
 SUPPRESSED_NO_EVIDENCE = "no-failing-specs-extracted"
 SUPPRESSED_CAP = "per-run-cap-reached"
 
@@ -227,19 +229,31 @@ def plan_dispatches(
             )
             continue
 
-        # Drop specs an open PR, a recent no-fix verdict or an upstream fix already
-        # accounts for; dispatch only what is left.
+        # Drop specs an open PR, a product bug, a recent no-fix verdict or an upstream
+        # fix already accounts for; dispatch only what is left. Which source dropped
+        # each one is tracked so the summary names the real blocker: reporting every
+        # empty remainder as "open-pr-covers-all-specs" hid the other three.
         if not cand.job_level:
-            remaining = [
-                s
-                for s, fp in zip(cand.specs, cand.spec_fingerprints)
-                if fp not in covered_fingerprints
-                and fp not in product_bug_fingerprints
-                and fp not in no_fix
-                and fp not in fixed_upstream
-            ]
+            accounted: list[str] = []
+            remaining = []
+            for spec, fp in zip(cand.specs, cand.spec_fingerprints):
+                if fp in covered_fingerprints:
+                    accounted.append(SUPPRESSED_PR_COVERED)
+                elif fp in product_bug_fingerprints:
+                    accounted.append(SUPPRESSED_PRODUCT_BUG)
+                elif fp in no_fix:
+                    accounted.append(SUPPRESSED_RECENT_NO_FIX)
+                elif fp in fixed_upstream:
+                    accounted.append(SUPPRESSED_FIXED_UPSTREAM)
+                else:
+                    remaining.append(spec)
             if not remaining:
-                plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_COVERED))
+                sources = sorted(set(accounted))
+                plan.suppressed.append(
+                    Suppression(cand, sources[0], "")
+                    if len(sources) == 1
+                    else Suppression(cand, SUPPRESSED_ALL_ACCOUNTED, ",".join(sources))
+                )
                 continue
             cand.specs = remaining
         elif fps and all(f in covered_fingerprints for f in fps):

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -248,6 +248,13 @@ def test_crashed_run_suppresses_nothing():
     assert plan.verdict_fingerprints({"prs": "broken"}, ["76a3348c"]) == set()
 
 
+def test_malformed_prs_shapes_suppress_nothing():
+    # A readable manifest whose `prs` is missing, null or an object must not be read
+    # as "opened nothing": only a genuine empty list is a no-fix verdict.
+    for meta in ({}, {"prs": None}, {"prs": {}}, {"other": 1}):
+        assert plan.verdict_fingerprints(meta, ["76a3348c"]) == set(), meta
+
+
 def test_verdict_without_fingerprints_suppresses_nothing():
     assert plan.verdict_fingerprints({"prs": []}, None) == set()
     assert plan.verdict_fingerprints({"prs": []}, []) == set()
@@ -257,6 +264,45 @@ def test_verdict_fingerprints_are_normalised_and_deduped():
     assert plan.verdict_fingerprints(
         {"prs": []}, ["76a3348c", "76a3348c", "", None]
     ) == {"76a3348c"}
+
+
+def test_mixed_suppression_sources_are_named_not_reported_as_pr_coverage():
+    # Each spec is dropped by a different source. Reporting the whole candidate as
+    # "open-pr-covers-all-specs" would hide the other sources from the summary.
+    by_pr = _spec(name="covered by pr")
+    by_upstream = _spec(name="fixed upstream")
+    cand = _cand(specs=[by_pr, by_upstream])
+    fp = {
+        s.test_name: classify.spec_fingerprint(
+            "main", classify.SURFACE_SM_E2E, s.file, s.test_name
+        )
+        for s in (by_pr, by_upstream)
+    }
+
+    result = _plan(
+        [cand],
+        covered_fingerprints={fp["covered by pr"]},
+        fixed_upstream_fingerprints={fp["fixed upstream"]},
+    )
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_ALL_ACCOUNTED
+    assert result.suppressed[0].detail == ",".join(
+        sorted({plan.SUPPRESSED_PR_COVERED, plan.SUPPRESSED_FIXED_UPSTREAM})
+    )
+
+
+def test_single_suppression_source_keeps_its_own_reason():
+    # Only one source accounts for every spec, so the specific reason survives.
+    a, b = _spec(name="a"), _spec(name="b")
+    cand = _cand(specs=[a, b])
+    fps = {
+        classify.spec_fingerprint("main", classify.SURFACE_SM_E2E, s.file, s.test_name)
+        for s in (a, b)
+    }
+    # Partial overlap with a second source would otherwise be indistinguishable.
+    result = _plan([cand], covered_fingerprints=fps)
+    assert result.suppressed[0].reason == plan.SUPPRESSED_PR_COVERED
+    assert result.suppressed[0].detail == ""
 
 
 def test_product_bug_suppresses_the_candidate():

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -119,6 +119,76 @@ def test_partially_covered_candidate_dispatches_only_uncovered_specs():
     assert [s.test_name for s in result.dispatches[0].specs] == ["new failure"]
 
 
+def test_recent_no_fix_verdict_suppresses_the_candidate():
+    # An agent already investigated this inside the cooldown and could not fix it
+    # safely; its own uploaded manifest is the only record, since no PR was opened.
+    cand = _cand()
+    result = _plan([cand], recent_no_fix_fingerprints=set(cand.spec_fingerprints))
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_RECENT_NO_FIX
+
+
+def test_no_fix_spec_does_not_block_a_new_failure_beside_it():
+    tracked = _spec(name="unfixable")
+    fresh = _spec(name="new failure")
+    cand = _cand(specs=[tracked, fresh])
+    tracked_fp = classify.spec_fingerprint(
+        "main", classify.SURFACE_SM_E2E, tracked.file, tracked.test_name
+    )
+
+    result = _plan([cand], recent_no_fix_fingerprints={tracked_fp})
+    assert len(result.dispatches) == 1
+    assert [s.test_name for s in result.dispatches[0].specs] == ["new failure"]
+
+
+def test_no_fix_defaults_to_nothing_suppressed():
+    # The argument is optional so callers that predate it keep dispatching.
+    result = plan.plan_dispatches(
+        [_cand()],
+        covered_fingerprints=set(),
+        inflight_keys=set(),
+        open_pr_keys=set(),
+        product_bug_fingerprints=set(),
+    )
+    assert len(result.dispatches) == 1
+
+
+# ---------------------------------------------------------------------------
+# Reading a past run's verdict off its own artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_of_a_run_that_opened_nothing_suppresses_its_fingerprints():
+    assert plan.verdict_fingerprints(
+        {"category": "not-determined", "prs": []}, ["76a3348c", "2e9d6176"]
+    ) == {"76a3348c", "2e9d6176"}
+
+
+def test_verdict_of_a_run_that_opened_a_pr_suppresses_nothing():
+    # Already covered by that PR's own coverage block; double-counting it here would
+    # keep suppressing after the PR is closed or merged.
+    assert plan.verdict_fingerprints({"prs": [{"number": 1}]}, ["76a3348c"]) == set()
+
+
+def test_crashed_run_suppresses_nothing():
+    # No manifest is an infrastructure failure, not a verdict, and must not be
+    # mistaken for "we looked and there was nothing to do".
+    assert plan.verdict_fingerprints(None, ["76a3348c"]) == set()
+    assert plan.verdict_fingerprints("not json", ["76a3348c"]) == set()
+    assert plan.verdict_fingerprints({"prs": "broken"}, ["76a3348c"]) == set()
+
+
+def test_verdict_without_fingerprints_suppresses_nothing():
+    assert plan.verdict_fingerprints({"prs": []}, None) == set()
+    assert plan.verdict_fingerprints({"prs": []}, []) == set()
+
+
+def test_verdict_fingerprints_are_normalised_and_deduped():
+    assert plan.verdict_fingerprints(
+        {"prs": []}, ["76a3348c", "76a3348c", "", None]
+    ) == {"76a3348c"}
+
+
 def test_product_bug_suppresses_the_candidate():
     cand = _cand()
     result = _plan([cand], product_bug_fingerprints=set(cand.spec_fingerprints))
@@ -157,6 +227,42 @@ def test_in_flight_is_checked_before_cap_so_the_reason_is_useful():
     assert plan.SUPPRESSED_IN_FLIGHT in reasons
     assert len(result.dispatches) == 1
     assert result.dispatches[0].surface == classify.SURFACE_SAAS_E2E
+
+
+# ---------------------------------------------------------------------------
+# Spec dedupe
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_collapses_the_same_spec_from_two_reports():
+    # SaaS 8.8/8.9 publish json-report-v1 and json-report-v2; discover concatenates
+    # both, so a spec failing in each generation arrives twice.
+    a, b = _spec(name="flow"), _spec(name="flow")
+    assert [s.test_name for s in plan.dedupe_specs([a, b])] == ["flow"]
+
+
+def test_dedupe_keeps_distinct_tests_and_distinct_files():
+    specs = [
+        _spec(name="flow"),
+        _spec(name="connector"),
+        _spec(name="flow", file="tests/8.9/other.spec.ts"),
+    ]
+    assert len(plan.dedupe_specs(specs)) == 3
+
+
+def test_dedupe_preserves_order():
+    specs = [_spec(name="b"), _spec(name="a"), _spec(name="b")]
+    assert [s.test_name for s in plan.dedupe_specs(specs)] == ["b", "a"]
+
+
+def test_duplicated_specs_are_dispatched_once():
+    # Run 31016165246 dispatched two failing tests as four, with each fingerprint
+    # repeated, because nothing deduped across the two reports.
+    cand = _cand(specs=[_spec(name="flow"), _spec(name="connector")] * 2)
+    result = _plan([cand])
+    dispatched = result.dispatches[0]
+    assert [s.test_name for s in dispatched.specs] == ["flow", "connector"]
+    assert len(dispatched.fingerprints) == len(set(dispatched.fingerprints)) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -153,6 +153,76 @@ def test_no_fix_defaults_to_nothing_suppressed():
     assert len(result.dispatches) == 1
 
 
+def test_fixed_upstream_suppresses_the_candidate():
+    # The run executed the published package, and the fix merged after it started.
+    cand = _cand()
+    result = _plan([cand], fixed_upstream_fingerprints=set(cand.spec_fingerprints))
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_FIXED_UPSTREAM
+
+
+def test_fixed_upstream_spec_does_not_block_a_new_failure_beside_it():
+    stale = _spec(name="already fixed upstream")
+    fresh = _spec(name="new failure")
+    cand = _cand(specs=[stale, fresh])
+    stale_fp = classify.spec_fingerprint(
+        "main", classify.SURFACE_SM_E2E, stale.file, stale.test_name
+    )
+
+    result = _plan([cand], fixed_upstream_fingerprints={stale_fp})
+    assert len(result.dispatches) == 1
+    assert [s.test_name for s in result.dispatches[0].specs] == ["new failure"]
+
+
+# ---------------------------------------------------------------------------
+# Base refs the fix agent accepts
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_base_ref_is_not_dispatched():
+    # The fix workflow rejects anything outside its whitelist on its first step, so
+    # dispatching it spends a runner to produce a confusing failure (run 31115770750
+    # on ci/alwaysgreen-helm-live-check).
+    result = _plan([_cand(base_ref="ci/alwaysgreen-helm-live-check")])
+    assert result.dispatches == []
+    assert result.suppressed[0].reason == plan.SUPPRESSED_UNSUPPORTED_REF
+    assert result.suppressed[0].detail == "ci/alwaysgreen-helm-live-check"
+
+
+def test_every_supported_base_ref_is_dispatchable():
+    for ref in plan.SUPPORTED_BASE_REFS:
+        result = _plan([_cand(base_ref=ref)])
+        assert len(result.dispatches) == 1, ref
+
+
+def test_unsupported_ref_is_reported_before_any_other_reason():
+    # Checked first so the summary names the real blocker rather than the cap.
+    result = _plan(
+        [_cand(base_ref="feature/x"), _cand(surface=classify.SURFACE_SAAS_E2E)],
+        max_dispatches=1,
+    )
+    assert result.suppressed[0].reason == plan.SUPPRESSED_UNSUPPORTED_REF
+
+
+# ---------------------------------------------------------------------------
+# Suite of a spec
+# ---------------------------------------------------------------------------
+
+
+def test_spec_suite_from_a_mapped_spec_path():
+    assert plan.spec_suite("tests/SM-8.10/smoke-tests.spec.ts") == "SM-8.10"
+    assert plan.spec_suite("tests/8.9/smoke-tests.spec.ts") == "8.9"
+
+
+def test_spec_suite_is_none_for_anything_else():
+    # A saas-ci synthetic spec carries a workflow path, and a bare filename means the
+    # report gave no rootDir to map from.
+    assert plan.spec_suite(".github/workflows/playwright_saas.yml") is None
+    assert plan.spec_suite("smoke-tests.spec.ts") is None
+    assert plan.spec_suite("") is None
+    assert plan.spec_suite("tests/") is None
+
+
 # ---------------------------------------------------------------------------
 # Reading a past run's verdict off its own artifacts
 # ---------------------------------------------------------------------------

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -102,6 +102,16 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      # Ahead of validation because `Observe build status` is a local action running
+      # under `if: always()`. With the checkout after a failing step, it died on
+      # "Did you forget to run actions/checkout" and buried the real error — which is
+      # all run 31115770750 showed for a rejected base_ref.
+      - name: Checkout main for tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Validate inputs
         id: target
         env:
@@ -128,12 +138,6 @@ jobs:
             echo "suite=${suite}"
             echo "chart=camunda-platform-${version}"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Checkout main for tooling
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 1
-          persist-credentials: false
 
       # The bundled JSON inputs exist because workflow_dispatch caps at 10 inputs.
       # Unpacked once here into step outputs so later steps read plain strings.
@@ -525,23 +529,42 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
 
+      # Gated on `always()` alone, not on the ctx step's outputs: a failure before ctx
+      # runs leaves them empty, which used to mean an early failure was silent in the
+      # thread. The bundle is re-read from the raw input below as a fallback.
       - name: Slack thread reply
-        if: ${{ always() && steps.ctx.outputs.slack_ts != '' }}
+        if: always()
         continue-on-error: true
         env:
           SLACK_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           SLACK_TS: ${{ steps.ctx.outputs.slack_ts }}
           SLACK_CHANNEL: ${{ steps.ctx.outputs.slack_channel }}
+          INPUT_SLACK: ${{ inputs.slack }}
           SURFACE: ${{ inputs.surface }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           JOB_STATUS: ${{ job.status }}
         run: |
           set -euo pipefail
-          if [ -f /tmp/fix-meta.json ] && [ "$(jq '.prs | length' /tmp/fix-meta.json)" -gt 0 ]; then
+          # ctx unpacks the bundle, but it may never have run.
+          if [ -z "${SLACK_TS}" ] && [ -n "${INPUT_SLACK}" ]; then
+            SLACK_TS=$(jq -r '.ts // ""' <<<"${INPUT_SLACK}" 2>/dev/null || echo "")
+            SLACK_CHANNEL=$(jq -r '.channel // ""' <<<"${INPUT_SLACK}" 2>/dev/null || echo "")
+          fi
+          if [ -z "${SLACK_TS}" ] || [ -z "${SLACK_CHANNEL}" ]; then
+            echo "no slack thread to reply to"
+            exit 0
+          fi
+          # -1 when absent or unparseable, so a broken manifest reports the no-verdict
+          # branch instead of erroring on an empty numeric comparison.
+          pr_count=-1
+          if [ -f /tmp/fix-meta.json ]; then
+            pr_count=$(jq '.prs | length' /tmp/fix-meta.json 2>/dev/null || echo -1)
+          fi
+          if [ "${pr_count}" -gt 0 ]; then
             links=$(jq -r '[.prs[] | "<\(.url // "")|PR #\(.number)>"] | join("  ")' /tmp/fix-meta.json)
             text=":white_check_mark: *${SURFACE}* — ${links}"
-          elif [ "${JOB_STATUS}" = "failure" ] && [ ! -f /tmp/fix-meta.json ]; then
-            text=":x: *${SURFACE}* — agent failed, no fix applied"
+          elif [ "${JOB_STATUS}" = "failure" ] && [ "${pr_count}" -lt 0 ]; then
+            text=":x: *${SURFACE}* — agent failed before producing a verdict, no fix applied"
           else
             # The analysis is the whole value of a no-fix run, and it used to reach the
             # on-call only as a 14-day artifact they had to know to download.

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -502,7 +502,7 @@ jobs:
               n=$(jq '.prs | length' /tmp/fix-meta.json 2>/dev/null || echo 0)
               if [ "$n" -eq 0 ]; then
                 echo ":warning: **No fix applied.**"
-                reason=$(jq -r '.reason // .root_cause // ""' /tmp/fix-meta.json)
+                reason=$(jq -r '.reason // .why_no_pr // .root_cause // ""' /tmp/fix-meta.json)
                 [ -n "$reason" ] && { echo ""; echo "**Reason:** ${reason}"; }
               else
                 jq -r '.prs[] | "### :white_check_mark: [PR #\(.number)](\(.url // ""))", "", "**Branch:** `\(.branch // "?")`", ""' \
@@ -540,10 +540,19 @@ jobs:
           if [ -f /tmp/fix-meta.json ] && [ "$(jq '.prs | length' /tmp/fix-meta.json)" -gt 0 ]; then
             links=$(jq -r '[.prs[] | "<\(.url // "")|PR #\(.number)>"] | join("  ")' /tmp/fix-meta.json)
             text=":white_check_mark: *${SURFACE}* — ${links}"
-          elif [ "${JOB_STATUS}" = "failure" ]; then
+          elif [ "${JOB_STATUS}" = "failure" ] && [ ! -f /tmp/fix-meta.json ]; then
             text=":x: *${SURFACE}* — agent failed, no fix applied"
           else
+            # The analysis is the whole value of a no-fix run, and it used to reach the
+            # on-call only as a 14-day artifact they had to know to download.
             text=":warning: *${SURFACE}* — no fix determined, manual investigation needed"
+            if [ -f /tmp/fix-meta.json ]; then
+              reason=$(jq -r '.reason // .why_no_pr // .root_cause // ""' \
+                         /tmp/fix-meta.json 2>/dev/null | head -c 700 || true)
+              if [ -n "${reason}" ]; then
+                text="${text}"$'\n'"${reason}"
+              fi
+            fi
           fi
           payload=$(jq -nc --arg c "$SLACK_CHANNEL" --arg ts "$SLACK_TS" \
             --arg t "${text}"$'\n'"<${RUN_URL}|Agent run ↗>" \

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -130,9 +130,15 @@ usually is not. And `camunda-docs` describing the new copy or behaviour for this
 settles it as intended — cite it in the PR body.
 
 If it is still genuinely ambiguous, do **not** pick one. Write `category: "not-determined"`
-to `/tmp/fix-meta.json` with the evidence, name both candidate fixes, and leave the
-fingerprint unclaimed so a recurrence is re-triaged. A human deciding in ten minutes beats
-either wrong PR.
+to `/tmp/fix-meta.json` with the evidence and name both candidate fixes. A human deciding in
+ten minutes beats either wrong PR.
+
+Your `reason` is the entire output of such a run, so write it for the on-call engineer who
+picks this up: the workflow posts it to the Slack thread and to the job summary. The run's
+manifest is also uploaded as an artifact, and triage reads it back — a verdict that opened
+nothing keeps its fingerprints out of dispatch for a cooldown period, so the same
+investigation is not repeated on every subsequent red run. It expires on its own; no issue
+is filed and nothing needs closing.
 
 **A test-side fix does not turn the run green by itself.** The helm e2e job runs the
 published `@camunda/e2e-test-suite` package, not the repo source, so a locator fix takes
@@ -281,6 +287,9 @@ Write `/tmp/fix-meta.json` before stopping, always:
   "reason": "Required when prs is empty: what you found and why no change was safe."
 }
 ```
+
+`reason` is mandatory whenever `prs` is empty — it is the Slack thread reply and the job
+summary, and it is all the next reader gets.
 
 `owner` and `repo` are required — PRs can land in any of the four repositories and the
 workflow uses them to label and request review.

--- a/docs/alwaysgreen/FIX-AGENT.md
+++ b/docs/alwaysgreen/FIX-AGENT.md
@@ -146,6 +146,11 @@ effect only once that package is published. Say so in the PR body: until then th
 stays red and the same failure will be re-dispatched unless your PR carries the coverage
 block.
 
+The other side of that lag: triage withholds a spec whose `tests/<suite>/` or
+`pages/<suite>/` code changed in the e2e repo *after* the failing run started, because the
+run executed source that is already superseded. So if you find the fix already merged
+upstream, that is expected — say so in `reason` and open nothing.
+
 ## When the surface is helm-install
 
 There is no Playwright report: the install never got far enough to run tests. Your evidence


### PR DESCRIPTION
## Description

Across the first 12 `AlwaysGreen Fix Agent` runs, 5 opened a PR, 5 finished with
`"prs": []`, and 2 crashed. The no-PR verdicts were mostly *correct* — the problem
is that the system threw the work away and then paid for it again.

| | |
|---|---|
| Runs that opened a PR | all 5 were `sm-smoke-e2e` or `helm-install` |
| `saas-smoke-e2e` dispatches | 0 of 5 opened a PR |
| No-PR runs whose cause was already fixed upstream | 3 of 5 |

Five fixes, in two commits. None of them creates an issue, a label, or any other
new artifact — every new signal is read from something the pipeline already produces.

### 1. A no-fix verdict is remembered (no issue filed)

Every suppression input the planner reads is PR- or issue-shaped: an open fix PR's
coverage block, its `alwaysgreen-key:` label, an open product-bug issue, or an
in-flight agent run. A verdict with an empty `prs` list populates **none** of them,
so the identical failure is dispatched again on the next red run.

The agent already uploads its manifest as `alwaysgreen-fix-<run_id>`, so triage
reads those artifacts back. A completed run whose manifest opened no PR keeps its
fingerprints out of dispatch for a cooldown window — 7 days, overridable via
`ALWAYSGREEN_NO_FIX_COOLDOWN_DAYS`, capped at 20 artifact reads per triage run.
The cooldown expires on its own rather than suppressing a surface indefinitely.

Fails closed by construction: a crashed agent leaves no manifest and a malformed
one does not parse, and neither suppresses anything — an infrastructure failure
must never be mistaken for a verdict. A run that *did* open a PR also contributes
nothing, since that PR's coverage block already covers it.

### 2. Stale dispatches are withheld

The suite runs the published `@camunda/e2e-test-suite` package, not repo source, so
a merged test fix keeps failing until the package publishes. Runs
[30887597964](https://github.com/camunda/camunda/actions/runs/30887597964) and
[31016165246](https://github.com/camunda/camunda/actions/runs/31016165246) each
spent a full agent run concluding that e2e PR #2899 — merged **33 minutes after the
first of them started** — had already fixed the failing locators.

Triage now withholds a spec whose `tests/<suite>/` or `pages/<suite>/` code changed
in the e2e repo *after the failing run started*. Anchoring to the run's start makes
it self-limiting: once the fix has landed, a later run that still fails started
after the commit, nothing matches, and the agent is dispatched normally. It only
ever withholds the window between a run beginning and a fix landing mid-flight. The
withheld fingerprints and the commits behind them are logged — nothing is dropped
silently.

### 3. Unsupported base refs are not dispatched

The fix workflow validates `base_ref` against a whitelist on its first step; triage
had no matching check. Run
[31115770750](https://github.com/camunda/camunda/actions/runs/31115770750) spent a
runner on `ci/alwaysgreen-helm-live-check` just to fail there. Triage now suppresses
an unsupported ref before dispatching, from a `SUPPORTED_BASE_REFS` set that must
stay in sync with that case statement.

### 4. Early failures are legible and no longer silent

That same run reported its failure as `Did you forget to run actions/checkout` —
because `Observe build status` is a local action running under `if: always()` and
the checkout came *after* the step that failed. The checkout now runs first, so the
real error survives. And the Slack reply was gated on `steps.ctx.outputs.slack_ts`,
which is empty when the failure precedes that step, so an early failure was
**completely silent in the thread**; it now falls back to the raw dispatch input.
The manifest is read defensively there too, so an unparseable one reports the
no-verdict branch instead of erroring on an empty numeric comparison.

### 5. Two dispatch-idempotency bugs

- **Duplicate specs.** SaaS runs on 8.8/8.9 publish one Playwright report per
  Tasklist generation (`json-report-v1`, `json-report-v2`) and `discover`
  concatenated both without deduping. Run
  [31016165246](https://github.com/camunda/camunda/actions/runs/31016165246)
  dispatched two failing tests as four, with every fingerprint repeated
  (`["16050013","c0bb49fd","16050013","c0bb49fd"]`). Now deduped by
  `(file, test_name)` before anything derives fingerprints.
- **Coverage read scoped to one repo.** `covered_fingerprints()` read only the
  monorepo while fix PRs land in three, so a coverage block in the e2e or chart repo
  was invisible and its specs stayed dispatchable. It now scopes to `FIX_PR_REPOS`,
  matching `open_fix_pr_keys()`.

Also: the agent's `reason` now reaches the Slack thread and the job summary, instead
of surviving only as a 14-day artifact the on-call had to know to download.

### Validation

- `pytest .github/scripts` — **146 passed**, 26 new cases: cooldown suppression,
  upstream-fix suppression, unsupported-ref suppression and its ordering, partial
  suppression beside a fresh failure, verdict extraction (opened-a-PR, crashed,
  unparseable, no fingerprints, normalise/dedupe), suite derivation, spec dedupe, and
  the observed duplication regression.
- `actionlint -shellcheck=shellcheck` clean on the changed workflow.
- The `Slack thread reply` step was extracted and driven against a stubbed `curl`
  for all four paths: PR opened, no-fix verdict (reason present), early failure with
  `ctx` never run (falls back to the raw input — previously silent), and no thread at
  all (quiet exit).
- `Scripts / Python Unit Tests` and `Lint / Actionlint` both passed on the previous
  push of this branch. Two bugs were caught by local verification before pushing: a
  `printf` format beginning with `-` being read as an option, and `SC2016` on
  markdown backticks inside a single-quoted format.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

n/a — found while investigating why the fix agent kept reporting "no fix determined".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
