### PR TITLE
docs: add dedup-check step and gh CLI fallback to create-issue skill

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -15,12 +15,7 @@ gh auth status  # must succeed
 ```
 
 If this fails, do not abort. Check whether `mcp__github__*` tools are available in this session; if
-so, use them for the rest of this skill's flow instead of the `gh` examples shown below:
-`mcp__github__search_issues` for the dedup check in Step 1.5, `mcp__github__issue_write` (method
-`create`/`update`) for the `gh issue create` calls in Steps 6-7, `mcp__github__sub_issue_write` for
-the parent sub-issue registration, and `mcp__github__list_issue_types` plus `mcp__github__issue_write`'s
-`type` parameter for setting the native GitHub Issue Type (simpler than the GraphQL-mutation approach
-shown in Step 7). MCP tools use separate credentials, so they often keep working through a `gh`
+so, use them for the rest of this skill's flow instead of the `gh` examples shown below.MCP tools use separate credentials, so they often keep working through a `gh`
 auth failure (stale token, sandbox restrictions, a transient rate limit), though they are not
 immune to failures of their own (their own rate limits, service-side restrictions). If MCP tools
 are not available either, retry `gh auth status` once before asking the user to check their
@@ -60,9 +55,7 @@ gh search issues '<title keywords>' --repo camunda/camunda --state open --limit 
 gh search issues '<title keywords>' --repo camunda/camunda --state closed --limit 10
 ```
 
-`--state` only accepts one value at a time (`open` or `closed`), not `all` — run both. (If `gh`
-auth is unavailable, use `mcp__github__search_issues` instead, per the Prerequisites fallback
-above.)
+`--state` only accepts one value at a time (`open` or `closed`), not `all` — run both.
 
 If a close match turns up, surface it to the user before proceeding - show the issue number,
 state, and title, and ask whether to link the new work to it, comment on the existing issue

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -18,12 +18,13 @@ If this fails, do not abort. Check whether `mcp__github__*` tools are available 
 so, use them for the rest of this skill's flow instead of the `gh` examples shown below:
 `mcp__github__search_issues` for the dedup check in Step 1.5, `mcp__github__issue_write` (method
 `create`/`update`) for the `gh issue create` calls in Steps 6-7, `mcp__github__sub_issue_write` for
-the parent sub-issue registration, and `mcp__github__list_issue_types` plus the `type` parameter on
-`issue_write` for setting the native GitHub Issue Type (`issue_write` accepts `type` directly, which
-is simpler than the GraphQL-mutation approach shown in Step 7). `gh` auth failures can stem from a
-stale token, sandbox restrictions, or a transient rate limit, none of which affect MCP tools since
-they use separate credentials. If MCP tools are not available either, retry `gh auth status` once
-before asking the user to check their authentication.
+the parent sub-issue registration, and `mcp__github__list_issue_types` plus `mcp__github__issue_write`'s
+`type` parameter for setting the native GitHub Issue Type (simpler than the GraphQL-mutation approach
+shown in Step 7). MCP tools use separate credentials, so they often keep working through a `gh`
+auth failure (stale token, sandbox restrictions, a transient rate limit), though they are not
+immune to failures of their own (their own rate limits, service-side restrictions). If MCP tools
+are not available either, retry `gh auth status` once before asking the user to check their
+authentication.
 
 ## Procedure
 
@@ -50,23 +51,18 @@ its `labels:` field to infer the `kind/` label.
 
 If the issue type is ambiguous, ask the user to pick one before proceeding.
 
-### Step 1.5 - Check for existing issues
+### Step 1.5 — Check for existing issues
 
-Before drafting anything, search for likely duplicates. Build a query from the issue's
-likely title keywords and search with `mcp__github__search_issues` (owner `camunda`, repo
-`camunda`):
-
-```
-mcp__github__search_issues(owner="camunda", repo="camunda", query="<title keywords> repo:camunda/camunda")
-```
-
-Broad queries can exceed the tool's max-output-token limit. When that happens, the tool saves
-its result to a file instead of returning it inline and the response says so - do not try to
-read that file whole. Grep it for the compact per-issue fields instead:
+Before drafting anything, search for likely duplicates using the issue's likely title keywords:
 
 ```bash
-grep -oE '"number":[0-9]+,"state":"[a-z]+","title":"[^"]*"' <saved-result-file>
+gh search issues '<title keywords>' --repo camunda/camunda --state open --limit 10
+gh search issues '<title keywords>' --repo camunda/camunda --state closed --limit 10
 ```
