### PR TITLE
Accept CONFIGURATION-role fields on agent-instance history items

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
@@ -184,6 +184,46 @@ public interface UpdateAgentInstanceCommandStep1 {
     }
   }
 
+  /**
+   * A snapshot of the agent instance's operational limits, as recorded on a CONFIGURATION history
+   * item.
+   */
+  interface AgentInstanceLimits {
+    long getMaxTokens();
+
+    int getMaxModelCalls();
+
+    int getMaxToolCalls();
+
+    /**
+     * Creates a limits snapshot with the given values.
+     *
+     * @param maxTokens the token limit. Use -1 for no limit.
+     * @param maxModelCalls the model-call limit. Use -1 for no limit.
+     * @param maxToolCalls the tool-call limit. Use -1 for no limit.
+     * @return a new {@link AgentInstanceLimits}
+     */
+    static AgentInstanceLimits of(
+        final long maxTokens, final int maxModelCalls, final int maxToolCalls) {
+      return new AgentInstanceLimits() {
+        @Override
+        public long getMaxTokens() {
+          return maxTokens;
+        }
+
+        @Override
+        public int getMaxModelCalls() {
+          return maxModelCalls;
+        }
+
+        @Override
+        public int getMaxToolCalls() {
+          return maxToolCalls;
+        }
+      };
+    }
+  }
+
   /** A single conversation history item to append as part of an update batch. */
   final class HistoryItem {
     private String historyItemId;
@@ -193,6 +233,11 @@ public interface UpdateAgentInstanceCommandStep1 {
     private OffsetDateTime producedAt;
     private List<AgentInstanceHistoryToolCall> toolCalls;
     private AgentInstanceHistoryMetrics metrics;
+    private List<AgentTool> tools;
+    private String model;
+    private String provider;
+    private AgentInstanceLimits limits;
+    private List<AgentInstanceHistoryContent> systemPrompt;
 
     /**
      * Sets the caller-assigned identifier used to detect and dedupe retries of the same item.
@@ -275,6 +320,61 @@ public interface UpdateAgentInstanceCommandStep1 {
       return this;
     }
 
+    /**
+     * Sets the tools available to the agent as of this entry. CONFIGURATION items only.
+     *
+     * @param tools the tools. May be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem tools(final List<AgentTool> tools) {
+      this.tools = tools;
+      return this;
+    }
+
+    /**
+     * Sets the LLM model identifier as of this entry. CONFIGURATION items only.
+     *
+     * @param model the model identifier. May be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem model(final String model) {
+      this.model = model;
+      return this;
+    }
+
+    /**
+     * Sets the LLM provider as of this entry. CONFIGURATION items only.
+     *
+     * @param provider the provider identifier. May be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem provider(final String provider) {
+      this.provider = provider;
+      return this;
+    }
+
+    /**
+     * Sets the operational limits as of this entry. CONFIGURATION items only.
+     *
+     * @param limits the limits. May be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem limits(final AgentInstanceLimits limits) {
+      this.limits = limits;
+      return this;
+    }
+
+    /**
+     * Sets the system prompt, as content blocks, as of this entry. CONFIGURATION items only.
+     *
+     * @param systemPrompt the system prompt content blocks. May be null.
+     * @return this builder for method chaining
+     */
+    public HistoryItem systemPrompt(final List<AgentInstanceHistoryContent> systemPrompt) {
+      this.systemPrompt = systemPrompt;
+      return this;
+    }
+
     public String getHistoryItemId() {
       return historyItemId;
     }
@@ -301,6 +401,26 @@ public interface UpdateAgentInstanceCommandStep1 {
 
     public AgentInstanceHistoryMetrics getMetrics() {
       return metrics;
+    }
+
+    public List<AgentTool> getTools() {
+      return tools;
+    }
+
+    public String getModel() {
+      return model;
+    }
+
+    public String getProvider() {
+      return provider;
+    }
+
+    public AgentInstanceLimits getLimits() {
+      return limits;
+    }
+
+    public List<AgentInstanceHistoryContent> getSystemPrompt() {
+      return systemPrompt;
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
 import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentInstanceLimits;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
 import io.camunda.client.api.response.DocumentMetadata;
 import io.camunda.client.api.response.DocumentReferenceResponse;
@@ -190,5 +191,25 @@ final class AgentInstanceHistoryMapper {
       protocolTools.add(protocolTool);
     }
     return protocolTools;
+  }
+
+  static io.camunda.client.protocol.rest.AgentInstanceLimits toProtocolLimits(
+      final AgentInstanceLimits limits) {
+    if (limits == null) {
+      return null;
+    }
+    if (limits.getMaxTokens() < -1) {
+      throw new IllegalArgumentException("maxTokens must be >= -1");
+    }
+    if (limits.getMaxModelCalls() < -1) {
+      throw new IllegalArgumentException("maxModelCalls must be >= -1");
+    }
+    if (limits.getMaxToolCalls() < -1) {
+      throw new IllegalArgumentException("maxToolCalls must be >= -1");
+    }
+    return new io.camunda.client.protocol.rest.AgentInstanceLimits()
+        .maxTokens(limits.getMaxTokens())
+        .maxModelCalls(limits.getMaxModelCalls())
+        .maxToolCalls(limits.getMaxToolCalls());
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
 import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
 import io.camunda.client.api.response.DocumentMetadata;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
@@ -167,5 +168,27 @@ final class AgentInstanceHistoryMapper {
         .inputTokens(metrics.getInputTokens())
         .outputTokens(metrics.getOutputTokens())
         .durationMs(metrics.getDurationMs());
+  }
+
+  static List<io.camunda.client.protocol.rest.AgentTool> toProtocolTools(
+      final List<AgentTool> tools) {
+    if (tools == null) {
+      return null;
+    }
+    final List<io.camunda.client.protocol.rest.AgentTool> protocolTools =
+        new ArrayList<>(tools.size());
+    for (final AgentTool tool : tools) {
+      final io.camunda.client.protocol.rest.AgentTool protocolTool =
+          new io.camunda.client.protocol.rest.AgentTool();
+      protocolTool.name(tool.getName());
+      if (tool.getDescription() != null) {
+        protocolTool.description(tool.getDescription());
+      }
+      if (tool.getElementId() != null) {
+        protocolTool.elementId(tool.getElementId());
+      }
+      protocolTools.add(protocolTool);
+    }
+    return protocolTools;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
@@ -179,6 +179,9 @@ final class AgentInstanceHistoryMapper {
     final List<io.camunda.client.protocol.rest.AgentTool> protocolTools =
         new ArrayList<>(tools.size());
     for (final AgentTool tool : tools) {
+      if (tool == null) {
+        throw new IllegalArgumentException("tools must not contain null elements");
+      }
       final io.camunda.client.protocol.rest.AgentTool protocolTool =
           new io.camunda.client.protocol.rest.AgentTool();
       protocolTool.name(tool.getName());

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
@@ -158,7 +158,15 @@ public class UpdateAgentInstanceCommandImpl
         .content(AgentInstanceHistoryMapper.toProtocolContent(item.getContent()))
         .toolCalls(AgentInstanceHistoryMapper.toProtocolToolCalls(item.getToolCalls()))
         .metrics(AgentInstanceHistoryMapper.toProtocolMetrics(item.getMetrics()))
-        .producedAt(item.getProducedAt().toString());
+        .producedAt(item.getProducedAt().toString())
+        .tools(AgentInstanceHistoryMapper.toProtocolTools(item.getTools()))
+        .model(item.getModel())
+        .provider(item.getProvider())
+        .limits(AgentInstanceHistoryMapper.toProtocolLimits(item.getLimits()))
+        .systemPrompt(
+            item.getSystemPrompt() != null
+                ? AgentInstanceHistoryMapper.toProtocolContent(item.getSystemPrompt())
+                : null);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
@@ -140,9 +140,6 @@ public class UpdateAgentInstanceCommandImpl
     ArgumentUtil.ensureGreaterThan("loopIteration", item.getLoopIteration(), 0);
     ArgumentUtil.ensureNotNull("role", item.getRole());
     ArgumentUtil.ensureNotNull("content", item.getContent());
-    if (item.getContent().isEmpty()) {
-      throw new IllegalArgumentException("content must not be empty");
-    }
     ArgumentUtil.ensureNotNull("producedAt", item.getProducedAt());
 
     final AgentInstanceHistoryRoleEnum protoRole =

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
@@ -37,7 +37,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UpdateAgentInstanceCommandImpl
@@ -98,23 +97,7 @@ public class UpdateAgentInstanceCommandImpl
 
   @Override
   public UpdateAgentInstanceCommandStep2 tools(final List<AgentTool> tools) {
-    final List<io.camunda.client.protocol.rest.AgentTool> protocolTools =
-        tools.stream()
-            .map(
-                apiTool -> {
-                  final io.camunda.client.protocol.rest.AgentTool protocolTool =
-                      new io.camunda.client.protocol.rest.AgentTool();
-                  protocolTool.name(apiTool.getName());
-                  if (apiTool.getDescription() != null) {
-                    protocolTool.description(apiTool.getDescription());
-                  }
-                  if (apiTool.getElementId() != null) {
-                    protocolTool.elementId(apiTool.getElementId());
-                  }
-                  return protocolTool;
-                })
-            .collect(Collectors.toList());
-    request.tools(protocolTools);
+    request.tools(AgentInstanceHistoryMapper.toProtocolTools(tools));
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -904,19 +904,23 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
     }
 
     @Test
-    void shouldRejectEmptyContentListInHistoryItem() {
-      assertThatThrownBy(
-              () ->
-                  client
-                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                      .jobKey(JOB_KEY)
-                      .history(
-                          Collections.singletonList(
-                              historyItem("item-1").content(Collections.emptyList())))
-                      .execute())
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("content must not be empty");
+    void shouldAllowEmptyContentListInHistoryItem() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item = historyItem("item-1").content(Collections.emptyList());
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getHistory().get(0).getContent()).isEmpty();
     }
 
     @Test

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentInstanceLimits;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.HistoryItem;
 import io.camunda.client.api.response.UpdateAgentInstanceResponse;
@@ -497,6 +498,236 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
       assertThat(body.getHistory())
           .singleElement()
           .satisfies(item -> assertThat(item.getHistoryItemId()).isEqualTo("item-1"));
+    }
+  }
+
+  @Nested
+  class ConfigurationFieldsTest {
+
+    @Test
+    void shouldMapHistoryItemToolsWithAllFields() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item =
+          historyItem("item-1")
+              .tools(Arrays.asList(AgentTool.of("search", "A web search tool", "searchTask")));
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
+          body.getHistory().get(0);
+      assertThat(mappedItem.getTools())
+          .singleElement()
+          .satisfies(
+              tool -> {
+                assertThat(tool.getName()).isEqualTo("search");
+                assertThat(tool.getDescription()).isEqualTo("A web search tool");
+                assertThat(tool.getElementId()).isEqualTo("searchTask");
+              });
+    }
+
+    @Test
+    void shouldMapHistoryItemToolWithNameOnlyOmittingNullOptionalFields() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item =
+          historyItem("item-1").tools(Arrays.asList(AgentTool.of("summarize")));
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      final io.camunda.client.protocol.rest.AgentTool tool =
+          body.getHistory().get(0).getTools().get(0);
+      assertThat(tool.getName()).isEqualTo("summarize");
+      assertThat(tool.getDescription()).isNull();
+      assertThat(tool.getElementId()).isNull();
+    }
+
+    @Test
+    void shouldMapHistoryItemModelAndProvider() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item = historyItem("item-1").model("gpt-4").provider("openai");
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
+          body.getHistory().get(0);
+      assertThat(mappedItem.getModel()).isEqualTo("gpt-4");
+      assertThat(mappedItem.getProvider()).isEqualTo("openai");
+    }
+
+    @Test
+    void shouldMapHistoryItemLimits() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item = historyItem("item-1").limits(AgentInstanceLimits.of(1000L, 10, 20));
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      final io.camunda.client.protocol.rest.AgentInstanceLimits limits =
+          body.getHistory().get(0).getLimits();
+      assertThat(limits.getMaxTokens()).isEqualTo(1000L);
+      assertThat(limits.getMaxModelCalls()).isEqualTo(10);
+      assertThat(limits.getMaxToolCalls()).isEqualTo(20);
+    }
+
+    @Test
+    void shouldRejectHistoryItemLimitsBelowMinimum() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1").limits(AgentInstanceLimits.of(-2L, 0, 0)))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("maxTokens must be >= -1");
+    }
+
+    @Test
+    void shouldRejectHistoryItemMaxModelCallsBelowMinimum() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1").limits(AgentInstanceLimits.of(1000L, -2, 0)))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("maxModelCalls must be >= -1");
+    }
+
+    @Test
+    void shouldRejectHistoryItemMaxToolCallsBelowMinimum() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1").limits(AgentInstanceLimits.of(1000L, 10, -2)))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("maxToolCalls must be >= -1");
+    }
+
+    @Test
+    void shouldMapHistoryItemSystemPrompt() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item =
+          historyItem("item-1")
+              .systemPrompt(Collections.singletonList(AgentInstanceHistoryContent.text("be nice")));
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
+          body.getHistory().get(0);
+      assertThat(mappedItem.getSystemPrompt()).hasSize(1);
+      assertThat(mappedItem.getSystemPrompt().get(0)).isInstanceOf(AgentInstanceTextContent.class);
+      assertThat(((AgentInstanceTextContent) mappedItem.getSystemPrompt().get(0)).getText())
+          .isEqualTo("be nice");
+    }
+
+    @Test
+    void shouldSendExplicitEmptyToolsAndSystemPromptDistinctFromAbsent() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item =
+          historyItem("item-1")
+              .tools(Collections.emptyList())
+              .systemPrompt(Collections.emptyList());
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
+          body.getHistory().get(0);
+      assertThat(mappedItem.getTools()).isNotNull().isEmpty();
+      assertThat(mappedItem.getSystemPrompt()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void shouldLeaveConfigurationFieldsNullWhenAbsentFromHistoryItem() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(historyItem("item-1")))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
+          body.getHistory().get(0);
+      assertThat(mappedItem.getTools()).isNull();
+      assertThat(mappedItem.getModel()).isNull();
+      assertThat(mappedItem.getProvider()).isNull();
+      assertThat(mappedItem.getLimits()).isNull();
+      assertThat(mappedItem.getSystemPrompt()).isNull();
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -46,6 +46,7 @@ import io.camunda.client.util.RestGatewayService;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -67,647 +68,666 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
         .producedAt(PRODUCED_AT);
   }
 
