### PR TITLE
Exclude non-leasing streams from matching leased jobs (2/3)

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -47,6 +47,7 @@ import java.time.InstantSource;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import org.agrona.collections.MutableBoolean;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -154,16 +155,17 @@ public class BpmnJobActivationBehavior {
 
     final String jobType = wrappedJobRecord.getType();
     final JobKind jobKind = wrappedJobRecord.getJobKind();
+    final var leaseMismatch = new MutableBoolean(false);
     final Optional<JobStream> optionalJobStream =
         jobStreamer.streamFor(
             wrappedJobRecord.getTypeBuffer(),
             jobActivationProperties ->
                 isAuthorized(jobActivationProperties, wrappedJobRecord)
-                    && isLeaseCompatible(jobActivationProperties, wrappedJobRecord));
+                    && isLeaseCompatible(jobActivationProperties, wrappedJobRecord, leaseMismatch));
 
     if (optionalJobStream.isEmpty()) {
       // the job stays activatable; a long poll checks its secret references when it collects it
-      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
+      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes, leaseMismatch.get());
       return true;
     }
 
@@ -199,7 +201,7 @@ public class BpmnJobActivationBehavior {
         jobBatchRecord.getLength() + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER)) {
       // the job is not activated, so it stays available; the notification lets a long poll collect
       // it, and the caller stops handing out jobs this batch can no longer take
-      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
+      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes, false);
       return false;
     }
     final var jobBatchKey = keyGenerator.nextKey();
@@ -264,16 +266,19 @@ public class BpmnJobActivationBehavior {
     if (parked) {
       jobMetrics.countJobEvent(JobAction.SKIPPED_UNCACHED_SECRET, jobKind, jobType);
     } else {
-      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
+      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes, false);
     }
     return batchHadRoom;
   }
 
   /** Notifies the workers of the job type unless this batch of jobs already did. */
   private void notifyJobAvailableOnce(
-      final String jobType, final JobKind jobKind, final Set<String> notifiedJobTypes) {
+      final String jobType,
+      final JobKind jobKind,
+      final Set<String> notifiedJobTypes,
+      final boolean leasedJobSkipped) {
     if (notifiedJobTypes.add(jobType)) {
-      notifyJobAvailable(jobType, jobKind);
+      notifyJobAvailable(jobType, jobKind, leasedJobSkipped);
     }
   }
 
@@ -315,12 +320,19 @@ public class BpmnJobActivationBehavior {
   }
 
   public void notifyJobAvailableAsSideEffect(final JobRecord jobRecord) {
-    notifyJobAvailable(jobRecord.getType(), jobRecord.getJobKind());
+    notifyJobAvailable(jobRecord.getType(), jobRecord.getJobKind(), false);
   }
 
