### PR TITLE
ci: stop taking a Harbor login in Optimize jobs that never pull from it

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -132,7 +132,6 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-build
         with:
-          harbor: true
           maven-cache-key-modifier: optimize-tests
           time-zone: Europe/Berlin
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -232,7 +231,6 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-build
         with:
-          harbor: true
           maven-cache-key-modifier: optimize-tests
           time-zone: Europe/Berlin
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -520,7 +518,6 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-build
         with:
-          harbor: true
           maven-cache-key-modifier: optimize-e2e-smoke
           time-zone: Europe/Berlin
           vault-address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-build
         with:
-          harbor: true
           maven-cache-key-modifier: optimize-e2e-nightly
           time-zone: Europe/Berlin
           vault-address: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
## Description

Drops `harbor: true` from four Optimize jobs that never pull from or push to `registry.camunda.cloud`.

**Why.** Harbor runs in `ldap_auth` mode against `ldap.camunda.com` and does not cache auth results, so every `docker login registry.camunda.cloud` is a live LDAP bind. When LDAP degrades the login fails and the job dies in `Setup Maven` before a single test runs.

On 2026-08-13 a six-minute LDAP outage produced 4,816 `LDAP Result Code 200 "Network Error": context deadline exceeded` binds and took out both Optimize integration-test jobs on `stable/8.8` (INC-7155). Harbor itself was healthy throughout — no restarts, no credential rotation, no rate limiting. The same signature recurs roughly weekly (08-02, 08-07, 08-11, twice on 08-13) and is not specific to this repository: three other CI accounts and around 20 enterprise customers were locked out of the registry during that window.

**Why removal rather than migration.** These four jobs never needed the login, so the cheapest way to make them immune to LDAP is to stop asking for it:

| Job | Why Harbor isn't needed |
| --- | --- |
| `optimize-it-elasticsearch` / `optimize-it-opensearch` (the INC-7155 jobs) | Start OpenSearch/Elasticsearch from compose files whose images all come from DockerHub or `docker.elastic.co`; `build-zeebe` explicitly excludes Docker images; no `registry.camunda.cloud` reference exists anywhere under `optimize/`. The only Testcontainers use in this path is `Testcontainers.exposeHostPorts(9200)`, which pulls no image. |
| `Optimize / E2E / Self-Managed (Smoke)` | Uses `optimize/client/docker-compose.yml` — only `camunda/camunda`, `camunda/identity`, `camunda/keycloak`, `elasticsearch`, `opensearch`. All public. |
| `optimize-e2e-tests-sm-nightly` | Same compose file, same conclusion. |

The `harbor` input on `setup-build` defaults to `"false"`, so dropping the line is sufficient — nothing else in these jobs changes.

**Left untouched deliberately.** The two Optimize workflows that genuinely use Harbor keep their login: `optimize-ci-build-reusable` pushes the built image there, and `optimize-release-optimize-c8-only` pulls `team-optimize/optimize` through `docker-compose.smoketest.yml`.

**Relationship to the robot-account work.** This is complementary to, not a replacement for, #60169, which moves the remaining Harbor logins in `setup-build` to `robot$camunda-monorepo-ci` (robot accounts live in Harbor's own database and bypass LDAP entirely). That PR fixes the logins we still need; this one removes four we never did. Both are needed.

Widening the retry window was considered and rejected: 48s of retries cannot ride out a 6–15 minute outage.

**Still on LDAP, out of scope here.** `c8run-release-rc` and `c8run-release-public` log in with `regctl` using a distribution-team account from a different Vault path (`secret/data/products/distribution/ci`), so they need their own robot account and a hand-off to `@distro-medic` / `@infra-medic`.

### Verification

- `actionlint` clean on both changed files — the only findings are pre-existing self-hosted runner-label warnings, identical in count and content on unmodified `main` (they require the CI-supplied `actionlint.yaml`).
- Diff is four deleted lines and nothing else.
- `.github/conftest-unified-ci-rules.rego` makes no reference to Harbor or `setup-build`, and no job or step was added, removed, or renamed, so CI-analytics coverage is unaffected.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related to INC-7155