-  // ── Happy-path: request routing ───────────────────────────────────────────
+  @Nested
+  class RequestRoutingTest {
 
-  @Test
-  void shouldSendPatchToCorrectUrl() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+    @Test
+    void shouldSendPatchToCorrectUrl() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
 
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .execute();
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .execute();
 
-    // then
-    final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getMethod()).isEqualTo(RequestMethod.PATCH);
-    assertThat(request.getUrl()).isEqualTo("/v2/agent-instances/1234");
+      // then
+      final LoggedRequest request = RestGatewayService.getLastRequest();
+      assertThat(request.getMethod()).isEqualTo(RequestMethod.PATCH);
+      assertThat(request.getUrl()).isEqualTo("/v2/agent-instances/1234");
+    }
+
+    @Test
+    void shouldSendAllOptionalFieldsInRequestBody() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .status(AgentInstanceUpdateStatus.THINKING)
+          .inputTokens(100L)
+          .outputTokens(200L)
+          .modelCalls(3)
+          .toolCalls(2)
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getElementInstanceKey()).isEqualTo(String.valueOf(ELEMENT_INSTANCE_KEY));
+      assertThat(body.getStatus()).isEqualTo(AgentInstanceUpdateStatusEnum.THINKING);
+      assertThat(body.getMetrics().getInputTokens()).isEqualTo(100L);
+      assertThat(body.getMetrics().getOutputTokens()).isEqualTo(200L);
+      assertThat(body.getMetrics().getModelCalls()).isEqualTo(3);
+      assertThat(body.getMetrics().getToolCalls()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldSendOnlyElementInstanceKeyWhenNoOtherFieldsSet() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getElementInstanceKey()).isEqualTo(String.valueOf(ELEMENT_INSTANCE_KEY));
+      assertThat(body.getStatus()).isNull();
+      assertThat(body.getMetrics()).isNull();
+      assertThat(body.getTools()).isNull();
+      assertThat(body.getJobKey()).isNull();
+      assertThat(body.getJobLease()).isNull();
+      assertThat(body.getHistory()).isNull();
+    }
   }
 
