### PR TITLE
fix: use status endpoint instead of topology in Spring Boot starter health check

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/health/HealthCheck.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/health/HealthCheck.java
@@ -16,7 +16,7 @@
 package io.camunda.client.health;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.response.Topology;
+import io.camunda.client.api.response.StatusResponse;
 
 public class HealthCheck {
   private final CamundaClient camundaClient;
@@ -26,11 +26,11 @@ public class HealthCheck {
   }
 
   public CheckResult health() {
-    final Topology topology = camundaClient.newTopologyRequest().send().join();
-    if (topology.getBrokers().isEmpty()) {
-      return CheckResult.DOWN;
-    } else {
+    final StatusResponse status = camundaClient.newStatusRequest().send().join();
+    if (status.getStatus() == StatusResponse.Status.UP) {
       return CheckResult.UP;
+    } else {
+      return CheckResult.DOWN;
     }
   }
 


### PR DESCRIPTION
## Summary
- `HealthCheck` derived UP/DOWN from `newTopologyRequest()`, checking whether the broker list was non-empty.
- The topology endpoint is heavier (full broker/partition listing) and not meant to answer an aggregated health question.
- Switches to `newStatusRequest()`, which returns the cluster's aggregated `StatusResponse.Status` (UP/DOWN) directly in a single lightweight call.

## Test plan
- [x] `./mvnw verify -pl clients/camunda-spring-boot-starter -DskipTests=false` — 782 tests pass, dependency-analyze clean, revapi clean