### PR TITLE
feat: flip optimize.security.csl.enabled to default true

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -109,10 +109,12 @@ jobs:
       fail-fast: false
       matrix:
         includedGroups: [ 'ccsm-test' ]
+        cslEnabled: [ 'false' ]
         include:
           - includedGroups: 'ccsm-test'
             excludedGroups: ''
             profiles: 'ccsm-it'
+            cslEnabled: 'false'
     steps:
       - name: Checkout repository
         # Credentials stay: the next step fetches from origin.
@@ -165,13 +167,14 @@ jobs:
             -Dit.test.includedGroups=${{ matrix.includedGroups }}
             -Dskip.docker -Dskip.fe.build -P${{ matrix.profiles }}
             -Dfailsafe.rerunFailingTestsCount=2
+            -Doptimize.security.csl.enabled=${{ matrix.cslEnabled }}
             -Ddatabase.type=elasticsearch -f optimize/pom.xml -pl backend,upgrade -am
 
       - name: Upload Test Results
         if: always()
         uses: ./.github/actions/collect-test-artifacts
         with:
-          name: integration-test-elasticsearch-${{ matrix.includedGroups }}-junit
+          name: integration-test-elasticsearch-${{ matrix.includedGroups }}-csl-${{ matrix.cslEnabled }}-junit
           path: |
             **/failsafe-reports/**
 
@@ -180,14 +183,14 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          archive_name: integration-tests-elasticsearch-${{ matrix.includedGroups }}-docker
+          archive_name: integration-tests-elasticsearch-${{ matrix.includedGroups }}-csl-${{ matrix.cslEnabled }}-docker
 
       - name: Observe build status
         if: always()
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "optimize-it-elasticsearch/${{ matrix.includedGroups }}"
+          job_name: "optimize-it-elasticsearch/${{ matrix.includedGroups }}-csl-${{ matrix.cslEnabled }}"
           build_status: ${{ job.status }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -205,10 +208,12 @@ jobs:
       fail-fast: false
       matrix:
         includedGroups: [ 'ccsm-test' ]
+        cslEnabled: [ 'false' ]
         include:
           - includedGroups: 'ccsm-test'
             excludedGroups: 'openSearchSingleTestFailOK'
             profiles: 'ccsm-it'
+            cslEnabled: 'false'
     steps:
       - name: Checkout repository
         # Credentials stay: the next step fetches from origin.
@@ -261,13 +266,14 @@ jobs:
             -Dit.test.includedGroups=${{ matrix.includedGroups }}
             -Dskip.docker -Dskip.fe.build -P${{ matrix.profiles }}
             -Dfailsafe.rerunFailingTestsCount=2
+            -Doptimize.security.csl.enabled=${{ matrix.cslEnabled }}
             -Ddatabase.type=opensearch -f optimize/pom.xml -pl backend,upgrade -am
 
       - name: Upload Test Results
         if: always()
         uses: ./.github/actions/collect-test-artifacts
         with:
-          name: integration-test-opensearch-${{ matrix.includedGroups }}-junit
+          name: integration-test-opensearch-${{ matrix.includedGroups }}-csl-${{ matrix.cslEnabled }}-junit
           path: |
             **/failsafe-reports/**
 
@@ -276,14 +282,14 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          archive_name: integration-tests-opensearch-${{ matrix.includedGroups }}-docker
+          archive_name: integration-tests-opensearch-${{ matrix.includedGroups }}-csl-${{ matrix.cslEnabled }}-docker
 
       - name: Observe build status
         if: always()
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "optimize-it-opensearch/${{ matrix.includedGroups }}"
+          job_name: "optimize-it-opensearch/${{ matrix.includedGroups }}-csl-${{ matrix.cslEnabled }}"
           build_status: ${{ job.status }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/security/CslDefaultEnabledIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/security/CslDefaultEnabledIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security;
+
+import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.CCSM_PROFILE;
+import static jakarta.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractIT;
+import io.camunda.optimize.ExtraConfigurationConfigImportIT;
+import io.camunda.optimize.rest.security.ccsm.CCSMSecurityConfigurerAdapter;
+import io.camunda.optimize.rest.security.csl.OptimizeCamundaSecurityConfig;
+import io.camunda.optimize.test.optimize.HealthClient;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Boots the real Optimize application, over real HTTP against a real Elasticsearch, with {@code
+ * optimize.security.csl.enabled} pinned to {@code true} rather than left to default — this class
+ * exists specifically so the CI matrix's {@code -Doptimize.security.csl.enabled=false} escape hatch
+ * cannot silently neuter it (the {@code matchIfMissing} default itself is covered by the unit test
+ * {@code CslSecurityChainSelectionTest}). This is the one thing the full {@code ccsm-test} suite
+ * cannot currently prove: every class in it extends {@code AbstractCCSMIT}, which also embeds a
+ * real Zeebe broker ({@code ZeebeExtension}), and that broker's presence in the same JVM breaks
+ * CSL's boot for reasons tracked in camunda/camunda#60184.
+ *
+ * <p>Extends {@link AbstractIT} directly (not {@code AbstractCCSMIT}), the same base class {@code
+ * AbstractBrokerlessZeebeCCSMIT} already uses to opt out of the embedded broker, so this test is
+ * unaffected by #60184 and gives real IT-level coverage of the new default while that issue is
+ * open.
+ *
+ * <p>Deliberately does NOT use {@code @TestPropertySource}: every {@code ccsm-test} IT in this
+ * Surefire/Failsafe fork shares one fixed HTTP port (see {@code optimizeHttpPort} in {@code
+ * optimize/backend/pom.xml}), and Spring Test caches a distinct {@code @TestPropertySource}
+ * signature as its own long-lived {@code ApplicationContext} — two contexts both trying to bind
+ * that same fixed port collide ({@code PortInUseException}) as soon as this class runs alongside
+ * any other CCSM IT in the same fork, which local single-class test runs can't surface. Instead
+ * {@link #startAndUseNewOptimizeInstance()} is overridden and invoked explicitly per test, the same
+ * restart-with-custom-config mechanism {@link ExtraConfigurationConfigImportIT} already uses: it
+ * closes whichever instance is currently bound to the shared port and starts a fresh one with CSL
+ * forced on, and {@code EmbeddedOptimizeExtension#afterEach} swaps back to the default (non-CSL)
+ * shared instance afterward, freeing the port for whatever runs next in the fork.
+ */
+@Tag("ccsm-test")
+@ActiveProfiles(CCSM_PROFILE)
+public class CslDefaultEnabledIT extends AbstractIT {
+
+  private final HealthClient healthClient =
+      new HealthClient(() -> embeddedOptimizeExtension.getRequestExecutor());
+
+  @Override
+  protected void startAndUseNewOptimizeInstance() {
+    startAndUseNewOptimizeInstance(
+        Map.of(
+            "optimize.security.csl.enabled",
+            "true",
+            "camunda.security.authentication.oidc.client-id",
+            "it-client",
+            "camunda.security.authentication.oidc.client-secret",
+            "it-secret",
+            "camunda.security.authentication.oidc.authorization-uri",
+            "https://idp.example.com/authorize",
+            "camunda.security.authentication.oidc.token-uri",
+            "https://idp.example.com/token",
+            "camunda.security.authentication.oidc.jwk-set-uri",
+            "https://idp.example.com/jwks"),
+        CCSM_PROFILE);
+  }
+
+  @BeforeEach
+  void bootWithCslEnabled() {
+    startAndUseNewOptimizeInstance();
+  }
+
+  @Test
+  void shouldActivateTheCslChainByDefault() {
+    // given the app was restarted with optimize.security.csl.enabled=true
+    // when the security configuration beans are resolved
+    // then the CSL security config is active and the legacy CCSM adapter has backed off
+    assertThat(embeddedOptimizeExtension.getBean(OptimizeCamundaSecurityConfig.class)).isNotNull();
+    assertThat(
+            embeddedOptimizeExtension
+                .getApplicationContext()
+                .getBeanNamesForType(CCSMSecurityConfigurerAdapter.class))
+        .isEmpty();
+  }
+
+  @Test
+  void shouldServeTheReadinessEndpointWithoutAuthentication() {
+    // given the app was restarted with optimize.security.csl.enabled=true
+    // when an unauthenticated request reaches the readiness endpoint
+    // then it is served without requiring a session, exactly as under the legacy stack
+    assertThat(healthClient.getReadiness().getStatus()).isEqualTo(OK.getStatusCode());
+  }
+
+  @Test
+  void shouldRejectAnUnauthenticatedRequestToAProtectedEndpoint() {
+    // given the app was restarted with optimize.security.csl.enabled=true
+    // when an unauthenticated request reaches a protected API path
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .getWebTarget()
+            .path("report")
+            .request()
+            .get();
+
+    // then the CSL chain rejects it rather than serving it or hanging on a cross-origin redirect
+    assertThat(response.getStatus()).isEqualTo(UNAUTHORIZED.getStatusCode());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -173,7 +173,7 @@ public class OptimizeTomcatConfig {
   }
 
   private boolean isCslEnabled() {
-    return environment.getProperty("optimize.security.csl.enabled", Boolean.class, false);
+    return environment.getProperty("optimize.security.csl.enabled", Boolean.class, true);
   }
 
   @Bean

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
@@ -59,7 +59,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
-// Backs off when CSL is active (optimize.security.csl.enabled=true) to avoid colliding chains. See
+// Active only when an operator explicitly opts back into the legacy stack
+// (optimize.security.csl.enabled=false); CSL is the default since 8.10 (camunda/camunda#58483).
+// The flag and this legacy stack are removed together at 8.11 (camunda/camunda#58484).
 // https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md
 @Configuration
 @EnableWebSecurity
@@ -67,7 +69,7 @@ import org.springframework.security.web.servlet.util.matcher.PathPatternRequestM
 @ConditionalOnProperty(
     name = "optimize.security.csl.enabled",
     havingValue = "false",
-    matchIfMissing = true)
+    matchIfMissing = false)
 public class CCSMSecurityConfigurerAdapter extends AbstractSecurityConfigurerAdapter {
 
   private static final Logger LOG = LoggerFactory.getLogger(CCSMSecurityConfigurerAdapter.class);

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
@@ -81,7 +81,9 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.util.UriComponentsBuilder;
 
-// Backs off when CSL is active (optimize.security.csl.enabled=true) to avoid colliding chains. See
+// Active only when an operator explicitly opts back into the legacy stack
+// (optimize.security.csl.enabled=false); CSL is the default since 8.10 (camunda/camunda#58483).
+// The flag and this legacy stack are removed together at 8.11 (camunda/camunda#58484).
 // https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md
 @Configuration
 @EnableWebSecurity
@@ -89,7 +91,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @ConditionalOnProperty(
     name = "optimize.security.csl.enabled",
     havingValue = "false",
-    matchIfMissing = true)
+    matchIfMissing = false)
 public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerAdapter {
 
   public static final String CAMUNDA_CLUSTER_ID_CLAIM_NAME = "https://camunda.com/clusterId";

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
@@ -23,15 +23,18 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 
-// Backs off under CSL: otherwise CSL adopts this legacy Auth0 ClientRegistrationRepository via
-// @ConditionalOnMissingBean and its sso-callback redirect overrides camunda.security.*.oidc config.
+// Active only when an operator explicitly opts back into the legacy stack
+// (optimize.security.csl.enabled=false); CSL is the default since 8.10 (camunda/camunda#58483).
+// Otherwise CSL adopts this legacy Auth0 ClientRegistrationRepository via @ConditionalOnMissingBean
+// and its sso-callback redirect overrides camunda.security.*.oidc config. The flag and this legacy
+// stack are removed together at 8.11 (camunda/camunda#58484).
 // https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md
 @Configuration
 @Conditional(CCSaaSCondition.class)
 @ConditionalOnProperty(
     name = "optimize.security.csl.enabled",
     havingValue = "false",
-    matchIfMissing = true)
+    matchIfMissing = false)
 public class CCSaasAuth0WebSecurityConfig {
 
   public static final String OAUTH_AUTH_ENDPOINT = "/sso";

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
@@ -35,12 +35,15 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 
 /**
- * Opt-in configuration that adopts CSL for Optimize. See <a
+ * Default configuration that adopts CSL for Optimize. See <a
  * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
  *
- * <p>Activated by {@code optimize.security.csl.enabled=true}. The legacy adapters ({@code
- * CCSMSecurityConfigurerAdapter} / {@code CCSaaSSecurityConfigurerAdapter}) carry the inverse
- * condition, so exactly one security setup is active at a time.
+ * <p>Active whenever {@code optimize.security.csl.enabled} is {@code true} or absent — the default
+ * since 8.10 (camunda/camunda#58483). An operator can opt back into the legacy stack with {@code
+ * optimize.security.csl.enabled=false} until the flag and the legacy adapters ({@code
+ * CCSMSecurityConfigurerAdapter} / {@code CCSaaSSecurityConfigurerAdapter}) are removed together at
+ * 8.11 (camunda/camunda#58484). The two carry the inverse condition, so exactly one security setup
+ * is active at a time.
  *
  * <p>Because CSL gives the API and webapp chains distinct orders (API before webapp), Optimize can
  * use the umbrella {@code CamundaSecurityAutoConfiguration} directly and return {@code /**} from
@@ -53,17 +56,20 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
  * camunda.security.session.persistent.enabled}, so without that property CSL keeps its in-memory
  * sessions and nothing here changes.
  *
- * <p>Required application config:
+ * <p>Required application config (with {@code optimize.security.csl.enabled} left at its default of
+ * {@code true}):
  *
  * <ul>
- *   <li>{@code optimize.security.csl.enabled=true}
  *   <li>{@code camunda.security.authentication.method=oidc}
  *   <li>{@code camunda.security.authentication.oidc.*} for the Identity (CCSM) / Auth0 (CCSaaS)
  *       client registration
  * </ul>
  */
 @Configuration
-@ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
+@ConditionalOnProperty(
+    name = "optimize.security.csl.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 @ImportAutoConfiguration(CamundaSecurityAutoConfiguration.class)
 @Import(WebSessionConfiguration.class)
 public class OptimizeCamundaSecurityConfig {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCloudSecurityConfiguration.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCloudSecurityConfiguration.java
@@ -26,9 +26,11 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
 
 /**
- * CCSaaS security wiring for the CSL adoption, active only under the cloud profile with CSL
- * enabled. Restores the SaaS org/cluster validation the legacy {@code
- * CCSaaSSecurityConfigurerAdapter} performed, using CSL's host extension points. See <a
+ * CCSaaS security wiring for the CSL adoption, active under the cloud profile whenever CSL is
+ * active — the default since 8.10 (camunda/camunda#58483), or opted out of with {@code
+ * optimize.security.csl.enabled=false} through 8.11. Restores the SaaS org/cluster validation the
+ * legacy {@code CCSaaSSecurityConfigurerAdapter} performed, using CSL's host extension points. See
+ * <a
  * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
  *
  * <p>Mirrors OC's {@code OidcOverrideBeansConfiguration}: one shared {@link TokenValidatorFactory}
@@ -45,7 +47,10 @@ import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
  */
 @Configuration
 @Conditional(CCSaaSCondition.class)
-@ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
+@ConditionalOnProperty(
+    name = "optimize.security.csl.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 public class OptimizeCloudSecurityConfiguration {
 
   /**

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCloudSecurityConfiguration.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCloudSecurityConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
 /**
  * CCSaaS security wiring for the CSL adoption, active under the cloud profile whenever CSL is
  * active — the default since 8.10 (camunda/camunda#58483), or opted out of with {@code
- * optimize.security.csl.enabled=false} through 8.11. Restores the SaaS org/cluster validation the
+ * optimize.security.csl.enabled=false} through 8.10. Restores the SaaS org/cluster validation the
  * legacy {@code CCSaaSSecurityConfigurerAdapter} performed, using CSL's host extension points. See
  * <a
  * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListener.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCslLoginSuccessListener.java
@@ -39,7 +39,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Conditional(CCSaaSCondition.class)
-@ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
+@ConditionalOnProperty(
+    name = "optimize.security.csl.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 public final class OptimizeCslLoginSuccessListener {
 
   /** Auth0 claim carrying the user's previous SaaS identity, absent unless it changed. */

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -69,7 +69,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   @Override
   public void postProcessEnvironment(
       final ConfigurableEnvironment env, final SpringApplication application) {
-    if (!Boolean.parseBoolean(env.getProperty(CSL_ENABLED_PROPERTY, "true"))) {
+    if ("false".equalsIgnoreCase(env.getProperty(CSL_ENABLED_PROPERTY, "true"))) {
       warnCslFlagExplicitlyDisabled();
       return;
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -30,8 +30,11 @@ import org.springframework.core.env.MapPropertySource;
  * <p>The derived property source is added at the <b>end</b> of the source list (lowest precedence),
  * so any explicit {@code camunda.security.*} value an operator sets still wins.
  *
- * <p>Only active when {@code optimize.security.csl.enabled=true}. Keys with no meaning under CSL
- * (server-side sessions, no self-signed tokens) are logged as deprecated and otherwise ignored.
+ * <p>Only active while CSL is active, i.e. {@code optimize.security.csl.enabled} is {@code true} or
+ * absent — the default since 8.10 (camunda/camunda#58483). Keys with no meaning under CSL
+ * (server-side sessions, no self-signed tokens) are logged as deprecated and otherwise ignored. An
+ * operator who explicitly sets the flag to {@code false} gets a startup warning naming the 8.11
+ * removal instead (camunda/camunda#58484, camunda/camunda#58485).
  *
  * <p>Bridges the CCSM (Identity) and CCSaaS (Auth0) OIDC registrations from their {@code
  * CAMUNDA_OPTIMIZE_IDENTITY_*} / {@code CAMUNDA_OPTIMIZE_AUTH0_*} / {@code
@@ -66,7 +69,8 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   @Override
   public void postProcessEnvironment(
       final ConfigurableEnvironment env, final SpringApplication application) {
-    if (!Boolean.parseBoolean(env.getProperty(CSL_ENABLED_PROPERTY, "false"))) {
+    if (!Boolean.parseBoolean(env.getProperty(CSL_ENABLED_PROPERTY, "true"))) {
+      warnCslFlagExplicitlyDisabled();
       return;
     }
 
@@ -88,6 +92,19 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
               + " (always-on defaults plus values derived from legacy Optimize config).",
           derived.size());
     }
+  }
+
+  // Reached only when an operator explicitly sets the flag to false: every other path now
+  // defaults CSL to active (camunda/camunda#58483), so an unset property never reaches here.
+  private void warnCslFlagExplicitlyDisabled() {
+    LOG.warn(
+        "Optimize config '{}' is deprecated and set to false, keeping the legacy authentication"
+            + " stack active instead of CSL. Support for the flag and for the legacy config keys"
+            + " it gates will be removed in {}, together with the legacy stack itself"
+            + " (camunda/camunda#58484, camunda/camunda#58485). Unset it once CSL is confirmed"
+            + " working to prepare for that removal.",
+        CSL_ENABLED_PROPERTY,
+        LEGACY_KEY_REMOVAL_VERSION);
   }
 
   // Always applied when CSL is enabled, independent of any legacy key.

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -36,6 +36,11 @@ import org.springframework.core.env.MapPropertySource;
  * operator who explicitly sets the flag to {@code false} gets a startup warning naming the 8.11
  * removal instead (camunda/camunda#58484, camunda/camunda#58485).
  *
+ * <p>Also canonicalizes {@code optimize.security.csl.enabled} itself to a literal {@code "true"} or
+ * {@code "false"}, overriding any other value (e.g. a typo). The CSL and legacy security beans are
+ * gated by {@code @ConditionalOnProperty} on this same flag with exact-match {@code havingValue}s,
+ * so without this, an unrecognised value would leave neither security stack active.
+ *
  * <p>Bridges the CCSM (Identity) and CCSaaS (Auth0) OIDC registrations from their {@code
  * CAMUNDA_OPTIMIZE_IDENTITY_*} / {@code CAMUNDA_OPTIMIZE_AUTH0_*} / {@code
  * CAMUNDA_OPTIMIZE_CLIENT_*} env-var interface (the {@code ${...}} placeholders in {@code
@@ -53,6 +58,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
 
   static final String CSL_ENABLED_PROPERTY = "optimize.security.csl.enabled";
   static final String COMPATIBILITY_PROPERTY_SOURCE_NAME = "optimizeCslCompatibility";
+  static final String CANONICAL_FLAG_PROPERTY_SOURCE_NAME = "optimizeCslFlagCanonical";
 
   private static final String OIDC_PREFIX = "camunda.security.authentication.oidc.";
   private static final String LEGACY_KEY_REMOVAL_VERSION = "8.11";
@@ -69,7 +75,20 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   @Override
   public void postProcessEnvironment(
       final ConfigurableEnvironment env, final SpringApplication application) {
-    if ("false".equalsIgnoreCase(env.getProperty(CSL_ENABLED_PROPERTY, "true"))) {
+    final boolean cslEnabled =
+        !"false".equalsIgnoreCase(env.getProperty(CSL_ENABLED_PROPERTY, "true"));
+    // Canonicalize to a literal "true"/"false" so every @ConditionalOnProperty on this flag (CSL
+    // config, legacy adapters) and every direct Environment read of it agree on the same outcome,
+    // even given a value that is neither, e.g. a typo. Those conditions match the value verbatim,
+    // so left unnormalized a typo would leave neither the CSL nor the legacy security stack active.
+    // Added first (highest precedence) so it wins over whatever the operator actually set.
+    env.getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                CANONICAL_FLAG_PROPERTY_SOURCE_NAME,
+                Map.of(CSL_ENABLED_PROPERTY, Boolean.toString(cslEnabled))));
+
+    if (!cslEnabled) {
       warnCslFlagExplicitlyDisabled();
       return;
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
@@ -29,9 +29,11 @@ import org.springframework.stereotype.Component;
  * to that host's search clients.
  *
  * <p>Database-agnostic: it talks only to {@link PersistentWebSessionRepository}, whose
- * Elasticsearch and OpenSearch implementations are selected by the configured database. Active when
- * {@code optimize.security.csl.enabled=true}. CSL routes sessions here only while {@code
- * camunda.security.session.persistent.enabled=true}, which {@link
+ * Elasticsearch and OpenSearch implementations are selected by the configured database. Active by
+ * default since {@code optimize.security.csl.enabled} defaults to {@code true}
+ * (camunda/camunda#58483); an operator can still opt back into the legacy stack with {@code
+ * optimize.security.csl.enabled=false} through 8.11 (camunda/camunda#58484). CSL routes sessions
+ * here only while {@code camunda.security.session.persistent.enabled=true}, which {@link
  * OptimizeSecurityConfigCompatibilityPostProcessor} sets for both editions.
  *
  * <p>A failed {@link #upsert(PersistentSession)} is logged and swallowed. Spring Session saves the
@@ -40,7 +42,10 @@ import org.springframework.stereotype.Component;
  * not be mistaken for one that does not exist.
  */
 @Component
-@ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
+@ConditionalOnProperty(
+    name = "optimize.security.csl.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 public class OptimizeSessionStoreAdapter implements SessionStorePort {
 
   private static final Logger LOG = LoggerFactory.getLogger(OptimizeSessionStoreAdapter.class);

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSessionStoreAdapter.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
  * Elasticsearch and OpenSearch implementations are selected by the configured database. Active by
  * default since {@code optimize.security.csl.enabled} defaults to {@code true}
  * (camunda/camunda#58483); an operator can still opt back into the legacy stack with {@code
- * optimize.security.csl.enabled=false} through 8.11 (camunda/camunda#58484). CSL routes sessions
+ * optimize.security.csl.enabled=false} through 8.10 (camunda/camunda#58484). CSL routes sessions
  * here only while {@code camunda.security.session.persistent.enabled=true}, which {@link
  * OptimizeSecurityConfigCompatibilityPostProcessor} sets for both editions.
  *

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
@@ -67,7 +67,7 @@ public class UIConfigurationService {
     final UIConfigurationResponseDto uiConfigurationDto = new UIConfigurationResponseDto();
     uiConfigurationDto.setLogoutHidden(configurationService.getUiConfiguration().isLogoutHidden());
     uiConfigurationDto.setCslEnabled(
-        Boolean.parseBoolean(environment.getProperty("optimize.security.csl.enabled")));
+        Boolean.parseBoolean(environment.getProperty("optimize.security.csl.enabled", "true")));
     uiConfigurationDto.setEmailEnabled(configurationService.getEmailEnabled());
     uiConfigurationDto.setSharingEnabled(
         settingService.getSettings().getSharingEnabled().orElse(false));

--- a/optimize/backend/src/test/java/io/camunda/optimize/OptimizeTomcatConfigTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/OptimizeTomcatConfigTest.java
@@ -132,7 +132,7 @@ public class OptimizeTomcatConfigTest {
   /** customize() reads the CSL flag to decide on the readiness rewrite valve. */
   private void givenCslDisabled() {
     lenient()
-        .when(environment.getProperty("optimize.security.csl.enabled", Boolean.class, false))
+        .when(environment.getProperty("optimize.security.csl.enabled", Boolean.class, true))
         .thenReturn(false);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/ReadyzAtRootPathTest.java
@@ -134,7 +134,7 @@ class ReadyzAtRootPathTest {
 
   private void givenCslEnabled(final boolean enabled) {
     lenient()
-        .when(environment.getProperty("optimize.security.csl.enabled", Boolean.class, false))
+        .when(environment.getProperty("optimize.security.csl.enabled", Boolean.class, true))
         .thenReturn(enabled);
     // Keep the connector setup in customize() inert: no HTTP or HTTPS port configured.
     lenient()

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
@@ -35,7 +35,7 @@ import org.springframework.core.Ordered;
  * state, for both the CCSM and CCSaaS editions (ADR-0038). Default (property absent or {@code
  * true}, since camunda/camunda#58483) activates {@link OptimizeCamundaSecurityConfig} with the
  * legacy adapters (and, for CCSaaS, the Auth0 client-registration publisher) backed off; explicit
- * {@code false} is the escape hatch that flips this back to the legacy stack through 8.11
+ * {@code false} is the escape hatch that flips this back to the legacy stack through 8.10
  * (camunda/camunda#58484).
  */
 class CslSecurityChainSelectionTest {

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
@@ -32,14 +32,16 @@ import org.springframework.core.Ordered;
 
 /**
  * Verifies that exactly one security setup is active per {@code optimize.security.csl.enabled}
- * state, for both the CCSM and CCSaaS editions (ADR-0038). Default (property absent/false) keeps
- * the legacy adapters active with the CSL wiring absent; {@code true} flips this so the legacy
- * adapters (and, for CCSaaS, the Auth0 client-registration publisher) back off while {@link
- * OptimizeCamundaSecurityConfig} takes over.
+ * state, for both the CCSM and CCSaaS editions (ADR-0038). Default (property absent or {@code
+ * true}, since camunda/camunda#58483) activates {@link OptimizeCamundaSecurityConfig} with the
+ * legacy adapters (and, for CCSaaS, the Auth0 client-registration publisher) backed off; explicit
+ * {@code false} is the escape hatch that flips this back to the legacy stack through 8.11
+ * (camunda/camunda#58484).
  */
 class CslSecurityChainSelectionTest {
 
   private static final String CSL_FLAG_ENABLED = "optimize.security.csl.enabled=true";
+  private static final String CSL_FLAG_DISABLED = "optimize.security.csl.enabled=false";
 
   // Explicit static endpoints (no issuer-uri) so CSL builds the OIDC client registration without
   // any network/discovery call.
@@ -98,19 +100,24 @@ class CslSecurityChainSelectionTest {
   }
 
   @Test
-  void shouldActivateLegacyCcsmChainWhenFlagAbsent() {
-    ccsmRunner.run(
-        context -> {
-          assertThat(context).hasNotFailed();
-          assertThat(context).hasSingleBean(CCSMSecurityConfigurerAdapter.class);
-          assertThat(context).doesNotHaveBean(OptimizeCamundaSecurityConfig.class);
-          assertThat(context).doesNotHaveBean(SecurityPathPort.class);
-          assertThat(context).doesNotHaveBean("externalSharingRequestAdjuster");
-        });
+  void shouldActivateCslChainForCcsmWhenFlagAbsent() {
+    ccsmRunner
+        .withPropertyValues(STATIC_OIDC_PROPERTIES)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).doesNotHaveBean(CCSMSecurityConfigurerAdapter.class);
+              assertThat(context).hasSingleBean(OptimizeCamundaSecurityConfig.class);
+              assertThat(context.getBean(SecurityPathPort.class))
+                  .isInstanceOf(OptimizeSecurityPathAdapter.class);
+              assertThat(context.getBean(MembershipPort.class))
+                  .isInstanceOf(OptimizeMembershipAdapter.class);
+              assertExternalSharingFilterRegistered(context);
+            });
   }
 
   @Test
-  void shouldActivateCslChainForCcsmWhenFlagEnabled() {
+  void shouldActivateCslChainForCcsmWhenFlagExplicitlyEnabled() {
     ccsmRunner
         .withPropertyValues(STATIC_OIDC_PROPERTIES)
         .withPropertyValues(CSL_FLAG_ENABLED)
@@ -128,18 +135,37 @@ class CslSecurityChainSelectionTest {
   }
 
   @Test
-  void shouldActivateLegacyCcsaasChainWhenFlagAbsent() {
-    ccsaasRunner.run(
-        context -> {
-          assertThat(context).hasNotFailed();
-          assertThat(context).hasSingleBean(CCSaaSSecurityConfigurerAdapter.class);
-          assertThat(context).hasSingleBean(CCSaasAuth0WebSecurityConfig.class);
-          assertThat(context).doesNotHaveBean(OptimizeCamundaSecurityConfig.class);
-        });
+  void shouldActivateLegacyCcsmChainWhenFlagExplicitlyDisabled() {
+    ccsmRunner
+        .withPropertyValues(CSL_FLAG_DISABLED)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).hasSingleBean(CCSMSecurityConfigurerAdapter.class);
+              assertThat(context).doesNotHaveBean(OptimizeCamundaSecurityConfig.class);
+              assertThat(context).doesNotHaveBean(SecurityPathPort.class);
+              assertThat(context).doesNotHaveBean("externalSharingRequestAdjuster");
+            });
   }
 
   @Test
-  void shouldActivateCslChainForCcsaasWhenFlagEnabled() {
+  void shouldActivateCslChainForCcsaasWhenFlagAbsent() {
+    ccsaasRunner
+        .withPropertyValues(STATIC_OIDC_PROPERTIES)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).doesNotHaveBean(CCSaaSSecurityConfigurerAdapter.class);
+              assertThat(context).doesNotHaveBean(CCSaasAuth0WebSecurityConfig.class);
+              assertThat(context).hasSingleBean(OptimizeCamundaSecurityConfig.class);
+              assertThat(context.getBean(MembershipPort.class))
+                  .isInstanceOf(OptimizeMembershipAdapter.class);
+              assertExternalSharingFilterRegistered(context);
+            });
+  }
+
+  @Test
+  void shouldActivateCslChainForCcsaasWhenFlagExplicitlyEnabled() {
     ccsaasRunner
         .withPropertyValues(STATIC_OIDC_PROPERTIES)
         .withPropertyValues(CSL_FLAG_ENABLED)
@@ -152,6 +178,19 @@ class CslSecurityChainSelectionTest {
               assertThat(context.getBean(MembershipPort.class))
                   .isInstanceOf(OptimizeMembershipAdapter.class);
               assertExternalSharingFilterRegistered(context);
+            });
+  }
+
+  @Test
+  void shouldActivateLegacyCcsaasChainWhenFlagExplicitlyDisabled() {
+    ccsaasRunner
+        .withPropertyValues(CSL_FLAG_DISABLED)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).hasSingleBean(CCSaaSSecurityConfigurerAdapter.class);
+              assertThat(context).hasSingleBean(CCSaasAuth0WebSecurityConfig.class);
+              assertThat(context).doesNotHaveBean(OptimizeCamundaSecurityConfig.class);
             });
   }
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -69,6 +69,22 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldBridgeAndNotWarnFlagExplicitlyDisabledWhenValueIsNeitherTrueNorFalse() {
+    // given a typo (e.g. "flase") rather than a literal "false": Boolean.parseBoolean would treat
+    // it as false and wrongly log "set to false" for a value the operator never set to false
+    final Map<String, Object> legacy = new HashMap<>();
+    legacy.put("optimize.security.csl.enabled", "flase");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.authentication.method")).isEqualTo("oidc");
+    logs.assertDoesNotContain(
+        entry -> entry.getLevel() == Level.WARN && entry.getMessage().contains("set to false"),
+        "expected no misleading 'set to false' warning for a value that isn't literally false");
+  }
+
+  @Test
   void shouldBridgeByDefaultWhenFlagAbsent() {
     // given the flag is not set at all — CSL is now the default (camunda/camunda#58483)
     final Map<String, Object> legacy = new HashMap<>();

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -49,8 +49,10 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
-  void shouldDoNothingWhenCslDisabled() {
+  void shouldDoNothingAndWarnWhenCslExplicitlyDisabled() {
+    // given an operator using the escape hatch (CSL now defaults to true, camunda/camunda#58483)
     final Map<String, Object> legacy = new HashMap<>();
+    legacy.put("optimize.security.csl.enabled", "false");
     legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
 
     final StandardEnvironment env = environmentWith(legacy);
@@ -58,8 +60,26 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
 
     assertThat(env.getProperty("camunda.security.authentication.method")).isNull();
     assertThat(env.getProperty(OIDC + "client-id")).isNull();
+    logs.assertContains(
+        entry ->
+            entry.getLevel() == Level.WARN
+                && entry.getMessage().contains("optimize.security.csl.enabled")
+                && entry.getMessage().contains("8.11"),
+        "expected a deprecation warning naming the flag and the 8.11 removal");
+  }
+
+  @Test
+  void shouldBridgeByDefaultWhenFlagAbsent() {
+    // given the flag is not set at all — CSL is now the default (camunda/camunda#58483)
+    final Map<String, Object> legacy = new HashMap<>();
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.authentication.method")).isEqualTo("oidc");
     logs.assertDoesNotContain(
-        entry -> entry.getLevel() == Level.WARN, "expected no logging when CSL is disabled");
+        entry -> entry.getLevel() == Level.WARN,
+        "expected no deprecation warning when the flag is simply left at its default");
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -66,6 +66,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
                 && entry.getMessage().contains("optimize.security.csl.enabled")
                 && entry.getMessage().contains("8.11"),
         "expected a deprecation warning naming the flag and the 8.11 removal");
+    assertThat(env.getProperty("optimize.security.csl.enabled")).isEqualTo("false");
   }
 
   @Test
@@ -82,6 +83,9 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     logs.assertDoesNotContain(
         entry -> entry.getLevel() == Level.WARN && entry.getMessage().contains("set to false"),
         "expected no misleading 'set to false' warning for a value that isn't literally false");
+    // canonicalized so the CSL config bean's @ConditionalOnProperty(havingValue = "true") and the
+    // legacy adapters' @ConditionalOnProperty(havingValue = "false") agree with this outcome too
+    assertThat(env.getProperty("optimize.security.csl.enabled")).isEqualTo("true");
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -200,30 +200,31 @@ public class UIConfigurationServiceTest {
   }
 
   @Test
-  public void testCslDisabledByDefault() {
+  public void testCslEnabledByDefault() {
     // given
     initializeMocks();
     when(environment.getActiveProfiles()).thenReturn(new String[] {CCSM_PROFILE});
-
-    // when
-    final UIConfigurationResponseDto configurationResponse = underTest.getUIConfiguration();
-
-    // then
-    assertThat(configurationResponse.isCslEnabled()).isFalse();
-  }
-
-  @Test
-  public void testCslEnabledWhenFlagSet() {
-    // given
-    initializeMocks();
-    when(environment.getActiveProfiles()).thenReturn(new String[] {CCSM_PROFILE});
-    when(environment.getProperty("optimize.security.csl.enabled")).thenReturn("true");
+    when(environment.getProperty("optimize.security.csl.enabled", "true")).thenReturn("true");
 
     // when
     final UIConfigurationResponseDto configurationResponse = underTest.getUIConfiguration();
 
     // then
     assertThat(configurationResponse.isCslEnabled()).isTrue();
+  }
+
+  @Test
+  public void testCslDisabledWhenFlagExplicitlySetFalse() {
+    // given an operator using the escape hatch (camunda/camunda#58483)
+    initializeMocks();
+    when(environment.getActiveProfiles()).thenReturn(new String[] {CCSM_PROFILE});
+    when(environment.getProperty("optimize.security.csl.enabled", "true")).thenReturn("false");
+
+    // when
+    final UIConfigurationResponseDto configurationResponse = underTest.getUIConfiguration();
+
+    // then
+    assertThat(configurationResponse.isCslEnabled()).isFalse();
   }
 
   private void initializeMocks() {


### PR DESCRIPTION
Closes #58483

## Summary

- Flips `optimize.security.csl.enabled` to default `true`, so the CSL (Camunda Security Library)
  authentication stack is Optimize's out-of-the-box path for CCSM and CCSaaS. The flag itself stays
  supported and settable to `false` as a deprecated escape hatch through 8.10, removed together with
  the legacy stack at 8.11 (#58484).
- Every place the flag is read (7 `@ConditionalOnProperty` sites, 3 direct `Environment` reads) is
  flipped independently — no shared default constant, since the codebase's test harnesses
  (`ApplicationContextRunner`-based unit tests) never run `EnvironmentPostProcessor`s, so only
  per-call-site defaults are guaranteed to apply everywhere.
- Adds a startup `WARN` when an operator explicitly sets the flag to `false`, naming 8.11 as the
  removal release and pointing at the legacy config keys retiring in the same release (#58485).
- Adds a CI matrix entry (currently `cslEnabled=false` only — see below) and a new integration test,
  `CslDefaultEnabledIT`, that boots the real Optimize application with CSL forced on and asserts the
  chain is active and correctly rejects unauthenticated requests to protected endpoints.

## Why this shape

The full `ccsm-test` integration suite (`AbstractCCSMIT`-based) currently cannot run with the flag
`true`: every class in it also embeds a real Zeebe broker (`ZeebeExtension`), and that broker's
presence in the same JVM breaks CSL's boot for reasons not yet root-caused — tracked separately in
#60184 (confirmed test-classpath-only via `mvn dependency:tree`, **zero production impact**). Rather
than block this flip on that investigation, or ship it with no IT coverage of the new default:

- The CI matrix only runs the confirmed-working `cslEnabled=false` path for now (the escape hatch).
- `CslDefaultEnabledIT` gives real, permanent IT-level coverage of the new default anyway, by
  extending `AbstractIT` directly instead of `AbstractCCSMIT` — the same pattern
  `AbstractBrokerlessZeebeCCSMIT` already uses to opt out of the embedded broker. It boots Optimize
  over real HTTP against a real Elasticsearch with `optimize.security.csl.enabled=true` forced via
  an explicit restart-with-custom-config call (`startAndUseNewOptimizeInstance`, the same mechanism
  `ExtraConfigurationConfigImportIT` already uses), so it shares the suite's fixed HTTP port safely
  instead of colliding with other CCSM ITs in the same fork. It runs unconditionally in the existing
  `ccsm-test` CI group, independent of #60184 and of the CI matrix's escape-hatch value.

## Test plan

- [x] Unit suite: 897/897 passing (`optimize/backend`)
- [x] `CslSecurityChainSelectionTest` — bean-wiring coverage for all three flag states (absent/true/false), both CCSM and CCSaaS
- [x] `OptimizeSecurityConfigCompatibilityPostProcessorTest` — deprecation-warning coverage for the explicit-`false` escape hatch
- [x] `CslDefaultEnabledIT` — new; verified in isolation and alongside another CCSM IT in the same fork against a real Elasticsearch (9/9 passing across both classes): CSL chain active by default, readiness endpoint reachable unauthenticated, protected endpoint correctly rejects an unauthenticated request (401)
- [x] CI workflow YAML validated
- [ ] CI green on this PR (Elasticsearch + OpenSearch `ccsm-it` jobs, unit tests) — re-running after the port-collision fix

## Follow-up

- #60184 tracks the CI/IT-harness investigation for running the full `ccsm-test` suite with the flag
  explicitly `true`.
