### PR TITLE
ci: regenerate ApiPath union nightly to catch spec-side path renames

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -154,11 +154,16 @@ jobs:
           # package.json), which must not be mistaken for a deliberate absence:
           # collapsing the two would silently disable path detection and
           # recreate the staleness #60109 exists to end, one level up.
+          #
+          # The `|| rc=$?` is load-bearing. The runner invokes this with
+          # `bash -e`, which `set -uo pipefail` above does not undo, so a bare
+          # call would abort the step the moment node exits non-zero — killing
+          # the very branch that reports a deliberate absence.
+          rc=0
           node -e "
             const pkg = require('./package.json');
             process.exit((pkg.scripts || {})['paths:regenerate'] ? 0 : 3);
-          "
-          rc=$?
+          " || rc=$?
           case "$rc" in
             0)
               echo "available=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -407,8 +407,14 @@ jobs:
                 # same request every run.
                 marker='<!-- regenerate-api-paths: follow-up-commits-notice -->'
                 seen=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json comments \
-                  --jq "[.comments[] | select(.body | contains(\"${marker}\"))] | length" 2>/dev/null || echo "")
-                if [ "${seen:-0}" = "0" ]; then
+                  --jq "[.comments[] | select(.body | contains(\"${marker}\"))] | length" 2>/dev/null || true)
+                if [ -z "$seen" ]; then
+                  # Unreadable means we cannot tell whether the notice is
+                  # already there. Staying quiet risks one missed courtesy
+                  # comment that the next run posts anyway; assuming it is
+                  # absent risks duplicating it on every blip.
+                  echo "  could not check for an existing notice on #${number} — not posting, to avoid a duplicate."
+                elif [ "$seen" = "0" ]; then
                   gh pr comment "$number" --repo "$GITHUB_REPOSITORY" \
                     --body "${marker}
               A newer regeneration run produced a different path set, but this PR carries follow-up commits — not closing it automatically. Please rebase or close it by hand." || true
@@ -496,6 +502,7 @@ jobs:
       - name: Report stage failures
         if: always()
         env:
+          PATHS_FEATURE:   ${{ steps.paths-feature.outcome }}
           REGEN_RESPONSES: ${{ steps.regen-responses.outcome }}
           DIFF_RESPONSES:  ${{ steps.diff.outcome }}
           REGEN_PATHS:     ${{ steps.regen-paths.outcome }}
@@ -503,7 +510,13 @@ jobs:
         run: |
           set -uo pipefail
           failed=0
+          # The availability probe is tracked here too. It is not one of the
+          # continue-on-error stages, so a failure there aborts the job before
+          # the rest run — but this step still executes under if: always(), and
+          # reporting "no stage failures" directly beneath its error would send
+          # whoever triages it looking in the wrong place.
           for stage in \
+            "API paths availability probe:${PATHS_FEATURE}" \
             "responses regeneration:${REGEN_RESPONSES}" \
             "responses diff:${DIFF_RESPONSES}" \
             "API paths regeneration:${REGEN_PATHS}" \

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -136,7 +136,25 @@ jobs:
             echo '{"responses":null}' > /tmp/responses.before.json
           fi
 
+      # paths:regenerate (added by #59888) may not exist yet on every matrix
+      # ref — stable branches lag main until the feature is backported. Gate
+      # every apiPaths.ts step on this so an unrelated ref without the script
+      # doesn't fail the whole job; the steps activate automatically once the
+      # backport lands.
+      - name: Check API paths feature availability
+        id: paths-feature
+        working-directory: ${{ env.SUITE_DIR }}
+        run: |
+          set -euo pipefail
+          if node -e "process.exit(require('./package.json').scripts['paths:regenerate'] ? 0 : 1)"; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "No paths:regenerate script on ${TARGET_REF} — apiPaths.ts regeneration not backported to this ref yet, skipping."
+          fi
+
       - name: Snapshot committed API paths (pre-regeneration)
+        if: steps.paths-feature.outputs.available == 'true'
         run: |
           set -euo pipefail
           if [ -f "$PATHS_FILE" ]; then
@@ -151,6 +169,7 @@ jobs:
         run: npm run responses:regenerate
 
       - name: Regenerate API paths
+        if: steps.paths-feature.outputs.available == 'true'
         working-directory: ${{ env.SUITE_DIR }}
         run: npm run paths:regenerate
 
@@ -186,6 +205,7 @@ jobs:
 
       - name: Detect API path changes
         id: diff-paths
+        if: steps.paths-feature.outputs.available == 'true'
         run: |
           set -euo pipefail
 
@@ -376,6 +396,7 @@ jobs:
         env:
           CHANGED: ${{ steps.diff.outputs.changed }}
           PR_URL:  ${{ steps.pr.outputs.url }}
+          PATHS_FEATURE_AVAILABLE: ${{ steps.paths-feature.outputs.available }}
           CHANGED_PATHS: ${{ steps.diff-paths.outputs.changed }}
           PR_URL_PATHS:  ${{ steps.pr-paths.outputs.url }}
         run: |
@@ -394,7 +415,9 @@ jobs:
             echo ""
             echo "## API paths regeneration — \`${TARGET_REF}\`"
             echo ""
