### PR TITLE
Skip backup checkpoint/retention when tenant's recovering

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -138,11 +138,7 @@ public class BackupRetention extends Actor {
     LOG.info("Backup retention initialized with cleanup schedule {}", retentionSchedule);
     backupStore = backupStoreFactory.get();
     metrics.register();
-    final var next =
-        retentionSchedule.nextExecution(Instant.ofEpochMilli(ActorClock.currentTimeMillis()));
-    LOG.debug("Scheduling next retention task in {} ", next);
-    metrics.recordNextExecution(next.get());
-    actor.runAt(next.get().toEpochMilli(), this::reschedulingTask);
+    scheduleNextRetention();
   }
 
   @Override
@@ -157,6 +153,13 @@ public class BackupRetention extends Actor {
   }
 
   private void reschedulingTask() {
+    if (topologyManager.isRecovering(physicalTenantId)) {
+      LOG.debug(
+          "Skipping backup retention, physical tenant {} is in recovery mode", physicalTenantId);
+      scheduleNextRetention();
+      return;
+    }
+
     performRetention()
         .onComplete(
             (v, err) -> {
@@ -166,13 +169,15 @@ public class BackupRetention extends Actor {
               } else {
                 LOG.debug("Backup retention task completed successfully");
               }
-              final var next =
-                  retentionSchedule.nextExecution(
-                      Instant.ofEpochMilli(ActorClock.currentTimeMillis()));
-              LOG.debug("Scheduling next retention task in {} ", next);
-              metrics.recordNextExecution(next.get());
-              actor.runAt(next.get().toEpochMilli(), this::reschedulingTask);
+              scheduleNextRetention();
             });
+  }
+
+  private void scheduleNextRetention() {
+    final var next = retentionSchedule.nextExecution(ActorClock.currentInstant());
+    LOG.debug("Scheduling next retention task in {} ", next);
+    metrics.recordNextExecution(next.get());
+    actor.runAt(next.get().toEpochMilli(), this::reschedulingTask);
   }
 
   private ActorFuture<Void> performRetention() {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.schedule;
 
 import io.camunda.zeebe.backup.client.api.BackupRequestHandler;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
@@ -39,6 +40,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
   private final Schedule checkpointSchedule;
   private final Schedule backupSchedule;
   private final BackupRequestHandler backupRequestHandler;
+  private final BrokerTopologyManager topologyManager;
   private final SchedulerMetrics metrics;
 
   private long markerErrorDelayMs;
@@ -51,6 +53,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
       final Schedule checkpointSchedule,
       final Schedule backupSchedule,
       final BackupRequestHandler backupRequestHandler,
+      final BrokerTopologyManager topologyManager,
       final MeterRegistry meterRegistry) {
     super("CheckpointScheduler", null, Map.of(ACTOR_PROP_PHYSICAL_TENANT, physicalTenantId));
     this.physicalTenantId = physicalTenantId;
@@ -58,6 +61,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
     this.backupSchedule = backupSchedule;
     metrics = new SchedulerMetrics(meterRegistry);
     this.backupRequestHandler = backupRequestHandler;
+    this.topologyManager = topologyManager;
     markerErrorStrategy =
         new ExponentialBackoff(BACKOFF_MAX_DELAY_MS, BACKOFF_INITIAL_DELAY_MS, 1.2, 0);
     backupErrorStrategy =
@@ -85,6 +89,9 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
   }
 
   private void markerSchedulingTask() {
+    if (rescheduledRecoveringTenant(CheckpointType.MARKER)) {
+      return;
+    }
     acquirePartitionStates(CheckpointStateResponse::getCheckpointStates)
         .thenApply(this::determineNextCheckpoint, this)
         .andThen(this::markerCheckpoint, this)
@@ -92,12 +99,47 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
   }
 
   private void backupSchedulingTask() {
+    if (rescheduledRecoveringTenant(CheckpointType.SCHEDULED_BACKUP)) {
+      return;
+    }
     acquirePartitionStates(CheckpointStateResponse::getBackupStates)
         .thenApply(this::determineNextBackup, this)
         .andThen(this::backupCheckpoint, this)
         .onComplete(
             (res, err) -> handleExecutionCompletion(res, err, CheckpointType.SCHEDULED_BACKUP),
             this);
+  }
+
+  /**
+   * Skips this tick's requests while the physical tenant is recovering, rescheduling the loop on
+   * its normal schedule instead.
+   *
+   * <p>A recovering tenant is having its partitions restored, so a checkpoint taken now would
+   * capture a half-restored state; a tenant whose mode this broker cannot see yet is treated the
+   * same way. The loop keeps ticking rather than stopping, so it picks the schedule back up on its
+   * own as soon as the tenant returns to processing mode — no restart of the actor is needed.
+   *
+   * @return {@code true} if the tick was skipped, in which case the loop is already rescheduled
+   */
+  private boolean rescheduledRecoveringTenant(final CheckpointType type) {
+    if (!topologyManager.isRecovering(physicalTenantId)) {
+      return false;
+    }
+
+    final var tickSchedule = type == CheckpointType.MARKER ? checkpointSchedule : backupSchedule;
+    final var next = nextExecution(tickSchedule, ActorClock.currentInstant());
+    metrics.recordNextExecution(next, type);
+    LOG.debug(
+        "Skipping {} checkpoint, physical tenant {} is in recovery mode. Next attempt at {}",
+        type,
+        physicalTenantId,
+        next);
+
+    final Runnable task =
+        type == CheckpointType.MARKER ? this::markerSchedulingTask : this::backupSchedulingTask;
+    final long delay = Math.max(0, next.toEpochMilli() - ActorClock.currentTimeMillis());
+    schedule(Duration.ofMillis(delay), task);
+    return true;
   }
 
   /**

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -697,4 +697,42 @@ public class RetentionTest {
       verifyNoDeleteCommandSent(backup5.id().checkpointId());
     }
   }
+
+  @Nested
+  class RecoveringTenant {
+
+    @Test
+    void shouldNotTouchBackupsWhileTenantIsRecovering() {
+      // given — no retention round runs, so neither the topology nor the store is consulted
+      reset(topologyManager, clusterState);
+      when(topologyManager.isRecovering(DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(true);
+
+      // when
+      runRetentionCycle();
+
+      // then — the store is not even listed, so a recovering tenant sees no retention activity
+      verify(backupStore, never()).list(any());
+      verifyNoDeleteCommands();
+    }
+
+    @Test
+    void shouldKeepTickingWhileTenantIsRecovering() {
+      // given — recovery ends after the first tick was skipped
+      final var now = actorScheduler.getClock().instant();
+      when(topologyManager.isRecovering(DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(true, false);
+      when(backupStore.list(any()))
+          .thenReturn(CompletableFuture.completedFuture(createDefaultBackups(1, 1, now)));
+
+      // when — the first tick finds the tenant recovering
+      runRetentionCycle();
+      verify(backupStore, never()).list(any());
+
+      // when — the tick after that finds it back in processing mode
+      actorScheduler.updateClock(Duration.ofSeconds(10));
+      actorScheduler.workUntilDone();
+
+      // then — the loop was still ticking on its own schedule, so it resumes without a restart
+      verify(backupStore, times(1)).list(any());
+    }
+  }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
@@ -61,12 +61,13 @@ public class CheckpointScheduleTest {
 
   private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private CheckpointScheduler checkpointScheduler;
+  private BrokerTopologyManager topologyManager;
 
   @BeforeEach
   void setup() {
     meterRegistry.clear();
     brokerClient = mock(BrokerClient.class);
-    final var topologyManager = mock(BrokerTopologyManager.class);
+    topologyManager = mock(BrokerTopologyManager.class);
     final var clusterState = mock(BrokerClusterState.class);
     lenient().when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
     lenient()
@@ -538,6 +539,59 @@ public class CheckpointScheduleTest {
     verify(backupRequestHandler, times(2)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
+  @Test
+  void shouldNotSendAnyRequestWhileTenantIsRecovering() {
+    // given
+    final var now = actorScheduler.getClock().getCurrentTime();
+    checkpointScheduler =
+        createScheduler(
+            new Schedule.IntervalSchedule(Duration.ofSeconds(5)),
+            new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
+    when(topologyManager.isRecovering(DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(true);
+    lenient()
+        .when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(
+            CompletableFuture.completedStage(
+                checkpointState(now.toEpochMilli(), now.toEpochMilli())));
+
+    // when
+    actorScheduler.submitActor(checkpointScheduler);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(5));
+    actorScheduler.workUntilDone();
+
+    // then — not even the state query is sent, so a recovering tenant sees no traffic at all
+    verify(backupRequestHandler, never()).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
+    verify(backupRequestHandler, never()).checkpoint(eq(DEFAULT_PHYSICAL_TENANT_ID), any());
+  }
+
+  @Test
+  void shouldKeepTickingWhileTenantIsRecovering() {
+    // given — recovery ends after the first two ticks were skipped
+    final var now = actorScheduler.getClock().getCurrentTime();
+    checkpointScheduler =
+        createScheduler(new Schedule.IntervalSchedule(Duration.ofSeconds(5)), null);
+    when(topologyManager.isRecovering(DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(true, true, false);
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedStage(checkpointState(now.toEpochMilli(), 0L)));
+
+    // when — the initial tick and the one 5s later are skipped
+    actorScheduler.submitActor(checkpointScheduler);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(5));
+    actorScheduler.workUntilDone();
+    verify(backupRequestHandler, never()).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // when — the tick after that finds the tenant back in processing mode
+    actorScheduler.updateClock(Duration.ofSeconds(5));
+    actorScheduler.workUntilDone();
+
+    // then — the loop was still ticking on its own schedule, so it resumes without a restart
+    verify(backupRequestHandler, times(1)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
+    verify(backupRequestHandler, times(1))
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.MARKER);
+  }
+
   private CheckpointStateResponse checkpointState(
       final long checkpointTimestamp, final long backupTimestamp) {
     final var response = new CheckpointStateResponse();
@@ -568,7 +622,12 @@ public class CheckpointScheduleTest {
       final Schedule checkpointSchedule,
       final Schedule backupSchedule) {
     return new CheckpointScheduler(
-        physicalTenantId, checkpointSchedule, backupSchedule, backupRequestHandler, meterRegistry);
+        physicalTenantId,
+        checkpointSchedule,
+        backupSchedule,
+        backupRequestHandler,
+        topologyManager,
+        meterRegistry);
   }
 
   private Gauge getGauge(final String gaugeName, final CheckpointType type) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import org.jspecify.annotations.NonNull;
 
 public interface BrokerTopologyManager extends ClusterConfigurationUpdateListener {
@@ -35,6 +36,27 @@ public interface BrokerTopologyManager extends ClusterConfigurationUpdateListene
    * also includes information about brokers which are currently unreachable.
    */
   CurrentClusterConfiguration getClusterConfiguration();
