### PR TITLE
ci: verify auto-unskip PRs against a live environment and fix what went stale

### DIFF
--- a/.github/scripts/test_unskip_plan_cell.py
+++ b/.github/scripts/test_unskip_plan_cell.py
@@ -1,0 +1,278 @@
+"""Unit tests for unskip-plan-cell.py
+
+Run with:
+    pytest .github/scripts/test_unskip_plan_cell.py
+"""
+
+import importlib.util
+import json
+import os
+import sys
+
+import pytest
+
+# Load the hyphen-named module via importlib and register it so mock.patch works.
+_SCRIPT = os.path.join(os.path.dirname(__file__), "unskip-plan-cell.py")
+_spec = importlib.util.spec_from_file_location("unskip_plan_cell", _SCRIPT)
+p = importlib.util.module_from_spec(_spec)
+sys.modules["unskip_plan_cell"] = p
+_spec.loader.exec_module(p)
+
+SCOPE = {
+    "specs": [
+        {
+            "file": "tests/operate/dashboard.spec.ts",
+            "tests": [{"test_name": "navigate", "bug": "https://x/issues/1"}],
+        },
+        {
+            "file": "tests/tasklist/v1/task-panel.spec.ts",
+            "tests": [{"test_name": "scrolling", "bug": "https://x/issues/2"}],
+        },
+        {
+            "file": "tests/api/v2/variable/variable-search-api.spec.ts",
+            "tests": [{"test_name": "search", "bug": None}],
+        },
+    ],
+    "manual_markers": [
+        {"path": "tests/operate/operations.spec.ts", "line": 12, "bug": "https://x/3"},
+        {"path": "tests/api/v2/clock/clock-pin-api.spec.ts", "line": 8, "bug": None},
+    ],
+}
+
+
+def listing(entries):
+    """Build a Playwright `--list` report tree from (file, project) pairs."""
+    suites = []
+    for spec_file, project in entries:
+        suites.append(
+            {
+                "title": spec_file,
+                "file": spec_file,
+                "specs": [],
+                "suites": [
+                    {
+                        "title": "a describe",
+                        "file": spec_file,
+                        "specs": [
+                            {
+                                "title": "a test",
+                                "file": spec_file,
+                                "tests": [{"projectName": project}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    return {"suites": suites, "errors": []}
+
+
+class TestCandidatePaths:
+    def test_e2e_candidates_exclude_api_and_include_marker_only_files(self):
+        assert p.candidate_paths(SCOPE, "e2e") == [
+            "tests/operate/dashboard.spec.ts",
+            "tests/operate/operations.spec.ts",
+            "tests/tasklist/v1/task-panel.spec.ts",
+        ]
+
+    def test_api_candidates_are_only_api_paths(self):
+        assert p.candidate_paths(SCOPE, "api") == [
+            "tests/api/v2/clock/clock-pin-api.spec.ts",
+            "tests/api/v2/variable/variable-search-api.spec.ts",
+        ]
+
+    def test_marker_without_a_path_is_ignored(self):
+        scope = {"specs": [], "manual_markers": [{"line": 3}]}
+        assert p.candidate_paths(scope, "e2e") == []
+
+
+class TestPlan:
+    def test_v2_mode_keeps_only_the_specs_playwright_lists(self):
+        # In v2 mode `tests/tasklist/v1/**` is in testIgnore, so it never lists.
+        result = p.plan(
+            SCOPE,
+            listing([("tests/operate/dashboard.spec.ts", "chromium")]),
+            "e2e",
+        )
+        assert result["spec_paths"] == ["tests/operate/dashboard.spec.ts"]
+        assert result["projects"] == ["chromium"]
+
+    def test_v1_mode_keeps_the_v1_spec_under_its_teardown_project(self):
+        result = p.plan(
+            SCOPE,
+            listing([("tests/tasklist/v1/task-panel.spec.ts", "chromium-subset")]),
+            "e2e",
+        )
+        assert result["spec_paths"] == ["tests/tasklist/v1/task-panel.spec.ts"]
+        assert result["projects"] == ["chromium-subset"]
+
+    def test_cross_browser_and_component_scoped_projects_are_dropped(self):
+        # CI runs `--project=chromium`; firefox/msedge and the component-scoped
+        # aliases (operate-e2e) would re-run the very same specs.
+        result = p.plan(
+            SCOPE,
+            listing(
+                [
+                    ("tests/operate/dashboard.spec.ts", "chromium"),
+                    ("tests/operate/dashboard.spec.ts", "firefox"),
+                    ("tests/operate/dashboard.spec.ts", "msedge"),
+                    ("tests/operate/dashboard.spec.ts", "operate-e2e"),
+                ]
+            ),
+            "e2e",
+        )
+        assert result["projects"] == ["chromium"]
+        assert result["unsupported"] == []
+
+    def test_a_spec_needing_an_unprovided_project_is_reported_not_pruned(self):
+        # optimize-startup wants an Optimize container the verify env never
+        # starts — silently dropping it would read as "verified".
+        result = p.plan(
+            SCOPE,
+            listing([("tests/operate/dashboard.spec.ts", "optimize-startup")]),
+            "e2e",
+        )
+        assert result["spec_paths"] == []
+        assert result["unsupported"] == [
+            {"file": "tests/operate/dashboard.spec.ts", "projects": ["optimize-startup"]}
+        ]
+
+    def test_a_spec_reachable_under_chromium_is_not_reported_unsupported(self):
+        result = p.plan(
+            SCOPE,
+            listing(
+                [
+                    ("tests/operate/dashboard.spec.ts", "chromium"),
+                    ("tests/operate/dashboard.spec.ts", "optimize-startup"),
+                ]
+            ),
+            "e2e",
+        )
+        assert result["spec_paths"] == ["tests/operate/dashboard.spec.ts"]
+        assert result["unsupported"] == []
+
+    def test_api_specs_map_to_the_api_projects(self):
+        result = p.plan(
+            SCOPE,
+            listing(
+                [
+                    ("tests/api/v2/variable/variable-search-api.spec.ts", "api-tests"),
+                    ("tests/api/v2/clock/clock-pin-api.spec.ts", "api-tests-subset"),
+                ]
+            ),
+            "api",
+        )
+        assert result["projects"] == ["api-tests", "api-tests-subset"]
+
+    def test_a_file_outside_the_scope_is_never_added(self):
+        result = p.plan(
+            SCOPE,
+            listing([("tests/operate/unrelated.spec.ts", "chromium")]),
+            "e2e",
+        )
+        assert result["spec_paths"] == []
+
+    def test_nothing_listed_prunes_the_cell(self):
+        result = p.plan(SCOPE, listing([]), "e2e")
+        assert result["spec_paths"] == []
+        assert result["fallback"] is False
+
+    def test_unreadable_list_falls_back_to_every_candidate(self):
+        result = p.plan(SCOPE, None, "api")
+        assert result["spec_paths"] == p.candidate_paths(SCOPE, "api")
+        assert result["projects"] == []
+        assert result["fallback"] is True
+
+
+class TestLoadJson:
+    def test_reads_plain_json(self, tmp_path):
+        path = tmp_path / "a.json"
+        path.write_text('{"suites": []}', encoding="utf-8")
+        assert p.load_json(str(path)) == {"suites": []}
+
+    def test_tolerates_a_tool_banner_before_the_body(self, tmp_path):
+        # Some npx/bun wrappers print e.g. "◇ injected env (6) from .env" on
+        # stdout ahead of the report.
+        path = tmp_path / "b.json"
+        path.write_text('◇ injected env (6) from .env\n{\n  "suites": []\n}\n', encoding="utf-8")
+        assert p.load_json(str(path)) == {"suites": []}
+
+    def test_missing_or_garbage_returns_none(self, tmp_path):
+        assert p.load_json(str(tmp_path / "nope.json")) is None
+        path = tmp_path / "c.json"
+        path.write_text("not json at all", encoding="utf-8")
+        assert p.load_json(str(path)) is None
+
+
+class TestCmdPlan:
+    def _run(self, tmp_path, monkeypatch, list_payload, category="e2e"):
+        scope_file = tmp_path / "scope.json"
+        scope_file.write_text(json.dumps(SCOPE), encoding="utf-8")
+        list_file = tmp_path / "list.json"
+        list_file.write_text(json.dumps(list_payload), encoding="utf-8")
+        out_file = tmp_path / "cell.json"
+        github_output = tmp_path / "gh_output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+        args = type(
+            "Args",
+            (),
+            {
+                "scope": str(scope_file),
+                "list": str(list_file),
+                "category": category,
+                "cell": "e2e-es-v2",
+                "database": "es",
+                "tasklist_mode": "v2",
+                "out": str(out_file),
+            },
+        )
+        p.cmd_plan(args)
+        outputs = dict(
+            line.split("=", 1)
+            for line in github_output.read_text(encoding="utf-8").splitlines()
+        )
+        return json.loads(out_file.read_text(encoding="utf-8")), outputs
+
+    def test_emits_project_args_and_carries_tests_and_markers(
+        self, tmp_path, monkeypatch
+    ):
+        cell, outputs = self._run(
+            tmp_path,
+            monkeypatch,
+            listing(
+                [
+                    ("tests/operate/dashboard.spec.ts", "chromium"),
+                    ("tests/operate/operations.spec.ts", "chromium"),
+                ]
+            ),
+        )
+        assert outputs["run"] == "true"
+        assert outputs["project_args"] == "--project=chromium"
+        assert outputs["test_count"] == "1"
+        assert outputs["marker_count"] == "1"
+        assert cell["unskipped_tests"] == [
+            {
+                "file": "tests/operate/dashboard.spec.ts",
+                "test_name": "navigate",
+                "bug": "https://x/issues/1",
+            }
+        ]
+        assert cell["manual_markers"][0]["path"] == "tests/operate/operations.spec.ts"
+
+    def test_pruned_cell_reports_run_false(self, tmp_path, monkeypatch):
+        _, outputs = self._run(tmp_path, monkeypatch, listing([]))
+        assert outputs["run"] == "false"
+        assert outputs["spec_paths"] == ""
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("tests/api/v2/x.spec.ts", "api"),
+        ("tests/operate/x.spec.ts", "e2e"),
+        ("tests/tasklist/v1/x.spec.ts", "e2e"),
+    ],
+)
+def test_category_of(path, expected):
+    assert p.category_of(path) == expected

--- a/.github/scripts/test_unskip_scope.py
+++ b/.github/scripts/test_unskip_scope.py
@@ -1,0 +1,208 @@
+"""Unit tests for unskip-scope.py
+
+Run with:
+    pytest .github/scripts/test_unskip_scope.py
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+# Load the hyphen-named module via importlib and register it so mock.patch works.
+_SCRIPT = os.path.join(os.path.dirname(__file__), "unskip-scope.py")
+_spec = importlib.util.spec_from_file_location("unskip_scope", _SCRIPT)
+u = importlib.util.module_from_spec(_spec)
+sys.modules["unskip_scope"] = u
+_spec.loader.exec_module(u)
+
+SUITE = u.SUITE
+
+# Verbatim excerpt of camunda/camunda#60156's diff (stable/8.9 E2E unskip).
+REAL_DIFF = f"""diff --git a/{SUITE}/tests/operate/dashboard.spec.ts b/{SUITE}/tests/operate/dashboard.spec.ts
+--- a/{SUITE}/tests/operate/dashboard.spec.ts
++++ b/{SUITE}/tests/operate/dashboard.spec.ts
+@@ -148,8 +148,7 @@ test.describe('Dashboard', () => {{
+     }});
+   }});
+
+-  //Skipped due to bug 45129: https://github.com/camunda/camunda/issues/45129
+-  test.skip('Navigate to processes view (same truncated error message)', async ({{
++  test('Navigate to processes view (same truncated error message)', async ({{
+     operateDashboardPage,
+   }}) => {{
+diff --git a/{SUITE}/tests/operate/operations.spec.ts b/{SUITE}/tests/operate/operations.spec.ts
+--- a/{SUITE}/tests/operate/operations.spec.ts
++++ b/{SUITE}/tests/operate/operations.spec.ts
+@@ -65,9 +65,8 @@ test.describe('Operations', () => {{
+   }});
+
+-  // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
+   // !Note: assert the code after the bug is fixed
+-  test.skip('Retry and cancel single instance', async ({{
++  test('Retry and cancel single instance', async ({{
+     page,
+   }}) => {{
+"""
+
+
+class TestParseDiff:
+    def test_extracts_unskipped_tests_with_their_bugs(self):
+        files = u.parse_diff(REAL_DIFF)
+        assert sorted(files) == [
+            "tests/operate/dashboard.spec.ts",
+            "tests/operate/operations.spec.ts",
+        ]
+        assert files["tests/operate/dashboard.spec.ts"]["tests"] == [
+            {
+                "test_name": "Navigate to processes view (same truncated error message)",
+                "bug": "https://github.com/camunda/camunda/issues/45129",
+            }
+        ]
+
+    def test_marker_separated_from_the_call_by_kept_prose_still_attributes(self):
+        # operations.spec.ts keeps a "!Note:" comment between marker and call.
+        tests = u.parse_diff(REAL_DIFF)["tests/operate/operations.spec.ts"]["tests"]
+        assert tests[0]["bug"] == "https://github.com/camunda/camunda/issues/42375"
+
+    def test_ignores_files_outside_the_suite_and_non_specs(self):
+        diff = (
+            "+++ b/operate/client/src/App.tsx\n"
+            "+  test('not a suite spec', async () => {\n"
+            f"+++ b/{SUITE}/utils/helper.ts\n"
+            "+  test('not a spec file', async () => {\n"
+        )
+        assert u.parse_diff(diff) == {}
+
+    @pytest.mark.parametrize(
+        "line,expected",
+        [
+            ("+  test(\"double quoted\", async () => {", "double quoted"),
+            ("+  test.describe('a describe block', () => {", "a describe block"),
+            ("+    test.step(`a step`, async () => {", "a step"),
+        ],
+    )
+    def test_recognises_every_flipped_call_shape(self, line, expected):
+        diff = f"+++ b/{SUITE}/tests/operate/x.spec.ts\n{line}\n"
+        tests = u.parse_diff(diff)["tests/operate/x.spec.ts"]["tests"]
+        assert tests[0]["test_name"] == expected
+
+    def test_test_without_a_marker_has_no_bug(self):
+        diff = f"+++ b/{SUITE}/tests/operate/x.spec.ts\n+  test('orphan', async () => {{\n"
+        tests = u.parse_diff(diff)["tests/operate/x.spec.ts"]["tests"]
+        assert tests[0]["bug"] is None
+
+    def test_a_marker_is_consumed_by_only_one_test(self):
+        diff = (
+            f"+++ b/{SUITE}/tests/operate/x.spec.ts\n"
+            "-  // Skipped due to bug: https://github.com/camunda/camunda/issues/1\n"
+            "+  test('first', async () => {\n"
+            "+  test('second', async () => {\n"
+        )
+        tests = u.parse_diff(diff)["tests/operate/x.spec.ts"]["tests"]
+        assert tests[0]["bug"] == "https://github.com/camunda/camunda/issues/1"
+        assert tests[1]["bug"] is None
+
+
+class TestParseManualMarkers:
+    BODY = f"""## Auto-Unskip
+
+### Files Changed (1)
+
+- `{SUITE}/tests/operate/dashboard.spec.ts`: 1 skip(s) removed
+
+### ⚠️ Needs manual review — left untouched (2)
+
+- [ ] **[`operations.spec.ts`:120](https://github.com/camunda/camunda/blob/sha/x#L120)** — closed bug [camunda/camunda#42375](https://github.com/camunda/camunda/issues/42375)
+  - Why it was skipped: Skip is inside a conditional/ternary.
+  - Path: `{SUITE}/tests/operate/operations.spec.ts`
+- [ ] **[`task-panel.spec.ts`:44](https://github.com/camunda/camunda/blob/sha/y#L44)** — closed bug [camunda/camunda#44583](https://github.com/camunda/camunda/issues/44583)
+  - Why it was skipped: Marker sits above commented-out code.
+  - Path: `{SUITE}/tests/tasklist/v1/task-panel.spec.ts`
+
+### Checklist
+
+- [ ] On-demand test run passes on this branch
+"""
+
+    def test_extracts_every_marker_with_path_line_bug_and_reason(self):
+        markers = u.parse_manual_markers(self.BODY)
+        assert len(markers) == 2
+        assert markers[0] == {
+            "line": 120,
+            "bug": "https://github.com/camunda/camunda/issues/42375",
+            "bug_key": "camunda/camunda#42375",
+            "path": "tests/operate/operations.spec.ts",
+            "reason": "Skip is inside a conditional/ternary.",
+        }
+        assert markers[1]["path"] == "tests/tasklist/v1/task-panel.spec.ts"
+
+    def test_stops_at_the_next_section(self):
+        # The trailing "Checklist" items are also `- [ ]` lines; they must not
+        # be read as markers.
+        assert len(u.parse_manual_markers(self.BODY)) == 2
+
+    def test_body_without_the_section_yields_nothing(self):
+        assert u.parse_manual_markers("## Auto-Unskip\n\n### Files Changed\n") == []
+
+    def test_empty_body_is_tolerated(self):
+        assert u.parse_manual_markers("") == []
+        assert u.parse_manual_markers(None) == []
+
+
+class TestVersionOf:
+    @pytest.mark.parametrize(
+        "base,expected",
+        [
+            ("main", ("main", "main")),
+            ("stable/8.9", ("8.9", "stable-8.9")),
+            ("stable/8.7", ("8.7", "stable-8.7")),
+        ],
+    )
+    def test_maps_base_branch_to_version(self, base, expected):
+        assert u.version_of(base) == expected
+
+    def test_rejects_an_unsupported_base(self):
+        with pytest.raises(SystemExit):
+            u.version_of("release-8.9.1")
+
+
+class TestBuildMatrix:
+    def test_e2e_on_89_covers_both_tasklist_generations(self):
+        cells = u.build_matrix("8.9", has_e2e=True, has_api=False)
+        assert [c["tasklist_mode"] for c in cells] == ["v1", "v2"]
+        assert {c["database"] for c in cells} == {"es"}
+
+    def test_e2e_on_main_is_v2_only(self):
+        cells = u.build_matrix("main", has_e2e=True, has_api=False)
+        assert [c["cell"] for c in cells] == ["e2e-es-v2"]
+
+    def test_e2e_on_87_is_v1_only(self):
+        cells = u.build_matrix("8.7", has_e2e=True, has_api=False)
+        assert [c["cell"] for c in cells] == ["e2e-es-v1"]
+
+    def test_api_adds_rdbms_only_where_the_nightly_runs_it(self):
+        assert [c["database"] for c in u.build_matrix("8.9", False, True)] == [
+            "es",
+            "h2",
+        ]
+        assert [c["database"] for c in u.build_matrix("8.8", False, True)] == ["es"]
+
+    def test_mixed_pr_unions_both_categories(self):
+        cells = u.build_matrix("8.9", has_e2e=True, has_api=True)
+        assert [c["cell"] for c in cells] == [
+            "e2e-es-v1",
+            "e2e-es-v2",
+            "api-es",
+            "api-h2",
+        ]
+
+    def test_no_specs_yields_no_cells(self):
+        assert u.build_matrix("8.9", has_e2e=False, has_api=False) == []
+
+    def test_unknown_version_falls_back_to_the_safe_dimensions(self):
+        assert [c["cell"] for c in u.build_matrix("9.0", True, True)] == [
+            "e2e-es-v2",
+            "api-es",
+        ]

--- a/.github/scripts/test_unskip_scope.py
+++ b/.github/scripts/test_unskip_scope.py
@@ -96,6 +96,7 @@ class TestParseDiff:
     def test_a_marker_is_consumed_by_only_one_test(self):
         diff = (
             f"+++ b/{SUITE}/tests/operate/x.spec.ts\n"
+            "@@ -1,4 +1,3 @@\n"
             "-  // Skipped due to bug: https://github.com/camunda/camunda/issues/1\n"
             "+  test('first', async () => {\n"
             "+  test('second', async () => {\n"
@@ -103,6 +104,51 @@ class TestParseDiff:
         tests = u.parse_diff(diff)["tests/operate/x.spec.ts"]["tests"]
         assert tests[0]["bug"] == "https://github.com/camunda/camunda/issues/1"
         assert tests[1]["bug"] is None
+
+    def test_stacked_markers_attribute_the_nearest_one(self):
+        # A test skipped for two bugs: the marker directly above the call is the
+        # attached one, so the most recent pending marker must win (not the
+        # oldest).
+        diff = (
+            f"+++ b/{SUITE}/tests/operate/x.spec.ts\n"
+            "@@ -1,5 +1,3 @@\n"
+            "-  // Skipped due to bug: https://github.com/camunda/camunda/issues/1\n"
+            "-  // Skipped due to bug: https://github.com/camunda/camunda/issues/2\n"
+            "+  test('one', async () => {\n"
+        )
+        tests = u.parse_diff(diff)["tests/operate/x.spec.ts"]["tests"]
+        assert tests[0]["bug"] == "https://github.com/camunda/camunda/issues/2"
+
+    def test_an_unconsumed_marker_does_not_leak_into_a_later_hunk(self):
+        # The first hunk removes a marker without flipping a call (e.g. only a
+        # stale comment was dropped). That marker must not be attributed to the
+        # next hunk's test.
+        diff = (
+            f"+++ b/{SUITE}/tests/operate/x.spec.ts\n"
+            "@@ -1,3 +1,2 @@\n"
+            "-  // Skipped due to bug: https://github.com/camunda/camunda/issues/1\n"
+            "@@ -40,4 +39,4 @@\n"
+            "-  // Skipped due to bug: https://github.com/camunda/camunda/issues/2\n"
+            "+  test('later', async () => {\n"
+        )
+        tests = u.parse_diff(diff)["tests/operate/x.spec.ts"]["tests"]
+        assert len(tests) == 1
+        assert tests[0]["bug"] == "https://github.com/camunda/camunda/issues/2"
+
+    def test_a_hunk_with_no_marker_leaves_the_test_unattributed(self):
+        diff = (
+            f"+++ b/{SUITE}/tests/operate/x.spec.ts\n"
+            "@@ -1,3 +1,2 @@\n"
+            "-  // Skipped due to bug: https://github.com/camunda/camunda/issues/1\n"
+            "+  test('one', async () => {\n"
+            "@@ -40,4 +39,4 @@\n"
+            "+  test('two', async () => {\n"
+        )
+        tests = u.parse_diff(diff)["tests/operate/x.spec.ts"]["tests"]
+        assert [t["bug"] for t in tests] == [
+            "https://github.com/camunda/camunda/issues/1",
+            None,
+        ]
 
 
 class TestParseManualMarkers:

--- a/.github/scripts/unskip-plan-cell.py
+++ b/.github/scripts/unskip-plan-cell.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Plan one environment cell of an unskip-verify run.
+
+The matrix covers every environment dimension a version runs, but a given
+spec only executes in some of them — `playwright.config.ts` selects
+`tests/tasklist/v1/**` in Tasklist v1 mode and everything else in v2 mode,
+and puts `task-panel.spec.ts` in its own teardown project. Rather than
+re-implementing those rules here (they differ per branch), ask Playwright
+itself with `--list` and read the answer back.
+
+Subcommands:
+    candidates  Print the scope's spec paths for this cell's category — the
+                path filters to hand to `playwright test --list`.
+    plan        Read that `--list` JSON and emit what the cell should actually
+                run: `spec_paths`, `project_args`, and the un-skipped tests
+                and manual-review markers that belong to those files. Emits
+                `run=false` when nothing executes here, so the cell can exit
+                before standing up an environment.
+
+An unreadable or empty `--list` result never prunes: the cell falls back to
+running every candidate path with no project filter.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# The projects CI itself runs: `--project=chromium` for E2E and
+# `--project=api-tests` for API (each pulling in its own `-subset` teardown).
+# Verifying under exactly these keeps the signal comparable to the nightly.
+ALLOWED_PROJECTS = {
+    "chromium",
+    "chromium-subset",
+    "api-tests",
+    "api-tests-subset",
+}
+
+# Projects that re-run the same specs under another browser or a
+# component-scoped alias of chromium — dropping them is free.
+REDUNDANT_PROJECTS = {
+    "firefox",
+    "firefox-subset",
+    "msedge",
+    "msedge-subset",
+    "webkit",
+    "webkit-subset",
+    "operate-e2e",
+    "tasklist-e2e",
+    "identity-e2e",
+}
+
+
+def load_json(path):
+    """Parse a JSON file, tolerating a tool banner printed before the body."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            raw = handle.read()
+    except OSError:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError:
+        pass
+    start = raw.find("\n{")
+    if start == -1:
+        return None
+    try:
+        return json.loads(raw[start + 1 :])
+    except ValueError:
+        return None
+
+
+def category_of(spec_path):
+    return "api" if spec_path.startswith("tests/api/") else "e2e"
+
+
+def candidate_paths(scope, category):
+    """Every scope path in this category — diff files plus marker-only files."""
+    paths = {s["file"] for s in scope.get("specs", [])}
+    paths |= {m["path"] for m in scope.get("manual_markers", []) if m.get("path")}
+    return sorted(p for p in paths if category_of(p) == category)
+
+
+def walk_specs(node, acc):
+    """Collect (file, projectName) from a Playwright `--list` report tree."""
+    if isinstance(node, list):
+        for item in node:
+            walk_specs(item, acc)
+        return
+    if not isinstance(node, dict):
+        return
+    for spec in node.get("specs", []) or []:
+        spec_file = spec.get("file") or node.get("file")
+        for test in spec.get("tests", []) or []:
+            project = test.get("projectName") or test.get("projectId")
+            if spec_file and project:
+                acc.append((spec_file, project))
+    walk_specs(node.get("suites", []) or [], acc)
+
+
+def plan(scope, listing, category):
+    """Return the cell plan: which paths run here, and under which projects.
+
+    A candidate lands in one of three buckets: it runs here (listed under a
+    project CI runs), it needs a project this environment cannot provide (e.g.
+    `optimize-startup`, which wants an Optimize container) — reported so a human
+    sees it — or it simply does not run in this dimension and is pruned.
+    """
+    candidates = candidate_paths(scope, category)
+    if listing is None:
+        return {
+            "spec_paths": candidates,
+            "projects": [],
+            "unsupported": [],
+            "fallback": True,
+        }
+
+    found = []
+    walk_specs(listing.get("suites", []), found)
+    allowed = set(candidates)
+    by_file = {}
+    for spec_file, project in found:
+        if spec_file in allowed:
+            by_file.setdefault(spec_file, set()).add(project)
+
+    spec_paths, projects, unsupported = set(), set(), []
+    for spec_file, listed in by_file.items():
+        runnable = listed & ALLOWED_PROJECTS
+        if runnable:
+            spec_paths.add(spec_file)
+            projects |= runnable
+            continue
+        other = sorted(listed - REDUNDANT_PROJECTS)
+        if other:
+            unsupported.append({"file": spec_file, "projects": other})
+    return {
+        "spec_paths": sorted(spec_paths),
+        "projects": sorted(projects),
+        "unsupported": sorted(unsupported, key=lambda u: u["file"]),
+        "fallback": False,
+    }
+
+
+def emit_outputs(pairs):
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        for key, value in pairs:
+            print(f"{key}={value}")
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in pairs:
+            handle.write(f"{key}={value}\n")
+
+
+def cmd_candidates(args):
+    scope = load_json(args.scope)
+    if scope is None:
+        sys.exit(f"::error::cannot read scope file {args.scope}")
+    print(" ".join(candidate_paths(scope, args.category)))
+
+
+def cmd_plan(args):
+    scope = load_json(args.scope)
+    if scope is None:
+        sys.exit(f"::error::cannot read scope file {args.scope}")
+    result = plan(scope, load_json(args.list), args.category)
+    spec_paths = result["spec_paths"]
+
+    by_file = {s["file"]: s for s in scope.get("specs", [])}
+    cell = {
+        "cell": args.cell,
+        "category": args.category,
+        "database": args.database,
+        "tasklist_mode": args.tasklist_mode,
+        "spec_paths": spec_paths,
+        "projects": result["projects"],
+        "fallback": result["fallback"],
+        "unsupported": result.get("unsupported", []),
+        "unskipped_tests": [
+            {"file": path, **test}
+            for path in spec_paths
+            for test in by_file.get(path, {}).get("tests", [])
+        ],
+        "manual_markers": [
+            marker
+            for marker in scope.get("manual_markers", [])
+            if marker.get("path") in spec_paths
+        ],
+    }
+    with open(args.out, "w", encoding="utf-8") as handle:
+        json.dump(cell, handle, indent=2)
+
+    project_args = " ".join(f"--project={p}" for p in result["projects"])
+    emit_outputs(
+        [
+            ("run", "true" if spec_paths else "false"),
+            ("spec_paths", " ".join(spec_paths)),
+            ("project_args", project_args),
+            ("spec_count", len(spec_paths)),
+            ("test_count", len(cell["unskipped_tests"])),
+            ("marker_count", len(cell["manual_markers"])),
+            ("unsupported_count", len(cell["unsupported"])),
+        ]
+    )
+    for entry in cell["unsupported"]:
+        print(
+            f"::warning::{entry['file']} only runs under "
+            f"{', '.join(entry['projects'])}, which this environment does not "
+            f"provide — not verified here."
+        )
+    if not spec_paths:
+        print(f"Cell {args.cell}: no scope spec runs in this dimension — pruning.")
+    else:
+        print(
+            f"Cell {args.cell}: {len(spec_paths)} spec(s), "
+            f"projects=[{', '.join(result['projects']) or 'all'}], "
+            f"{len(cell['manual_markers'])} manual marker(s)"
+            + (" (list unavailable — no pruning)" if result["fallback"] else "")
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    candidates = sub.add_parser("candidates")
+    candidates.add_argument("--scope", required=True)
+    candidates.add_argument("--category", required=True, choices=["e2e", "api"])
+    candidates.set_defaults(func=cmd_candidates)
+
+    planner = sub.add_parser("plan")
+    planner.add_argument("--scope", required=True)
+    planner.add_argument("--list", required=True)
+    planner.add_argument("--category", required=True, choices=["e2e", "api"])
+    planner.add_argument("--cell", default="")
+    planner.add_argument("--database", default="es")
+    planner.add_argument("--tasklist-mode", dest="tasklist_mode", default="v2")
+    planner.add_argument("--out", default="cell-plan.json")
+    planner.set_defaults(func=cmd_plan)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/unskip-scope.py
+++ b/.github/scripts/unskip-scope.py
@@ -48,6 +48,7 @@ API_DATABASES = {
 }
 
 DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")
+DIFF_HUNK_RE = re.compile(r"^@@ ")
 # `test('title'`, `test.describe('title'`, `test.step('title'` — the three call
 # shapes the unskip transform flips. Quote style varies across the suite.
 TEST_CALL_RE = re.compile(
@@ -115,7 +116,10 @@ def parse_diff(diff):
 
     A test is attributed to the bug whose skip marker was removed immediately
     above it; markers and the `test(` call can be separated by kept prose
-    comments, so the most recent unconsumed marker in the hunk wins.
+    comments, so the most recent unconsumed marker wins — the nearest marker is
+    the attached one when several stack up. Pending markers are dropped at each
+    hunk boundary: a marker and the call it guards are always in the same hunk,
+    so one that never finds a test cannot leak into a later one.
     """
     files = {}
     current = None
@@ -132,6 +136,9 @@ def parse_diff(diff):
             continue
         if current is None:
             continue
+        if DIFF_HUNK_RE.match(line):
+            pending_bugs = []
+            continue
         if SKIP_MARKER_RE.match(line):
             found = ISSUE_URL_RE.search(line)
             if found:
@@ -142,7 +149,7 @@ def parse_diff(diff):
             files[current]["tests"].append(
                 {
                     "test_name": test_match.group(1),
-                    "bug": pending_bugs.pop(0) if pending_bugs else None,
+                    "bug": pending_bugs.pop() if pending_bugs else None,
                 }
             )
     return files

--- a/.github/scripts/unskip-scope.py
+++ b/.github/scripts/unskip-scope.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Derive the verification scope of an auto-unskip PR.
+
+The auto-unskip workflow (camunda/qa-metrics-exporter) opens one PR per
+branch + category that flips `test.skip(` back to `test(` for tests whose
+referenced bug is closed. This script reads that PR and emits everything the
+unskip-verify agent needs:
+
+* `scope.json` — the changed spec files, the test titles each one un-skipped
+  (with the closed bug they reference), and the "Needs manual review" markers
+  the unskip workflow deliberately left untouched.
+* `$GITHUB_OUTPUT` — `pr_number`, `base_ref`, `version`, `safe_version`,
+  `has_e2e`, `has_api`, `spec_count` and `matrix`: one cell per environment
+  dimension the target version actually runs (mirrors the dimensions of
+  c8-orchestration-cluster-e2e-tests-on-demand.yml). Cells whose specs do not
+  execute in that dimension prune themselves later, via `playwright --list`.
+
+Usage:
+    unskip-scope.py --pr 60156 [--repo camunda/camunda] [--out scope.json]
+    unskip-scope.py --branch auto/unskip-closed-bugs-camunda-stable-8.9-e2e
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+SUITE = "qa/c8-orchestration-cluster-e2e-test-suite"
+
+# Tasklist generations the E2E matrix runs per version, and secondary-storage
+# backends the API matrix runs. Mirrors the on-demand workflow's own matrix
+# expressions — keep the two in sync when a version is added or retired.
+E2E_TASKLIST_MODES = {
+    "main": ["v2"],
+    "8.9": ["v1", "v2"],
+    "8.8": ["v1", "v2"],
+    "8.7": ["v1"],
+    "8.6": ["v1"],
+}
+API_DATABASES = {
+    "main": ["es", "h2"],
+    "8.9": ["es", "h2"],
+    "8.8": ["es"],
+    "8.7": ["es"],
+    "8.6": ["es"],
+}
+
+DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")
+# `test('title'`, `test.describe('title'`, `test.step('title'` — the three call
+# shapes the unskip transform flips. Quote style varies across the suite.
+TEST_CALL_RE = re.compile(
+    r"^\+\s*(?:test|test\.describe|test\.step)\(\s*['\"`](.+?)['\"`]"
+)
+ISSUE_URL_RE = re.compile(r"https://github\.com/[\w.-]+/[\w.-]+/issues/\d+")
+SKIP_MARKER_RE = re.compile(r"^-\s*//.*\bskip\w*\b", re.IGNORECASE)
+# Rendered by _unskip-core.yml: "- [ ] **[`file.spec.ts`:120](url)** — closed bug [owner/repo#n](url)"
+MANUAL_ITEM_RE = re.compile(r"^- \[[ xX]\] \*\*\[`[^`]+`:(\d+)\]")
+MANUAL_PATH_RE = re.compile(r"^\s+- Path: `(.+?)`\s*$")
+MANUAL_REASON_RE = re.compile(r"^\s+- Why it was skipped: (.+?)\s*$")
+MANUAL_BUG_RE = re.compile(r"closed bug \[([^\]]+)\]\(([^)]+)\)")
+
+
+def gh(args, repo):
+    """Run a `gh` command and return stdout, or exit with its error."""
+    cmd = ["gh"] + args + ["--repo", repo]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        sys.exit(f"::error::{' '.join(cmd)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def resolve_pr(repo, pr_number, branch):
+    """Return the PR metadata dict, looking it up by branch when needed."""
+    if not pr_number:
+        if not branch:
+            sys.exit("::error::one of --pr or --branch is required")
+        listing = json.loads(
+            gh(
+                [
+                    "pr",
+                    "list",
+                    "--head",
+                    branch,
+                    "--state",
+                    "open",
+                    "--json",
+                    "number",
+                    "--limit",
+                    "1",
+                ],
+                repo,
+            )
+        )
+        if not listing:
+            sys.exit(f"::error::no open PR found for branch {branch}")
+        pr_number = listing[0]["number"]
+    fields = "number,baseRefName,headRefName,body,title,url,state"
+    return json.loads(gh(["pr", "view", str(pr_number), "--json", fields], repo))
+
+
+def version_of(base_ref):
+    """`stable/8.9` -> ("8.9", "stable-8.9"); `main` -> ("main", "main")."""
+    if base_ref == "main":
+        return "main", "main"
+    if base_ref.startswith("stable/"):
+        version = base_ref.split("/", 1)[1]
+        return version, f"stable-{version}"
+    sys.exit(f"::error::unsupported base branch: {base_ref}")
+
+
+def parse_diff(diff):
+    """Map each changed suite-relative spec path to its un-skipped tests.
+
+    A test is attributed to the bug whose skip marker was removed immediately
+    above it; markers and the `test(` call can be separated by kept prose
+    comments, so the most recent unconsumed marker in the hunk wins.
+    """
+    files = {}
+    current = None
+    pending_bugs = []
+    for line in diff.splitlines():
+        match = DIFF_FILE_RE.match(line)
+        if match:
+            path = match.group(1)
+            current = None
+            pending_bugs = []
+            if path.startswith(f"{SUITE}/") and path.endswith(".spec.ts"):
+                current = path[len(SUITE) + 1 :]
+                files.setdefault(current, {"file": current, "tests": []})
+            continue
+        if current is None:
+            continue
+        if SKIP_MARKER_RE.match(line):
+            found = ISSUE_URL_RE.search(line)
+            if found:
+                pending_bugs.append(found.group(0))
+            continue
+        test_match = TEST_CALL_RE.match(line)
+        if test_match:
+            files[current]["tests"].append(
+                {
+                    "test_name": test_match.group(1),
+                    "bug": pending_bugs.pop(0) if pending_bugs else None,
+                }
+            )
+    return files
+
+
+def parse_manual_markers(body):
+    """Extract the checklist under "Needs manual review" from the PR body."""
+    if not body:
+        return []
+    markers = []
+    in_section = False
+    current = None
+    for line in body.splitlines():
+        if line.startswith("###"):
+            in_section = "Needs manual review" in line
+            if not in_section and current:
+                markers.append(current)
+                current = None
+            continue
+        if not in_section:
+            continue
+        item = MANUAL_ITEM_RE.match(line)
+        if item:
+            if current:
+                markers.append(current)
+            bug = MANUAL_BUG_RE.search(line)
+            current = {
+                "line": int(item.group(1)),
+                "bug": bug.group(2) if bug else None,
+                "bug_key": bug.group(1) if bug else None,
+                "path": None,
+                "reason": "",
+            }
+            continue
+        if current is None:
+            continue
+        path = MANUAL_PATH_RE.match(line)
+        if path:
+            raw = path.group(1)
+            current["path"] = (
+                raw[len(SUITE) + 1 :] if raw.startswith(f"{SUITE}/") else raw
+            )
+            continue
+        reason = MANUAL_REASON_RE.match(line)
+        if reason:
+            current["reason"] = reason.group(1)
+    if current:
+        markers.append(current)
+    return [m for m in markers if m["path"]]
+
+
+def build_matrix(version, has_e2e, has_api):
+    """One cell per environment dimension this version's matrix covers."""
+    cells = []
+    if has_e2e:
+        for mode in E2E_TASKLIST_MODES.get(version, ["v2"]):
+            cells.append(
+                {
+                    "cell": f"e2e-es-{mode}",
+                    "category": "e2e",
+                    "database": "es",
+                    "tasklist_mode": mode,
+                }
+            )
+    if has_api:
+        for database in API_DATABASES.get(version, ["es"]):
+            cells.append(
+                {
+                    "cell": f"api-{database}",
+                    "category": "api",
+                    "database": database,
+                    # API jobs have no tasklist dimension; the env script's
+                    # default (v2) matches what on-demand's API jobs run.
+                    "tasklist_mode": "v2",
+                }
+            )
+    return cells
+
+
+def emit_outputs(pairs):
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        for key, value in pairs:
+            print(f"{key}={value}")
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in pairs:
+            handle.write(f"{key}={value}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", type=int, default=0)
+    parser.add_argument("--branch", default="")
+    parser.add_argument(
+        "--repo", default=os.environ.get("GITHUB_REPOSITORY", "camunda/camunda")
+    )
+    parser.add_argument("--out", default="scope.json")
+    args = parser.parse_args()
+
+    pr = resolve_pr(args.repo, args.pr, args.branch)
+    version, safe_version = version_of(pr["baseRefName"])
+
+    diff = gh(["pr", "diff", str(pr["number"])], args.repo)
+    files = parse_diff(diff)
+    markers = parse_manual_markers(pr.get("body", ""))
+
+    # A manual-review marker can sit in a file the transform never touched, so
+    # it widens the run scope beyond the diff.
+    for marker in markers:
+        files.setdefault(marker["path"], {"file": marker["path"], "tests": []})
+
+    specs = sorted(files.values(), key=lambda f: f["file"])
+    has_api = any(f["file"].startswith("tests/api/") for f in specs)
+    has_e2e = any(not f["file"].startswith("tests/api/") for f in specs)
+
+    scope = {
+        "pr_number": pr["number"],
+        "pr_url": pr["url"],
+        "branch": pr["headRefName"],
+        "base_ref": pr["baseRefName"],
+        "version": version,
+        "safe_version": safe_version,
+        "specs": specs,
+        "manual_markers": markers,
+    }
+    with open(args.out, "w", encoding="utf-8") as handle:
+        json.dump(scope, handle, indent=2)
+
+    matrix = {"include": build_matrix(version, has_e2e, has_api)}
+    emit_outputs(
+        [
+            ("pr_number", pr["number"]),
+            ("branch", pr["headRefName"]),
+            ("base_ref", pr["baseRefName"]),
+            ("version", version),
+            ("safe_version", safe_version),
+            ("has_e2e", str(has_e2e).lower()),
+            ("has_api", str(has_api).lower()),
+            ("spec_count", len(specs)),
+            ("manual_marker_count", len(markers)),
+            ("matrix", json.dumps(matrix)),
+        ]
+    )
+    print(
+        f"PR #{pr['number']} ({pr['baseRefName']}): {len(specs)} spec file(s), "
+        f"{sum(len(f['tests']) for f in specs)} un-skipped test(s), "
+        f"{len(markers)} manual marker(s), {len(matrix['include'])} matrix cell(s)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/c8-orchestration-cluster-unskip-verify.yml
+++ b/.github/workflows/c8-orchestration-cluster-unskip-verify.yml
@@ -1,0 +1,710 @@
+# description: Live-environment verification agent for auto-unskip PRs in the C8 Orchestration
+#              Cluster E2E/API suite. Dispatched per PR by camunda/qa-metrics-exporter's
+#              unskip workflow (or manually). For every environment dimension the target
+#              version runs, it stands up that environment, runs the un-skipped specs, and —
+#              when they are red — lets Claude Code fix them and push onto the same PR branch.
+# type: CI
+# owner: @camunda/test-automation-team
+---
+name: C8 Orchestration Cluster Unskip Verify Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Unskip PR branch (e.g. auto/unskip-closed-bugs-camunda-stable-8.9-e2e)'
+        required: false
+        default: ''
+      pr_number:
+        description: 'Unskip PR number (alternative to branch)'
+        required: false
+        default: ''
+      trigger_on_demand:
+        description: 'Dispatch the full-matrix on-demand run on the final branch state'
+        type: boolean
+        required: false
+        default: true
+      slack_thread_ts:
+        description: 'Slack thread ts to reply to (posted by the unskip workflow)'
+        required: false
+        default: ''
+      slack_channel:
+        description: 'Slack channel ID for the thread reply'
+        required: false
+        default: ''
+      send_slack_notification:
+        description: 'Post a Slack reply when done'
+        type: boolean
+        required: false
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+
+# Cells push to the same PR branch, and a second dispatch for the same PR would
+# race them. Queue instead of cancelling — a cancelled run leaves a live Docker
+# environment and a half-verified PR.
+concurrency:
+  group: unskip-verify-${{ github.event.inputs.pr_number || github.event.inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Resolve unskip PR scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      pr_number: ${{ steps.scope.outputs.pr_number }}
+      branch: ${{ steps.scope.outputs.branch }}
+      base_ref: ${{ steps.scope.outputs.base_ref }}
+      version: ${{ steps.scope.outputs.version }}
+      safe_version: ${{ steps.scope.outputs.safe_version }}
+      spec_count: ${{ steps.scope.outputs.spec_count }}
+      manual_marker_count: ${{ steps.scope.outputs.manual_marker_count }}
+      matrix: ${{ steps.scope.outputs.matrix }}
+      cell_count: ${{ steps.cells.outputs.count }}
+
+    steps:
+      - name: Checkout main for workflow tooling
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve scope from the unskip PR
+        id: scope
+        env:
+          # Read workflow_dispatch inputs through env to avoid template injection
+          # (zizmor: template-injection — github.event.inputs.* is attacker-controllable)
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PR: ${{ github.event.inputs.pr_number }}
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${INPUT_PR}" ] && [ -z "${INPUT_BRANCH}" ]; then
+            echo "::error::one of pr_number or branch must be provided"
+            exit 1
+          fi
+          python3 .github/scripts/unskip-scope.py \
+            --repo "$REPO" \
+            --pr "${INPUT_PR:-0}" \
+            --branch "${INPUT_BRANCH}" \
+            --out /tmp/unskip-scope.json
+
+      - name: Count matrix cells
+        id: cells
+        env:
+          MATRIX: ${{ steps.scope.outputs.matrix }}
+        run: |
+          set -euo pipefail
+          count=$(printf '%s' "$MATRIX" | jq '.include | length')
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          if [ "$count" -eq 0 ]; then
+            echo "::warning::No spec files changed by this unskip PR — nothing to verify."
+          fi
+
+      - name: Upload scope
+        uses: actions/upload-artifact@v7
+        with:
+          name: unskip-scope
+          path: /tmp/unskip-scope.json
+          retention-days: 14
+
+  verify:
+    name: Verify ${{ matrix.cell }}
+    needs: prepare
+    if: ${{ needs.prepare.outputs.cell_count != '0' }}
+    runs-on: ubuntu-latest
+    # 120 (not 90): the api-h2 cell builds a full Camunda distribution from
+    # source, exactly as c8-orchestration-cluster-e2e-tests-on-demand.yml's own
+    # H2/RDBMS job does, before a single test can run.
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      # Cells commit to the same PR branch — serialize so a later cell always
+      # starts from the previous cell's pushed state.
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+
+    steps:
+      - name: Checkout main for workflow tooling
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          # The agent works inside the workspace-cli checkout, which is
+          # re-authenticated with the bot token below; keep the short-lived
+          # GITHUB_TOKEN out of .git/config (zizmor: artipacked).
+          persist-credentials: false
+
+      - name: Download scope
+        uses: actions/download-artifact@v6
+        with:
+          name: unskip-scope
+          path: /tmp/scope
+
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
+            secret/data/products/qa/ci/common GH_TOKEN | GH_PAT ;
+
+      - name: Generate GitHub App Token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: camunda
+
+      - name: Configure git with GitHub App token
+        env:
+          TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global user.name  "qa-processes[bot]"
+          git config --global user.email "qa-processes[bot]@users.noreply.github.com"
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Install workspace-cli
+        env:
+          GOPRIVATE: github.com/camunda/*
+          GOTOOLCHAIN: auto
+          GH_PAT: ${{ steps.secrets.outputs.GH_PAT }}
+        run: |
+          # workspace-cli is a private repo; the qa-processes app token doesn't have access.
+          # Git selects the longest-matching insteadOf, so this wins over the global
+          # qa-processes rewrite set in "Configure git with GitHub App token".
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/camunda/workspace-cli".insteadOf "https://github.com/camunda/workspace-cli"
+          go install github.com/camunda/workspace-cli/cmd/workspace@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code@2.1.156
+          claude --version
+
+      - name: Create workspace on the unskip PR branch
+        id: ws
+        env:
+          BRANCH: ${{ needs.prepare.outputs.branch }}
+          CELL: ${{ matrix.cell }}
+        run: |
+          set -euo pipefail
+          name="unskip-${CELL}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$HOME/.workspace-templates"
+          cp qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-unskip.yaml \
+             qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-unskip.guidance.md \
+             "$HOME/.workspace-templates/"
+          workspace create "${name}" --manifest camunda-orchestration-cluster-unskip
+
+          ws_dir="$HOME/workspaces/${name}/camunda"
+          git -C "$ws_dir" fetch --depth 1 origin "${BRANCH}"
+          git -C "$ws_dir" checkout "${BRANCH}"
+          git -C "$ws_dir" log --oneline -1
+
+          {
+            echo "name=${name}"
+            echo "dir=${ws_dir}"
+            echo "suite=${ws_dir}/qa/c8-orchestration-cluster-e2e-test-suite"
+          } >> "$GITHUB_OUTPUT"
+
+      # The agent's operating manual and the verify-environment scripts live on
+      # `main` only — stable/8.7…8.9 carry neither. Stage main's copies into the
+      # PR-branch checkout and mark them untracked-and-ignored so they can never
+      # end up in a commit. start-verify-env.sh still reads the *checked-out*
+      # branch's own docker-compose.yml, so it stays correct per branch.
+      - name: Stage agent manual and verify-env scripts from main
+        env:
+          SUITE: ${{ steps.ws.outputs.suite }}
+          WS_DIR: ${{ steps.ws.outputs.dir }}
+        run: |
+          set -euo pipefail
+          src=qa/c8-orchestration-cluster-e2e-test-suite
+          cp "$src/AGENTS.md" /tmp/unskip-agent-manual.md
+          mkdir -p "$SUITE/scripts"
+          cp "$src/scripts/start-verify-env.sh" "$src/scripts/stop-verify-env.sh" "$SUITE/scripts/"
+          chmod +x "$SUITE/scripts/start-verify-env.sh" "$SUITE/scripts/stop-verify-env.sh"
+          {
+            echo "qa/c8-orchestration-cluster-e2e-test-suite/scripts/start-verify-env.sh"
+            echo "qa/c8-orchestration-cluster-e2e-test-suite/scripts/stop-verify-env.sh"
+            echo "qa/c8-orchestration-cluster-e2e-test-suite/.env"
+          } >> "$WS_DIR/.git/info/exclude"
+
+      - name: Read suite Node version
+        id: node
+        env:
+          SUITE: ${{ steps.ws.outputs.suite }}
+        run: echo "version=$(cat "$SUITE/.nvmrc")" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ steps.node.outputs.version }}
+
+      - name: Install suite dependencies
+        working-directory: ${{ steps.ws.outputs.suite }}
+        run: npm ci
+
+      # Ask Playwright which of the scope's specs actually run in this
+      # dimension — `playwright.config.ts` selects tests/tasklist/v1/** in v1
+      # mode and everything else in v2 mode, and routes task-panel.spec.ts to
+      # its own teardown project. Listing needs no server, so a cell with
+      # nothing to run exits before paying for an environment.
+      - name: Plan cell
+        id: plan
+        working-directory: ${{ steps.ws.outputs.suite }}
+        env:
+          CATEGORY: ${{ matrix.category }}
+          CELL: ${{ matrix.cell }}
+          DATABASE: ${{ matrix.database }}
+          TASKLIST_MODE: ${{ matrix.tasklist_mode }}
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: ${{ matrix.tasklist_mode == 'v1' && 'false' || 'true' }}
+        run: |
+          set -euo pipefail
+          scripts="$GITHUB_WORKSPACE/.github/scripts"
+          candidates=$(python3 "$scripts/unskip-plan-cell.py" candidates \
+            --scope /tmp/scope/unskip-scope.json --category "$CATEGORY")
+          echo "Candidate specs: ${candidates:-<none>}"
+
+          if [ -n "$candidates" ]; then
+            read -ra paths <<< "$candidates"
+            # `--list` exits 1 when the filters match nothing, but still writes a
+            # valid report with empty suites — that is the prune signal, not an
+            # error. Only an UNPARSEABLE report means "cannot prune", and the
+            # planner then falls back to running every candidate.
+            npx playwright test --list --reporter=json "${paths[@]}" \
+              > /tmp/pw-list.json 2>/tmp/pw-list.err || true
+            if ! python3 -c "import sys,json; json.load(open('/tmp/pw-list.json'))" 2>/dev/null \
+               && ! grep -q '^{' /tmp/pw-list.json 2>/dev/null; then
+              echo "::warning::playwright --list produced no usable report; skipping the prune step"
+              tail -20 /tmp/pw-list.err || true
+              rm -f /tmp/pw-list.json
+            fi
+          fi
+
+          python3 "$scripts/unskip-plan-cell.py" plan \
+            --scope /tmp/scope/unskip-scope.json \
+            --list /tmp/pw-list.json \
+            --category "$CATEGORY" --cell "$CELL" \
+            --database "$DATABASE" --tasklist-mode "$TASKLIST_MODE" \
+            --out /tmp/cell-plan.json
+
+      - name: Install Playwright browsers
+        if: ${{ steps.plan.outputs.run == 'true' }}
+        working-directory: ${{ steps.ws.outputs.suite }}
+        run: npx playwright install --with-deps chromium
+
+      - name: Start verify environment
+        if: ${{ steps.plan.outputs.run == 'true' }}
+        working-directory: ${{ steps.ws.outputs.suite }}
+        env:
+          DATABASE: ${{ matrix.database }}
+          TASKLIST_MODE: ${{ matrix.tasklist_mode }}
+        run: ./scripts/start-verify-env.sh "$DATABASE" "$TASKLIST_MODE"
+
+      # Reproduce gate: run the un-skipped specs untouched. Green here means the
+      # closed bug really is fixed and the PR needs no code change at all.
+      - name: Baseline run
+        id: baseline
+        if: ${{ steps.plan.outputs.run == 'true' }}
+        working-directory: ${{ steps.ws.outputs.suite }}
+        env:
+          SPEC_PATHS: ${{ steps.plan.outputs.spec_paths }}
+          PROJECT_ARGS: ${{ steps.plan.outputs.project_args }}
+        run: |
+          set -uo pipefail
+          read -ra args <<< "$PROJECT_ARGS $SPEC_PATHS"
+          npx playwright test "${args[@]}"
+          status=$?
+          mkdir -p /tmp/baseline
+          cp json-report/results.json /tmp/baseline/results.json 2>/dev/null || true
+          if [ "$status" -eq 0 ]; then
+            echo "result=green" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=red" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Baseline exit status: ${status}"
+          exit 0
+
+      - name: Run Claude Code unskip-verify agent
+        id: agent
+        if: ${{ steps.plan.outputs.run == 'true' && (steps.baseline.outputs.result == 'red' || steps.plan.outputs.marker_count != '0') }}
+        working-directory: ${{ steps.ws.outputs.suite }}
+        env:
+          ANTHROPIC_API_KEY: ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          # Fallback ONLY, for a repo the camunda-scoped App token cannot reach.
+          GH_PAT: ${{ steps.secrets.outputs.GH_PAT }}
+          SUITE_DIR: ${{ steps.ws.outputs.suite }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          BRANCH: ${{ needs.prepare.outputs.branch }}
+          BASE_REF: ${{ needs.prepare.outputs.base_ref }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          CELL: ${{ matrix.cell }}
+          CATEGORY: ${{ matrix.category }}
+          DATABASE: ${{ matrix.database }}
+          TASKLIST_MODE: ${{ matrix.tasklist_mode }}
+          SPEC_PATHS: ${{ steps.plan.outputs.spec_paths }}
+          PROJECT_ARGS: ${{ steps.plan.outputs.project_args }}
+          BASELINE: ${{ steps.baseline.outputs.result }}
+          MARKER_COUNT: ${{ steps.plan.outputs.marker_count }}
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: ${{ matrix.tasklist_mode == 'v1' && 'false' || 'true' }}
+        run: |
+          set -euo pipefail
+
+          # The prompt stays terse on purpose: every diagnosis step, constraint,
+          # and the result-manifest schema live in the agent manual, so the team
+          # can change agent behaviour without editing CI.
+          prompt=$(cat <<EOF
+          You are the Camunda orchestration-cluster unskip-verify agent.
+          Workspace: ${SUITE_DIR} (already on the unskip PR branch ${BRANCH}).
+
+          STEP 0 — read /tmp/unskip-agent-manual.md, the "## Unskip Verify Agent"
+          section. That file is your full operating manual: the loop, the
+          constraints, and the /tmp/unskip-meta.json schema. It is main's copy of
+          the suite AGENTS.md — authoritative even when the branch you are on
+          carries an older AGENTS.md.
+
+          /tmp/cell-plan.json describes this environment cell: the spec files that
+          run here, the Playwright projects to pass, the un-skipped tests with the
+          closed bug each one references, and any manual-review markers to handle
+          in the second pass.
+
+          The environment is ALREADY RUNNING (database=${DATABASE},
+          tasklist=${TASKLIST_MODE}) and dependencies are installed. Never restart,
+          rebuild, or tear it down. Re-run tests with exactly:
+            npx playwright test ${PROJECT_ARGS} ${SPEC_PATHS}
+          The baseline run of those specs was: ${BASELINE}
+          (report: /tmp/baseline/results.json). Manual-review markers: ${MARKER_COUNT}.
+
+          Context (env vars already exported):
+            PR_NUMBER=${PR_NUMBER}  BRANCH=${BRANCH}  BASE_REF=${BASE_REF}
+            VERSION=${VERSION}  CELL=${CELL}  CATEGORY=${CATEGORY}  REPO=${REPO}
+
+          Commit onto THIS branch and push it — never open a new PR, never create
+          another branch. Commit titles use the 'test:' type (commitlint rejects
+          'fix:' for test-only changes).
+
+          When done, write /tmp/unskip-meta.json and stop.
+          EOF
+          )
+
+          claude -p "$prompt" --dangerously-skip-permissions || echo "::warning::agent exited non-zero"
+
+      - name: Stop verify environment
+        if: ${{ always() && steps.plan.outputs.run == 'true' }}
+        working-directory: ${{ steps.ws.outputs.suite }}
+        run: ./scripts/stop-verify-env.sh || true
+
+      - name: Collect cell result
+        if: always()
+        env:
+          CELL: ${{ matrix.cell }}
+          CATEGORY: ${{ matrix.category }}
+          DATABASE: ${{ matrix.database }}
+          TASKLIST_MODE: ${{ matrix.tasklist_mode }}
+          RUN: ${{ steps.plan.outputs.run }}
+          BASELINE: ${{ steps.baseline.outputs.result }}
+          AGENT_RAN: ${{ steps.agent.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/cell
+          meta='{}'
+          [ -f /tmp/unskip-meta.json ] && meta=$(cat /tmp/unskip-meta.json)
+          plan='{}'
+          [ -f /tmp/cell-plan.json ] && plan=$(cat /tmp/cell-plan.json)
+
+          # verdict precedence: what the agent reported, else what the run showed.
+          jq -n \
+            --arg cell "$CELL" --arg category "$CATEGORY" \
+            --arg database "$DATABASE" --arg tasklist_mode "$TASKLIST_MODE" \
+            --arg run "$RUN" --arg baseline "${BASELINE:-}" \
+            --arg agent "${AGENT_RAN:-skipped}" --arg run_url "$RUN_URL" \
+            --argjson meta "$meta" --argjson plan "$plan" \
+            '{
+              cell: $cell, category: $category, database: $database,
+              tasklist_mode: $tasklist_mode, run_url: $run_url,
+              applicable: ($run == "true"),
+              baseline: (if $baseline == "" then null else $baseline end),
+              agent_step: $agent,
+              verdict: ($meta.verdict //
+                        (if $run != "true" then "not-applicable"
+                         elif $baseline == "green" then "green"
+                         else "blocked" end)),
+              meta: $meta,
+              plan: {spec_paths: ($plan.spec_paths // []),
+                     unskipped_tests: ($plan.unskipped_tests // []),
+                     manual_markers: ($plan.manual_markers // []),
+                     unsupported: ($plan.unsupported // [])}
+            }' > "/tmp/cell/cell-result-${CELL}.json"
+          cat "/tmp/cell/cell-result-${CELL}.json"
+
+      - name: Upload cell artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unskip-cell-${{ matrix.cell }}
+          path: |
+            /tmp/cell/
+            /tmp/cell-plan.json
+            /tmp/unskip-meta.json
+            /tmp/baseline/results.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload Playwright report
+        if: ${{ always() && steps.plan.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: unskip-report-${{ matrix.cell }}
+          path: |
+            ${{ steps.ws.outputs.suite }}/html-report/
+            ${{ steps.ws.outputs.suite }}/test-results/
+          retention-days: 14
+          if-no-files-found: ignore
+
+  finalize:
+    name: Report verification outcome
+    needs: [prepare, verify]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Download cell results
+        continue-on-error: true
+        uses: actions/download-artifact@v6
+        with:
+          pattern: unskip-cell-*
+          path: /tmp/cells
+
+      - name: Aggregate
+        id: agg
+        run: |
+          set -euo pipefail
+          # cell-result-<cell>.json is uniquely named so its depth inside the
+          # artifact (which varies with what else got uploaded) never matters.
+          find /tmp/cells -name 'cell-result-*.json' -print0 2>/dev/null \
+            | xargs -0 -r jq -s '.' > /tmp/cells.json || true
+          [ -s /tmp/cells.json ] || echo '[]' > /tmp/cells.json
+          jq -c '.' /tmp/cells.json
+
+          total=$(jq '[.[] | select(.applicable)] | length' /tmp/cells.json)
+          bad=$(jq '[.[] | select(.applicable and (.verdict | IN("green","fixed") | not))] | length' /tmp/cells.json)
+          changed=$(jq '[.[] | select(.meta.pushed == true)] | length' /tmp/cells.json)
+          # A spec that could not run anywhere (e.g. it needs a project this
+          # environment cannot provide) must not read as "verified".
+          unsupported=$(jq '[.[] | .plan.unsupported[]?] | unique_by(.file) | length' /tmp/cells.json)
+          if [ "$total" -eq 0 ] && [ "$unsupported" -eq 0 ]; then
+            status=not-applicable
+          elif [ "$bad" -eq 0 ] && [ "$unsupported" -eq 0 ]; then
+            status=verified
+          else
+            status=unverified
+          fi
+          {
+            echo "status=${status}"
+            echo "total=${total}"
+            echo "bad=${bad}"
+            echo "changed=${changed}"
+            echo "unsupported=${unsupported}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Render verification section
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS: ${{ steps.agg.outputs.status }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Unskip verification"
+            echo ""
+            case "$STATUS" in
+              verified)       echo "✅ Every un-skipped test passes against a live environment." ;;
+              unverified)     echo "⚠️ Not fully verified — see the table below." ;;
+              not-applicable) echo "ℹ️ No spec in this PR runs in any verified environment dimension." ;;
+            esac
+            echo ""
+            echo "| Environment | Baseline | Outcome | Notes |"
+            echo "|---|---|---|---|"
+            jq -r '.[] |
+              [ "`\(.cell)` (db=\(.database), tasklist=\(.tasklist_mode))",
+                (.baseline // "—"),
+                (if .verdict == "green" then "✅ green (no change needed)"
+                 elif .verdict == "fixed" then "✅ fixed"
+                 elif .verdict == "partial" then "⚠️ partially fixed"
+                 elif .verdict == "not-applicable" then "— not run here"
+                 else "❌ \(.verdict)" end),
+                ((.meta.root_cause // .meta.note // "") | gsub("\n"; " "))
+              ] | "| " + join(" | ") + " |"' /tmp/cells.json
+            echo ""
+            jq -r '.[] | .meta.tests[]? |
+              "- `\(.file)` › \(.test_name) — **\(.outcome)**" +
+              (if .note then " — \(.note)" else "" end)' /tmp/cells.json
+            jq -r '.[] | .meta.manual_markers[]? |
+              "- manual marker `\(.path)`:\(.line) — **\(.outcome)**" +
+              (if .note then " — \(.note)" else "" end)' /tmp/cells.json
+            jq -r '[.[] | .plan.unsupported[]?] | unique_by(.file)[] |
+              "- ⚠️ `\(.file)` was NOT verified — it only runs under \(.projects | join(", ")), " +
+              "which this environment does not provide."' /tmp/cells.json
+            echo ""
+            echo "<sub>[Verification run ↗](${RUN_URL})</sub>"
+          } > /tmp/verify-section.md
+          cat /tmp/verify-section.md
+
+      - name: Patch PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [ -n "$PR_NUMBER" ] || exit 0
+          gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' > /tmp/pr-body.md
+          # Idempotent: drop any previous section before appending this run's.
+          sed -i '/^## Unskip verification/,$d' /tmp/pr-body.md
+          sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' /tmp/pr-body.md
+          printf '\n\n' >> /tmp/pr-body.md
+          cat /tmp/verify-section.md >> /tmp/pr-body.md
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --body-file /tmp/pr-body.md
+
+      - name: Label PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          STATUS: ${{ steps.agg.outputs.status }}
+        run: |
+          set -euo pipefail
+          [ -n "$PR_NUMBER" ] || exit 0
+          gh label create "verified" --repo "$REPO" --color "0E8A16" \
+            --description "Verified green in a live environment" 2>/dev/null || true
+          gh label create "unverified" --repo "$REPO" --color "FBCA04" \
+            --description "Could not be verified green in a live environment" 2>/dev/null || true
+          case "$STATUS" in
+            verified)
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "verified" --remove-label "unverified" || true
+              ;;
+            unverified)
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "unverified" --remove-label "verified" || true
+              ;;
+            *)
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "verified" --remove-label "unverified" || true
+              ;;
+          esac
+
+      # Full-matrix regression net, dispatched on the FINAL branch state so it
+      # covers the agent's commits (and the dimensions this run did not verify:
+      # camunda_mode, cross-browser projects).
+      - name: Trigger on-demand run
+        if: ${{ github.event.inputs.trigger_on_demand != 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ needs.prepare.outputs.branch }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [ -n "$BRANCH" ] || exit 0
+          output=$(gh workflow run c8-orchestration-cluster-e2e-tests-on-demand.yml \
+            --repo "$REPO" -f branch="$BRANCH" 2>&1) || {
+              echo "::warning::on-demand dispatch failed: ${output}"
+              exit 0
+            }
+          echo "$output"
+          url=$(echo "$output" | grep -o 'https://github\.com/[^[:space:]]*/runs/[0-9]*' | head -1 || true)
+          if [ -n "$url" ] && [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "🔬 Full-matrix on-demand run on the verified branch: ${url}"
+          fi
+
+      - name: Write job summary
+        if: always()
+        env:
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          BASE_REF: ${{ needs.prepare.outputs.base_ref }}
+          REPO: ${{ github.repository }}
+          STATUS: ${{ steps.agg.outputs.status }}
+          CHANGED: ${{ steps.agg.outputs.changed }}
+        run: |
+          {
+            echo "## Unskip Verify — PR #${PR_NUMBER} (\`${BASE_REF}\`)"
+            echo ""
+            echo "**Outcome:** \`${STATUS}\` · **cells that pushed a fix:** ${CHANGED}"
+            echo ""
+            echo "[PR ↗](https://github.com/${REPO}/pull/${PR_NUMBER})"
+            echo ""
+            cat /tmp/verify-section.md 2>/dev/null || true
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Import Slack token
+        id: slack-secrets
+        if: ${{ always() && github.event.inputs.send_slack_notification == 'true' }}
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+
+      - name: Slack thread reply
+        if: ${{ always() && github.event.inputs.send_slack_notification == 'true' }}
+        env:
+          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
+          SLACK_THREAD_TS: ${{ github.event.inputs.slack_thread_ts }}
+          SLACK_CHANNEL: ${{ github.event.inputs.slack_channel }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          BASE_REF: ${{ needs.prepare.outputs.base_ref }}
+          REPO: ${{ github.repository }}
+          STATUS: ${{ steps.agg.outputs.status }}
+          CHANGED: ${{ steps.agg.outputs.changed }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "$STATUS" in
+            verified)   icon=":white_check_mark:"; summary="all un-skipped tests green" ;;
+            unverified) icon=":warning:";          summary="still failing — needs a look" ;;
+            *)          icon=":grey_question:";    summary="nothing to verify" ;;
+          esac
+          [ "${CHANGED:-0}" != "0" ] && summary="${summary} (agent pushed fixes)"
+          text="${icon} Unskip verify — <https://github.com/${REPO}/pull/${PR_NUMBER}|PR #${PR_NUMBER}> (\`${BASE_REF}\`): ${summary}"$'\n'"<${RUN_URL}|Verification run ↗>"
+          payload=$(jq -nc \
+            --arg channel "$SLACK_CHANNEL" \
+            --arg thread_ts "$SLACK_THREAD_TS" \
+            --arg text "$text" \
+            '{channel: $channel, thread_ts: $thread_ts, text: $text, mrkdwn: true}')
+          curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_USER_OAUTH_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$payload" | jq '.' || true

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -858,6 +858,220 @@ filed/reused issue (a dispatch may yield several bugs):
 fingerprint marker to suppress re-dispatch while the issue is open; once the skip PR merges the test
 no longer runs, and when the issue is later closed the skip should be removed so the test runs again.
 
+## Unskip Verify Agent
+
+This section is read automatically by the Claude Code agent dispatched from
+`c8-orchestration-cluster-unskip-verify.yml`. It is a *different* job from the Nightly
+Fix Agent above: nothing is failing in CI yet. A weekly workflow in
+`camunda/qa-metrics-exporter` opens one PR per branch + category that flips
+`test.skip(` back to `test(` for every test whose referenced bug is now **closed**,
+and your job is to answer the question that PR cannot answer on its own — *do those
+tests actually pass now?* — and to make them pass when they don't.
+
+A test that has been skipped for weeks or months is usually stale in some small way
+(a renamed selector, a changed default, a flow that gained a confirmation step) even
+when the product bug really is fixed. Repairing that staleness is the main value here.
+
+### Context you receive
+
+The calling workflow prepares everything before you start:
+
+* **The environment is already running** — `scripts/start-verify-env.sh` has been run
+  for this cell (`DATABASE`, `TASKLIST_MODE`), `npm ci` is done, Chromium is
+  installed, and `.env` is written. **Never restart, rebuild, or tear it down**, and
+  never start a second one. You are changing test code, not product code.
+* **`/tmp/cell-plan.json`** — this cell's plan:
+  * `spec_paths` — the spec files that actually execute in this dimension.
+  * `projects` — the Playwright projects to pass.
+  * `unskipped_tests` — `{file, test_name, bug}` for each test this PR un-skipped
+    (`bug` is the closed issue the skip marker pointed at).
+  * `manual_markers` — `{path, line, bug, reason}` for skips the unskip workflow
+    deliberately left in place (see the second pass below).
+* **`/tmp/baseline/results.json`** — the Playwright JSON report of the reproduce run,
+  and `BASELINE` (`green` / `red`) tells you its outcome at a glance.
+* Env vars: `PR_NUMBER`, `BRANCH`, `BASE_REF`, `VERSION`, `CELL`, `CATEGORY`,
+  `DATABASE`, `TASKLIST_MODE`, `SPEC_PATHS`, `PROJECT_ARGS`, `REPO`.
+
+Re-run the scoped specs with exactly:
+
+```bash
+npx playwright test $PROJECT_ARGS $SPEC_PATHS
+```
+
+Never run the full suite, and never widen the scope beyond `spec_paths`.
+
+### The loop
+
+**Pass 1 — the un-skipped tests.**
+
+1. If `BASELINE=green`, every un-skipped test in this cell already passes. Do not
+   touch the code. Go straight to Pass 2.
+2. Otherwise, read the failures out of `/tmp/baseline/results.json` (error message,
+   `snippet`, and the trace/screenshot under `test-results/`) and diagnose each one
+   the same way the Nightly Fix Agent does — the "### Diagnosis steps" guidance above
+   applies verbatim, minus the artifact download (you have a live environment
+   instead, which is strictly better evidence).
+3. Classify every failure before editing:
+   * **Test-side staleness** — selector moved, an added dialog, a changed label, a
+     wait that is now too short, an assertion that contradicts current *documented*
+     behaviour. This is the expected case. Fix it.
+   * **Product-side** — the closed bug is not actually fixed, or a new regression
+     broke the flow. See "When the product is still broken" below. **Do not fix it
+     test-side and do not re-skip it.**
+4. Apply the fix and re-run the scoped specs against the same environment. Green →
+   done. Still red → refine and retry. **Maximum 3 iterations** — a hard cost cap,
+   not a suggestion.
+5. **A shared root cause applies to every sibling flow in this PR.** These tests were
+   skipped around the same time, often by the same change; when one fix explains more
+   than one failure, apply it to all of them in this PR rather than fixing one and
+   letting the next cell rediscover it.
+
+**Pass 2 — the manual-review markers.**
+
+`cell_plan.manual_markers` lists skips the unskip workflow refused to touch
+automatically: a skip inside a conditional/ternary, or a marker sitting above
+commented-out code that could not be re-enabled without unbalancing brackets. Their
+bugs are closed too, so they are in scope for you — this pass is the whole reason a
+human-quality agent is doing this job.
+
+For each marker, in the file at `path` around `line`:
+
+1. Re-enable the test the way the code actually shapes it — pick the live branch of a
+   ternary and drop the dead one, or uncomment the block and drop the marker comment.
+   Keep prose/`!Note:` comments; they are documentation, not code.
+2. Run the scoped specs. Fix what is stale, exactly as in Pass 1 (the 3-iteration cap
+   covers both passes together — do not spend the whole budget here).
+3. If re-enabling it cannot be done safely — the commented-out code no longer
+   compiles against the current page objects, the ternary guards a genuinely
+   version-specific path, or the flow it tests no longer exists — **leave the marker
+   exactly as it was** and record it as `left-as-is` with a one-line reason. A marker
+   you cannot resolve is a fine outcome; a marker you resolve badly is not.
+
+### When the product is still broken
+
+If a test is red because the product genuinely misbehaves — the closed bug was not
+actually fixed, or something regressed since — then:
+
+1. Confirm it against the three gates in "## Product-Bug Escalation" above (not
+   flaky, pinned to a product change, the test itself is still correct).
+2. **Leave the test un-skipped and failing.** Do NOT re-add `test.skip(`, do NOT mask
+   it with a longer timeout, a viewport pin, or a weakened assertion. The PR is
+   *supposed* to go red here: that is the signal a human needs.
+3. Reopen the closed issue the marker referenced (`gh issue reopen`) — or file a new
+   one per "### Filing the bug ticket (dedupe FIRST)" when the original is not the
+   right home — and comment on it linking this verification run.
+4. Comment on the unskip PR (`gh pr comment $PR_NUMBER --repo $REPO`) with the test,
+   the evidence, and the reopened issue link.
+5. Record the test as `product-bug` in the result manifest with the issue URL. The
+   calling workflow labels the PR `unverified` and a human decides whether to drop
+   that test from the PR or keep waiting on the fix.
+
+Use the default `GH_TOKEN` (qa-processes) for every `gh` call first; only if one
+fails retry that same command once with `GH_TOKEN="$GH_PAT"`.
+
+### Committing
+
+You are working **on the unskip PR's own branch**, already checked out.
+
+1. Lint every file you touched, from the suite directory:
+
+   ```bash
+   npx prettier --write <changed-files>
+   npx eslint <changed-files> --fix
+   ```
+
+   Fix any remaining eslint errors before committing.
+
+2. Commit with the `test:` type (commitlint rejects `fix:` for test-only changes):
+   `git commit -m "test: <what was stale and how it was fixed> (unskip ${VERSION})"`.
+
+3. Push onto the same branch:
+
+   ```bash
+   git push origin HEAD:"$BRANCH"
+   ```
+
+   Environment cells run one at a time, each from the branch's current tip, so this
+   is normally a fast-forward. Only if the push is *rejected* — another cell landed
+   a commit meanwhile — rebase onto the new tip and push again; never force-push:
+
+   ```bash
+   git fetch origin "$BRANCH" && git rebase FETCH_HEAD && git push origin HEAD:"$BRANCH"
+   ```
+4. **Never open a new PR and never create another branch.** Every change belongs to
+   the PR being verified.
+
+### Constraints
+
+- **Allowed:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`,
+  `npx prettier`, `npx eslint`, and `npx playwright test` **scoped to `$SPEC_PATHS`**.
+- **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`/`docker compose`, `kubectl`,
+  `helm`, `npm install`, `npm ci`, `npm run build`, the `start-verify-env.sh` /
+  `stop-verify-env.sh` scripts, and any unscoped `npx playwright test`. The
+  environment is provisioned for you and torn down for you.
+- **Re-skipping is forbidden.** This agent exists to *remove* skips. `test.skip()` /
+  `test.fixme()` / `test.only` must not appear in any diff you produce — not for a
+  product bug (leave it red and escalate), not for flakiness (fix the wait), not for
+  a test you find hard to repair (report it and leave it red).
+- **Never weaken a check to go green:** no viewport pinning for a responsive-layout
+  failure (see the Nightly Fix Agent constraint above — it applies here in full), no
+  deleted assertions, no `continue-on-error`, no timeout lowered to skip a slow step.
+  Fix the wait, or fix a provably-wrong assertion after confirming intended behaviour
+  in `camunda-docs` for this exact version.
+- **Never edit `json-body-assertions/_generated/responses.json` by hand** —
+  regenerate it with `npm run responses:regenerate`.
+- **Minimal diff:** only the files carrying un-skipped tests or the page objects and
+  helpers they depend on. No refactoring, no dependency bumps, no formatting sweeps.
+
+### Result manifest
+
+Always write `/tmp/unskip-meta.json` before stopping, even when you changed nothing:
+
+```json
+{
+  "verdict": "green",
+  "iterations": 0,
+  "pushed": false,
+  "root_cause": "One sentence, or empty when nothing was wrong.",
+  "fix": "One sentence describing what changed, or empty.",
+  "tests": [
+    {
+      "file": "tests/operate/dashboard.spec.ts",
+      "test_name": "Navigate to processes view (same truncated error message)",
+      "outcome": "green",
+      "bug": "https://github.com/camunda/camunda/issues/45129",
+      "note": ""
+    }
+  ],
+  "manual_markers": [
+    {"path": "tests/operate/operations.spec.ts", "line": 66, "outcome": "unskipped-fixed", "note": ""}
+  ],
+  "product_bugs": []
+}
+```
+
+`verdict` — the cell as a whole:
+
+| `verdict` |                          Meaning                           |
+|-----------|------------------------------------------------------------|
+| `green`   | Everything passed untouched; nothing was committed.        |
+| `fixed`   | Everything passes after your changes, which are pushed.    |
+| `partial` | Some tests/markers are green, at least one is still red.   |
+| `blocked` | Nothing could be made green (product bug, or no safe fix). |
+
+`tests[].outcome` — one per entry in `cell_plan.unskipped_tests`: `green` (passed
+untouched), `fixed` (passed after your change), `still-red` (no safe fix found), or
+`product-bug` (escalated — set `note` to the reopened/filed issue URL).
+
+`manual_markers[].outcome` — one per entry in `cell_plan.manual_markers`:
+`unskipped-green`, `unskipped-fixed`, `left-as-is`, or `product-bug`.
+
+`pushed` must be `true` if and only if you pushed at least one commit — the workflow
+reports it, and a `fixed` verdict with `pushed: false` is a contradiction that will be
+read as a bug in your run. `product_bugs` uses the same object shape as the Nightly
+Fix Agent's manifest (`repo`, `component`, `issue_url`, `root_cause`,
+`suspect_commit`), but there is **no skip PR** — the failing test stays un-skipped.
+
 ## Workflow-Level Failure Fix Agent
 
 This section is read by the fix agent when `/tmp/test_specs.json` contains an empty array — the nightly run failed without producing test results, or failed in a non-test step.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-unskip.guidance.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-unskip.guidance.md
@@ -1,0 +1,63 @@
+# C8 Orchestration Cluster Unskip Verify — Workspace Guidance
+
+## Role
+
+You are a Camunda QA engineer verifying an **auto-unskip PR**. Tests that were skipped
+because of a bug have been un-skipped now that the bug is closed, and you check whether
+they actually pass against a live environment — repairing whatever went stale while they
+were dormant. Nothing is failing in CI yet; you are the first thing that runs these tests
+in months. You operate exclusively within `camunda/camunda` at
+`qa/c8-orchestration-cluster-e2e-test-suite/`.
+
+## Repository
+
+- **`{{.WorkspacePath}}/camunda/`** — The Camunda 8 monorepo, already checked out on the
+  unskip PR's own branch (`auto/unskip-closed-bugs-...`). The test suite lives at
+  `qa/c8-orchestration-cluster-e2e-test-suite/`. Tests are Playwright + TypeScript. API
+  tests live under `tests/api/`, E2E UI tests under `tests/operate/`, `tests/tasklist/`,
+  `tests/identity/`. Page objects are in `pages/`. The suite is version-segregated by
+  branch — always work in the branch already checked out here.
+
+## Operating manual
+
+Read `/tmp/unskip-agent-manual.md` and follow the **"## Unskip Verify Agent"** section
+exactly. It is main's copy of the suite AGENTS.md and **outranks** the `AGENTS.md` on the
+branch you are checked out on (stable branches carry an older copy without this section).
+It contains:
+- The two passes (un-skipped tests, then the manual-review markers)
+- What to do when the product — not the test — is still broken
+- Commit and push rules (this PR's branch only, never a new PR)
+- Result manifest schema (`/tmp/unskip-meta.json`)
+
+## Key inputs
+
+```
+/tmp/cell-plan.json          # this cell's specs, projects, tests, markers
+/tmp/baseline/results.json   # the reproduce run's Playwright JSON report
+/tmp/unskip-agent-manual.md  # YOUR OPERATING MANUAL — read this first
+```
+
+## Key paths
+
+```
+{{.WorkspacePath}}/camunda/
+  qa/c8-orchestration-cluster-e2e-test-suite/
+    tests/          # Playwright specs
+    pages/          # Page Object Model classes
+    utils/          # Helpers (waitForAssertion, zeebeClient, etc.)
+    fixtures.ts     # Playwright fixture definitions
+```
+
+## Constraints
+
+- The environment is ALREADY RUNNING and is torn down for you — never start, restart, or
+  stop it, and never run `npm ci` / `npx playwright install`
+- Run tests ONLY as `npx playwright test $PROJECT_ARGS $SPEC_PATHS` — never the full suite
+- NEVER re-add `test.skip()`, `test.fixme()`, or `test.only` — this agent removes skips.
+  A genuine product bug stays un-skipped and red, with the issue reopened
+- Max 3 fix-and-re-run iterations across both passes
+- Commit type must be `test:` — commitlint rejects `fix:` for test-only changes
+- Run `npx prettier --write <files>` + `npx eslint <files> --fix` before committing
+- Commit and push onto the PR's existing branch; never open a second PR
+- Always write `/tmp/unskip-meta.json` before stopping, even when nothing changed
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-unskip.yaml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-unskip.yaml
@@ -1,0 +1,22 @@
+name: camunda-orchestration-cluster-unskip
+description: "Unskip-verify workspace for C8 orchestration cluster E2E and API tests"
+purpose: |
+  You are a Camunda QA engineer verifying an auto-unskip PR in
+  qa/c8-orchestration-cluster-e2e-test-suite/ inside camunda/camunda. Tests whose
+  bug is now closed have been un-skipped; you run them against a live environment
+  and repair whatever went stale while they were dormant.
+  Read /tmp/unskip-agent-manual.md — the "## Unskip Verify Agent" section — for the
+  loop and constraints before doing anything else. That file is main's copy of the
+  suite AGENTS.md and outranks the AGENTS.md on the branch you are checked out on.
+
+repos:
+  - url: https://github.com/camunda/camunda.git
+    path: camunda
+    default_branch: main
+
+# Derive workspace AGENTS.md from the repo's own AGENTS.md at create time.
+# Refresh with:
+#   workspace templates derive-guidance camunda-orchestration-cluster-unskip --ai claude --force
+derive:
+  agents_from: AGENTS.md
+  ai_guidance: camunda-orchestration-cluster-unskip.guidance.md


### PR DESCRIPTION
## Description

The weekly auto-unskip PRs (from `camunda/qa-metrics-exporter`) only know that a
test's referenced bug is **closed** — they cannot say whether the test actually
passes. And a test that has been skipped for weeks or months is usually stale in
some small way (renamed selector, added confirmation dialog, changed default)
even when the product bug really is fixed. So those PRs sit unverified, and the
full-matrix on-demand run we dispatch today reports red without fixing anything.

This adds a verification agent that answers the question and repairs the staleness.

### Flow

For each unskip PR, per environment dimension the target version actually runs:

```
resolve PR → derive scope from its diff + body → plan the cell (playwright --list)
  → start-verify-env.sh → baseline run of the un-skipped specs
  → green?  done — no agent, no cost, no code change
  → red?    Claude Code diagnoses, fixes, re-runs (≤3 iterations), pushes onto
            the SAME PR branch
  → PR body result table + verified/unverified label + full-matrix on-demand run
    dispatched on the final (fixed) branch + Slack thread reply
```

### What's here

| File | |
|---|---|
| `.github/workflows/c8-orchestration-cluster-unskip-verify.yml` | `prepare` → `verify` (matrix) → `finalize` |
| `.github/scripts/unskip-scope.py` (+ tests) | PR diff/body → un-skipped tests, their closed bugs, the "Needs manual review" markers, and the matrix |
| `.github/scripts/unskip-plan-cell.py` (+ tests) | per-cell spec paths + Playwright projects; prunes cells that run nothing |
| `qa/…/AGENTS.md` → `## Unskip Verify Agent` | the agent's operating manual |
| `qa/…/workspace-templates/camunda-orchestration-cluster-unskip.*` | workspace-cli manifest + guidance |

It reuses `scripts/start-verify-env.sh` from #59965 unchanged.

### Design notes

**The matrix covers every dimension the version runs**, mirroring
`c8-orchestration-cluster-e2e-tests-on-demand.yml`: E2E `v1`+`v2` on 8.8/8.9,
`v2` on main, `v1` on 8.7; API ES+H2 on 8.9/main, ES elsewhere. Cells are
serialized (`max-parallel: 1`) because they all push to the same PR branch, and
each one asks `playwright --list` whether its specs execute in that dimension
**before** standing up an environment — so `tests/tasklist/v1/**` costs nothing
in the v2 cell. Project selection is read back from that listing rather than
hardcoded, since `playwright.config.ts` differs per branch. A spec that only
runs under a project this environment cannot provide (e.g. `optimize-startup`)
is reported explicitly, never silently counted as verified.

**A genuine product regression stays un-skipped and red.** The agent reopens the
closed issue and comments on the PR with the evidence; it must not re-add
`test.skip()`, pin a viewport, or weaken an assertion to go green. Removing
skips is the whole point of this job, so re-skipping is forbidden outright —
the red PR is the signal a human needs.

**Second pass for the markers the unskip workflow won't touch.** Ternary/
conditional skips and commented-out blocks are listed in the PR body under
"Needs manual review" and today nobody gets to them. The agent un-skips those
too, verifies them the same way, and leaves anything it cannot resolve safely
byte-identical with a stated reason.

**Stable branches need main's agent assets.** `stable/8.6`–`8.9` carry neither
the `AGENTS.md` agent sections nor a `scripts/` directory — both live only on
`main`. The workflow stages main's copies into the PR-branch checkout and adds
them to `.git/info/exclude` so they can never land in a commit;
`start-verify-env.sh` still self-detects the compose shape from the checked-out
branch, so it stays correct on 8.7's pre-consolidation split. Worth flagging on
its own: this is also why #59965's Live Docker Verify loop cannot currently run
on a stable-branch dispatch, and that step is liftable into
`c8-orchestration-cluster-e2e-nightly-fix.yml` to close the same gap.

## Test plan

- [x] 43 unit tests for both scripts (`pytest .github/scripts/test_unskip_*.py`).
- [x] `unskip-scope.py` against the three live unskip PRs — #60156 → 4 specs / 2
      cells (`e2e-es-v1`, `e2e-es-v2`), #60155 → 15 specs / `api-es`+`api-h2`,
      #60157 → 2 specs / `api-es`.
- [x] `unskip-plan-cell.py` against the real suite: correct `chromium` +
      `chromium-subset` selection (so `task-panel.spec.ts`, which lives only in
      the teardown project, is not missed) and `api-tests` for API specs.
- [x] `actionlint` + `shellcheck` clean; `./mvnw spotless:apply -N` clean.
- [ ] **No end-to-end run yet** — no agent invocation, no `start-verify-env.sh`
      on a runner, and the H2 cell (which builds the distribution from source,
      ~20 min) is unexercised. Cheapest smoke test is a manual
      `workflow_dispatch` with `pr_number=60157` (8.8 API, 2 specs, one ES cell).

Paired with camunda/qa-metrics-exporter#165, which dispatches this per PR.

## Related issues

n/a — follow-up to #59965.

