### PR TITLE
Basic auth membership context propagator

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/BasicAuthBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/BasicAuthBeansConfiguration.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.authentication.config;
 
+import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
@@ -20,6 +22,7 @@ import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import jakarta.annotation.PostConstruct;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.Authentication;
@@ -64,9 +67,25 @@ public class BasicAuthBeansConfiguration {
         .orElse(false);
   }
 
+  /**
+   * Physical-tenant-aware propagator for the lazy membership lists built during BASIC-auth login,
+   * so they still resolve once the request scope that built them is gone.
+   *
+   * <p>Not redundant with CSL's bean of the same type, which defaults to {@code identity()}: this
+   * wins only because this configuration is a plain {@code @Import} while CSL arrives via the
+   * deferred {@code @ImportAutoConfiguration}. Removing it silently restores the no-op.
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  public MembershipResolutionContextPropagator membershipResolutionContextPropagator() {
+    return new PhysicalTenantMembershipContextPropagator();
+  }
+
   @Bean
   public CamundaAuthenticationConverter<Authentication> usernamePasswordAuthenticationConverter(
-      final MembershipPort membershipPort) {
-    return new LazyUsernamePasswordAuthenticationTokenConverter(membershipPort);
+      final MembershipPort membershipPort,
+      final MembershipResolutionContextPropagator membershipResolutionContextPropagator) {
+    return new LazyUsernamePasswordAuthenticationTokenConverter(
+        membershipPort, membershipResolutionContextPropagator);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/BasicAuthBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/BasicAuthBeansConfiguration.java
@@ -68,12 +68,13 @@ public class BasicAuthBeansConfiguration {
   }
 
   /**
-   * Physical-tenant-aware propagator for the lazy membership lists built during BASIC-auth login,
-   * so they still resolve once the request scope that built them is gone.
+   * Carries the physical tenant into the lazy membership lists built during BASIC-auth login, so
+   * they still work after the request that created them has ended.
    *
-   * <p>Not redundant with CSL's bean of the same type, which defaults to {@code identity()}: this
-   * wins only because this configuration is a plain {@code @Import} while CSL arrives via the
-   * deferred {@code @ImportAutoConfiguration}. Removing it silently restores the no-op.
+   * <p>This looks redundant next to CSL's bean of the same type, but it is not: CSL's does nothing
+   * ({@code identity()}). This one is used only because this configuration is a plain
+   * {@code @Import} while CSL is loaded later, via {@code @ImportAutoConfiguration}. Delete it and
+   * the no-op quietly takes over.
    */
   @Bean
   @ConditionalOnMissingBean

--- a/authentication/src/main/java/io/camunda/authentication/config/BasicAuthBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/BasicAuthBeansConfiguration.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.config;
 
-import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
@@ -22,7 +21,6 @@ import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import jakarta.annotation.PostConstruct;
 import java.util.Map;
 import java.util.Optional;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.Authentication;