-            if [ "${CHANGED_PATHS:-false}" = "true" ]; then
+            if [ "${PATHS_FEATURE_AVAILABLE:-false}" != "true" ]; then
+              echo ":fast_forward: \`paths:regenerate\` not backported to this ref yet — skipped."
+            elif [ "${CHANGED_PATHS:-false}" = "true" ]; then
               echo ":white_check_mark: API path changes detected."
               if [ -n "${PR_URL_PATHS:-}" ]; then
                 echo ""

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -136,11 +136,11 @@ jobs:
             echo '{"responses":null}' > /tmp/responses.before.json
           fi
 
-      # The typed-buildUrl line (#59880, #60009, #60010, #59888) is main-only
-      # and deliberately so: a rename on a released stable branch would itself
-      # be a breaking change. Gating each apiPaths.ts step on the script being
-      # present lets those refs skip that half instead of failing, and starts
-      # working on its own if the line is ever backported.
+      # Only main has the typed buildUrl and its generator script, and that is
+      # deliberate: a rename on a released stable branch would itself be a
+      # breaking change. Gating each apiPaths.ts step on the script being
+      # present lets the other refs skip that half instead of failing, and
+      # starts working on its own if the script ever reaches them.
       - name: Check API paths feature availability
         id: paths-feature
         working-directory: ${{ env.SUITE_DIR }}
@@ -149,8 +149,8 @@ jobs:
           # Exit 3 means "asked and answered: no such script". Anything else
           # non-zero means the probe itself broke (unreadable or unparseable
           # package.json), which must not be mistaken for a deliberate absence:
-          # collapsing the two would silently disable path detection and
-          # recreate the staleness #60109 exists to end, one level up.
+          # collapsing the two would silently disable path detection and leave
+          # the union going stale unnoticed — the exact rot this job prevents.
           #
           # The `|| rc=$?` is load-bearing. The runner invokes this with
           # `bash -e`, which `set -uo pipefail` above does not undo, so a bare

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -148,13 +148,37 @@ jobs:
         id: paths-feature
         working-directory: ${{ env.SUITE_DIR }}
         run: |
-          set -euo pipefail
-          if node -e "process.exit((require('./package.json').scripts || {})['paths:regenerate'] ? 0 : 1)"; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "No paths:regenerate script on ${TARGET_REF} — typed buildUrl is main-only, skipping apiPaths.ts regeneration."
-          fi
+          set -uo pipefail
+          # Exit 3 means "asked and answered: no such script". Anything else
+          # non-zero means the probe itself broke (unreadable or unparseable
+          # package.json), which must not be mistaken for a deliberate absence:
+          # collapsing the two would silently disable path detection and
+          # recreate the staleness #60109 exists to end, one level up.
+          node -e "
+            const pkg = require('./package.json');
+            process.exit((pkg.scripts || {})['paths:regenerate'] ? 0 : 3);
+          "
+          rc=$?
+          case "$rc" in
+            0)
+              echo "available=true" >> "$GITHUB_OUTPUT"
+              ;;
+            3)
+              echo "available=false" >> "$GITHUB_OUTPUT"
+              echo "No paths:regenerate script on ${TARGET_REF} — typed buildUrl is main-only, skipping apiPaths.ts regeneration."
+              ;;
+            *)
+              echo "available=false" >> "$GITHUB_OUTPUT"
+              # On main the script is expected, so a broken probe is a real
+              # fault and should stop the paths half loudly. On stable refs the
+              # script is absent by design, so warn rather than fail the job.
+              if [ "$TARGET_REF" = "main" ]; then
+                echo "::error::Could not probe ${SUITE_DIR}/package.json on ${TARGET_REF} (node exit ${rc}). Path detection is disabled until this is fixed."
+                exit 1
+              fi
+              echo "::warning::Could not probe ${SUITE_DIR}/package.json on ${TARGET_REF} (node exit ${rc}). Skipping apiPaths.ts regeneration for this ref."
+              ;;
+          esac
 
       - name: Snapshot committed API paths (pre-regeneration)
         if: steps.paths-feature.outputs.available == 'true'
@@ -167,17 +191,31 @@ jobs:
             : > /tmp/apiPaths.before.ts
           fi
 
+      # The two artifacts share this job only for its setup. From here on they
+      # are independent pipelines, so each failure-capable step is marked
+      # continue-on-error and each downstream step is gated on its own
+      # pipeline's outcome. Without that, a generator throw on one side would
+      # abort the job before the other side ever reached its commit and PR
+      # steps, costing that ref an unrelated regeneration PR for the day.
+      # "Report stage failures" below turns any swallowed failure back into a
+      # red job, so continue-on-error never hides a broken pipeline.
       - name: Regenerate responses
+        id: regen-responses
+        continue-on-error: true
         working-directory: ${{ env.SUITE_DIR }}
         run: npm run responses:regenerate
 
       - name: Regenerate API paths
+        id: regen-paths
+        continue-on-error: true
         if: steps.paths-feature.outputs.available == 'true'
         working-directory: ${{ env.SUITE_DIR }}
         run: npm run paths:regenerate
 
       - name: Detect response changes (ignore metadata)
         id: diff
+        continue-on-error: true
+        if: steps.regen-responses.outcome == 'success'
         run: |
           set -euo pipefail
 
@@ -208,7 +246,8 @@ jobs:
 
       - name: Detect API path changes
         id: diff-paths
-        if: steps.paths-feature.outputs.available == 'true'
+        continue-on-error: true
+        if: steps.paths-feature.outputs.available == 'true' && steps.regen-paths.outcome == 'success'
         run: |
           set -euo pipefail
 