-  @Test
-  void shouldSendAllOptionalFieldsInRequestBody() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+  @Nested
+  class ToolsMappingTest {
 
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .status(AgentInstanceUpdateStatus.THINKING)
-        .inputTokens(100L)
-        .outputTokens(200L)
-        .modelCalls(3)
-        .toolCalls(2)
-        .execute();
+    @Test
+    void shouldMapToolsWithAllFields() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
 
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getElementInstanceKey()).isEqualTo(String.valueOf(ELEMENT_INSTANCE_KEY));
-    assertThat(body.getStatus()).isEqualTo(AgentInstanceUpdateStatusEnum.THINKING);
-    assertThat(body.getMetrics().getInputTokens()).isEqualTo(100L);
-    assertThat(body.getMetrics().getOutputTokens()).isEqualTo(200L);
-    assertThat(body.getMetrics().getModelCalls()).isEqualTo(3);
-    assertThat(body.getMetrics().getToolCalls()).isEqualTo(2);
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .tools(Arrays.asList(AgentTool.of("search", "A web search tool", "searchTask")))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getTools())
+          .singleElement()
+          .satisfies(
+              tool -> {
+                assertThat(tool.getName()).isEqualTo("search");
+                assertThat(tool.getDescription()).isEqualTo("A web search tool");
+                assertThat(tool.getElementId()).isEqualTo("searchTask");
+              });
+    }
+
+    @Test
+    void shouldMapToolWithNameOnlyOmittingNullOptionalFields() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .tools(Arrays.asList(AgentTool.of("summarize")))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getTools()).hasSize(1);
+      final io.camunda.client.protocol.rest.AgentTool tool = body.getTools().get(0);
+      assertThat(tool.getName()).isEqualTo("summarize");
+      assertThat(tool.getDescription()).isNull();
+      assertThat(tool.getElementId()).isNull();
+    }
+
+    @Test
+    void shouldSendEmptyToolsList() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .tools(Collections.emptyList())
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getTools()).isEmpty();
+    }
+
+    @Test
+    void shouldMapMultipleToolsMixingOptionalFields() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .tools(
+              Arrays.asList(
+                  AgentTool.of("search", "Search the web", "searchTask"),
+                  AgentTool.of("summarize")))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getTools())
+          .extracting(
+              io.camunda.client.protocol.rest.AgentTool::getName,
+              io.camunda.client.protocol.rest.AgentTool::getDescription,
+              io.camunda.client.protocol.rest.AgentTool::getElementId)
+          .containsExactly(
+              tuple("search", "Search the web", "searchTask"), tuple("summarize", null, null));
+    }
   }
 
-  @Test
-  void shouldSendOnlyElementInstanceKeyWhenNoOtherFieldsSet() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+  @Nested
+  class AgentInstanceKeyValidationTest {
 
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .execute();
-
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getElementInstanceKey()).isEqualTo(String.valueOf(ELEMENT_INSTANCE_KEY));
-    assertThat(body.getStatus()).isNull();
-    assertThat(body.getMetrics()).isNull();
-    assertThat(body.getTools()).isNull();
-    assertThat(body.getJobKey()).isNull();
-    assertThat(body.getJobLease()).isNull();
-    assertThat(body.getHistory()).isNull();
+    @ParameterizedTest(name = "agentInstanceKey={0} should be rejected")
+    @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+    void shouldRejectNonPositiveAgentInstanceKey(final long invalidKey) {
+      assertThatThrownBy(() -> client.newUpdateAgentInstanceCommand(invalidKey))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("agentInstanceKey must be greater than 0");
+    }
   }
 
-  // ── Tools mapping ─────────────────────────────────────────────────────────
+  @Nested
+  class ElementInstanceKeyValidationTest {
 
-  @Test
-  void shouldMapToolsWithAllFields() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
-
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .tools(Arrays.asList(AgentTool.of("search", "A web search tool", "searchTask")))
-        .execute();
-
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getTools())
-        .singleElement()
-        .satisfies(
-            tool -> {
-              assertThat(tool.getName()).isEqualTo("search");
-              assertThat(tool.getDescription()).isEqualTo("A web search tool");
-              assertThat(tool.getElementId()).isEqualTo("searchTask");
-            });
+    @ParameterizedTest(name = "elementInstanceKey={0} should be rejected")
+    @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+    void shouldRejectNonPositiveElementInstanceKey(final long invalidKey) {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(invalidKey)
+                      .execute())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("elementInstanceKey must be greater than 0");
+    }
   }
 
-  @Test
-  void shouldMapToolWithNameOnlyOmittingNullOptionalFields() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+  @Nested
+  class JobKeyValidationTest {
 
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .tools(Arrays.asList(AgentTool.of("summarize")))
-        .execute();
+    @ParameterizedTest(name = "jobKey={0} should be rejected")
+    @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+    void shouldRejectNonPositiveJobKey(final long invalidKey) {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(invalidKey))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("jobKey must be greater than 0");
+    }
 
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getTools()).hasSize(1);
-    final io.camunda.client.protocol.rest.AgentTool tool = body.getTools().get(0);
-    assertThat(tool.getName()).isEqualTo("summarize");
-    assertThat(tool.getDescription()).isNull();
-    assertThat(tool.getElementId()).isNull();
+    @Test
+    void shouldRejectHistoryWithoutJobKey() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .history(Collections.singletonList(historyItem("item-1")))
+                      .execute())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("jobKey must be set when history is not empty");
+    }
   }
 
-  @Test
-  void shouldSendEmptyToolsList() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+  @Nested
+  class JobLeaseValidationTest {
 
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .tools(Collections.emptyList())
-        .execute();
+    @Test
+    void shouldRejectNullJobLease() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobLease(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("jobLease must not be null");
+    }
 
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getTools()).isEmpty();
+    @ParameterizedTest(name = "jobLease=''{0}'' should be rejected")
+    @ValueSource(strings = {"", " "})
+    void shouldRejectBlankJobLease(final String jobLease) {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobLease(jobLease))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("jobLease must not be blank");
+    }
   }
 
-  @Test
-  void shouldMapMultipleToolsMixingOptionalFields() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+  @Nested
+  class HistoryBatchMappingTest {
 
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .tools(
-            Arrays.asList(
-                AgentTool.of("search", "Search the web", "searchTask"), AgentTool.of("summarize")))
-        .execute();
+    @Test
+    void shouldSendSingleHistoryItemWithRequiredFieldsOnly() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
 
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getTools())
-        .extracting(
-            io.camunda.client.protocol.rest.AgentTool::getName,
-            io.camunda.client.protocol.rest.AgentTool::getDescription,
-            io.camunda.client.protocol.rest.AgentTool::getElementId)
-        .containsExactly(
-            tuple("search", "Search the web", "searchTask"), tuple("summarize", null, null));
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(historyItem("item-1")))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getHistory())
+          .singleElement()
+          .satisfies(
+              item -> {
+                assertThat(item.getHistoryItemId()).isEqualTo("item-1");
+                assertThat(item.getLoopIteration()).isEqualTo(1);
+                assertThat(item.getRole()).isEqualTo(AgentInstanceHistoryRoleEnum.USER);
+                assertThat(item.getContent()).hasSize(1);
+                assertThat(item.getContent().get(0)).isInstanceOf(AgentInstanceTextContent.class);
+                assertThat(((AgentInstanceTextContent) item.getContent().get(0)).getText())
+                    .isEqualTo("hello");
+                assertThat(item.getProducedAt()).isEqualTo("2025-06-01T12:00Z");
+                assertThat(item.getToolCalls()).isNull();
+                assertThat(item.getMetrics()).isNull();
+              });
+    }
+
+    @Test
+    void shouldMapHistoryItemWithToolCallsAndMetrics() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item =
+          historyItem("item-1")
+              .toolCalls(
+                  Collections.singletonList(
+                      new AgentInstanceHistoryToolCall()
+                          .toolCallId("call-1")
+                          .toolName("search")
+                          .elementId("searchTask")
+                          .arguments(Collections.<String, Object>singletonMap("query", "weather"))))
+              .metrics(
+                  new AgentInstanceHistoryMetrics()
+                      .inputTokens(100L)
+                      .outputTokens(50L)
+                      .durationMs(200L));
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getHistory()).isNotNull().hasSize(1);
+      final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
+          body.getHistory().get(0);
+      assertThat(mappedItem.getToolCalls())
+          .singleElement()
+          .satisfies(
+              (final AgentInstanceToolCall toolCall) -> {
+                assertThat(toolCall.getToolCallId()).isEqualTo("call-1");
+                assertThat(toolCall.getToolName()).isEqualTo("search");
+                assertThat(toolCall.getElementId()).isEqualTo("searchTask");
+                assertThat(toolCall.getArguments()).containsEntry("query", "weather");
+              });
+      assertThat(mappedItem.getMetrics().getInputTokens()).isEqualTo(100L);
+      assertThat(mappedItem.getMetrics().getOutputTokens()).isEqualTo(50L);
+      assertThat(mappedItem.getMetrics().getDurationMs()).isEqualTo(200L);
+    }
+
+    @Test
+    void shouldMapHistoryItemWithDocumentContent() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final DocumentReferenceResponseImpl doc =
+          new DocumentReferenceResponseImpl(
+              new DocumentReference()
+                  .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
+                  .documentId("doc-abc")
+                  .storeId("store-1"));
+      final HistoryItem item =
+          historyItem("item-1")
+              .content(Collections.singletonList(AgentInstanceHistoryContent.document(doc)));
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getHistory())
+          .singleElement()
+          .satisfies(
+              mappedItem -> {
+                assertThat(mappedItem.getContent()).hasSize(1);
+                assertThat(mappedItem.getContent().get(0))
+                    .isInstanceOf(AgentInstanceDocumentContent.class);
+                final AgentInstanceDocumentContent docContent =
+                    (AgentInstanceDocumentContent) mappedItem.getContent().get(0);
+                assertThat(docContent.getDocumentReference().getCamundaDocumentType())
+                    .isEqualTo(CamundaDocumentTypeEnum.CAMUNDA);
+                assertThat(docContent.getDocumentReference().getDocumentId()).isEqualTo("doc-abc");
+                assertThat(docContent.getDocumentReference().getStoreId()).isEqualTo("store-1");
+              });
+    }
+
+    @Test
+    void shouldSendMultipleHistoryItemsInOrder() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(
+              Arrays.asList(historyItem("item-1"), historyItem("item-2"), historyItem("item-3")))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getHistory())
+          .extracting(io.camunda.client.protocol.rest.AgentInstanceHistoryItem::getHistoryItemId)
+          .containsExactly("item-1", "item-2", "item-3");
+    }
+
+    @Test
+    void shouldCombineJobKeyJobLeaseStatusToolsAndHistoryInOneRequest() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .jobLease(JOB_LEASE)
+          .status(AgentInstanceUpdateStatus.THINKING)
+          .tools(Collections.singletonList(AgentTool.of("search")))
+          .history(Collections.singletonList(historyItem("item-1")))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      assertThat(body.getJobKey()).isEqualTo("91011");
+      assertThat(body.getJobLease()).isEqualTo(JOB_LEASE);
+      assertThat(body.getStatus()).isEqualTo(AgentInstanceUpdateStatusEnum.THINKING);
+      assertThat(body.getTools())
+          .singleElement()
+          .satisfies(tool -> assertThat(tool.getName()).isEqualTo("search"));
+      assertThat(body.getHistory())
+          .singleElement()
+          .satisfies(item -> assertThat(item.getHistoryItemId()).isEqualTo("item-1"));
+    }
   }
 
