### PR TITLE
feat: execute a rebalance's leadership transfers one at a time

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -433,6 +433,12 @@ public class Raft {
      */
     private int maxTransferAttempts = 3;
 
+    /**
+     * How long the coordinator waits for a partition with no contactable leader to get one before
+     * giving up with {@code NO_LEADER}.
+     */
+    private Duration leaderWaitTimeout = Duration.ofMinutes(1);
+
     public DataSize getReplicationLagThreshold() {
       return replicationLagThreshold;
     }
@@ -467,6 +473,17 @@ public class Raft {
             "maxTransferAttempts must be positive but was %s".formatted(maxTransferAttempts));
       }
       this.maxTransferAttempts = maxTransferAttempts;
+    }
+
+    public Duration getLeaderWaitTimeout() {
+      return leaderWaitTimeout;
+    }
+
+    public void setLeaderWaitTimeout(final Duration leaderWaitTimeout) {
+      if (leaderWaitTimeout == null || leaderWaitTimeout.isNegative()) {
+        throw new IllegalArgumentException("leaderWaitTimeout must be non-negative");
+      }
+      this.leaderWaitTimeout = leaderWaitTimeout;
     }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -633,6 +633,10 @@ public class BrokerBasedPropertiesOverride {
         .getRaft()
         .setRebalanceMaxTransferAttempts(raft.getRebalance().getMaxTransferAttempts());
     override
+        .getCluster()
+        .getRaft()
+        .setRebalanceLeaderWaitTimeout(raft.getRebalance().getLeaderWaitTimeout());
+    override
         .getExperimental()
         .getRaft()
         .setPreallocateSegmentFiles(raft.isPreallocateSegmentFiles());

--- a/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
@@ -50,7 +50,8 @@ public class ClusterRaftTest {
         "camunda.cluster.raft.preallocate-segment-files=false",
         "camunda.cluster.raft.rebalance.replication-lag-threshold=16MB",
         "camunda.cluster.raft.rebalance.replication-timeout=30s",
-        "camunda.cluster.raft.rebalance.max-transfer-attempts=5"
+        "camunda.cluster.raft.rebalance.max-transfer-attempts=5",
+        "camunda.cluster.raft.rebalance.leader-wait-timeout=2m"
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -110,7 +111,8 @@ public class ClusterRaftTest {
       assertThat(brokerCfg.getCluster().getRaft())
           .returns(DataSize.ofMegabytes(16), RaftCfg::getRebalanceReplicationLagThreshold)
           .returns(Duration.ofSeconds(30), RaftCfg::getRebalanceReplicationTimeout)
-          .returns(5, RaftCfg::getRebalanceMaxTransferAttempts);
+          .returns(5, RaftCfg::getRebalanceMaxTransferAttempts)
+          .returns(Duration.ofMinutes(2), RaftCfg::getRebalanceLeaderWaitTimeout);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/RaftRebalanceValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RaftRebalanceValidationTest.java
@@ -72,6 +72,26 @@ final class RaftRebalanceValidationTest {
   }
 
   @Test
+  void shouldAcceptZeroLeaderWaitTimeout() {
+    // given
+    final var rebalance = new Rebalance();
+
+    // when / then
+    assertThatCode(() -> rebalance.setLeaderWaitTimeout(Duration.ZERO)).doesNotThrowAnyException();
+    assertThat(rebalance.getLeaderWaitTimeout()).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  void shouldRejectNegativeLeaderWaitTimeout() {
+    // given
+    final var rebalance = new Rebalance();
+
+    // when / then
+    assertThatThrownBy(() -> rebalance.setLeaderWaitTimeout(Duration.ofSeconds(-1)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void shouldAcceptValidValues() {
     // given
     final var rebalance = new Rebalance();
@@ -82,6 +102,7 @@ final class RaftRebalanceValidationTest {
               rebalance.setReplicationLagThreshold(DataSize.ofMegabytes(16));
               rebalance.setReplicationTimeout(Duration.ofSeconds(30));
               rebalance.setMaxTransferAttempts(5);
+              rebalance.setLeaderWaitTimeout(Duration.ofMinutes(2));
             })
         .doesNotThrowAnyException();
   }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -61,6 +61,7 @@ cluster.raft.min-step-down-failure-count
 cluster.raft.preallocate-segment-files
 cluster.raft.prefer-snapshot-replication-threshold
 cluster.raft.priority-election-enabled
+cluster.raft.rebalance.leader-wait-timeout
 cluster.raft.rebalance.max-transfer-attempts
 cluster.raft.rebalance.replication-lag-threshold
 cluster.raft.rebalance.replication-timeout

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferProtocol.java
@@ -20,6 +20,7 @@ import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultResponse;
+import io.camunda.cluster.PartitionId;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.jspecify.annotations.NullMarked;
@@ -37,18 +38,14 @@ public interface LeadershipTransferProtocol {
    * through {@link #onResult}.
    */
   CompletableFuture<LeadershipTransferInitiateResponse> initiate(
-      MemberId leader,
-      String partitionGroup,
-      int partitionId,
-      LeadershipTransferInitiateRequest request);
+      MemberId leader, PartitionId partitionId, LeadershipTransferInitiateRequest request);
 
   /**
    * Handles the terminal outcome the given partition's leader reports back. The result is
    * correlated to the initiate request by {@link LeadershipTransferResultRequest#correlationId()}.
    */
   void onResult(
-      String partitionGroup,
-      int partitionId,
+      PartitionId partitionId,
       Function<LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
           handler);
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/LeadershipTransferProtocol.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultResponse;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Allows the rebalancing coordinator to address the leadership transfer protocol from (potentially)
+ * outside the Raft group of the partition.
+ */
+@NullMarked
+public interface LeadershipTransferProtocol {
+
+  /**
+   * Asks the current leader of the given partition to transfer its leadership. The response only
+   * says whether the transfer was accepted or skipped (accepted transfers report their outcome
+   * through {@link #onResult}.
+   */
+  CompletableFuture<LeadershipTransferInitiateResponse> initiate(
+      MemberId leader,
+      String partitionGroup,
+      int partitionId,
+      LeadershipTransferInitiateRequest request);
+
+  /**
+   * Handles the terminal outcome the given partition's leader reports back. The result is
+   * correlated to the initiate request by {@link LeadershipTransferResultRequest#correlationId()}.
+   */
+  void onResult(
+      String partitionGroup,
+      int partitionId,
+      Function<LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
+          handler);
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RebalanceConfiguration.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RebalanceConfiguration.java
@@ -31,4 +31,18 @@ import org.jspecify.annotations.NullMarked;
  */
 @NullMarked
 public record RebalanceConfiguration(
-    long replicationLagThreshold, Duration replicationTimeout, int maxTransferAttempts) {}
+    long replicationLagThreshold, Duration replicationTimeout, int maxTransferAttempts) {
+
+  /**
+   * Headroom on top of the transfer's own budget. A leader's pause watchdog is a backstop against a
+   * transfer getting stuck, so this should be sized to be unreachable during a healthy transfer.
+   */
+  private static final Duration PAUSE_BUDGET_SLACK = Duration.ofSeconds(5);
+
+  /** How long the partition may stay frozen before the watchdog treats the transfer as stuck. */
+  public Duration pauseBudget(final Duration heartbeatInterval) {
+    return replicationTimeout
+        .plus(heartbeatInterval.multipliedBy(maxTransferAttempts))
+        .plus(PAUSE_BUDGET_SLACK);
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RebalanceMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RebalanceMetrics.java
@@ -7,28 +7,20 @@
  */
 package io.atomix.raft.metrics;
 
-import io.atomix.raft.LeadershipTransferResult;
-import io.atomix.raft.metrics.RebalanceMetricsDoc.RebalanceKeyNames;
 import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
-import java.util.EnumMap;
-import java.util.Map;
 
 /** Metrics for coordinated leadership transfer (rebalancing). */
 public class RebalanceMetrics extends RaftMetrics {
 
-  private final MeterRegistry meterRegistry;
   private final Timer partitionPauseDuration;
   private final StatefulGauge partitionPaused;
-  private final Map<LeadershipTransferResult, Timer> partitionTransferDuration =
-      new EnumMap<>(LeadershipTransferResult.class);
 
   public RebalanceMetrics(final String partitionName, final MeterRegistry meterRegistry) {
     super(partitionName);
-    this.meterRegistry = meterRegistry;
     partitionPauseDuration =
         Timer.builder(RebalanceMetricsDoc.PARTITION_PAUSE_DURATION.getName())
             .description(RebalanceMetricsDoc.PARTITION_PAUSE_DURATION.getDescription())
@@ -50,22 +42,5 @@ public class RebalanceMetrics extends RaftMetrics {
 
   public void setPartitionPaused(final boolean paused) {
     partitionPaused.set(paused ? 1 : 0);
-  }
-
-  public void observeTransferDuration(
-      final LeadershipTransferResult result, final Duration duration) {
-    partitionTransferDuration
-        .computeIfAbsent(result, this::registerTransferDuration)
-        .record(duration);
-  }
-
-  private Timer registerTransferDuration(final LeadershipTransferResult result) {
-    return Timer.builder(RebalanceMetricsDoc.PARTITION_TRANSFER_DURATION.getName())
-        .description(RebalanceMetricsDoc.PARTITION_TRANSFER_DURATION.getDescription())
-        .serviceLevelObjectives(RebalanceMetricsDoc.PARTITION_TRANSFER_DURATION.getTimerSLOs())
-        .tag(RebalanceKeyNames.RESULT.asString(), result.name())
-        .tag(PartitionKeyNames.PARTITION.asString(), partition)
-        .tag(PartitionKeyNames.PHYSICAL_TENANT.asString(), partitionGroupName)
-        .register(meterRegistry);
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RebalanceMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RebalanceMetricsDoc.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+import java.util.stream.Stream;
 
 /** Metrics for coordinated leadership transfer (rebalancing). */
 @SuppressWarnings("NullableProblems")
@@ -20,9 +22,19 @@ public enum RebalanceMetricsDoc implements ExtendedMeterDocumentation {
    * leader waited for the desired leader to catch up during a leadership transfer.
    */
   PARTITION_PAUSE_DURATION {
+    private static final Duration[] BUCKETS =
+        Stream.of(100, 250, 500, 1_000, 2_500, 5_000, 10_000, 15_000, 20_000, 30_000, 60_000)
+            .map(Duration::ofMillis)
+            .toArray(Duration[]::new);
+
     @Override
     public String getBaseUnit() {
       return "ms";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
     }
 
     @Override
@@ -71,45 +83,6 @@ public enum RebalanceMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public KeyName[] getKeyNames() {
       return new KeyName[] {PartitionKeyNames.PARTITION, PartitionKeyNames.PHYSICAL_TENANT};
-    }
-  },
-
-  /** Duration of a per-partition coordinated leadership transfer attempt, tagged by result. */
-  PARTITION_TRANSFER_DURATION {
-    @Override
-    public String getBaseUnit() {
-      return "ms";
-    }
-
-    @Override
-    public String getName() {
-      return "zeebe.cluster.rebalance.partition.duration";
-    }
-
-    @Override
-    public Type getType() {
-      return Type.TIMER;
-    }
-
-    @Override
-    public String getDescription() {
-      return "Duration of a per-partition coordinated leadership transfer attempt, by result";
-    }
-
-    @Override
-    public KeyName[] getKeyNames() {
-      return new KeyName[] {
-        RebalanceKeyNames.RESULT, PartitionKeyNames.PARTITION, PartitionKeyNames.PHYSICAL_TENANT
-      };
-    }
-  };
-
-  public enum RebalanceKeyNames implements KeyName {
-    RESULT;
-
-    @Override
-    public String asString() {
-      return "result";
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/LeadershipTransferClient.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/LeadershipTransferClient.java
@@ -19,6 +19,7 @@ import static io.atomix.raft.partition.RaftPartition.PARTITION_NAME_FORMAT;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.raft.LeadershipTransferProtocol;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
@@ -36,7 +37,7 @@ import org.jspecify.annotations.NullMarked;
  * outside the Raft group of the partition.
  */
 @NullMarked
-public final class LeadershipTransferClient implements AutoCloseable {
+public final class LeadershipTransferClient implements LeadershipTransferProtocol, AutoCloseable {
 
   private final ClusterCommunicationService communicationService;
   private final Duration requestTimeout;
@@ -49,11 +50,7 @@ public final class LeadershipTransferClient implements AutoCloseable {
     this.requestTimeout = requestTimeout;
   }
 
-  /**
-   * Asks the current leader of the given partition to transfer its leadership. The response only
-   * says whether the transfer was accepted or skipped (accepted transfers report their outcome
-   * through {@link #onResult}.
-   */
+  @Override
   public CompletableFuture<LeadershipTransferInitiateResponse> initiate(
       final MemberId leader,
       final String partitionGroup,
@@ -68,10 +65,7 @@ public final class LeadershipTransferClient implements AutoCloseable {
         requestTimeout);
   }
 
-  /**
-   * Handles the terminal outcome the given partition's leader reports back. The result is
-   * correlated to the initiate request by {@link LeadershipTransferResultRequest#correlationId()}.
-   */
+  @Override
   public void onResult(
       final String partitionGroup,
       final int partitionId,

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/LeadershipTransferClient.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/LeadershipTransferClient.java
@@ -25,6 +25,7 @@ import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.utils.serializer.Serializer;
+import io.camunda.cluster.PartitionId;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -53,11 +54,10 @@ public final class LeadershipTransferClient implements LeadershipTransferProtoco
   @Override
   public CompletableFuture<LeadershipTransferInitiateResponse> initiate(
       final MemberId leader,
-      final String partitionGroup,
-      final int partitionId,
+      final PartitionId partitionId,
       final LeadershipTransferInitiateRequest request) {
     return communicationService.send(
-        subjects(partitionGroup, partitionId).getLeadershipTransferInitiateSubject(),
+        subjects(partitionId).getLeadershipTransferInitiateSubject(),
         request,
         serializer::encode,
         serializer::decode,
@@ -67,12 +67,11 @@ public final class LeadershipTransferClient implements LeadershipTransferProtoco
 
   @Override
   public void onResult(
-      final String partitionGroup,
-      final int partitionId,
+      final PartitionId partitionId,
       final Function<
               LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
           handler) {
-    final var subject = subjects(partitionGroup, partitionId).getLeadershipTransferResultSubject();
+    final var subject = subjects(partitionId).getLeadershipTransferResultSubject();
     subscriptions.add(subject);
     communicationService.replyTo(subject, serializer::decode, handler, serializer::encode);
   }
@@ -83,7 +82,8 @@ public final class LeadershipTransferClient implements LeadershipTransferProtoco
     subscriptions.clear();
   }
 
-  private RaftMessageContext subjects(final String partitionGroup, final int partitionId) {
-    return new RaftMessageContext(PARTITION_NAME_FORMAT.formatted(partitionGroup, partitionId));
+  private RaftMessageContext subjects(final PartitionId partitionId) {
+    return new RaftMessageContext(
+        PARTITION_NAME_FORMAT.formatted(partitionId.group(), partitionId.number()));
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAttempt.java
@@ -89,13 +89,6 @@ import org.slf4j.LoggerFactory;
 final class LeadershipTransferAttempt {
   private static final Logger LOG = LoggerFactory.getLogger(LeadershipTransferAttempt.class);
 
-  /**
-   * Headroom on top of the steps' own budgets. The watchdog is a backstop against the attempt
-   * getting stuck, not a timeout anyone should hit, so this is sized to be unreachable on a healthy
-   * transfer rather than tight.
-   */
-  private static final Duration PAUSE_BUDGET_SLACK = Duration.ofSeconds(5);
-
   private final RaftContext raft;
   private final LeaderRole leader;
   private final MemberId desiredLeader;
@@ -247,12 +240,7 @@ final class LeadershipTransferAttempt {
 
   /** How long the partition may stay frozen before the watchdog treats the transfer as stuck. */
   private Duration pauseBudget() {
-    return configuration.replicationTimeout().plus(promotionBudget()).plus(PAUSE_BUDGET_SLACK);
-  }
-
-  /** The wall time {@link TimeoutNowPromotion} can spend spacing out its attempts. */
-  private Duration promotionBudget() {
-    return raft.getHeartbeatInterval().multipliedBy(configuration.maxTransferAttempts());
+    return configuration.pauseBudget(raft.getHeartbeatInterval());
   }
 
   private void reportResult(final LeadershipTransferResult result) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAttempt.java
@@ -231,7 +231,6 @@ final class LeadershipTransferAttempt {
     }
     finished = true;
     finishListener.run();
-    observeDuration(result);
     if (!leader.isRunning()) {
       // the step-down that ended this leader already lifted the freeze
       reportResult(result);
@@ -243,7 +242,6 @@ final class LeadershipTransferAttempt {
   private void abandon(final LeadershipTransferResult result) {
     finished = true;
     finishListener.run();
-    observeDuration(result);
     reportResult(result);
   }
 
@@ -255,11 +253,6 @@ final class LeadershipTransferAttempt {
   /** The wall time {@link TimeoutNowPromotion} can spend spacing out its attempts. */
   private Duration promotionBudget() {
     return raft.getHeartbeatInterval().multipliedBy(configuration.maxTransferAttempts());
-  }
-
-  private void observeDuration(final LeadershipTransferResult result) {
-    raft.getRebalanceMetrics()
-        .observeTransferDuration(result, Duration.ofMillis(System.currentTimeMillis() - startMs));
   }
 
   private void reportResult(final LeadershipTransferResult result) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
@@ -23,7 +23,6 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import java.time.Duration;
-import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -49,7 +48,7 @@ public class RaftLeadershipTransferCatchUpTest {
           });
 
   @Test
-  public void shouldRecordTransferDurationWhenTheTransferSucceeds() throws Exception {
+  public void shouldReportTransferredWhenTheDesiredLeaderCatchesUpAndTakesOver() throws Exception {
     // given
     raftRule.appendEntries(5);
     final var leader = raftRule.getLeader().orElseThrow();
@@ -61,12 +60,10 @@ public class RaftLeadershipTransferCatchUpTest {
 
     // then
     assertThat(ack.accepted()).isTrue();
-    Awaitility.await("the attempt is measured once the transfer succeeds")
-        .atMost(Duration.ofSeconds(15))
-        .untilAsserted(
-            () ->
-                assertThat(transferDurationCount(LeadershipTransferResult.TRANSFERRED))
-                    .isEqualTo(1));
+    assertThat(driver.reportedResult())
+        .succeedsWithin(Duration.ofSeconds(15))
+        .extracting(LeadershipTransferResultRequest::result)
+        .isEqualTo(LeadershipTransferResult.TRANSFERRED);
   }
 
   @Test
@@ -131,15 +128,5 @@ public class RaftLeadershipTransferCatchUpTest {
 
     // then
     assertThatNoException().isThrownBy(raftRule::appendEntry);
-  }
-
-  private long transferDurationCount(final LeadershipTransferResult result) {
-    final var timer =
-        raftRule
-            .getMeterRegistry()
-            .find("zeebe.cluster.rebalance.partition.duration")
-            .tag("result", result.name())
-            .timer();
-    return timer == null ? 0 : timer.count();
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/impl/LeadershipTransferClientTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/impl/LeadershipTransferClientTest.java
@@ -31,6 +31,7 @@ import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.utils.serializer.Serializer;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -111,7 +112,7 @@ final class LeadershipTransferClientTest {
     // when
     final var response =
         client
-            .initiate(LEADER_ID, PARTITION_GROUP, PARTITION_ID, request)
+            .initiate(LEADER_ID, new PartitionId(PARTITION_GROUP, PARTITION_ID), request)
             .get(10, TimeUnit.SECONDS);
 
     // then
@@ -124,8 +125,7 @@ final class LeadershipTransferClientTest {
     // given
     final var received = new CompletableFuture<LeadershipTransferResultRequest>();
     client.onResult(
-        PARTITION_GROUP,
-        PARTITION_ID,
+        new PartitionId(PARTITION_GROUP, PARTITION_ID),
         request -> {
           received.complete(request);
           return CompletableFuture.completedFuture(

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -17,15 +17,17 @@ import org.jspecify.annotations.NonNull;
 public interface BrokerTopologyManager extends ClusterConfigurationUpdateListener {
 
   /**
-   * Returns live topology for the given physical tenant (partition group). May return {@code null}
-   * or an uninitialized topology if the group is not (yet) known; callers must handle both.
+   * Returns live topology for the given physical tenant (partition group). Never returns {@code
+   * null}: a group that is not (yet) known is represented by an uninitialized {@link
+   * BrokerClusterState}.
    */
-  BrokerClusterState getTopology(@NonNull String physicalTenantId);
+  @NonNull BrokerClusterState getTopology(@NonNull String physicalTenantId);
 
   /**
    * Returns live topology for the default partition group. Equivalent to {@code
    * getTopology("default")}.
    */
+  @NonNull
   default BrokerClusterState getTopology() {
     return getTopology(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -70,7 +70,7 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   @Override
-  public BrokerClusterState getTopology(final @NonNull String physicalTenantId) {
+  public @NonNull BrokerClusterState getTopology(final @NonNull String physicalTenantId) {
     return topologyPerGroup.getOrDefault(
         physicalTenantId, BrokerClientTopologyImpl.uninitialized());
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStep.java
@@ -7,7 +7,11 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import io.atomix.raft.RebalanceConfiguration;
+import io.atomix.raft.partition.impl.LeadershipTransferClient;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionLeaders;
+import io.camunda.zeebe.rebalance.ClusterRebalanceMetrics;
+import io.camunda.zeebe.rebalance.PartitionBalanceMetrics;
 import io.camunda.zeebe.rebalance.ProtoBufRebalanceSerializer;
 import io.camunda.zeebe.rebalance.RebalanceCoordinator;
 import io.camunda.zeebe.rebalance.RebalanceRequestServer;
@@ -34,6 +38,8 @@ public class RebalanceCoordinatorStep implements StartupStep<BrokerStartupContex
   private @Nullable Actor rebalanceCoordinatorActor;
   private @Nullable RebalanceCoordinator rebalanceCoordinator;
   private @Nullable RebalanceRequestServer rebalanceRequestServer;
+  private @Nullable LeadershipTransferClient leadershipTransferClient;
+  private @Nullable PartitionBalanceMetrics partitionBalanceMetrics;
 
   @Override
   public String getName() {
@@ -48,6 +54,20 @@ public class RebalanceCoordinatorStep implements StartupStep<BrokerStartupContex
 
     final var localMember =
         brokerStartupContext.getClusterServices().getMembershipService().getLocalMember().id();
+    final var partitionLeaders =
+        new TopologyPartitionLeaders(brokerStartupContext.getBrokerClient().getTopologyManager());
+    final var newLeadershipTransferClient =
+        new LeadershipTransferClient(
+            brokerStartupContext.getClusterServices().getCommunicationService(),
+            brokerStartupContext
+                .getBrokerConfiguration()
+                .getExperimental()
+                .getRaft()
+                .getRequestTimeout());
+    final var rebalanceMetrics =
+        new ClusterRebalanceMetrics(brokerStartupContext.getMeterRegistry());
+    final var newPartitionBalanceMetrics =
+        new PartitionBalanceMetrics(brokerStartupContext.getMeterRegistry(), partitionLeaders);
     rebalanceCoordinatorActor = Actor.newActor().name("RebalanceCoordinator").build();
 
     brokerStartupContext
@@ -60,16 +80,35 @@ public class RebalanceCoordinatorStep implements StartupStep<BrokerStartupContex
                 started.completeExceptionally(error);
                 return;
               }
+              leadershipTransferClient = newLeadershipTransferClient;
+              partitionBalanceMetrics = newPartitionBalanceMetrics;
+              brokerStartupContext
+                  .getClusterConfigurationService()
+                  .addUpdateListener(partitionBalanceMetrics);
+              final var raftCfg =
+                  brokerStartupContext.getBrokerConfiguration().getCluster().getRaft();
               rebalanceCoordinator =
                   new RebalanceCoordinator(
                       localMember,
                       rebalanceCoordinatorActor,
                       new SequentialRebalanceRunner(
+                          localMember,
                           rebalanceCoordinatorActor,
-                          new TopologyPartitionLeaders(
-                              brokerStartupContext.getBrokerClient().getTopologyManager())),
+                          partitionLeaders,
+                          leadershipTransferClient,
+                          rebalanceMetrics,
+                          raftCfg.getRebalanceLeaderWaitTimeout(),
+                          new RebalanceConfiguration(
+                              raftCfg.getRebalanceReplicationLagThreshold().toBytes(),
+                              raftCfg.getRebalanceReplicationTimeout(),
+                              raftCfg.getRebalanceMaxTransferAttempts()),
+                          brokerStartupContext
+                              .getBrokerConfiguration()
+                              .getCluster()
+                              .getHeartbeatInterval()),
                       () -> brokerStartupContext.getRequestIdGenerator().nextId(),
-                      Clock.systemUTC());
+                      Clock.systemUTC(),
+                      rebalanceMetrics);
               rebalanceRequestServer =
                   new RebalanceRequestServer(
                       brokerStartupContext.getClusterServices().getCommunicationService(),
@@ -100,12 +139,21 @@ public class RebalanceCoordinatorStep implements StartupStep<BrokerStartupContex
           .getClusterConfigurationService()
           .removeUpdateListener(rebalanceCoordinator);
     }
-
+    if (partitionBalanceMetrics != null) {
+      brokerStartupContext
+          .getClusterConfigurationService()
+          .removeUpdateListener(partitionBalanceMetrics);
+      partitionBalanceMetrics = null;
+    }
     closeRebalanceCoordinator()
         .onComplete(
             (ok, error) -> {
               rebalanceCoordinator = null;
               rebalanceCoordinatorActor = null;
+              if (leadershipTransferClient != null) {
+                leadershipTransferClient.close();
+                leadershipTransferClient = null;
+              }
               if (error != null) {
                 stopped.completeExceptionally(error);
               } else {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionLeaders.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionLeaders.java
@@ -27,12 +27,7 @@ public final class TopologyPartitionLeaders implements PartitionLeaders {
 
   @Override
   public PartitionGroupLeaders forGroup(final String physicalTenantId) {
-    final var topology = topologyManager.getTopology(physicalTenantId);
-    if (topology == null) {
-      throw new IllegalStateException(
-          "Topology for physical tenant %s is unavailable".formatted(physicalTenantId));
-    }
-    return new TopologyGroupLeaders(topology);
+    return new TopologyGroupLeaders(topologyManager.getTopology(physicalTenantId));
   }
 
   private record TopologyGroupLeaders(BrokerClusterState topology)

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -16,6 +16,7 @@ public final class RaftCfg implements ConfigurationEntry {
       DataSize.ofMegabytes(8);
   public static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
   public static final int DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS = 3;
+  public static final Duration DEFAULT_REBALANCE_LEADER_WAIT_TIMEOUT = Duration.ofMinutes(1);
   private static final FlushConfig DEFAULT_FLUSH_CONFIG = new FlushConfig(true, Duration.ZERO);
 
   private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
@@ -24,6 +25,7 @@ public final class RaftCfg implements ConfigurationEntry {
   private DataSize rebalanceReplicationLagThreshold = DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD;
   private Duration rebalanceReplicationTimeout = DEFAULT_REBALANCE_REPLICATION_TIMEOUT;
   private int rebalanceMaxTransferAttempts = DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS;
+  private Duration rebalanceLeaderWaitTimeout = DEFAULT_REBALANCE_LEADER_WAIT_TIMEOUT;
 
   public boolean isEnablePriorityElection() {
     return enablePriorityElection;
@@ -65,6 +67,14 @@ public final class RaftCfg implements ConfigurationEntry {
     this.rebalanceMaxTransferAttempts = rebalanceMaxTransferAttempts;
   }
 
+  public Duration getRebalanceLeaderWaitTimeout() {
+    return rebalanceLeaderWaitTimeout;
+  }
+
+  public void setRebalanceLeaderWaitTimeout(final Duration rebalanceLeaderWaitTimeout) {
+    this.rebalanceLeaderWaitTimeout = rebalanceLeaderWaitTimeout;
+  }
+
   @Override
   public String toString() {
     return "RaftCfg{"
@@ -78,6 +88,8 @@ public final class RaftCfg implements ConfigurationEntry {
         + rebalanceReplicationTimeout
         + ", rebalanceMaxTransferAttempts="
         + rebalanceMaxTransferAttempts
+        + ", rebalanceLeaderWaitTimeout="
+        + rebalanceLeaderWaitTimeout
         + '}';
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStepTest.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -18,15 +20,39 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.BrokerMemberId;
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultResponse;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.rebalance.RebalanceCoordinator;
+import io.camunda.zeebe.rebalance.RebalanceOverrides;
+import io.camunda.zeebe.rebalance.TriggerRebalanceRequest;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -52,6 +78,7 @@ class RebalanceCoordinatorStepTest {
     actorSchedulerRule.before();
 
     testBrokerStartupContext = new MockBrokerStartupContext();
+    testBrokerStartupContext.setBrokerConfiguration(new BrokerCfg());
     testBrokerStartupContext.setConcurrencyControl(spyConcurrencyControl);
     testBrokerStartupContext.setActorSchedulingService(actorSchedulerRule.get());
     testBrokerStartupContext.setClusterConfigurationService(clusterConfigurationService);
@@ -89,7 +116,8 @@ class RebalanceCoordinatorStepTest {
 
       // then
       assertThat(startupFuture.isDone()).isFalse();
-      verify(clusterConfigurationService, never()).addUpdateListener(any());
+      verify(clusterConfigurationService, never())
+          .addUpdateListener(any(RebalanceCoordinator.class));
 
       // when
       submitActorFuture.complete(null);
@@ -115,7 +143,8 @@ class RebalanceCoordinatorStepTest {
 
       // then
       assertThat(startupFuture).failsWithin(TIME_OUT);
-      verify(clusterConfigurationService, never()).addUpdateListener(any());
+      verify(clusterConfigurationService, never())
+          .addUpdateListener(any(RebalanceCoordinator.class));
       verifyNoInteractions(communicationService);
     }
 
@@ -193,6 +222,116 @@ class RebalanceCoordinatorStepTest {
 
       // then
       assertThat(secondShutdownFuture).succeedsWithin(TIME_OUT);
+    }
+
+    @Test
+    void shouldNotInitiateTheNextTransferAfterShutdownDuringAnInFlightTransfer() {
+      // given
+      final var member1 = MemberId.from(1);
+      final var member2 = MemberId.from(2);
+      when(testBrokerStartupContext
+              .getClusterServices()
+              .getMembershipService()
+              .getLocalMember()
+              .id())
+          .thenReturn(member1);
+      final var topology = mock(BrokerClusterState.class);
+      when(topology.getLeaderForPartition(1)).thenReturn(new BrokerMemberId(member1));
+      when(topology.getLeaderForPartition(2)).thenReturn(new BrokerMemberId(member1));
+      final var topologyManager = mock(BrokerTopologyManager.class);
+      when(topologyManager.getTopology(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(topology);
+      final var brokerClient = mock(BrokerClient.class);
+      when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
+      testBrokerStartupContext.setBrokerClient(brokerClient);
+      when(testBrokerStartupContext.getRequestIdGenerator().nextId()).thenReturn(1L);
+
+      final var startupFuture = sut.startup(testBrokerStartupContext);
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+
+      final ArgumentCaptor<RebalanceCoordinator> coordinatorCaptor =
+          ArgumentCaptor.forClass(RebalanceCoordinator.class);
+      verify(clusterConfigurationService, timeout(TIME_OUT.toMillis()))
+          .addUpdateListener(coordinatorCaptor.capture());
+      final var registeredCoordinator = coordinatorCaptor.getValue();
+
+      registeredCoordinator.onClusterConfigurationUpdated(
+          twoPartitionsForTransfer(member1, member2));
+      assertThat(
+              registeredCoordinator.triggerRebalance(
+                  new TriggerRebalanceRequest(RebalanceOverrides.none(), false)))
+          .succeedsWithin(TIME_OUT);
+
+      // the first partition's transfer is in flight; capture the handler its leader would use to
+      // report the outcome back
+      verify(communicationService, timeout(TIME_OUT.toMillis()))
+          .send(any(), any(), any(), any(), eq(member1), any());
+      final ArgumentCaptor<Function> resultHandlerCaptor = ArgumentCaptor.forClass(Function.class);
+      verify(communicationService, timeout(TIME_OUT.toMillis()).times(4))
+          .replyTo(any(), any(), resultHandlerCaptor.capture(), any());
+      @SuppressWarnings("unchecked")
+      final Function<
+              LeadershipTransferResultRequest, CompletableFuture<LeadershipTransferResultResponse>>
+          firstTransferResultHandler = resultHandlerCaptor.getAllValues().get(3);
+
+      // when
+      final var shutdownFuture = sut.shutdown(testBrokerStartupContext);
+      assertThat(shutdownFuture).succeedsWithin(TIME_OUT);
+      firstTransferResultHandler.apply(
+          LeadershipTransferResultRequest.builder()
+              .withLeader(member1)
+              .withDesiredLeader(member2)
+              .withResult(LeadershipTransferResult.TRANSFERRED)
+              .withCorrelationId(1)
+              .build());
+
+      // then
+      verify(communicationService, after(500).times(1))
+          .send(any(), any(), any(), any(), any(), any());
+    }
+
+    private CurrentClusterConfiguration twoPartitionsForTransfer(
+        final MemberId from, final MemberId to) {
+      final var partitionConfig = DynamicPartitionConfig.init();
+      final Map<Integer, PartitionState> partitions =
+          Map.of(
+              1,
+              PartitionState.active(1, partitionConfig),
+              2,
+              PartitionState.active(1, partitionConfig));
+      final Map<Integer, PartitionState> desiredPartitions =
+          Map.of(
+              1,
+              PartitionState.active(2, partitionConfig),
+              2,
+              PartitionState.active(2, partitionConfig));
+      final var groupMembers =
+          Map.of(
+              from, BrokerPartitionState.initialize(partitions),
+              to, BrokerPartitionState.initialize(desiredPartitions));
+      final Map<MemberId, BrokerState> globalMembers =
+          Map.of(from, BrokerState.initializeAsActive(), to, BrokerState.initializeAsActive());
+      final var group =
+          new PartitionGroupConfiguration(
+              PartitionGroupConfiguration.INITIAL_VERSION,
+              PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+              groupMembers,
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty());
+      final var globalConfiguration =
+          new GlobalConfiguration(
+              GlobalConfiguration.INITIAL_VERSION,
+              Optional.empty(),
+              globalMembers,
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty());
+      return new CurrentClusterConfiguration(
+          CurrentClusterConfiguration.INITIAL_VERSION,
+          globalConfiguration,
+          Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, group),
+          PhasedChangeState.empty());
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionLeadersTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionLeadersTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.broker.partitioning.topology;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -18,6 +17,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.impl.BrokerClientTopologyImpl;
 import org.junit.jupiter.api.Test;
 
 final class TopologyPartitionLeadersTest {
@@ -54,14 +54,16 @@ final class TopologyPartitionLeadersTest {
   }
 
   @Test
-  void shouldFailToObtainAGroupViewWhenTheTopologyIsNotYetKnown() {
+  void shouldReportNoLeaderWhenTheTopologyIsNotYetKnown() {
     // given
-    when(topologyManager.getTopology("tenant-a")).thenReturn(null);
+    when(topologyManager.getTopology("tenant-a"))
+        .thenReturn(BrokerClientTopologyImpl.uninitialized());
 
-    // when / then
-    assertThatThrownBy(() -> partitionLeaders.forGroup("tenant-a"))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("tenant-a");
+    // when
+    final var leader = partitionLeaders.forGroup("tenant-a").currentLeader(3);
+
+    // then
+    assertThat(leader).isEmpty();
   }
 
   @Test

--- a/zeebe/rebalance/pom.xml
+++ b/zeebe/rebalance/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-cluster</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -72,7 +71,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/zeebe/rebalance/pom.xml
+++ b/zeebe/rebalance/pom.xml
@@ -74,6 +74,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetrics.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetrics.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.rebalance.ClusterRebalanceMetricsDoc.ClusterRebalanceKeyNames;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+
+/** Metrics for the cluster-wide side of a rebalance (coordinated leadership transfer). */
+@NullMarked
+public final class ClusterRebalanceMetrics {
+
+  private final MeterRegistry registry;
+  private final Map<RebalanceOutcome, Timer> elapsed = new EnumMap<>(RebalanceOutcome.class);
+  private final Map<PartitionOutcome, Timer> partitionDurations = new HashMap<>();
+  private final Map<PartitionId, StatefulGauge> partitionStates = new HashMap<>();
+
+  public ClusterRebalanceMetrics(final MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Publishes the rebalance counts from the moment this member takes the coordinating role, before
+   * it has anything to count.
+   */
+  public void startCoordinating() {
+    for (final var outcome : RebalanceOutcome.values()) {
+      elapsed.computeIfAbsent(outcome, this::registerElapsed);
+    }
+  }
+
+  public void observeElapsed(final RebalanceOutcome outcome, final Duration duration) {
+    elapsed.computeIfAbsent(outcome, this::registerElapsed).record(duration);
+  }
+
+  /**
+   * Records the rebalance outcome for one partition, and how long it took.
+   *
+   * @param result the {@link PartitionRebalanceOutcome} the partition reached
+   */
+  public void observePartitionDuration(
+      final PartitionId partition, final String result, final Duration duration) {
+    partitionDurations
+        .computeIfAbsent(new PartitionOutcome(partition, result), this::registerPartitionDuration)
+        .record(duration);
+  }
+
+  /**
+   * Publishes where the rebalance stands with each partition, replacing whatever state the last
+   * rebalance left behind.
+   */
+  public void setPartitionStates(final List<PartitionRebalance> partitions) {
+    final Map<PartitionId, PartitionRebalanceProgress> progress = new HashMap<>();
+    partitions.forEach(
+        partition ->
+            progress.put(
+                new PartitionId(partition.physicalTenantId(), partition.partitionId()),
+                partition.progress()));
+
+    final var superseded = partitionStates.entrySet().iterator();
+    while (superseded.hasNext()) {
+      final var partition = superseded.next();
+      if (!progress.containsKey(partition.getKey())) {
+        registry.remove(partition.getValue());
+        superseded.remove();
+      }
+    }
+    progress.forEach(
+        (partition, state) ->
+            partitionStates
+                .computeIfAbsent(partition, this::registerPartitionState)
+                .set(metricValue(state)));
+  }
+
+  /**
+   * Stops publishing the per-partition rebalance state when the member is no longer the rebalance
+   * coordinator.
+   */
+  public void stopCoordinating() {
+    partitionStates.values().forEach(registry::remove);
+    partitionStates.clear();
+  }
+
+  /**
+   * Ensure we have a stable ordinal for dashboards to match against (so Java enum reordering
+   * doesn't change it).
+   */
+  private static int metricValue(final PartitionRebalanceProgress progress) {
+    return switch (progress) {
+      case PENDING -> 1;
+      case TRANSFERRING -> 2;
+      case COMPLETED -> 3;
+    };
+  }
+
+  private Timer registerElapsed(final RebalanceOutcome outcome) {
+    return Timer.builder(ClusterRebalanceMetricsDoc.REBALANCE_ELAPSED.getName())
+        .description(ClusterRebalanceMetricsDoc.REBALANCE_ELAPSED.getDescription())
+        .serviceLevelObjectives(ClusterRebalanceMetricsDoc.REBALANCE_ELAPSED.getTimerSLOs())
+        .tag(ClusterRebalanceKeyNames.RESULT.asString(), outcome.name())
+        .register(registry);
+  }
+
+  private Timer registerPartitionDuration(final PartitionOutcome outcome) {
+    return Timer.builder(ClusterRebalanceMetricsDoc.PARTITION_DURATION.getName())
+        .description(ClusterRebalanceMetricsDoc.PARTITION_DURATION.getDescription())
+        .serviceLevelObjectives(ClusterRebalanceMetricsDoc.PARTITION_DURATION.getTimerSLOs())
+        .tags(PartitionKeyNames.tags(outcome.partition()))
+        .tag(ClusterRebalanceKeyNames.RESULT.asString(), outcome.result())
+        .register(registry);
+  }
+
+  private StatefulGauge registerPartitionState(final PartitionId partition) {
+    return StatefulGauge.builder(ClusterRebalanceMetricsDoc.PARTITION_STATE.getName())
+        .description(ClusterRebalanceMetricsDoc.PARTITION_STATE.getDescription())
+        .tags(PartitionKeyNames.tags(partition))
+        .register(registry);
+  }
+
+  private record PartitionOutcome(PartitionId partition, String result) {}
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetrics.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetrics.java
@@ -93,6 +93,10 @@ public final class ClusterRebalanceMetrics {
   public void stopCoordinating() {
     partitionStates.values().forEach(registry::remove);
     partitionStates.clear();
+    partitionDurations.values().forEach(registry::remove);
+    partitionDurations.clear();
+    elapsed.values().forEach(registry::remove);
+    elapsed.clear();
   }
 
   /**

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetricsDoc.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetricsDoc.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+/** Metrics for the cluster-wide side of a rebalance (coordinated leadership transfer). */
+@SuppressWarnings("NullableProblems")
+public enum ClusterRebalanceMetricsDoc implements ExtendedMeterDocumentation {
+  /** How long a whole cluster-wide rebalance took, tagged by how it ended. */
+  REBALANCE_ELAPSED {
+    private static final Duration[] BUCKETS =
+        Stream.of(1, 5, 10, 30, 60, 120, 300, 600, 1_800, 3_600)
+            .map(Duration::ofSeconds)
+            .toArray(Duration[]::new);
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.cluster.rebalance.elapsed";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Duration of a cluster-wide rebalance, by how it ended";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {ClusterRebalanceKeyNames.RESULT};
+    }
+  },
+
+  /** How long the coordinator spent on one partition, tagged by the outcome. */
+  PARTITION_DURATION {
+    private static final Duration[] BUCKETS =
+        Stream.of(100, 500, 1_000, 2_500, 5_000, 10_000, 20_000, 30_000, 60_000, 120_000, 300_000)
+            .map(Duration::ofMillis)
+            .toArray(Duration[]::new);
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.cluster.rebalance.partition.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Duration the rebalance spent on one partition, by what became of it";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {
+        PartitionKeyNames.PARTITION,
+        PartitionKeyNames.PHYSICAL_TENANT,
+        ClusterRebalanceKeyNames.RESULT
+      };
+    }
+  },
+
+  /**
+   * Where the most recent rebalance got to with a partition, as a single value per partition:
+   * {@code 1} pending, {@code 2} transferring, {@code 3} completed.
+   *
+   * <p>Outlives the rebalance, so that where a partition stands can be read after the fact; a
+   * rebalance may well be over inside a single metrics scrape.
+   */
+  PARTITION_STATE {
+    @Override
+    public String getName() {
+      return "zeebe.cluster.rebalance.partition.state";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Where the last rebalance got to with a partition: 1 pending, 2 transferring, "
+          + "3 completed";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION, PartitionKeyNames.PHYSICAL_TENANT};
+    }
+  };
+
+  public enum ClusterRebalanceKeyNames implements KeyName {
+    /** How a whole rebalance, or the rebalance's work on one partition, ended. */
+    RESULT {
+      @Override
+      public String asString() {
+        return "result";
+      }
+    }
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/LeadershipTransferResultMapping.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/LeadershipTransferResultMapping.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.atomix.raft.LeadershipTransferResult;
+
+/**
+ * Maps {@link LeadershipTransferResult} onto {@link PartitionRebalanceOutcome} one case at a time
+ * rather than by name, so that we can verify the switch is exhaustive.
+ */
+final class LeadershipTransferResultMapping {
+
+  private LeadershipTransferResultMapping() {}
+
+  static PartitionRebalanceOutcome toOutcome(final LeadershipTransferResult result) {
+    return switch (result) {
+      case TRANSFERRED -> PartitionRebalanceOutcome.TRANSFERRED;
+      case ALREADY_LEADER -> PartitionRebalanceOutcome.ALREADY_LEADER;
+      case NOT_MEMBER -> PartitionRebalanceOutcome.NOT_MEMBER;
+      case NOT_REPLICATING -> PartitionRebalanceOutcome.NOT_REPLICATING;
+      case UNREACHABLE -> PartitionRebalanceOutcome.UNREACHABLE;
+      case NOT_COORDINATOR -> PartitionRebalanceOutcome.NOT_COORDINATOR;
+      case STALE_CONFIGURATION -> PartitionRebalanceOutcome.STALE_CONFIGURATION;
+      case TRANSFER_IN_PROGRESS -> PartitionRebalanceOutcome.TRANSFER_IN_PROGRESS;
+      case LAG_TOO_HIGH -> PartitionRebalanceOutcome.LAG_TOO_HIGH;
+      case LEADER_INITIALIZING -> PartitionRebalanceOutcome.LEADER_INITIALIZING;
+      case CONFIGURATION_CHANGE_IN_PROGRESS ->
+          PartitionRebalanceOutcome.CONFIGURATION_CHANGE_IN_PROGRESS;
+      case PAUSE_FAILED -> PartitionRebalanceOutcome.PAUSE_FAILED;
+      case REPLICATION_TIMED_OUT -> PartitionRebalanceOutcome.REPLICATION_TIMED_OUT;
+      case TIMEOUT_NOW_EXHAUSTED -> PartitionRebalanceOutcome.TIMEOUT_NOW_EXHAUSTED;
+      case LEADER_CHANGED -> PartitionRebalanceOutcome.LEADER_CHANGED;
+    };
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalanceMetrics.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalanceMetrics.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reports, for each partition of every physical tenant's partition group, whether leadership is
+ * where the cluster configuration wants it.
+ */
+@NullMarked
+public final class PartitionBalanceMetrics implements ClusterConfigurationUpdateListener {
+
+  private final MeterRegistry registry;
+  private final PartitionLeaders partitionLeaders;
+  private final Map<PartitionId, Gauge> gauges = new HashMap<>();
+
+  private volatile @Nullable CurrentClusterConfiguration configuration;
+
+  public PartitionBalanceMetrics(
+      final MeterRegistry registry, final PartitionLeaders partitionLeaders) {
+    this.registry = registry;
+    this.partitionLeaders = partitionLeaders;
+  }
+
+  @Override
+  public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
+    onClusterConfigurationUpdated(CurrentClusterConfiguration.fromLegacy(clusterConfiguration));
+  }
+
+  @Override
+  public synchronized void onClusterConfigurationUpdated(
+      final CurrentClusterConfiguration updated) {
+    if (updated.isUninitialized()) {
+      return;
+    }
+    configuration = updated;
+    final Set<PartitionId> current =
+        updated.partitionGroups().entrySet().stream()
+            .flatMap(
+                entry ->
+                    entry
+                        .getValue()
+                        .partitionIds()
+                        .mapToObj(partitionId -> new PartitionId(entry.getKey(), partitionId)))
+            .collect(java.util.stream.Collectors.toSet());
+
+    final var gone = gauges.entrySet().iterator();
+    while (gone.hasNext()) {
+      final var gauge = gone.next();
+      if (!current.contains(gauge.getKey())) {
+        registry.remove(gauge.getValue());
+        gone.remove();
+      }
+    }
+    current.forEach(partition -> gauges.computeIfAbsent(partition, this::register));
+  }
+
+  private Gauge register(final PartitionId partition) {
+    return Gauge.builder(
+            PartitionBalanceMetricsDoc.PARTITION_BALANCED.getName(),
+            () -> isBalanced(partition) ? 1 : 0)
+        .description(PartitionBalanceMetricsDoc.PARTITION_BALANCED.getDescription())
+        .tags(PartitionKeyNames.tags(partition))
+        .register(registry);
+  }
+
+  private boolean isBalanced(final PartitionId partition) {
+    final var known = configuration;
+    if (known == null) {
+      return false;
+    }
+    final var group = known.partitionGroups().get(partition.group());
+    if (group == null) {
+      return false;
+    }
+    final var desiredLeader = group.getDesiredLeader(partition.number());
+    final var currentLeader =
+        partitionLeaders.forGroup(partition.group()).currentLeader(partition.number());
+    return desiredLeader.isPresent() && desiredLeader.equals(currentLeader);
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalanceMetricsDoc.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalanceMetricsDoc.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+/** Whether leadership is where the cluster configuration wants it. */
+public enum PartitionBalanceMetricsDoc implements ExtendedMeterDocumentation {
+  /**
+   * Whether a partition is led by the member the cluster configuration gives the highest priority
+   * for it: {@code 1} when it is, {@code 0} when it is led by another member or by nobody at all.
+   */
+  PARTITION_BALANCED {
+    @Override
+    public String getName() {
+      return "zeebe.cluster.partition.balanced";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "1 when a partition is led by its highest-priority member, 0 otherwise";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION, PartitionKeyNames.PHYSICAL_TENANT};
+    }
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
@@ -108,4 +108,15 @@ public record PartitionRebalance(
         PartitionRebalanceProgress.COMPLETED,
         PartitionRebalanceOutcome.TRANSFERRED);
   }
+
+  /** Records that leadership moved to a member other than the current or desired leader. */
+  public PartitionRebalance leaderChanged(final MemberId newLeader) {
+    return new PartitionRebalance(
+        physicalTenantId,
+        partitionId,
+        newLeader,
+        desiredLeader,
+        PartitionRebalanceProgress.COMPLETED,
+        PartitionRebalanceOutcome.LEADER_CHANGED);
+  }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -110,6 +110,9 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
     if (overrides.maxTransferAttempts() != null) {
       builder.setMaxTransferAttempts(overrides.maxTransferAttempts());
     }
+    if (overrides.leaderWaitTimeout() != null) {
+      builder.setLeaderWaitTimeoutMillis(overrides.leaderWaitTimeout().toMillis());
+    }
     return builder.build();
   }
 
@@ -121,7 +124,10 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
         overrides.hasReplicationTimeoutMillis()
             ? Duration.ofMillis(overrides.getReplicationTimeoutMillis())
             : null,
-        overrides.hasMaxTransferAttempts() ? overrides.getMaxTransferAttempts() : null);
+        overrides.hasMaxTransferAttempts() ? overrides.getMaxTransferAttempts() : null,
+        overrides.hasLeaderWaitTimeoutMillis()
+            ? Duration.ofMillis(overrides.getLeaderWaitTimeoutMillis())
+            : null);
   }
 
   private Rebalance.RebalanceStatusResponse encodeStatus(final RebalanceStatus status) {

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Nulls;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.function.LongSupplier;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ public final class RebalanceCoordinator
   private final RebalanceRunner runner;
   private final LongSupplier rebalanceIdGenerator;
   private final Clock clock;
+  private final ClusterRebalanceMetrics metrics;
 
   /**
    * The configuration this member coordinates under, or {@code null} while it does not coordinate.
@@ -59,12 +61,14 @@ public final class RebalanceCoordinator
       final ConcurrencyControl executor,
       final RebalanceRunner runner,
       final LongSupplier rebalanceIdGenerator,
-      final Clock clock) {
+      final Clock clock,
+      final ClusterRebalanceMetrics metrics) {
     this.localMemberId = localMemberId;
     this.executor = executor;
     this.runner = runner;
     this.rebalanceIdGenerator = rebalanceIdGenerator;
     this.clock = clock;
+    this.metrics = metrics;
   }
 
   @Override
@@ -199,10 +203,8 @@ public final class RebalanceCoordinator
     if (error != null) {
       LOG.warn("Rebalance {} failed", rebalance.id(), error);
       outcome = RebalanceOutcome.FAILED;
-    } else if (rebalance.isCancelRequested()) {
-      outcome = RebalanceOutcome.CANCELLED;
     } else {
-      outcome = RebalanceOutcome.COMPLETED;
+      outcome = aggregateOutcome(rebalance);
     }
     final var finishedAt = clock.instant();
     rebalance.finish(finishedAt);
@@ -214,7 +216,24 @@ public final class RebalanceCoordinator
             rebalance.partitions(),
             rebalance.startedAt(),
             finishedAt);
+    metrics.observeElapsed(outcome, Duration.between(rebalance.startedAt(), finishedAt));
     LOG.info("Rebalance {} finished as {}", rebalance.id(), outcome);
+  }
+
+  private static RebalanceOutcome aggregateOutcome(final RebalanceRun rebalance) {
+    final var anyUnsuccessful =
+        rebalance.partitions().stream()
+            .filter(partition -> partition.progress() == PartitionRebalanceProgress.COMPLETED)
+            .map(PartitionRebalance::outcome)
+            .anyMatch(
+                outcome ->
+                    outcome != PartitionRebalanceOutcome.TRANSFERRED
+                        && outcome != PartitionRebalanceOutcome.ALREADY_LEADER
+                        && outcome != PartitionRebalanceOutcome.CANCELLED);
+    if (anyUnsuccessful) {
+      return RebalanceOutcome.FAILED;
+    }
+    return rebalance.isCancelRequested() ? RebalanceOutcome.CANCELLED : RebalanceOutcome.COMPLETED;
   }
 
   private void updateCoordinatorRole(final CurrentClusterConfiguration clusterConfiguration) {
@@ -228,6 +247,7 @@ public final class RebalanceCoordinator
     if (nowCoordinating != (configuration != null)) {
       if (nowCoordinating) {
         LOG.info("Coordinating rebalances as the lowest-id member of the cluster configuration");
+        metrics.startCoordinating();
       } else {
         LOG.info("No longer coordinating rebalances, {} is now the lowest-id member", coordinator);
         discardState();
@@ -244,6 +264,7 @@ public final class RebalanceCoordinator
     }
     running = null;
     lastCompleted = null;
+    metrics.stopCoordinating();
   }
 
   /**

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceOverrides.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceOverrides.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.rebalance;
 
+import io.atomix.raft.RebalanceConfiguration;
 import java.time.Duration;
 import org.jspecify.annotations.Nullable;
 
@@ -20,13 +21,16 @@ import org.jspecify.annotations.Nullable;
  *     desired leader to finish replicating.
  * @param maxTransferAttempts The maximum number of TimeoutNow requests the current leader sends
  *     (including the initial request).
+ * @param leaderWaitTimeout How long the coordinator waits for a partition with no current leader to
+ *     get one before giving up with {@code NO_LEADER}.
  */
 public record RebalanceOverrides(
     @Nullable Long replicationLagThreshold,
     @Nullable Duration replicationTimeout,
-    @Nullable Integer maxTransferAttempts) {
+    @Nullable Integer maxTransferAttempts,
+    @Nullable Duration leaderWaitTimeout) {
 
-  private static final RebalanceOverrides NONE = new RebalanceOverrides(null, null, null);
+  private static final RebalanceOverrides NONE = new RebalanceOverrides(null, null, null, null);
 
   public RebalanceOverrides {
     if (replicationLagThreshold != null && replicationLagThreshold < 0) {
@@ -42,10 +46,26 @@ public record RebalanceOverrides(
       throw new IllegalArgumentException(
           "maxTransferAttempts must be positive but was " + maxTransferAttempts);
     }
+    if (leaderWaitTimeout != null && leaderWaitTimeout.isNegative()) {
+      throw new IllegalArgumentException(
+          "leaderWaitTimeout must be non-negative but was " + leaderWaitTimeout);
+    }
   }
 
   /** Overrides nothing, so all configured defaults are used. */
   public static RebalanceOverrides none() {
     return NONE;
+  }
+
+  /**
+   * The settings a transfer under this override runs with merged onto the given base configuration.
+   */
+  public RebalanceConfiguration applyTo(final RebalanceConfiguration configured) {
+    return new RebalanceConfiguration(
+        replicationLagThreshold != null
+            ? replicationLagThreshold
+            : configured.replicationLagThreshold(),
+        replicationTimeout != null ? replicationTimeout : configured.replicationTimeout(),
+        maxTransferAttempts != null ? maxTransferAttempts : configured.maxTransferAttempts());
   }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.rebalance;
 
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ public final class RebalanceRun {
   private final Instant startedAt;
   private final List<PartitionRebalance> partitions = new ArrayList<>();
 
+  private long partitionStartedAtNanos = System.nanoTime();
   private boolean cancelRequested;
   private boolean abandoned;
   private @Nullable Instant finishedAt;
@@ -77,6 +79,19 @@ public final class RebalanceRun {
   /** Records that this rebalance finished at the given instant. */
   public void finish(final Instant finishedAt) {
     this.finishedAt = finishedAt;
+  }
+
+  /**
+   * Starts tracking elapsed time for rebalancing a single partition. Only one partition is ever in
+   * flight.
+   */
+  public void startPartition() {
+    partitionStartedAtNanos = System.nanoTime();
+  }
+
+  /** How long the rebalance has been working on the latest partition it got to. */
+  public Duration partitionElapsed() {
+    return Duration.ofNanos(System.nanoTime() - partitionStartedAtNanos);
   }
 
   /**

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -23,9 +23,12 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
@@ -97,6 +100,12 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
   private final Duration leaderWaitTimeout;
   private final RebalanceConfiguration configuration;
   private final Duration heartbeatInterval;
+
+  /** The transfer each partition is currently in, if any. */
+  private final Map<PartitionId, ActiveTransfer> activeTransfers = new HashMap<>();
+
+  /** Partitions for which a result handler has already been registered. */
+  private final Set<PartitionId> registeredResultHandlers = new HashSet<>();
 
   public SequentialRebalanceRunner(
       final MemberId localMemberId,
@@ -287,13 +296,8 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
                 PartitionRebalanceProgress.TRANSFERRING));
     publish(rebalance);
     final var partitionId = new PartitionId(partition.physicalTenantId(), partition.partitionId());
-    transfers.onResult(
-        partitionId,
-        result -> {
-          executor.run(() -> onTransferResultReported(rebalance, index, result, completion));
-          return CompletableFuture.completedFuture(
-              LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
-        });
+    activeTransfers.put(partitionId, new ActiveTransfer(rebalance, index, completion));
+    registerResultHandler(partitionId);
     LOG.info(
         "Rebalance {} is requesting {} to transfer leadership of partition {} to desired leader {}",
         rebalance.id(),
@@ -306,6 +310,19 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
             (response, error) -> onTransferInitiated(rebalance, index, response, error, completion),
             executor);
     watchTransfer(rebalance, index, Duration.ZERO, completion);
+  }
+
+  private void registerResultHandler(final PartitionId partitionId) {
+    if (!registeredResultHandlers.add(partitionId)) {
+      return;
+    }
+    transfers.onResult(
+        partitionId,
+        result -> {
+          executor.run(() -> onTransferResultReported(partitionId, result));
+          return CompletableFuture.completedFuture(
+              LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
+        });
   }
 
   /** Watches the topology for the transfer in flight taking effect. */
@@ -437,10 +454,16 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
   }
 
   private void onTransferResultReported(
-      final RebalanceRun rebalance,
-      final int index,
-      final LeadershipTransferResultRequest result,
-      final ActorFuture<Void> completion) {
+      final PartitionId partitionId, final LeadershipTransferResultRequest result) {
+    final var active = activeTransfers.get(partitionId);
+    if (active == null) {
+      // No transfer is currently active for this partition, e.g. a late result from an earlier
+      // rebalance whose transfer of some other partition has since moved on.
+      return;
+    }
+    final var rebalance = active.rebalance();
+    final var index = active.index();
+    final var completion = active.completion();
     if (isOver(rebalance, completion)
         || result.correlationId() != rebalance.id()
         || rebalance.partition(index).progress() != PartitionRebalanceProgress.TRANSFERRING) {
@@ -558,4 +581,6 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
   private static boolean isOver(final RebalanceRun rebalance, final ActorFuture<Void> completion) {
     return completion.isDone() || rebalance.isAbandoned();
   }
+
+  private record ActiveTransfer(RebalanceRun rebalance, int index, ActorFuture<Void> completion) {}
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -286,9 +286,9 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
                 pending.desiredLeader(),
                 PartitionRebalanceProgress.TRANSFERRING));
     publish(rebalance);
+    final var partitionId = new PartitionId(partition.physicalTenantId(), partition.partitionId());
     transfers.onResult(
-        partition.physicalTenantId(),
-        partition.partitionId(),
+        partitionId,
         result -> {
           executor.run(() -> onTransferResultReported(rebalance, index, result, completion));
           return CompletableFuture.completedFuture(
@@ -301,11 +301,7 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
         partition,
         desiredLeader);
     transfers
-        .initiate(
-            leader,
-            partition.physicalTenantId(),
-            partition.partitionId(),
-            createTransferInitiateRequest(rebalance, desiredLeader))
+        .initiate(leader, partitionId, createTransferInitiateRequest(rebalance, desiredLeader))
         .whenCompleteAsync(
             (response, error) -> onTransferInitiated(rebalance, index, response, error, completion),
             executor);

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -421,6 +421,15 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
     if (response.accepted()) {
       return;
     }
+    if (response.status() != Status.OK) {
+      LOG.warn(
+          "Rebalance {} failed requesting current leader of partition {} to transfer leadership: "
+              + "{} (will still watch for outcome)",
+          rebalance.id(),
+          partition,
+          response.error());
+      return;
+    }
     final var rejectionReason = response.rejectionReason();
     LOG.warn(
         "Rebalance {} was declined requesting transfer of partition {}: {}",

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -7,39 +7,141 @@
  */
 package io.camunda.zeebe.rebalance;
 
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferProtocol;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.RebalanceConfiguration;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Runs a single rebalance request, one partition at a time.
  *
+ * <p>This starts by generating the rebalance plan - we identify the desired leader for each
+ * partition as well as the current leader. In particular the desired leader must be identified at
+ * the start of the run so that we have a fixed target to work towards.
+ *
+ * <p>A partition already led by its desired leader is completed as {@link
+ * PartitionRebalanceOutcome#ALREADY_LEADER}. Every other partition is processed in order, and only
+ * one transfer is ever in flight. Each transfer is handed to the partition's current leader, which
+ * owns it from there: the coordinator learns of the outcome when that leader reports it back (or by
+ * seeing leadership move in the topology), and moves on to the next partition.
+ *
+ * <pre>
+ *   run()
+ *     |
+ *     | plan(): identify current and desired leaders
+ *     v
+ *   PENDING --------------------------.
+ *     |                               |
+ *     |                               v
+ *     |                             COMPLETED(ALREADY_LEADER)  (already led by the desired leader)
+ *     |
+ *     | no current leader: wait for one to appear
+ *     v
+ *   PENDING (waiting) ----------------.
+ *     |                               |
+ *     |                               v
+ *     |                             COMPLETED(NO_LEADER)  (none appeared within leaderWaitTimeout)
+ *     |
+ *     | one partition in flight at a time, in order
+ *     v
+ *   TRANSFERRING ----------------------.
+ *     |                                |
+ *     |                                v
+ *     |                              COMPLETED(<PartitionRebalanceOutcome>)
+ *     |                              COMPLETED(NO_RESPONSE)  (no report, no topology move, watchdog
+ *     |                                                       expired)
+ *     |
+ *     | leader reports TRANSFERRED, or the topology confirms the desired leader first
+ *     v
+ *   COMPLETED(TRANSFERRED)
+ * </pre>
+ *
  * <p>Runs entirely on the coordinator's actor thread.
  */
 public final class SequentialRebalanceRunner implements RebalanceRunner {
+  /**
+   * How often the topology is checked for a leader appearing, or for the transfer in flight having
+   * taken effect.
+   */
+  @VisibleForTesting static final Duration LEADERSHIP_OBSERVATION_INTERVAL = Duration.ofSeconds(1);
+
+  /** Headroom to apply to the leader-side pause budget for our own per-transfer timeout. */
+  @VisibleForTesting static final Duration COORDINATOR_WATCHDOG_SLACK = Duration.ofSeconds(5);
 
   private static final Logger LOG = LoggerFactory.getLogger(SequentialRebalanceRunner.class);
-
+  private final MemberId localMemberId;
   private final ConcurrencyControl executor;
   private final PartitionLeaders partitionLeaders;
+  private final LeadershipTransferProtocol transfers;
+  private final ClusterRebalanceMetrics metrics;
+  private final Duration leaderWaitTimeout;
+  private final RebalanceConfiguration configuration;
+  private final Duration heartbeatInterval;
 
   public SequentialRebalanceRunner(
-      final ConcurrencyControl executor, final PartitionLeaders partitionLeaders) {
+      final MemberId localMemberId,
+      final ConcurrencyControl executor,
+      final PartitionLeaders partitionLeaders,
+      final LeadershipTransferProtocol transfers,
+      final ClusterRebalanceMetrics metrics,
+      final Duration leaderWaitTimeout,
+      final RebalanceConfiguration configuration,
+      final Duration heartbeatInterval) {
+    this.localMemberId = localMemberId;
     this.executor = executor;
     this.partitionLeaders = partitionLeaders;
+    this.transfers = transfers;
+    this.metrics = metrics;
+    this.leaderWaitTimeout = leaderWaitTimeout;
+    this.configuration = configuration;
+    this.heartbeatInterval = heartbeatInterval;
   }
 
   @Override
   public ActorFuture<Void> run(final RebalanceRun rebalance) {
     rebalance.plan(plan(rebalance.configuration()));
     logPlan(rebalance);
-    return executor.createCompletedFuture();
+    publish(rebalance);
+    final ActorFuture<Void> completion = executor.createFuture();
+    if (rebalance.dryRun()) {
+      completion.asNullable().complete(null);
+    } else {
+      observePlanned(rebalance);
+      transferFrom(rebalance, 0, completion);
+    }
+    return completion;
+  }
+
+  /**
+   * Records the partitions resolved in the planning stage (already led by their desired leader).
+   */
+  private void observePlanned(final RebalanceRun rebalance) {
+    for (final var partition : rebalance.partitions()) {
+      if (partition.progress() == PartitionRebalanceProgress.COMPLETED) {
+        observeTransferOutcome(
+            partition, Objects.requireNonNull(partition.outcome()), Duration.ZERO);
+      }
+    }
   }
 
   /** Decides what the rebalance will do to each partition. */
@@ -80,14 +182,363 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
         physicalTenantId, partitionId, currentLeader.orElse(null), desiredLeader);
   }
 
+  /** Process the first partition that the rebalance still has to transfer. */
+  private void transferFrom(
+      final RebalanceRun rebalance, final int fromIndex, final ActorFuture<Void> completion) {
+    for (int index = fromIndex; index < rebalance.partitionCount(); index++) {
+      if (rebalance.isCancelRequested() || rebalance.isAbandoned()) {
+        break;
+      }
+      if (rebalance.partition(index).progress() == PartitionRebalanceProgress.PENDING) {
+        rebalance.startPartition();
+        initiate(rebalance, index, completion);
+        return;
+      }
+    }
+    if (rebalance.isCancelRequested()) {
+      cancelPending(rebalance);
+    }
+    completion.asNullable().complete(null);
+  }
+
+  private void initiate(
+      final RebalanceRun rebalance, final int index, final ActorFuture<Void> completion) {
+    final var partition = rebalance.partition(index);
+    final var leader = partition.currentLeader();
+    if (leader == null) {
+      waitForLeader(rebalance, index, Duration.ZERO, completion);
+      return;
+    }
+    beginTransfer(rebalance, index, leader, completion);
+  }
+
+  /**
+   * Waits for a partition with no current leader to get one (up to the rebalance's leader-wait
+   * timeout).
+   */
+  private void waitForLeader(
+      final RebalanceRun rebalance,
+      final int index,
+      final Duration waited,
+      final ActorFuture<Void> completion) {
+    final var timeout = leaderWaitTimeout(rebalance);
+    final var remaining = timeout.minus(waited);
+    if (remaining.isZero() || remaining.isNegative()) {
+      LOG.warn(
+          "Rebalance {} giving up on transferring partition {}: no leader appeared within {}",
+          rebalance.id(),
+          rebalance.partition(index),
+          timeout);
+      resolveWithOutcome(rebalance, index, PartitionRebalanceOutcome.NO_LEADER, completion);
+      return;
+    }
+    final var delay =
+        remaining.compareTo(LEADERSHIP_OBSERVATION_INTERVAL) < 0
+            ? remaining
+            : LEADERSHIP_OBSERVATION_INTERVAL;
+    executor.schedule(
+        delay,
+        () -> {
+          if (isOver(rebalance, completion)
+              || rebalance.partition(index).progress() != PartitionRebalanceProgress.PENDING) {
+            return;
+          }
+          if (rebalance.isCancelRequested()) {
+            transferFrom(rebalance, index, completion);
+            return;
+          }
+          final var partition = rebalance.partition(index);
+          final var observedLeader =
+              partitionLeaders
+                  .forGroup(partition.physicalTenantId())
+                  .currentLeader(partition.partitionId());
+          if (observedLeader.isPresent()) {
+            rebalance.updatePartition(
+                index,
+                pending ->
+                    new PartitionRebalance(
+                        pending.physicalTenantId(),
+                        pending.partitionId(),
+                        observedLeader.get(),
+                        pending.desiredLeader(),
+                        PartitionRebalanceProgress.PENDING));
+            beginTransfer(rebalance, index, observedLeader.get(), completion);
+            return;
+          }
+          waitForLeader(rebalance, index, waited.plus(delay), completion);
+        });
+  }
+
+  private void beginTransfer(
+      final RebalanceRun rebalance,
+      final int index,
+      final MemberId leader,
+      final ActorFuture<Void> completion) {
+    final var partition = rebalance.partition(index);
+    final var desiredLeader = partition.desiredLeader();
+    rebalance.updatePartition(
+        index,
+        pending ->
+            new PartitionRebalance(
+                pending.physicalTenantId(),
+                pending.partitionId(),
+                leader,
+                pending.desiredLeader(),
+                PartitionRebalanceProgress.TRANSFERRING));
+    publish(rebalance);
+    transfers.onResult(
+        partition.physicalTenantId(),
+        partition.partitionId(),
+        result -> {
+          executor.run(() -> onTransferResultReported(rebalance, index, result, completion));
+          return CompletableFuture.completedFuture(
+              LeadershipTransferResultResponse.builder().withStatus(Status.OK).build());
+        });
+    LOG.info(
+        "Rebalance {} is requesting {} to transfer leadership of partition {} to desired leader {}",
+        rebalance.id(),
+        leader,
+        partition,
+        desiredLeader);
+    transfers
+        .initiate(
+            leader,
+            partition.physicalTenantId(),
+            partition.partitionId(),
+            createTransferInitiateRequest(rebalance, desiredLeader))
+        .whenCompleteAsync(
+            (response, error) -> onTransferInitiated(rebalance, index, response, error, completion),
+            executor);
+    watchTransfer(rebalance, index, Duration.ZERO, completion);
+  }
+
+  /** Watches the topology for the transfer in flight taking effect. */
+  private void watchTransfer(
+      final RebalanceRun rebalance,
+      final int index,
+      final Duration waited,
+      final ActorFuture<Void> completion) {
+    executor.schedule(
+        LEADERSHIP_OBSERVATION_INTERVAL,
+        () -> {
+          if (isOver(rebalance, completion)
+              || rebalance.partition(index).progress() != PartitionRebalanceProgress.TRANSFERRING) {
+            return;
+          }
+          final var partition = rebalance.partition(index);
+          final var observed =
+              partitionLeaders
+                  .forGroup(partition.physicalTenantId())
+                  .currentLeader(partition.partitionId());
+          if (observed.map(partition.desiredLeader()::equals).orElse(false)) {
+            LOG.info(
+                "Rebalance {} saw partition {} led by desired leader {} without notification from "
+                    + "previous leader",
+                rebalance.id(),
+                partition,
+                observed.get());
+            resolveTransferred(rebalance, index, completion);
+            return;
+          }
+          if (observed.isPresent()
+              && !Objects.equals(observed.get(), partition.currentLeader())
+              && !observed.get().equals(partition.desiredLeader())) {
+            LOG.warn(
+                "Rebalance {} saw partition {} led by {} instead of the current or desired leader",
+                rebalance.id(),
+                partition,
+                observed.get());
+            resolveLeaderChanged(rebalance, index, observed.get(), completion);
+            return;
+          }
+          final var waitedSoFar = waited.plus(LEADERSHIP_OBSERVATION_INTERVAL);
+          final var timeout = transferWatchdogTimeout(rebalance);
+          if (waitedSoFar.compareTo(timeout) >= 0) {
+            LOG.warn(
+                "Rebalance {} giving up on transferring partition {}: current leader neither"
+                    + " reported an outcome nor gave up leadership within {}",
+                rebalance.id(),
+                partition,
+                timeout);
+            resolveWithOutcome(rebalance, index, PartitionRebalanceOutcome.NO_RESPONSE, completion);
+            return;
+          }
+          watchTransfer(rebalance, index, waitedSoFar, completion);
+        });
+  }
+
+  private Duration leaderWaitTimeout(final RebalanceRun rebalance) {
+    final var override = rebalance.overrides().leaderWaitTimeout();
+    return override != null ? override : leaderWaitTimeout;
+  }
+
+  private Duration transferWatchdogTimeout(final RebalanceRun rebalance) {
+    final var effective = rebalance.overrides().applyTo(configuration);
+    return effective.pauseBudget(heartbeatInterval).plus(COORDINATOR_WATCHDOG_SLACK);
+  }
+
+  private LeadershipTransferInitiateRequest createTransferInitiateRequest(
+      final RebalanceRun rebalance, final MemberId desiredLeader) {
+    final var request =
+        LeadershipTransferInitiateRequest.builder()
+            .withDesiredLeader(desiredLeader)
+            .withCoordinator(localMemberId)
+            .withCoordinatorConfigVersion(rebalance.configuration().version())
+            .withCorrelationId(rebalance.id());
+    final var overrides = rebalance.overrides();
+    if (overrides.replicationLagThreshold() != null) {
+      request.withReplicationLagThreshold(overrides.replicationLagThreshold());
+    }
+    if (overrides.replicationTimeout() != null) {
+      request.withReplicationTimeout(overrides.replicationTimeout());
+    }
+    if (overrides.maxTransferAttempts() != null) {
+      request.withMaxTransferAttempts(overrides.maxTransferAttempts());
+    }
+    return request.build();
+  }
+
+  private void onTransferInitiated(
+      final RebalanceRun rebalance,
+      final int index,
+      final @Nullable LeadershipTransferInitiateResponse response,
+      final @Nullable Throwable error,
+      final ActorFuture<Void> completion) {
+    if (isOver(rebalance, completion)
+        || rebalance.partition(index).progress() != PartitionRebalanceProgress.TRANSFERRING) {
+      return;
+    }
+    final var partition = rebalance.partition(index);
+    if (error != null || response == null) {
+      LOG.warn(
+          "Rebalance {} failed requesting current leader of partition {} to transfer leadership "
+              + "(will still watch for outcome)",
+          rebalance.id(),
+          partition,
+          error);
+      return;
+    }
+    if (response.accepted()) {
+      return;
+    }
+    final var rejectionReason = response.rejectionReason();
+    LOG.warn(
+        "Rebalance {} was declined requesting transfer of partition {}: {}",
+        rebalance.id(),
+        partition,
+        rejectionReason);
+    resolveWithOutcome(
+        rebalance, index, LeadershipTransferResultMapping.toOutcome(rejectionReason), completion);
+  }
+
+  private void onTransferResultReported(
+      final RebalanceRun rebalance,
+      final int index,
+      final LeadershipTransferResultRequest result,
+      final ActorFuture<Void> completion) {
+    if (isOver(rebalance, completion)
+        || result.correlationId() != rebalance.id()
+        || rebalance.partition(index).progress() != PartitionRebalanceProgress.TRANSFERRING) {
+      // A result left over from an earlier rebalance, or one for a transfer already resolved.
+      return;
+    }
+    final var partition = rebalance.partition(index);
+    if (result.result() == LeadershipTransferResult.TRANSFERRED) {
+      LOG.info(
+          "Rebalance {} moved leadership of partition {} to desired leader {}",
+          rebalance.id(),
+          partition,
+          result.desiredLeader());
+      resolveTransferred(rebalance, index, completion);
+      return;
+    }
+    LOG.warn(
+        "Rebalance {} transfer of partition {} completed with result {}",
+        rebalance.id(),
+        partition,
+        result.result());
+    resolveWithOutcome(
+        rebalance, index, LeadershipTransferResultMapping.toOutcome(result.result()), completion);
+  }
+
+  /** Completes a partition with a given outcome and moves on to the next. */
+  private void resolveWithOutcome(
+      final RebalanceRun rebalance,
+      final int index,
+      final PartitionRebalanceOutcome outcome,
+      final ActorFuture<Void> completion) {
+    rebalance.updatePartition(index, partition -> partition.completed(outcome));
+    observeTransferOutcome(rebalance.partition(index), outcome, rebalance.partitionElapsed());
+    publish(rebalance);
+    transferFrom(rebalance, index + 1, completion);
+  }
+
+  /** Completes a partition with leadership having reached the desired leader. */
+  private void resolveTransferred(
+      final RebalanceRun rebalance, final int index, final ActorFuture<Void> completion) {
+    rebalance.updatePartition(index, PartitionRebalance::transferred);
+    observeTransferOutcome(
+        rebalance.partition(index),
+        PartitionRebalanceOutcome.TRANSFERRED,
+        rebalance.partitionElapsed());
+    publish(rebalance);
+    transferFrom(rebalance, index + 1, completion);
+  }
+
+  /** Completes a partition with leadership having moved to a member other than expected. */
+  private void resolveLeaderChanged(
+      final RebalanceRun rebalance,
+      final int index,
+      final MemberId newLeader,
+      final ActorFuture<Void> completion) {
+    rebalance.updatePartition(index, partition -> partition.leaderChanged(newLeader));
+    observeTransferOutcome(
+        rebalance.partition(index),
+        PartitionRebalanceOutcome.LEADER_CHANGED,
+        rebalance.partitionElapsed());
+    publish(rebalance);
+    transferFrom(rebalance, index + 1, completion);
+  }
+
+  private void observeTransferOutcome(
+      final PartitionRebalance partition,
+      final PartitionRebalanceOutcome outcome,
+      final Duration took) {
+    metrics.observePartitionDuration(
+        new PartitionId(partition.physicalTenantId(), partition.partitionId()),
+        outcome.name(),
+        took);
+  }
+
+  private void cancelPending(final RebalanceRun rebalance) {
+    var cancelledAny = false;
+    for (int index = 0; index < rebalance.partitionCount(); index++) {
+      final var partition = rebalance.partition(index);
+      if (partition.progress() != PartitionRebalanceProgress.PENDING) {
+        continue;
+      }
+      rebalance.updatePartition(
+          index, pending -> pending.completed(PartitionRebalanceOutcome.CANCELLED));
+      observeTransferOutcome(partition, PartitionRebalanceOutcome.CANCELLED, Duration.ZERO);
+      cancelledAny = true;
+    }
+    if (cancelledAny) {
+      publish(rebalance);
+    }
+  }
+
+  private void publish(final RebalanceRun rebalance) {
+    metrics.setPartitionStates(rebalance.partitions());
+  }
+
   private void logPlan(final RebalanceRun rebalance) {
     final var toTransfer =
         rebalance.partitions().stream()
             .filter(partition -> partition.progress() == PartitionRebalanceProgress.PENDING)
             .toList();
     LOG.info(
-        "Rebalance {} covers {} partitions, {} of them already led by the leader it wants. It will "
-            + "transfer, in order: {}",
+        "Rebalance {} sees {} partitions ({} of them already led by desired leader). To be "
+            + "transferred: {}",
         rebalance.id(),
         rebalance.partitionCount(),
         rebalance.partitionCount() - toTransfer.size(),
@@ -97,5 +548,9 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
                     "%s from %s to %s"
                         .formatted(partition, partition.currentLeader(), partition.desiredLeader()))
             .toList());
+  }
+
+  private static boolean isOver(final RebalanceRun rebalance, final ActorFuture<Void> completion) {
+    return completion.isDone() || rebalance.isAbandoned();
   }
 }

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -15,6 +15,7 @@ message RebalanceOverrides {
   optional uint64 replicationLagThresholdBytes = 1;
   optional uint64 replicationTimeoutMillis = 2;
   optional uint32 maxTransferAttempts = 3;
+  optional uint64 leaderWaitTimeoutMillis = 4;
 }
 
 message RebalanceStatusResponse {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetricsTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetricsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+final class ClusterRebalanceMetricsTest {
+
+  private static final String GROUP = "default";
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+  private static final MemberId MEMBER_2 = MemberId.from("2");
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final ClusterRebalanceMetrics metrics = new ClusterRebalanceMetrics(registry);
+
+  @Test
+  void shouldReplaceTheStatesOfThePreviousRebalance() {
+    // given
+    metrics.setPartitionStates(
+        List.of(
+            PartitionRebalance.pending(GROUP, 1, MEMBER_1, MEMBER_2).transferred(),
+            PartitionRebalance.pending(GROUP, 2, MEMBER_1, MEMBER_2)
+                .completed(PartitionRebalanceOutcome.NO_RESPONSE)));
+
+    // when
+    metrics.setPartitionStates(List.of(PartitionRebalance.pending(GROUP, 1, MEMBER_1, MEMBER_2)));
+
+    // then
+    assertThat(state(1)).isEqualTo(1);
+    assertThat(gauge(2)).isNull();
+  }
+
+  @Test
+  void shouldReportCompletedAsItsOwnGaugeValueRegardlessOfOutcome() {
+    // when
+    metrics.setPartitionStates(
+        List.of(
+            PartitionRebalance.pending(GROUP, 1, MEMBER_1, MEMBER_2)
+                .completed(PartitionRebalanceOutcome.CANCELLED)));
+
+    // then
+    assertThat(state(1)).isEqualTo(3);
+  }
+
+  @Test
+  void shouldStopReportingStatesOnceItStopsCoordinating() {
+    // given
+    metrics.setPartitionStates(
+        List.of(PartitionRebalance.pending(GROUP, 1, MEMBER_1, MEMBER_2).transferred()));
+
+    // when
+    metrics.stopCoordinating();
+
+    // then
+    assertThat(gauge(1)).isNull();
+  }
+
+  @Test
+  void shouldReportEveryOutcomeAsSoonAsItCoordinates() {
+    // when
+    metrics.startCoordinating();
+
+    // then
+    assertThat(registry.find("zeebe.cluster.rebalance.elapsed").timers())
+        .extracting(timer -> timer.getId().getTag("result"))
+        .containsExactlyInAnyOrder("COMPLETED", "CANCELLED", "FAILED");
+  }
+
+  private double state(final int partitionId) {
+    return registry
+        .get("zeebe.cluster.rebalance.partition.state")
+        .tag("partition", String.valueOf(partitionId))
+        .tag("physicalTenant", GROUP)
+        .gauge()
+        .value();
+  }
+
+  private @Nullable Gauge gauge(final int partitionId) {
+    return registry
+        .find("zeebe.cluster.rebalance.partition.state")
+        .tag("partition", String.valueOf(partitionId))
+        .gauge();
+  }
+}

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetricsTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ClusterRebalanceMetricsTest.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.rebalance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PartitionId;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -78,6 +80,49 @@ final class ClusterRebalanceMetricsTest {
         .containsExactlyInAnyOrder("COMPLETED", "CANCELLED", "FAILED");
   }
 
+  @Test
+  void shouldDeregisterEveryCoordinatorOwnedMeterWhenCoordinationStops() {
+    // given
+    metrics.setPartitionStates(
+        List.of(PartitionRebalance.pending(GROUP, 1, MEMBER_1, MEMBER_2).transferred()));
+    metrics.observePartitionDuration(
+        new PartitionId(GROUP, 1), "TRANSFERRED", Duration.ofSeconds(1));
+    metrics.observeElapsed(RebalanceOutcome.COMPLETED, Duration.ofSeconds(1));
+
+    // when
+    metrics.stopCoordinating();
+
+    // then
+    assertThat(gauge(1)).isNull();
+    assertThat(registry.find("zeebe.cluster.rebalance.partition.duration").timers()).isEmpty();
+    assertThat(registry.find("zeebe.cluster.rebalance.elapsed").timers()).isEmpty();
+  }
+
+  @Test
+  void shouldNotReuseStaleMeterMapEntriesAfterCoordinationRestarts() {
+    // given
+    metrics.observePartitionDuration(
+        new PartitionId(GROUP, 1), "TRANSFERRED", Duration.ofSeconds(1));
+    metrics.observeElapsed(RebalanceOutcome.COMPLETED, Duration.ofSeconds(1));
+    metrics.stopCoordinating();
+
+    // when
+    metrics.observePartitionDuration(
+        new PartitionId(GROUP, 1), "TRANSFERRED", Duration.ofSeconds(2));
+    metrics.observeElapsed(RebalanceOutcome.COMPLETED, Duration.ofSeconds(2));
+
+    // then
+    assertThat(partitionDurationCount(1, "TRANSFERRED")).isEqualTo(1);
+    assertThat(registry.get("zeebe.cluster.rebalance.elapsed").timers()).hasSize(1);
+    assertThat(
+            registry
+                .get("zeebe.cluster.rebalance.elapsed")
+                .tag("result", RebalanceOutcome.COMPLETED.name())
+                .timer()
+                .count())
+        .isEqualTo(1);
+  }
+
   private double state(final int partitionId) {
     return registry
         .get("zeebe.cluster.rebalance.partition.state")
@@ -92,5 +137,15 @@ final class ClusterRebalanceMetricsTest {
         .find("zeebe.cluster.rebalance.partition.state")
         .tag("partition", String.valueOf(partitionId))
         .gauge();
+  }
+
+  private long partitionDurationCount(final int partitionId, final String result) {
+    return registry
+        .get("zeebe.cluster.rebalance.partition.duration")
+        .tag("partition", String.valueOf(partitionId))
+        .tag("physicalTenant", GROUP)
+        .tag("result", result)
+        .timer()
+        .count();
   }
 }

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionBalanceMetricsTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionBalanceMetricsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class PartitionBalanceMetricsTest {
+
+  private static final String GROUP = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+  private static final MemberId MEMBER_2 = MemberId.from("2");
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final Map<Integer, MemberId> leaders = new HashMap<>();
+  private final PartitionLeaders partitionLeaders =
+      physicalTenantId ->
+          partitionId ->
+              GROUP.equals(physicalTenantId)
+                  ? Optional.ofNullable(leaders.get(partitionId))
+                  : Optional.empty();
+  private final PartitionBalanceMetrics metrics =
+      new PartitionBalanceMetrics(registry, partitionLeaders);
+
+  @Test
+  void shouldReportAPartitionLedByItsHighestPriorityMemberAsBalanced() {
+    // given
+    leaders.put(1, MEMBER_2);
+
+    // when
+    metrics.onClusterConfigurationUpdated(configurationWithPriorities(Map.of(MEMBER_1, 1)));
+
+    // then
+    assertThat(balanced(1)).isEqualTo(1);
+  }
+
+  @Test
+  void shouldReportAPartitionLedByAnotherMemberAsUnbalanced() {
+    // given
+    leaders.put(1, MEMBER_1);
+
+    // when
+    metrics.onClusterConfigurationUpdated(configurationWithPriorities(Map.of(MEMBER_1, 1)));
+
+    // then
+    assertThat(balanced(1)).isZero();
+  }
+
+  @Test
+  void shouldReportAPartitionWithNoLeaderAsUnbalanced() {
+    // when
+    metrics.onClusterConfigurationUpdated(configurationWithPriorities(Map.of(MEMBER_1, 1)));
+
+    // then
+    assertThat(balanced(1)).isZero();
+  }
+
+  @Test
+  void shouldFollowLeadershipWithoutBeingToldItMoved() {
+    // given
+    metrics.onClusterConfigurationUpdated(configurationWithPriorities(Map.of(MEMBER_1, 1)));
+    assertThat(balanced(1)).isZero();
+
+    // when
+    leaders.put(1, MEMBER_2);
+
+    // then
+    assertThat(balanced(1)).isEqualTo(1);
+  }
+
+  @Test
+  void shouldReportNothingUntilAConfigurationArrives() {
+    // when
+    metrics.onClusterConfigurationUpdated(ClusterConfiguration.uninitialized());
+
+    // then
+    assertThat(registry.find("zeebe.cluster.partition.balanced").gauges()).isEmpty();
+  }
+
+  @Test
+  void shouldStopReportingOnAPartitionTheConfigurationNoLongerHas() {
+    // given
+    metrics.onClusterConfigurationUpdated(
+        ClusterConfiguration.init()
+            .addMember(MEMBER_1, MemberState.initializeAsActive(partitions(1, 2))));
+
+    // when
+    metrics.onClusterConfigurationUpdated(
+        ClusterConfiguration.init()
+            .addMember(MEMBER_1, MemberState.initializeAsActive(partitions(1))));
+
+    // then
+    assertThat(registry.find("zeebe.cluster.partition.balanced").tag("partition", "2").gauge())
+        .isNull();
+    assertThat(registry.find("zeebe.cluster.partition.balanced").tag("partition", "1").gauge())
+        .isNotNull();
+  }
+
+  private double balanced(final int partitionId) {
+    return registry
+        .get("zeebe.cluster.partition.balanced")
+        .tag("partition", String.valueOf(partitionId))
+        .tag("physicalTenant", GROUP)
+        .gauge()
+        .value();
+  }
+
+  private ClusterConfiguration configurationWithPriorities(
+      final Map<MemberId, Integer> lowerPriorities) {
+    var configuration = ClusterConfiguration.init();
+    for (final var entry : lowerPriorities.entrySet()) {
+      configuration =
+          configuration.addMember(
+              entry.getKey(),
+              MemberState.initializeAsActive(
+                  Map.of(
+                      1, PartitionState.active(entry.getValue(), DynamicPartitionConfig.init()))));
+    }
+    return configuration.addMember(
+        MEMBER_2,
+        MemberState.initializeAsActive(
+            Map.of(1, PartitionState.active(9, DynamicPartitionConfig.init()))));
+  }
+
+  private Map<Integer, PartitionState> partitions(final int... partitionIds) {
+    final Map<Integer, PartitionState> partitions = new HashMap<>();
+    for (final var partitionId : partitionIds) {
+      partitions.put(partitionId, PartitionState.active(1, DynamicPartitionConfig.init()));
+    }
+    return partitions;
+  }
+}

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
@@ -46,7 +46,8 @@ final class ProtoBufRebalanceSerializerTest {
   void shouldRoundTripATriggerThatOverridesEverything() {
     // given
     final var request =
-        new TriggerRebalanceRequest(new RebalanceOverrides(8192L, Duration.ofMinutes(2), 7), true);
+        new TriggerRebalanceRequest(
+            new RebalanceOverrides(8192L, Duration.ofMinutes(2), 7, Duration.ZERO), true);
 
     // when
     final var decoded =
@@ -59,7 +60,8 @@ final class ProtoBufRebalanceSerializerTest {
   @Test
   void shouldDistinguishAnOverriddenSettingFromAnAbsentOne() {
     // given
-    final var request = new TriggerRebalanceRequest(new RebalanceOverrides(0L, null, null), false);
+    final var request =
+        new TriggerRebalanceRequest(new RebalanceOverrides(0L, null, null, null), false);
 
     // when
     final var decoded =
@@ -90,7 +92,7 @@ final class ProtoBufRebalanceSerializerTest {
         new RebalanceStatus(
             new RebalanceStatus.Running(
                 42,
-                new RebalanceOverrides(null, Duration.ofSeconds(15), null),
+                new RebalanceOverrides(null, Duration.ofSeconds(15), null, null),
                 true,
                 true,
                 List.of(

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.scheduler.ActorTask;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -80,7 +81,7 @@ final class RebalanceCoordinatorTest {
   void shouldReportTheRebalanceItStarted() {
     // given
     final var coordinator = coordinatingWith(new BlockedRunner());
-    final var overrides = new RebalanceOverrides(4096L, Duration.ofSeconds(30), 5);
+    final var overrides = new RebalanceOverrides(4096L, Duration.ofSeconds(30), 5, null);
 
     // when
     final var triggered =
@@ -408,7 +409,12 @@ final class RebalanceCoordinatorTest {
     final var runner = new BlockedRunner();
     final var coordinator =
         new RebalanceCoordinator(
-            LOWEST_ID_MEMBER, executor, runner, nextRebalanceId::getAndIncrement, stepClock);
+            LOWEST_ID_MEMBER,
+            executor,
+            runner,
+            nextRebalanceId::getAndIncrement,
+            stepClock,
+            new ClusterRebalanceMetrics(new SimpleMeterRegistry()));
     coordinator.onClusterConfigurationUpdated(
         CurrentClusterConfiguration.fromLegacy(
             ClusterConfiguration.init()
@@ -494,7 +500,12 @@ final class RebalanceCoordinatorTest {
   private RebalanceCoordinator startCoordinator(
       final MemberId localMemberId, final RebalanceRunner runner) {
     return new RebalanceCoordinator(
-        localMemberId, executor, runner, nextRebalanceId::getAndIncrement, clock);
+        localMemberId,
+        executor,
+        runner,
+        nextRebalanceId::getAndIncrement,
+        clock,
+        new ClusterRebalanceMetrics(new SimpleMeterRegistry()));
   }
 
   private void configurationWithBothMembers(final RebalanceCoordinator coordinator) {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
@@ -100,7 +100,8 @@ final class RebalanceForwardingTest {
   void shouldForwardATriggerToTheCoordinator() {
     // given
     final var request =
-        new TriggerRebalanceRequest(new RebalanceOverrides(2048L, Duration.ofSeconds(20), 3), true);
+        new TriggerRebalanceRequest(
+            new RebalanceOverrides(2048L, Duration.ofSeconds(20), 3, null), true);
     COORDINATOR.status =
         new RebalanceStatus(
             new RebalanceStatus.Running(9, request.overrides(), true, false, List.of()), null);

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -12,6 +12,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.LeadershipTransferProtocol;
+import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.RebalanceConfiguration;
+import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
+import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
+import io.atomix.raft.protocol.LeadershipTransferResultRequest;
+import io.atomix.raft.protocol.LeadershipTransferResultResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
@@ -21,26 +30,57 @@ import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 final class SequentialRebalanceRunnerTest {
 
   private static final String GROUP = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+  private static final MemberId COORDINATOR = MemberId.from("0");
   private static final MemberId MEMBER_1 = MemberId.from("1");
   private static final MemberId MEMBER_2 = MemberId.from("2");
+  private static final MemberId MEMBER_3 = MemberId.from("3");
 
+  private static final long OBSERVATIONS_UNTIL_LEADER_WAIT_TIMEOUT = 6;
+
+  private static final Duration LEADER_WAIT_TIMEOUT =
+      SequentialRebalanceRunner.LEADERSHIP_OBSERVATION_INTERVAL.multipliedBy(
+          (int) OBSERVATIONS_UNTIL_LEADER_WAIT_TIMEOUT);
+
+  private static final Duration TEST_HEARTBEAT_INTERVAL = Duration.ofSeconds(1);
+
+  private static final RebalanceConfiguration TEST_CONFIGURATION =
+      new RebalanceConfiguration(1024L, Duration.ofSeconds(2), 1);
+
+  private static final Duration TRANSFER_WATCHDOG_TIMEOUT =
+      TEST_CONFIGURATION
+          .pauseBudget(TEST_HEARTBEAT_INTERVAL)
+          .plus(SequentialRebalanceRunner.COORDINATOR_WATCHDOG_SLACK);
+
+  private static final long OBSERVATIONS_UNTIL_WATCHDOG_TIMEOUT =
+      TRANSFER_WATCHDOG_TIMEOUT.toMillis()
+          / SequentialRebalanceRunner.LEADERSHIP_OBSERVATION_INTERVAL.toMillis();
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
-  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final TestConcurrencyControl executor = new TestConcurrencyControl(true);
   private final Map<String, Map<Integer, MemberId>> leaders = new HashMap<>();
   private final Set<String> unavailableGroups = new HashSet<>();
   private final Map<String, Integer> groupLookups = new HashMap<>();
+  private final RecordingTransfers transfers = new RecordingTransfers();
   private final PartitionLeaders partitionLeaders =
       physicalTenantId -> {
         groupLookups.merge(physicalTenantId, 1, Integer::sum);
@@ -58,7 +98,7 @@ final class SequentialRebalanceRunnerTest {
     leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
 
     // when
-    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    final var rebalance = planDryRun(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
 
     // then
     assertThat(rebalance.partitions())
@@ -71,7 +111,7 @@ final class SequentialRebalanceRunnerTest {
     leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_2);
 
     // when
-    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    final var rebalance = planDryRun(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
 
     // then
     assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
@@ -82,7 +122,7 @@ final class SequentialRebalanceRunnerTest {
   @Test
   void shouldPlanATransferForAPartitionWithNoLeaderAtAll() {
     // given / when
-    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    final var rebalance = planDryRun(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
 
     // then
     assertThat(rebalance.partition(0).currentLeader()).isNull();
@@ -95,7 +135,7 @@ final class SequentialRebalanceRunnerTest {
     leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
 
     // when
-    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    final var rebalance = planDryRun(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
 
     // then
     assertThat(rebalance.partition(0).currentLeader()).isNull();
@@ -108,7 +148,8 @@ final class SequentialRebalanceRunnerTest {
     unavailableGroups.add(GROUP);
 
     // when / then
-    assertThatThrownBy(() -> run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2))))
+    assertThatThrownBy(
+            () -> planDryRun(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2))))
         .isInstanceOf(IllegalStateException.class);
   }
 
@@ -127,7 +168,7 @@ final class SequentialRebalanceRunnerTest {
                         3, active(1)))));
 
     // when
-    run(configuration);
+    planDryRun(configuration);
 
     // then
     assertThat(groupLookups).containsEntry(GROUP, 1);
@@ -136,7 +177,7 @@ final class SequentialRebalanceRunnerTest {
   @Test
   void shouldPlanATransferWithNoOutcomeYet() {
     // given / when
-    final var rebalance = run(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    final var rebalance = planDryRun(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
 
     // then
     assertThat(rebalance.partition(0).outcome()).isNull();
@@ -157,7 +198,7 @@ final class SequentialRebalanceRunnerTest {
                         2, active(1)))));
 
     // when
-    final var rebalance = run(configuration);
+    final var rebalance = planDryRun(configuration);
 
     // then
     assertThat(rebalance.partitions())
@@ -178,7 +219,7 @@ final class SequentialRebalanceRunnerTest {
                     Map.of(MEMBER_1, Map.of(1, active(2)), MEMBER_2, Map.of(1, active(1)))));
 
     // when
-    final var rebalance = run(configuration);
+    final var rebalance = planDryRun(configuration);
 
     // then
     assertThat(rebalance.partitions())
@@ -199,7 +240,7 @@ final class SequentialRebalanceRunnerTest {
                 "tenant-a", Map.of(MEMBER_1, Map.of(1, active(1)))));
 
     // when
-    final var rebalance = run(configuration);
+    final var rebalance = planDryRun(configuration);
 
     // then
     assertThat(rebalance.partitions())
@@ -207,11 +248,579 @@ final class SequentialRebalanceRunnerTest {
         .containsExactly(tuple("tenant-a", 1), tuple("tenant-b", 1), tuple("tenant-b", 2));
   }
 
-  private RebalanceRun run(final CurrentClusterConfiguration configuration) {
+  @Test
+  void shouldNotAskAnyLeaderForADryRun() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+
+    // when
+    final var rebalance = planDryRun(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    assertThat(transfers.initiated).isEmpty();
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.PENDING);
+  }
+
+  @Test
+  void shouldAskTheCurrentLeaderToTransferToTheDesiredLeader() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+
+    // when
+    start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    final var initiated = transfers.lastInitiated();
+    assertThat(initiated.leader()).isEqualTo(MEMBER_1);
+    assertThat(initiated.physicalTenantId()).isEqualTo(GROUP);
+    assertThat(initiated.partitionId()).isEqualTo(1);
+    assertThat(initiated.request().desiredLeader()).isEqualTo(MEMBER_2);
+    assertThat(initiated.request().coordinator()).isEqualTo(COORDINATOR);
+    assertThat(initiated.request().correlationId()).isEqualTo(7);
+  }
+
+  @Test
+  void shouldApplyTheRebalancesOverridesToEachTransfer() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var overrides =
+        new RebalanceOverrides(4096L, Duration.ofSeconds(30), 5, Duration.ofSeconds(40));
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+
+    // when
+    start(new RebalanceRun(7, overrides, false, configuration, Instant.EPOCH));
+
+    // then
+    final var request = transfers.lastInitiated().request();
+    assertThat(request.replicationLagThreshold()).isEqualTo(4096L);
+    assertThat(request.replicationTimeout()).isEqualTo(Duration.ofSeconds(30));
+    assertThat(request.maxTransferAttempts()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldStartARebalanceWhenLeaderWaitTimeoutIsShorterThanTheTransferBudget() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
     final var rebalance =
         new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
-    new SequentialRebalanceRunner(executor, partitionLeaders).run(rebalance).join();
+
+    // when
+    run(rebalance, LEADER_WAIT_TIMEOUT);
+
+    // then
+    assertThat(transfers.initiated).hasSize(1);
+  }
+
+  @Test
+  void shouldUseARequestLevelLeaderWaitTimeoutOverrideOnlyForTheMissingLeaderWait() {
+    // given
+    final var overrideObservations = OBSERVATIONS_UNTIL_LEADER_WAIT_TIMEOUT - 2;
+    final var overrideTimeout =
+        SequentialRebalanceRunner.LEADERSHIP_OBSERVATION_INTERVAL.multipliedBy(
+            (int) overrideObservations);
+    final var overrides = new RebalanceOverrides(null, null, null, overrideTimeout);
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance = new RebalanceRun(7, overrides, false, configuration, Instant.EPOCH);
+
+    // when
+    start(rebalance);
+    for (long observation = 0; observation < overrideObservations; observation++) {
+      executor.runAll();
+    }
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.NO_LEADER);
+    assertThat(transfers.initiated).isEmpty();
+  }
+
+  @Test
+  void shouldNotChangeWhenNoResponseOccursWhenLeaderWaitTimeoutIsOverridden() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var shortLeaderWaitTimeout = SequentialRebalanceRunner.LEADERSHIP_OBSERVATION_INTERVAL;
+    final var overrides = new RebalanceOverrides(null, null, null, shortLeaderWaitTimeout);
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance = new RebalanceRun(7, overrides, false, configuration, Instant.EPOCH);
+    start(rebalance);
+    transfers.accept();
+
+    // when
+    for (long observation = 0;
+        observation < OBSERVATIONS_UNTIL_WATCHDOG_TIMEOUT - 1;
+        observation++) {
+      executor.runAll();
+    }
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+
+    // when
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.NO_RESPONSE);
+  }
+
+  @Test
+  void shouldDeriveTheWatchdogFromRequestOverridesOfReplicationTimeoutAndMaxTransferAttempts() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var overrides = new RebalanceOverrides(null, Duration.ofSeconds(10), null, null);
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance = new RebalanceRun(7, overrides, false, configuration, Instant.EPOCH);
+    start(rebalance);
+    transfers.accept();
+
+    // when
+    for (long observation = 0; observation < OBSERVATIONS_UNTIL_WATCHDOG_TIMEOUT; observation++) {
+      executor.runAll();
+    }
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+  }
+
+  @Test
+  void shouldNotResolveNoResponseBeforeTheLeaderSidePauseWatchdogCouldRecoverThePartition() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    transfers.accept();
+    final var pauseBudgetObservations =
+        TEST_CONFIGURATION.pauseBudget(TEST_HEARTBEAT_INTERVAL).toSeconds();
+
+    // when
+    for (long observation = 0; observation < pauseBudgetObservations; observation++) {
+      executor.runAll();
+    }
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+  }
+
+  @Test
+  void shouldTransferOnlyOnePartitionAtATime() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    final var rebalance = start(twoPartitionsConfiguration());
+    transfers.accept();
+
+    // when
+    final var initiatedWhileOneWasInFlight = transfers.initiated.size();
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(initiatedWhileOneWasInFlight).isEqualTo(1);
+    assertThat(transfers.initiated).hasSize(2);
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.TRANSFERRED);
+    assertThat(rebalance.partition(1).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+  }
+
+  @Test
+  void shouldRecordLeadershipMovingToTheDesiredLeader() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    transfers.accept();
+
+    // when
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.TRANSFERRED);
+    assertThat(rebalance.partition(0).currentLeader()).isEqualTo(MEMBER_2);
+  }
+
+  @Test
+  void shouldMapEveryDeclinedTransferToTheIdenticallyNamedOutcome() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // when
+    transfers.decline(LeadershipTransferResult.LAG_TOO_HIGH);
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.LAG_TOO_HIGH);
+  }
+
+  @Test
+  void shouldMapEveryReportedResultToTheIdenticallyNamedOutcome() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    transfers.accept();
+
+    // when
+    transfers.report(LeadershipTransferResult.TIMEOUT_NOW_EXHAUSTED);
+
+    // then
+    assertThat(rebalance.partition(0).outcome())
+        .isEqualTo(PartitionRebalanceOutcome.TIMEOUT_NOW_EXHAUSTED);
+  }
+
+  @Test
+  void shouldWaitForATopologyResponseWhenTheInitiateRequestCannotBeAnswered() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // when
+    transfers.fail(new RuntimeException("no route to the leader"));
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+  }
+
+  @Test
+  void shouldCompleteWithNoLeaderWhenNoneAppearsWithinTheLeaderWaitTimeout() {
+    // given
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // when
+    for (long observation = 0;
+        observation < OBSERVATIONS_UNTIL_LEADER_WAIT_TIMEOUT;
+        observation++) {
+      executor.runAll();
+    }
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.NO_LEADER);
+    assertThat(transfers.initiated).isEmpty();
+  }
+
+  @Test
+  void shouldInitiateOnceALeaderAppearsWhileWaiting() {
+    // given
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // when
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(transfers.lastInitiated().leader()).isEqualTo(MEMBER_1);
+  }
+
+  @Test
+  void shouldNotInitiateATransferWhenCancelledWhileWaitingForALeader() {
+    // given
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    final var completion = run(rebalance);
+
+    // when
+    rebalance.requestCancel();
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    executor.runAll();
+
+    // then
+    assertThat(transfers.initiated).isEmpty();
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.CANCELLED);
+    assertThat(completion.isDone()).isTrue();
+  }
+
+  @Test
+  void shouldResolveImmediatelyWithNoLeaderWhenLeaderWaitTimeoutIsZero() {
+    // given
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+
+    // when
+    run(rebalance, Duration.ZERO);
+
+    // then
+    assertThat(transfers.initiated).isEmpty();
+    assertThat(executor.scheduledTasks()).isZero();
+
+    // when
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    executor.runAll();
+
+    // then
+    assertThat(transfers.initiated).isEmpty();
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.NO_LEADER);
+  }
+
+  @Test
+  void shouldMoveOnWhenTheTopologyShowsLeadershipReachedTheDesiredLeader() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    final var rebalance = start(twoPartitionsConfiguration());
+    transfers.accept();
+
+    // when
+    leaders.get(GROUP).put(1, MEMBER_2);
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.TRANSFERRED);
+    assertThat(transfers.lastInitiated().partitionId()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldGiveUpWithNoResponseWhenTheWatchdogExpires() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    transfers.accept();
+
+    // when
+    for (long observation = 0; observation < OBSERVATIONS_UNTIL_WATCHDOG_TIMEOUT; observation++) {
+      executor.runAll();
+    }
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.NO_RESPONSE);
+  }
+
+  @Test
+  void shouldContinueToTheNextPartitionOnlyAfterTheWatchdogExpiresWithNoResponse() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    final var rebalance = start(twoPartitionsConfiguration());
+    transfers.accept();
+
+    // when
+    for (long observation = 0;
+        observation < OBSERVATIONS_UNTIL_WATCHDOG_TIMEOUT - 1;
+        observation++) {
+      executor.runAll();
+    }
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(transfers.initiated).hasSize(1);
+
+    // when
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.NO_RESPONSE);
+    assertThat(rebalance.partition(1).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(transfers.initiated).hasSize(2);
+  }
+
+  @Test
+  void shouldContinueToTheNextPartitionOnlyAfterTheWatchdogExpiresWhenInitiationFailed() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    final var rebalance = start(twoPartitionsConfiguration());
+
+    // when
+    transfers.fail(new RuntimeException("no route to the leader"));
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(transfers.initiated).hasSize(1);
+
+    // when
+    for (long observation = 0; observation < OBSERVATIONS_UNTIL_WATCHDOG_TIMEOUT; observation++) {
+      executor.runAll();
+    }
+
+    // then
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.NO_RESPONSE);
+    assertThat(rebalance.partition(1).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(transfers.initiated).hasSize(2);
+  }
+
+  @Test
+  void shouldCompleteWithLeaderChangedWhenATopologyShowsAThirdMemberLeading() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    final var rebalance = start(twoPartitionsConfiguration());
+    transfers.accept();
+
+    // when
+    groupLeaders.put(1, MEMBER_3);
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome())
+        .isEqualTo(PartitionRebalanceOutcome.LEADER_CHANGED);
+    assertThat(rebalance.partition(0).currentLeader()).isEqualTo(MEMBER_3);
+    assertThat(rebalance.partition(1).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(transfers.lastInitiated().partitionId()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldContinueToTheNextPartitionAfterAnUnsuccessfulOutcome() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    start(twoPartitionsConfiguration());
+
+    // when
+    transfers.decline(LeadershipTransferResult.LAG_TOO_HIGH);
+
+    // then
+    assertThat(transfers.initiated).hasSize(2);
+    assertThat(transfers.lastInitiated().partitionId()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldCompleteTheInFlightTransferThenCancelEveryUntouchedPartition() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    final var rebalance = start(twoPartitionsConfiguration());
+    transfers.accept();
+
+    // when
+    rebalance.requestCancel();
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(transfers.initiated).hasSize(1);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.TRANSFERRED);
+    assertThat(rebalance.partition(1).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(1).outcome()).isEqualTo(PartitionRebalanceOutcome.CANCELLED);
+  }
+
+  @Test
+  void shouldTakeOnNoFurtherPartitionOnceTheRebalanceIsAbandoned() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    final var rebalance = start(twoPartitionsConfiguration());
+    transfers.accept();
+
+    // when
+    rebalance.abandon();
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(transfers.initiated).hasSize(1);
+  }
+
+  @Test
+  void shouldAccountForAPartitionByWhatItsLeaderReported() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+    transfers.accept();
+
+    // when
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(partitionDurationCount(1, LeadershipTransferResult.TRANSFERRED.name())).isEqualTo(1);
+  }
+
+  @Test
+  void shouldAccountForAPartitionAlreadyBalancedAtPlanTime() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_2);
+
+    // when
+    start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    assertThat(partitionDurationCount(1, PartitionRebalanceOutcome.ALREADY_LEADER.name()))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldReportNoPendingPartitionAsCompletedWhenTheRunFinishes() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_2);
+
+    // when
+    start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // then
+    assertThat(partitionStateGauge(1)).isEqualTo(3);
+  }
+
+  private double partitionStateGauge(final int partitionId) {
+    return registry
+        .get("zeebe.cluster.rebalance.partition.state")
+        .tag("partition", String.valueOf(partitionId))
+        .tag("physicalTenant", GROUP)
+        .gauge()
+        .value();
+  }
+
+  private long partitionDurationCount(final int partitionId, final String result) {
+    return registry
+        .get("zeebe.cluster.rebalance.partition.duration")
+        .tag("partition", String.valueOf(partitionId))
+        .tag("physicalTenant", GROUP)
+        .tag("result", result)
+        .timer()
+        .count();
+  }
+
+  private RebalanceRun planDryRun(final CurrentClusterConfiguration configuration) {
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), true, configuration, Instant.EPOCH);
+    run(rebalance).join();
     return rebalance;
+  }
+
+  private RebalanceRun start(final CurrentClusterConfiguration configuration) {
+    return start(
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH));
+  }
+
+  private RebalanceRun start(final RebalanceRun rebalance) {
+    run(rebalance);
+    return rebalance;
+  }
+
+  private ActorFuture<Void> run(final RebalanceRun rebalance) {
+    return run(rebalance, LEADER_WAIT_TIMEOUT);
+  }
+
+  private ActorFuture<Void> run(final RebalanceRun rebalance, final Duration leaderWaitTimeout) {
+    return new SequentialRebalanceRunner(
+            COORDINATOR,
+            executor,
+            partitionLeaders,
+            transfers,
+            new ClusterRebalanceMetrics(registry),
+            leaderWaitTimeout,
+            TEST_CONFIGURATION,
+            TEST_HEARTBEAT_INTERVAL)
+        .run(rebalance);
   }
 
   private PartitionState active(final int priority) {
@@ -224,6 +833,15 @@ final class SequentialRebalanceRunnerTest {
     prioritiesForPartitionOne.forEach(
         (memberId, priority) -> partitionsPerMember.put(memberId, Map.of(1, active(priority))));
     return configurationOf(Map.of(group, partitionsPerMember));
+  }
+
+  private CurrentClusterConfiguration twoPartitionsConfiguration() {
+    return configurationOf(
+        Map.of(
+            GROUP,
+            Map.of(
+                MEMBER_1, Map.of(1, active(1), 2, active(1)),
+                MEMBER_2, Map.of(1, active(2), 2, active(2)))));
   }
 
   private CurrentClusterConfiguration configurationOf(
@@ -261,5 +879,83 @@ final class SequentialRebalanceRunnerTest {
         globalConfiguration,
         groups,
         PhasedChangeState.empty());
+  }
+
+  private static final class RecordingTransfers implements LeadershipTransferProtocol {
+
+    private final List<Initiated> initiated = new ArrayList<>();
+    private final Map<
+            PartitionId,
+            Function<
+                LeadershipTransferResultRequest,
+                CompletableFuture<LeadershipTransferResultResponse>>>
+        resultHandlers = new HashMap<>();
+
+    private CompletableFuture<LeadershipTransferInitiateResponse> pending;
+
+    @Override
+    public CompletableFuture<LeadershipTransferInitiateResponse> initiate(
+        final MemberId leader,
+        final String partitionGroup,
+        final int partitionId,
+        final LeadershipTransferInitiateRequest request) {
+      initiated.add(new Initiated(leader, partitionGroup, partitionId, request));
+      pending = new CompletableFuture<>();
+      return pending;
+    }
+
+    @Override
+    public void onResult(
+        final String partitionGroup,
+        final int partitionId,
+        final Function<
+                LeadershipTransferResultRequest,
+                CompletableFuture<LeadershipTransferResultResponse>>
+            handler) {
+      resultHandlers.put(new PartitionId(partitionGroup, partitionId), handler);
+    }
+
+    Initiated lastInitiated() {
+      return initiated.get(initiated.size() - 1);
+    }
+
+    void accept() {
+      pending.complete(LeadershipTransferInitiateResponse.builder().withStatus(Status.OK).build());
+    }
+
+    void decline(final LeadershipTransferResult reason) {
+      pending.complete(
+          LeadershipTransferInitiateResponse.builder()
+              .withStatus(Status.OK)
+              .withRejectionReason(reason)
+              .build());
+    }
+
+    void fail(final Throwable error) {
+      pending.completeExceptionally(error);
+    }
+
+    void report(final LeadershipTransferResult result) {
+      reportWithCorrelationId(lastInitiated().request().correlationId(), result);
+    }
+
+    void reportWithCorrelationId(final long correlationId, final LeadershipTransferResult result) {
+      final var last = lastInitiated();
+      resultHandlers
+          .get(new PartitionId(last.physicalTenantId(), last.partitionId()))
+          .apply(
+              LeadershipTransferResultRequest.builder()
+                  .withLeader(last.leader())
+                  .withDesiredLeader(last.request().desiredLeader())
+                  .withResult(result)
+                  .withCorrelationId(correlationId)
+                  .build());
+    }
+
+    private record Initiated(
+        MemberId leader,
+        String physicalTenantId,
+        int partitionId,
+        LeadershipTransferInitiateRequest request) {}
   }
 }

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -787,6 +787,133 @@ final class SequentialRebalanceRunnerTest {
     assertThat(partitionStateGauge(1)).isEqualTo(3);
   }
 
+  @Test
+  void shouldRegisterOneResultHandlerForTwoTransfersOfTheSamePartition() {
+    // given
+    final var runner = newRunner();
+    final var partitionId = new PartitionId(GROUP, 1);
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var firstRun =
+        new RebalanceRun(
+            7,
+            RebalanceOverrides.none(),
+            false,
+            groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)),
+            Instant.EPOCH);
+    runner.run(firstRun);
+
+    // when
+    final var secondRun =
+        new RebalanceRun(
+            9,
+            RebalanceOverrides.none(),
+            false,
+            groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_3, 2)),
+            Instant.EPOCH);
+    runner.run(secondRun);
+
+    // then
+    assertThat(transfers.initiated).hasSize(2);
+    assertThat(transfers.resultHandlerRegistrations(partitionId)).isEqualTo(1);
+  }
+
+  @Test
+  void shouldRouteAResultToWhicheverTransferIsCurrentlyActiveForThePartition() {
+    // given
+    final var runner = newRunner();
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var firstRun =
+        new RebalanceRun(
+            7,
+            RebalanceOverrides.none(),
+            false,
+            groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)),
+            Instant.EPOCH);
+    runner.run(firstRun);
+    final var secondRun =
+        new RebalanceRun(
+            9,
+            RebalanceOverrides.none(),
+            false,
+            groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_3, 2)),
+            Instant.EPOCH);
+    runner.run(secondRun);
+
+    // when
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(secondRun.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(secondRun.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.TRANSFERRED);
+    assertThat(firstRun.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+  }
+
+  @Test
+  void shouldNotCompleteTheCurrentTransferWithAStaleCorrelationId() {
+    // given
+    final var runner = newRunner();
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var firstRun =
+        new RebalanceRun(
+            7,
+            RebalanceOverrides.none(),
+            false,
+            groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)),
+            Instant.EPOCH);
+    runner.run(firstRun);
+    final var secondRun =
+        new RebalanceRun(
+            9,
+            RebalanceOverrides.none(),
+            false,
+            groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_3, 2)),
+            Instant.EPOCH);
+    runner.run(secondRun);
+
+    // when
+    transfers.reportWithCorrelationId(firstRun.id(), LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(secondRun.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(secondRun.partition(0).outcome()).isNull();
+  }
+
+  @Test
+  void shouldUseASeparateResultHandlerForEachPartition() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_1);
+    groupLeaders.put(2, MEMBER_1);
+    final var runner = newRunner();
+    final var rebalance =
+        new RebalanceRun(
+            7, RebalanceOverrides.none(), false, twoPartitionsConfiguration(), Instant.EPOCH);
+
+    // when
+    runner.run(rebalance);
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(transfers.resultHandlerRegistrations(new PartitionId(GROUP, 1))).isEqualTo(1);
+    assertThat(transfers.resultHandlerRegistrations(new PartitionId(GROUP, 2))).isEqualTo(1);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.TRANSFERRED);
+    assertThat(rebalance.partition(1).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+  }
+
+  private SequentialRebalanceRunner newRunner() {
+    return new SequentialRebalanceRunner(
+        COORDINATOR,
+        executor,
+        partitionLeaders,
+        transfers,
+        new ClusterRebalanceMetrics(registry),
+        LEADER_WAIT_TIMEOUT,
+        TEST_CONFIGURATION,
+        TEST_HEARTBEAT_INTERVAL);
+  }
+
   private double partitionStateGauge(final int partitionId) {
     return registry
         .get("zeebe.cluster.rebalance.partition.state")
@@ -907,6 +1034,7 @@ final class SequentialRebalanceRunnerTest {
                 LeadershipTransferResultRequest,
                 CompletableFuture<LeadershipTransferResultResponse>>>
         resultHandlers = new HashMap<>();
+    private final Map<PartitionId, Integer> resultHandlerRegistrations = new HashMap<>();
 
     private CompletableFuture<LeadershipTransferInitiateResponse> pending;
 
@@ -928,10 +1056,15 @@ final class SequentialRebalanceRunnerTest {
                 CompletableFuture<LeadershipTransferResultResponse>>
             handler) {
       resultHandlers.put(partitionId, handler);
+      resultHandlerRegistrations.merge(partitionId, 1, Integer::sum);
     }
 
     Initiated lastInitiated() {
       return initiated.get(initiated.size() - 1);
+    }
+
+    int resultHandlerRegistrations(final PartitionId partitionId) {
+      return resultHandlerRegistrations.getOrDefault(partitionId, 0);
     }
 
     void accept() {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -913,23 +913,21 @@ final class SequentialRebalanceRunnerTest {
     @Override
     public CompletableFuture<LeadershipTransferInitiateResponse> initiate(
         final MemberId leader,
-        final String partitionGroup,
-        final int partitionId,
+        final PartitionId partitionId,
         final LeadershipTransferInitiateRequest request) {
-      initiated.add(new Initiated(leader, partitionGroup, partitionId, request));
+      initiated.add(new Initiated(leader, partitionId.group(), partitionId.number(), request));
       pending = new CompletableFuture<>();
       return pending;
     }
 
     @Override
     public void onResult(
-        final String partitionGroup,
-        final int partitionId,
+        final PartitionId partitionId,
         final Function<
                 LeadershipTransferResultRequest,
                 CompletableFuture<LeadershipTransferResultResponse>>
             handler) {
-      resultHandlers.put(new PartitionId(partitionGroup, partitionId), handler);
+      resultHandlers.put(partitionId, handler);
     }
 
     Initiated lastInitiated() {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferProtocol;
 import io.atomix.raft.LeadershipTransferResult;
+import io.atomix.raft.RaftError;
 import io.atomix.raft.RebalanceConfiguration;
 import io.atomix.raft.protocol.LeadershipTransferInitiateRequest;
 import io.atomix.raft.protocol.LeadershipTransferInitiateResponse;
@@ -468,6 +469,22 @@ final class SequentialRebalanceRunnerTest {
     // then
     assertThat(rebalance.partition(0).outcome())
         .isEqualTo(PartitionRebalanceOutcome.TIMEOUT_NOW_EXHAUSTED);
+  }
+
+  @Test
+  void shouldNotThrowWhenInitiationRespondsWithErrorAndNoRejectionReason() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var rebalance = start(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));
+
+    // when
+    transfers.error(RaftError.Type.ILLEGAL_MEMBER_STATE);
+    leaders.get(GROUP).put(1, MEMBER_2);
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.TRANSFERRED);
   }
 
   @Test
@@ -933,6 +950,14 @@ final class SequentialRebalanceRunnerTest {
 
     void fail(final Throwable error) {
       pending.completeExceptionally(error);
+    }
+
+    void error(final RaftError.Type type) {
+      pending.complete(
+          LeadershipTransferInitiateResponse.builder()
+              .withStatus(Status.ERROR)
+              .withError(new RaftError(type, null))
+              .build());
     }
 
     void report(final LeadershipTransferResult result) {


### PR DESCRIPTION
Adds the execution mechanism for planned rebalances to the coordinator. For each planned transfer, the runner invokes the transfer request to the current leader, waits for leadership to change, and records the result.

Transfers run one partition at a time. If the rebalance is cancelled, any already-initiated transfer will continue (including observation of results), but no further transfers will be initiated.

If a partition doesn't have any leader when the rebalance is planned, the coordinator will wait up to the configured (or overridden) `leaderWaitTimeout` for one to appear.

The time that the coordinator will wait for each transfer after initiating it is derived from the leader's pause budget plus a fixed overhead - if we exceed this we'll move on to the next partition. The overhead should be sized such that a healthy transfer won't hit the coordinator-side timeout.

Leadership changes can be observed either by notification from the prior leader (after the transfer process finished), or by updates to the topology.