@@ -217,15 +256,24 @@ jobs:
             exit 1
           fi
 
-          # Unlike responses.json, apiPaths.ts carries no generatedAt/commit/
-          # specSha256 metadata fields — a plain byte-for-byte compare is
-          # sufficient, no normalization needed.
-          if cmp -s /tmp/apiPaths.before.ts "$PATHS_FILE"; then
-            echo "No API path changes. Nothing to do."
+          # Compare the union members, not the file bytes. The generated file
+          # is prettier-formatted, so a prettier version or config bump would
+          # otherwise register as a change and open a PR asserting an endpoint
+          # was added, renamed, or removed — a claim this job would be making
+          # falsely. The members are the only part carrying that meaning.
+          members() {
+            grep -oE "\| '[^']+'" "$1" | sed "s/^| '//; s/'$//" | sort || true
+          }
+
+          members /tmp/apiPaths.before.ts > /tmp/apiPaths.before.members
+          members "$PATHS_FILE"          > /tmp/apiPaths.after.members
+
+          if cmp -s /tmp/apiPaths.before.members /tmp/apiPaths.after.members; then
+            echo "No API path changes (formatting-only churn, if any). Nothing to do."
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "API path changes detected:"
-            diff /tmp/apiPaths.before.ts "$PATHS_FILE" || true
+            diff /tmp/apiPaths.before.members /tmp/apiPaths.after.members || true
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -338,10 +386,30 @@ jobs:
               # remaining PRs are looked at. Treat unknown as "leave it alone".
               commits=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" \
                 --json commits --jq '.commits | length' 2>/dev/null || true)
-              if [ -z "$commits" ] || [ "$commits" -gt 1 ]; then
-                echo "PR #${number} (commits: ${commits:-unreadable}) — not the bot's single commit, leaving open."
-                gh pr comment "$number" --repo "$GITHUB_REPOSITORY" \
-                  --body "A newer regeneration run produced a different path set, but this PR does not look like an untouched bot commit — not closing it automatically. Please rebase or close it by hand." || true
+
+              if [ -z "$commits" ]; then
+                # No comment here: the PR is most likely an ordinary untouched
+                # bot PR, and telling its author to rebase would be wrong.
+                # Silence costs one day — the next run reconsiders it.
+                echo "PR #${number}: commit count unreadable — leaving open, will reconsider next run."
+                continue
+              fi
+
+              if [ "$commits" -gt 1 ]; then
+                echo "PR #${number} has ${commits} commits — follow-up work on top of the bot's commit, leaving open."
+                # These PRs stay open for days by design, and this step runs
+                # nightly, so post the notice once instead of re-posting the
+                # same request every run.
+                marker='<!-- regenerate-api-paths: follow-up-commits-notice -->'
+                seen=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json comments \
+                  --jq "[.comments[] | select(.body | contains(\"${marker}\"))] | length" 2>/dev/null || echo "")
+                if [ "${seen:-0}" = "0" ]; then
+                  gh pr comment "$number" --repo "$GITHUB_REPOSITORY" \
+                    --body "${marker}
+              A newer regeneration run produced a different path set, but this PR carries follow-up commits — not closing it automatically. Please rebase or close it by hand." || true
+                else
+                  echo "  notice already posted on #${number}, not repeating it."
+                fi
                 continue
               fi
               echo "Closing stale PR #${number} (branch: ${branch})"
@@ -414,6 +482,39 @@ jobs:
           number=$(gh pr view "$url" --repo "$GITHUB_REPOSITORY" --json number --jq '.number')
           echo "number=${number}" >> "$GITHUB_OUTPUT"
           echo "Opened PR #${number}: ${url}"
+
+      # continue-on-error above buys independence between the two artifacts,
+      # not permission to fail quietly. Both pipelines have finished by now, so
+      # each has had its chance to commit and open its PR; turning any
+      # swallowed failure back into a red job here reports the fault without
+      # having let it take the other artifact down.
+      - name: Report stage failures
+        if: always()
+        env:
+          REGEN_RESPONSES: ${{ steps.regen-responses.outcome }}
+          DIFF_RESPONSES:  ${{ steps.diff.outcome }}
+          REGEN_PATHS:     ${{ steps.regen-paths.outcome }}
+          DIFF_PATHS:      ${{ steps.diff-paths.outcome }}
+        run: |
+          set -uo pipefail
+          failed=0
+          for stage in \
+            "responses regeneration:${REGEN_RESPONSES}" \
+            "responses diff:${DIFF_RESPONSES}" \
+            "API paths regeneration:${REGEN_PATHS}" \
+            "API paths diff:${DIFF_PATHS}"; do
+            name="${stage%%:*}"
+            outcome="${stage##*:}"
+            if [ "$outcome" = "failure" ]; then
+              echo "::error::${name} failed on ${TARGET_REF}."
+              failed=1
+            fi
+          done
+          if [ "$failed" = "1" ]; then
+            echo "One pipeline failed; the other was allowed to finish independently. See the step logs above."
+            exit 1
+          fi
+          echo "No stage failures."
 
       - name: Job summary
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -1,10 +1,18 @@
-# description: Regenerates the JSON-body response assertions for the C8 Orchestration
-#              Cluster E2E test suite across all supported refs (main, stable/8.9,
-#              stable/8.8) via a matrix. For each ref it runs
-#              `npm run responses:regenerate` + `npm run lint:fix` and opens a PR
-#              (reviewer: @camunda/test-automation-team) ONLY when the actual API
-#              response schemas change. Metadata-only churn (generatedAt / commit /
-#              specSha256) is ignored and never opens a PR.
+# description: Regenerates two OpenAPI-derived, checked-in artifacts for the C8
+#              Orchestration Cluster E2E test suite across all supported refs
+#              (main, stable/8.9, stable/8.8) via a matrix:
+#                - json-body-assertions/_generated/responses.json, via
+#                  `npm run responses:regenerate` + `npm run lint:fix`
+#                - utils/_generated/apiPaths.ts (the `ApiPath` union consumed by
+#                  `buildUrl`), via `npm run paths:regenerate`
+#              Each artifact is diffed, committed, and PR'd independently
+#              (reviewer: @camunda/test-automation-team) — a PR is opened only
+#              when that artifact's own content actually changed, so a rename or
+#              removal in rest-api.yaml can no longer hide behind a stale-but-
+#              internally-consistent apiPaths.ts indefinitely (see #60109).
+#              Metadata-only churn in responses.json (generatedAt / commit /
+#              specSha256) is ignored and never opens a PR; apiPaths.ts carries
+#              no such metadata, so any diff there is a real path change.
 # type: CI
 # owner: @camunda/test-automation-team
 ---
