### PR TITLE
ci: log in to Harbor with a robot account

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -151,7 +151,21 @@ runs:
         secret/data/github.com/organizations/camunda NEXUS_USR | ci-account-username;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
-        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
+        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+  # Kept separate from "Import Secrets" so that jobs which do not ask for Harbor
+  # never depend on this path resolving.
+  - name: Import Harbor Secrets
+    if: >-
+      steps.is-fork.outputs.is-fork != 'true' &&
+      inputs.harbor == 'true'
+    id: harbor-secrets
+    uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+    with:
+      url: ${{ inputs.vault-address }}
+      method: approle
+      roleId: ${{ inputs.vault-role-id }}
+      secretId: ${{ inputs.vault-secret-id }}
+      secrets: |
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
@@ -282,8 +296,8 @@ runs:
       inputs.harbor == 'true'
     uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
     env:
-      DOCKER_USERNAME: ${{ steps.secrets.outputs.harbor-username }}
-      DOCKER_PASSWORD: ${{ steps.secrets.outputs.harbor-password }}
+      DOCKER_USERNAME: ${{ steps.harbor-secrets.outputs.harbor-username }}
+      DOCKER_PASSWORD: ${{ steps.harbor-secrets.outputs.harbor-password }}
     with:
       max_attempts: 3
       retry_wait_seconds: 10

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: "false"
   harbor:
     description: |
-      If enabled, logs into Harbor with a CI account.
+      If enabled, logs into Harbor with a Harbor robot account.
       Harbor login is automatically disabled for fork PRs.
     required: false
     default: "false"
@@ -151,7 +151,9 @@ runs:
         secret/data/github.com/organizations/camunda NEXUS_USR | ci-account-username;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
-        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
+        secret/data/products/camunda/ci/harbor HARBOR_USR | harbor-username;
+        secret/data/products/camunda/ci/harbor HARBOR_PSW | harbor-password
   - name: Setup Java
     uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
     with:
@@ -280,8 +282,8 @@ runs:
       inputs.harbor == 'true'
     uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
     env:
-      DOCKER_USERNAME: ${{ steps.secrets.outputs.ci-account-username }}
-      DOCKER_PASSWORD: ${{ steps.secrets.outputs.ci-account-password }}
+      DOCKER_USERNAME: ${{ steps.secrets.outputs.harbor-username }}
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.harbor-password }}
     with:
       max_attempts: 3
       retry_wait_seconds: 10

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -152,8 +152,8 @@ runs:
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
         secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
-        secret/data/products/camunda/ci/harbor HARBOR_USR | harbor-username;
-        secret/data/products/camunda/ci/harbor HARBOR_PSW | harbor-password
+        secret/data/products/camunda/ci/harbor username | harbor-username;
+        secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
     uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
     with:


### PR DESCRIPTION
## Description

**Draft / example for INC-7155.** Opened by Infra as a worked example so @yanavasileva and team can extend the same pattern to the remaining Harbor logins. Do not merge until the companion infra-core PR reaches prod (see Blocked on).

### Why

Harbor runs in `ldap_auth` mode and does **not** cache auth results, so every `docker login` with the `ci-account` credentials is a live LDAP bind against `ldap.camunda.com`.

On 2026-08-13 between 09:01 and 09:07 UTC, LDAP timed out and Harbor logged 4,816 of these:

```
LDAP Result Code 200 "Network Error": context deadline exceeded
```

All three login attempts fell inside that window, so `Setup Maven` failed and took `optimize-it-opensearch/ccsm-test` and `optimize-it-elasticsearch/ccsm-test` with it. Harbor itself was healthy throughout, and the credentials were never wrong.

It was not a one-off: the same signature recurs roughly weekly (08-02 for 15 min with 32k failures, 08-07, 08-11, twice on 08-13), and it hit `ci-infrastructure-experience`, `ci-web-modeler`, `ci-cawemo` and ~20 enterprise customers too.

**Hardening the retry window will not fix this.** These outages run 6 to 15 minutes; the current retry budget is ~48 seconds.

### What

Harbor **robot accounts** live in Harbor's own database and never touch LDAP. This switches the `setup-build` Harbor login to `robot$camunda-monorepo-ci`, read from Vault at `secret/products/camunda/ci/harbor`.

The `ci-account` credentials stay exactly where they are for Camunda Nexus / Maven, which still authenticates via LDAP. Only the Harbor login step changes.

The robot has push+pull on the projects this pipeline builds into: `team-zeebe`, `team-camunda`, `team-optimize`, `team-reliability-testing` and `hotfixes`. That covers all 15 jobs calling `setup-build` with `harbor: true`.

No Vault policy change is needed: the existing `read-products-camunda` policy already grants `products/camunda/*`.

### Extending this

Two Harbor consumers bypass `setup-build` and log in directly with `regctl`, using `secret/data/products/distribution/ci`:

- `.github/workflows/c8run-release-rc.yaml`
- `.github/workflows/c8run-release-public.yaml`

Those still authenticate via LDAP and remain exposed. Same fix applies, they just need their own robot account scoped to `team-distribution` and `library`. Happy to add it, just say the word.

Also worth a look: `optimize-e2e-smoke` and `optimize-e2e-tests-sm-nightly` take a Harbor login but the compose file they use (`optimize/client/docker-compose.yml`) contains no Harbor image, so they may not need it at all.

## Blocked on

- camunda/infra-core#13907 — creates the robot account and the Vault secret. **Must reach prod before this merges**, otherwise the Vault lookup fails.

## Testing

Not yet run. The Vault path does not exist in prod until the infra-core PR lands, so CI here will fail the secret import until then. Once it does, any job with `harbor: true` exercises the change.

## Related

- INC-7155 ([Slack thread](https://camunda.slack.com/archives/C0BPTLSGEBV/p1786693626053019))