+
+  /**
+   * Returns whether the given physical tenant has any broker in {@link Mode#RECOVERING}, or whether
+   * its mode cannot be determined at all.
+   *
+   * <p>A mode change flips brokers one at a time, so "any" covers the whole transition window: the
+   * tenant counts as recovering from the moment the first broker enters recovery until the last one
+   * has left it. Callers that must not act on a half-transitioned tenant can rely on that.
+   *
+   * <p>The unknown half of the name covers a tenant the cluster configuration holds no brokers for
+   * — not configured, or no configuration gossiped to this broker yet. Recovery cannot be ruled out
+   * there either, so callers gating work on this method hold off and retry rather than act on a
+   * tenant whose state they cannot see.
+   */
+  default boolean isRecovering(@NonNull final String physicalTenantId) {
+    final var partitionGroup = getClusterConfiguration().partitionGroup(physicalTenantId);
+    return partitionGroup == null
+        || partitionGroup.members().isEmpty()
+        || partitionGroup.members().values().stream()
+            .anyMatch(member -> member.mode() == Mode.RECOVERING);
+  }
 
   /**
    * Adds the topology listener. For each existing broker-group pair, the listener will be notified

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -984,6 +985,77 @@ final class BrokerTopologyManagerTest {
     assertThat(topologyManager.getTopology("unknown-group").isInitialized()).isFalse();
   }
 
+  @Test
+  void shouldReportUnknownTenantAsRecoveringOrUnknown() {
+    // given -- no configuration was ever received for this tenant
+
+    // when / then -- recovery cannot be ruled out, so callers must hold off rather than act
+    assertThat(topologyManager.isRecovering("unknowntenant")).isTrue();
+  }
+
+  @Test
+  void shouldReportTenantWithoutBrokersAsRecoveringOrUnknown() {
+    // given -- a configured group that carries no brokers at all
+    final var configuration = configureTenantWithMode(Map.of());
+
+    // when
+    topologyManager.onClusterConfigurationUpdated(configuration);
+    actorSchedulerRule.workUntilDone();
+
+    // then -- there is no broker whose mode could rule recovery out
+    assertThat(topologyManager.isRecovering("tenant1")).isTrue();
+  }
+
+  @Test
+  void shouldNotReportTenantAsRecoveringOrUnknownWhileEveryBrokerIsProcessing() {
+    // given
+    final var configuration =
+        configureTenantWithMode(
+            Map.of(MemberId.from("1"), Mode.PROCESSING, MemberId.from("2"), Mode.PROCESSING));
+
+    // when
+    topologyManager.onClusterConfigurationUpdated(configuration);
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    assertThat(topologyManager.isRecovering("tenant1")).isFalse();
+  }
+
+  @Test
+  void shouldReportTenantAsRecoveringWhileOnlyOneBrokerHasEnteredRecovery() {
+    // given -- a mode change that has flipped one of the two brokers so far
+    final var configuration =
+        configureTenantWithMode(
+            Map.of(MemberId.from("1"), Mode.RECOVERING, MemberId.from("2"), Mode.PROCESSING));
+
+    // when
+    topologyManager.onClusterConfigurationUpdated(configuration);
+    actorSchedulerRule.workUntilDone();
+
+    // then -- the tenant counts as recovering for the whole transition window
+    assertThat(topologyManager.isRecovering("tenant1")).isTrue();
+  }
+
+  @Test
+  void shouldNotReportTenantAsRecoveringBecauseAnotherTenantIs() {
+    // given
+    final var configuration =
+        configureTenantsWithModes(
+            Map.of(
+                "tenant1",
+                Map.of(MemberId.from("1"), Mode.RECOVERING),
+                DEFAULT_PHYSICAL_TENANT_ID,
+                Map.of(MemberId.from("1"), Mode.PROCESSING)));
+
+    // when
+    topologyManager.onClusterConfigurationUpdated(configuration);
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    assertThat(topologyManager.isRecovering(DEFAULT_PHYSICAL_TENANT_ID)).isFalse();
+    assertThat(topologyManager.isRecovering("tenant1")).isTrue();
+  }
+
   private void addTopologyListener(final BrokerTopologyListener listener) {
     topologyManager.addTopologyListener(listener);
     actorSchedulerRule.workUntilDone();
@@ -1026,6 +1098,43 @@ final class BrokerTopologyManagerTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty());
+  }
+
+  // builds a cluster configuration holding only a "tenant1" group, whose members are in the given
+  // modes
+  private static CurrentClusterConfiguration configureTenantWithMode(
+      final Map<MemberId, Mode> modeByMember) {
+    return configureTenantsWithModes(Map.of("tenant1", modeByMember));
+  }
+
+  private static CurrentClusterConfiguration configureTenantsWithModes(
+      final Map<String, Map<MemberId, Mode>> modeByMemberByTenant) {
+    final Map<String, PartitionGroupConfiguration> groups = new HashMap<>();
+    modeByMemberByTenant.forEach(
+        (physicalTenantId, modeByMember) -> {
+          final Map<MemberId, BrokerPartitionState> members = new HashMap<>();
+          modeByMember.forEach(
+              (memberId, mode) ->
+                  members.put(
+                      memberId,
+                      BrokerPartitionState.initialize(
+                              Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))
+                          .setMode(mode)));
+          groups.put(
+              physicalTenantId,
+              new PartitionGroupConfiguration(
+                  PartitionGroupConfiguration.INITIAL_VERSION,
+                  PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+                  members,
+                  Optional.empty(),
+                  Optional.empty(),
+                  Optional.empty()));
+        });
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfigWithMember(MemberId.from("1")),
+        groups,
+        PhasedChangeState.empty());
   }
 
   private static PartitionGroupConfiguration incrementIncarnation(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -160,6 +160,7 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
               checkpointSchedule,
               backupSchedule,
               backupRequestHandler,
+              brokerClient.getTopologyManager(),
               tenantMeterRegistry);
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When a tenant is in recovery mode backups & checkpoints cannot be processed. To reduce error noise on backup/retetnion schedule ticks we deliberately skip these ticks when the tenant is discovered to be in recovery mode.

The operation is rescheduled normally so it won't be missed when the tenant enters processing mode again

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56076
