### PR TITLE
feat: exclude disabled physical tenants from cluster-wide operations

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
@@ -118,5 +118,18 @@ public interface ConfigurationChangeCoordinator {
     default boolean isForced() {
       return false;
     }
+
+    /**
+     * Whether {@link #phases(CurrentClusterConfiguration)} should see disabled physical tenants
+     * (see {@link CurrentClusterConfiguration#activePartitionGroups()}). Defaults to {@code false}:
+     * the coordinator passes a view with disabled partition groups removed, so a request that
+     * enumerates "all physical tenants" when none is explicitly targeted automatically skips
+     * disabled ones, and a request that explicitly targets a disabled tenant by id sees it as
+     * absent. Override to {@code true} for a request that must operate on disabled tenants as well,
+     * e.g. one that manages tenant availability itself.
+     */
+    default boolean applyToDisabledTenants() {
+      return false;
+    }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -187,7 +187,18 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                       // application — uses the new multi-group model directly, so supporting
                       // non-default groups in the future only requires changing what phases()
                       // returns, not this coordinator.
-                      final var generatedPhases = request.phases(currentConfiguration);
+                      //
+                      // Requests that don't opt into targeting disabled physical tenants only see
+                      // active partition groups here, so phases() can never generate a phase that
+                      // targets a disabled tenant. Validation and application below still use the
+                      // unfiltered configuration: the generated phases are already restricted to
+                      // active groups, so validating/applying them against the full configuration
+                      // is safe and lets a phase's post-condition still observe disabled groups.
+                      final var configurationForPhases =
+                          request.applyToDisabledTenants()
+                              ? currentConfiguration
+                              : currentConfiguration.withoutDisabledPartitionGroups();
+                      final var generatedPhases = request.phases(configurationForPhases);
                       if (generatedPhases.isLeft()) {
                         failFuture(future, generatedPhases.getLeft());
                         return;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -594,6 +594,18 @@ public record CurrentClusterConfiguration(
   }
 
   /**
+   * A view of this configuration with every disabled partition group (see {@link
+   * #activePartitionGroups()}) removed, leaving {@link #version()}, {@link #globalConfiguration()}
+   * and {@link #phasedChangeState()} unchanged. Intended for {@link
+   * io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest#phases}
+   * implementations that enumerate all physical tenants and must not target a disabled one.
+   */
+  public CurrentClusterConfiguration withoutDisabledPartitionGroups() {
+    return new CurrentClusterConfiguration(
+        version, globalConfiguration, activePartitionGroups(), phasedChangeState);
+  }
+
+  /**
    * Returns the desired leader of every partition in the cluster, grouped by partition group id.
    * Partition ids are unique only within a group, so the outer group-id key is required to
    * disambiguate them. See {@link PartitionGroupConfiguration#desiredLeaders()} for how the

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -27,6 +27,8 @@ import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
@@ -37,6 +39,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -566,5 +569,86 @@ final class NewModelConfigurationChangeCoordinatorTest {
         .failsWithin(Duration.ofSeconds(5))
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(ConcurrentModificationException.class);
+  }
+
+  /**
+   * Same as {@link #twoMemberClusterWithSecondGroup()}, except the second group ("tenanta") is
+   * disabled.
+   */
+  private CurrentClusterConfiguration twoMemberClusterWithDisabledSecondGroup() {
+    final var base = twoMemberClusterWithSecondGroup();
+    final var disabledTenantA = base.partitionGroup("tenanta").disable();
+    return new CurrentClusterConfiguration(
+        base.version(),
+        base.globalConfiguration(),
+        Map.of(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            base.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+            "tenanta",
+            disabledTenantA),
+        base.phasedChangeState());
+  }
+
+  @Test
+  void shouldExcludeDisabledPartitionGroupFromPhasesByDefault() {
+    // given — a cluster with an active "default" group and a disabled "tenanta" group
+    wire(MEMBER_0, twoMemberClusterWithDisabledSecondGroup());
+    final CurrentClusterConfiguration[] seenByPhases = new CurrentClusterConfiguration[1];
+    final ConfigurationChangeRequest request =
+        new ConfigurationChangeRequest() {
+          @Override
+          public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+              final ClusterConfiguration clusterConfiguration) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public Either<Exception, List<Phase>> phases(
+              final CurrentClusterConfiguration clusterConfiguration) {
+            seenByPhases[0] = clusterConfiguration;
+            return Either.right(List.of());
+          }
+        };
+
+    // when
+    coordinator.applyOperations(request).join();
+
+    // then — the request only sees the active group; the disabled one is filtered out
+    assertThat(seenByPhases[0].partitionGroups().keySet())
+        .containsExactly(CurrentClusterConfiguration.DEFAULT_GROUP);
+  }
+
+  @Test
+  void shouldPassDisabledPartitionGroupsWhenRequestOptsIn() {
+    // given — a cluster with an active "default" group and a disabled "tenanta" group
+    wire(MEMBER_0, twoMemberClusterWithDisabledSecondGroup());
+    final CurrentClusterConfiguration[] seenByPhases = new CurrentClusterConfiguration[1];
+    final ConfigurationChangeRequest request =
+        new ConfigurationChangeRequest() {
+          @Override
+          public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+              final ClusterConfiguration clusterConfiguration) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public Either<Exception, List<Phase>> phases(
+              final CurrentClusterConfiguration clusterConfiguration) {
+            seenByPhases[0] = clusterConfiguration;
+            return Either.right(List.of());
+          }
+
+          @Override
+          public boolean applyToDisabledTenants() {
+            return true;
+          }
+        };
+
+    // when
+    coordinator.applyOperations(request).join();
+
+    // then — the request opted in, so it sees the disabled group too
+    assertThat(seenByPhases[0].partitionGroups().keySet())
+        .containsExactlyInAnyOrder(CurrentClusterConfiguration.DEFAULT_GROUP, "tenanta");
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -803,6 +803,43 @@ class CurrentClusterConfigurationTest {
   }
 
   @Nested
+  class WithoutDisabledPartitionGroups {
+
+    @Test
+    void shouldExcludeADisabledGroupButKeepOtherFields() {
+      // given — "a" is enabled, "b" is disabled
+      final var config =
+          config(
+              global(1, Map.of()),
+              Map.of("a", group(1, Map.of()), "b", group(1, Map.of()).disable()),
+              PhasedChangeState.empty());
+
+      // when
+      final var view = config.withoutDisabledPartitionGroups();
+
+      // then
+      assertThat(view.partitionGroups()).containsOnlyKeys("a");
+      assertThat(view.version()).isEqualTo(config.version());
+      assertThat(view.globalConfiguration()).isEqualTo(config.globalConfiguration());
+      assertThat(view.phasedChangeState()).isEqualTo(config.phasedChangeState());
+    }
+
+    @Test
+    void shouldReturnEveryGroupWhenNoneIsDisabled() {
+      // given
+      final var config =
+          config(
+              global(1, Map.of()),
+              Map.of("a", group(1, Map.of()), "b", group(1, Map.of())),
+              PhasedChangeState.empty());
+
+      // when / then
+      assertThat(config.withoutDisabledPartitionGroups().partitionGroups())
+          .containsOnlyKeys("a", "b");
+    }
+  }
+
+  @Nested
   class PlanTransitions {
 
     private static GlobalPhase globalPhase() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
@@ -11,14 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.management.cluster.ConfigurationChange.StatusEnum;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.actuator.ExportersActuator;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
 import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
@@ -39,6 +42,12 @@ import org.junit.jupiter.params.provider.MethodSource;
  * a fresh full-cluster bootstrap. This verifies the whole path end-to-end: a brand-new physical
  * tenant's partitions become visible via the client-facing (physical-tenant-scoped) topology
  * endpoint, and a process can be deployed to and instantiated within it.
+ *
+ * <p>Also covers the inverse: a physical tenant later removed from every broker's static
+ * configuration is disabled rather than deleted (see {@code
+ * PhysicalTenantAvailabilityInitializer}), and a cluster-wide operation that targets every physical
+ * tenant when none is explicitly given must not target it — otherwise the resulting change plan
+ * would stall forever waiting on an unreachable share of the plan that no broker runs any more.
  */
 @ZeebeIntegration
 final class PhysicalTenantProvisioningIT {
@@ -195,6 +204,45 @@ final class PhysicalTenantProvisioningIT {
               assertThat(info.getDisabled()).isNull();
               assertThat(info.getRouting()).isNotNull();
             });
+  }
+
+  @Test
+  void shouldCompleteClusterWideExporterDisableAfterTenantIsRemovedFromConfig() {
+    // given - tenantB is provisioned by adding it to every broker's configuration and restarting
+    restartCluster(cluster);
+    try (final var tenantBClient =
+        TENANTS_AFTER.newClientBuilder(cluster.availableGateway(), TENANT_B).build()) {
+      await("tenantB's topology is complete after provisioning")
+          .atMost(Duration.ofSeconds(60))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(tenantBClient.newTopologyRequest().send().join())
+                      .isComplete(BROKERS_COUNT, TENANT_B_PARTITIONS_COUNT, BROKERS_COUNT));
+    }
+
+    // when - tenantB is removed from every broker's local static configuration and the cluster is
+    // restarted again, disabling it: its partition assignment is retained, but no broker runs its
+    // partitions any more
+    cluster.shutdown();
+    cluster.brokers().values().forEach(broker -> broker.removePtConfig(TENANT_B));
+    cluster.start().awaitCompleteTopology();
+
+    // then - a cluster-wide exporter-disable request (no physical tenant explicitly targeted)
+    // completes instead of stalling forever: if it were still generated for tenantB's retained
+    // (but now unreachable) partition assignment, the change plan would never observe an ack for
+    // that share and would stay IN_PROGRESS
+    final var actuator = ClusterActuator.of(cluster.availableGateway());
+    final var response =
+        ExportersActuator.of(cluster.availableGateway())
+            .disableExporter(TestStandaloneBroker.RECORDING_EXPORTER_ID);
+    await("the cluster-wide exporter-disable change completes")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(actuator.getChange(response.getChangeId()).getStatus())
+                    .isEqualTo(StatusEnum.COMPLETED));
   }
 
   public static Stream<Arguments> restartStrategies() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantProvisioningIT.java