-  // ── Argument validation: agentInstanceKey ────────────────────────────────
+  @Nested
+  class HistoryBatchValidationTest {
 
-  @ParameterizedTest(name = "agentInstanceKey={0} should be rejected")
-  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
-  void shouldRejectNonPositiveAgentInstanceKey(final long invalidKey) {
-    assertThatThrownBy(() -> client.newUpdateAgentInstanceCommand(invalidKey))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("agentInstanceKey must be greater than 0");
+    @Test
+    void shouldRejectNullHistoryList() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .history(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("history must not be null");
+    }
+
+    @Test
+    void shouldRejectNullElementInHistoryList() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(Collections.singletonList(null)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("history must not contain null elements");
+    }
+
+    @Test
+    void shouldRejectNullHistoryItemId() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(historyItem("item-1").historyItemId(null))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("historyItemId must not be null");
+    }
+
+    @ParameterizedTest(name = "historyItemId=''{0}'' should be rejected")
+    @ValueSource(strings = {"", " "})
+    void shouldRejectBlankHistoryItemId(final String historyItemId) {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1").historyItemId(historyItemId))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("historyItemId must not be blank");
+    }
+
+    @ParameterizedTest(name = "loopIteration={0} should be rejected")
+    @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+    void shouldRejectNonPositiveLoopIteration(final int loopIteration) {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1").loopIteration(loopIteration))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("loopIteration must be greater than 0");
+    }
+
+    @Test
+    void shouldRejectNullRoleInHistoryItem() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(Collections.singletonList(historyItem("item-1").role(null))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("role must not be null");
+    }
+
+    @Test
+    void shouldRejectNullContentInHistoryItem() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(Collections.singletonList(historyItem("item-1").content(null))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("content must not be null");
+    }
+
+    @Test
+    void shouldRejectNullProducedAtInHistoryItem() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(Collections.singletonList(historyItem("item-1").producedAt(null))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("producedAt must not be null");
+    }
+
+    @Test
+    void shouldRejectBlankTextContentInHistoryItem() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1")
+                                  .content(
+                                      Collections.singletonList(
+                                          AgentInstanceHistoryContent.text(" ")))))
+                      .execute())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("text content value must not be null or blank");
+    }
+
+    @Test
+    void shouldRejectEmptyContentListInHistoryItem() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1").content(Collections.emptyList())))
+                      .execute())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("content must not be empty");
+    }
+
+    @Test
+    void shouldRejectBlankToolCallIdInHistoryItem() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1")
+                                  .toolCalls(
+                                      Collections.singletonList(
+                                          new AgentInstanceHistoryToolCall()
+                                              .toolCallId(" ")
+                                              .toolName("search")))))
+                      .execute())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("toolCallId must not be null or blank");
+    }
   }
 
-  // ── Argument validation: elementInstanceKey ───────────────────────────────
+  @Nested
+  class ResponseParsingTest {
 
-  @ParameterizedTest(name = "elementInstanceKey={0} should be rejected")
-  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
-  void shouldRejectNonPositiveElementInstanceKey(final long invalidKey) {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(invalidKey)
-                    .execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("elementInstanceKey must be greater than 0");
-  }
+    @Test
+    void shouldParseCreatedHistoryInResponseOrderWithDuplicateFlag() {
+      // given
+      final AgentInstanceUpdateResult response =
+          new AgentInstanceUpdateResult()
+              .createdHistory(
+                  Arrays.asList(
+                      new AgentInstanceCreatedHistoryItem()
+                          .historyItemId("item-1")
+                          .historyItemKey("100")
+                          .isDuplicate(false),
+                      new AgentInstanceCreatedHistoryItem()
+                          .historyItemId("item-2")
+                          .historyItemKey("101")
+                          .isDuplicate(true),
+                      new AgentInstanceCreatedHistoryItem()
+                          .historyItemId("item-3")
+                          .historyItemKey("102")
+                          .isDuplicate(false)));
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY, response);
 
-  // ── Argument validation: jobKey ───────────────────────────────────────────
+      // when
+      final UpdateAgentInstanceResponse result =
+          client
+              .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .execute();
 
-  @ParameterizedTest(name = "jobKey={0} should be rejected")
-  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
-  void shouldRejectNonPositiveJobKey(final long invalidKey) {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(invalidKey))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("jobKey must be greater than 0");
-  }
+      // then
+      assertThat(result.getCreatedHistory())
+          .isNotNull()
+          .extracting(
+              CreatedHistoryItem::getHistoryItemId,
+              CreatedHistoryItem::getHistoryItemKey,
+              CreatedHistoryItem::isDuplicate)
+          .containsExactly(
+              tuple("item-1", 100L, false),
+              tuple("item-2", 101L, true),
+              tuple("item-3", 102L, false));
+    }
 
-  // ── Argument validation: jobLease ─────────────────────────────────────────
+    @Test
+    void shouldReturnEmptyCreatedHistoryWhenResponseHasNoBody() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
 
-  @Test
-  void shouldRejectNullJobLease() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobLease(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("jobLease must not be null");
-  }
+      // when
+      final UpdateAgentInstanceResponse result =
+          client
+              .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .execute();
 