@@ -28,7 +36,7 @@ env:
 
 jobs:
   regenerate:
-    name: Regenerate responses (${{ matrix.ref }})
+    name: Regenerate responses & API paths (${{ matrix.ref }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -53,6 +61,7 @@ jobs:
     env:
       SUITE_DIR: qa/c8-orchestration-cluster-e2e-test-suite
       RESPONSES_FILE: qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+      PATHS_FILE: qa/c8-orchestration-cluster-e2e-test-suite/utils/_generated/apiPaths.ts
       # matrix context is available to job-level env; shell steps read these
       # instead of interpolating ${{ matrix.* }} directly (injection-safe).
       TARGET_REF: ${{ matrix.ref }}
@@ -69,6 +78,16 @@ jobs:
           # so the short-lived GITHUB_TOKEN must not linger in .git/config
           # (zizmor: artipacked).
           persist-credentials: false
+
+      # Both artifact branches below are created FROM this SHA explicitly
+      # (git checkout -B "$branch" "$BASE_SHA"), never from "whatever HEAD
+      # happens to be" — otherwise, if both responses.json and apiPaths.ts
+      # changed, the second branch created would be based on the first
+      # branch's commit instead of on ${{ matrix.ref }}, contaminating one
+      # artifact's PR with the other's change.
+      - name: Record base commit
+        id: base
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -117,9 +136,23 @@ jobs:
             echo '{"responses":null}' > /tmp/responses.before.json
           fi
 
+      - name: Snapshot committed API paths (pre-regeneration)
+        run: |
+          set -euo pipefail
+          if [ -f "$PATHS_FILE" ]; then
+            cp "$PATHS_FILE" /tmp/apiPaths.before.ts
+          else
+            echo "No existing API paths file at $PATHS_FILE — will be treated as a change."
+            : > /tmp/apiPaths.before.ts
+          fi
+
       - name: Regenerate responses
         working-directory: ${{ env.SUITE_DIR }}
         run: npm run responses:regenerate
+
+      - name: Regenerate API paths
+        working-directory: ${{ env.SUITE_DIR }}
+        run: npm run paths:regenerate
 
       - name: Detect response changes (ignore metadata)
         id: diff
@@ -151,25 +184,67 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create branch, commit & push
+      - name: Detect API path changes
+        id: diff-paths
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "$PATHS_FILE" ]; then
+            echo "::error::Regeneration did not produce $PATHS_FILE"
+            exit 1
+          fi
+
+          # Unlike responses.json, apiPaths.ts carries no generatedAt/commit/
+          # specSha256 metadata fields — a plain byte-for-byte compare is
+          # sufficient, no normalization needed.
+          if cmp -s /tmp/apiPaths.before.ts "$PATHS_FILE"; then
+            echo "No API path changes. Nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "API path changes detected:"
+            diff /tmp/apiPaths.before.ts "$PATHS_FILE" || true
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create branch, commit & push (responses)
         id: push
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          BASE_SHA: ${{ steps.base.outputs.sha }}
         run: |
           set -euo pipefail
           stamp="$(date -u +%Y%m%d-%H%M%S)"
           branch="regenerate-responses-${SAFE}-${stamp}-${GITHUB_RUN_ID}"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
-          git checkout -b "$branch"
+          git checkout -B "$branch" "$BASE_SHA"
           # Stage ONLY the generated responses file — nothing else.
           git add -- "$RESPONSES_FILE"
           # 'test:' prefix — commitlint rejects 'fix:' for this kind of change.
           git commit -m "test: regenerate API response assertions from latest ${TARGET_REF} OpenAPI spec"
           git push origin "$branch"
-      
-      - name: Close stale regeneration PRs
+
+      - name: Create branch, commit & push (API paths)
+        id: push-paths
+        if: steps.diff-paths.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set -euo pipefail
+          stamp="$(date -u +%Y%m%d-%H%M%S)"
+          branch="regenerate-api-paths-${SAFE}-${stamp}-${GITHUB_RUN_ID}"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+
+          git checkout -B "$branch" "$BASE_SHA"
+          # Stage ONLY the generated API paths file — nothing else.
+          git add -- "$PATHS_FILE"
+          # 'test:' prefix — commitlint rejects 'fix:' for this kind of change.
+          git commit -m "test: regenerate API path union from latest ${TARGET_REF} OpenAPI spec"
+          git push origin "$branch"
+
+      - name: Close stale regeneration PRs (responses)
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
@@ -202,7 +277,38 @@ jobs:
             done <<< "$stale"
           fi
 
-      - name: Open pull request
+      - name: Close stale regeneration PRs (API paths)
+        if: steps.diff-paths.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          title="test: regenerate API path union from latest ${TARGET_REF} OpenAPI spec"
+
+          export TITLE="$title"
+          export PREFIX="regenerate-api-paths-${SAFE}-"
+          stale=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "$TARGET_REF" \
+            --state open \
+            --limit 200 \
+            --search "in:title \"${title}\"" \
+            --json number,headRefName,title \
+            --jq '.[] | select(.title == env.TITLE) | select(.headRefName | startswith(env.PREFIX)) | "\(.number) \(.headRefName)"')
+
+          if [ -z "$stale" ]; then
+            echo "No stale PRs found."
+          else
+            while IFS=" " read -r number branch; do
+              echo "Closing stale PR #${number} (branch: ${branch})"
+              gh pr close "$number" \
+                --repo "$GITHUB_REPOSITORY" \
+                --comment "Superseded by a newer regeneration run — closing in favour of the incoming PR." \
+                --delete-branch
+            done <<< "$stale"
+          fi
+
+      - name: Open pull request (responses)
         id: pr
         if: steps.diff.outputs.changed == 'true'
         env:
