### PR TITLE
ci: Increase timeout for CI database integration tests

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -118,6 +118,7 @@ jobs:
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
+    # Temporary increase (PT tests create schemas for multiple tenants sequentially); revert after #60105 lands.
     timeout-minutes: 25
     runs-on: ${{ inputs.runs-on }}
     env:

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -118,7 +118,7 @@ jobs:
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
-    timeout-minutes: 20
+    timeout-minutes: 25
     runs-on: ${{ inputs.runs-on }}
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
as reported in [#inc-7188-unsuccessful-job-ci-physical-tenant-acceptance-testsopensearch-on](https://camunda.slack.com/archives/C0BQ9EZRS1Y), 
`physical-tenant-acceptance-tests/opensearch` is timing out after 20 minutes
It is a known issue as the PT tests are taking longer, requiring schema creation for 2 tenants. This is currently done sequentially.
This will be changed in https://github.com/camunda/camunda/pull/60105 that will handle the schema creation in parallel (https://github.com/camunda/camunda/actions/runs/31794936178/job/94750915029?pr=60105 is less than 15 minutes)

**temporarily** increase the timeout of the CI to 25 minutes until the PR above gets merged

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
