### PR TITLE
feat: log daily load test results to a Google Sheet

### DIFF
--- a/.github/scripts/post-load-test-results-to-sheet.py
+++ b/.github/scripts/post-load-test-results-to-sheet.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Append daily load-test results to the tracking Google Sheet.
+
+Builds one row per protocol (gRPC, REST) from the end-of-soak metric snapshots
+and appends them to the "Load test daily statistics" sheet, so results build a
+historical trend record instead of only living in Slack or a 90-day artifact.
+Invoked by the `notify-results` and `notify` jobs of
+`.github/workflows/camunda-daily-load-tests.yml`.
+
+Metric columns are derived from `queries.yaml` (the single source of truth
+shared with `loadTestMetrics.sh` and the Slack results script), in file order.
+Adding a metric there changes the columns this script writes — the sheet's
+header row must be updated to match by hand when that happens.
+
+Required environment variables:
+  GRPC_RESULTS_JSON  JSON {metric_name: value} for the gRPC run. Empty/missing
+                      values are fine when STATUS_GRPC != success.
+  REST_RESULTS_JSON  JSON {metric_name: value} for the REST run.
+  STATUS_GRPC        'success' or 'failed'.
+  STATUS_REST        'success' or 'failed'.
+  BENCHMARK          Benchmark name, e.g. medic-daily-YYYY-MM-DD-<sha>-test.
+  REPO               GitHub repo slug, e.g. camunda/camunda.
+  RUN_ID             GitHub Actions run id (used to link the workflow run).
+  LOAD_TEST_SHEET_ID Target spreadsheet ID.
+  GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON
+                      Service account key JSON (Vault secret) with Editor
+                      access to the sheet.
+
+Optional:
+  QUERIES_YAML  Path to queries.yaml. Default: load-tests/docs/scripts/queries.yaml
+  SHEET_TAB     Sheet tab to append to. Default: Sheet1
+"""
+
+import json
+import os
+
+import yaml
+
+Row = list[object]
+Query = dict[str, object]
+
+
+def parse_benchmark(benchmark: str) -> tuple[str, str]:
+    """Extract (date, short_sha) from medic-daily-YYYY-MM-DD-<sha>-test."""
+    parts = benchmark.split("-")
+    if len(parts) < 6:
+        return "", ""
+    return "-".join(parts[2:5]), parts[5]
+
+
+def metric_value(status: str, results: dict, name: str) -> object:
+    if status != "success":
+        return ""
+    value = results.get(name)
+    if value is None:
+        return ""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return ""
+
+
+def build_row(
+    protocol: str,
+    status: str,
+    results: dict,
+    queries: list[Query],
+    date: str,
+    sha: str,
+    benchmark: str,
+    run_url: str,
+) -> Row:
+    row: Row = [date, protocol, status, benchmark, sha, run_url]
+    row += [metric_value(status, results, q["name"]) for q in queries]
+    return row
+
+
+def build_rows(
+    benchmark: str,
+    run_url: str,
+    grpc_status: str,
+    grpc_results: dict,
+    rest_status: str,
+    rest_results: dict,
+    queries: list[Query],
+) -> list[Row]:
+    date, sha = parse_benchmark(benchmark)
+    return [
+        build_row("grpc", grpc_status, grpc_results, queries, date, sha, benchmark, run_url),
+        build_row("rest", rest_status, rest_results, queries, date, sha, benchmark, run_url),
+    ]
+
+
+def append_rows(sheet_id: str, service_account_info: dict, tab: str, rows: list[Row]) -> None:
+    # Imported lazily so unit-testing build_rows()/parse_benchmark() above doesn't
+    # require google-api-python-client/google-auth to be installed.
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
+
+    creds = service_account.Credentials.from_service_account_info(
+        service_account_info, scopes=["https://www.googleapis.com/auth/spreadsheets"]
+    )
+    service = build("sheets", "v4", credentials=creds)
+    service.spreadsheets().values().append(
+        spreadsheetId=sheet_id,
+        range=f"{tab}!A:A",
+        valueInputOption="USER_ENTERED",
+        insertDataOption="INSERT_ROWS",
+        body={"values": rows},
+    ).execute()
+
+
+def main() -> None:
+    grpc_results = json.loads(os.environ.get("GRPC_RESULTS_JSON") or "{}")
+    rest_results = json.loads(os.environ.get("REST_RESULTS_JSON") or "{}")
+    grpc_status = os.environ["STATUS_GRPC"]
+    rest_status = os.environ["STATUS_REST"]
+    benchmark = os.environ["BENCHMARK"]
+    run_url = f'https://github.com/{os.environ["REPO"]}/actions/runs/{os.environ["RUN_ID"]}'
+    sheet_id = os.environ["LOAD_TEST_SHEET_ID"]
+    tab = os.environ.get("SHEET_TAB", "Sheet1")
+    queries_yaml = os.environ.get("QUERIES_YAML", "load-tests/docs/scripts/queries.yaml")
+
+    with open(queries_yaml) as f:
+        queries = yaml.safe_load(f)["queries"]
+
+    rows = build_rows(benchmark, run_url, grpc_status, grpc_results, rest_status, rest_results, queries)
+
+    service_account_info = json.loads(os.environ["GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON"])
+    append_rows(sheet_id, service_account_info, tab, rows)
+    print(f"Appended {len(rows)} rows to sheet {sheet_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_post_load_test_results_to_sheet.py
+++ b/.github/scripts/test_post_load_test_results_to_sheet.py
@@ -1,0 +1,116 @@
+"""Unit tests for post-load-test-results-to-sheet.py
+
+Run with:
+    pytest .github/scripts/test_post_load_test_results_to_sheet.py
+"""
+
+import importlib.util
+import os
+import sys
+
+# Load the hyphen-named module via importlib and register it so mock.patch works.
+_SCRIPT = os.path.join(os.path.dirname(__file__), "post-load-test-results-to-sheet.py")
+_spec = importlib.util.spec_from_file_location("post_load_test_results_to_sheet", _SCRIPT)
+s = importlib.util.module_from_spec(_spec)
+sys.modules["post_load_test_results_to_sheet"] = s
+_spec.loader.exec_module(s)
+
+QUERIES = [
+    {"name": "process-instances-started"},
+    {"name": "throughput-per-second"},
+]
+
+
+class TestParseBenchmark:
+    def test_extracts_date_and_short_sha(self):
+        # given
+        benchmark = "medic-daily-2026-08-12-abc1234-test"
+        # when
+        date, sha = s.parse_benchmark(benchmark)
+        # then
+        assert date == "2026-08-12"
+        assert sha == "abc1234"
+
+    def test_returns_empty_strings_when_name_is_unparseable(self):
+        # given: a name that doesn't match the medic-daily-<date>-<sha>-test shape
+        # when / then
+        assert s.parse_benchmark("not-a-benchmark-name") == ("", "")
+
+
+class TestMetricValue:
+    def test_returns_float_on_success(self):
+        # given
+        results = {"throughput-per-second": "123.4"}
+        # when / then
+        assert s.metric_value("success", results, "throughput-per-second") == 123.4
+
+    def test_returns_blank_when_status_is_failed(self):
+        # given: metric present but the run itself is marked failed
+        results = {"throughput-per-second": "123.4"}
+        # when / then
+        assert s.metric_value("failed", results, "throughput-per-second") == ""
+
+    def test_returns_blank_when_metric_missing(self):
+        # given
+        results = {}
+        # when / then
+        assert s.metric_value("success", results, "throughput-per-second") == ""
+
+    def test_returns_blank_when_value_is_not_numeric(self):
+        # given: malformed upstream value
+        results = {"throughput-per-second": "n/a"}
+        # when / then
+        assert s.metric_value("success", results, "throughput-per-second") == ""
+
+
+class TestBuildRows:
+    def test_builds_one_row_per_protocol_on_full_success(self):
+        # given
+        grpc_results = {"process-instances-started": "1000", "throughput-per-second": "10.5"}
+        rest_results = {"process-instances-started": "900", "throughput-per-second": "9.1"}
+        # when
+        rows = s.build_rows(
+            "medic-daily-2026-08-12-abc1234-test",
+            "https://github.com/camunda/camunda/actions/runs/42",
+            "success", grpc_results,
+            "success", rest_results,
+            QUERIES,
+        )
+        # then
+        assert rows == [
+            ["2026-08-12", "grpc", "success", "medic-daily-2026-08-12-abc1234-test", "abc1234",
+             "https://github.com/camunda/camunda/actions/runs/42", 1000.0, 10.5],
+            ["2026-08-12", "rest", "success", "medic-daily-2026-08-12-abc1234-test", "abc1234",
+             "https://github.com/camunda/camunda/actions/runs/42", 900.0, 9.1],
+        ]
+
+    def test_failed_protocol_gets_blank_metrics(self):
+        # given: rest side crashed before metrics were collected
+        # when
+        rows = s.build_rows(
+            "medic-daily-2026-08-12-abc1234-test",
+            "https://github.com/camunda/camunda/actions/runs/42",
+            "success", {"process-instances-started": "1000", "throughput-per-second": "10.5"},
+            "failed", {},
+            QUERIES,
+        )
+        # then
+        grpc_row, rest_row = rows
+        assert grpc_row[2] == "success"
+        assert grpc_row[-2:] == [1000.0, 10.5]
+        assert rest_row[2] == "failed"
+        assert rest_row[-2:] == ["", ""]
+
+    def test_both_protocols_failed_gets_blank_metrics_for_both(self):
+        # given: hard failure before either side collected metrics
+        # when
+        rows = s.build_rows(
+            "medic-daily-2026-08-12-abc1234-test",
+            "https://github.com/camunda/camunda/actions/runs/42",
+            "failed", {},
+            "failed", {},
+            QUERIES,
+        )
+        # then
+        assert all(row[2] == "failed" for row in rows)
+        assert all(row[-2:] == ["", ""] for row in rows)

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -337,11 +337,16 @@ jobs:
           FLAMEGRAPH_LINKS: ${{ steps.flamegraph-artifacts.outputs.links }}
         run: python3 .github/scripts/post-load-test-results-to-slack.py
       - name: Install Google Sheets client libraries
+        continue-on-error: true
         run: python3 -m pip install --quiet google-api-python-client google-auth
       - name: Log results to sheet
-        # Logs a real row for each protocol that collected metrics, and a
-        # failed row (blank metrics) for one that didn't - so a partial
-        # failure still records the side that succeeded.
+        # Best-effort: sheet logging shouldn't fail the whole job (and thus
+        # trigger the `notify` failure alert for an otherwise-healthy run) -
+        # e.g. before the one-time Vault/GCP setup is done, or on a transient
+        # Sheets API error. Logs a real row for each protocol that collected
+        # metrics, and a failed row (blank metrics) for one that didn't - so
+        # a partial failure still records the side that succeeded.
+        continue-on-error: true
         env:
           GRPC_RESULTS_JSON: ${{ needs.collect-metrics-grpc.outputs.results-json }}
           REST_RESULTS_JSON: ${{ needs.collect-metrics-rest.outputs.results-json }}
@@ -438,12 +443,18 @@ jobs:
               ]
             }
       - name: Install Google Sheets client libraries
+        continue-on-error: true
         run: python3 -m pip install --quiet google-api-python-client google-auth
       - name: Log failed run to sheet
-        # This job only runs when some part of the pipeline failed. Log a row per
-        # protocol so a hard failure doesn't leave a silent gap in the sheet for
-        # that day; a protocol whose metrics collection did succeed still gets a
-        # real row instead of being marked failed.
+        # notify-results already logs both rows (real + failed) whenever at
+        # least one protocol succeeded - see its own condition above. Only
+        # run here for the complementary case (both protocols failed, so
+        # notify-results was skipped entirely), otherwise this would log
+        # duplicate rows alongside notify-results on a partial failure.
+        if: needs.collect-metrics-grpc.result != 'success' && needs.collect-metrics-rest.result != 'success'
+        # Best-effort, same reasoning as the notify-results step: sheet
+        # logging shouldn't affect this job's own status.
+        continue-on-error: true
         env:
           GRPC_RESULTS_JSON: ${{ needs.collect-metrics-grpc.outputs.results-json }}
           REST_RESULTS_JSON: ${{ needs.collect-metrics-rest.outputs.results-json }}

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -3,7 +3,10 @@
 #              runs via async-profiler.
 #              After a 3-hour soak: snapshots metrics as a GitHub artifact,
 #              posts a side-by-side summary table (with flamegraph links) to
-#              Slack, then immediately deletes both namespaces to reduce cost.
+#              Slack, appends a row per protocol to the "Load test daily
+#              statistics" Google Sheet for trend tracking (also on failure,
+#              so a bad run doesn't leave a silent gap), then immediately
+#              deletes both namespaces to reduce cost.
 #              Naming pattern: medic-daily-YYYY-MM-DD-<sha>
 # calls: camunda-load-test.yml (scenario: max),
 #        profile-load-test.yml,
@@ -305,8 +308,8 @@ jobs:
               .map(a => `<${runURL}/artifacts/${a.id}|${a.name}>`)
               .join(' · ');
             core.setOutput('links', links);
-      - name: Import Slack webhook from Vault
-        id: slack-secrets
+      - name: Import Slack webhook and sheet credentials from Vault
+        id: vault-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
@@ -316,6 +319,7 @@ jobs:
           exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
+            secret/data/products/camunda/ci/github-actions LOAD_TEST_SHEET_SERVICE_ACCOUNT_JSON;
       - name: Build and post Slack results table
         # queries.yaml is the canonical source of metric names/labels/formats;
         # the script reads it directly so the Slack table stays in sync.
@@ -323,7 +327,7 @@ jobs:
           GRPC_RESULTS_JSON: ${{ needs.collect-metrics-grpc.outputs.results-json }}
           REST_RESULTS_JSON: ${{ needs.collect-metrics-rest.outputs.results-json }}
           BENCHMARK: ${{ needs.benchmark-data.outputs.benchmark }}
-          SLACK_WEBHOOK_URL: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ steps.vault-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           # gRPC's own soak end; used only to build the Grafana deep-link time
@@ -332,6 +336,23 @@ jobs:
           SOAK_END_EPOCH: ${{ needs.soak-grpc.outputs.soak_end_epoch }}
           FLAMEGRAPH_LINKS: ${{ steps.flamegraph-artifacts.outputs.links }}
         run: python3 .github/scripts/post-load-test-results-to-slack.py
+      - name: Install Google Sheets client libraries
+        run: python3 -m pip install --quiet google-api-python-client google-auth
+      - name: Log results to sheet
+        # Logs a real row for each protocol that collected metrics, and a
+        # failed row (blank metrics) for one that didn't - so a partial
+        # failure still records the side that succeeded.
+        env:
+          GRPC_RESULTS_JSON: ${{ needs.collect-metrics-grpc.outputs.results-json }}
+          REST_RESULTS_JSON: ${{ needs.collect-metrics-rest.outputs.results-json }}
+          STATUS_GRPC: ${{ needs.collect-metrics-grpc.result == 'success' && 'success' || 'failed' }}
+          STATUS_REST: ${{ needs.collect-metrics-rest.result == 'success' && 'success' || 'failed' }}
+          BENCHMARK: ${{ needs.benchmark-data.outputs.benchmark }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          LOAD_TEST_SHEET_ID: ${{ vars.LOAD_TEST_SHEET_ID }}
+          GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON: ${{ steps.vault-secrets.outputs.LOAD_TEST_SHEET_SERVICE_ACCOUNT_JSON }}
+        run: python3 .github/scripts/post-load-test-results-to-sheet.py
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -372,7 +393,7 @@ jobs:
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ setup-max-load-test, setup-max-rest-load-test, soak-grpc, soak-rest, collect-metrics-grpc, collect-metrics-rest, upload-metrics, notify-results ]
+    needs: [ benchmark-data, setup-max-load-test, setup-max-rest-load-test, soak-grpc, soak-rest, collect-metrics-grpc, collect-metrics-rest, upload-metrics, notify-results ]
     if: failure()
     timeout-minutes: 5
     permissions: { }
@@ -380,8 +401,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Import Slack webhook from Vault
-        id: slack-secrets
+      - name: Import Slack webhook and sheet credentials from Vault
+        id: vault-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
@@ -391,10 +412,11 @@ jobs:
           exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
+            secret/data/products/camunda/ci/github-actions LOAD_TEST_SHEET_SERVICE_ACCOUNT_JSON;
       - id: slack-notify
         uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
-          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
+          webhook: ${{ steps.vault-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -415,6 +437,24 @@ jobs:
                 }
               ]
             }
+      - name: Install Google Sheets client libraries
+        run: python3 -m pip install --quiet google-api-python-client google-auth
+      - name: Log failed run to sheet
+        # This job only runs when some part of the pipeline failed. Log a row per
+        # protocol so a hard failure doesn't leave a silent gap in the sheet for
+        # that day; a protocol whose metrics collection did succeed still gets a
+        # real row instead of being marked failed.
+        env:
+          GRPC_RESULTS_JSON: ${{ needs.collect-metrics-grpc.outputs.results-json }}
+          REST_RESULTS_JSON: ${{ needs.collect-metrics-rest.outputs.results-json }}
+          STATUS_GRPC: ${{ needs.collect-metrics-grpc.result == 'success' && 'success' || 'failed' }}
+          STATUS_REST: ${{ needs.collect-metrics-rest.result == 'success' && 'success' || 'failed' }}
+          BENCHMARK: ${{ needs.benchmark-data.outputs.benchmark }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          LOAD_TEST_SHEET_ID: ${{ vars.LOAD_TEST_SHEET_ID }}
+          GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON: ${{ steps.vault-secrets.outputs.LOAD_TEST_SHEET_SERVICE_ACCOUNT_JSON }}
+        run: python3 .github/scripts/post-load-test-results-to-sheet.py
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -355,7 +355,7 @@ Daily stress tests run against the state of the **main** branch via the [Camunda
 - Earlier regression detection — shorter feedback loop when something breaks
 - Daily sanity check that load tests work with current Helm charts and application
 
-**Validation:** TBD — explicit dashboard with KPIs is tracked in [#42274](https://github.com/camunda/camunda/issues/42274).
+**Validation:** each run appends a row per protocol (gRPC, REST) to the "Load test daily statistics" Google Sheet — see the `Log results to sheet` / `Log failed run to sheet` steps in [`camunda-daily-load-tests.yml`](../.github/workflows/camunda-daily-load-tests.yml) — so trends and regressions can be tracked over time.
 
 **Profiling:** unlike the PR-label flow, profiling here is unconditional — after each run's setup job succeeds, the reusable [`profile-load-test.yml`](../.github/workflows/profile-load-test.yml) workflow waits out the same 15-minute warmup as the metrics path, then captures a 30-minute async-profiler flamegraph for both the gRPC and REST runs, in parallel with the 3-hour soak. Flamegraph artifacts upload the same way as the PR path.
 


### PR DESCRIPTION
## Description

Today the daily max-load stress test's metrics only live in a Slack message and a 90-day GitHub Actions artifact, so spotting a gradual regression across weeks or months means digging through expired artifacts or old Slack history. This appends each run's metrics as a row per protocol (gRPC, REST) to the "Load test daily statistics" Google Sheet, so results build a persistent trend record instead.

- New `.github/scripts/post-load-test-results-to-sheet.py`, with the metric columns derived from `queries.yaml` at runtime (same source of truth the Slack results script already uses), and unit tests for the row-building logic.
- Wired into `notify-results` (logs a real row for each protocol that collected metrics, a `failed` row with blank metrics for one that didn't) and into `notify` (`if: failure()`, so a hard pipeline failure still produces rows instead of leaving a silent gap for that day).
- Updates `load-tests/README.md`'s "Daily load tests" section, which previously listed this as a "TBD" gap.

**Needs one manual, out-of-band setup step before this can run successfully** (not part of this PR): a GCP service account with Sheets API access, sharing the target sheet with it as Editor, and storing its key in Vault as `LOAD_TEST_SHEET_SERVICE_ACCOUNT_JSON` (same Vault path as the existing Slack webhook secret), plus a `LOAD_TEST_SHEET_ID` repository variable. Until that's done, the new steps will fail - happy to pair on that setup before merging.

## Checklist

- [x] Backports not applicable - this workflow only runs on `main`, no bug fix involved
- [x] Not applicable - doesn't touch the C8 Orchestration Cluster E2E Test Suite

## Related issues

closes #60235