@@ -83,7 +83,7 @@ final class PhysicalTenantProvisioningIT {
           .build();
 
   @ParameterizedTest
-  @MethodSource("restartStrategies")
+  @MethodSource("restartStrategiesWithNewTenants")
   void shouldProvisionNewPhysicalTenantAddedAfterInitialBootstrapOnRestart(
       final Consumer<TestCluster> restarter) {
     // given - the cluster is up and running with only the default tenant and tenantA
@@ -152,10 +152,13 @@ final class PhysicalTenantProvisioningIT {
     }
   }
 
-  @Test
-  void shouldMarkPhysicalTenantDisabledOnActuatorWhenRemovedFromConfigAfterRestart() {
+  @ParameterizedTest
+  @MethodSource("restartStrategiesWithRemovingTenants")
+  void shouldMarkPhysicalTenantDisabledOnActuatorWhenRemovedFromConfigAfterRestart(
+      final Consumer<TestCluster> restarter) {
     // given - tenantB is provisioned by adding it to every broker's configuration and restarting
-    restartCluster(cluster);
+    restartClusterWithTenantB();
+
     try (final var tenantBClient =
         TENANTS_AFTER.newClientBuilder(cluster.availableGateway(), TENANT_B).build()) {
       await("tenantB's topology is complete after provisioning")
@@ -169,9 +172,8 @@ final class PhysicalTenantProvisioningIT {
 
     // when - tenantB is removed from every broker's local static configuration and the cluster is
     // restarted again
-    cluster.shutdown();
-    cluster.brokers().values().forEach(broker -> broker.removePtConfig(TENANT_B));
-    cluster.start().awaitCompleteTopology();
+
+    restarter.accept(cluster);
 
     // then - the physical-tenant-scoped actuator reports tenantB as disabled, with no routing
     // state or partitions: it is retained in the configuration, just not running anywhere
@@ -206,10 +208,21 @@ final class PhysicalTenantProvisioningIT {
             });
   }
 
+  private void restartClusterWithTenantB() {
+    restartCluster(
+        cluster,
+        broker -> {
+          TENANTS_AFTER.configure(broker);
+          broker.withPtConfig(
+              TENANT_B,
+              camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
+        });
+  }
+
   @Test
   void shouldCompleteClusterWideExporterDisableAfterTenantIsRemovedFromConfig() {
     // given - tenantB is provisioned by adding it to every broker's configuration and restarting
-    restartCluster(cluster);
+    restartClusterWithTenantB();
     try (final var tenantBClient =
         TENANTS_AFTER.newClientBuilder(cluster.availableGateway(), TENANT_B).build()) {
       await("tenantB's topology is complete after provisioning")
@@ -245,38 +258,50 @@ final class PhysicalTenantProvisioningIT {
                     .isEqualTo(StatusEnum.COMPLETED));
   }
 
-  public static Stream<Arguments> restartStrategies() {
+  public static Stream<Arguments> restartStrategiesWithNewTenants() {
+    return restartStrategies(
+        broker -> {
+          TENANTS_AFTER.configure(broker);
+          broker.withPtConfig(
+              TENANT_B,
+              camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
+        });
+  }
+
+  public static Stream<Arguments> restartStrategiesWithRemovingTenants() {
+    return restartStrategies(broker -> broker.removePtConfig(TENANT_B));
+  }
+
+  private static Stream<Arguments> restartStrategies(
+      final Consumer<TestStandaloneBroker> brokerConfigurator) {
     return Stream.of(
         Arguments.of(
             Named.of(
                 "Full restart",
-                (Consumer<TestCluster>) PhysicalTenantProvisioningIT::restartCluster)),
+                (Consumer<TestCluster>) cluster -> restartCluster(cluster, brokerConfigurator))),
         Arguments.of(
             Named.of(
                 "Rolling restart (coordinator first)",
-                (Consumer<TestCluster>) cluster -> rollingRestart(cluster, true))),
+                (Consumer<TestCluster>)
+                    cluster -> rollingRestart(cluster, true, brokerConfigurator))),
         Arguments.of(
             Named.of(
                 "Rolling restart (coordinator last)",
-                (Consumer<TestCluster>) cluster -> rollingRestart(cluster, false))));
+                (Consumer<TestCluster>)
+                    cluster -> rollingRestart(cluster, false, brokerConfigurator))));
   }
 