-  @ParameterizedTest(name = "jobLease=''{0}'' should be rejected")
-  @ValueSource(strings = {"", " "})
-  void shouldRejectBlankJobLease(final String jobLease) {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobLease(jobLease))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("jobLease must not be blank");
-  }
-
-  // ── Happy-path: history batch ─────────────────────────────────────────────
-
-  @Test
-  void shouldSendSingleHistoryItemWithRequiredFieldsOnly() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
-
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .jobKey(JOB_KEY)
-        .history(Collections.singletonList(historyItem("item-1")))
-        .execute();
-
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getHistory())
-        .singleElement()
-        .satisfies(
-            item -> {
-              assertThat(item.getHistoryItemId()).isEqualTo("item-1");
-              assertThat(item.getLoopIteration()).isEqualTo(1);
-              assertThat(item.getRole()).isEqualTo(AgentInstanceHistoryRoleEnum.USER);
-              assertThat(item.getContent()).hasSize(1);
-              assertThat(item.getContent().get(0)).isInstanceOf(AgentInstanceTextContent.class);
-              assertThat(((AgentInstanceTextContent) item.getContent().get(0)).getText())
-                  .isEqualTo("hello");
-              assertThat(item.getProducedAt()).isEqualTo("2025-06-01T12:00Z");
-              assertThat(item.getToolCalls()).isNull();
-              assertThat(item.getMetrics()).isNull();
-            });
-  }
-
-  @Test
-  void shouldMapHistoryItemWithToolCallsAndMetrics() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
-    final HistoryItem item =
-        historyItem("item-1")
-            .toolCalls(
-                Collections.singletonList(
-                    new AgentInstanceHistoryToolCall()
-                        .toolCallId("call-1")
-                        .toolName("search")
-                        .elementId("searchTask")
-                        .arguments(Collections.<String, Object>singletonMap("query", "weather"))))
-            .metrics(
-                new AgentInstanceHistoryMetrics()
-                    .inputTokens(100L)
-                    .outputTokens(50L)
-                    .durationMs(200L));
-
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .jobKey(JOB_KEY)
-        .history(Collections.singletonList(item))
-        .execute();
-
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getHistory()).isNotNull().hasSize(1);
-    final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
-        body.getHistory().get(0);
-    assertThat(mappedItem.getToolCalls())
-        .singleElement()
-        .satisfies(
-            (final AgentInstanceToolCall toolCall) -> {
-              assertThat(toolCall.getToolCallId()).isEqualTo("call-1");
-              assertThat(toolCall.getToolName()).isEqualTo("search");
-              assertThat(toolCall.getElementId()).isEqualTo("searchTask");
-              assertThat(toolCall.getArguments()).containsEntry("query", "weather");
-            });
-    assertThat(mappedItem.getMetrics().getInputTokens()).isEqualTo(100L);
-    assertThat(mappedItem.getMetrics().getOutputTokens()).isEqualTo(50L);
-    assertThat(mappedItem.getMetrics().getDurationMs()).isEqualTo(200L);
-  }
-
-  @Test
-  void shouldMapHistoryItemWithDocumentContent() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
-    final DocumentReferenceResponseImpl doc =
-        new DocumentReferenceResponseImpl(
-            new DocumentReference()
-                .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
-                .documentId("doc-abc")
-                .storeId("store-1"));
-    final HistoryItem item =
-        historyItem("item-1")
-            .content(Collections.singletonList(AgentInstanceHistoryContent.document(doc)));
-
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .jobKey(JOB_KEY)
-        .history(Collections.singletonList(item))
-        .execute();
-
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getHistory())
-        .singleElement()
-        .satisfies(
-            mappedItem -> {
-              assertThat(mappedItem.getContent()).hasSize(1);
-              assertThat(mappedItem.getContent().get(0))
-                  .isInstanceOf(AgentInstanceDocumentContent.class);
-              final AgentInstanceDocumentContent docContent =
-                  (AgentInstanceDocumentContent) mappedItem.getContent().get(0);
-              assertThat(docContent.getDocumentReference().getCamundaDocumentType())
-                  .isEqualTo(CamundaDocumentTypeEnum.CAMUNDA);
-              assertThat(docContent.getDocumentReference().getDocumentId()).isEqualTo("doc-abc");
-              assertThat(docContent.getDocumentReference().getStoreId()).isEqualTo("store-1");
-            });
-  }
-
-  @Test
-  void shouldSendMultipleHistoryItemsInOrder() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
-
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .jobKey(JOB_KEY)
-        .history(Arrays.asList(historyItem("item-1"), historyItem("item-2"), historyItem("item-3")))
-        .execute();
-
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getHistory())
-        .extracting(io.camunda.client.protocol.rest.AgentInstanceHistoryItem::getHistoryItemId)
-        .containsExactly("item-1", "item-2", "item-3");
-  }
-
-  @Test
-  void shouldCombineJobKeyJobLeaseStatusToolsAndHistoryInOneRequest() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
-
-    // when
-    client
-        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-        .jobKey(JOB_KEY)
-        .jobLease(JOB_LEASE)
-        .status(AgentInstanceUpdateStatus.THINKING)
-        .tools(Collections.singletonList(AgentTool.of("search")))
-        .history(Collections.singletonList(historyItem("item-1")))
-        .execute();
-
-    // then
-    final AgentInstanceUpdateRequest body =
-        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
-    assertThat(body.getJobKey()).isEqualTo("91011");
-    assertThat(body.getJobLease()).isEqualTo(JOB_LEASE);
-    assertThat(body.getStatus()).isEqualTo(AgentInstanceUpdateStatusEnum.THINKING);
-    assertThat(body.getTools())
-        .singleElement()
-        .satisfies(tool -> assertThat(tool.getName()).isEqualTo("search"));
-    assertThat(body.getHistory())
-        .singleElement()
-        .satisfies(item -> assertThat(item.getHistoryItemId()).isEqualTo("item-1"));
-  }
-
-  // ── Argument validation: history batch ────────────────────────────────────
-
-  @Test
-  void shouldRejectNullHistoryList() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .history(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("history must not be null");
-  }
-
-  @Test
-  void shouldRejectNullElementInHistoryList() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(Collections.singletonList(null)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("history must not contain null elements");
-  }
-
-  @Test
-  void shouldRejectNullHistoryItemId() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(Collections.singletonList(historyItem("item-1").historyItemId(null))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("historyItemId must not be null");
-  }
-
-  @ParameterizedTest(name = "historyItemId=''{0}'' should be rejected")
-  @ValueSource(strings = {"", " "})
-  void shouldRejectBlankHistoryItemId(final String historyItemId) {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(
-                        Collections.singletonList(
-                            historyItem("item-1").historyItemId(historyItemId))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("historyItemId must not be blank");
-  }
-
-  @ParameterizedTest(name = "loopIteration={0} should be rejected")
-  @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
-  void shouldRejectNonPositiveLoopIteration(final int loopIteration) {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(
-                        Collections.singletonList(
-                            historyItem("item-1").loopIteration(loopIteration))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("loopIteration must be greater than 0");
-  }
-
-  @Test
-  void shouldRejectNullRoleInHistoryItem() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(Collections.singletonList(historyItem("item-1").role(null))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("role must not be null");
-  }
-
-  @Test
-  void shouldRejectNullContentInHistoryItem() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(Collections.singletonList(historyItem("item-1").content(null))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("content must not be null");
-  }
-
-  @Test
-  void shouldRejectNullProducedAtInHistoryItem() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(Collections.singletonList(historyItem("item-1").producedAt(null))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("producedAt must not be null");
-  }
-
-  @Test
-  void shouldRejectBlankTextContentInHistoryItem() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(
-                        Collections.singletonList(
-                            historyItem("item-1")
-                                .content(
-                                    Collections.singletonList(
-                                        AgentInstanceHistoryContent.text(" ")))))
-                    .execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("text content value must not be null or blank");
-  }
-
-  @Test
-  void shouldRejectEmptyContentListInHistoryItem() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(
-                        Collections.singletonList(
-                            historyItem("item-1").content(Collections.emptyList())))
-                    .execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("content must not be empty");
-  }
-
-  @Test
-  void shouldRejectBlankToolCallIdInHistoryItem() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .history(
-                        Collections.singletonList(
-                            historyItem("item-1")
-                                .toolCalls(
-                                    Collections.singletonList(
-                                        new AgentInstanceHistoryToolCall()
-                                            .toolCallId(" ")
-                                            .toolName("search")))))
-                    .execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("toolCallId must not be null or blank");
-  }
-
-  // ── Argument validation: jobKey required when history is set ─────────────
-
-  @Test
-  void shouldRejectHistoryWithoutJobKey() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .history(Collections.singletonList(historyItem("item-1")))
-                    .execute())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("jobKey must be set when history is not empty");
-  }
-
-  // ── Response parsing: createdHistory ──────────────────────────────────────
-
-  @Test
-  void shouldParseCreatedHistoryInResponseOrderWithDuplicateFlag() {
-    // given
-    final AgentInstanceUpdateResult response =
-        new AgentInstanceUpdateResult()
-            .createdHistory(
-                Arrays.asList(
-                    new AgentInstanceCreatedHistoryItem()
-                        .historyItemId("item-1")
-                        .historyItemKey("100")
-                        .isDuplicate(false),
-                    new AgentInstanceCreatedHistoryItem()
-                        .historyItemId("item-2")
-                        .historyItemKey("101")
-                        .isDuplicate(true),
-                    new AgentInstanceCreatedHistoryItem()
-                        .historyItemId("item-3")
-                        .historyItemKey("102")
-                        .isDuplicate(false)));
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY, response);
-
-    // when
-    final UpdateAgentInstanceResponse result =
-        client
-            .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-            .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-            .execute();
-
-    // then
-    assertThat(result.getCreatedHistory())
-        .isNotNull()
-        .extracting(
-            CreatedHistoryItem::getHistoryItemId,
-            CreatedHistoryItem::getHistoryItemKey,
-            CreatedHistoryItem::isDuplicate)
-        .containsExactly(
-            tuple("item-1", 100L, false),
-            tuple("item-2", 101L, true),
-            tuple("item-3", 102L, false));
-  }
-
-  @Test
-  void shouldReturnEmptyCreatedHistoryWhenResponseHasNoBody() {
-    // given
-    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
-
-    // when
-    final UpdateAgentInstanceResponse result =
-        client
-            .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
-            .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-            .execute();
-
-    // then
-    assertThat(result.getCreatedHistory()).isNotNull().isEmpty();
+      // then
+      assertThat(result.getCreatedHistory()).isNotNull().isEmpty();
+    }
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -899,6 +899,22 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessage("toolCallId must not be null or blank");
     }