-  private void notifyJobAvailable(final String jobType, final JobKind jobKind) {
+  private void notifyJobAvailable(
+      final String jobType, final JobKind jobKind, final boolean leaseMismatch) {
     sideEffectWriter.appendSideEffect(
         () -> {
+          if (leaseMismatch) {
+            // push-side counterpart of the skip JobBatchCollector counts when a poll request
+            // without withLease encounters an already-leased job: here, a stream matched the
+            // type but not the lease, so the job is demoted to waiting for a poller instead
+            jobMetrics.countJobEvent(JobAction.SKIPPED, jobKind, jobType);
+          }
           jobStreamer.notifyWorkAvailable(jobType);
           jobMetrics.countJobEvent(JobAction.WORKERS_NOTIFIED, jobKind, jobType);
           return true;
@@ -417,7 +429,13 @@ public class BpmnJobActivationBehavior {
   }
 
   private boolean isLeaseCompatible(
-      final JobActivationProperties jobActivationProperties, final JobRecord jobRecord) {
-    return jobActivationProperties.withLease() || !jobRecord.hasLeaseToken();
+      final JobActivationProperties jobActivationProperties,
+      final JobRecord jobRecord,
+      final MutableBoolean leaseMismatch) {
+    if (jobActivationProperties.withLease() || !jobRecord.hasLeaseToken()) {
+      return true;
+    }
+    leaseMismatch.set(true);
+    return false;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -272,14 +272,29 @@ public class BpmnJobActivationBehavior {
     return batchHadRoom;
   }
 
-  /** Notifies the workers of the job type unless this batch of jobs already did. */
+  /**
+   * Notifies the workers of the job type unless this batch of jobs already did. The lease-skip
+   * metric is counted independently of that dedup: several same-type jobs demoted within one
+   * shared-notification batch must each be counted, even though the batch notifies workers only
+   * once for all of them.
+   */
   private void notifyJobAvailableOnce(
       final String jobType,
       final JobKind jobKind,
       final Set<String> notifiedJobTypes,
       final boolean leasedJobSkipped) {
+    if (leasedJobSkipped) {
+      // push-side counterpart of the skip JobBatchCollector counts when a poll request without
+      // withLease encounters an already-leased job: here, a stream matched the type but not the
+      // lease, so the job is demoted to waiting for a poller instead
+      sideEffectWriter.appendSideEffect(
+          () -> {
+            jobMetrics.countJobEvent(JobAction.SKIPPED_LEASED, jobKind, jobType);
+            return true;
+          });
+    }
     if (notifiedJobTypes.add(jobType)) {
-      notifyJobAvailable(jobType, jobKind, leasedJobSkipped);
+      notifyJobAvailable(jobType, jobKind);
     }
   }
 
@@ -321,19 +336,12 @@ public class BpmnJobActivationBehavior {
   }
 
   public void notifyJobAvailableAsSideEffect(final JobRecord jobRecord) {
-    notifyJobAvailable(jobRecord.getType(), jobRecord.getJobKind(), false);
+    notifyJobAvailable(jobRecord.getType(), jobRecord.getJobKind());
   }
 
-  private void notifyJobAvailable(
-      final String jobType, final JobKind jobKind, final boolean leasedJobSkipped) {
+  private void notifyJobAvailable(final String jobType, final JobKind jobKind) {
     sideEffectWriter.appendSideEffect(
         () -> {
-          if (leasedJobSkipped) {
-            // push-side counterpart of the skip JobBatchCollector counts when a poll request
-            // without withLease encounters an already-leased job: here, a stream matched the
-            // type but not the lease, so the job is demoted to waiting for a poller instead
-            jobMetrics.countJobEvent(JobAction.SKIPPED, jobKind, jobType);
-          }
           jobStreamer.notifyWorkAvailable(jobType);
           jobMetrics.countJobEvent(JobAction.WORKERS_NOTIFIED, jobKind, jobType);
           return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -47,7 +47,7 @@ import java.time.InstantSource;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import org.agrona.collections.MutableBoolean;
+import java.util.function.Predicate;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -155,17 +155,18 @@ public class BpmnJobActivationBehavior {
 
     final String jobType = wrappedJobRecord.getType();
     final JobKind jobKind = wrappedJobRecord.getJobKind();
-    final var leaseMismatch = new MutableBoolean(false);
+    final var leaseAwarePredicate = new LeaseAwarePredicate(wrappedJobRecord);
     final Optional<JobStream> optionalJobStream =
         jobStreamer.streamFor(
             wrappedJobRecord.getTypeBuffer(),
             jobActivationProperties ->
                 isAuthorized(jobActivationProperties, wrappedJobRecord)
-                    && isLeaseCompatible(jobActivationProperties, wrappedJobRecord, leaseMismatch));
+                    && leaseAwarePredicate.test(jobActivationProperties));
 
     if (optionalJobStream.isEmpty()) {
       // the job stays activatable; a long poll checks its secret references when it collects it
-      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes, leaseMismatch.get());
+      notifyJobAvailableOnce(
+          jobType, jobKind, notifiedJobTypes, leaseAwarePredicate.isLeasedJobSkipped());
       return true;
     }
 
@@ -324,10 +325,10 @@ public class BpmnJobActivationBehavior {
   }
 
   private void notifyJobAvailable(
-      final String jobType, final JobKind jobKind, final boolean leaseMismatch) {
+      final String jobType, final JobKind jobKind, final boolean leasedJobSkipped) {
     sideEffectWriter.appendSideEffect(
         () -> {
-          if (leaseMismatch) {
+          if (leasedJobSkipped) {
             // push-side counterpart of the skip JobBatchCollector counts when a poll request
             // without withLease encounters an already-leased job: here, a stream matched the
             // type but not the lease, so the job is demoted to waiting for a poller instead
@@ -428,14 +429,33 @@ public class BpmnJobActivationBehavior {
         || authorizedProcessIds.contains(AuthorizationScope.id(jobRecord.getBpmnProcessId()));
   }
 
-  private boolean isLeaseCompatible(
-      final JobActivationProperties jobActivationProperties,
-      final JobRecord jobRecord,
-      final MutableBoolean leaseMismatch) {
-    if (jobActivationProperties.withLease() || !jobRecord.hasLeaseToken()) {
-      return true;
+  /**
+   * Matches streams that are lease-compatible for the given job, tracking whether an already-leased
+   * job was skipped because an otherwise-authorized candidate does not request leases. That
+   * distinction is what {@link #publishWork} needs to decide whether falling back to a notification
+   * is a plain "no stream registered" case or a skip due to lease incompatibility. Authorization is
+   * a separate concern with no state to track, so it stays a plain method composed alongside this
+   * predicate at the call site rather than folded into it.
+   */
+  private static final class LeaseAwarePredicate implements Predicate<JobActivationProperties> {
+    private final JobRecord jobRecord;
+    private boolean leasedJobSkipped;
+
+    private LeaseAwarePredicate(final JobRecord jobRecord) {
+      this.jobRecord = jobRecord;
     }
-    leaseMismatch.set(true);
-    return false;
+
+    @Override
+    public boolean test(final JobActivationProperties jobActivationProperties) {
+      if (jobActivationProperties.withLease() || !jobRecord.hasLeaseToken()) {
+        return true;
+      }
+      leasedJobSkipped = true;
+      return false;
+    }
+
+    private boolean isLeasedJobSkipped() {
+      return leasedJobSkipped;
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -157,7 +157,9 @@ public class BpmnJobActivationBehavior {
     final Optional<JobStream> optionalJobStream =
         jobStreamer.streamFor(
             wrappedJobRecord.getTypeBuffer(),
-            jobActivationProperties -> isAuthorized(jobActivationProperties, wrappedJobRecord));
+            jobActivationProperties ->
+                isAuthorized(jobActivationProperties, wrappedJobRecord)
+                    && isLeaseCompatible(jobActivationProperties, wrappedJobRecord));
 
     if (optionalJobStream.isEmpty()) {
       // the job stays activatable; a long poll checks its secret references when it collects it
@@ -412,5 +414,10 @@ public class BpmnJobActivationBehavior {
       final JobRecord jobRecord, final Set<AuthorizationScope> authorizedProcessIds) {
     return authorizedProcessIds.contains(AuthorizationScope.WILDCARD)
         || authorizedProcessIds.contains(AuthorizationScope.id(jobRecord.getBpmnProcessId()));
+  }
+
+  private boolean isLeaseCompatible(
+      final JobActivationProperties jobActivationProperties, final JobRecord jobRecord) {
+    return jobActivationProperties.withLease() || !jobRecord.hasLeaseToken();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -164,9 +164,18 @@ public class BpmnJobActivationBehavior {
                     && leaseAwarePredicate.test(jobActivationProperties));
 
     if (optionalJobStream.isEmpty()) {
+      if (leaseAwarePredicate.isLeasedJobSkipped()) {
+        // push-side counterpart of the skip JobBatchCollector counts when a poll request without
+        // withLease encounters an already-leased job: here, a stream matched the type but not the
+        // lease, so the job is demoted to waiting for a poller instead
+        sideEffectWriter.appendSideEffect(
+            () -> {
+              jobMetrics.countJobEvent(JobAction.SKIPPED_LEASED, jobKind, jobType);
+              return true;
+            });
+      }
       // the job stays activatable; a long poll checks its secret references when it collects it
-      notifyJobAvailableOnce(
-          jobType, jobKind, notifiedJobTypes, leaseAwarePredicate.isLeasedJobSkipped());
+      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
       return true;
     }
 
@@ -202,7 +211,7 @@ public class BpmnJobActivationBehavior {
         jobBatchRecord.getLength() + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER)) {
       // the job is not activated, so it stays available; the notification lets a long poll collect
       // it, and the caller stops handing out jobs this batch can no longer take
-      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes, false);
+      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
       return false;
     }
     final var jobBatchKey = keyGenerator.nextKey();
@@ -267,32 +276,14 @@ public class BpmnJobActivationBehavior {
     if (parked) {
       jobMetrics.countJobEvent(JobAction.SKIPPED_UNCACHED_SECRET, jobKind, jobType);
     } else {
-      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes, false);
+      notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
     }
     return batchHadRoom;
   }
 
-  /**
-   * Notifies the workers of the job type unless this batch of jobs already did. The lease-skip
-   * metric is counted independently of that dedup: several same-type jobs demoted within one
-   * shared-notification batch must each be counted, even though the batch notifies workers only
-   * once for all of them.
-   */
+  /** Notifies the workers of the job type unless this batch of jobs already did. */
   private void notifyJobAvailableOnce(
-      final String jobType,
-      final JobKind jobKind,
-      final Set<String> notifiedJobTypes,
-      final boolean leasedJobSkipped) {
-    if (leasedJobSkipped) {
-      // push-side counterpart of the skip JobBatchCollector counts when a poll request without
-      // withLease encounters an already-leased job: here, a stream matched the type but not the
-      // lease, so the job is demoted to waiting for a poller instead
-      sideEffectWriter.appendSideEffect(
-          () -> {
-            jobMetrics.countJobEvent(JobAction.SKIPPED_LEASED, jobKind, jobType);
-            return true;
-          });
-    }
+      final String jobType, final JobKind jobKind, final Set<String> notifiedJobTypes) {
     if (notifiedJobTypes.add(jobType)) {
       notifyJobAvailable(jobType, jobKind);
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
@@ -231,6 +231,28 @@ public final class ActivatableJobsPushWithLeaseTest {
         .isEmpty();
   }
 
+  @Test
+  public void shouldTreatLeasingAndNonLeasingRegistrationsAsDistinctIdentities() {
+    // given
+    final JobActivationPropertiesImpl leasing =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(TIMEOUT_MS)
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .setWithLease(true);
+    final JobActivationPropertiesImpl nonLeasing =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(TIMEOUT_MS)
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .setWithLease(false);
+
+    // then
+    assertThat(leasing)
+        .describedAs("a leasing and a non-leasing registration must remain distinct identities")
+        .isNotEqualTo(nonLeasing);
+  }
+
   /**
    * Waits until the job has settled on one of two outcomes: pushed to {@code jobStream}, or
    * notified for polling. The caller asserts on which outcome actually occurred.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.Strings;
@@ -183,6 +184,128 @@ public final class ActivatableJobsPushWithLeaseTest {
   }
 
   @Test
+  public void shouldNotPushRetriedLeasedJobToNonLeasingStream() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final int notificationsBefore = JOB_STREAMER.notificationsForJob(jobType);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().getFirst();
+    final long jobKey = batchRecord.getValue().getJobKeys().getFirst();
+    final String leaseToken = job.getLeaseToken();
+    final RecordingJobStream jobStream = registerStream(false);
+
+    // when
+    ENGINE
+        .job()
+        .withKey(jobKey)
+        .ofInstance(job.getProcessInstanceKey())
+        .withLeaseToken(leaseToken)
+        .withRetries(3)
+        .fail();
+
+    // then
+    awaitPushOrNotify(jobStream, notificationsBefore);
+    assertThat(jobStream.getActivatedJobs())
+        .describedAs(
+            "a leased job that becomes activatable again by failing with retries left "
+                + "must not be pushed to a non-leasing stream")
+        .isEmpty();
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(jobMetric("skipped", jobType, JobKind.BPMN_ELEMENT))
+                    .describedAs(
+                        "demoting a push to notify-only counts the same skip signal the poll "
+                            + "path already counts for a lease mismatch")
+                    .isOne());
+  }
+
+  @Test
+  public void shouldNotPushRecurredLeasedJobToNonLeasingStream() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final int notificationsBefore = JOB_STREAMER.notificationsForJob(jobType);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().getFirst();
+    final long jobKey = batchRecord.getValue().getJobKeys().getFirst();
+    final String leaseToken = job.getLeaseToken();
+    final Duration backOff = Duration.ofDays(1);
+    ENGINE
+        .job()
+        .withKey(jobKey)
+        .ofInstance(job.getProcessInstanceKey())
+        .withLeaseToken(leaseToken)
+        .withRetries(3)
+        .withBackOff(backOff)
+        .fail();
+    final RecordingJobStream jobStream = registerStream(false);
+
+    // when
+    ENGINE.increaseTime(
+        backOff.plus(Duration.ofMillis(JobBackoffCheckScheduler.BACKOFF_RESOLUTION)));
+
+    // then
+    jobRecords(JobIntent.RECURRED_AFTER_BACKOFF).withType(jobType).await();
+    awaitPushOrNotify(jobStream, notificationsBefore);
+    assertThat(jobStream.getActivatedJobs())
+        .describedAs(
+            "a leased job that recurs after its backoff elapses must not be pushed to a "
+                + "non-leasing stream")
+        .isEmpty();
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(jobMetric("skipped", jobType, JobKind.BPMN_ELEMENT))
+                    .describedAs(
+                        "demoting a push to notify-only counts the same skip signal the poll "
+                            + "path already counts for a lease mismatch")
+                    .isOne());
+  }
+
+  @Test
+  public void shouldNotPushIncidentResolvedLeasedJobToNonLeasingStream() {
+    // given
+    final Record<JobRecordValue> created = ENGINE.createJob(jobType, PROCESS_ID);
+    final long processInstanceKey = created.getValue().getProcessInstanceKey();
+    final int notificationsBefore = JOB_STREAMER.notificationsForJob(jobType);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().getFirst();
+    final long jobKey = batchRecord.getValue().getJobKeys().getFirst();
+    final String leaseToken = job.getLeaseToken();
+    ENGINE
+        .job()
+        .withKey(jobKey)
+        .ofInstance(processInstanceKey)
+        .withLeaseToken(leaseToken)
+        .withRetries(0)
+        .fail();
+    ENGINE.job().ofInstance(processInstanceKey).withType(jobType).withRetries(1).updateRetries();
+    final RecordingJobStream jobStream = registerStream(false);
+
+    // when
+    ENGINE.incident().ofInstance(processInstanceKey).resolve();
+
+    // then
+    awaitPushOrNotify(jobStream, notificationsBefore);
+    assertThat(jobStream.getActivatedJobs())
+        .describedAs(
+            "a leased job that becomes activatable again by resolving its incident must "
+                + "not be pushed to a non-leasing stream")
+        .isEmpty();
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(jobMetric("skipped", jobType, JobKind.BPMN_ELEMENT))
+                    .describedAs(
+                        "demoting a push to notify-only counts the same skip signal the poll "
+                            + "path already counts for a lease mismatch")
+                    .isOne());
+  }
+
+  @Test
   public void shouldNotPushTimedOutLeasedJobToNonLeasingStream() {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
@@ -277,6 +400,18 @@ public final class ActivatableJobsPushWithLeaseTest {
             .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
             .setWithLease(withLease);
     return JOB_STREAMER.addJobStream(BufferUtil.wrapString(jobType), properties);
+  }
+
+  private double jobMetric(final String action, final String type, final JobKind kind) {
+    return ENGINE
+        .getMeterRegistry()
+        .get("zeebe.job.events.total")
+        .tag("action", action)
+        .tag("partition", "1")
+        .tag("type", type)
+        .tag("job_kind", kind.name())
+        .counter()
+        .count();
   }
 
   private String persistedLeaseToken() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.Strings;
@@ -178,6 +180,71 @@ public final class ActivatableJobsPushWithLeaseTest {
     assertThat(jobStream.getActivatedJobs().getFirst().jobRecord().getLeaseToken())
         .describedAs("a freshly created job pushed to a non-leasing stream carries no lease token")
         .isEmpty();
+  }
+
+  @Test
+  public void shouldNotPushTimedOutLeasedJobToNonLeasingStream() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final long timeout = 10L;
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withTimeout(timeout).withLease().activate();
+    assertThat(batchRecord.getValue().getJobs().getFirst().getLeaseToken())
+        .describedAs("the job under test must actually be leased")
+        .isNotEmpty();
+    final int notificationsBefore = JOB_STREAMER.notificationsForJob(jobType);
+    final RecordingJobStream jobStream = registerStream(false);
+
+    // when
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+
+    // then
+    jobRecords(TIMED_OUT).withType(jobType).await();
+    awaitPushOrNotify(jobStream, notificationsBefore);
+    assertThat(jobStream.getActivatedJobs())
+        .describedAs("a timed-out job is never pushed, leased or not")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldNotPushYieldedLeasedJobToNonLeasingStream() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().getFirst();
+    final long jobKey = batchRecord.getValue().getJobKeys().getFirst();
+    assertThat(job.getLeaseToken())
+        .describedAs("the job under test must actually be leased")
+        .isNotEmpty();
+    final int notificationsBefore = JOB_STREAMER.notificationsForJob(jobType);
+    final RecordingJobStream jobStream = registerStream(false);
+
+    // when
+    ENGINE.job().withKey(jobKey).withType(jobType).ofInstance(job.getProcessInstanceKey()).yield();
+
+    // then
+    jobRecords(JobIntent.YIELDED).withType(jobType).await();
+    awaitPushOrNotify(jobStream, notificationsBefore);
+    assertThat(jobStream.getActivatedJobs())
+        .describedAs("a yielded job is never pushed, leased or not")
+        .isEmpty();
+  }
+
+  /**
+   * Waits until the job has settled on one of two outcomes: pushed to {@code jobStream}, or
+   * notified for polling. The caller asserts on which outcome actually occurred.
+   */
+  private void awaitPushOrNotify(
+      final RecordingJobStream jobStream, final int notificationsBefore) {
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        !jobStream.getActivatedJobs().isEmpty()
+                            || JOB_STREAMER.notificationsForJob(jobType) > notificationsBefore)
+                    .describedAs("the job must have settled by either being pushed or notified")
+                    .isTrue());
   }
 
   private RecordingJobStream registerStream(final boolean withLease) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushWithLeaseTest.java
@@ -355,6 +355,46 @@ public final class ActivatableJobsPushWithLeaseTest {
   }
 
   @Test
+  public void shouldPushLeasedJobToLeasingStreamWhenNonLeasingStreamAlsoOpen() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().getFirst();
+    final long jobKey = batchRecord.getValue().getJobKeys().getFirst();
+    final String leaseToken = job.getLeaseToken();
+
+    final RecordingJobStream nonLeasingStream = registerStream(false);
+    final RecordingJobStream leasingStream = registerStream(true);
+
+    // when
+    ENGINE
+        .job()
+        .withKey(jobKey)
+        .ofInstance(job.getProcessInstanceKey())
+        .withLeaseToken(leaseToken)
+        .withRetries(3)
+        .fail();
+
+    // then
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        leasingStream.getActivatedJobs().size()
+                            + nonLeasingStream.getActivatedJobs().size())
+                    .isPositive());
+    assertThat(leasingStream.getActivatedJobs())
+        .describedAs("a leased job must be pushed to the leasing stream, not left for pollers")
+        .hasSize(1);
+    assertThat(nonLeasingStream.getActivatedJobs())
+        .describedAs(
+            "a leased job must never be pushed to a non-leasing stream, even when a leasing "
+                + "stream is open alongside it")
+        .isEmpty();
+  }
+
+  @Test
   public void shouldTreatLeasingAndNonLeasingRegistrationsAsDistinctIdentities() {
     // given
     final JobActivationPropertiesImpl leasing =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretPushInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretPushInjectionTest.java
@@ -395,6 +395,63 @@ public final class JobSecretPushInjectionTest {
   }
 
   /**
+   * A lease-skip counting regression, but this suite is the only place that can reproduce it:
+   * {@code SecretReferenceBatchReactivateJobsProcessor} reactivating jobs a resolved secret parked
+   * together is the only production path that demotes several same-type leased jobs within one
+   * shared-notification batch. Every trigger {@link ActivatableJobsPushWithLeaseTest} covers
+   * processes a single job per command, so none of them can build that precondition.
+   */
+  @Test
+  public void shouldCountEveryLeaseSkipWhenABatchDemotesJobsOfTheSameType() {
+    // given - two jobs already leased via a leasing stream, each carrying its own lease token
+    JOB_STREAMER.clearStreams();
+    final RecordingJobStream leasingStream = registerLeasingJobStream();
+    CACHED_SECRETS.put(SECRET_NAME, SECRET_VALUE);
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    final long firstJobKey =
+        jobKeyOf(engine.processInstance().ofBpmnProcessId(PROCESS_ID).create());
+    final long secondJobKey =
+        jobKeyOf(engine.processInstance().ofBpmnProcessId(PROCESS_ID).create());
+    Awaitility.await("until both jobs are leased on the leasing stream")
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> assertThat(leasingStream.getActivatedJobs()).hasSize(2));
+    final String firstToken = leaseTokenOf(leasingStream, firstJobKey);
+    final String secondToken = leaseTokenOf(leasingStream, secondJobKey);
+
+    // and - each job parks for secret resolution again once its cached value is evicted
+    CACHED_SECRETS.remove(SECRET_NAME);
+    engine.job().withKey(firstJobKey).withLeaseToken(firstToken).withRetries(3).fail();
+    engine.job().withKey(secondJobKey).withLeaseToken(secondToken).withRetries(3).fail();
+    awaitResolutionRequests(2);
+
+    // and - only a non-leasing stream remains registered by the time the reference resolves
+    JOB_STREAMER.clearStreams();
+    final RecordingJobStream nonLeasingStream = registerJobStream();
+    final double skippedBefore = skippedMetric();
+
+    // when - the reference resolves, reactivating both jobs through one shared-notification batch
+    CACHED_SECRETS.put(SECRET_NAME, SECRET_VALUE);
+    completeResolution();
+    RecordingExporter.secretReferenceRecords(SecretReferenceIntent.BATCH_JOBS_REACTIVATED)
+        .withSecretReference(SECRET_NAME)
+        .getFirst();
+
+    // then - the batch demotes both jobs from push to notify-only, and each must count on its own
+    Awaitility.await("until the skip signal accounts for both demoted jobs")
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                assertThat(skippedMetric() - skippedBefore)
+                    .describedAs(
+                        "a batch that demotes several same-type leased jobs must count every "
+                            + "demotion, not only the first job of the type")
+                    .isEqualTo(2));
+    assertThat(nonLeasingStream.getActivatedJobs())
+        .describedAs("neither leased job may be pushed to a non-leasing stream")
+        .isEmpty();
+  }
+
+  /**
    * A reactivation sizes its record batch against what handing each job out will write into that
    * same batch, but the sizing and the writing live in different classes. The processor's own test
    * mocks the writer, so it can only check the arithmetic; this drives the chain on a real record
@@ -573,6 +630,34 @@ public final class JobSecretPushInjectionTest {
             .setTimeout(30_000L)
             .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
     return JOB_STREAMER.addJobStream(BufferUtil.wrapString(JOB_TYPE), properties);
+  }
+
+  private RecordingJobStream registerLeasingJobStream() {
+    final var worker = BufferUtil.wrapString("test");
+    final var properties =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(30_000L)
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .setWithLease(true);
+    return JOB_STREAMER.addJobStream(BufferUtil.wrapString(JOB_TYPE), properties);
+  }
+
+  private String leaseTokenOf(final RecordingJobStream jobStream, final long jobKey) {
+    return jobStream.getActivatedJobs().stream()
+        .filter(activatedJob -> activatedJob.jobKey() == jobKey)
+        .findFirst()
+        .orElseThrow()
+        .jobRecord()
+        .getLeaseToken();
+  }
+
+  private double skippedMetric() {
+    // the counter is only registered once the first lease-skip fires, so a read taken before any
+    // job has been demoted for a lease collision must treat "not registered yet" as zero rather
+    // than fail: shouldCountEveryLeaseSkipWhenABatchDemotesJobsOfTheSameType reads this as a
+    // before/after delta, and its "before" snapshot runs before that first demotion happens
+    return findJobCounter("skipped").map(Counter::count).orElse(0.0);
   }
 
   private long jobKeyOf(final long processInstanceKey) {


### PR DESCRIPTION
## Description

**Lease-ness now participates in push-path stream matching:** a job that already holds a lease is never pushed to a non-leasing stream. This closes the gap PR1 explicitly deferred, and is where the actual fencing guarantee lands. This is PR 2 of the 3-PR stack for #56457 (PR1, #59894, already merged).

### Why the check happens before stream selection

`RemoteStreamerImpl` shuffles matching candidates and picks the first with consumers. A lease check applied *after* selection would strand a leased job non-deterministically instead of reliably excluding non-leasing streams — so the check is evaluated during candidate matching, before a stream is selected.

### Coverage

- **Five triggers** that can reach the push path with an already-leased job: fail-with-retries, backoff-recur, and incident-resolve (previously unguarded), plus timeout and yield as regression pins (these never reached push at all, so behavior is unchanged).
- **Registration identity:** leasing and non-leasing registrations for the same job type stay distinct rather than merging into one aggregate.

### Metric

The demotion from push to waiting-for-pollers now increments the existing `skipped` job-events counter — the same action the poll path already reports, no new metric or label. Push stays distinguishable from a poll skip because a demotion also emits `workers notified`, while a poll skip emits `skipped` alone.

> **Known noise:** this signal is currently diluted by an unrelated overload — uncached-secret skips also report `skipped` — tracked separately as #59794 and not introduced by this PR.

### Validation

- Extended `ActivatableJobsPushWithLeaseTest` with the trigger matrix, the mixed-stream selection case, the registration-identity pin, and the metric assertion.
- Relevant existing streaming, priority, multi-tenancy, and notification regression suites remain green and unmodified.
- Checked the notify path (`jobStreamer.notifyWorkAvailable` → a woken poller's ordinary activate-jobs request) for a comparable gap: **none found.** Every trigger converges on `JobBatchCollector`'s existing poll-side lease guard, since the lease token is read from stored `JobRecord` state rather than a freshly-built one.

## Checklist

- [ ] Enable backports when necessary

## Related issues

Part of #56457