-  private static void restartCluster(final TestCluster cluster) {
+  private static void restartCluster(
+      final TestCluster cluster, final Consumer<TestStandaloneBroker> brokerConfigurator) {
     cluster.shutdown();
-    cluster
-        .brokers()
-        .values()
-        .forEach(
-            broker -> {
-              TENANTS_AFTER.configure(broker);
-              broker.withPtConfig(
-                  TENANT_B,
-                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
-            });
+    cluster.brokers().values().forEach(brokerConfigurator);
     cluster.start().awaitCompleteTopology();
   }
 
-  private static void rollingRestart(final TestCluster cluster, final boolean ascending) {
+  private static void rollingRestart(
+      final TestCluster cluster,
+      final boolean ascending,
+      final Consumer<TestStandaloneBroker> brokerConfigurator) {
     cluster.brokers().values().stream()
         .sorted(
             ascending
@@ -285,10 +310,7 @@ final class PhysicalTenantProvisioningIT {
         .forEach(
             broker -> {
               broker.stop();
-              TENANTS_AFTER.configure(broker);
-              broker.withPtConfig(
-                  TENANT_B,
-                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITIONS_COUNT));
+              brokerConfigurator.accept(broker);
               broker.start();
               cluster.await(TestHealthProbe.READY, Duration.ofSeconds(30));
             });

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -24,6 +24,8 @@ import io.camunda.zeebe.management.cluster.AddZoneRequest;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterZoneMigrationRequest;
+import io.camunda.zeebe.management.cluster.ConfigurationChange;
+import io.camunda.zeebe.management.cluster.GetConfigurationChangesResponse;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
@@ -326,6 +328,27 @@ public interface ClusterActuator {
   @RequestLine("DELETE /changes/{changeId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   GetTopologyResponse cancelChange(@Param final long changeId);
+
+  /**
+   * Returns the status and operations of one configuration change - the pending plan if {@code
+   * changeId} matches it, otherwise the last completed change.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     no change with this id is known
+   */
+  @RequestLine("GET /changes/{changeId}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  ConfigurationChange getChange(@Param final long changeId);
+
+  /**
+   * Lists every configuration change currently known to this broker (the pending plan, if any, and
+   * the last completed change).
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("GET /changes")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  GetConfigurationChangesResponse getChanges();
 
   // invalid parameter types
   @RequestLine("POST /brokers")


### PR DESCRIPTION
## Summary

Task 2 of #60070: excludes disabled physical tenants from cluster-wide operations (exporter enable/disable/delete, and any future request that enumerates every physical tenant when none is explicitly targeted). Stacked on #60151 (task 3).

Rather than have each `ConfigurationChangeRequest` implementation filter `partitionGroups()` itself, this centralizes the exclusion in the coordinator:

- `ConfigurationChangeRequest.applyToDisabledTenants()` — new default method, `false` by default.
- `CurrentClusterConfiguration.withoutDisabledPartitionGroups()` — a view with disabled partition groups removed, built on the existing `activePartitionGroups()`.
- `ConfigurationChangeCoordinatorImpl` passes this filtered view into `phases()` unless the request opts in via `applyToDisabledTenants()`.

`ExporterDisable/Enable/DeleteRequestTransformer` needed **no changes** — they already derive the "all tenants" fan-out and existence checks purely from the `CurrentClusterConfiguration` passed to `phases()`, so they get correct exclusion behavior automatically. This also means any future `ConfigurationChangeRequest` gets the same protection for free.

### Behavior change for explicitly-targeted disabled tenants

Explicitly targeting a disabled tenant by id now fails with the same `NotFound` error used for a tenant that never existed (since it's absent from the filtered view), rather than silently succeeding against a stalled exporter. Requests that must see disabled tenants (e.g. one managing tenant availability itself) can override `applyToDisabledTenants()` to opt out of the filtering.