@@ -65,21 +63,6 @@ public class BasicAuthBeansConfiguration {
         .map(Map::values)
         .map(values -> values.stream().anyMatch(OidcConfiguration::isAnyPropertySet))
         .orElse(false);
-  }
-
-  /**
-   * Carries the physical tenant into the lazy membership lists built during BASIC-auth login, so
-   * they still work after the request that created them has ended.
-   *
-   * <p>This looks redundant next to CSL's bean of the same type, but it is not: CSL's does nothing
-   * ({@code identity()}). This one is used only because this configuration is a plain
-   * {@code @Import} while CSL is loaded later, via {@code @ImportAutoConfiguration}. Delete it and
-   * the no-op quietly takes over.
-   */
-  @Bean
-  @ConditionalOnMissingBean
-  public MembershipResolutionContextPropagator membershipResolutionContextPropagator() {
-    return new PhysicalTenantMembershipContextPropagator();
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/MembershipResolutionContextPropagatorConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/MembershipResolutionContextPropagatorConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers the host's {@link MembershipResolutionContextPropagator} once, method-agnostically, so
+ * no auth chain can forget to wire it. CSL defines its own bean of this type that does nothing
+ * ({@code identity()}); this one wins because this configuration is a plain {@code @Import} while
+ * CSL loads later, via {@code @ImportAutoConfiguration}.
+ */
+@Configuration
+public class MembershipResolutionContextPropagatorConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public MembershipResolutionContextPropagator membershipResolutionContextPropagator() {
+    return new PhysicalTenantMembershipContextPropagator();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -10,7 +10,6 @@ package io.camunda.authentication.config;
 import static java.util.stream.Collectors.toMap;
 
 import io.camunda.authentication.pt.PhysicalTenantOidcProviders;
-import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
 import io.camunda.security.api.context.OidcClaimsProvider;
@@ -107,12 +106,6 @@ public class OidcOverrideBeansConfiguration {
       throw new IllegalStateException(
           "Creation of initial users is not supported with `OIDC` authentication method");
     }
-  }
-
-  @Bean
-  @ConditionalOnMissingBean
-  public MembershipResolutionContextPropagator membershipResolutionContextPropagator() {
-    return new PhysicalTenantMembershipContextPropagator();
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -61,6 +61,7 @@ import org.springframework.security.web.firewall.StrictHttpFirewall;
 @Import({
   OidcOverrideBeansConfiguration.class,
   BasicAuthBeansConfiguration.class,
+  MembershipResolutionContextPropagatorConfiguration.class,
   SaasCspModeCompatibility.class,
   PhysicalTenantSecurityConfiguration.class,
   ClusterAdminBasicSecurityConfiguration.class,

--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthBeansConfigurationConverterWiringTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
+import io.camunda.security.core.port.out.MembershipPort;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.security.spring.context.CamundaAuthenticationBeansConfiguration;
+import io.camunda.spring.utils.PhysicalTenantContext;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Checks that BASIC-auth login wraps its lazy membership lists with the host's propagator, so the
+ * lists still work after the request that created them has ended.
+ */
+@ExtendWith(MockitoExtension.class)
+class BasicAuthBeansConfigurationConverterWiringTest {
+
+  @Mock private MembershipPort membershipPort;
+
+  @Test
+  void shouldSupplyLibraryNoOpPropagatorWithoutThisConfiguration() {
+    // given only the library's propagator bean, and a supplier we never call — all that matters is
+    // which object comes back
+    final Supplier<List<String>> probe = List::of;
+
+    // when the container is asked for a propagator
+    // then it returns the same supplier, so it wraps nothing. This shows the library really does
+    // define a propagator bean; without that, the next test would prove nothing.
+    libraryContext()
+        .run(
+            context ->
+                assertThat(
+                        context
+                            .getBean(MembershipResolutionContextPropagator.class)
+                            .decorate(probe))
+                    .isSameAs(probe));
+  }
+
+  @Test
+  void shouldResolvePhysicalTenantPropagatorRatherThanTheLibraryDefault() {
+    // given the library's propagator bean
+    // when this configuration is added the same way WebSecurityConfig adds it
+    // then Spring picks ours and the library's steps aside
+    libraryContext()
+        .withUserConfiguration(BasicAuthBeansConfiguration.class)
+        .run(
+            context ->
+                assertThat(context.getBean(MembershipResolutionContextPropagator.class))
+                    .isInstanceOf(PhysicalTenantMembershipContextPropagator.class));
+  }
+
+  @Test
+  void shouldResolveMembershipAgainstTenantCapturedAtLoginAfterRequestScopeEnds() {
+    // given a login that carries a physical tenant, converted with the real propagator
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenant-a");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    final Map<String, String> tenantSeenBy = new HashMap<>();
+    when(membershipPort.groupIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenBy.put("groupIds", PhysicalTenantContext.current());
+              return List.of("group-1");
+            });
+    when(membershipPort.roleIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenBy.put("roleIds", PhysicalTenantContext.current());
+              return List.of("role-1");
+            });
+    when(membershipPort.tenantIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenBy.put("tenantIds", PhysicalTenantContext.current());
+              return List.of("tenant-1");
+            });
+
+    final var configuration = configuration();
+    final var authentication =
+        configuration
+            .usernamePasswordAuthenticationConverter(
+                membershipPort, configuration.membershipResolutionContextPropagator())
+            .convert(new UsernamePasswordAuthenticationToken("alice", "pw"));
+
+    // when the request has ended before any list is read, as happens when a stored session writes
+    // the authentication out
+    RequestContextHolder.resetRequestAttributes();
+
+    // then every lookup uses the tenant from login time. Without the wrapping it would throw here.
+    assertThat(authentication.authenticatedGroupIds()).containsExactly("group-1");
+    assertThat(authentication.authenticatedRoleIds()).containsExactly("role-1");
+    assertThat(authentication.authenticatedTenantIds()).containsExactly("tenant-1");
+    assertThat(tenantSeenBy)
+        .containsEntry("groupIds", "tenant-a")
+        .containsEntry("roleIds", "tenant-a")
+        .containsEntry("tenantIds", "tenant-a");
+  }
+
+  @AfterEach
+  void clearRequestScope() {
+    // if a test fails early, the request it bound would leak into the next test
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  private static BasicAuthBeansConfiguration configuration() {
+    return new BasicAuthBeansConfiguration(new CamundaSecurityLibraryProperties());
+  }
+
+  /**
+   * A BASIC-auth context with the library configuration that defines the competing propagator bean.
+   * The beans added here are only what it needs to start up; none of them affect the assertions.
+   */
+  private ApplicationContextRunner libraryContext() {
+    return new ApplicationContextRunner()
+        .withPropertyValues("camunda.security.authentication.method=basic")
+        .withBean(CamundaSecurityLibraryProperties.class, CamundaSecurityLibraryProperties::new)
+        .withBean(MembershipPort.class, () -> membershipPort)
+        .withBean(HttpServletRequest.class, MockHttpServletRequest::new)
+        .withConfiguration(AutoConfigurations.of(CamundaAuthenticationBeansConfiguration.class));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthBeansConfigurationConverterWiringTest.java
@@ -21,7 +21,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,22 +43,16 @@ class BasicAuthBeansConfigurationConverterWiringTest {
   @Mock private MembershipPort membershipPort;
 
   @Test
-  void shouldSupplyLibraryNoOpPropagatorWithoutThisConfiguration() {
-    // given only the library's propagator bean, and a supplier we never call — all that matters is
-    // which object comes back
-    final Supplier<List<String>> probe = List::of;
-
+  void shouldSupplyLibraryPropagatorWithoutThisConfiguration() {
+    // given only the library's propagator bean
     // when the container is asked for a propagator
-    // then it returns the same supplier, so it wraps nothing. This shows the library really does
-    // define a propagator bean; without that, the next test would prove nothing.
+    // then it returns the library's, not ours — proof the library defines one at all, without which
+    // the next test would prove nothing
     libraryContext()
         .run(
             context ->
-                assertThat(
-                        context
-                            .getBean(MembershipResolutionContextPropagator.class)
-                            .decorate(probe))
-                    .isSameAs(probe));
+                assertThat(context.getBean(MembershipResolutionContextPropagator.class))
+                    .isNotInstanceOf(PhysicalTenantMembershipContextPropagator.class));
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthBeansConfigurationConverterWiringTest.java
@@ -61,7 +61,7 @@ class BasicAuthBeansConfigurationConverterWiringTest {
     // when this configuration is added the same way WebSecurityConfig adds it
     // then Spring picks ours and the library's steps aside
     libraryContext()
-        .withUserConfiguration(BasicAuthBeansConfiguration.class)
+        .withUserConfiguration(MembershipResolutionContextPropagatorConfiguration.class)
         .run(
             context ->
                 assertThat(context.getBean(MembershipResolutionContextPropagator.class))
@@ -99,7 +99,7 @@ class BasicAuthBeansConfigurationConverterWiringTest {
     final var authentication =
         configuration
             .usernamePasswordAuthenticationConverter(
-                membershipPort, configuration.membershipResolutionContextPropagator())
+                membershipPort, new PhysicalTenantMembershipContextPropagator())
             .convert(new UsernamePasswordAuthenticationToken("alice", "pw"));
 
     // when the request has ended before any list is read, as happens when a stored session writes

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha66</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha67</version.camunda-security-library>
     <version.checkstyle>13.10.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Description

BASIC-auth login built its lazy group/role/tenant lists without decorating them with the
host's `MembershipResolutionContextPropagator`, so no physical-tenant context was carried
into deferred resolution. `DefaultMembershipService` routes every membership query through
`PhysicalTenantContext.current()`, which throws when neither a request scope nor a
propagated tenant is bound. A persistent web session serialises the `CamundaAuthentication`
from `SessionRepositoryFilter`'s commit — after the request has been dispatched — forcing
the lazy lists to materialise with the scope already gone. OIDC was fixed for this in
#56261; BASIC auth was never migrated.

Declares the propagator as a bean and passes it to the converter's propagator-accepting
constructor, mirroring what `OidcOverrideBeansConfiguration` already does for OIDC. This
requires camunda-security-library `0.1.0-alpha67`, the first release containing
camunda-security-library#608.

## Related issues

Closes #59959
