### PR TITLE
Only fail secret injection when an unresolved placeholder actually survives

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -16,7 +16,9 @@ import java.util.Deque;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.camunda.feel.syntaxtree.ConstContext;
+import org.camunda.feel.syntaxtree.ConstList;
 import org.camunda.feel.syntaxtree.Exp;
+import org.camunda.feel.syntaxtree.If;
 import org.camunda.feel.syntaxtree.ParsedExpression;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -40,8 +42,15 @@ import scala.jdk.javaapi.CollectionConverters;
  *
  * <p>Known gaps (an undetected or less-specific reference is simply not resolved, so nothing
  * leaks): a {@code camunda} bound by an iterator/parameter/context key still reports the reference;
- * and a reference inside a context produced by a non-context expression (e.g. {@code =if c then {x:
- * camunda.secrets.token} else null}) is reported at the enclosing path, not the inner {@code x}.
+ * a reference inside a FEEL list literal (e.g. {@code =[camunda.secrets.token]}) is reported at the
+ * enclosing path, not per element; a reference inside a context produced by a non-context
+ * expression (e.g. {@code =if c then {x: camunda.secrets.token} else null}) is reported at the
+ * enclosing path, not the inner {@code x}; and, conversely, a reference inside a nested condition
+ * within such a container literal (e.g. {@code =if c then {x: if camunda.secrets.flag = "on" then 1
+ * else 2} else null}) is rejected at deploy time even though no placeholder ever lands there,
+ * because {@link #hasImpreciseReference} scans the whole container subtree rather than each
+ * reference's own position - fixing that needs {@code collect()} itself to track position, which is
+ * a larger refactor left for later.
  */
 @NullMarked
 public record SecretReference(String storeId, String name) {
@@ -93,6 +102,71 @@ public record SecretReference(String storeId, String name) {
     final var secrets = new ArrayList<DetectedSecret>();
     collect(feelExpression.getParsedExpression().expression(), new ArrayDeque<>(), secrets);
     return secrets;
+  }
+
+  /**
+   * True when the expression contains a {@code camunda.secrets.<name>} reference that {@link
+   * #parse} can only report at an enclosing path, not the reference's own leaf: inside a FEEL list
+   * literal, or inside a context literal produced by a branch of the expression rather than being
+   * its own root (see this class's "Known gaps" above). Used to reject such a mapping at deploy
+   * time instead of letting every instance of the element whose evaluated expression produces that
+   * container hit the same {@code SECRET_RESOLUTION_ERROR} incident - unconditionally for a list
+   * literal, or only the instances that take the producing branch for a conditional context.
+   *
+   * <p>This does not attempt to cover every way a FEEL expression could produce a container value
+   * (e.g. a function call, a {@code for...return}) - only the two shapes above. Anything else stays
+   * undetected, same as the rest of this class's documented limitations; JobSecretInjector's
+   * runtime guard is the safety net for those.
+   */
+  public static boolean hasImpreciseReference(@Nullable final Expression expression) {
+    if (!(expression instanceof final FeelExpression feelExpression)) {
+      return false;
+    }
+    return isImprecise(feelExpression.getParsedExpression().expression());
+  }
+
+  private static boolean isImprecise(final Exp node) {
+    if (node instanceof final ConstContext context) {
+      // collect() descends this precisely, entry by entry; the same question applies one level
+      // deeper for each entry, since an entry can itself hide a container reached only through an
+      // If branch or a list
+      return CollectionConverters.asJava(context.entries()).stream()
+          .anyMatch(entry -> isImprecise(entry._2()));
+    }
+    // collect() would use the getVariableReferences() fallback over the whole node here, which
+    // flattens the subtree onto the current path - a reference is imprecise exactly when it sits
+    // inside a container literal within the subtree; one not under any container contributes a
+    // scalar and stays leaf-precise
+    return containsReferenceInsideContainerLiteral(node);
+  }
+
+  /**
+   * True when a secret reference sits inside a {@link ConstList} or {@link ConstContext} literal
+   * that {@link #isImprecise} does not reach by descending {@code ConstContext} entries key by key
+   * - i.e. the literal is this node itself, or one reached through an {@link If} branch. A {@link
+   * ConstContext} is treated differently depending on how it's reached: {@link #isImprecise}
+   * descends its own entries key by key (precise, mirroring {@link #collect}), but reached any
+   * other way, {@code collect()} never descends into it and every reference inside lands at the
+   * enclosing path (imprecise).
+   */
+  private static boolean containsReferenceInsideContainerLiteral(final Exp node) {
+    if (node instanceof ConstList || node instanceof ConstContext) {
+      return containsReference(node);
+    }
+    if (node instanceof final If ifExp) {
+      return containsReferenceInsideContainerLiteral(ifExp.statement())
+          || containsReferenceInsideContainerLiteral(ifExp.elseStatement());
+    }
+    return false;
+  }
+
+  private static boolean containsReference(final Exp node) {
+    for (final var reference : new ParsedExpression(node, "").getVariableReferences()) {
+      if (isSecretReference(reference.getFullQualifiedName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLeafPrecisionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLeafPrecisionValidator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Rejects a deployment when a {@code camunda.secrets.<name>} reference sits inside a FEEL list
+ * literal, or inside a context literal produced by a branch of the expression rather than being the
+ * expression's own root (see {@link SecretReference}'s class javadoc, "Known gaps"). Both shapes
+ * make {@link SecretReference#parse} report the reference at an enclosing path instead of its own
+ * leaf, which can never resolve to a text value at injection - every instance of the element whose
+ * evaluated expression produces that container would hit the same {@code SECRET_RESOLUTION_ERROR}
+ * incident until the mapping is fixed: unconditionally for a list literal, or only the instances
+ * that take the producing branch for a conditional context. Rejecting at deploy time catches this
+ * before any instance runs.
+ *
+ * <p>This does not attempt to cover every way a FEEL expression could produce a container value
+ * (e.g. a function call) - only the two shapes named above; see {@link
+ * SecretReference#hasImpreciseReference}. Anything else stays undetected, same as {@link
+ * SecretReference}'s own documented limitations; {@code JobSecretInjector}'s runtime guard is the
+ * safety net for those.
+ */
+@NullMarked
+final class SecretReferenceLeafPrecisionValidator implements ModelElementValidator<ZeebeInput> {
+
+  private final ExpressionLanguage expressionLanguage;
+
+  SecretReferenceLeafPrecisionValidator(final ExpressionLanguage expressionLanguage) {
+    this.expressionLanguage = expressionLanguage;
+  }
+
+  @Override
+  public Class<ZeebeInput> getElementType() {
+    return ZeebeInput.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeInput element, final ValidationResultCollector validationResultCollector) {
+    final String source = element.getSource();
+    if (source == null) {
+      return;
+    }
+
+    final Expression expression = expressionLanguage.parseExpression(source);
+    if (!expression.isValid()) {
+      // invalid expressions are reported separately by the expression validator
+      return;
+    }
+
+    if (SecretReference.hasImpreciseReference(expression)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Input mapping source '%s' puts a secret reference inside a list, or inside a "
+                  + "context built by an 'if' branch. Camunda can only replace a secret where "
+                  + "the mapping assigns it directly to a value, so this secret would never be "
+                  + "filled in. Assign each secret reference to its own input mapping instead.",
+              source));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -50,6 +50,9 @@ public final class ZeebeRuntimeValidators {
         // property value (inbound), so both forms are handled uniformly
         SecretReferenceLiteralValidator.forInput(expressionLanguage),
         SecretReferenceLiteralValidator.forProperty(expressionLanguage),
+        // reject a secret reference Camunda could never fill in, because it sits inside a list
+        // or inside a context built by an 'if' branch
+        new SecretReferenceLeafPrecisionValidator(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeOutput.class)
             .hasValidExpression(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -51,7 +51,9 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
   // named distinctly from BpmnIncidentBehavior#SECRET_INJECTION_FAILED_MESSAGE: same error type,
   // different cause-neutral fallback text, because that one is shared with the job-push path and
-  // this one is reached only when this path's own FailedInjectionJob carries no path/placeholder
+  // this one is reached only when this path's own FailedInjectionJob carries no path/placeholder.
+  // Once the job-push path also names the mismatch (#60404), the two fallbacks - and this path's
+  // named-mismatch message alongside the job-push one - become candidates to merge (#60405)
   private static final String SECRET_INJECTION_UNKNOWN_CAUSE_MESSAGE =
       "The job with key '%s' can not be activated, because injecting its secret values "
           + "failed. Resolve the incident, or use process instance modification to "

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -49,6 +49,20 @@ import java.util.Map;
 @ExcludeAuthorizationCheck
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
 
+  // named distinctly from BpmnIncidentBehavior#SECRET_INJECTION_FAILED_MESSAGE: same error type,
+  // different cause-neutral fallback text, because that one is shared with the job-push path and
+  // this one is reached only when this path's own FailedInjectionJob carries no path/placeholder
+  private static final String SECRET_INJECTION_UNKNOWN_CAUSE_MESSAGE =
+      "The job with key '%s' can not be activated, because injecting its secret values "
+          + "failed. Resolve the incident, or use process instance modification to "
+          + "reactivate the element and create a fresh job.";
+
+  private static final String SECRET_REFERENCE_UNRESOLVED_MESSAGE =
+      "The job with key '%s' can not be activated, because the secret reference '%s' "
+          + "could not be resolved at '%s'. Fix the variable's value or the input "
+          + "mapping that sets it, then resolve the incident, or use process instance "
+          + "modification to reactivate the element and create a fresh job.";
+
   /** Scratch copy of the batch that carries the injected secret values to the response only. */
   private final JobBatchRecord responseValue = new JobBatchRecord();
 
@@ -325,19 +339,27 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   }
 
   /**
-   * Raises an incident for a job whose secret value injection failed. The incident message is a
-   * fixed text shared with the job push, which raises the same incident for the same cause: the
-   * failure details are only logged, so no secret-related data (the exception may quote the
-   * variables document) can end up in persisted records. The job is also excluded from activation
-   * until this incident is resolved (see IncidentCreatedV2Applier's SECRET_RESOLUTION_ERROR
-   * handling), so it does not loop through repeated failing injections.
+   * Raises an incident for a job whose secret value injection failed. When the mismatched reference
+   * is known, the message names its placeholder and JSON pointer path - never the secret's value,
+   * and never anything from the exception's own (log-only) message; an unrelated failure (e.g.
+   * invalid msgpack) has neither, so the message stays cause-neutral instead of naming a mismatch
+   * that was never established. Unlike the job-push path's {@link
+   * BpmnIncidentBehavior#SECRET_INJECTION_FAILED_MESSAGE}, this path has a {@link
+   * FailedInjectionJob} to draw on, so its cause-neutral fallback is its own, separate message
+   * rather than that shared one. The job is also excluded from activation until this incident is
+   * resolved (see IncidentCreatedV2Applier's SECRET_RESOLUTION_ERROR handling), so it does not loop
+   * through repeated failing injections.
    */
   private void raiseIncidentJobSecretInjectionFailed(final FailedInjectionJob failed) {
-    raiseJobIncident(
-        failed.jobKey(),
-        failed.job(),
-        ErrorType.SECRET_RESOLUTION_ERROR,
-        BpmnIncidentBehavior.SECRET_INJECTION_FAILED_MESSAGE.formatted(failed.jobKey()));
+    final String message =
+        failed.path() == null
+            ? String.format(SECRET_INJECTION_UNKNOWN_CAUSE_MESSAGE, failed.jobKey())
+            : String.format(
+                SECRET_REFERENCE_UNRESOLVED_MESSAGE,
+                failed.jobKey(),
+                failed.placeholder(),
+                failed.path());
+    raiseJobIncident(failed.jobKey(), failed.job(), ErrorType.SECRET_RESOLUTION_ERROR, message);
   }
 
   private void raiseMessageSizeExceededIncident(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReferen
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup.CachedSecret;
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup.Secret;
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup.SecretCheckResult;
+import io.camunda.zeebe.engine.processing.job.JobSecretLookup.SecretPointerMismatchException;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -42,9 +43,10 @@ import org.slf4j.LoggerFactory;
  *       registered via {@link #registerForInjection}.
  *   <li>{@link #injectSecretValues} replaces the placeholder text {@code camunda.secrets.<name>} of
  *       the registered jobs with the cached value on a response-only copy of the batch, at the JSON
- *       pointer recorded for each reference. Jobs whose values would grow the response beyond the
+ *       pointer recorded for each reference (see {@link JobSecretLookup} for how a reference that
+ *       finds no placeholder is tolerated). Jobs whose values would grow the response beyond the
  *       max message size are dropped from the activation instead, and a job whose injection fails
- *       is dropped and reported for an incident.
+ *       is dropped and reported for an incident, naming the mismatched pointer when it is known.
  * </ol>
  *
  * <p>The cached values are read once at check time and reused for the injection, so a value evicted
@@ -53,7 +55,9 @@ import org.slf4j.LoggerFactory;
  * on the response only: state, records, and logs keep the placeholders.
  *
  * <p>The job-push path injects the same values into the job it streams, see {@code
- * BpmnJobActivationBehavior#publishWork}.
+ * BpmnJobActivationBehavior#publishWork}; it shares {@link JobSecretLookup}, so it tolerates the
+ * same shapes, but reports a failed injection with a generic incident message rather than naming
+ * the mismatched pointer (tracked separately).
  */
 public final class JobSecretInjector {
 
@@ -158,10 +162,11 @@ public final class JobSecretInjector {
    * first job whose values would push the response past that is dropped together with every job
    * after it, from the response batch and the to-be-activated batch alike (both must still contain
    * the same jobs), so the dropped jobs stay activatable and the next activation, with a fresh
-   * batch, picks them up right away. A job whose injection fails is dropped the same way; its
-   * failure details are only logged, so no secret-related data can end up in persisted records.
-   * Must run before the ACTIVATED event is appended. Returns the dropped job the caller must raise
-   * an incident for: a job whose injection failed, or a job whose values can never fit any batch.
+   * batch, picks them up right away. A job whose injection fails is dropped the same way; the
+   * exception's own message is only logged, but its placeholder and JSON pointer (never its value)
+   * are carried out for the incident message. Must run before the ACTIVATED event is appended.
+   * Returns the dropped job the caller must raise an incident for: a job whose injection failed, or
+   * a job whose values can never fit any batch.
    *
    * @param baseLength the length the batch already occupies before any value is injected, i.e. the
    *     length of the collected activation command; the injected growth is measured on top of it
@@ -212,7 +217,8 @@ public final class JobSecretInjector {
   /**
    * Drops the job whose injection failed and every job after it from both batches, and returns it
    * for an incident, so the job cannot loop through activation with a failing injection. The
-   * failure details are only logged, so no secret-related data can end up in persisted records.
+   * exception's own message is only logged; only its placeholder and JSON pointer are carried out
+   * for the incident message (see JobBatchActivateProcessor#raiseIncidentJobSecretInjectionFailed).
    */
   private static FailedInjectionJob dropJobsWhoseInjectionFailed(
       final JobBatchRecord responseBatch,
@@ -228,7 +234,11 @@ public final class JobSecretInjector {
         removed.jobKey(),
         removed.job().getType(),
         failure);
-    return new FailedInjectionJob(removed.jobKey(), removed.job());
+    if (failure instanceof final SecretPointerMismatchException mismatch) {
+      return new FailedInjectionJob(
+          removed.jobKey(), removed.job(), mismatch.path(), mismatch.placeholder());
+    }
+    return new FailedInjectionJob(removed.jobKey(), removed.job(), null, null);
   }
 
   /**
@@ -287,8 +297,13 @@ public final class JobSecretInjector {
    */
   public record OversizedJob(long jobKey, JobRecord job, int growth) implements DroppedJob {}
 
-  /** A job dropped from the batch because injecting its secret values failed. */
-  public record FailedInjectionJob(long jobKey, JobRecord job) implements DroppedJob {}
+  /**
+   * A job dropped from the batch because injecting its secret values failed. {@code path} and
+   * {@code placeholder} identify the secret whose pointer didn't match, or are both {@code null}
+   * for an unrelated failure (e.g. the job's variables are not valid msgpack).
+   */
+  public record FailedInjectionJob(long jobKey, JobRecord job, String path, String placeholder)
+      implements DroppedJob {}
 
   /** A registered job: its index in the batch, the job, and its cached secrets. */
   record JobWithCachedSecrets(int index, JobRecord job, List<CachedSecret> cachedSecrets) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -57,7 +57,8 @@ import org.slf4j.LoggerFactory;
  * <p>The job-push path injects the same values into the job it streams, see {@code
  * BpmnJobActivationBehavior#publishWork}; it shares {@link JobSecretLookup}, so it tolerates the
  * same shapes, but reports a failed injection with a generic incident message rather than naming
- * the mismatched pointer (tracked separately).
+ * the mismatched pointer (tracked in <a
+ * href="https://github.com/camunda/camunda/issues/60404">#60404</a>).
  */
 public final class JobSecretInjector {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretLookup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretLookup.java
@@ -19,10 +19,13 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobSecretReference;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.io.DirectBufferInputStream;
+import org.jspecify.annotations.Nullable;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
 
 /**
@@ -37,9 +40,17 @@ import org.msgpack.jackson.dataformat.MessagePackFactory;
  * #injectedVariablesOf(JobRecord, List)} cannot lose a value that was evicted from the cache in
  * between, and the values live no longer than the result the caller holds.
  *
+ * <p>A checked reference means a secret is *possibly* referenced by the evaluated expression, not
+ * that one certainly is: FEEL evaluates only one branch of a conditional, so detection records a
+ * reference for every branch at the same pointer. A reference that finds no placeholder therefore
+ * fails the injection only when placeholder-shaped text survives at its path once every reference
+ * has been attempted - a sibling reference at the same path may be the one that resolves it.
+ *
  * <p>The replacement is textual: every occurrence of the placeholder in the addressed leaf is
  * replaced, including text that merely spells out the placeholder next to a real reference at the
- * same path. This can only surface a secret in a leaf that already receives that secret.
+ * same path. This can only surface a secret in a leaf that already receives that secret. The
+ * residual scan for a surviving placeholder reads the injected result rather than the original
+ * text, so a secret value that itself contains placeholder-shaped text would fail closed too.
  */
 public final class JobSecretLookup {
 
@@ -75,9 +86,11 @@ public final class JobSecretLookup {
   }
 
   /**
-   * Returns the job's variables with every secret placeholder replaced by the value read for it, or
-   * {@code null} when no placeholder was found. A failure propagates to the caller, which must keep
-   * the job from being activated and report it for an incident.
+   * Returns the job's variables with every secret placeholder replaced by its cached value, or
+   * {@code null} when nothing was replaced. A reference that finds no placeholder is only a failure
+   * when placeholder-shaped text survives at its path. That check runs once per distinct path,
+   * after every reference has been attempted, because a sibling reference at the same path may be
+   * the one that resolves it.
    *
    * <p>Only the secrets of a {@link #check(JobRecord)} of the same job may be passed in; a value
    * read for another job is not addressed by this job's paths.
@@ -86,13 +99,41 @@ public final class JobSecretLookup {
       throws IOException {
     final DirectBuffer variables = job.getVariablesBuffer();
     final JsonNode document = variablesMapper.readTree(new DirectBufferInputStream(variables));
-    // a placeholder can be absent (e.g. fetchVariables excluded the variable); an unchanged job
-    // must keep its original encoding and stay out of any growth budget, so it returns null
     boolean changed = false;
+    // keyed by path and filled with putIfAbsent so a FEEL conditional's branches, which all
+    // register their reference at the same path, are scanned only once
+    final var unresolved = new LinkedHashMap<String, Secret>();
     for (final CachedSecret cachedSecret : cachedSecrets) {
-      changed |= replaceInLeaf(document, cachedSecret);
+      final LeafResult result = replaceInLeaf(document, cachedSecret);
+      if (result.replaced()) {
+        changed = true;
+      } else if (result.unresolvedNode() != null) {
+        unresolved.putIfAbsent(cachedSecret.secret().path(), cachedSecret.secret());
+      }
     }
+    if (!unresolved.isEmpty()) {
+      failIfAnyPlaceholderSurvives(document, unresolved.values());
+    }
+    // an unchanged job must keep its original encoding and stay out of any growth budget
     return changed ? variablesMapper.writeValueAsBytes(document) : null;
+  }
+
+  /**
+   * Throws when placeholder-shaped text survives at the path of a reference that found no
+   * placeholder of its own, scanning each distinct path once. Reads the document fresh for each one
+   * rather than a node captured during the loop above: a sibling reference at the same path can
+   * still replace the placeholder after this secret's own attempt found nothing, and a text node is
+   * immutable, so a node captured mid-loop would never reflect that later replacement - the outcome
+   * would then depend on which reference is attempted first.
+   */
+  private static void failIfAnyPlaceholderSurvives(
+      final JsonNode document, final Collection<Secret> unresolved) {
+    for (final Secret secret : unresolved) {
+      final JsonNode node = deepestExisting(document, JsonPointer.compile(secret.path())).node();
+      if (node != null && holdsPlaceholder(node)) {
+        throw new SecretPointerMismatchException(secret.path(), secret.placeholder());
+      }
+    }
   }
 
   /**
@@ -107,38 +148,103 @@ public final class JobSecretLookup {
   }
 
   /**
-   * Replaces the placeholder in the text leaf addressed by the secret's JSON pointer. Pointers that
-   * do not address a text leaf of an object (e.g. the path no longer matches the variables, or it
-   * runs into an array) are skipped defensively. A text leaf that does not contain the expected
-   * placeholder is not skipped: it means the referenced value changed between input mapping
-   * evaluation and job creation, so it fails the injection instead (see the class javadoc).
+   * Replaces the placeholder in the text leaf addressed by the secret's JSON pointer. Returns a
+   * replaced result when it did, an absent result when nothing of ours is at that pointer at all
+   * (an unset key, e.g. because the worker's fetchVariables excluded it), or an unresolved result
+   * carrying the node the caller must scan for a surviving placeholder — the leaf, or the scalar or
+   * array the pointer tried to descend into.
+   *
+   * <p>Nothing is thrown here: whether a non-replacement is a failure depends on what the other
+   * references at the same path do, which is only known once they have all been attempted.
    */
-  private static boolean replaceInLeaf(final JsonNode document, final CachedSecret cachedSecret) {
+  private static LeafResult replaceInLeaf(
+      final JsonNode document, final CachedSecret cachedSecret) {
     final Secret secret = cachedSecret.secret();
     if (!secret.path().startsWith("/")) {
-      return false;
+      return LeafResult.ABSENT;
     }
     final JsonPointer pointer = JsonPointer.compile(secret.path());
-    final JsonNode parent = document.at(pointer.head());
-    final JsonNode leaf = document.at(pointer);
-    if (!parent.isObject() || !leaf.isTextual()) {
-      return false;
+    final Walked walked = deepestExisting(document, pointer);
+    final JsonNode stopped = walked.node();
+    if (stopped == null) {
+      // the walk stopped on a container that simply lacks our key: our slot is unset, so there is
+      // nothing to replace and nothing that could have been left behind
+      return LeafResult.ABSENT;
     }
-    final String text = leaf.textValue();
+    if (!stopped.isTextual() || walked.parent() == null) {
+      // either a container or array at the leaf, a scalar the pointer tried to descend into, or a
+      // text leaf whose immediate parent isn't a genuine object property and so can't be written to
+      return LeafResult.unresolved(stopped);
+    }
+    final String text = stopped.textValue();
     final String replaced = text.replace(secret.placeholder(), cachedSecret.value());
     if (replaced.equals(text)) {
-      throw new IllegalStateException(
-          "Secret reference '"
-              + secret.placeholder()
-              + "' at "
-              + secret.path()
-              + " does not match the job's variables — the referenced value changed since the "
-              + "placeholder was baked in (job variables are re-read from the current variable "
-              + "scope on every activation attempt, so a later merge into that scope can overwrite "
-              + "it)");
+      return LeafResult.unresolved(stopped);
     }
-    ((ObjectNode) parent).put(pointer.last().getMatchingProperty(), replaced);
-    return true;
+    walked.parent().put(pointer.last().getMatchingProperty(), replaced);
+    return LeafResult.REPLACED;
+  }
+
+  /**
+   * Walks the pointer segment by segment from the document root, returning the deepest existing
+   * node it reaches together with the object that holds it - captured during the same walk instead
+   * of re-resolving the pointer's head afterwards. The node is {@code null} when an object simply
+   * doesn't hold the next key: our slot is legitimately unset, e.g. because the worker's
+   * fetchVariables excluded it. An array is different: the cluster-variable scanner does produce
+   * array-index pointers, for a secret nested inside a {@code SECRET_REFERENCE} variable's list
+   * (see {@code ClusterVariableSecretReferenceScanner}), and injection can only write into an
+   * object via {@code ObjectNode.put} - it can never write into an array, in range or not. A
+   * missing array index is therefore not read as absent; the array itself is returned so the caller
+   * fails closed on it, exactly like an in-range index whose element is reached but sits one level
+   * below an array rather than an object (see the {@code parent} check below). The parent is {@code
+   * null} whenever the node isn't reached through a genuine object property one segment up - a
+   * scalar or array immediately above it can't be written back to by key. Walking segment by
+   * segment - rather than asking {@link JsonNode#at} for the leaf and its parent separately - is
+   * what makes tracking both possible in one pass, at a cost of one key lookup per segment.
+   */
+  private static Walked deepestExisting(final JsonNode document, final JsonPointer pointer) {
+    JsonNode current = document;
+    ObjectNode parentIfObject = null;
+    for (JsonPointer remaining = pointer; !remaining.matches(); remaining = remaining.tail()) {
+      if (!current.isContainerNode()) {
+        // a scalar occupies this path already; the remaining segments have nothing to descend into
+        return new Walked(current, null);
+      }
+      parentIfObject = current.isObject() ? (ObjectNode) current : null;
+      final JsonNode next =
+          current.isArray()
+              ? current.get(remaining.getMatchingIndex())
+              : current.get(remaining.getMatchingProperty());
+      if (next == null) {
+        // an object missing the key is unset; an array is never writable, whether or not the
+        // index exists - fail closed by scanning the array itself instead of treating it as absent
+        return new Walked(current.isArray() ? current : null, null);
+      }
+      current = next;
+    }
+    return new Walked(current, parentIfObject);
+  }
+
+  /**
+   * True when the node still holds text that looks like an unresolved {@code
+   * camunda.secrets.<name>} placeholder. Reads the node *after* every replacement, so a placeholder
+   * that resolved is already overwritten by its value and cannot match — which also avoids
+   * tokenising the original text, something adjacent placeholders do not survive (the name class is
+   * greedy, so {@code camunda.secrets.a} followed directly by {@code camunda.secrets.b} reads as
+   * one token). A container is descended, since that is the whole reason it is a failure.
+   */
+  private static boolean holdsPlaceholder(final JsonNode node) {
+    if (node.isTextual()) {
+      return SecretReference.REFERENCE_PATTERN.matcher(node.textValue()).find();
+    }
+    if (node.isContainerNode()) {
+      for (final JsonNode child : node) {
+        if (holdsPlaceholder(child)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**
@@ -177,4 +283,64 @@ public final class JobSecretLookup {
    * caller holds and no longer.
    */
   public record CachedSecret(Secret secret, String value) {}
+
+  /**
+   * Thrown by {@link #injectedVariablesOf} when a secret reference's JSON pointer exists but
+   * doesn't address a text leaf of an object, or addresses one whose content doesn't contain the
+   * expected placeholder, and no sibling reference at the same path resolved it either.
+   * Package-private: only {@link JobSecretInjector} inspects {@link #path()} and {@link
+   * #placeholder()} to name the mismatch in a {@code SECRET_RESOLUTION_ERROR} incident; the
+   * job-push path catches it as a plain failure and falls back to a generic incident message, since
+   * this exception's own message is log-only and never persisted.
+   */
+  static final class SecretPointerMismatchException extends RuntimeException {
+    private final String path;
+    private final String placeholder;
+
+    SecretPointerMismatchException(final String path, final String placeholder) {
+      super(
+          "Secret reference '"
+              + placeholder
+              + "' at '"
+              + path
+              + "' does not address a text leaf of the job's variables, or its content no longer "
+              + "matches the placeholder - the referenced value or its containing structure "
+              + "changed since the placeholder was baked in (job variables are re-read from the "
+              + "current variable scope on every activation attempt, so a later merge into that "
+              + "scope can overwrite it), or the mapping that produced it never addresses a "
+              + "single text value in the first place.");
+      this.path = path;
+      this.placeholder = placeholder;
+    }
+
+    String path() {
+      return path;
+    }
+
+    String placeholder() {
+      return placeholder;
+    }
+  }
+
+  /**
+   * The outcome of {@link #replaceInLeaf}: whether the placeholder was replaced, and - when it
+   * wasn't - the node the caller must scan for a surviving one, {@code null} when nothing of ours
+   * is at the pointer at all. A boolean flag rather than a sentinel node: Jackson caches small
+   * nodes like {@code BooleanNode.TRUE}, so a real leaf holding that same value could otherwise
+   * collide with an identity-based "was it replaced" signal.
+   */
+  private record LeafResult(boolean replaced, @Nullable JsonNode unresolvedNode) {
+    private static final LeafResult REPLACED = new LeafResult(true, null);
+    private static final LeafResult ABSENT = new LeafResult(false, null);
+
+    private static LeafResult unresolved(final JsonNode node) {
+      return new LeafResult(false, node);
+    }
+  }
+
+  /**
+   * The result of {@link #deepestExisting}: the deepest node a pointer walk reaches, and - only
+   * when that node is reached through a genuine object property - the object holding it.
+   */
+  private record Walked(@Nullable JsonNode node, @Nullable ObjectNode parent) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretLookup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretLookup.java
@@ -50,7 +50,9 @@ import org.msgpack.jackson.dataformat.MessagePackFactory;
  * replaced, including text that merely spells out the placeholder next to a real reference at the
  * same path. This can only surface a secret in a leaf that already receives that secret. The
  * residual scan for a surviving placeholder reads the injected result rather than the original
- * text, so a secret value that itself contains placeholder-shaped text would fail closed too.
+ * text, so a secret value that itself contains placeholder-shaped text would fail closed when
+ * another reference at the same path triggers the check - a lone reference that replaces its own
+ * placeholder cleanly is never rescanned.
  */
 public final class JobSecretLookup {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretLookup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretLookup.java
@@ -205,26 +205,35 @@ public final class JobSecretLookup {
    * what makes tracking both possible in one pass, at a cost of one key lookup per segment.
    */
   private static Walked deepestExisting(final JsonNode document, final JsonPointer pointer) {
-    JsonNode current = document;
-    ObjectNode parentIfObject = null;
+    JsonNode node = document;
+    // the object directly above `node`, or null when `node` sits under a scalar or array and so
+    // can't be written back to by key; recomputed on each descent
+    ObjectNode writableParent = null;
     for (JsonPointer remaining = pointer; !remaining.matches(); remaining = remaining.tail()) {
-      if (!current.isContainerNode()) {
+      if (!node.isContainerNode()) {
         // a scalar occupies this path already; the remaining segments have nothing to descend into
-        return new Walked(current, null);
+        return new Walked(node, null);
       }
-      parentIfObject = current.isObject() ? (ObjectNode) current : null;
-      final JsonNode next =
-          current.isArray()
-              ? current.get(remaining.getMatchingIndex())
-              : current.get(remaining.getMatchingProperty());
-      if (next == null) {
+      writableParent = node.isObject() ? (ObjectNode) node : null;
+      final JsonNode child = childOf(node, remaining);
+      if (child == null) {
         // an object missing the key is unset; an array is never writable, whether or not the
         // index exists - fail closed by scanning the array itself instead of treating it as absent
-        return new Walked(current.isArray() ? current : null, null);
+        return new Walked(node.isArray() ? node : null, null);
       }
-      current = next;
+      node = child;
     }
-    return new Walked(current, parentIfObject);
+    return new Walked(node, writableParent);
+  }
+
+  /**
+   * The child the pointer's leading segment selects from {@code container}: by index when it is an
+   * array, by property name when it is an object. {@code null} when no such child exists.
+   */
+  private static @Nullable JsonNode childOf(final JsonNode container, final JsonPointer segment) {
+    return container.isArray()
+        ? container.get(segment.getMatchingIndex())
+        : container.get(segment.getMatchingProperty());
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
@@ -162,6 +162,186 @@ class SecretReferenceTest {
     assertThat(new SecretReference("token").reference()).isEqualTo("camunda.secrets.token");
   }
 
+  @ParameterizedTest(name = "[{index}] {0}")
+  @ValueSource(
+      strings = {
+        // case A: a secret reference inside a FEEL list literal
+        "=[camunda.secrets.x]",
+        "=[camunda.secrets.x, camunda.secrets.y]",
+        "=[1, camunda.secrets.x]",
+        // case B: a secret reference inside a context literal produced by a branch, not the root
+        "=if true then {x: camunda.secrets.token} else null",
+        "=if true then null else {x: camunda.secrets.token}",
+        // nested if/then/else, reference several branches deep
+        "=if a then (if b then {x: camunda.secrets.token} else null) else null",
+        // a list nested inside a context produced by a branch
+        "=if a then {x: [camunda.secrets.token]} else null",
+        // a list nested inside a root context (the list itself is still not descended)
+        "={x: [camunda.secrets.token]}",
+        // mixed: the then-branch alone is imprecise, so the whole conditional still is
+        "=if c then {x: camunda.secrets.a} else camunda.secrets.b"
+      })
+  void shouldReportImpreciseReference(final String source) {
+    // when / then
+    assertThat(SecretReference.hasImpreciseReference(expressionLanguage.parseExpression(source)))
+        .isTrue();
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @ValueSource(
+      strings = {
+        // a plain scalar reference
+        "=camunda.secrets.token",
+        // embedded in a string via concatenation - still a single scalar leaf
+        "=\"Bearer \" + camunda.secrets.token",
+        // a context literal is descended precisely, at the root and nested
+        "={x: camunda.secrets.token}",
+        "={x: {y: camunda.secrets.token}}",
+        // a list or conditional with no secret reference inside is not flagged
+        "=[1, 2, 3]",
+        "=if true then 1 else 2",
+        // no reference at all
+        "=userId + orderId",
+        // not an expression: the whole value is a literal, parse() already returns nothing for it
+        "camunda.secrets.token",
+        // container and secret in different branches: the secret branch is leaf-precise and the
+        // container branch leaves no placeholder
+        "=if useDefault then {x: \"literal\"} else camunda.secrets.token",
+        // same, list variant
+        "=if useDefault then [1, 2] else camunda.secrets.token",
+        // the secret is only in the condition, so no placeholder ever reaches the mapping target
+        "=if camunda.secrets.flag = \"on\" then {x: 1} else null"
+      })
+  void shouldNotReportImpreciseReference(final String source) {
+    // when / then
+    assertThat(SecretReference.hasImpreciseReference(expressionLanguage.parseExpression(source)))
+        .isFalse();
+  }
+
+  @Test
+  void shouldNotReportImpreciseReferenceForNullExpression() {
+    // when / then
+    assertThat(SecretReference.hasImpreciseReference(null)).isFalse();
+  }
+
+  @Test
+  void shouldReportBothBranchesOfAConditionalAtTheEnclosingPath() {
+    // given - FEEL takes one branch, but detection cannot know which, so both are recorded
+    final var source = "=if cond then camunda.secrets.x else camunda.secrets.y";
+
+    // when
+    final var located = SecretReference.parse(expressionLanguage.parseExpression(source));
+
+    // then - both at the empty path, i.e. the mapping target's own leaf
+    assertThat(located)
+        .extracting(DetectedSecret::path, DetectedSecret::secret)
+        .containsExactlyInAnyOrder(
+            tuple(List.of(), new SecretReference("x")), tuple(List.of(), new SecretReference("y")));
+  }
+
+  @Test
+  void shouldReportEveryBranchOfNestedConditionals() {
+    // given
+    final var source =
+        "=if a then (if b then camunda.secrets.p else camunda.secrets.q) else camunda.secrets.r";
+
+    // when / then
+    assertThat(referencesIn(source))
+        .containsExactlyInAnyOrder(
+            new SecretReference("p"), new SecretReference("q"), new SecretReference("r"));
+  }
+
+  @Test
+  void shouldReportConditionalNestedInsideConcatenation() {
+    // given
+    final var source =
+        "=\"Bearer \" + (if prod then camunda.secrets.prodT else camunda.secrets.devT)";
+
+    // when / then
+    assertThat(referencesIn(source))
+        .containsExactlyInAnyOrder(new SecretReference("prodT"), new SecretReference("devT"));
+  }
+
+  @Test
+  void shouldReportOnlyTheSecretBranchWhenTheOtherIsALiteral() {
+    // given
+    final var source = "=if true then \"localSecret\" else camunda.secrets.prod";
+
+    // when / then
+    assertThat(referencesIn(source)).containsExactly(new SecretReference("prod"));
+  }
+
+  @Test
+  void shouldReportSecretUsedOnlyInAConditionalCondition() {
+    // given - the secret is compared, never mapped, but it is still a reference
+    final var source = "=if camunda.secrets.flag = \"on\" then \"a\" else \"b\"";
+
+    // when / then
+    assertThat(referencesIn(source)).containsExactly(new SecretReference("flag"));
+  }
+
+  @Test
+  void shouldDeduplicateTheSameSecretInBothBranches() {
+    // given - one reference, so injection always finds its placeholder
+    final var source = "=if c then camunda.secrets.t else camunda.secrets.t";
+
+    // when / then
+    assertThat(referencesIn(source)).containsExactly(new SecretReference("t"));
+  }
+
+  @Test
+  void shouldReportSecretWrappedInAFunctionCall() {
+    // given - the reference is detected even though the function will mangle the placeholder
+    // beyond matching at injection
+    final var source = "=upper case(camunda.secrets.token)";
+
+    // when / then
+    assertThat(referencesIn(source)).containsExactly(new SecretReference("token"));
+  }
+
+  @Test
+  void shouldReportSecretInsideAListLiteralAtTheEnclosingPath() {
+    // given - a list literal is not descended, so the reference lands on the enclosing path
+    final var source = "=[camunda.secrets.X, camunda.secrets.Y]";
+
+    // when
+    final var located = SecretReference.parse(expressionLanguage.parseExpression(source));
+
+    // then
+    assertThat(located)
+        .extracting(DetectedSecret::path, DetectedSecret::secret)
+        .containsExactlyInAnyOrder(
+            tuple(List.of(), new SecretReference("X")), tuple(List.of(), new SecretReference("Y")));
+  }
+
+  @Test
+  void shouldReportSecretBehindAListIndexAtTheEnclosingPath() {
+    // given - indexing a list literal yields a text leaf at runtime, so this resolves fine
+    final var source = "=[camunda.secrets.x][1]";
+
+    // when
+    final var located = SecretReference.parse(expressionLanguage.parseExpression(source));
+
+    // then
+    assertThat(located)
+        .extracting(DetectedSecret::path, DetectedSecret::secret)
+        .containsExactly(tuple(List.of(), new SecretReference("x")));
+  }
+
+  @Test
+  void shouldReportSecretInsideAForReturnAtTheEnclosingPath() {
+    // given - produces a list at runtime, which injection cannot address
+    final var source = "=for i in [1, 2] return camunda.secrets.token";
+
+    // when
+    final var located = SecretReference.parse(expressionLanguage.parseExpression(source));
+
+    // then
+    assertThat(located)
+        .extracting(DetectedSecret::path, DetectedSecret::secret)
+        .containsExactly(tuple(List.of(), new SecretReference("token")));
+  }
+
   static Stream<Arguments> sourcesWithReferences() {
     return Stream.of(
         arguments("=camunda.secrets.token", refs("token")),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
@@ -257,6 +257,45 @@ class FlowNodeSecretReferenceTest {
     assertThat(secretReferences).containsExactly(entry("/a", Set.of(new SecretReference("s2"))));
   }
 
+  @Test
+  void shouldKeyBothConditionalBranchesToTheSameTargetPointer() {
+    // given - two references, one leaf
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression(
+                    "if cond then camunda.secrets.x else camunda.secrets.y", "authToken"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - both land on the mapping target's pointer, not on separate ones
+    assertThat(secretReferences)
+        .containsExactly(
+            entry("/authToken", Set.of(new SecretReference("x"), new SecretReference("y"))));
+  }
+
+  @Test
+  void shouldKeepAPreciseEntryAndAConditionalEntryOnSeparatePointers() {
+    // given - a context mixes a precise reference with a conditional entry
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression(
+                    "{a: camunda.secrets.x, b: if c then camunda.secrets.y else null}", "cfg"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - "/cfg/a" and "/cfg/b" are separate keys; the conditional entry is still scoped to its
+    // own context key because the context itself is descended precisely
+    assertThat(secretReferences)
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "/cfg/a", Set.of(new SecretReference("x")),
+                "/cfg/b", Set.of(new SecretReference("y"))));
+  }
+
   private ExecutableFlowNode transform(final Consumer<ServiceTaskBuilder> modifier) {
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess("process")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLeafPrecisionValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLeafPrecisionValidatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import java.time.InstantSource;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+import org.junit.jupiter.api.Test;
+
+final class SecretReferenceLeafPrecisionValidatorTest {
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final SecretReferenceLeafPrecisionValidator sut =
+      new SecretReferenceLeafPrecisionValidator(expressionLanguage);
+
+  @Test
+  void shouldRejectSecretReferenceInsideListLiteral() {
+    // when
+    final var collector = validate("=[camunda.secrets.token]");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
+  @Test
+  void shouldRejectSecretReferenceInsideContextProducedByAnIfBranch() {
+    // when
+    final var collector = validate("=if true then {x: camunda.secrets.token} else null");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
+  @Test
+  void shouldAllowPlainSecretReferenceExpression() {
+    // when
+    final var collector = validate("=camunda.secrets.token");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldAllowSecretReferenceInsideAContextLiteralAtTheRoot() {
+    // when - descended precisely by SecretReference#collect, not through the fallback
+    final var collector = validate("={x: camunda.secrets.token}");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldAllowListLiteralWithoutASecretReference() {
+    // when
+    final var collector = validate("=[1, 2, 3]");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldAllowPlainStaticValue() {
+    // when
+    final var collector = validate("hello world");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldIgnoreNullSource() {
+    // when
+    final var collector = validate(null);
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldIgnoreInvalidExpression() {
+    // when - reported separately by the expression validator
+    final var collector = validate("=this is not valid feel {{{");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  private ValidationResultCollector validate(final String source) {
+    final var element = mock(ZeebeInput.class);
+    when(element.getSource()).thenReturn(source);
+    final var collector = mock(ValidationResultCollector.class);
+    sut.validate(element, collector);
+    return collector;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
@@ -13,8 +13,11 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.SecretStoreRegistries;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -146,6 +149,50 @@ public final class SecretReferenceInputMappingTest {
     assertThat(job.getVariables())
         .containsEntry("region", "eu-1")
         .containsEntry("authToken", "camunda.secrets.token");
+  }
+
+  @Test
+  public void shouldResolveConditionalWhoseTakenBranchIsAContextWithoutSecrets() {
+    // given - "if true then {x: \"literal\"} else camunda.secrets.token" always takes the context
+    // branch, which holds no secret reference; the untaken branch's reference is leaf-precise
+    // (deploy-time validation permits this shape) and must leave the taken branch untouched
+    final var process =
+        Bpmn.createExecutableProcess("secret-conditional-context")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("secret-conditional-context-job")
+                        .zeebeInputExpression(
+                            "if true then {x: \"literal\"} else camunda.secrets.token",
+                            "authToken"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("secret-conditional-context").create();
+
+    // then - the context literal survives untouched, and no incident is raised
+    final JobRecordValue job =
+        ENGINE
+            .jobs()
+            .withType("secret-conditional-context-job")
+            .activate()
+            .getValue()
+            .getJobs()
+            .getFirst();
+    assertThat(job.getVariables()).containsEntry("authToken", Map.of("x", "literal"));
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
   }
 
   @Test
@@ -289,5 +336,52 @@ public final class SecretReferenceInputMappingTest {
     assertThat(rejected.getRejectionReason())
         .contains("camunda.secrets.token")
         .contains("must be used as an expression");
+  }
+
+  @Test
+  public void shouldRejectSecretReferenceInsideListLiteralInInputMapping() {
+    // given - a secret reference inside a FEEL list literal is recorded at the enclosing path,
+    // which can never resolve to a text leaf at injection (#58614)
+    final var process =
+        Bpmn.createExecutableProcess("secret-list")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType("job").zeebeInputExpression("[camunda.secrets.token]", "creds"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejected = ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    assertThat(rejected.getRejectionReason())
+        .contains("camunda.secrets.token")
+        .contains("would never be filled in");
+  }
+
+  @Test
+  public void shouldRejectSecretReferenceInsideContextProducedByAnIfBranchInInputMapping() {
+    // given - a reference inside a context produced by a branch of the expression is recorded
+    // at the enclosing path too (#58614)
+    final var process =
+        Bpmn.createExecutableProcess("secret-if-context")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("job")
+                        .zeebeInputExpression(
+                            "if true then {x: camunda.secrets.token} else null", "creds"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejected = ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    assertThat(rejected.getRejectionReason())
+        .contains("camunda.secrets.token")
+        .contains("would never be filled in");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
@@ -151,6 +151,147 @@ public final class SecretReferenceInputMappingTest {
         .containsEntry("authToken", "camunda.secrets.token");
   }
 
+  // ---- tolerated conditionals (#58614): detection records a reference for every branch at the
+  // same pointer, but only the branch FEEL actually took ever puts a placeholder there - so the
+  // untaken branch's reference must be ignored rather than fail the job closed.
+
+  @Test
+  public void shouldResolveTakenBranchOfConditionalOverTwoSecretsWhenConditionIsTrue() {
+    // given - "if useProd then camunda.secrets.prodToken else camunda.secrets.devToken"
+    final var process =
+        Bpmn.createExecutableProcess("secret-conditional-branches-true")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("secret-conditional-branches-true-job")
+                        .zeebeInputExpression(
+                            "if useProd then camunda.secrets.prodToken else camunda.secrets.devToken",
+                            "authToken"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("secret-conditional-branches-true")
+            .withVariable("useProd", true)
+            .create();
+
+    // then - the exported record keeps the taken branch's own placeholder (resolution only ever
+    // reaches the activation response, never the persisted record - see the class-level Javadoc),
+    // and no incident is raised for the untaken branch's reference
+    final JobRecordValue job =
+        ENGINE
+            .jobs()
+            .withType("secret-conditional-branches-true-job")
+            .activate()
+            .getValue()
+            .getJobs()
+            .getFirst();
+    assertThat(job.getVariables()).containsEntry("authToken", "camunda.secrets.prodToken");
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldResolveTakenBranchOfConditionalOverTwoSecretsWhenConditionIsFalse() {
+    // given - the mirror of the above, so the outcome cannot depend on which reference is
+    // materialized first
+    final var process =
+        Bpmn.createExecutableProcess("secret-conditional-branches-false")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("secret-conditional-branches-false-job")
+                        .zeebeInputExpression(
+                            "if useProd then camunda.secrets.prodToken else camunda.secrets.devToken",
+                            "authToken"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("secret-conditional-branches-false")
+            .withVariable("useProd", false)
+            .create();
+
+    // then
+    final JobRecordValue job =
+        ENGINE
+            .jobs()
+            .withType("secret-conditional-branches-false-job")
+            .activate()
+            .getValue()
+            .getJobs()
+            .getFirst();
+    assertThat(job.getVariables()).containsEntry("authToken", "camunda.secrets.devToken");
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldResolveConditionalWhoseTakenBranchIsAPlainLiteral() {
+    // given - "if true then \"localSecret\" else camunda.secrets.prod" always takes the
+    // literal branch; the untaken branch's reference is still recorded at the same pointer
+    final var process =
+        Bpmn.createExecutableProcess("secret-conditional-literal")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("secret-conditional-literal-job")
+                        .zeebeInputExpression(
+                            "if true then \"localSecret\" else camunda.secrets.prod", "authToken"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("secret-conditional-literal").create();
+
+    // then - the literal survives untouched, and no incident is raised for the untaken reference
+    final JobRecordValue job =
+        ENGINE
+            .jobs()
+            .withType("secret-conditional-literal-job")
+            .activate()
+            .getValue()
+            .getJobs()
+            .getFirst();
+    assertThat(job.getVariables()).containsEntry("authToken", "localSecret");
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+
   @Test
   public void shouldResolveConditionalWhoseTakenBranchIsAContextWithoutSecrets() {
     // given - "if true then {x: \"literal\"} else camunda.secrets.token" always takes the context
@@ -184,6 +325,49 @@ public final class SecretReferenceInputMappingTest {
             .getJobs()
             .getFirst();
     assertThat(job.getVariables()).containsEntry("authToken", Map.of("x", "literal"));
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldResolveConditionalWhoseTakenBranchIsNullToNoValue() {
+    // given - "if false then camunda.secrets.token else null" always takes the null branch;
+    // detection still records the reference at the mapping target's pointer, but no
+    // placeholder ever reaches it
+    final var process =
+        Bpmn.createExecutableProcess("secret-conditional-null")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("secret-conditional-null-job")
+                        .zeebeInputExpression(
+                            "if false then camunda.secrets.token else null", "authToken"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("secret-conditional-null").create();
+
+    // then - the variable is null, not a placeholder, and no incident is raised
+    final JobRecordValue job =
+        ENGINE
+            .jobs()
+            .withType("secret-conditional-null-job")
+            .activate()
+            .getValue()
+            .getJobs()
+            .getFirst();
+    assertThat(job.getVariables()).containsEntry("authToken", null);
     assertThat(
             RecordingExporter.<Boolean>expectNoMatchingRecords(
                 records ->

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ClusterVariableSecretInjectionIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ClusterVariableSecretInjectionIncidentTest.java
@@ -318,4 +318,275 @@ public final class ClusterVariableSecretInjectionIncidentTest {
                 assertThat(secretActivation.getActivationResponse().getJobs().get(0).getVariables())
                     .containsEntry("authToken", "resolved-B"));
   }
+
+  @Test
+  public void
+      shouldInjectTakenBranchWhenConditionalSelectsBetweenTwoClusterVariableSecretReferences() {
+    // given - two tenant-scoped SECRET_REFERENCE cluster variables and a conditional input
+    // mapping selecting between them (#58614). Detection folds both branches onto the same target
+    // pointer regardless of which one FEEL actually took, so both secrets are registered as needing
+    // resolution, but only the taken branch's placeholder is ever baked into the job's variables -
+    // this is the end-to-end proof of the tolerance rule for composed (cluster-variable) pointers,
+    // not just direct camunda.secrets.* references
+    engine
+        .clusterVariables()
+        .withName("prodCreds")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("token", "camunda.secrets.prodToken"))
+        .create();
+    engine
+        .clusterVariables()
+        .withName("devCreds")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("token", "camunda.secrets.devToken"))
+        .create();
+
+    final var process =
+        Bpmn.createExecutableProcess(BPMN_PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeInputExpression(
+                            "if useProd then camunda.vars.tenant.prodCreds.token else camunda.vars.tenant.devCreds.token",
+                            "authToken"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // both branches' secrets must be cached, or checkSecrets parks the job on the untaken branch's
+    // reference before injection ever runs
+    secretActivation.putSecret("prodToken", "resolved-prod");
+    secretActivation.putSecret("devToken", "resolved-dev");
+
+    // when
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(BPMN_PROCESS_ID)
+            .withVariable("useProd", true)
+            .create();
+    engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - the taken (prod) branch is injected; the untaken (dev) branch's reference finds no
+    // placeholder to replace and is ignored rather than failing the job closed
+    assertThat(secretActivation.awaitActivationResponse().getJobs().get(0).getVariables())
+        .containsEntry("authToken", "resolved-prod")
+        .doesNotContainValue("resolved-dev");
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+
+  // ---- characterisation of a known gap (https://github.com/camunda/camunda/issues/60108): if the
+  // cluster-variable update inside the window removes the secret reference entirely - rather than
+  // pointing it at a different secret, as the mismatch tests above do - there is no reference left
+  // to compare the stale baked-in placeholder against. With nothing registered, checkSecrets and
+  // JobSecretInjector never even look at the job, so it activates with its ELEMENT_ACTIVATING-time
+  // placeholder untouched: the worker receives it unresolved, and no incident is raised. These
+  // three tests pin *today's* behavior deliberately - fixing them needs the baked text and the
+  // reference set to come from one read of ClusterVariableState instead of two independent ones
+  // (input-mapping evaluation and job creation), which is tracked separately. A future fix is
+  // expected to flip these tests; that flip is the signal the gap closed, not a regression.
+
+  @Test
+  public void
+      shouldLeaveStalePlaceholderUnresolvedWhenClusterVariableIsRetargetedToALiteralInsideTheWindow() {
+    // given - same deterministic window as the incident tests above, but the update replaces
+    // the SECRET_REFERENCE value with a plain literal (no camunda.secrets.* leaves) instead of
+    // pointing at a different secret
+    engine
+        .clusterVariables()
+        .withName("creds")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("token", "camunda.secrets.tokenA"))
+        .create();
+
+    final var process =
+        Bpmn.createExecutableProcess(BPMN_PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeInputExpression("camunda.vars.tenant.creds.token", "authToken"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(BPMN_PROCESS_ID).create();
+    final long listenerJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(START_EL_TYPE)
+            .getFirst()
+            .getKey();
+
+    // and - while the listener job is pending, the variable is retargeted to a plain literal: the
+    // scanner then detects zero references, so the resolver folds nothing for this variable
+    engine
+        .clusterVariables()
+        .withName("creds")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withValue(Map.of("token", "not-a-secret"))
+        .update();
+
+    engine.job().withKey(listenerJobKey).complete();
+
+    // when - activating with request metadata present, so a response is written at all
+    engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - the worker receives the stale placeholder unresolved, and no incident is raised
+    assertThat(secretActivation.awaitActivationResponse().getJobs().get(0).getVariables())
+        .containsEntry("authToken", "camunda.secrets.tokenA");
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldLeaveStalePlaceholderUnresolvedWhenClusterVariableIsDeletedInsideTheWindow() {
+    // given - same window, but the variable is deleted entirely instead of retargeted
+    engine
+        .clusterVariables()
+        .withName("creds")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("token", "camunda.secrets.tokenA"))
+        .create();
+
+    final var process =
+        Bpmn.createExecutableProcess(BPMN_PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeInputExpression("camunda.vars.tenant.creds.token", "authToken"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(BPMN_PROCESS_ID).create();
+    final long listenerJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(START_EL_TYPE)
+            .getFirst()
+            .getKey();
+
+    // and - while the listener job is pending, the variable is deleted: resolveInstance then finds
+    // nothing to fold at all
+    engine.clusterVariables().withName("creds").setTenantScope().withTenantId(TENANT).delete();
+
+    engine.job().withKey(listenerJobKey).complete();
+
+    // when
+    engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - same characterisation as above: unresolved placeholder reaches the worker, no incident
+    assertThat(secretActivation.awaitActivationResponse().getJobs().get(0).getVariables())
+        .containsEntry("authToken", "camunda.secrets.tokenA");
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
+  public void
+      shouldLeaveStalePlaceholderUnresolvedWhenClusterVariableSecretMovesOutsideTheAccessedPathInsideTheWindow() {
+    // given - same window, but the update restructures the value so the secret moves outside
+    // the field path the input mapping accesses ({"token": X} -> {"nested": {"token": X}}); the
+    // resolver's rebase of the stored pointer against the accessed field path then fails to match
+    engine
+        .clusterVariables()
+        .withName("creds")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("token", "camunda.secrets.tokenA"))
+        .create();
+
+    final var process =
+        Bpmn.createExecutableProcess(BPMN_PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeInputExpression("camunda.vars.tenant.creds.token", "authToken"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(BPMN_PROCESS_ID).create();
+    final long listenerJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(START_EL_TYPE)
+            .getFirst()
+            .getKey();
+
+    // and - while the listener job is pending, the secret is nested one level deeper than the
+    // accessed field path ("token"), so the rebase against that path no longer matches
+    engine
+        .clusterVariables()
+        .withName("creds")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withValue(Map.of("nested", Map.of("token", "camunda.secrets.tokenB")))
+        .update();
+
+    engine.job().withKey(listenerJobKey).complete();
+
+    // when
+    engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - same characterisation: the stale placeholder from the original path reaches the
+    // worker unresolved, and no incident is raised
+    assertThat(secretActivation.awaitActivationResponse().getJobs().get(0).getVariables())
+        .containsEntry("authToken", "camunda.secrets.tokenA");
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .incidentRecords()
+                        .withIntent(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ClusterVariableSecretInjectionIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ClusterVariableSecretInjectionIncidentTest.java
@@ -165,7 +165,10 @@ public final class ClusterVariableSecretInjectionIncidentTest {
             .getFirst();
     assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.SECRET_RESOLUTION_ERROR);
     assertThat(incident.getValue().getErrorMessage())
-        .contains("Correct the mismatched variable and resolve the incident");
+        .contains("camunda.secrets.tokenB")
+        .contains("/authToken")
+        .contains("could not be resolved at")
+        .contains("Fix the variable's value or the input mapping that sets it");
 
     // and - the job is excluded from activation: a later poll does not hand it out either
     final Record<JobBatchRecordValue> secondAttempt =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -749,73 +749,6 @@ final class JobSecretInjectorTest {
     }
 
     @Test
-    void shouldDropAndReportJobWhoseSecretPlaceholderDoesNotMatch() {
-      // given - the second job's variables hold a text leaf that does not contain the reference's
-      // placeholder, as if the referenced value changed between input mapping evaluation and job
-      // creation; a job with a matching placeholder precedes it and a plain job follows it
-      final Map<String, Object> fitting = Map.of("auth", "camunda.secrets.token");
-      final var response =
-          batchWith(
-              job(fitting, ref("token", "/auth")),
-              job(Map.of("auth", "camunda.secrets.other"), ref("token", "/auth")),
-              job(Map.of("foo", "bar")));
-      final var activated = copyOf(response);
-
-      // when
-      final var droppedJob = inject(response, activated, Map.of("token", "resolved"));
-
-      // then - the mismatched job and every job after it are dropped from both batches; the job
-      // before it keeps its injected value on the response only
-      assertThat(variablesOfAllJobs(response)).containsExactly(Map.of("auth", "resolved"));
-      assertThat(jobKeysOf(response)).containsExactly(100L);
-      assertThat(variablesOfAllJobs(activated)).containsExactly(fitting);
-      assertThat(jobKeysOf(activated)).containsExactly(100L);
-      assertThat(response.getTruncated()).isTrue();
-      assertThat(activated.getTruncated()).isTrue();
-
-      // and - the mismatched job is reported for an incident
-      assertThat(droppedJob)
-          .hasValueSatisfying(
-              dropped -> {
-                assertThat(dropped).isInstanceOf(FailedInjectionJob.class);
-                assertThat(dropped.jobKey()).isEqualTo(101L);
-              });
-    }
-
-    @Test
-    void shouldDropJobWithOneMismatchedSecretAmongSeveralAtDifferentPaths() {
-      // given - two references at different paths on the same job; one placeholder is present in
-      // the variables, the other isn't
-      final var response =
-          batchWith(
-              job(
-                  Map.of("auth", "camunda.secrets.token", "key", "camunda.secrets.other"),
-                  ref("token", "/auth"),
-                  ref("apiKey", "/key")));
-      final var activated = copyOf(response);
-
-      // when
-      final var droppedJob = inject(response, activated, Map.of("token", "t", "apiKey", "k"));
-
-      // then - the whole job is dropped, not a partial injection that leaves the mismatched leaf
-      // stale on the response
-      assertThat(variablesOfAllJobs(response)).isEmpty();
-      assertThat(jobKeysOf(response)).isEmpty();
-      assertThat(variablesOfAllJobs(activated)).isEmpty();
-      assertThat(jobKeysOf(activated)).isEmpty();
-      assertThat(response.getTruncated()).isTrue();
-      assertThat(activated.getTruncated()).isTrue();
-
-      // and - the job is reported for an incident
-      assertThat(droppedJob)
-          .hasValueSatisfying(
-              dropped -> {
-                assertThat(dropped).isInstanceOf(FailedInjectionJob.class);
-                assertThat(dropped.jobKey()).isEqualTo(100L);
-              });
-    }
-
-    @Test
     void shouldDropExceedingAndRemainingJobsFromBothBatches() {
       // given - the first job's value fits, the second job's value exceeds the remaining budget,
       // and a third job without secret references follows
@@ -892,6 +825,563 @@ final class JobSecretInjectorTest {
       assertThat(response.getTruncated()).isFalse();
       assertThat(activated.getTruncated()).isFalse();
       assertThat(oversizedJob).isEmpty();
+    }
+
+    @Test
+    void shouldIgnoreReferenceWhenLeafIsNull() {
+      // given - "=if flag then camunda.secrets.token else null" took the else branch
+      final var original = new LinkedHashMap<String, Object>();
+      original.put("t", null);
+      final var batch = batchWith(job(original, ref("token", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("token", "resolved"));
+
+      // then - no placeholder survives at /t, so the job activates untouched
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldIgnoreReferenceWhenLeafIsANumber() {
+      // given - "=if flag then camunda.secrets.retries else 3" took the else branch
+      final var original = Map.of("t", 3);
+      final var batch = batchWith(job(original, ref("retries", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("retries", "resolved"));
+
+      // then
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldIgnoreReferenceWhenLeafIsABooleanTrue() {
+      // given - a leaf holding literal `true` must not be mistaken for a "placeholder replaced"
+      // signal: Jackson caches BooleanNode.TRUE as a singleton, so an identity-based check for
+      // that outcome could otherwise collide with a genuine boolean-true leaf
+      final var original = Map.of("t", true);
+      final var batch = batchWith(job(original, ref("token", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("token", "resolved"));
+
+      // then
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldInjectSiblingEntryWhenOtherEntryIsNull() {
+      // given - a context whose entries mix a precise reference with a conditional one that
+      // evaluated to null
+      final var original = new LinkedHashMap<String, Object>();
+      original.put("a", "camunda.secrets.x");
+      original.put("b", null);
+      final var wrapped =
+          batchWith(job(Map.of("cfg", original), ref("x", "/cfg/a"), ref("y", "/cfg/b")));
+
+      // when
+      final var dropped = inject(wrapped, copyOf(wrapped), Map.of("x", "vx", "y", "vy"));
+
+      // then - /cfg/a resolves; /cfg/b holds no placeholder so it is ignored
+      assertThat(dropped).isEmpty();
+      final var expected = new LinkedHashMap<String, Object>();
+      expected.put("a", "vx");
+      expected.put("b", null);
+      assertThat(variablesOf(wrapped, 0)).isEqualTo(Map.of("cfg", expected));
+    }
+
+    @Test
+    void shouldInjectEvaluatedBranchAndIgnoreTheOther() {
+      // given - "=if cond then camunda.secrets.x else camunda.secrets.y", cond true
+      final var batch =
+          batchWith(job(Map.of("t", "camunda.secrets.x"), ref("x", "/t"), ref("y", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("x", "vx", "y", "vy"));
+
+      // then - x resolves, y's branch never ran and leaves nothing behind
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("t", "vx"));
+    }
+
+    @Test
+    void shouldInjectEvaluatedBranchRegardlessOfReferenceOrder() {
+      // given - the mirror of the above, so the outcome cannot depend on which reference is
+      // materialized first
+      final var batch =
+          batchWith(job(Map.of("t", "camunda.secrets.y"), ref("x", "/t"), ref("y", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("x", "vx", "y", "vy"));
+
+      // then
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("t", "vy"));
+    }
+
+    @Test
+    void shouldInjectOneOfThreeReferencesAtTheSamePath() {
+      // given - nested conditionals put three references on one leaf
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("t", "camunda.secrets.q"),
+                  ref("p", "/t"),
+                  ref("q", "/t"),
+                  ref("r", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("p", "vp", "q", "vq", "r", "vr"));
+
+      // then
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("t", "vq"));
+    }
+
+    @Test
+    void shouldInjectEvaluatedBranchInsideSurroundingText() {
+      // given - a conditional nested inside a concatenation
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("auth", "Bearer camunda.secrets.devT"),
+                  ref("prodT", "/auth"),
+                  ref("devT", "/auth")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("prodT", "vp", "devT", "vd"));
+
+      // then
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("auth", "Bearer vd"));
+    }
+
+    @Test
+    void shouldIgnoreReferenceWhenLeafHoldsUnrelatedText() {
+      // given - "=if true then \"localSecret\" else camunda.secrets.prod"
+      final var original = Map.of("t", "localSecret");
+      final var batch = batchWith(job(original, ref("prod", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("prod", "resolved"));
+
+      // then
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldIgnoreReferenceWhenAFunctionMangledThePlaceholder() {
+      // given - "=upper case(camunda.secrets.token)" - the placeholder is no longer matchable
+      // and no lowercase token survives either
+      final var original = Map.of("t", "CAMUNDA.SECRETS.TOKEN");
+      final var batch = batchWith(job(original, ref("token", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("token", "resolved"));
+
+      // then
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldIgnoreReferenceUsedOnlyInACondition() {
+      // given - "=if camunda.secrets.flag = \"on\" then \"a\" else \"b\"" - the secret was
+      // compared, never mapped
+      final var original = Map.of("t", "b");
+      final var batch = batchWith(job(original, ref("flag", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("flag", "resolved"));
+
+      // then
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldDropAndReportJobWhoseSurvivingPlaceholderNamesAnotherSecret() {
+      // given - the leaf holds a stale placeholder for a secret the job no longer
+      // references; a resolvable job precedes it and a plain job follows it
+      final Map<String, Object> fitting = Map.of("auth", "camunda.secrets.token");
+      final var response =
+          batchWith(
+              job(fitting, ref("token", "/auth")),
+              job(Map.of("authToken", "camunda.secrets.tokenA"), ref("tokenB", "/authToken")),
+              job(Map.of("foo", "bar")));
+      final var activated = copyOf(response);
+
+      // when
+      final var dropped = inject(response, activated, Map.of("token", "resolved", "tokenB", "vb"));
+
+      // then - the mismatched job and everything after it are dropped; the job before it keeps its
+      // injected value on the response only
+      assertThat(variablesOfAllJobs(response)).containsExactly(Map.of("auth", "resolved"));
+      assertThat(jobKeysOf(response)).containsExactly(100L);
+      assertThat(variablesOfAllJobs(activated)).containsExactly(fitting);
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(job.jobKey()).isEqualTo(101L);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/authToken");
+                assertThat(((FailedInjectionJob) job).placeholder())
+                    .isEqualTo("camunda.secrets.tokenB");
+              });
+    }
+
+    @Test
+    void shouldDropJobWithOneMismatchedSecretAmongSeveralAtDifferentPaths() {
+      // given - two references on the SAME job at different paths: one resolves, the other's
+      // placeholder survives; a preceding job resolves cleanly and must not be swept up by the
+      // later drop
+      final Map<String, Object> preceding = Map.of("auth", "camunda.secrets.pre");
+      final var response =
+          batchWith(
+              job(preceding, ref("pre", "/auth")),
+              job(
+                  Map.of("auth", "camunda.secrets.token", "key", "camunda.secrets.other"),
+                  ref("token", "/auth"),
+                  ref("apiKey", "/key")));
+      final var activated = copyOf(response);
+
+      // when
+      final var dropped =
+          inject(response, activated, Map.of("pre", "resolved-pre", "token", "t", "apiKey", "k"));
+
+      // then - by the time /key's surviving placeholder is found, a genuine secret has already
+      // been written into the live document at /auth; the whole job must still be dropped from
+      // both batches so that partial write never reaches the response
+      assertThat(variablesOfAllJobs(response)).containsExactly(Map.of("auth", "resolved-pre"));
+      assertThat(jobKeysOf(response)).containsExactly(100L);
+      assertThat(variablesOfAllJobs(activated)).containsExactly(preceding);
+      assertThat(jobKeysOf(activated)).containsExactly(100L);
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+
+      // and - the mismatched job is reported for an incident
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(job.jobKey()).isEqualTo(101L);
+              });
+    }
+
+    @Test
+    void shouldDropJobWhenSiblingReferencesLeaveAPlaceholderBehind() {
+      // given - two references at the path, neither resolves the placeholder actually there
+      final var response =
+          batchWith(job(Map.of("t", "camunda.secrets.tokenA"), ref("x", "/t"), ref("y", "/t")));
+      final var activated = copyOf(response);
+
+      // when
+      final var dropped = inject(response, activated, Map.of("x", "vx", "y", "vy"));
+
+      // then - siblings do not launder a surviving placeholder
+      assertThat(jobKeysOf(response)).isEmpty();
+      assertThat(jobKeysOf(activated)).isEmpty();
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(job.jobKey()).isEqualTo(100L);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/t");
+                // TimSort is stable and the fixture order is fixed, so "x" always wins today, but
+                // that's an artifact of tie-breaking, not a contract - either sibling is correct
+                assertThat(((FailedInjectionJob) job).placeholder())
+                    .isIn("camunda.secrets.x", "camunda.secrets.y");
+              });
+    }
+
+    @Test
+    void shouldDropJobWhenIntermediateSegmentHoldsAPlaceholder() {
+      // given - the recorded path descends into what is now a string, and that string holds
+      // the placeholder
+      final var batch =
+          batchWith(job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth/nested")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("token", "resolved"));
+
+      // then - the scalar the walk stopped at is what gets scanned
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/auth/nested");
+              });
+      assertThat(jobKeysOf(batch)).isEmpty();
+    }
+
+    // ---- array pointers: injection can only write into an object, so an array hop always fails
+    // closed, whether the index is in range or out of it ----
+
+    @Test
+    void shouldDropJobWhenPointerRunsIntoAnArrayWithANonNumericSegment() {
+      // given - the recorded path descends into what is now a list, using a non-numeric segment;
+      // an array missing the index must fail closed, the same as an object whose parent can't be
+      // written to, rather than being read as an unset key
+      final var response =
+          batchWith(
+              job(Map.of("foo", List.of("camunda.secrets.token")), ref("token", "/foo/nested")));
+      final var activated = copyOf(response);
+
+      // when
+      final var dropped = inject(response, activated, Map.of("token", "resolved"));
+
+      // then - the array itself is scanned, so the placeholder inside it is found
+      assertThat(jobKeysOf(response)).isEmpty();
+      assertThat(jobKeysOf(activated)).isEmpty();
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(job.jobKey()).isEqualTo(100L);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/foo/nested");
+                assertThat(((FailedInjectionJob) job).placeholder())
+                    .isEqualTo("camunda.secrets.token");
+              });
+    }
+
+    @Test
+    void shouldDropJobWhenClusterVariableSecretIsNestedInAnArrayElement() {
+      // given - the cluster-variable scanner does produce this shape: a secret nested inside a
+      // SECRET_REFERENCE variable's list is recorded at an in-range array-index pointer (see
+      // ClusterVariableSecretReferenceScanner), so the pointer reaches exactly the placeholder -
+      // but injection can only write into an object via ObjectNode.put, so the array element can
+      // never be written to, in range or not
+      final var response =
+          batchWith(
+              job(Map.of("items", List.of("camunda.secrets.token")), ref("token", "/items/0")));
+      final var activated = copyOf(response);
+
+      // when
+      final var dropped = inject(response, activated, Map.of("token", "resolved"));
+
+      // then - the in-range element fails closed the same way an out-of-range one does
+      assertThat(jobKeysOf(response)).isEmpty();
+      assertThat(jobKeysOf(activated)).isEmpty();
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(job.jobKey()).isEqualTo(100L);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/items/0");
+                assertThat(((FailedInjectionJob) job).placeholder())
+                    .isEqualTo("camunda.secrets.token");
+              });
+    }
+
+    @Test
+    void shouldDropJobWhenPointerIndexIsOutOfRangeForAList() {
+      // given - the recorded path indexes past the end of what is now a shorter list
+      final var response =
+          batchWith(
+              job(
+                  Map.of("items", List.of("a", "camunda.secrets.token")),
+                  ref("token", "/items/5")));
+      final var activated = copyOf(response);
+
+      // when
+      final var dropped = inject(response, activated, Map.of("token", "resolved"));
+
+      // then
+      assertThat(jobKeysOf(response)).isEmpty();
+      assertThat(jobKeysOf(activated)).isEmpty();
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(job.jobKey()).isEqualTo(100L);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/items/5");
+                assertThat(((FailedInjectionJob) job).placeholder())
+                    .isEqualTo("camunda.secrets.token");
+              });
+    }
+
+    @Test
+    void shouldDropJobWhenComposedClusterVariablePointerOvershootsIntoAPlaceholder() {
+      // given - "=string(camunda.vars.env.creds)" stringified the value, so the composed
+      // pointer overshoots into a string that still holds the placeholder
+      final var response =
+          batchWith(job(Map.of("foo", "{token: camunda.secrets.X}"), ref("X", "/foo/token")));
+      final var activated = copyOf(response);
+
+      // when
+      final var dropped = inject(response, activated, Map.of("X", "resolved"));
+
+      // then
+      assertThat(jobKeysOf(response)).isEmpty();
+      assertThat(jobKeysOf(activated)).isEmpty();
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(job.jobKey()).isEqualTo(100L);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/foo/token");
+                assertThat(((FailedInjectionJob) job).placeholder()).isEqualTo("camunda.secrets.X");
+              });
+    }
+
+    @Test
+    void shouldDropJobWhenLeafIsAListOfPlaceholders() {
+      // given - a list literal or a "for ... return" produced an array whose elements are
+      // placeholders
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("foo", List.of("camunda.secrets.X", "camunda.secrets.Y")),
+                  ref("X", "/foo"),
+                  ref("Y", "/foo")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("X", "vx", "Y", "vy"));
+
+      // then - array elements are never addressed, and the placeholders inside are found
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/foo");
+              });
+      assertThat(jobKeysOf(batch)).isEmpty();
+    }
+
+    @Test
+    void shouldDropJobWhenLeafIsAnObjectHoldingAPlaceholder() {
+      // given - the pointer addresses a container whose contents hold the placeholder
+      final var response =
+          batchWith(job(Map.of("cfg", Map.of("a", "camunda.secrets.token")), ref("token", "/cfg")));
+      final var activated = copyOf(response);
+
+      // when
+      final var dropped = inject(response, activated, Map.of("token", "resolved"));
+
+      // then
+      assertThat(jobKeysOf(response)).isEmpty();
+      assertThat(jobKeysOf(activated)).isEmpty();
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(dropped)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job).isInstanceOf(FailedInjectionJob.class);
+                assertThat(job.jobKey()).isEqualTo(100L);
+                assertThat(((FailedInjectionJob) job).path()).isEqualTo("/cfg");
+                assertThat(((FailedInjectionJob) job).placeholder())
+                    .isEqualTo("camunda.secrets.token");
+              });
+    }
+
+    @Test
+    void shouldLeaveUnclaimedLookalikeTextBesideAResolvedReference() {
+      // given - the leaf holds a second placeholder-shaped token that no reference claims; it
+      // is literal customer text, not a reference
+      final var batch =
+          batchWith(job(Map.of("t", "camunda.secrets.x and camunda.secrets.z"), ref("x", "/t")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("x", "vx"));
+
+      // then - x resolves and nothing at /t is unsatisfied, so no scan runs and z passes through
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("t", "vx and camunda.secrets.z"));
+    }
+
+    @Test
+    void shouldIgnoreReferenceWhoseKeyWasNeverMapped() {
+      // given - a secret was added to a cluster variable after the input mapping ran, so its
+      // key is not in the job's variables at all
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("creds", Map.of("a", "camunda.secrets.X")),
+                  ref("X", "/creds/a"),
+                  ref("Y", "/creds/b")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("X", "vx", "Y", "vy"));
+
+      // then - /creds/b is simply unset, so it is absent rather than unsatisfied
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("creds", Map.of("a", "vx")));
+    }
+
+    @Test
+    void shouldLeaveOrphanedPlaceholderWhenNoReferenceClaimsIt() {
+      // given - a secret was removed from a cluster variable after the input mapping baked
+      // both placeholders in, so only one reference reaches the job. Characterises today's
+      // behavior: the orphan passes through, because no reference at /creds/b is unsatisfied
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("creds", Map.of("a", "camunda.secrets.X", "b", "camunda.secrets.Y")),
+                  ref("X", "/creds/a")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("X", "vx"));
+
+      // then - known gap: fixing this needs the reference set and the baked text to come from one
+      // read of ClusterVariableState (tracked separately)
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0))
+          .isEqualTo(Map.of("creds", Map.of("a", "vx", "b", "camunda.secrets.Y")));
+    }
+
+    @Test
+    void shouldInjectAdjacentPlaceholdersWithoutTokenisingThem() {
+      // given - two placeholders concatenated with no separator. They do not tokenise cleanly
+      // (the name class is greedy), which is why the residual scan reads the injected result
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("combined", "camunda.secrets.acamunda.secrets.b"),
+                  ref("a", "/combined"),
+                  ref("b", "/combined")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("a", "VA", "b", "VB"));
+
+      // then - both resolve and no incident is raised for the unmatchable token shape
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("combined", "VAVB"));
+    }
+
+    @Test
+    void shouldNotIncidentOnAdjacentPlaceholdersWhenAThirdReferenceIsUnsatisfied() {
+      // given - the regression the post-injection scan exists for: two adjacent placeholders both
+      // resolve, and a third reference at the same path finds nothing
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("combined", "camunda.secrets.acamunda.secrets.b"),
+                  ref("a", "/combined"),
+                  ref("b", "/combined"),
+                  ref("c", "/combined")));
+
+      // when
+      final var dropped = inject(batch, copyOf(batch), Map.of("a", "VA", "b", "VB", "c", "VC"));
+
+      // then - nothing placeholder-shaped survives, so c's absence is not a failure
+      assertThat(dropped).isEmpty();
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("combined", "VAVB"));
     }
 
     @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -895,32 +895,6 @@ final class JobSecretInjectorTest {
     }
 
     @Test
-    void shouldSkipWhenPointerDoesNotAddressATextLeaf() {
-      // given - the pointer addresses a container, not a text leaf
-      final var original = Map.of("cfg", Map.of("a", "camunda.secrets.token"));
-      final var batch = batchWith(job(original, ref("token", "/cfg")));
-
-      // when
-      inject(batch, Map.of("token", "resolved"));
-
-      // then - defensively left untouched
-      assertThat(variablesOf(batch, 0)).isEqualTo(original);
-    }
-
-    @Test
-    void shouldSkipWhenIntermediateSegmentIsMissing() {
-      // given - the recorded path no longer matches the variables document
-      final var original = Map.of("auth", "camunda.secrets.token");
-      final var batch = batchWith(job(original, ref("token", "/auth/nested")));
-
-      // when
-      inject(batch, Map.of("token", "resolved"));
-
-      // then - defensively left untouched
-      assertThat(variablesOf(batch, 0)).isEqualTo(original);
-    }
-
-    @Test
     void shouldSkipWhenLeafIsMissing() {
       // given
       final var original = Map.of("present", "camunda.secrets.token");
@@ -943,19 +917,6 @@ final class JobSecretInjectorTest {
       inject(batch, Map.of("token", "resolved"));
 
       // then
-      assertThat(variablesOf(batch, 0)).isEqualTo(original);
-    }
-
-    @Test
-    void shouldSkipArraysOnThePointerPath() {
-      // given - the pointer runs into an array element
-      final var original = Map.of("items", List.of("camunda.secrets.token"));
-      final var batch = batchWith(job(original, ref("token", "/items/0")));
-
-      // when
-      inject(batch, Map.of("token", "resolved"));
-
-      // then - array elements are never addressed; the document is untouched
       assertThat(variablesOf(batch, 0)).isEqualTo(original);
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Defines what happens when a secret reference's JSON pointer doesn't address a text leaf at injection.
Before this the replacement was just silently skipped, so the worker got the literal
`camunda.secrets.<name>` placeholder with no incident and no signal anything was wrong.

The rule: a registered secret reference means a secret is *possibly* referenced by the evaluated
expression, not that one certainly is. FEEL only evaluates one branch of a conditional but detection
can't know which, so every reference in every branch ends up recorded at the same pointer. A reference
that finds no placeholder is therefore only a failure when placeholder-shaped text actually survives at
that path.

How each case from the issue ends up:

| | Case | How it's handled now |
| --- | --- | --- |
| **A** | `=[camunda.secrets.X, camunda.secrets.Y]` → `foo`; both recorded at `/foo`, which holds an array | Rejected at deploy time, since a list literal is decidable from the source alone. Already-deployed definitions fail closed at runtime instead: the array is scanned, both placeholders are found, incident |
| **B** | `=if flag then {x: camunda.secrets.token} else null` → `foo`; recorded at `/foo`, not `/foo/x` | Also rejected at deploy time. At runtime the branch matters: the object branch fails closed, while the `else null` branch leaves no placeholder behind so the job just activates |
| **C** | `token` recorded at `/auth/nested`, but `auth` now holds a string containing the placeholder | The pointer walk stops at the scalar it can't descend into and scans that; the placeholder is found, incident |
| **D** | `token` recorded at `/token`, but the worker activated with `fetchVariables: ["orderId"]` | Still a no-op, as required. An object that simply doesn't hold our key means the slot is legitimately unset, so nothing is scanned and no incident is raised |
| **E1** | `=string(camunda.vars.env.creds)` → `foo`; pointer composed as `/foo/token` over what is actually a string | Same shape as C — the walk stops at the string, the placeholder is found, incident |
| **E2** | Cluster variable retargeted from `A` to `B` inside the `ELEMENT_ACTIVATING`→`ELEMENT_ACTIVATED` window; variables hold `A`, the job's reference is `B` | `B`'s placeholder isn't there, but `A` survives in the leaf, so it fails closed |

The rule also covers shapes the issue doesn't list, where nothing placeholder-shaped is left behind and
the job activates normally: `=if cond then camunda.secrets.x else camunda.secrets.y` resolves the taken
branch and ignores the other, a container literal in one branch with a leaf-precise secret in the other
deploys and injects normally, a taken branch that is a plain literal or `null` leaves nothing to
resolve, and a leaf whose placeholder was legitimately overwritten by a non-secret value no longer
fails either.

Two implementation details worth knowing before touching that code:

1. The residual scan reads the leaf *after* all replacements, rather than tokenising the original text
   and subtracting whatever resolved. `REFERENCE_PATTERN`'s name class is greedy, so two adjacent
   placeholders tokenise as one bogus token and a leaf where everything resolved fine would incident.
2. The node to scan is re-derived after the loop rather than captured at the point a reference fails.
   `TextNode` is immutable so `put()` installs a *new* node, and a captured one goes stale as soon as a
   sibling at the same path resolves, which makes the outcome depend on which reference is attempted
   first.

One gap filed separately instead of fixed: #60108. A `SECRET_REFERENCE` cluster variable can change
inside that same window so its reference disappears altogether, and then there's nothing registered to
arm the residual check, so the stale placeholder still reaches the worker. Three characterisation tests
pin today's behaviour — them flipping is the signal it's fixed. Claude did most of the legwork here.
Worth knowing that one full `zeebe/engine` run had `MessageStartProcessInstanceCrossPartitionMetricsTest`
and `ProcessEventsClaimsTest` fail; both are unrelated to secrets, both pass on retry, and both were
green in two other full runs of the same code.

The tolerance rule lives in `JobSecretLookup`, shared by the long-poll batch path this issue is about
and the job-push path, so it also stops the job-push path over-firing on the same conditionals - that
path had no tolerance at all before this, throwing on any leaf a reference's pointer failed to match.
Its incident still reports a generic failure rather than naming the mismatched reference; giving it the
same detail as the batch path is a separate follow-up, not done here.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #58614 