+
+`--state` only accepts one value at a time (`open` or `closed`), not `all` — run both. (If `gh`
+auth is unavailable, use `mcp__github__search_issues` instead, per the Prerequisites fallback
+above.)
 
 If a close match turns up, surface it to the user before proceeding - show the issue number,
 state, and title, and ask whether to link the new work to it, comment on the existing issue

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -14,6 +14,17 @@ missing parent links, wrong component labels, and skipped required fields.
 gh auth status  # must succeed
 ```
 
+If this fails, do not abort. Check whether `mcp__github__*` tools are available in this session; if
+so, use them for the rest of this skill's flow instead of the `gh` examples shown below:
+`mcp__github__search_issues` for the dedup check in Step 1.5, `mcp__github__issue_write` (method
+`create`/`update`) for the `gh issue create` calls in Steps 6-7, `mcp__github__sub_issue_write` for
+the parent sub-issue registration, and `mcp__github__list_issue_types` plus the `type` parameter on
+`issue_write` for setting the native GitHub Issue Type (`issue_write` accepts `type` directly, which
+is simpler than the GraphQL-mutation approach shown in Step 7). `gh` auth failures can stem from a
+stale token, sandbox restrictions, or a transient rate limit, none of which affect MCP tools since
+they use separate credentials. If MCP tools are not available either, retry `gh auth status` once
+before asking the user to check their authentication.
+
 ## Procedure
 
 ### Step 1 — Read available templates
@@ -38,6 +49,28 @@ its `labels:` field to infer the `kind/` label.
 | Tech debt, cleanup             | `6. tech debt.yml`         | `kind/tech-debt`       |
 
 If the issue type is ambiguous, ask the user to pick one before proceeding.
+
+### Step 1.5 - Check for existing issues
+
+Before drafting anything, search for likely duplicates. Build a query from the issue's
+likely title keywords and search with `mcp__github__search_issues` (owner `camunda`, repo
+`camunda`):
+
+```
+mcp__github__search_issues(owner="camunda", repo="camunda", query="<title keywords> repo:camunda/camunda")
+```
+
+Broad queries can exceed the tool's max-output-token limit. When that happens, the tool saves
+its result to a file instead of returning it inline and the response says so - do not try to
+read that file whole. Grep it for the compact per-issue fields instead:
+
+```bash
+grep -oE '"number":[0-9]+,"state":"[a-z]+","title":"[^"]*"' <saved-result-file>
+```
+
+If a close match turns up, surface it to the user before proceeding - show the issue number,
+state, and title, and ask whether to link the new work to it, comment on the existing issue
+instead, or proceed with a new issue anyway. Do not silently create a near-duplicate.
 
 ### Step 2 — Read the template and collect field values
 


### PR DESCRIPTION
## Description

Supersedes [#59381](https://github.com/camunda/camunda/pull/59381) (closed without merging; the head branch had to be force-pushed to reword a paragraph, which GitHub then refused to let me reopen against).

A real session using the `create-issue` project skill (`.claude/skills/create-issue/SKILL.md`) surfaced two gaps:

1. **No duplicate-check step.** The skill went straight from reading templates into drafting a body, with no step that searched for existing issues first, risking a near-duplicate being created silently.
2. **No `gh` CLI fallback.** Every command example assumes a valid `gh` token, with no guidance in the skill on how to recover when `gh` auth fails for any reason (stale token, sandbox restrictions, a transient rate limit) while `mcp__github__*` tools keep working.

This PR is a `.claude/skills` improvement only, no functional/product code changes.

### What was added

- **New Step 1.5, check for existing issues**, inserted between the existing Step 1 (read templates) and Step 2 (collect field values), before drafting begins.
- **A fallback note after Prerequisites**: if `gh auth status` fails, check whether `mcp__github__*` tools are available and, if so, use them for the rest of the flow instead of the `gh` CLI examples shown in the skill (`search_issues`, `issue_write` for create/update, `sub_issue_write` for the parent relationship, `list_issue_types` plus the `type` parameter on `issue_write`).

No other steps were renumbered.

## Checklist

- [x] Enable backports when necessary - not applicable, this only changes a local agent skill file, not versioned product docs.
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. - not applicable.

## Related issues

No related issue, filed directly from gaps found in real sessions using this skill.