### PR TITLE
feat: resolve secret references in expression endpoint to placeholders

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -308,6 +308,42 @@ public class ExpressionEvaluationIT {
         .contains("No function found with name 'invalid_function' and 0 parameters");
   }
 
+  // ============ SECRET REFERENCE TESTS ============
+
+  @Test
+  void shouldEvaluateSecretReferenceToItsPlaceholder() {
+    // inbound connectors have no job, so they resolve secret references through this endpoint; a
+    // camunda.secrets.<name> reference must evaluate to its own placeholder, never the real value
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.secrets.TEST")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("camunda.secrets.TEST");
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateSecretReferenceInsideConcatenation() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=\"Bearer \" + camunda.secrets.TEST")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("Bearer camunda.secrets.TEST");
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
   // ============ GLOBAL SCOPED CLUSTER VARIABLE TESTS ============
 
   @Test

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
@@ -31,9 +31,14 @@ public class ExpressionBehavior {
       final ExpressionLanguage expressionLanguage,
       final Duration expressionEvaluationTimeout,
       final VariableState variableState) {
+    // Resolve camunda.secrets.<name> references to their own placeholder string (as the engine
+    // does for input mappings), so callers of the expression endpoint — e.g. inbound connectors,
+    // which have no job to trigger job-activation resolution — receive the reference text instead
+    // of null. Only that path is affected; camunda.vars.* and every other lookup forward unchanged.
     clusterExpressionProcessor =
         new ExpressionProcessor(
-            expressionLanguage, namespaceFullClusterContext, expressionEvaluationTimeout);
+                expressionLanguage, namespaceFullClusterContext, expressionEvaluationTimeout)
+            .withSecretReferenceContext();
     this.variableState = variableState;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceExpressionEvaluationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceExpressionEvaluationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * End-to-end coverage for handling {@code camunda.secrets.<name>} in the expression evaluation
+ * endpoint ({@code POST /v2/expression/evaluation}).
+ *
+ * <p>Inbound connectors have no job, so job-activation secret resolution never runs for them; they
+ * resolve FEEL through this endpoint instead. A secret reference must therefore evaluate to its own
+ * string-literal placeholder (never {@code null} and never the resolved value), mirroring the
+ * input-mapping behavior. No secret store is configured on purpose: the placeholder resolution is a
+ * pure text mapping, independent of any store.
+ */
+public final class SecretReferenceExpressionEvaluationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldResolveSecretReferenceToItsPlaceholder() {
+    // when
+    final var record = ENGINE.expression().withExpression("=camunda.secrets.TEST").resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("camunda.secrets.TEST");
+  }
+
+  @Test
+  public void shouldConcatenateSecretReferencePlaceholder() {
+    // when
+    final var record =
+        ENGINE.expression().withExpression("=\"Bearer \" + camunda.secrets.TEST").resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("Bearer camunda.secrets.TEST");
+  }
+
+  @Test
+  public void shouldNotShadowClusterVariables() {
+    // given
+    ENGINE.clusterVariables().withName("region").setGlobalScope().withValue("\"eu-1\"").create();
+
+    // when
+    final var record = ENGINE.expression().withExpression("=camunda.vars.cluster.region").resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("eu-1");
+  }
+
+  @Test
+  public void shouldLetCamundaBodyVariableTakePrecedenceOverSecretPlaceholder() {
+    // given - a body variable named `camunda` keeps precedence, so the secret context does not
+    // intercept and the missing `token` member resolves to null instead of a placeholder
+    // when
+    final var record =
+        ENGINE
+            .expression()
+            .withExpression("=camunda.secrets.token")
+            .withVariables(Map.of("camunda", Map.of("vars", Map.of("env", Map.of("KEY", "v")))))
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isNull();
+  }
+}


### PR DESCRIPTION
## Description

Inbound connectors are adding support for `camunda.secrets.<name>` references. Unlike outbound connectors, they have no job, so the engine's job-activation secret resolution never runs for them — they evaluate FEEL through `POST /v2/expression/evaluation` instead. That endpoint did not know the secret namespace, so a reference failed at the `secrets` lookup and evaluated to `null`, forcing connectors into two secret-resolution passes.

This wires the **existing** secret-aware evaluation context (already used for input mappings via `ExpressionProcessor.withSecretReferenceContext()`) into the expression endpoint. A reference now resolves to its own string-literal placeholder:

| Expression | Before | After |
|---|---|---|
| `=camunda.secrets.TEST` | `null` + warning | `"camunda.secrets.TEST"` |
| `="Bearer " + camunda.secrets.TEST` | `null` + warning | `"Bearer camunda.secrets.TEST"` |

## Notes for reviewers

- **Security invariant preserved:** the endpoint returns only the placeholder, never the resolved secret value — consistent with "secret values are never persisted/exported". The transformation is a pure text mapping, so it stays replication/replay-safe.
- **Scope:** `ExpressionBehavior.resolveExpression` is called only by the expression endpoint, so no BPMN evaluation path is affected. `camunda.vars.*` and every other lookup forward unchanged; a variable literally named `camunda` keeps precedence.
- **Unconditional** rather than behind a request flag — matches the engine's input-mapping semantics and the connectors use case. This is the one product decision worth confirming.
- Behavior change is observable (`null` → placeholder), but secrets are a new 8.10 feature so compat exposure is minimal. A docs update in `camunda-docs` should follow.

## Tests

- `SecretReferenceExpressionEvaluationTest` (engine): placeholder resolution, concatenation, `camunda.vars.*` not shadowed, `camunda` body variable precedence. **Green locally.**
- `ExpressionEvaluationIT` (acceptance): end-to-end REST cases for the placeholder and concatenation.

Closes #60239
