### PR TITLE
fix: prevent AWS OpenSearch IT credentials from expiring mid-test-run

### DIFF
--- a/.github/actions/setup-aws-opensearch-env/action.yml
+++ b/.github/actions/setup-aws-opensearch-env/action.yml
@@ -4,8 +4,9 @@ name: Setup AWS OpenSearch env
 # owner: @camunda/data-layer
 
 description: |
-  Imports OpenSearch endpoints from Vault, resolves OS URL for a selected 
-  version, and configures AWS credentials.
+  Imports OpenSearch endpoints from Vault, resolves OS URL for a selected
+  version, and exports the web identity env vars AWS SDKs need to assume
+  the OpenSearch role on their own.
 
 inputs:
   vault-address:
@@ -68,10 +69,3 @@ runs:
 
         echo "OPENSEARCH_URL=$OS_URL" >> "$GITHUB_ENV"
         echo "opensearch-url=$OS_URL" >> "$GITHUB_OUTPUT"
-
-    - name: Pre-login to AWS
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-      with:
-        aws-region: ${{ env.AWS_REGION }}
-        web-identity-token-file: ${{ env.AWS_WEB_IDENTITY_TOKEN_FILE }}
-        role-to-assume: ${{ env.AWS_ROLE_ARN }}

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -208,6 +208,12 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jeasy</groupId>
       <artifactId>easy-random-core</artifactId>
       <scope>test</scope>
@@ -770,6 +776,9 @@
             <dep>io.camunda:zeebe-opensearch-exporter</dep>
             <dep>io.camunda:camunda-exporter</dep>
             <dep>org.springframework.boot:spring-boot-starter-log4j2</dep>
+            <!-- This dependency is indirectly used by the awssk auth plugin. It requires these
+                 classes on the classpath in order to resolve the AWS credentials -->
+            <dep>software.amazon.awssdk:sts</dep>
           </ignoredUnusedDeclaredDependencies>
           <!--
             The servlet API (jakarta.servlet.HttpServletRequest, used by web-session tests to

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -82,6 +82,11 @@
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
     </dependency>
 
@@ -198,4 +203,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- This dependency is indirectly used by the awssk auth plugin. It requires these
+                 classes on the classpath in order to resolve the AWS credentials -->
+            <dep>software.amazon.awssdk:sts</dep>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -300,6 +300,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
@@ -315,6 +320,11 @@
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- This dependency is indirectly used by the awssk auth plugin. It requires these
+                 classes on the classpath in order to resolve the AWS credentials -->
+            <dep>software.amazon.awssdk:sts</dep>
+          </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Description

AWS OpenSearch integration test jobs on `main` were intermittently failing with `[security_exception] The security token included in the request is expired` whenever a matrix leg ran past the one-hour mark (job timeout budget is 360 minutes). See INC-7138 ([run 31667526656](https://github.com/camunda/camunda/actions/runs/31667526656)); the same signature also appears in earlier failed runs of the same leg (Aug 6, Aug 1).

**Root cause**: `setup-aws-opensearch-env` exported `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE` so the AWS SDK's default credential chain could assume the role itself and refresh indefinitely from the EKS-projected, kubelet-rotated token — but it then also ran `aws-actions/configure-aws-credentials`, which performs a one-shot STS exchange and writes *static* `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` into the job env. `DefaultCredentialsProvider` resolves the environment-variable provider before the web-identity provider, so those frozen, non-refreshing keys silently shadowed the refreshable chain. At the one-hour STS session boundary, every OpenSearch request started failing — and everything downstream that depends on OpenSearch state (Awaitility polls for indexed documents, audit-log entries, MCP-server searchability) failed too as a side effect, accounting for most of the errors in an affected run.

**Fix**: remove the extra login step so every AWS SDK caller in these jobs (the Java `OpensearchConnector`, and the boto3-based index-cleanup script) assumes the role on its own and refreshes for as long as the job runs.

**Prerequisite**: two of the five matrix legs (`search-client-connect`, `camunda-exporter`) had `software.amazon.awssdk:auth` but not `software.amazon.awssdk:sts` — AWS SDK v2 reflectively loads `StsWebIdentityCredentialsProviderFactory` from `sts` to perform the web-identity exchange, and throws `IllegalStateException` without it. That exception is caught broadly by `OpensearchConnector.shouldCreateAWSBasedTransport()` and silently downgrades to an unsigned transport, which AWS OpenSearch would then reject — a much harder failure to diagnose than the one this PR fixes. The first commit declares `sts` explicitly in those two modules, plus `qa-acceptance-tests` (which only had it by accident, transitively via `camunda-zeebe`).

## Checklist

- [ ] Enable backports when necessary — **open question for reviewer**: does this need `backport stable/8.x`? It's a CI-only fix with no runtime behavior change, but flagging per contributor policy since backport decisions are the engineer's call.
- [x] Not applicable — this PR does not touch the C8 Orchestration Cluster E2E Test Suite.

## Related issues

No tracked GitHub issue exists for this — it surfaced as incident INC-7138 (internal, not GitHub).

## Verification

- `./mvnw dependency:analyze-only` on all three changed modules: `sts` resolves and is not flagged as unused-declared.
- `./mvnw install -Dquickly` on `search-client-connect` and `camunda-exporter`: builds clean.
- `./mvnw spotless:apply`: no reformatting needed.
- `actionlint` on the three consuming workflows: identical finding count to `main` baseline (pre-existing, unrelated).
- Not verifiable locally: actual credential refresh past 60 minutes, since it requires the EKS projected token and the private OpenSearch endpoint. Recommend a manual dispatch of `zeebe-aws-os-dispatch-tests.yml` on this branch and confirming a `>60min` leg logs no `security_exception`.