### PR TITLE
feat: reject plaintext secret references in zeebe:property values

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -11,19 +11,29 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty;
 import java.util.LinkedHashSet;
+import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Rejects a deployment when a {@code camunda.secrets.<name>} reference is used as a string literal
- * in an input-mapping source; only expression usage (a FEEL path) is allowed. This removes the
- * literal-vs-expression ambiguity, so a reference left in a valid input mapping is always an
- * expression.
+ * in a source the engine may resolve as an expression; only expression usage (a FEEL path) is
+ * allowed. This removes the literal-vs-expression ambiguity, so a reference left in a valid source
+ * is always an expression.
+ *
+ * <p>It applies uniformly to the two places a secret reference can be authored: a {@link
+ * ZeebeInput} mapping source (outbound) and a {@link ZeebeProperty} value (inbound). Both are
+ * validated by the same rule so the two forms behave identically. Use {@link
+ * #forInput(ExpressionLanguage)} and {@link #forProperty(ExpressionLanguage)} to obtain the two
+ * registrations.
  *
  * <p>Detection is purely static: a static value (no leading {@code =}) is scanned as a whole, and a
  * FEEL expression is scanned only inside its double-quoted string literals. A bare path such as
@@ -33,7 +43,8 @@ import org.jspecify.annotations.NullMarked;
  * deployment.
  */
 @NullMarked
-final class SecretReferenceLiteralValidator implements ModelElementValidator<ZeebeInput> {
+final class SecretReferenceLiteralValidator<T extends ModelElementInstance>
+    implements ModelElementValidator<T> {
 
   // Matches one whole double-quoted string literal, so only quoted text is scanned for a reference.
   // As a regex (after Java unescaping): "(?:\\.|[^"\\])*"
@@ -45,21 +56,44 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
   // e.g. it matches "ab" and "a\"b".
   private static final Pattern STRING_LITERAL = Pattern.compile("\"(?:\\\\.|[^\"\\\\])*\"");
 
+  private final Class<T> elementType;
+  private final Function<T, @Nullable String> sourceExtractor;
+  private final String location;
   private final ExpressionLanguage expressionLanguage;
 
-  SecretReferenceLiteralValidator(final ExpressionLanguage expressionLanguage) {
+  private SecretReferenceLiteralValidator(
+      final Class<T> elementType,
+      final Function<T, @Nullable String> sourceExtractor,
+      final String location,
+      final ExpressionLanguage expressionLanguage) {
+    this.elementType = elementType;
+    this.sourceExtractor = sourceExtractor;
+    this.location = location;
     this.expressionLanguage = expressionLanguage;
   }
 
-  @Override
-  public Class<ZeebeInput> getElementType() {
-    return ZeebeInput.class;
+  /** Validates the source of an input mapping ({@code zeebe:input}). */
+  static SecretReferenceLiteralValidator<ZeebeInput> forInput(
+      final ExpressionLanguage expressionLanguage) {
+    return new SecretReferenceLiteralValidator<>(
+        ZeebeInput.class, ZeebeInput::getSource, "input mapping source", expressionLanguage);
+  }
+
+  /** Validates the value of a property ({@code zeebe:property}). */
+  static SecretReferenceLiteralValidator<ZeebeProperty> forProperty(
+      final ExpressionLanguage expressionLanguage) {
+    return new SecretReferenceLiteralValidator<>(
+        ZeebeProperty.class, ZeebeProperty::getValue, "property value", expressionLanguage);
   }
 
   @Override
-  public void validate(
-      final ZeebeInput element, final ValidationResultCollector validationResultCollector) {
-    final String source = element.getSource();
+  public Class<T> getElementType() {
+    return elementType;
+  }
+
+  @Override
+  public void validate(final T element, final ValidationResultCollector validationResultCollector) {
+    final String source = sourceExtractor.apply(element);
     if (source == null) {
       return;
     }
@@ -87,8 +121,8 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
           0,
           String.format(
               "Secret reference(s) %s must be used as an expression (e.g. '=camunda.secrets.<name>'),"
-                  + " not as a string literal, in input mapping source '%s'.",
-              formatted, source));
+                  + " not as a string literal, in %s '%s'.",
+              formatted, location, source));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -46,8 +46,10 @@ public final class ZeebeRuntimeValidators {
             .hasValidExpression(ZeebeInput::getSource, ExpressionVerification::isOptional)
             .hasValidPath(ZeebeInput::getTarget)
             .build(expressionLanguage),
-        // reject secret references used as a string literal in an input mapping
-        new SecretReferenceLiteralValidator(expressionLanguage),
+        // reject secret references used as a string literal in an input mapping (outbound) or a
+        // property value (inbound), so both forms are handled uniformly
+        SecretReferenceLiteralValidator.forInput(expressionLanguage),
+        SecretReferenceLiteralValidator.forProperty(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeOutput.class)
             .hasValidExpression(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
@@ -15,135 +15,169 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty;
 import java.time.InstantSource;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 final class SecretReferenceLiteralValidatorTest {
 
-  private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage(
-          new ZeebeFeelEngineClock(InstantSource.system()));
-  private final SecretReferenceLiteralValidator sut =
-      new SecretReferenceLiteralValidator(expressionLanguage);
+  /**
+   * The two authoring locations behave identically, so every case runs against both the input
+   * mapping source and the property value.
+   */
+  private static Stream<Arguments> validators() {
+    return Stream.of(
+        Arguments.of("input", inputValidator()), Arguments.of("property", propertyValidator()));
+  }
 
-  @Test
-  void shouldRejectStaticValueThatIsASecretReference() {
+  @ParameterizedTest(name = "[{0}] rejects static value that is a secret reference")
+  @MethodSource("validators")
+  void shouldRejectStaticValueThatIsASecretReference(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("camunda.secrets.token");
+    final var collector = validate("camunda.secrets.token", validate);
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token"));
   }
 
-  @Test
-  void shouldRejectFeelStringLiteralThatIsASecretReference() {
+  @ParameterizedTest(name = "[{0}] rejects FEEL string literal that is a secret reference")
+  @MethodSource("validators")
+  void shouldRejectFeelStringLiteralThatIsASecretReference(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("=\"camunda.secrets.token\"");
+    final var collector = validate("=\"camunda.secrets.token\"", validate);
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token"));
   }
 
-  @Test
-  void shouldRejectSecretReferenceEmbeddedInAStringLiteral() {
+  @ParameterizedTest(name = "[{0}] rejects secret reference embedded in a string literal")
+  @MethodSource("validators")
+  void shouldRejectSecretReferenceEmbeddedInAStringLiteral(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("=\"Bearer camunda.secrets.token\"");
+    final var collector = validate("=\"Bearer camunda.secrets.token\"", validate);
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token"));
   }
 
-  @Test
-  void shouldAllowSecretReferenceUsedAsAnExpression() {
+  @ParameterizedTest(name = "[{0}] allows secret reference used as an expression")
+  @MethodSource("validators")
+  void shouldAllowSecretReferenceUsedAsAnExpression(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("=camunda.secrets.token");
+    final var collector = validate("=camunda.secrets.token", validate);
 
     // then
     verifyNoInteractions(collector);
   }
 
-  @Test
-  void shouldAllowSecretReferenceExpressionInsideConcatenation() {
+  @ParameterizedTest(name = "[{0}] allows secret reference expression inside concatenation")
+  @MethodSource("validators")
+  void shouldAllowSecretReferenceExpressionInsideConcatenation(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("=\"Bearer \" + camunda.secrets.token");
+    final var collector = validate("=\"Bearer \" + camunda.secrets.token", validate);
 
     // then
     verifyNoInteractions(collector);
   }
 
-  @Test
-  void shouldRejectSecretReferenceInsideObjectLiteral() {
+  @ParameterizedTest(name = "[{0}] rejects secret reference inside object literal")
+  @MethodSource("validators")
+  void shouldRejectSecretReferenceInsideObjectLiteral(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when - the reference is a string literal nested in a constant object
-    final var collector = validate("={\"auth\": \"camunda.secrets.token\"}");
+    final var collector = validate("={\"auth\": \"camunda.secrets.token\"}", validate);
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token"));
   }
 
-  @Test
-  void shouldRejectSecretReferenceInsideListLiteral() {
+  @ParameterizedTest(name = "[{0}] rejects secret reference inside list literal")
+  @MethodSource("validators")
+  void shouldRejectSecretReferenceInsideListLiteral(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when - the reference is a string literal nested in a constant list
-    final var collector = validate("=[\"camunda.secrets.token\"]");
+    final var collector = validate("=[\"camunda.secrets.token\"]", validate);
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token"));
   }
 
-  @Test
-  void shouldAllowSecretReferenceExpressionInsideObjectLiteral() {
+  @ParameterizedTest(name = "[{0}] allows secret reference expression inside object literal")
+  @MethodSource("validators")
+  void shouldAllowSecretReferenceExpressionInsideObjectLiteral(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when - the reference is an expression path inside the object, not a literal
-    final var collector = validate("={\"auth\": camunda.secrets.token}");
+    final var collector = validate("={\"auth\": camunda.secrets.token}", validate);
 
     // then
     verifyNoInteractions(collector);
   }
 
-  @Test
-  void shouldAllowClusterVariableExpression() {
+  @ParameterizedTest(name = "[{0}] allows cluster variable expression")
+  @MethodSource("validators")
+  void shouldAllowClusterVariableExpression(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("=camunda.vars.env.REGION");
+    final var collector = validate("=camunda.vars.env.REGION", validate);
 
     // then
     verifyNoInteractions(collector);
   }
 
-  @Test
-  void shouldAllowPlainStaticValue() {
+  @ParameterizedTest(name = "[{0}] allows plain static value")
+  @MethodSource("validators")
+  void shouldAllowPlainStaticValue(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("hello world");
+    final var collector = validate("hello world", validate);
 
     // then
     verifyNoInteractions(collector);
   }
 
-  @Test
-  void shouldAllowPlainStringLiteral() {
+  @ParameterizedTest(name = "[{0}] allows plain string literal")
+  @MethodSource("validators")
+  void shouldAllowPlainStringLiteral(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("=\"hello world\"");
+    final var collector = validate("=\"hello world\"", validate);
 
     // then
     verifyNoInteractions(collector);
   }
 
-  @Test
-  void shouldIgnoreNullSource() {
+  @ParameterizedTest(name = "[{0}] ignores null source")
+  @MethodSource("validators")
+  void shouldIgnoreNullSource(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate(null);
+    final var collector = validate(null, validate);
 
     // then
     verifyNoInteractions(collector);
   }
 
-  @Test
-  void shouldReportEverySecretReferenceInAnObjectLiteral() {
+  @ParameterizedTest(name = "[{0}] reports every secret reference in an object literal")
+  @MethodSource("validators")
+  void shouldReportEverySecretReferenceInAnObjectLiteral(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when - two distinct references appear as literals in one object
     final var collector =
-        validate("={\"a\": \"camunda.secrets.tokenA\", \"b\": \"camunda.secrets.tokenB\"}");
+        validate(
+            "={\"a\": \"camunda.secrets.tokenA\", \"b\": \"camunda.secrets.tokenB\"}", validate);
 
     // then - both are listed, not just the first
     verify(collector)
@@ -155,20 +189,45 @@ final class SecretReferenceLiteralValidatorTest {
                         && message.contains("camunda.secrets.tokenB")));
   }
 
-  @Test
-  void shouldRejectSecretReferenceContainingDigits() {
+  @ParameterizedTest(name = "[{0}] rejects secret reference containing digits")
+  @MethodSource("validators")
+  void shouldRejectSecretReferenceContainingDigits(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
     // when
-    final var collector = validate("camunda.secrets.token_2");
+    final var collector = validate("camunda.secrets.token_2", validate);
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token_2"));
   }
 
-  private ValidationResultCollector validate(final String source) {
-    final var element = mock(ZeebeInput.class);
-    when(element.getSource()).thenReturn(source);
+  private ValidationResultCollector validate(
+      final String source, final BiConsumer<String, ValidationResultCollector> validate) {
     final var collector = mock(ValidationResultCollector.class);
-    sut.validate(element, collector);
+    validate.accept(source, collector);
     return collector;
+  }
+
+  private static BiConsumer<String, ValidationResultCollector> inputValidator() {
+    final var expressionLanguage =
+        ExpressionLanguageFactory.createExpressionLanguage(
+            new ZeebeFeelEngineClock(InstantSource.system()));
+    final var sut = SecretReferenceLiteralValidator.forInput(expressionLanguage);
+    return (source, collector) -> {
+      final var element = mock(ZeebeInput.class);
+      when(element.getSource()).thenReturn(source);
+      sut.validate(element, collector);
+    };
+  }
+
+  private static BiConsumer<String, ValidationResultCollector> propertyValidator() {
+    final var expressionLanguage =
+        ExpressionLanguageFactory.createExpressionLanguage(
+            new ZeebeFeelEngineClock(InstantSource.system()));
+    final var sut = SecretReferenceLiteralValidator.forProperty(expressionLanguage);
+    return (source, collector) -> {
+      final var element = mock(ZeebeProperty.class);
+      when(element.getValue()).thenReturn(source);
+      sut.validate(element, collector);
+    };
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
@@ -187,4 +187,46 @@ public final class SecretReferenceInputMappingTest {
         .contains("camunda.secrets.token")
         .contains("must be used as an expression");
   }
+
+  @Test
+  public void shouldRejectStaticValueSecretReferenceInProperty() {
+    // given - a static property value equal to a secret reference is a string literal
+    final var process =
+        Bpmn.createExecutableProcess("secret-property-static")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType("job").zeebeProperty("authToken", "camunda.secrets.token"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejected = ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    assertThat(rejected.getRejectionReason())
+        .contains("camunda.secrets.token")
+        .contains("must be used as an expression");
+  }
+
+  @Test
+  public void shouldRejectFeelStringLiteralSecretReferenceInProperty() {
+    // given - a FEEL string literal property value equal to a secret reference
+    final var process =
+        Bpmn.createExecutableProcess("secret-property-feel")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType("job").zeebeProperty("authToken", "=\"camunda.secrets.token\""))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejected = ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    assertThat(rejected.getRejectionReason())
+        .contains("camunda.secrets.token")
+        .contains("must be used as an expression");
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretReferencePropertyDeploymentRejectionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretReferencePropertyDeploymentRejectionIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.secret;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.UUID;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage that a {@code camunda.secrets.<name>} reference written as a plaintext string
+ * literal in a {@code zeebe:property} value is rejected at deploy time, against a real gateway and
+ * a real client — the property counterpart to the {@code zeebe:input} guard.
+ *
+ * <p>The engine suites ({@code SecretReferenceLiteralValidatorTest}, {@code
+ * SecretReferenceInputMappingTest}) already cover the validation rule and its input-mapping form
+ * with an in-process engine. What only this level shows is that a rejected deployment surfaces to
+ * the client as a {@link ClientStatusException} carrying the reason, so the whole gateway to engine
+ * rejection path holds for properties. A literal reference is silently never resolved at runtime,
+ * so catching it at deployment is what stops the raw placeholder from leaking.
+ *
+ * <p>The guard is a static deploy-time check that never resolves the reference, so the broker runs
+ * with no secret store configured.
+ */
+@ZeebeIntegration
+final class SecretReferencePropertyDeploymentRejectionIT {
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker")
+  private static TestStandaloneBroker broker;
+
+  @AutoClose private final CamundaClient client = broker.newClientBuilder().build();
+
+  private final String processId = Strings.newRandomValidBpmnId();
+  private final String jobType = Strings.newRandomValidBpmnId();
+  private final String propertyName = "authToken";
+  // a FEEL reference is a path, so the name has to be a single alphanumeric segment
+  private final String secretName = "s" + UUID.randomUUID().toString().replace("-", "");
+  private final String secretReference = "camunda.secrets." + secretName;
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    broker = new TestStandaloneBroker().withUnauthenticatedAccess();
+  }
+
+  @Test
+  void shouldRejectStaticPlaintextSecretReferenceInPropertyValue() {
+    // given - a static property value (no leading '=') equal to a secret reference is a literal
+    final var process = processWithProperty(secretReference);
+
+    // when / then - the deployment is rejected and the reason reaches the client
+    assertThatThrownBy(() -> deploy(process))
+        .isInstanceOf(ClientStatusException.class)
+        .hasMessageContaining(secretReference)
+        .hasMessageContaining("must be used as an expression");
+  }
+
+  @Test
+  void shouldRejectFeelStringLiteralSecretReferenceInPropertyValue() {
+    // given - a FEEL string literal property value equal to a secret reference
+    final var process = processWithProperty("=\"" + secretReference + "\"");
+
+    // when / then
+    assertThatThrownBy(() -> deploy(process))
+        .isInstanceOf(ClientStatusException.class)
+        .hasMessageContaining(secretReference)
+        .hasMessageContaining("must be used as an expression");
+  }
+
+  @Test
+  void shouldAcceptSecretReferenceExpressionInPropertyValue() {
+    // given - the reference is a bare FEEL expression path, the only allowed form
+    final var process = processWithProperty("=" + secretReference);
+
+    // when / then - the guard does not over-reject a valid expression
+    assertThatCode(() -> deploy(process)).doesNotThrowAnyException();
+  }
+
+  private BpmnModelInstance processWithProperty(final String propertyValue) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .serviceTask(
+            "task", task -> task.zeebeJobType(jobType).zeebeProperty(propertyName, propertyValue))
+        .endEvent()
+        .done();
+  }
+
+  private void deploy(final BpmnModelInstance process) {
+    client.newDeployResourceCommand().addProcessModel(process, processId + ".bpmn").send().join();
+  }
+}


### PR DESCRIPTION
## Description

Closes #60238

The engine already rejects deployments where a `zeebe:input` mapping source uses a `camunda.secrets.<name>` reference as a plaintext string literal instead of a FEEL expression (a literal is silently never resolved, so the raw placeholder can leak). This extends the same deploy-time guard to `zeebe:property` values — the inbound counterpart — so inbound and outbound secret references are handled uniformly.

### Changes
- Generalized `SecretReferenceLiteralValidator` over the model element type with a source extractor + location label; factory methods `forInput` (`zeebe:input` source) and `forProperty` (`zeebe:property` value).
- Registered both validators in `ZeebeRuntimeValidators`.
- Parameterized the unit test over both input and property; added two end-to-end deployment-rejection tests for static and FEEL-string-literal secret references in a `zeebe:property`.

The static detection logic is unchanged and shared: a bare `=camunda.secrets.token` expression is allowed; any quoted/plaintext occurrence is rejected.

### Testing
`SecretReferenceLiteralValidatorTest` (28 cases) and `SecretReferenceInputMappingTest` (8 cases) pass locally.