+
+    @Test
+    void shouldRejectNullElementInToolsList() {
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                      .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .jobKey(JOB_KEY)
+                      .history(
+                          Collections.singletonList(
+                              historyItem("item-1").tools(Collections.singletonList(null))))
+                      .execute())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("tools must not contain null elements");
+    }
   }
 
   @Nested

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -729,6 +729,46 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
       assertThat(mappedItem.getLimits()).isNull();
       assertThat(mappedItem.getSystemPrompt()).isNull();
     }
+
+    @Test
+    void shouldMapAllConfigurationFieldsOnConfigurationHistoryItem() {
+      // given
+      gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+      final HistoryItem item =
+          historyItem("item-1")
+              .role(AgentInstanceHistoryRole.CONFIGURATION)
+              .tools(Arrays.asList(AgentTool.of("search", "A web search tool", "searchTask")))
+              .model("gpt-5")
+              .provider("openai")
+              .limits(AgentInstanceLimits.of(1000L, 10, 20))
+              .systemPrompt(Collections.singletonList(AgentInstanceHistoryContent.text("be nice")));
+
+      // when
+      client
+          .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+          .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+          .jobKey(JOB_KEY)
+          .history(Collections.singletonList(item))
+          .execute();
+
+      // then
+      final AgentInstanceUpdateRequest body =
+          gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+      final io.camunda.client.protocol.rest.AgentInstanceHistoryItem mappedItem =
+          body.getHistory().get(0);
+      assertThat(mappedItem.getRole()).isEqualTo(AgentInstanceHistoryRoleEnum.CONFIGURATION);
+      assertThat(mappedItem.getTools())
+          .singleElement()
+          .satisfies(tool -> assertThat(tool.getName()).isEqualTo("search"));
+      assertThat(mappedItem.getModel()).isEqualTo("gpt-5");
+      assertThat(mappedItem.getProvider()).isEqualTo("openai");
+      assertThat(mappedItem.getLimits().getMaxTokens()).isEqualTo(1000L);
+      assertThat(mappedItem.getLimits().getMaxModelCalls()).isEqualTo(10);
+      assertThat(mappedItem.getLimits().getMaxToolCalls()).isEqualTo(20);
+      assertThat(mappedItem.getSystemPrompt()).hasSize(1);
+      assertThat(((AgentInstanceTextContent) mappedItem.getSystemPrompt().get(0)).getText())
+          .isEqualTo("be nice");
+    }
   }
 
   @Nested

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -244,6 +244,35 @@ public class AgentInstanceMapper {
       }
     }
 
+    if (historyItem.getTools() != null) {
+      final List<AgentInstanceTool> tools =
+          historyItem.getTools().stream().map(this::mapTool).collect(Collectors.toList());
+      record.setTools(tools);
+      record.addChangedAttribute("tools");
+    }
+
+    if (historyItem.getModel() != null) {
+      record.setModel(historyItem.getModel());
+      record.addChangedAttribute("model");
+    }
+
+    if (historyItem.getProvider() != null) {
+      record.setProvider(historyItem.getProvider());
+      record.addChangedAttribute("provider");
+    }
+
+    if (historyItem.getLimits() != null) {
+      fillLimits(historyItem.getLimits(), record.getLimits());
+      record.addChangedAttribute("limits");
+    }
+
+    if (historyItem.getSystemPrompt() != null) {
+      for (final AgentInstanceMessageContent content : historyItem.getSystemPrompt()) {
+        record.addSystemPrompt(mapContent(content));
+      }
+      record.addChangedAttribute("systemPrompt");
+    }
+
     return record;
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -275,6 +275,10 @@ public class AgentInstanceRequestValidator {
       final String fieldPrefix, final List<AgentTool> tools, final List<String> violations) {
     for (int i = 0; i < tools.size(); i++) {
       final var tool = tools.get(i);
+      if (tool == null) {
+        violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(fieldPrefix + "[" + i + "]"));
+        continue;
+      }
       if (tool.getName() == null || tool.getName().isBlank()) {
         violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(fieldPrefix + "[" + i + "].name"));
       }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -22,6 +22,7 @@ import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
 import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
 import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
+import io.camunda.gateway.protocol.model.AgentTool;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -144,12 +145,7 @@ public class AgentInstanceRequestValidator {
           }
 
           if (request.getTools() != null) {
-            for (int i = 0; i < request.getTools().size(); i++) {
-              final var tool = request.getTools().get(i);
-              if (tool.getName() == null || tool.getName().isBlank()) {
-                violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("tools[" + i + "].name"));
-              }
-            }
+            validateTools("tools", request.getTools(), violations);
           }
 
           if (request.getJobKey() != null) {
@@ -247,6 +243,16 @@ public class AgentInstanceRequestValidator {
     final var expiresAt = ref.getMetadata().getExpiresAt();
     if (expiresAt != null && !expiresAt.isBlank()) {
       validateDate(expiresAt, fieldPrefix + ".documentReference.metadata.expiresAt", violations);
+    }
+  }
+
+  private void validateTools(
+      final String fieldPrefix, final List<AgentTool> tools, final List<String> violations) {
+    for (int i = 0; i < tools.size(); i++) {
+      final var tool = tools.get(i);
+      if (tool.getName() == null || tool.getName().isBlank()) {
+        violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(fieldPrefix + "[" + i + "].name"));
+      }
     }
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -204,6 +204,31 @@ public class AgentInstanceRequestValidator {
     } else {
       validateDate(historyItem.getProducedAt(), "history[" + index + "].producedAt", violations);
     }
+    if (historyItem.getTools() != null) {
+      validateTools("history[" + index + "].tools", historyItem.getTools(), violations);
+    }
+    if (historyItem.getLimits() != null) {
+      final var limits = historyItem.getLimits();
+      violations.addAll(
+          validateLimit("history[" + index + "].limits.maxTokens", limits.getMaxTokens()));
+      violations.addAll(
+          validateLimit("history[" + index + "].limits.maxModelCalls", limits.getMaxModelCalls()));
+      violations.addAll(
+          validateLimit("history[" + index + "].limits.maxToolCalls", limits.getMaxToolCalls()));
+    }
+    if (historyItem.getSystemPrompt() != null) {
+      if (historyItem.getSystemPrompt().isEmpty()) {
+        violations.add(
+            ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].systemPrompt"));
+      } else {
+        for (int i = 0; i < historyItem.getSystemPrompt().size(); i++) {
+          validateContentItem(
+              "history[" + index + "].systemPrompt[" + i + "]",
+              historyItem.getSystemPrompt().get(i),
+              violations);
+        }
+      }
+    }
   }
 
   private void validateContentItem(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -189,7 +189,7 @@ public class AgentInstanceRequestValidator {
     if (historyItem.getRole() == null) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].role"));
     }
