### PR TITLE
Fix Optimize's Netty version pin being silently overridden

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -145,6 +145,14 @@
         <artifactId>httpcore5-h2</artifactId>
         <version>${apache.http5-core.version}</version>
       </dependency>
+      <!-- Override Spring Boot's netty version to resolve CVE-2026-59901 -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Description

### The bug

Optimize's own `dependencyManagement` block re-imports `spring-boot-dependencies` without also importing `netty-bom`. Because Maven resolves a child POM's own dependency management ahead of anything inherited from the parent, this silently overrides the `netty-bom` import that `parent/pom.xml` deliberately places first so its Netty pin wins.

**Effect:** `optimize/pom.xml` declares `netty.version=4.1.136.Final`, but several transitively-pulled Netty artifacts (`netty-codec`, `netty-common`, `netty-buffer`, `netty-transport`, `netty-resolver`, `netty-transport-native-unix-common`, `netty-codec-socks`) never actually resolved to that version — they fell back to whichever older version Spring Boot's own BOM manages instead.

### How this surfaced

Found while investigating [CVE-2026-59901](https://github.com/netty/netty/security/advisories/GHSA-558v-64gr-wgg4) (a Netty `Bzip2Decoder` DoS, fixed in 4.1.136.Final): `netty-codec` — where the vulnerable class lives — was still resolving to 4.1.135.Final despite the pin.

**Optimize was never actually exploitable through this** — it doesn't use bzip2 compression anywhere and never invokes the `Bzip2Decoder` code path. This change doesn't close a real security gap; it stops vulnerability scanners from flagging a dependency Camunda already intended to have patched. The underlying issue is broader than this one CVE, though: any future `netty.version` bump would hit the same problem for these artifacts, since changing the property alone never reached them.

### The fix

Imports `netty-bom` in Optimize's own dependency management, before `spring-boot-dependencies` — mirroring the ordering already proven in `parent/pom.xml`.

**Verified** with `dependency:tree` against the submodules that actually pull Netty transitively (`optimize-commons`, `optimize-backend`): every Netty artifact now resolves to the declared `netty.version`, with no more artifacts silently "managed from" a lower version.

### Alternative considered: converging with `main`

`main` resolves this cleanly by inheriting dependency management entirely from `parent/pom.xml`, with no local override block. **Rejected for this branch:** `main` and `stable/optimize-8.7` diverged in September 2024 and have since evolved independently (829 commits unique to this branch, 53,000+ unique to `main`). `main`'s clean state isn't one portable commit — it's the end state of many unrelated changes, entangled with a different property-naming convention and BOM inventory. Reconciling that on a stable release branch is disproportionate risk for what's otherwise a small, self-contained fix.

### Scope

- `stable/optimize-8.6` — out of scope, no longer a supported release line.
- `main` — already resolves cleanly, no change needed.

## Checklist

Not applicable — this is not a CI change.

## Related issues

No tracking issue exists for this specific bug; it surfaced during the CVE-2026-59901 impact assessment for Optimize 8.7.26.
