### PR TITLE
docs: add load-tests row to create-issue component table

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -88,6 +88,7 @@ Map path prefixes to component labels:
 | `document/`              | `component/document-handling`    |
 | `testing/`               | `component/camunda-process-test` |
 | `qa/`                    | `component/qa`                   |
+| `load-tests/`            | `component/load-tests`           |
 | `.github/` or `.claude/` | `component/build-pipeline`       |
 
 **Zeebe label split — use the conceptual layer, not the path:**


### PR DESCRIPTION
## Description

`.claude/skills/create-issue/SKILL.md`, Step 3 maps modified file paths to component labels so the skill can auto-select the right `component/*` label instead of asking the user. The table covers `zeebe/`, `operate/`, `tasklist/`, `identity/`, `optimize/`, `clients/`, `webapp/`, `gateways/`, `db/`/`search/`, `document/`, `testing/`, and `qa/`, but never got a row for `load-tests/`.

`component/load-tests` has been a valid issue-template label since [#54777](https://github.com/camunda/camunda/pull/54777) (merged), so this is a leftover doc gap rather than a missing label: a change under `load-tests/` currently falls through to "ask the user" instead of being inferred like every other module.

## Checklist

- [x] Enable backports when necessary - not applicable, this only changes a local agent skill file, not versioned product docs.
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. - not applicable.

## Related issues

No related issue, found while creating a load-test bug report ([#60094](https://github.com/camunda/camunda/issues/60094)) and reflecting on the session afterward.