-    if (historyItem.getContent() == null || historyItem.getContent().isEmpty()) {
+    if (historyItem.getContent() == null) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].content"));
     } else {
       for (int i = 0; i < historyItem.getContent().size(); i++) {

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
@@ -13,6 +13,7 @@ import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemMetrics;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceLimits;
 import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
 import io.camunda.gateway.protocol.model.AgentInstanceMetricsDelta;
 import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
@@ -240,6 +241,110 @@ class AgentInstanceMapperTest {
       final var record = result.get();
       assertThat(record.getJobKey()).isEqualTo(2251799813685249L);
       assertThat(record.getJobLease()).isEqualTo("lease-abc");
+    }
+
+    @Test
+    void shouldMapConfigurationFieldsOntoHistoryRecord() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      final var item =
+          AgentInstanceHistoryItem.Builder.create()
+              .historyItemId("item-1")
+              .loopIteration(1)
+              .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+              .content(List.of(textContent("switching model")))
+              .producedAt("2025-06-01T12:00:00Z")
+              .build();
+      item.tools(
+          List.of(
+              AgentTool.Builder.create()
+                  .name("searchDatabase")
+                  .description("Searches the database")
+                  .elementId(null)
+                  .build()));
+      item.model("gpt-5");
+      item.provider("openai");
+      item.limits(
+          AgentInstanceLimits.Builder.create()
+              .maxModelCalls(10)
+              .maxTokens(1000L)
+              .maxToolCalls(5)
+              .build());
+      item.systemPrompt(List.of(textContent("be helpful")));
+      request.setHistory(List.of(item));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var mappedItem = result.get().getHistory().get(0);
+      assertThat(mappedItem.getTools()).hasSize(1);
+      assertThat(mappedItem.getTools().get(0).getName()).isEqualTo("searchDatabase");
+      assertThat(mappedItem.getModel()).isEqualTo("gpt-5");
+      assertThat(mappedItem.getProvider()).isEqualTo("openai");
+      assertThat(mappedItem.getLimits().getMaxModelCalls()).isEqualTo(10);
+      assertThat(mappedItem.getLimits().getMaxTokens()).isEqualTo(1000L);
+      assertThat(mappedItem.getLimits().getMaxToolCalls()).isEqualTo(5);
+      assertThat(mappedItem.getSystemPrompt()).hasSize(1);
+      assertThat(mappedItem.getSystemPrompt().get(0).getText()).isEqualTo("be helpful");
+      assertThat(mappedItem.getChangedAttributes())
+          .containsExactlyInAnyOrder("tools", "model", "provider", "limits", "systemPrompt");
+    }
+
+    @Test
+    void shouldLeaveConfigurationFieldsAtDefaultsWhenAbsentFromHistoryItem() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(List.of(historyItem("item-1", AgentInstanceHistoryRoleEnum.USER, "hi")));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var mappedItem = result.get().getHistory().get(0);
+      assertThat(mappedItem.getTools()).isEmpty();
+      assertThat(mappedItem.getModel()).isEmpty();
+      assertThat(mappedItem.getProvider()).isEmpty();
+      assertThat(mappedItem.getLimits().getMaxTokens()).isEqualTo(-1L);
+      assertThat(mappedItem.getLimits().getMaxModelCalls()).isEqualTo(-1);
+      assertThat(mappedItem.getLimits().getMaxToolCalls()).isEqualTo(-1);
+      assertThat(mappedItem.getSystemPrompt()).isEmpty();
+      assertThat(mappedItem.getChangedAttributes()).isEmpty();
+    }
+
+    @Test
+    void shouldTreatExplicitEmptyToolsAsProvided() {
+      // given
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      final var item = historyItem("item-1", AgentInstanceHistoryRoleEnum.CONFIGURATION, "hi");
+      item.tools(List.of());
+      request.setHistory(List.of(item));
+
+      // when
+      final Either<ProblemDetail, AgentInstanceRecord> result =
+          mapper.toUpdateAgentInstanceRecord(AGENT_INSTANCE_KEY, request);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var mappedItem = result.get().getHistory().get(0);
+      assertThat(mappedItem.getTools()).isEmpty();
+      assertThat(mappedItem.getChangedAttributes()).containsExactlyInAnyOrder("tools");
     }
 
     @Test

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceLimits;
 import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
 import io.camunda.gateway.protocol.model.AgentInstanceMetricsDelta;
 import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
@@ -34,90 +35,6 @@ class AgentInstanceRequestValidatorTest {
   private static final String JOB_KEY = "2251799813685249";
 
   private final AgentInstanceRequestValidator validator = new AgentInstanceRequestValidator();
-
-  private static AgentInstanceHistoryItem historyItem(final String historyItemId) {
-    final AgentInstanceMessageContent content =
-        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(1)
-        .role(AgentInstanceHistoryRoleEnum.USER)
-        .content(List.of(content))
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
-  }
-
-  private static AgentInstanceHistoryItem historyItemWithoutLoopIteration(
-      final String historyItemId) {
-    final AgentInstanceMessageContent content =
-        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(null)
-        .role(AgentInstanceHistoryRoleEnum.USER)
-        .content(List.of(content))
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
-  }
-
-  private static AgentInstanceHistoryItem historyItemWithoutRole(final String historyItemId) {
-    final AgentInstanceMessageContent content =
-        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(1)
-        .role(null)
-        .content(List.of(content))
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
-  }
-
-  private static AgentInstanceHistoryItem historyItemWithoutContent(final String historyItemId) {
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(1)
-        .role(AgentInstanceHistoryRoleEnum.USER)
-        .content(null)
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
-  }
-
-  private static AgentInstanceHistoryItem historyItemWithProducedAt(
-      final String historyItemId, final String producedAt) {
-    final AgentInstanceMessageContent content =
-        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(1)
-        .role(AgentInstanceHistoryRoleEnum.USER)
-        .content(List.of(content))
-        .producedAt(producedAt)
-        .build();
-  }
-
-  private static AgentInstanceHistoryItem historyItemWithLoopIteration(
-      final String historyItemId, final int loopIteration) {
-    final AgentInstanceMessageContent content =
-        AgentInstanceTextContent.Builder.create().contentType("TEXT").text("hello").build();
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(loopIteration)
-        .role(AgentInstanceHistoryRoleEnum.USER)
-        .content(List.of(content))
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
-  }
-
-  private static AgentInstanceHistoryItem historyItemWithContent(
-      final String historyItemId, final List<AgentInstanceMessageContent> content) {
-    return AgentInstanceHistoryItem.Builder.create()
-        .historyItemId(historyItemId)
-        .loopIteration(1)
-        .role(AgentInstanceHistoryRoleEnum.USER)
-        .content(content)
-        .producedAt("2025-06-01T12:00:00Z")
-        .build();
-  }
 
   @Nested
   @DisplayName("Existing update rules")
@@ -198,7 +115,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItem("item-1")));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -214,7 +144,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItem(null)));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId(null)
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -231,7 +174,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItem("  ")));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("  ")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -248,7 +204,32 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItem("item-1"), historyItem(null)));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build(),
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId(null)
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -265,7 +246,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithoutLoopIteration("item-1")));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(null)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -281,7 +275,20 @@ class AgentInstanceRequestValidatorTest {
           AgentInstanceUpdateRequest.Builder.create()
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
-      request.setHistory(List.of(historyItem("item-1")));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -298,7 +305,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey("not-a-number");
-      request.setHistory(List.of(historyItem("item-1")));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -318,7 +338,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithoutRole("item-1")));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(null)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -335,7 +368,15 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithoutContent("item-1")));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(null)
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -352,7 +393,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithProducedAt("item-1", null)));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt(null)
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -369,7 +423,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithProducedAt("item-1", "not-a-date")));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("not-a-date")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -427,7 +494,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithLoopIteration("item-1", 0)));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(0)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -445,7 +525,20 @@ class AgentInstanceRequestValidatorTest {
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithLoopIteration("item-1", -1)));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(-1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -458,14 +551,26 @@ class AgentInstanceRequestValidatorTest {
     @Test
     @DisplayName("Should reject a batch item with blank text content")
     void shouldRejectHistoryItemWithBlankTextContent() {
-      final AgentInstanceMessageContent content =
-          AgentInstanceTextContent.Builder.create().contentType("TEXT").text("  ").build();
       final var request =
           AgentInstanceUpdateRequest.Builder.create()
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithContent("item-1", List.of(content))));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          (AgentInstanceMessageContent)
+                              AgentInstanceTextContent.Builder.create()
+                                  .contentType("TEXT")
+                                  .text("  ")
+                                  .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -477,17 +582,26 @@ class AgentInstanceRequestValidatorTest {
     @Test
     @DisplayName("Should reject a batch item with document content missing a documentReference")
     void shouldRejectHistoryItemWithDocumentContentMissingDocumentReference() {
-      final AgentInstanceMessageContent content =
-          AgentInstanceDocumentContent.Builder.create()
-              .contentType("DOCUMENT")
-              .documentReference(null)
-              .build();
       final var request =
           AgentInstanceUpdateRequest.Builder.create()
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithContent("item-1", List.of(content))));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          (AgentInstanceMessageContent)
+                              AgentInstanceDocumentContent.Builder.create()
+                                  .contentType("DOCUMENT")
+                                  .documentReference(null)
+                                  .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
@@ -500,20 +614,290 @@ class AgentInstanceRequestValidatorTest {
     @Test
     @DisplayName("Should reject a batch item with object content missing an object")
     void shouldRejectHistoryItemWithObjectContentMissingObject() {
-      final AgentInstanceMessageContent content =
-          AgentInstanceObjectContent.Builder.create().contentType("OBJECT").object(null).build();
       final var request =
           AgentInstanceUpdateRequest.Builder.create()
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
               .build();
       request.setJobKey(JOB_KEY);
-      request.setHistory(List.of(historyItemWithContent("item-1", List.of(content))));
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          (AgentInstanceMessageContent)
+                              AgentInstanceObjectContent.Builder.create()
+                                  .contentType("OBJECT")
+                                  .object(null)
+                                  .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
 
       assertThat(result).isPresent();
       assertThat(result.get().getDetail()).isEqualTo("No history[0].content[0].object provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item tool without a name")
+    void shouldRejectHistoryItemToolWithoutName() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()
+                  .tools(
+                      List.of(
+                          AgentTool.Builder.create()
+                              .name(" ")
+                              .description(null)
+                              .elementId(null)
+                              .build()))));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].tools[0].name provided.");
+    }
+
+    @Test
+    @DisplayName("Should report the correct index for a second batch item tool without a name")
+    void shouldRejectSecondHistoryItemToolWithoutName() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()
+                  .tools(
+                      List.of(
+                          AgentTool.Builder.create()
+                              .name("search")
+                              .description(null)
+                              .elementId(null)
+                              .build(),
+                          AgentTool.Builder.create()
+                              .name(" ")
+                              .description(null)
+                              .elementId(null)
+                              .build()))));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].tools[1].name provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with an out-of-range limits.maxTokens")
+    void shouldRejectHistoryItemWithOutOfRangeMaxTokens() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()
+                  .limits(
+                      AgentInstanceLimits.Builder.create()
+                          .maxModelCalls(10)
+                          .maxTokens(-2L)
+                          .maxToolCalls(5)
+                          .build())));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("The value for history[0].limits.maxTokens is '-2' but must be >= -1.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with an out-of-range limits.maxModelCalls")
+    void shouldRejectHistoryItemWithOutOfRangeMaxModelCalls() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()
+                  .limits(
+                      AgentInstanceLimits.Builder.create()
+                          .maxModelCalls(-2)
+                          .maxTokens(1000L)
+                          .maxToolCalls(5)
+                          .build())));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("The value for history[0].limits.maxModelCalls is '-2' but must be >= -1.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with an out-of-range limits.maxToolCalls")
+    void shouldRejectHistoryItemWithOutOfRangeMaxToolCalls() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()
+                  .limits(
+                      AgentInstanceLimits.Builder.create()
+                          .maxModelCalls(10)
+                          .maxTokens(1000L)
+                          .maxToolCalls(-2)
+                          .build())));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("The value for history[0].limits.maxToolCalls is '-2' but must be >= -1.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with blank systemPrompt text content")
+    void shouldRejectHistoryItemWithBlankSystemPromptTextContent() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()
+                  .systemPrompt(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("  ")
+                              .build()))));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("No history[0].systemPrompt[0].text provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a batch item with an empty systemPrompt list")
+    void shouldRejectHistoryItemWithEmptySystemPrompt() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()
+                  .systemPrompt(List.of())));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].systemPrompt provided.");
     }
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -20,6 +20,7 @@ import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import io.camunda.gateway.protocol.model.AgentTool;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -677,6 +678,37 @@ class AgentInstanceRequestValidatorTest {
 
       assertThat(result).isPresent();
       assertThat(result.get().getDetail()).isEqualTo("No history[0].tools[0].name provided.");
+    }
+
+    @Test
+    @DisplayName("Should reject a null tool element in a batch item")
+    void shouldRejectNullToolInHistoryItem() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      request.setJobKey(JOB_KEY);
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("item-1")
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.CONFIGURATION)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()
+                  .tools(Arrays.asList((AgentTool) null))));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail()).isEqualTo("No history[0].tools[0] provided.");
     }
 
     @Test

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -362,8 +362,8 @@ class AgentInstanceRequestValidatorTest {
     }
 
     @Test
