### PR TITLE
test: send the documented Accept header for resource binary content

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
@@ -11,11 +11,11 @@ import {readFileSync} from 'node:fs';
 import {APIRequestContext} from 'playwright-core';
 import {
   assertStatusCode,
-  authHeaders,
   buildUrl,
   credentials,
   defaultHeaders,
   jsonHeaders,
+  octetStreamHeaders,
 } from '../http';
 import {generateUniqueId} from '../constants';
 
@@ -460,10 +460,6 @@ export function getResourceContent(
   });
 }
 
-// Workaround for bug #59831: https://github.com/camunda/camunda/issues/59831
-// The handler is mapped with the gateway's default JSON produces list, so an
-// explicit `Accept: application/octet-stream` — the media type the API spec
-// documents — is answered with 406. Send no Accept header until that is fixed.
 export function getResourceContentBinary(
   request: APIRequestContext,
   resourceKey: string,
@@ -471,7 +467,9 @@ export function getResourceContentBinary(
 ): Promise<APIResponse> {
   return request.get(
     buildUrl(RESOURCE_CONTENT_BINARY_ENDPOINT, {resourceKey}),
-    {headers: options.headers ?? authHeaders(credentials.accessToken)},
+    {
+      headers: options.headers ?? octetStreamHeaders(credentials.accessToken),
+    },
   );
 }
 


### PR DESCRIPTION
## Description

`GET /v2/resources/{resourceKey}/content/binary` used to answer `Accept: application/octet-stream` — the media type its own specification documents — with a 406 (#59831). The `getResourceContentBinary` helper worked around that by sending no `Accept` header at all, which meant every caller exercised a path real clients do not take: generated OpenAPI clients, connectors, and anything written from the docs send the declared media type explicitly.

#59890 fixed the endpoint, so this defaults the helper to `octetStreamHeaders(...)` and drops the workaround comment. The binary-content, resource-delete, and linked-generic-resource specs now all cover the header clients actually send and would catch a regression. Callers that need a different `Accept` still pass `options.headers`.

Verified against `camunda/camunda:8.10-SNAPSHOT` (reported version `8.10.0-SNAPSHOT`, commit `e5d1d82`, contains the fix commit `5cfc45e`):

- `Accept: application/octet-stream` → `200`, `Content-Type: application/octet-stream`, correct body
- unknown key with the same header → `404` as `application/problem+json`
- `*/*`, `application/*`, and any mixed list including a wildcard or octet-stream → `200`

Full request/response evidence and the complete `Accept` matrix are in [this comment on #59831](https://github.com/camunda/camunda/issues/59831#issuecomment-5314369120).

One behavior change surfaced during verification and worth noting for the release: a JSON-only `Accept: application/json` used to return 200 and now returns 406. That matches the specification, and the blast radius is small — wildcards, the documented media type, and an omitted header all still return 200.

Closes #59831

🤖 Generated with [Claude Code](https://claude.com/claude-code)