@@ -234,11 +340,44 @@ jobs:
           echo "number=${number}" >> "$GITHUB_OUTPUT"
           echo "Opened PR #${number}: ${url}"
 
+      - name: Open pull request (API paths)
+        id: pr-paths
+        if: steps.diff-paths.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          BRANCH:   ${{ steps.push-paths.outputs.branch }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' \
+            "Automated regeneration of the \`ApiPath\` literal union via \`npm run paths:regenerate\`." \
+            "" \
+            "This PR was opened because the **set of paths** in \`utils/_generated/apiPaths.ts\` changed — an endpoint was added, renamed, or removed in \`rest-api.yaml\`." \
+            "" \
+            "Please review the path changes against the upstream REST API spec, paying particular attention to renames/removals: those are otherwise silent (a stale-but-internally-consistent union produces no \`tsc\` error)." \
+            "" \
+            "_Opened by the C8 Orchestration Cluster responses-regeneration workflow for ${TARGET_REF}._" \
+            > /tmp/pr-body-paths.md
+
+          url=$(gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "$TARGET_REF" \
+            --head "$BRANCH" \
+            --title "test: regenerate API path union from latest ${TARGET_REF} OpenAPI spec" \
+            --body-file /tmp/pr-body-paths.md \
+            --reviewer "camunda/test-automation-team")
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+
+          number=$(gh pr view "$url" --repo "$GITHUB_REPOSITORY" --json number --jq '.number')
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+          echo "Opened PR #${number}: ${url}"
+
       - name: Job summary
         if: always()
         env:
           CHANGED: ${{ steps.diff.outputs.changed }}
           PR_URL:  ${{ steps.pr.outputs.url }}
+          CHANGED_PATHS: ${{ steps.diff-paths.outputs.changed }}
+          PR_URL_PATHS:  ${{ steps.pr-paths.outputs.url }}
         run: |
           {
             echo "## Responses regeneration — \`${TARGET_REF}\`"
@@ -251,6 +390,18 @@ jobs:
               fi
             else
               echo ":information_source: No response schema changes — metadata-only churn ignored, no PR opened."
+            fi
+            echo ""
+            echo "## API paths regeneration — \`${TARGET_REF}\`"
+            echo ""
+            if [ "${CHANGED_PATHS:-false}" = "true" ]; then
+              echo ":white_check_mark: API path changes detected."
+              if [ -n "${PR_URL_PATHS:-}" ]; then
+                echo ""
+                echo "**PR:** ${PR_URL_PATHS}"
+              fi
+            else
+              echo ":information_source: No API path changes — no PR opened."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
       

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -323,6 +323,22 @@ jobs:
             echo "No stale PRs found."
           else
             while IFS=" " read -r number branch; do
+              # A path PR for a rename is EXPECTED to be red: tsc fails on the
+              # call sites still using the removed path, and the natural fix is
+              # to push those call-site updates onto this branch. Until that
+              # lands on the base ref every later run still sees the same diff,
+              # so closing with --delete-branch would destroy the reviewer's
+              # follow-up work — the fix for the very rot this job exists to
+              # surface. The bot pushes exactly one commit, so anything above
+              # that is human work: leave those PRs alone.
+              commits=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" \
+                --json commits --jq '.commits | length')
+              if [ "$commits" -gt 1 ]; then
+                echo "PR #${number} has ${commits} commits — follow-up work on top of the bot's commit, leaving open."
+                gh pr comment "$number" --repo "$GITHUB_REPOSITORY" \
+                  --body "A newer regeneration run produced a different path set, but this PR carries follow-up commits — not closing it automatically. Please rebase or close it by hand."
+                continue
+              fi
               echo "Closing stale PR #${number} (branch: ${branch})"
               gh pr close "$number" \
                 --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -2,7 +2,7 @@
 #              Orchestration Cluster E2E test suite across all supported refs
 #              (main, stable/8.9, stable/8.8) via a matrix:
 #                - json-body-assertions/_generated/responses.json, via
-#                  `npm run responses:regenerate` + `npm run lint:fix`
+#                  `npm run responses:regenerate`
 #                - utils/_generated/apiPaths.ts (the `ApiPath` union consumed by
 #                  `buildUrl`), via `npm run paths:regenerate`
 #              Each artifact is diffed, committed, and PR'd independently
@@ -146,7 +146,7 @@ jobs:
         working-directory: ${{ env.SUITE_DIR }}
         run: |
           set -euo pipefail
-          if node -e "process.exit(require('./package.json').scripts['paths:regenerate'] ? 0 : 1)"; then
+          if node -e "process.exit((require('./package.json').scripts || {})['paths:regenerate'] ? 0 : 1)"; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
@@ -337,7 +337,7 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s\n' \
-            "Automated regeneration of the JSON body response assertions via \`npm run responses:regenerate\` (followed by \`npm run lint:fix\`)." \
+            "Automated regeneration of the JSON body response assertions via \`npm run responses:regenerate\`." \
             "" \
             "This PR was opened because the **response schemas** in \`json-body-assertions/_generated/responses.json\` changed." \
             "Metadata-only differences (\`generatedAt\`, \`commit\`, \`specSha256\`) do not trigger a PR." \

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -136,14 +136,11 @@ jobs:
             echo '{"responses":null}' > /tmp/responses.before.json
           fi
 
-      # The typed-buildUrl line (#59880, #60009, #60010, #59888) is main-only:
-      # none of it was backported, so stable refs have an untyped buildUrl, no
-      # apiPaths.ts, and no paths:regenerate script. That is defensible — the
-      # rot #59888 prevents is an endpoint renamed or removed in rest-api.yaml,
-      # which on a released stable branch would itself be a breaking change.
-      # Gate every apiPaths.ts step on the script actually being present, so
-      # refs without it skip that half of the job instead of failing it, and so
-      # the steps start working on their own if the line ever is backported.
+      # The typed-buildUrl line (#59880, #60009, #60010, #59888) is main-only
+      # and deliberately so: a rename on a released stable branch would itself
+      # be a breaking change. Gating each apiPaths.ts step on the script being
+      # present lets those refs skip that half instead of failing, and starts
+      # working on its own if the line is ever backported.
       - name: Check API paths feature availability
         id: paths-feature
         working-directory: ${{ env.SUITE_DIR }}
@@ -196,14 +193,11 @@ jobs:
             : > /tmp/apiPaths.before.ts
           fi
 
-      # The two artifacts share this job only for its setup. From here on they
-      # are independent pipelines, so each failure-capable step is marked
-      # continue-on-error and each downstream step is gated on its own
-      # pipeline's outcome. Without that, a generator throw on one side would
-      # abort the job before the other side ever reached its commit and PR
-      # steps, costing that ref an unrelated regeneration PR for the day.
-      # "Report stage failures" below turns any swallowed failure back into a
-      # red job, so continue-on-error never hides a broken pipeline.
+      # From here the two artifacts are independent pipelines: each
+      # failure-capable step is continue-on-error and each downstream step is
+      # gated on its own pipeline's outcome, so a throw on one side cannot
+      # abort the job before the other reaches its PR. "Report stage failures"
+      # at the end turns any swallowed failure back into a red job.
       - name: Regenerate responses
         id: regen-responses
         continue-on-error: true
@@ -376,19 +370,13 @@ jobs:
             echo "No stale PRs found."
           else
             while IFS=" " read -r number branch; do
-              # A path PR for a rename is EXPECTED to be red: tsc fails on the
-              # call sites still using the removed path, and the natural fix is
-              # to push those call-site updates onto this branch. Until that
-              # lands on the base ref every later run still sees the same diff,
-              # so closing with --delete-branch would destroy the reviewer's
-              # follow-up work — the fix for the very rot this job exists to
-              # surface. The bot pushes exactly one commit, so anything above
-              # that is human work: leave those PRs alone.
-              # An unreadable count must not close anything: this is one API
-              # call per stale PR, so a transient blip would otherwise both
-              # fail the job (losing that day's regeneration PR entirely, since
-              # the later steps never run) and abort the loop before the
-              # remaining PRs are looked at. Treat unknown as "leave it alone".
+              # A path PR for a rename is expected to be red, and the fix is to
+              # push call-site updates onto this branch. The base ref stays
+              # stale until it merges, so every later run sees the same diff —
+              # closing with --delete-branch would destroy that work. The bot
+              # pushes exactly one commit; anything above it is human work.
+              # One API call per stale PR, so a blip must not close anything or
+              # abort the loop before the remaining PRs are seen.
               commits=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" \
                 --json commits --jq '.commits | length' 2>/dev/null || true)
 
@@ -494,11 +482,8 @@ jobs:
           echo "number=${number}" >> "$GITHUB_OUTPUT"
           echo "Opened PR #${number}: ${url}"
 
-      # continue-on-error above buys independence between the two artifacts,
-      # not permission to fail quietly. Both pipelines have finished by now, so
-      # each has had its chance to commit and open its PR; turning any
-      # swallowed failure back into a red job here reports the fault without
-      # having let it take the other artifact down.
+      # Both pipelines have finished, so each has had its chance to open a PR;
+      # anything swallowed above becomes a red job here.
       - name: Report stage failures
         if: always()
         env:
@@ -510,11 +495,9 @@ jobs:
         run: |
           set -uo pipefail
           failed=0
-          # The availability probe is tracked here too. It is not one of the
-          # continue-on-error stages, so a failure there aborts the job before
-          # the rest run — but this step still executes under if: always(), and
-          # reporting "no stage failures" directly beneath its error would send
-          # whoever triages it looking in the wrong place.
+          # The probe is tracked too: it is not continue-on-error, so its failure
+          # aborts the job, but this step still runs under if: always() and
+          # would otherwise print "no stage failures" beneath its error.
           for stage in \
             "API paths availability probe:${PATHS_FEATURE}" \
             "responses regeneration:${REGEN_RESPONSES}" \

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -331,12 +331,17 @@ jobs:
               # follow-up work — the fix for the very rot this job exists to
               # surface. The bot pushes exactly one commit, so anything above
               # that is human work: leave those PRs alone.
+              # An unreadable count must not close anything: this is one API
+              # call per stale PR, so a transient blip would otherwise both
+              # fail the job (losing that day's regeneration PR entirely, since
+              # the later steps never run) and abort the loop before the
+              # remaining PRs are looked at. Treat unknown as "leave it alone".
               commits=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" \
-                --json commits --jq '.commits | length')
-              if [ "$commits" -gt 1 ]; then
-                echo "PR #${number} has ${commits} commits — follow-up work on top of the bot's commit, leaving open."
+                --json commits --jq '.commits | length' 2>/dev/null || true)
+              if [ -z "$commits" ] || [ "$commits" -gt 1 ]; then
+                echo "PR #${number} (commits: ${commits:-unreadable}) — not the bot's single commit, leaving open."
                 gh pr comment "$number" --repo "$GITHUB_REPOSITORY" \
-                  --body "A newer regeneration run produced a different path set, but this PR carries follow-up commits — not closing it automatically. Please rebase or close it by hand."
+                  --body "A newer regeneration run produced a different path set, but this PR does not look like an untouched bot commit — not closing it automatically. Please rebase or close it by hand." || true
                 continue
               fi
               echo "Closing stale PR #${number} (branch: ${branch})"

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -136,11 +136,14 @@ jobs:
             echo '{"responses":null}' > /tmp/responses.before.json
           fi
 
-      # paths:regenerate (added by #59888) may not exist yet on every matrix
-      # ref — stable branches lag main until the feature is backported. Gate
-      # every apiPaths.ts step on this so an unrelated ref without the script
-      # doesn't fail the whole job; the steps activate automatically once the
-      # backport lands.
+      # The typed-buildUrl line (#59880, #60009, #60010, #59888) is main-only:
+      # none of it was backported, so stable refs have an untyped buildUrl, no
+      # apiPaths.ts, and no paths:regenerate script. That is defensible — the
+      # rot #59888 prevents is an endpoint renamed or removed in rest-api.yaml,
+      # which on a released stable branch would itself be a breaking change.
+      # Gate every apiPaths.ts step on the script actually being present, so
+      # refs without it skip that half of the job instead of failing it, and so
+      # the steps start working on their own if the line ever is backported.
       - name: Check API paths feature availability
         id: paths-feature
         working-directory: ${{ env.SUITE_DIR }}
@@ -150,7 +153,7 @@ jobs:
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "No paths:regenerate script on ${TARGET_REF} — apiPaths.ts regeneration not backported to this ref yet, skipping."
+            echo "No paths:regenerate script on ${TARGET_REF} — typed buildUrl is main-only, skipping apiPaths.ts regeneration."
           fi
 
       - name: Snapshot committed API paths (pre-regeneration)
@@ -416,7 +419,7 @@ jobs:
             echo "## API paths regeneration — \`${TARGET_REF}\`"
             echo ""
             if [ "${PATHS_FEATURE_AVAILABLE:-false}" != "true" ]; then
-              echo ":fast_forward: \`paths:regenerate\` not backported to this ref yet — skipped."
+              echo ":fast_forward: No \`paths:regenerate\` on this ref (typed \`buildUrl\` is main-only) — skipped."
             elif [ "${CHANGED_PATHS:-false}" = "true" ]; then
               echo ":white_check_mark: API path changes detected."
               if [ -n "${PR_URL_PATHS:-}" ]; then

--- a/qa/c8-orchestration-cluster-e2e-test-suite/scripts/generate-api-paths.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/scripts/generate-api-paths.ts
@@ -21,13 +21,24 @@
  * keeps the suite free of a YAML-parser dependency.
  */
 
-import {readFileSync, mkdirSync, writeFileSync} from 'node:fs';
+import {readFileSync, existsSync, mkdirSync, writeFileSync} from 'node:fs';
 import {dirname, join} from 'node:path';
 
-const SPEC_PATH = join(
-  process.cwd(),
+// The spec moved under `v2/` after 8.8, and each branch carries its own copy of
+// this suite, so the location has to be resolved rather than assumed. Order is
+// load-bearing: on the post-move branches the old path still exists as a
+// relocation stub with no `paths:` block, so the `v2/` location must win.
+const SPEC_CANDIDATES = [
   '../../zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml',
-);
+  '../../zeebe/gateway-protocol/src/main/proto/rest-api.yaml',
+].map((relative) => join(process.cwd(), relative));
+
+const SPEC_PATH = SPEC_CANDIDATES.find((candidate) => existsSync(candidate));
+if (!SPEC_PATH) {
+  throw new Error(
+    `No REST API spec found. Looked in:\n  ${SPEC_CANDIDATES.join('\n  ')}`,
+  );
+}
 const OUTPUT_PATH = join(process.cwd(), 'utils/_generated/apiPaths.ts');
 
 const LICENSE_HEADER = `/*


### PR DESCRIPTION
Closes #60109

## Why

#59888 typed `buildUrl`'s first argument against `ApiPath`, a union generated from `rest-api.yaml`'s `paths:` keys. That file is checked in and only refreshed when someone runs `npm run paths:regenerate` by hand.

So a **rename or removal** in the spec goes unnoticed: the stale union stays internally consistent, `tsc` stays happy, and tests keep calling a dead path indefinitely. (A *new* endpoint is self-correcting — it is absent from the union, so the first caller fails to compile.) CI does not catch it either, since the suite lint job is path-filtered on `qa/c8-orchestration-cluster-e2e-test-suite/**` and never runs on a spec-only PR.

Adding a `paths:check` guard to `npm run lint` was considered and rejected in the issue: same path-filter blind spot, and it would block unrelated suite PRs whenever the spec moves.

## What this does

Extends the existing nightly `c8-orchestration-cluster-responses-regenerate.yml` job to regenerate `utils/_generated/apiPaths.ts` alongside `responses.json`. Each artifact is diffed, committed, and PR'd **independently**, so a path change never drags response-schema churn into the same PR. A rename now surfaces as a bot PR within 24h, and that PR's `tsc` failure names the dead path and its call sites.

Both artifacts share one job for setup only; they cannot fail each other (see fix 5).

## Scope

Two files: the workflow, and `scripts/generate-api-paths.ts` — the latter because running that generator across a multi-ref matrix is what this PR introduces, and it was not multi-ref-safe (fix 3). Raised in review and kept here deliberately.

## Fixes folded in

| # | Issue | Fix |
|---|---|---|
| 1 | Two branch-creating steps in one job — the second would inherit the first's commit | base SHA recorded once; both `checkout -B` from it explicitly |
| 2 | `paths:regenerate` absent on stable refs | availability gate; typed `buildUrl` is main-only by design, see below |
| 3 | Generator hardcoded `proto/v2/rest-api.yaml`, absent on 8.8 | ordered candidate list; `v2/` must win since post-move refs keep a 90-byte stub at the old path |
| 4 | Stale-PR close would delete a reviewer's follow-up commits | skipped when a PR carries commits beyond the bot's one |
| 5 | A failure in either pipeline killed the other's PR | per-pipeline `continue-on-error` + outcome gating, with a closing step that re-fails the job so nothing passes silently |
| 6 | Availability gate treated "probe broke" as "script absent" — silent staleness, one level up | probe exits 3 for deliberate absence, anything else is a fault: error on `main`, warning on stable |
| 7 | Rebase notice re-posted every nightly; wrong wording when the count was unreadable | posted once via marker; unreadable case stays silent and waits |
| 8 | `cmp` compared post-`prettier` bytes, so a formatting bump opened a PR claiming an endpoint changed | compares the extracted union members instead |

Fixes 3–4 are @hilalbursalii's catches; 5–8 are @slolatte's.

**On fix 2:** the typed-`buildUrl` line (#59880, #60009, #60010, #59888) is main-only — no backport labels, and both stable refs still take `pathTemplate: string`. That looks deliberate: the rot #59888 prevents is a rename or removal in `rest-api.yaml`, which on a released branch would itself be a breaking change. The gate keeps the job correct either way and activates on its own if the line is ever backported.

## Verification

- `npm run paths:regenerate` on `main`: 188 paths, no diff beyond the one the nightly is due to pick up.
- Generator spec resolution: 188 on `main`, 121 on a simulated 8.8 tree with no `v2/`, clear error when neither resolves.
- Each reworked shell block tested with the code lifted verbatim from the workflow — formatting churn no longer registers while a rename does; the probe separates present / absent / unparseable / missing `package.json`; the stale-PR guard closes a bot-only PR, comments once on a human-touched one, stays quiet when the notice exists, and does nothing when the count is unreadable.
- `actionlint`, `eslint`, `prettier --check` clean. CI green.
- Dispatched three times during development. [Run 3](https://github.com/camunda/camunda/actions/runs/31795160737) caught a real spec change (`/cluster/v2/topology`), opened #60176 and #60175 as two genuinely independent single-file PRs, and #60176 merged — so the end-to-end path is exercised.

**One gap, stated plainly:** the job does `checkout ref: ${{ matrix.ref }}`, so a dispatch runs *that ref's* suite code and only the workflow YAML comes from this branch. The `generate-api-paths.ts` change (fix 3) therefore cannot be exercised by CI until it is on `main`; it rests on the local verification above.

## Out of scope

- #60148 (endpoints with no test coverage) — a different problem.
- `camunda/api-test-generator` / `camunda-oca` — separate tool, not wired into this suite.
- Backporting the typed-`buildUrl` line — see fix 2. If the team disagrees, the right move is `/backport` on the whole stack (#60009, #60010, #60107), not #59888 alone.