-    @DisplayName("Should reject a batch item with missing content")
-    void shouldRejectHistoryItemWithMissingContent() {
+    @DisplayName("Should allow a batch item with an empty content list")
+    void shouldAllowHistoryItemWithEmptyContentList() {
       final var request =
           AgentInstanceUpdateRequest.Builder.create()
               .elementInstanceKey(ELEMENT_INSTANCE_KEY)
@@ -374,16 +374,15 @@ class AgentInstanceRequestValidatorTest {
               AgentInstanceHistoryItem.Builder.create()
                   .historyItemId("item-1")
                   .loopIteration(1)
-                  .role(AgentInstanceHistoryRoleEnum.USER)
-                  .content(null)
+                  .role(AgentInstanceHistoryRoleEnum.ASSISTANT)
+                  .content(List.of())
                   .producedAt("2025-06-01T12:00:00Z")
                   .build()));
 
       final Optional<ProblemDetail> result =
           validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
 
-      assertThat(result).isPresent();
-      assertThat(result.get().getDetail()).isEqualTo("No history[0].content provided.");
+      assertThat(result).isEmpty();
     }
 
     @Test

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -964,6 +964,39 @@ components:
           description: The agent-side timestamp of when this message was produced.
           type: string
           format: date-time
+        tools:
+          description: |
+            The complete list of tools available to the agent as of this entry. CONFIGURATION
+            items only; omit for other roles. Omit to leave the tool list unchanged; send an
+            empty array to clear it.
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/AgentTool'
+        model:
+          description: |
+            The LLM model identifier as of this entry. CONFIGURATION items only; omit for other
+            roles.
+          type: string
+        provider:
+          description: |
+            The LLM provider as of this entry. CONFIGURATION items only; omit for other roles.
+          type: string
+        limits:
+          description: |
+            The operational limits as of this entry. CONFIGURATION items only; omit for other
+            roles.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceLimits'
+        systemPrompt:
+          description: |
+            The system prompt, as content blocks, as of this entry. CONFIGURATION items only;
+            omit for other roles. Omit to leave the system prompt unchanged; when present, must
+            be non-empty.
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/AgentInstanceMessageContent'
 
     AgentInstanceHistoryItemCreationResult:
       description: Response returned after successfully appending a history item.


### PR DESCRIPTION
## Summary

`PATCH /agent-instances/{key}` history batch items with role `CONFIGURATION` now accept `tools`, `model`, `provider`, `limits`, and `systemPrompt` — previously only `toolCalls`/content fields were wired for this role.

- OpenAPI schema (`AgentInstanceHistoryItem`) gains the five fields; `tools` and `systemPrompt` are `nullable: true` (see design note below), `model`/`provider`/`limits` are plain optional.
- `AgentInstanceRequestValidator` rejects malformed values: blank tool names, out-of-range `limits`, blank or explicitly-empty `systemPrompt`.
- `AgentInstanceMapper` maps all five fields onto `AgentHistoryRecord` and populates `changedAttributes` per field actually provided, mirroring the existing `AgentInstanceRecord`-level pattern in the same mapper.
- The Java client SDK (`clients/java`) exposes the same fields on the history item builder and maps them 1:1 onto the wire DTO, preserving the null-vs-empty distinction.

## Design note: why `tools`/`systemPrompt` are `nullable: true`

For fields tracked via `changedAttributes`, "omitted" (don't touch) and "explicitly empty" (clear it) are different client intents that must survive distinctly through to the engine. With `nullable: true`, OpenAPI-Generator gives the field no default initializer, so an absent JSON key deserializes to `null`; without it, an optional array property defaults to `new ArrayList<>()` on the generated DTO, making an absent field and an explicitly-empty one indistinguishable. This is the one case where `docs/rest-api-endpoint-guidelines.md` §2.4's usual guidance (arrays don't need `nullable`, omission from `required` is enough) doesn't apply, since PATCH semantics need the omit-vs-clear distinction.

## Out of scope

Engine-side consumption of these fields and `changedAttributes` (`AgentHistoryBatchHelper`, `ALLOWED_ATTRIBUTES`) lives in a separate, still-open PR (#59935) and is not part of this change. This PR only prepares the gateway/wire/client side so that future engine wiring has correct data to consume.

## Test plan

- [x] `AgentInstanceRequestValidatorTest` — failure-path coverage for CONFIGURATION fields (happy paths are covered via the mapper tests, which pass through the same validator)
- [x] `AgentInstanceMapperTest` — happy-path and defaulting coverage for CONFIGURATION fields (failure paths covered via the validator tests)
- [x] `UpdateAgentInstanceCommandTest` — Java client builder and mapping coverage, organized under `@Nested` groups

Closes #59783
