### PR TITLE
feat: add REST endpoint for deleting a process definition's Optimize data

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/rest/PublicApiProcessDefinitionDeletionIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/rest/PublicApiProcessDefinitionDeletionIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.http.HttpStatus;
+
+public class PublicApiProcessDefinitionDeletionIT extends AbstractCCSMIT {
+
+  private static final String TEST_ACCESS_TOKEN = "test-access-token";
+
+  @BeforeEach
+  public void configurePublicApiToken() {
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getOptimizeApiConfiguration()
+        .setAccessToken(TEST_ACCESS_TOKEN);
+  }
+
+  @Test
+  public void shouldReturn202AndQueueJobForValidRequest() {
+    // given
+    final String processDefinitionKey = "100000000000001";
+    seedProcessDefinition(processDefinitionKey);
+
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest(processDefinitionKey)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.ACCEPTED.value());
+    final JobRegistryEntryDto entry =
+        embeddedOptimizeExtension
+            .getBean(JobRegistryReader.class)
+            .findLastByJobTypeAndEntityId(
+                JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionKey)
+            .orElseThrow();
+    assertThat(entry.getStatus()).isEqualTo(JobStatus.QUEUED);
+    assertThat(entry.getEntityType()).isEqualTo(EntityType.PROCESS_DEFINITION);
+  }
+
+  @Test
+  public void shouldReturn400WhenKeyIsNotNumeric() {
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest("not-a-number")
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  public void shouldReturn404WhenDefinitionNotFound() {
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest("100000000000002")
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = JobStatus.class,
+      names = {"QUEUED", "COMPLETED"})
+  public void shouldReturn409WhenBlockingEntryAlreadyExists(final JobStatus blockingStatus) {
+    // given
+    final String processDefinitionKey = "100000000000003";
+    seedProcessDefinition(processDefinitionKey);
+    seedJobRegistryEntry(processDefinitionKey, blockingStatus);
+
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest(processDefinitionKey)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+  }
+
+  @Test
+  public void shouldReturn409OnBackToBackDeleteRequestsForSameKey() {
+    // given
+    final String processDefinitionKey = "100000000000006";
+    seedProcessDefinition(processDefinitionKey);
+
+    // when
+    final Response firstResponse =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest(processDefinitionKey)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+    final Response secondResponse =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest(processDefinitionKey)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(firstResponse.getStatus()).isEqualTo(HttpStatus.ACCEPTED.value());
+    assertThat(secondResponse.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+  }
+
+  @Test
+  public void shouldReturn202AndQueueNewJobWhenExistingEntryHasFailedStatus() {
+    // given
+    final String processDefinitionKey = "100000000000004";
+    seedProcessDefinition(processDefinitionKey);
+    seedJobRegistryEntry(processDefinitionKey, JobStatus.FAILED);
+
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest(processDefinitionKey)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.ACCEPTED.value());
+  }
+
+  @Test
+  public void shouldReturn401WhenNoTokenProvided() {
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest("100000000000005")
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  private void seedJobRegistryEntry(final String processDefinitionKey, final JobStatus status) {
+    final JobRegistryWriter jobRegistryWriter =
+        embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+    final JobRegistryEntryDto entry =
+        jobRegistryWriter.createJobEntry(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionKey);
+    jobRegistryWriter.updateJobStatus(entry.getId(), status, null);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+
+  private void seedProcessDefinition(final String processDefinitionKey) {
+    embeddedOptimizeExtension
+        .getBean(ProcessDefinitionWriter.class)
+        .importProcessDefinitions(
+            List.of(
+                ProcessDefinitionOptimizeDto.builder()
+                    .id(processDefinitionKey)
+                    .key("aBpmnProcessId")
+                    .version("1")
+                    .name("aProcessName")
+                    .bpmn20Xml("<definitions/>")
+                    .build()));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/PublicApiRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/PublicApiRestService.java
@@ -27,6 +27,7 @@ import io.camunda.optimize.service.SettingsService;
 import io.camunda.optimize.service.collection.CollectionScopeService;
 import io.camunda.optimize.service.collection.CollectionService;
 import io.camunda.optimize.service.dashboard.DashboardService;
+import io.camunda.optimize.service.definition.ProcessDefinitionDeletionRequestService;
 import io.camunda.optimize.service.entities.EntityExportService;
 import io.camunda.optimize.service.entities.EntityImportService;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
@@ -41,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,6 +52,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -68,6 +71,7 @@ public class PublicApiRestService {
   public static final String REPORT_SUB_PATH = "/report";
   public static final String DASHBOARD_SUB_PATH = "/dashboard";
   public static final String LABELS_SUB_PATH = "/variables/labels";
+  public static final String PROCESS_DEFINITION_SUB_PATH = "/process-definition";
   public static final String DASHBOARD_EXPORT_DEFINITION_SUB_PATH =
       EXPORT_SUB_PATH + DASHBOARD_SUB_PATH + "/definition/json";
   private static final String REPORT_EXPORT_PATH = EXPORT_SUB_PATH + REPORT_SUB_PATH;
@@ -78,6 +82,8 @@ public class PublicApiRestService {
   private static final String REPORT_EXPORT_DATA_SUB_PATH =
       REPORT_EXPORT_BY_ID_PATH + "/result/json";
   private static final String DASHBOARD_BY_ID_PATH = DASHBOARD_SUB_PATH + "/{dashboardId}";
+  private static final String PROCESS_DEFINITION_BY_KEY_PATH =
+      PROCESS_DEFINITION_SUB_PATH + "/{processDefinitionKey}";
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(PublicApiRestService.class);
 
   private final JsonReportResultExportService jsonReportResultExportService;
@@ -89,6 +95,7 @@ public class PublicApiRestService {
   private final SettingsService settingsService;
   private final CollectionService collectionService;
   private final CollectionScopeService collectionScopeService;
+  private final ProcessDefinitionDeletionRequestService processDefinitionDeletionRequestService;
 
   public PublicApiRestService(
       final JsonReportResultExportService jsonReportResultExportService,
@@ -99,7 +106,8 @@ public class PublicApiRestService {
       final ProcessVariableLabelService processVariableLabelService,
       final SettingsService settingsService,
       final CollectionService collectionService,
-      final CollectionScopeService collectionScopeService) {
+      final CollectionScopeService collectionScopeService,
+      final ProcessDefinitionDeletionRequestService processDefinitionDeletionRequestService) {
     this.jsonReportResultExportService = jsonReportResultExportService;
     this.entityExportService = entityExportService;
     this.entityImportService = entityImportService;
@@ -109,6 +117,7 @@ public class PublicApiRestService {
     this.settingsService = settingsService;
     this.collectionService = collectionService;
     this.collectionScopeService = collectionScopeService;
+    this.processDefinitionDeletionRequestService = processDefinitionDeletionRequestService;
   }
 
   @GetMapping(REPORT_SUB_PATH)
@@ -170,6 +179,13 @@ public class PublicApiRestService {
   @DeleteMapping(DASHBOARD_BY_ID_PATH)
   public void deleteDashboardDefinition(final @PathVariable("dashboardId") String dashboardId) {
     dashboardService.deleteDashboard(dashboardId);
+  }
+
+  @DeleteMapping(PROCESS_DEFINITION_BY_KEY_PATH)
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public void deleteProcessDefinitionData(
+      final @PathVariable("processDefinitionKey") String processDefinitionKey) {
+    processDefinitionDeletionRequestService.queueProcessDefinitionDeletion(processDefinitionKey);
   }
 
   @PostMapping(LABELS_SUB_PATH)

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/PublicApiRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/PublicApiRestService.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -84,7 +83,6 @@ public class PublicApiRestService {
   private static final String DASHBOARD_BY_ID_PATH = DASHBOARD_SUB_PATH + "/{dashboardId}";
   private static final String PROCESS_DEFINITION_BY_KEY_PATH =
       PROCESS_DEFINITION_SUB_PATH + "/{processDefinitionKey}";
-  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(PublicApiRestService.class);
 
   private final JsonReportResultExportService jsonReportResultExportService;
   private final EntityExportService entityExportService;
@@ -181,11 +179,14 @@ public class PublicApiRestService {
     dashboardService.deleteDashboard(dashboardId);
   }
 
+  // The user-facing API follows the C8 notation and uses processDefinitionKey as the numeric
+  // identifier of a process definition. Since Optimize uses the C7 notation, here we switch to
+  // processDefinitionId.
   @DeleteMapping(PROCESS_DEFINITION_BY_KEY_PATH)
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void deleteProcessDefinitionData(
-      final @PathVariable("processDefinitionKey") String processDefinitionKey) {
-    processDefinitionDeletionRequestService.queueProcessDefinitionDeletion(processDefinitionKey);
+      final @PathVariable("processDefinitionKey") String processDefinitionId) {
+    processDefinitionDeletionRequestService.queueProcessDefinitionDeletion(processDefinitionId);
   }
 
   @PostMapping(LABELS_SUB_PATH)

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ProcessDefinitionReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ProcessDefinitionReaderES.java
@@ -70,6 +70,23 @@ public class ProcessDefinitionReaderES implements ProcessDefinitionReader {
   }
 
   @Override
+  public boolean processDefinitionExists(final String definitionId) {
+    final BoolQuery.Builder query =
+        new BoolQuery.Builder()
+            .must(m -> m.term(t -> t.field(PROCESS_DEFINITION_ID).value(definitionId)));
+
+    try {
+      return esClient.count(new String[] {PROCESS_DEFINITION_INDEX_NAME}, query) > 0;
+    } catch (final IOException e) {
+      final String reason =
+          String.format(
+              "Was not able to check existence of process definition with id [%s].", definitionId);
+      LOG.error(reason, e);
+      throw new OptimizeRuntimeException(reason, e);
+    }
+  }
+
+  @Override
   public Set<String> getAllNonOnboardedProcessDefinitionKeys() {
     final String defKeyAgg = "keyAgg";
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ProcessDefinitionReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ProcessDefinitionReaderES.java
@@ -53,7 +53,8 @@ public class ProcessDefinitionReaderES implements ProcessDefinitionReader {
   }
 
   @Override
-  public Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(final String definitionId) {
+  public Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(
+      final String definitionId, final boolean includeXml) {
     final BoolQuery.Builder query = new BoolQuery.Builder();
     query.must(m -> m.matchAll(l -> l));
     query.must(
@@ -63,7 +64,7 @@ public class ProcessDefinitionReaderES implements ProcessDefinitionReader {
                     l.field(PROCESS_DEFINITION_ID)
                         .terms(tt -> tt.value(List.of(FieldValue.of(definitionId))))));
 
-    return definitionReader.getDefinitions(DefinitionType.PROCESS, query, true).stream()
+    return definitionReader.getDefinitions(DefinitionType.PROCESS, query, includeXml).stream()
         .findFirst()
         .map(ProcessDefinitionOptimizeDto.class::cast);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ProcessDefinitionReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ProcessDefinitionReaderOS.java
@@ -49,13 +49,14 @@ public class ProcessDefinitionReaderOS implements ProcessDefinitionReader {
   }
 
   @Override
-  public Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(final String definitionId) {
+  public Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(
+      final String definitionId, final boolean includeXml) {
     final BoolQuery query =
         new BoolQuery.Builder()
             .must(QueryDSL.matchAll())
             .must(QueryDSL.term(PROCESS_DEFINITION_ID, definitionId))
             .build();
-    return definitionReader.getDefinitions(DefinitionType.PROCESS, query, true).stream()
+    return definitionReader.getDefinitions(DefinitionType.PROCESS, query, includeXml).stream()
         .findFirst()
         .map(ProcessDefinitionOptimizeDto.class::cast);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ProcessDefinitionReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ProcessDefinitionReaderOS.java
@@ -62,6 +62,20 @@ public class ProcessDefinitionReaderOS implements ProcessDefinitionReader {
   }
 
   @Override
+  public boolean processDefinitionExists(final String definitionId) {
+    final Query query =
+        new BoolQuery.Builder()
+            .must(QueryDSL.term(PROCESS_DEFINITION_ID, definitionId))
+            .build()
+            .toQuery();
+
+    final String errorMessage =
+        String.format(
+            "Was not able to check existence of process definition with id [%s].", definitionId);
+    return osClient.count(new String[] {PROCESS_DEFINITION_INDEX_NAME}, query, errorMessage) > 0;
+  }
+
+  @Override
   public Set<String> getAllNonOnboardedProcessDefinitionKeys() {
     final String defKeyAgg = "keyAgg";
     final Query query =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReader.java
@@ -32,6 +32,8 @@ public interface ProcessDefinitionReader {
   Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(
       final String definitionId, final boolean includeXml);
 
+  boolean processDefinitionExists(final String definitionId);
+
   Set<String> getAllNonOnboardedProcessDefinitionKeys();
 
   DefinitionReader getDefinitionReader();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReader.java
@@ -29,7 +29,8 @@ public interface ProcessDefinitionReader {
     return getDefinitionReader().getLatestVersionToKey(DefinitionType.PROCESS, key);
   }
 
-  Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(final String definitionId);
+  Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(
+      final String definitionId, final boolean includeXml);
 
   Set<String> getAllNonOnboardedProcessDefinitionKeys();
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestService.java
@@ -27,6 +27,8 @@ public class ProcessDefinitionDeletionRequestService {
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(ProcessDefinitionDeletionRequestService.class);
 
+  private static final String REST_API_IDENTIFIER_NAME = "processDefinitionKey";
+
   private final ProcessDefinitionReader processDefinitionReader;
   private final JobRegistryReader jobRegistryReader;
   private final JobRegistryWriter jobRegistryWriter;
@@ -40,47 +42,48 @@ public class ProcessDefinitionDeletionRequestService {
     this.jobRegistryWriter = jobRegistryWriter;
   }
 
-  public void queueProcessDefinitionDeletion(final String processDefinitionKey) {
+  public void queueProcessDefinitionDeletion(final String processDefinitionId) {
     LOG.info(
         "Received request to delete Optimize data for process definition [{}].",
-        processDefinitionKey);
+        processDefinitionId);
 
-    validateIsNumeric(processDefinitionKey);
-    validateDefinitionExists(processDefinitionKey);
-    validateNoBlockingJobExists(processDefinitionKey);
+    validateIsNumeric(processDefinitionId);
+    validateDefinitionExists(processDefinitionId);
+    validateNoBlockingJobExists(processDefinitionId);
 
     jobRegistryWriter.createJobEntry(
-        JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionKey);
+        JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionId);
   }
 
-  private void validateIsNumeric(final String processDefinitionKey) {
+  private void validateIsNumeric(final String processDefinitionId) {
     try {
-      Long.parseLong(processDefinitionKey);
+      Long.parseLong(processDefinitionId);
     } catch (final NumberFormatException e) {
       throw new BadRequestException(
-          String.format("processDefinitionKey [%s] must be numeric.", processDefinitionKey));
+          String.format("%s [%s] must be numeric.", REST_API_IDENTIFIER_NAME, processDefinitionId));
     }
   }
 
-  private void validateDefinitionExists(final String processDefinitionKey) {
-    if (processDefinitionReader.getProcessDefinition(processDefinitionKey, false).isEmpty()) {
+  private void validateDefinitionExists(final String processDefinitionId) {
+    if (!processDefinitionReader.processDefinitionExists(processDefinitionId)) {
       throw new NotFoundException(
           String.format(
-              "No process definition found for processDefinitionKey [%s].", processDefinitionKey));
+              "No process definition found for %s [%s].",
+              REST_API_IDENTIFIER_NAME, processDefinitionId));
     }
   }
 
-  private void validateNoBlockingJobExists(final String processDefinitionKey) {
+  private void validateNoBlockingJobExists(final String processDefinitionId) {
     final Optional<JobRegistryEntryDto> existingEntry =
         jobRegistryReader.findLastByJobTypeAndEntityId(
-            JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionKey);
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionId);
     final boolean deleteJobAlreadyExists =
         existingEntry.filter(entry -> entry.getStatus() != JobStatus.FAILED).isPresent();
     if (deleteJobAlreadyExists) {
       throw new OptimizeConflictException(
           String.format(
-              "A deletion job for processDefinitionKey [%s] already exists with status [%s].",
-              processDefinitionKey, existingEntry.get().getStatus()));
+              "A deletion job for %s [%s] already exists with status [%s].",
+              REST_API_IDENTIFIER_NAME, processDefinitionId, existingEntry.get().getStatus()));
     }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestService.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.definition;
+
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.rest.exceptions.BadRequestException;
+import io.camunda.optimize.rest.exceptions.NotFoundException;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.exceptions.conflict.OptimizeConflictException;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProcessDefinitionDeletionRequestService {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ProcessDefinitionDeletionRequestService.class);
+
+  private final ProcessDefinitionReader processDefinitionReader;
+  private final JobRegistryReader jobRegistryReader;
+  private final JobRegistryWriter jobRegistryWriter;
+
+  public ProcessDefinitionDeletionRequestService(
+      final ProcessDefinitionReader processDefinitionReader,
+      final JobRegistryReader jobRegistryReader,
+      final JobRegistryWriter jobRegistryWriter) {
+    this.processDefinitionReader = processDefinitionReader;
+    this.jobRegistryReader = jobRegistryReader;
+    this.jobRegistryWriter = jobRegistryWriter;
+  }
+
+  public void queueProcessDefinitionDeletion(final String processDefinitionKey) {
+    LOG.info(
+        "Received request to delete Optimize data for process definition [{}].",
+        processDefinitionKey);
+
+    validateIsNumeric(processDefinitionKey);
+    validateDefinitionExists(processDefinitionKey);
+    validateNoBlockingJobExists(processDefinitionKey);
+
+    jobRegistryWriter.createJobEntry(
+        JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionKey);
+  }
+
+  private void validateIsNumeric(final String processDefinitionKey) {
+    try {
+      Long.parseLong(processDefinitionKey);
+    } catch (final NumberFormatException e) {
+      throw new BadRequestException(
+          String.format("processDefinitionKey [%s] must be numeric.", processDefinitionKey));
+    }
+  }
+
+  private void validateDefinitionExists(final String processDefinitionKey) {
+    if (processDefinitionReader.getProcessDefinition(processDefinitionKey, false).isEmpty()) {
+      throw new NotFoundException(
+          String.format(
+              "No process definition found for processDefinitionKey [%s].", processDefinitionKey));
+    }
+  }
+
+  private void validateNoBlockingJobExists(final String processDefinitionKey) {
+    final Optional<JobRegistryEntryDto> existingEntry =
+        jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionKey);
+    final boolean deleteJobAlreadyExists =
+        existingEntry.filter(entry -> entry.getStatus() != JobStatus.FAILED).isPresent();
+    if (deleteJobAlreadyExists) {
+      throw new OptimizeConflictException(
+          String.format(
+              "A deletion job for processDefinitionKey [%s] already exists with status [%s].",
+              processDefinitionKey, existingEntry.get().getStatus()));
+    }
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/OptimizeRequestExecutor.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/OptimizeRequestExecutor.java
@@ -242,6 +242,17 @@ public class OptimizeRequestExecutor {
     return this;
   }
 
+  public OptimizeRequestExecutor buildDeleteProcessDefinitionDataRequest(
+      final String processDefinitionKey) {
+    path =
+        PublicApiRestService.PUBLIC_PATH
+            + PublicApiRestService.PROCESS_DEFINITION_SUB_PATH
+            + "/"
+            + processDefinitionKey;
+    method = DELETE;
+    return this;
+  }
+
   public OptimizeRequestExecutor withBearerToken(final String token) {
     requestHeaders.put(HttpHeaders.AUTHORIZATION, "Bearer " + token);
     authCookie = null;

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestServiceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.rest.exceptions.BadRequestException;
+import io.camunda.optimize.rest.exceptions.NotFoundException;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.exceptions.conflict.OptimizeConflictException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class ProcessDefinitionDeletionRequestServiceTest {
+
+  private static final String PROCESS_DEFINITION_KEY = "123456789";
+
+  private final ProcessDefinitionReader processDefinitionReader =
+      mock(ProcessDefinitionReader.class);
+  private final JobRegistryReader jobRegistryReader = mock(JobRegistryReader.class);
+  private final JobRegistryWriter jobRegistryWriter = mock(JobRegistryWriter.class);
+
+  private final ProcessDefinitionDeletionRequestService underTest =
+      new ProcessDefinitionDeletionRequestService(
+          processDefinitionReader, jobRegistryReader, jobRegistryWriter);
+
+  @Test
+  public void shouldQueueJobWhenKeyIsValidAndNoBlockingEntryExists() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
+        .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
+    when(jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY))
+        .thenReturn(Optional.empty());
+
+    // when
+    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
+
+    // then
+    verify(jobRegistryWriter)
+        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+  }
+
+  @Test
+  public void shouldQueueBothJobsWhenConcurrentRequestsRaceThePreCreationCheck() {
+    // given: two requests both check for a blocking entry before either has written its own,
+    // modelling the race window between the read and the write (no locking in between)
+    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
+        .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
+    when(jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY))
+        .thenReturn(Optional.empty());
+
+    // when
+    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
+    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
+
+    // then: both requests are allowed to queue their own job; concurrent duplicate deletion
+    // requests are accepted by design rather than deduplicated
+    verify(jobRegistryWriter, times(2))
+        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+  }
+
+  @Test
+  public void shouldRejectNonNumericKey() {
+    // when
+    final Throwable thrown =
+        catchThrowable(() -> underTest.queueProcessDefinitionDeletion("not-a-number"));
+
+    // then
+    assertThat(thrown).isInstanceOf(BadRequestException.class);
+    verify(jobRegistryWriter, never()).createJobEntry(any(), any(), any());
+  }
+
+  @Test
+  public void shouldRejectKeyNotFoundInProcessDefinitionIndex() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
+        .thenReturn(Optional.empty());
+
+    // when
+    final Throwable thrown =
+        catchThrowable(() -> underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY));
+
+    // then
+    assertThat(thrown).isInstanceOf(NotFoundException.class);
+    verify(jobRegistryWriter, never()).createJobEntry(any(), any(), any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = JobStatus.class,
+      names = {"QUEUED", "COMPLETED"})
+  public void shouldRejectWhenBlockingEntryAlreadyExists(final JobStatus blockingStatus) {
+    // given
+    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
+        .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
+    final JobRegistryEntryDto existingEntry =
+        new JobRegistryEntryDto(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+    existingEntry.setStatus(blockingStatus);
+    when(jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY))
+        .thenReturn(Optional.of(existingEntry));
+
+    // when
+    final Throwable thrown =
+        catchThrowable(() -> underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY));
+
+    // then
+    assertThat(thrown).isInstanceOf(OptimizeConflictException.class);
+    verify(jobRegistryWriter, never()).createJobEntry(any(), any(), any());
+  }
+
+  @Test
+  public void shouldQueueNewJobWhenExistingEntryHasFailedStatus() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
+        .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
+    final JobRegistryEntryDto failedEntry =
+        new JobRegistryEntryDto(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+    failedEntry.setStatus(JobStatus.FAILED);
+    when(jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY))
+        .thenReturn(Optional.of(failedEntry));
+
+    // when
+    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
+
+    // then
+    verify(jobRegistryWriter)
+        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestServiceTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
@@ -34,7 +33,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 public class ProcessDefinitionDeletionRequestServiceTest {
 
-  private static final String PROCESS_DEFINITION_KEY = "123456789";
+  private static final String PROCESS_DEFINITION_ID = "123456789";
 
   private final ProcessDefinitionReader processDefinitionReader =
       mock(ProcessDefinitionReader.class);
@@ -46,44 +45,42 @@ public class ProcessDefinitionDeletionRequestServiceTest {
           processDefinitionReader, jobRegistryReader, jobRegistryWriter);
 
   @Test
-  public void shouldQueueJobWhenKeyIsValidAndNoBlockingEntryExists() {
+  public void shouldQueueJobWhenIdIsValidAndNoBlockingEntryExists() {
     // given
-    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
-        .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
+    when(processDefinitionReader.processDefinitionExists(PROCESS_DEFINITION_ID)).thenReturn(true);
     when(jobRegistryReader.findLastByJobTypeAndEntityId(
-            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY))
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID))
         .thenReturn(Optional.empty());
 
     // when
-    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
+    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_ID);
 
     // then
     verify(jobRegistryWriter)
-        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID);
   }
 
   @Test
   public void shouldQueueBothJobsWhenConcurrentRequestsRaceThePreCreationCheck() {
     // given: two requests both check for a blocking entry before either has written its own,
     // modeling the race window between the read and the write
-    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
-        .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
+    when(processDefinitionReader.processDefinitionExists(PROCESS_DEFINITION_ID)).thenReturn(true);
     when(jobRegistryReader.findLastByJobTypeAndEntityId(
-            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY))
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID))
         .thenReturn(Optional.empty());
 
     // when
-    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
-    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
+    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_ID);
+    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_ID);
 
     // then: both requests are allowed to queue their own job; concurrent duplicate deletion
     // requests are accepted
     verify(jobRegistryWriter, times(2))
-        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID);
   }
 
   @Test
-  public void shouldRejectNonNumericKey() {
+  public void shouldRejectNonNumericId() {
     // when
     final Throwable thrown =
         catchThrowable(() -> underTest.queueProcessDefinitionDeletion("not-a-number"));
@@ -94,14 +91,13 @@ public class ProcessDefinitionDeletionRequestServiceTest {
   }
 
   @Test
-  public void shouldRejectKeyNotFoundInProcessDefinitionIndex() {
+  public void shouldRejectIdNotFoundInProcessDefinitionIndex() {
     // given
-    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
-        .thenReturn(Optional.empty());
+    when(processDefinitionReader.processDefinitionExists(PROCESS_DEFINITION_ID)).thenReturn(false);
 
     // when
     final Throwable thrown =
-        catchThrowable(() -> underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY));
+        catchThrowable(() -> underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_ID));
 
     // then
     assertThat(thrown).isInstanceOf(NotFoundException.class);
@@ -114,19 +110,18 @@ public class ProcessDefinitionDeletionRequestServiceTest {
       names = {"QUEUED", "COMPLETED"})
   public void shouldRejectWhenBlockingEntryAlreadyExists(final JobStatus blockingStatus) {
     // given
-    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
-        .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
+    when(processDefinitionReader.processDefinitionExists(PROCESS_DEFINITION_ID)).thenReturn(true);
     final JobRegistryEntryDto existingEntry =
         new JobRegistryEntryDto(
-            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID);
     existingEntry.setStatus(blockingStatus);
     when(jobRegistryReader.findLastByJobTypeAndEntityId(
-            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY))
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID))
         .thenReturn(Optional.of(existingEntry));
 
     // when
     final Throwable thrown =
-        catchThrowable(() -> underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY));
+        catchThrowable(() -> underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_ID));
 
     // then
     assertThat(thrown).isInstanceOf(OptimizeConflictException.class);
@@ -136,21 +131,20 @@ public class ProcessDefinitionDeletionRequestServiceTest {
   @Test
   public void shouldQueueNewJobWhenExistingEntryHasFailedStatus() {
     // given
-    when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
-        .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
+    when(processDefinitionReader.processDefinitionExists(PROCESS_DEFINITION_ID)).thenReturn(true);
     final JobRegistryEntryDto failedEntry =
         new JobRegistryEntryDto(
-            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID);
     failedEntry.setStatus(JobStatus.FAILED);
     when(jobRegistryReader.findLastByJobTypeAndEntityId(
-            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY))
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID))
         .thenReturn(Optional.of(failedEntry));
 
     // when
-    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
+    underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_ID);
 
     // then
     verify(jobRegistryWriter)
-        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
+        .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestServiceTest.java
@@ -65,7 +65,7 @@ public class ProcessDefinitionDeletionRequestServiceTest {
   @Test
   public void shouldQueueBothJobsWhenConcurrentRequestsRaceThePreCreationCheck() {
     // given: two requests both check for a blocking entry before either has written its own,
-    // modelling the race window between the read and the write (no locking in between)
+    // modeling the race window between the read and the write
     when(processDefinitionReader.getProcessDefinition(PROCESS_DEFINITION_KEY, false))
         .thenReturn(Optional.of(new ProcessDefinitionOptimizeDto()));
     when(jobRegistryReader.findLastByJobTypeAndEntityId(
@@ -77,7 +77,7 @@ public class ProcessDefinitionDeletionRequestServiceTest {
     underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_KEY);
 
     // then: both requests are allowed to queue their own job; concurrent duplicate deletion
-    // requests are accepted by design rather than deduplicated
+    // requests are accepted
     verify(jobRegistryWriter, times(2))
         .createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_KEY);
   }


### PR DESCRIPTION
## Summary
- Add `DELETE /api/public/process-definition/{processDefinitionKey}`, validating the key and queuing an async delete job. The endpoint does not delete data itself — it enqueues a `QUEUED` job entry for a not-yet-implemented dispatcher to pick up.
- `ProcessDefinitionDeletionRequestService` validates, in order: key is numeric (400), a matching process definition  exists (404), and no QUEUED/COMPLETED delete job is already registered for this key (409). A prior FAILED job does not block a retry.
- `ProcessDefinitionReader#getProcessDefinition` gained an `includeXml` parameter so the existence check doesn't fetch the (potentially large) BPMN XML it never uses.

Closes #59838

## Test plan
- [x] `ProcessDefinitionDeletionRequestServiceTest` (unit) — numeric/exists/
      blocking-status validation, including retry-after-FAILED
- [x] `PublicApiProcessDefinitionDeletionIT` — 202/404/409 (QUEUED+COMPLETED,
      parameterized)/202-after-FAILED/401/back-to-back-same-key