### PR TITLE
Feat/migration readiness actuator

### DIFF
--- a/cluster/src/main/java/io/camunda/cluster/migration/MigrationConditionStatus.java
+++ b/cluster/src/main/java/io/camunda/cluster/migration/MigrationConditionStatus.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.cluster.migration;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The status of a single upgrade-readiness condition, as reported by a {@link
+ * MigrationStatusProvider}.
+ *
+ * @param state whether the condition is met, confidently not yet met, or unknown
+ * @param detail a short, human-readable explanation, surfaced as-is in the upgrade-readiness
+ *     endpoint (e.g. {@code "schema version 8.9.0 has not yet migrated to 8.10.0"})
+ */
+@NullMarked
+public record MigrationConditionStatus(MigrationState state, String detail) {}

--- a/cluster/src/main/java/io/camunda/cluster/migration/MigrationState.java
+++ b/cluster/src/main/java/io/camunda/cluster/migration/MigrationState.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.cluster.migration;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The state of a single upgrade-readiness condition reported by a {@link MigrationStatusProvider}.
+ */
+@NullMarked
+public enum MigrationState {
+
+  /**
+   * The condition is fully satisfied for the current application version, computed with complete
+   * information.
+   */
+  MIGRATED,
+
+  /** The condition is confidently <b>not yet</b> satisfied. */
+  MIGRATION_IN_PROGRESS,
+
+  /**
+   * No confident answer is available, typically because part of a distributed lookup (a broker, a
+   * partition, a replica) did not respond in time.
+   */
+  UNKNOWN
+}

--- a/cluster/src/main/java/io/camunda/cluster/migration/MigrationStatusProvider.java
+++ b/cluster/src/main/java/io/camunda/cluster/migration/MigrationStatusProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.cluster.migration;
+
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Reports whether a single upgrade-readiness condition is met, per physical tenant
+ *
+ * <p>Some conditions are local to this node (e.g. schema-version checks against centralized, shared
+ * secondary storage); others need to resolve state distributed across partitions and replicas.
+ */
+@NullMarked
+public interface MigrationStatusProvider {
+
+  /**
+   * @return the stable identifier for this condition.
+   */
+  String conditionName();
+
+  /**
+   * @return the current status of this condition, keyed by physical tenant ID. Must not throw;
+   *     report {@link MigrationState#UNKNOWN} for a given tenant instead of omitting it whenever a
+   *     failure is scoped to that tenant.
+   */
+  Map<String, MigrationConditionStatus> getMigrationStatus();
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProvider.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProvider.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Reports whether the RDBMS schema of every configured physical tenant has migrated to the running
+ * application version, for the upgrade-readiness endpoint.
+ *
+ * <p>Reports one entry per physical tenant.
+ */
+public final class RdbmsSchemaMigrationStatusProvider implements MigrationStatusProvider {
+
+  public static final String CONDITION_NAME = "rdbmsSchemaMigrated";
+
+  private final Map<String, RdbmsSchemaVersionStore> versionStoresByPhysicalTenant;
+
+  @VisibleForTesting
+  RdbmsSchemaMigrationStatusProvider(
+      final Map<String, RdbmsSchemaVersionStore> versionStoresByPhysicalTenant) {
+    this.versionStoresByPhysicalTenant = versionStoresByPhysicalTenant;
+  }
+
+  /**
+   * Builds a provider from the per-physical-tenant {@link PerTenantSchemaConfig} map — the same
+   * input {@link DefaultRdbmsSchemaManagerRegistry#fromConfigs} consumes.
+   */
+  public static RdbmsSchemaMigrationStatusProvider fromConfigs(
+      final Map<String, PerTenantSchemaConfig> physicalTenantConfigs,
+      final String applicationVersion) {
+    final Map<String, RdbmsSchemaVersionStore> versionStores = new LinkedHashMap<>();
+    physicalTenantConfigs.forEach(
+        (physicalTenantId, config) ->
+            versionStores.put(
+                physicalTenantId,
+                new RdbmsSchemaVersionStore(
+                    config.dataSource(),
+                    StringUtils.trimToEmpty(config.prefix()),
+                    applicationVersion)));
+    return new RdbmsSchemaMigrationStatusProvider(versionStores);
+  }
+
+  @Override
+  public String conditionName() {
+    return CONDITION_NAME;
+  }
+
+  @Override
+  public Map<String, MigrationConditionStatus> getMigrationStatus() {
+    final var statusesByPhysicalTenant = new LinkedHashMap<String, MigrationConditionStatus>();
+    versionStoresByPhysicalTenant.forEach(
+        (physicalTenantId, versionStore) ->
+            statusesByPhysicalTenant.put(
+                physicalTenantId, toMigrationStatus(versionStore.getCurrentSchemaVersion())));
+    return statusesByPhysicalTenant;
+  }
+
+  /**
+   * Maps raw schema-version facts to the upgrade-readiness condition reported for one physical
+   * tenant.
+   *
+   * <ul>
+   *   <li>Schema version equals the application version ({@link Compatible.SameVersion}) → {@link
+   *       MigrationState#MIGRATED}.
+   *   <li>Schema version is one or more minors behind, on a supported upgrade path ({@link
+   *       Compatible.PatchUpgrade}/{@link Compatible.MinorUpgrade}), or no version has been
+   *       recorded yet (fresh database) → {@link MigrationState#MIGRATION_IN_PROGRESS}. This
+   *       includes externally-managed schemas ({@code auto-ddl=false}) that have not yet been
+   *       migrated by the operator's own tooling.
+   *   <li>An illegal upgrade path ({@link Incompatible}), an unparseable version ({@link
+   *       Indeterminate}, or an unparseable application version, or any read failure (e.g. a
+   *       connection error) → {@link MigrationState#UNKNOWN} — this is a "we don't know," not a "we
+   *       know it's not done."
+   * </ul>
+   */
+  @VisibleForTesting
+  MigrationConditionStatus toMigrationStatus(
+      final RdbmsSchemaVersionStore.CurrentSchemaVersion currentSchemaVersion) {
+    return switch (currentSchemaVersion.kind()) {
+      case AVAILABLE ->
+          toMigrationStatus(
+              VersionCompatibilityCheck.check(
+                  currentSchemaVersion.schemaVersion().orElseThrow(),
+                  currentSchemaVersion.stableApplicationVersion().orElseThrow()));
+      case FRESH_DATABASE ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "no schema version recorded yet for prefix '"
+                  + currentSchemaVersion.prefix()
+                  + "' (fresh database)");
+      case READ_FAILURE ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN, currentSchemaVersion.detail().orElseThrow());
+    };
+  }
+
+  private MigrationConditionStatus toMigrationStatus(
+      final VersionCompatibilityCheck.CheckResult result) {
+    return switch (result) {
+      case final Compatible.SameVersion same ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATED,
+              "schema version " + same.version() + " matches the application version");
+      case final Compatible.PatchUpgrade patch ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "schema version " + patch.from() + " has not yet migrated to " + patch.to());
+      case final Compatible.MinorUpgrade minor ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "schema version " + minor.from() + " has not yet migrated to " + minor.to());
+      case final Incompatible incompatible ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN, "incompatible schema upgrade path: " + incompatible);
+      case final Indeterminate indeterminate ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN,
+              "cannot determine schema version compatibility: " + indeterminate);
+    };
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -10,10 +10,6 @@ package io.camunda.db.rdbms;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VisibleForTesting;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Optional;
@@ -46,7 +42,6 @@ public class RdbmsSchemaVersionStore {
   private static final String SCHEMA_VERSION_TABLE = "RDBMS_SCHEMA_VERSION";
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsSchemaVersionStore.class);
-
   private final DataSource dataSource;
   private final String prefix;
 
@@ -82,10 +77,10 @@ public class RdbmsSchemaVersionStore {
    *             #INFERRED_PRE_VERSIONING_SCHEMA_VERSION} (an existing 8.9.x database).
    *         <li>Otherwise → fresh database; skip the check entirely.
    *       </ul>
-   *   <li>Validates the transition using {@link VersionCompatibilityCheck}. Only a {@link
-   *       Compatible} result allows startup to continue. An {@link Incompatible} result throws a
-   *       {@link RdbmsSchemaVersionIncompatibleException}. An {@link Indeterminate} result (e.g.
-   *       the stored schema version is not a valid semantic version) aborts startup with an {@link
+   *   <li>Validates the transition. Only same-version, patch-upgrade, and next-minor-upgrade paths
+   *       allow startup to continue. Incompatible paths throw a {@link
+   *       RdbmsSchemaVersionIncompatibleException}. An indeterminate path (e.g. the stored schema
+   *       version is not a valid semantic version) aborts startup with an {@link
    *       IllegalStateException}.
    *   <li>Any unexpected error (e.g. a DB connection failure) causes startup to fail with an {@link
    *       IllegalStateException}.
@@ -116,16 +111,14 @@ public class RdbmsSchemaVersionStore {
         return;
       }
 
-      final var result =
-          VersionCompatibilityCheck.check(currentSchemaVersion, stableAppVersion.get());
-      if (result instanceof Compatible) {
+      final var result = isCompatibleUpgradePath(currentSchemaVersion, stableAppVersion.get());
+      if (result) {
         LOG.debug(
-            "[RDBMS Schema] Version check passed for prefix '{}': schema={}, app={}, result={}",
+            "[RDBMS Schema] Version check passed for prefix '{}': schema={}, app={}",
             prefix,
             currentSchemaVersion,
-            stableAppVersion.get(),
-            result.getClass().getSimpleName());
-      } else if (result instanceof Incompatible) {
+            stableAppVersion.get());
+      } else {
         LOG.error(
             "[RDBMS Schema] Illegal upgrade path for prefix '{}': schema={}, app={}. "
                 + "Upgrade sequentially ({} → next minor). Skipping minors is not supported.",
@@ -135,19 +128,6 @@ public class RdbmsSchemaVersionStore {
             currentSchemaVersion);
         throw new RdbmsSchemaVersionIncompatibleException(
             currentSchemaVersion, stableAppVersion.get());
-      } else if (result instanceof Indeterminate) {
-        LOG.error(
-            "[RDBMS Schema] Cannot determine version compatibility for prefix '{}': schema={}, app={}. "
-                + "The stored schema version may be invalid. Startup aborted.",
-            prefix,
-            currentSchemaVersion,
-            stableAppVersion.get());
-        throw new IllegalStateException(
-            "[RDBMS Schema] Cannot determine version compatibility: schema="
-                + currentSchemaVersion
-                + ", app="
-                + stableAppVersion.get()
-                + ". The stored schema version may be invalid. Startup aborted.");
       }
     } catch (final RdbmsSchemaVersionIncompatibleException | IllegalStateException e) {
       throw e;
@@ -155,6 +135,45 @@ public class RdbmsSchemaVersionStore {
       LOG.error("[RDBMS Schema] Failed to determine current schema version. Startup aborted.", e);
       throw new IllegalStateException(
           "[RDBMS Schema] Failed to determine current schema version. Startup aborted.", e);
+    }
+  }
+
+  /**
+   * Resolves the current schema-version facts for the upgrade-readiness endpoint, without side
+   * effects — unlike {@link #checkCompatibility()}, this never throws and never writes; it only
+   * reads. The caller is responsible for mapping these facts to upgrade-readiness states.
+   */
+  public CurrentSchemaVersion getCurrentSchemaVersion() {
+    if (applicationVersion == null) {
+      throw new IllegalStateException("[RDBMS Schema] applicationVersion is not configured.");
+    }
+    if (dataSource == null) {
+      throw new IllegalStateException(
+          "[RDBMS Schema] dataSource is not configured for prefix '" + prefix + "'.");
+    }
+
+    try (final var connection = dataSource.getConnection()) {
+      final var currentSchemaVersion = resolveCurrentSchemaVersion(connection, prefix);
+      if (currentSchemaVersion == null) {
+        return CurrentSchemaVersion.freshDatabase(prefix);
+      }
+
+      final var stableAppVersion = toStableVersion(applicationVersion);
+      return stableAppVersion
+          .map(s -> CurrentSchemaVersion.available(prefix, currentSchemaVersion, s))
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "[RDBMS Schema] cannot parse application version '"
+                          + applicationVersion
+                          + "' as a semantic version"));
+    } catch (final Exception e) {
+      LOG.warn(
+          "[RDBMS Schema] Failed to determine current schema version for prefix '{}' during "
+              + "upgrade-readiness check.",
+          prefix,
+          e);
+      return CurrentSchemaVersion.readFailure(prefix, e);
     }
   }
 
@@ -297,6 +316,42 @@ public class RdbmsSchemaVersionStore {
         .map(sv -> sv.major() + "." + sv.minor() + "." + sv.patch());
   }
 
+  private boolean isCompatibleUpgradePath(
+      final String currentSchemaVersion, final String stableAppVersion) {
+    final var parsedSchemaVersion = SemanticVersion.parse(currentSchemaVersion);
+    final var parsedAppVersion = SemanticVersion.parse(stableAppVersion);
+
+    if (parsedSchemaVersion.isEmpty() || parsedAppVersion.isEmpty()) {
+      LOG.error(
+          "[RDBMS Schema] Cannot determine version compatibility for prefix '{}': schema={}, app={}. "
+              + "The stored schema version may be invalid. Startup aborted.",
+          prefix,
+          currentSchemaVersion,
+          stableAppVersion);
+      throw new IllegalStateException(
+          "[RDBMS Schema] Cannot determine version compatibility: schema="
+              + currentSchemaVersion
+              + ", app="
+              + stableAppVersion
+              + ". The stored schema version may be invalid. Startup aborted.");
+    }
+
+    final var schemaVersion = parsedSchemaVersion.get();
+    final var appVersion = parsedAppVersion.get();
+    if (schemaVersion.compareTo(appVersion) == 0) {
+      return true;
+    }
+    if (schemaVersion.preRelease() != null || appVersion.preRelease() != null) {
+      return false;
+    }
+    if (schemaVersion.compareTo(appVersion) > 0) {
+      return false;
+    }
+
+    return schemaVersion.major() == appVersion.major()
+        && schemaVersion.minor() - appVersion.minor() >= -1;
+  }
+
   private void upsertSingleSchemaVersionRow(
       final Connection connection, final String tableName, final String stableVersion)
       throws SQLException {
@@ -330,6 +385,44 @@ public class RdbmsSchemaVersionStore {
         connection.prepareStatement("INSERT INTO " + tableName + " (ID, VERSION) VALUES (1, ?)")) {
       insertStmt.setString(1, stableVersion);
       insertStmt.executeUpdate();
+    }
+  }
+
+  public record CurrentSchemaVersion(
+      CurrentSchemaVersion.Kind kind,
+      String prefix,
+      Optional<String> schemaVersion,
+      Optional<String> stableApplicationVersion,
+      Optional<String> detail) {
+
+    static CurrentSchemaVersion available(
+        final String prefix, final String schemaVersion, final String stableApplicationVersion) {
+      return new CurrentSchemaVersion(
+          Kind.AVAILABLE,
+          prefix,
+          Optional.of(schemaVersion),
+          Optional.of(stableApplicationVersion),
+          Optional.empty());
+    }
+
+    static CurrentSchemaVersion freshDatabase(final String prefix) {
+      return new CurrentSchemaVersion(
+          Kind.FRESH_DATABASE, prefix, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    static CurrentSchemaVersion readFailure(final String prefix, final Exception e) {
+      return new CurrentSchemaVersion(
+          Kind.READ_FAILURE,
+          prefix,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of("failed to read schema version: " + e.getMessage()));
+    }
+
+    public enum Kind {
+      AVAILABLE,
+      FRESH_DATABASE,
+      READ_FAILURE
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -145,11 +145,13 @@ public class RdbmsSchemaVersionStore {
    */
   public CurrentSchemaVersion getCurrentSchemaVersion() {
     if (applicationVersion == null) {
-      throw new IllegalStateException("[RDBMS Schema] applicationVersion is not configured.");
+      return CurrentSchemaVersion.readFailure(
+          prefix, new IllegalStateException("applicationVersion is not configured."));
     }
     if (dataSource == null) {
-      throw new IllegalStateException(
-          "[RDBMS Schema] dataSource is not configured for prefix '" + prefix + "'.");
+      return CurrentSchemaVersion.readFailure(
+          prefix,
+          new IllegalStateException("dataSource is not configured for prefix '" + prefix + "'."));
     }
 
     try (final var connection = dataSource.getConnection()) {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProviderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProviderTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the RDBMS upgrade-readiness condition, one entry per physical tenant. */
+class RdbmsSchemaMigrationStatusProviderTest {
+
+  @Test
+  void shouldReportConditionName() {
+    assertThat(provider(Map.of()).conditionName())
+        .isEqualTo(RdbmsSchemaMigrationStatusProvider.CONDITION_NAME);
+  }
+
+  @Test
+  void shouldReportNoTenantsWhenNoneAreConfigured() {
+    // when
+    final var statuses = provider(Map.of()).getMigrationStatus();
+
+    // then
+    assertThat(statuses).isEmpty();
+  }
+
+  @Test
+  void shouldReportEachTenantUnderItsOwnPhysicalTenantId() {
+    // given
+    final var tenantA = versionStore("8.10.0", "8.10.0");
+    final var tenantB = versionStore("8.9.0", "8.10.0");
+
+    // when
+    final var statuses =
+        provider(orderedMap("tenantA", tenantA, "tenantB", tenantB)).getMigrationStatus();
+
+    // then - no cross-tenant aggregation, each tenant reports independently
+    assertThat(statuses).hasSize(2);
+    assertThat(statuses.get("tenantA").state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(statuses.get("tenantB").state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportMigratedForSameVersion() {
+    // given - schema=8.10.0, app=8.10.0
+    final var status = singleStatus(versionStore("8.10.0", "8.10.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(status.detail()).contains("8.10.0");
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForPatchUpgrade() {
+    // given - schema=8.9.0, app=8.9.5 (not yet migrated to the running app's exact version)
+    final var status = singleStatus(versionStore("8.9.0", "8.9.5"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForMinorUpgrade() {
+    // given - schema=8.9.1, app=8.10.0
+    final var status = singleStatus(versionStore("8.9.1", "8.10.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForFreshDatabase() {
+    // given - resolveCurrentSchemaVersion returns null (fresh DB, not yet initialized)
+    final var status = singleStatus(versionStore(null, "8.11.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+    assertThat(status.detail()).contains("fresh database");
+  }
+
+  @Test
+  void shouldReportUnknownForIncompatibleUpgradePath() {
+    // given - schema=8.9.0, app=8.11.0 (skipped 8.10) - a real problem, not "in progress"
+    final var status = singleStatus(versionStore("8.9.0", "8.11.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownForIndeterminateSchemaVersion() {
+    // given - stored schema version is not a valid semantic version
+    final var status = singleStatus(versionStore("not-a-semver", "8.10.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownForUnparseableApplicationVersion() {
+    // given - app=development (not a semantic version)
+    final var status = singleStatus(versionStore("8.9.0", "development"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("development");
+  }
+
+  @Test
+  void shouldReportUnknownWhenReadingCurrentVersionFails() throws Exception {
+    // given - getConnection() throws
+    final var dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenThrow(new RuntimeException("DB connection refused"));
+    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
+
+    // when
+    final var status = singleStatus(store);
+
+    // then - a read failure must never throw; it must be reported as UNKNOWN
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("DB connection refused");
+  }
+
+  private static RdbmsSchemaMigrationStatusProvider provider(
+      final Map<String, RdbmsSchemaVersionStore> versionStoresByPhysicalTenant) {
+    return new RdbmsSchemaMigrationStatusProvider(versionStoresByPhysicalTenant);
+  }
+
+  private static MigrationConditionStatus singleStatus(final RdbmsSchemaVersionStore versionStore) {
+    return provider(Map.of("tenant", versionStore)).getMigrationStatus().get("tenant");
+  }
+
+  /**
+   * Builds a {@link RdbmsSchemaVersionStore} whose {@link
+   * RdbmsSchemaVersionStore#resolveCurrentSchemaVersion} returns {@code schemaVersion}, backed by a
+   * mock data source that yields a mock connection.
+   */
+  private static RdbmsSchemaVersionStore versionStore(
+      final String schemaVersion, final String appVersion) {
+    final var dataSource = mock(DataSource.class);
+    try {
+      when(dataSource.getConnection()).thenReturn(mock(Connection.class));
+    } catch (final SQLException e) {
+      throw new RuntimeException(e);
+    }
+    return new RdbmsSchemaVersionStore(dataSource, "", appVersion) {
+      @Override
+      protected String resolveCurrentSchemaVersion(
+          final Connection connection, final String prefix) {
+        return schemaVersion;
+      }
+    };
+  }
+
+  private static Map<String, RdbmsSchemaVersionStore> orderedMap(
+      final String keyA,
+      final RdbmsSchemaVersionStore valueA,
+      final String keyB,
+      final RdbmsSchemaVersionStore valueB) {
+    final var map = new LinkedHashMap<String, RdbmsSchemaVersionStore>();
+    map.put(keyA, valueA);
+    map.put(keyB, valueB);
+    return map;
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.db.rdbms.RdbmsSchemaVersionStore.CurrentSchemaVersion.Kind;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -170,6 +171,56 @@ class RdbmsSchemaVersionStoreTest {
     verify(dataSource, never()).getConnection();
   }
 
+  // ---- getCurrentSchemaVersion (upgrade-readiness facts) ----
+
+  @Test
+  void shouldReportAvailableCurrentSchemaVersion() {
+    // given - schema=8.10.0, app=8.10.0
+    final var currentSchemaVersion = versionStore("8.10.0", "8.10.0").getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.AVAILABLE);
+    assertThat(currentSchemaVersion.schemaVersion()).contains("8.10.0");
+    assertThat(currentSchemaVersion.stableApplicationVersion()).contains("8.10.0");
+  }
+
+  @Test
+  void shouldNormalizeApplicationVersionForCurrentSchemaVersion() {
+    // given - schema=8.9.0, app=8.10.0-SNAPSHOT
+    final var currentSchemaVersion =
+        versionStore("8.9.0", "8.10.0-SNAPSHOT").getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.AVAILABLE);
+    assertThat(currentSchemaVersion.stableApplicationVersion()).contains("8.10.0");
+  }
+
+  @Test
+  void shouldReportFreshDatabaseCurrentSchemaVersion() {
+    // given - resolveCurrentSchemaVersion returns null (fresh DB, not yet initialized)
+    final var currentSchemaVersion = versionStore(null, "8.11.0").getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.FRESH_DATABASE);
+    assertThat(currentSchemaVersion.schemaVersion()).isEmpty();
+  }
+
+  @Test
+  void shouldReportReadFailureCurrentSchemaVersion() throws Exception {
+    // given - getConnection() throws
+    final var dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenThrow(new RuntimeException("DB connection refused"));
+    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
+
+    // when
+    final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+    // then - a read failure must never throw; it must be reported as raw failure facts
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.READ_FAILURE);
+    assertThat(currentSchemaVersion.detail())
+        .hasValueSatisfying(s -> s.contains("DB connection refused"));
+  }
+
   // ---- toStableVersion ----
 
   @Test
@@ -190,8 +241,8 @@ class RdbmsSchemaVersionStoreTest {
   // ---- helpers ----
 
   /**
-   * Builds a {@link RdbmsSchemaVersionStore} whose {@link #resolveCurrentSchemaVersion} returns
-   * {@code schemaVersion}, backed by a mock data source that yields a mock connection.
+   * Builds a {@link RdbmsSchemaVersionStore} whose currentSchemaVersion returns {@code
+   * schemaVersion}, backed by a mock data source that yields a mock connection.
    */
   private static RdbmsSchemaVersionStore versionStore(
       final String schemaVersion, final String appVersion) {

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1228,6 +1228,21 @@
               </configOptions>
             </configuration>
           </execution>
+          <execution>
+            <id>upgrade-readiness</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>${project.basedir}/src/main/resources/api/cluster/upgrade-readiness-api.yaml</inputSpec>
+              <modelPackage>io.camunda.zeebe.management.cluster</modelPackage>
+              <minimalUpdate>true</minimalUpdate>
+              <ignoreFileOverride>${project.basedir}/src/main/resources/api/cluster/.openapi-generator-ignore</ignoreFileOverride>
+              <configOptions>
+                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+              </configOptions>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.db.rdbms.DefaultRdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.PerTenantSchemaConfig;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
+import io.camunda.db.rdbms.RdbmsSchemaMigrationStatusProvider;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.util.VersionUtil;
@@ -40,6 +41,32 @@ public class MyBatisConfiguration {
   public RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry(
       final RdbmsDataSources rdbmsDataSources,
       final PhysicalTenantResolver physicalTenantResolver) {
+    // VersionUtil.getVersion() may not be a valid semantic version during local development;
+    // the schema-version check is skipped in that case.
+    return DefaultRdbmsSchemaManagerRegistry.fromConfigs(
+        physicalTenantSchemaConfigs(rdbmsDataSources, physicalTenantResolver),
+        VersionUtil.getVersion());
+  }
+
+  /**
+   * Reports whether every physical tenant's RDBMS schema has migrated to the running application
+   * version, for the upgrade-readiness endpoint (camunda/product-hub#3067). Built from the same
+   * per-tenant configs as {@link #rdbmsSchemaManagerRegistry}, but independently — this needs to
+   * read the schema version regardless of whether this application's own Liquibase run applied it
+   * or an operator's external tooling did.
+   */
+  @Bean
+  public RdbmsSchemaMigrationStatusProvider rdbmsSchemaMigrationStatusProvider(
+      final RdbmsDataSources rdbmsDataSources,
+      final PhysicalTenantResolver physicalTenantResolver) {
+    return RdbmsSchemaMigrationStatusProvider.fromConfigs(
+        physicalTenantSchemaConfigs(rdbmsDataSources, physicalTenantResolver),
+        VersionUtil.getVersion());
+  }
+
+  private Map<String, PerTenantSchemaConfig> physicalTenantSchemaConfigs(
+      final RdbmsDataSources rdbmsDataSources,
+      final PhysicalTenantResolver physicalTenantResolver) {
     final Map<String, PerTenantSchemaConfig> physicalTenantConfigs = new LinkedHashMap<>();
     for (final String physicalTenantId : physicalTenantResolver.getAll().keySet()) {
       final var rdbms =
@@ -62,10 +89,7 @@ public class MyBatisConfiguration {
               rdbms.getAutoDdl(),
               rdbms.getDdlLockWaitTimeout()));
     }
-    // VersionUtil.getVersion() may not be a valid semantic version during local development;
-    // the schema-version check is skipped in that case.
-    return DefaultRdbmsSchemaManagerRegistry.fromConfigs(
-        physicalTenantConfigs, VersionUtil.getVersion());
+    return physicalTenantConfigs;
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/MigrationStatusAggregator.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/MigrationStatusAggregator.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Collects every registered {@link MigrationStatusProvider} and combines their per-physical-tenant
+ * statuses into an {@link UpgradeReadinessResponse}.
+ *
+ * <p>Keeps the last confirmed {@code MIGRATED} status per (physical tenant, condition) pair.
+ */
+public class MigrationStatusAggregator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MigrationStatusAggregator.class);
+
+  private final List<MigrationStatusProvider> providers;
+  private final Map<TenantCondition, MigrationConditionStatus> lastConfirmedMigrated =
+      new ConcurrentHashMap<>();
+  private final Set<String> knownPhysicalTenantIds = ConcurrentHashMap.newKeySet();
+
+  public MigrationStatusAggregator(final List<MigrationStatusProvider> providers) {
+    this.providers = providers;
+  }
+
+  public UpgradeReadinessResponse aggregate() {
+    final var conditionNames =
+        providers.stream().map(MigrationStatusProvider::conditionName).toList();
+    final var physicalTenants = new LinkedHashMap<String, Map<String, MigrationConditionStatus>>();
+
+    for (final var provider : providers) {
+      final var conditionName = provider.conditionName();
+      final var freshStatuses = safeGetMigrationStatus(provider);
+      knownPhysicalTenantIds.addAll(freshStatuses.keySet());
+      freshStatuses.forEach(
+          (physicalTenantId, status) -> {
+            final var resolved = resolveWithCache(physicalTenantId, conditionName, status);
+            physicalTenants
+                .computeIfAbsent(physicalTenantId, ignored -> new LinkedHashMap<>())
+                .put(conditionName, resolved);
+          });
+    }
+
+    backfillMissingPairs(physicalTenants, conditionNames);
+
+    final var upgradeable =
+        !physicalTenants.isEmpty()
+            && physicalTenants.values().stream()
+                .allMatch(
+                    conditions ->
+                        !conditions.isEmpty()
+                            && conditions.values().stream()
+                                .allMatch(status -> status.state() == MigrationState.MIGRATED));
+    return new UpgradeReadinessResponse(upgradeable, physicalTenants);
+  }
+
+  private Map<String, MigrationConditionStatus> safeGetMigrationStatus(
+      final MigrationStatusProvider provider) {
+    try {
+      return provider.getMigrationStatus();
+    } catch (final Exception e) {
+      LOG.warn(
+          "Upgrade-readiness provider '{}' failed; no fresh status for this poll.",
+          provider.conditionName(),
+          e);
+      return Map.of();
+    }
+  }
+
+  private MigrationConditionStatus resolveWithCache(
+      final String physicalTenantId,
+      final String conditionName,
+      final MigrationConditionStatus fresh) {
+    final var key = new TenantCondition(physicalTenantId, conditionName);
+    if (fresh.state() == MigrationState.MIGRATED) {
+      lastConfirmedMigrated.put(key, fresh);
+      return fresh;
+    }
+    final var cached = lastConfirmedMigrated.get(key);
+    return cached != null ? cached : fresh;
+  }
+
+  /**
+   * Fills in every (known physical tenant, registered condition) pair this poll did not freshly
+   * report — whether because a whole provider call failed, or because that provider simply did not
+   * report that tenant this cycle. A pair once confirmed {@code MIGRATED} is restored from the
+   * cache rather than defaulting to {@code UNKNOWN}, preserving the same monotonicity guarantee as
+   * a fresh, successful lookup would.
+   */
+  private void backfillMissingPairs(
+      final Map<String, Map<String, MigrationConditionStatus>> physicalTenants,
+      final List<String> conditionNames) {
+    for (final var physicalTenantId : knownPhysicalTenantIds) {
+      final var conditions =
+          physicalTenants.computeIfAbsent(physicalTenantId, ignored -> new LinkedHashMap<>());
+      for (final var conditionName : conditionNames) {
+        conditions.computeIfAbsent(
+            conditionName,
+            ignored -> {
+              final var cached =
+                  lastConfirmedMigrated.get(new TenantCondition(physicalTenantId, conditionName));
+              return cached != null
+                  ? cached
+                  : new MigrationConditionStatus(
+                      MigrationState.UNKNOWN, "no status reported for this poll");
+            });
+      }
+    }
+  }
+
+  private record TenantCondition(String physicalTenantId, String conditionName) {}
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/UpgradeReadinessEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/UpgradeReadinessEndpoint.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Reports whether this cluster has completed every condition required before the next minor-version
+ * upgrade can safely be triggered (see camunda/product-hub#3067).
+ *
+ * <p>Collects every {@link MigrationStatusProvider} bean registered in this process. The response
+ * only contains conditions for which a provider bean currently exists — {@code upgradeable} is
+ * intentionally not meaningful until every planned provider (RDBMS schema, Elasticsearch/OpenSearch
+ * schema, RocksDB snapshot, exporter flush) is registered; see {@link UpgradeReadinessResponse}.
+ */
+@Component
+@RestControllerEndpoint(id = "upgradeReadiness")
+public class UpgradeReadinessEndpoint {
+
+  private final MigrationStatusAggregator aggregator;
+
+  @Autowired
+  public UpgradeReadinessEndpoint(final List<MigrationStatusProvider> providers) {
+    aggregator = new MigrationStatusAggregator(providers);
+  }
+
+  @GetMapping(produces = "application/json")
+  public UpgradeReadinessResponse getUpgradeReadiness() {
+    return aggregator.aggregate();
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/UpgradeReadinessResponse.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/UpgradeReadinessResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import java.util.Map;
+
+/**
+ * Response body of the {@code upgradeReadiness} actuator endpoint.
+ *
+ * <p>Grouped by physical tenant first, condition name second — not "tenants" alone, since Camunda
+ * already has an unrelated multi-tenancy concept (process-engine tenants on process instances); a
+ * physical tenant is an independent engine inside one orchestration cluster (its own partition
+ * group, its own secondary storage).
+ *
+ * @param upgradeable {@code true} only once every registered condition reports {@code MIGRATED} for
+ *     every known physical tenant; {@code false} whenever nothing is known at all, since an empty
+ *     response must never be mistaken for readiness
+ * @param physicalTenants every known physical tenant's condition breakdown, keyed by physical
+ *     tenant ID, then by {@code conditionName()}. A physical tenant only appears once at least one
+ *     provider has reported it; a condition a provider does not report for a tenant it *does* know
+ *     about (e.g. a lookup gap, not "does not apply") is filled in as {@code UNKNOWN} rather than
+ *     omitted, so a gap can never be silently read as readiness.
+ */
+public record UpgradeReadinessResponse(
+    boolean upgradeable, Map<String, Map<String, MigrationConditionStatus>> physicalTenants) {}

--- a/dist/src/main/resources/api/cluster/upgrade-readiness-api.yaml
+++ b/dist/src/main/resources/api/cluster/upgrade-readiness-api.yaml
@@ -1,0 +1,103 @@
+openapi: "3.0.2"
+info:
+  title: Upgrade Readiness API
+  version: "1.0"
+  description: >
+    Management endpoint reporting whether this cluster has completed every condition required
+    before the next minor-version upgrade can safely be triggered (see camunda/product-hub#3067).
+servers:
+  - url: "{schema}://{host}:{port}/actuator/upgradeReadiness"
+    variables:
+      host:
+        default: localhost
+        description: Management server hostname
+      port:
+        default: "9600"
+        description: Management server port
+      schema:
+        default: http
+        description: Management server schema
+paths:
+  /:
+    get:
+      summary: Get the upgrade-readiness status of this cluster
+      description: >
+        Reports the state of every registered upgrade-readiness condition (e.g. RDBMS schema
+        migration, Elasticsearch/OpenSearch schema migration, RocksDB snapshot migration, exporter
+        flush), grouped by physical tenant. The set of conditions in the response reflects which
+        provider beans are currently registered in this process — not every condition is
+        necessarily present yet, so `upgradeable` should not be treated as meaningful until every
+        planned condition is registered.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpgradeReadinessResponse"
+components:
+  schemas:
+    UpgradeReadinessResponse:
+      title: Upgrade Readiness Response
+      description: >
+        Grouped by physical tenant first, condition name second — not "tenants" alone, since
+        Camunda already has an unrelated multi-tenancy concept (process-engine tenants on process
+        instances); a physical tenant is an independent engine inside one orchestration cluster
+        (its own partition group, its own secondary storage).
+      type: object
+      properties:
+        upgradeable:
+          description: >
+            `true` only once every registered condition reports `MIGRATED` for every known
+            physical tenant. `false` whenever nothing is known at all, since an empty response
+            must never be mistaken for readiness.
+          type: boolean
+          example: false
+        physicalTenants:
+          description: >
+            Every known physical tenant's condition breakdown, keyed by physical tenant ID, then
+            by condition name (e.g. `rdbmsSchemaMigrated`). A physical tenant only appears once at
+            least one provider has reported it; a condition a provider does not report for a
+            tenant it does know about (e.g. a lookup gap, not "does not apply") is filled in as
+            `UNKNOWN` rather than omitted, so a gap can never be silently read as readiness.
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              $ref: "#/components/schemas/MigrationConditionStatus"
+          example:
+            default:
+              rdbmsSchemaMigrated:
+                state: MIGRATED
+                detail: schema version 8.10.0 matches the application version
+      required:
+        - upgradeable
+        - physicalTenants
+
+    MigrationConditionStatus:
+      title: Migration Condition Status
+      description: The status of a single upgrade-readiness condition, as reported by a provider.
+      type: object
+      properties:
+        state:
+          allOf:
+            - $ref: "#/components/schemas/MigrationState"
+        detail:
+          description: >
+            A short, human-readable explanation, surfaced as-is from the reporting provider (e.g.
+            "schema version 8.9.0 has not yet migrated to 8.10.0").
+          type: string
+          example: schema version 8.10.0 matches the application version
+      required:
+        - state
+        - detail
+
+    MigrationState:
+      title: Migration State
+      description: The state of a single upgrade-readiness condition.
+      type: string
+      enum:
+        - MIGRATED
+        - MIGRATION_IN_PROGRESS
+        - UNKNOWN
+      example: MIGRATED

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -58,6 +58,7 @@ management.endpoint.flowControl.access=unrestricted
 management.endpoint.jobstreams.access=unrestricted
 management.endpoint.partitions.access=unrestricted
 management.endpoint.rebalance.access=unrestricted
+management.endpoint.upgradeReadiness.access=unrestricted
 management.endpoint.usage-metrics.access=unrestricted
 # Define keywords to sanitize in applicable endpoints; this will be applied to the configprops,
 # beans, and if enabled, the environment endpoint as well

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/MigrationStatusAggregatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/MigrationStatusAggregatorTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class MigrationStatusAggregatorTest {
+
+  @Test
+  void shouldReportNotUpgradeableWhenNoProviderIsRegistered() {
+    // given - staged rollout: not every provider exists yet
+    final var aggregator = new MigrationStatusAggregator(List.of());
+
+    // when
+    final var response = aggregator.aggregate();
+
+    // then - an empty condition set must never be mistaken for readiness
+    assertThat(response.upgradeable()).isFalse();
+    assertThat(response.physicalTenants()).isEmpty();
+  }
+
+  @Test
+  void shouldReportUpgradeableOnlyWhenEveryConditionIsMigratedForEveryTenant() {
+    // given
+    final var aggregator =
+        new MigrationStatusAggregator(
+            List.of(
+                provider("a", Map.of("default", migrated("a done"))),
+                provider("b", Map.of("default", migrated("b done")))));
+
+    // when
+    final var response = aggregator.aggregate();
+
+    // then
+    assertThat(response.upgradeable()).isTrue();
+    assertThat(response.physicalTenants().get("default")).hasSize(2);
+  }
+
+  @Test
+  void shouldReportEachPhysicalTenantIndependently() {
+    // given - a provider covering two physical tenants, one ready, one not
+    final var aggregator =
+        new MigrationStatusAggregator(
+            List.of(
+                provider(
+                    "a",
+                    Map.of(
+                        "tenantA", migrated("a done"),
+                        "tenantB", inProgress("b behind")))));
+
+    // when
+    final var response = aggregator.aggregate();
+
+    // then
+    assertThat(response.upgradeable()).isFalse();
+    assertThat(response.physicalTenants().get("tenantA").get("a").state())
+        .isEqualTo(MigrationState.MIGRATED);
+    assertThat(response.physicalTenants().get("tenantB").get("a").state())
+        .isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportNotUpgradeableWhenOneConditionIsNotMigratedForOneTenant() {
+    // given
+    final var aggregator =
+        new MigrationStatusAggregator(
+            List.of(
+                provider("a", Map.of("default", migrated("a done"))),
+                provider("b", Map.of("default", inProgress("b behind")))));
+
+    // when
+    final var response = aggregator.aggregate();
+
+    // then
+    assertThat(response.upgradeable()).isFalse();
+    assertThat(response.physicalTenants().get("default").get("b").state())
+        .isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportUnknownInsteadOfThrowingWhenAProviderThrows() {
+    // given - the only provider throws, and no tenant is known yet from anywhere else
+    final var aggregator = new MigrationStatusAggregator(List.of(throwingProvider("a", "boom")));
+
+    // when
+    final var response = aggregator.aggregate();
+
+    // then - a broken provider must never crash the endpoint; with no known tenant, there's
+    // simply nothing to report yet
+    assertThat(response.upgradeable()).isFalse();
+    assertThat(response.physicalTenants()).isEmpty();
+  }
+
+  @Test
+  void shouldBackfillUnknownWhenAProviderThrowsForATenantKnownFromAnotherProvider() {
+    // given - "default" is known via provider "a"; provider "b" fails the entire poll
+    final var aggregator =
+        new MigrationStatusAggregator(
+            List.of(
+                provider("a", Map.of("default", migrated("a done"))),
+                throwingProvider("b", "boom")));
+
+    // when
+    final var response = aggregator.aggregate();
+
+    // then - "b" must not silently disappear for "default": a gap is UNKNOWN, never omission
+    assertThat(response.upgradeable()).isFalse();
+    final var conditions = response.physicalTenants().get("default");
+    assertThat(conditions.get("a").state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(conditions.get("b").state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(conditions.get("b").detail()).contains("no status reported");
+  }
+
+  @Test
+  void shouldNeverRegressAConfirmedMigratedConditionWhenAProviderThrowsOnALaterPoll() {
+    // given - a provider that reports MIGRATED once, then throws entirely afterwards (e.g. a
+    // later distributed fan-out breaking)
+    final var flakyProvider = new FlakyProvider("a", migrated("done"));
+    final var aggregator = new MigrationStatusAggregator(List.of(flakyProvider));
+
+    // when - first poll confirms MIGRATED, second poll would otherwise lose the entry entirely
+    final var firstResponse = aggregator.aggregate();
+    final var secondResponse = aggregator.aggregate();
+
+    // then - monotonicity is preserved via the backfill, even under total provider failure
+    assertThat(firstResponse.physicalTenants().get("default").get("a").state())
+        .isEqualTo(MigrationState.MIGRATED);
+    assertThat(secondResponse.physicalTenants().get("default").get("a").state())
+        .isEqualTo(MigrationState.MIGRATED);
+  }
+
+  @Test
+  void shouldNotCacheANonMigratedStatus() {
+    // given - a provider that never reaches MIGRATED, then throws
+    final var flakyProvider = new FlakyProvider("a", inProgress("not yet"));
+    final var aggregator = new MigrationStatusAggregator(List.of(flakyProvider));
+
+    // when
+    aggregator.aggregate();
+    final var secondResponse = aggregator.aggregate();
+
+    // then - nothing was ever confirmed MIGRATED, so the backfill falls back to UNKNOWN
+    assertThat(secondResponse.physicalTenants().get("default").get("a").state())
+        .isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  private static MigrationConditionStatus migrated(final String detail) {
+    return new MigrationConditionStatus(MigrationState.MIGRATED, detail);
+  }
+
+  private static MigrationConditionStatus inProgress(final String detail) {
+    return new MigrationConditionStatus(MigrationState.MIGRATION_IN_PROGRESS, detail);
+  }
+
+  private static MigrationStatusProvider provider(
+      final String name, final Map<String, MigrationConditionStatus> statuses) {
+    return new MigrationStatusProvider() {
+      @Override
+      public String conditionName() {
+        return name;
+      }
+
+      @Override
+      public Map<String, MigrationConditionStatus> getMigrationStatus() {
+        return statuses;
+      }
+    };
+  }
+
+  private static MigrationStatusProvider throwingProvider(final String name, final String message) {
+    return new MigrationStatusProvider() {
+      @Override
+      public String conditionName() {
+        return name;
+      }
+
+      @Override
+      public Map<String, MigrationConditionStatus> getMigrationStatus() {
+        throw new RuntimeException(message);
+      }
+    };
+  }
+
+  /** A provider that returns {@code firstStatus} for tenant "default" once, then throws. */
+  private static final class FlakyProvider implements MigrationStatusProvider {
+    private final String name;
+    private final MigrationConditionStatus firstStatus;
+    private boolean calledOnce = false;
+
+    private FlakyProvider(final String name, final MigrationConditionStatus firstStatus) {
+      this.name = name;
+      this.firstStatus = firstStatus;
+    }
+
+    @Override
+    public String conditionName() {
+      return name;
+    }
+
+    @Override
+    public Map<String, MigrationConditionStatus> getMigrationStatus() {
+      if (!calledOnce) {
+        calledOnce = true;
+        return Map.of("default", firstStatus);
+      }
+      throw new RuntimeException("flaky provider failure");
+    }
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/UpgradeReadinessEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/UpgradeReadinessEndpointTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class UpgradeReadinessEndpointTest {
+
+  @Test
+  void shouldExposeEveryRegisteredProviderUnderItsConditionNamePerPhysicalTenant() {
+    // given
+    final MigrationStatusProvider provider =
+        new MigrationStatusProvider() {
+          @Override
+          public String conditionName() {
+            return "rdbmsSchemaMigrated";
+          }
+
+          @Override
+          public Map<String, MigrationConditionStatus> getMigrationStatus() {
+            return Map.of(
+                "default",
+                new MigrationConditionStatus(MigrationState.MIGRATED, "schema is current"));
+          }
+        };
+    final var endpoint = new UpgradeReadinessEndpoint(List.of(provider));
+
+    // when
+    final var response = endpoint.getUpgradeReadiness();
+
+    // then
+    assertThat(response.upgradeable()).isTrue();
+    assertThat(response.physicalTenants()).containsOnlyKeys("default");
+    assertThat(response.physicalTenants().get("default")).containsOnlyKeys("rdbmsSchemaMigrated");
+    assertThat(response.physicalTenants().get("default").get("rdbmsSchemaMigrated").state())
+        .isEqualTo(MigrationState.MIGRATED);
+  }
+
+  @Test
+  void shouldReportNotUpgradeableWhenNoProviderIsRegisteredYet() {
+    // given - staged rollout, before any MigrationStatusProvider bean exists
+    final var endpoint = new UpgradeReadinessEndpoint(List.of());
+
+    // when
+    final var response = endpoint.getUpgradeReadiness();
+
+    // then
+    assertThat(response.upgradeable()).isFalse();
+    assertThat(response.physicalTenants()).isEmpty();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.management;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.zeebe.qa.util.actuator.UpgradeReadinessActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end happy-path coverage for {@code GET /actuator/upgradeReadiness}
+ * (camunda/product-hub#3067) with RDBMS as the secondary storage: on a normally-booted, healthy
+ * broker — no chained-upgrade or migration scenario involved — the condition must settle on {@code
+ * MIGRATED} for the default physical tenant, and the endpoint must report the cluster as
+ * upgradeable.
+ *
+ * <p>Covers {@code RdbmsSchemaMigrationStatusProvider} (schema-version check against the shared
+ * RDBMS store) — the only provider wired for a single-node RDBMS broker today.
+ */
+@ZeebeIntegration
+final class UpgradeReadinessEndpointIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static final String H2_URL =
+      "jdbc:h2:mem:upgrade-readiness-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
+
+  @TestZeebe
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withSecondaryStorageType(SecondaryStorageType.rdbms)
+          .withUnifiedConfig(
+              cfg -> {
+                final var rdbms = cfg.getData().getSecondaryStorage().getRdbms();
+                rdbms.setUrl(H2_URL);
+                rdbms.setUsername("sa");
+                rdbms.setPassword("");
+              });
+
+  @Test
+  void shouldReportRdbmsSchemaMigratedForTheDefaultPhysicalTenant() {
+    Awaitility.await(
+            "until the rdbmsSchemaMigrated condition settles on MIGRATED for the default tenant")
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var response = UpgradeReadinessActuator.of(BROKER).get();
+
+              assertThat(response.physicalTenants()).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID);
+              final var defaultTenant = response.physicalTenants().get(DEFAULT_PHYSICAL_TENANT_ID);
+              assertThat(defaultTenant).containsKey("rdbmsSchemaMigrated");
+              assertThat(defaultTenant.get("rdbmsSchemaMigrated").state()).isEqualTo("MIGRATED");
+              assertThat(response.upgradeable()).isTrue();
+            });
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/UpgradeReadinessActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/UpgradeReadinessActuator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.actuator;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import feign.Feign;
+import feign.Headers;
+import feign.RequestLine;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.Map;
+
+/**
+ * Java interface for the {@code upgradeReadiness} actuator (camunda/product-hub#3067). To
+ * instantiate this interface, you can use {@link Feign}; see {@link #of(String)} as an example.
+ *
+ * <p>The response types here are deliberately decoupled from the real {@code
+ * io.camunda.zeebe.shared.management.UpgradeReadinessResponse}/{@code
+ * io.camunda.cluster.migration.MigrationConditionStatus} classes — same convention as {@link
+ * PartitionsActuator}'s own {@code PartitionStatus} — so a refactor of the server-side DTOs does
+ * not ripple into every test using this client. {@code state} is decoded as a plain {@link String}
+ * rather than the real {@code MigrationState} enum for the same reason.
+ */
+public interface UpgradeReadinessActuator {
+
+  /**
+   * Returns an {@link UpgradeReadinessActuator} instance using the given node as upstream.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link UpgradeReadinessActuator}
+   */
+  static UpgradeReadinessActuator of(final TestStandaloneBroker node) {
+    return of(node.actuatorUri("upgradeReadiness").toString());
+  }
+
+  /**
+   * Returns an {@link UpgradeReadinessActuator} instance using the given endpoint as upstream. The
+   * endpoint is expected to be a complete absolute URL, e.g.
+   * "http://localhost:9600/actuator/upgradeReadiness".
+   *
+   * @param endpoint the actuator URL to connect to
+   * @return a new instance of {@link UpgradeReadinessActuator}
+   */
+  static UpgradeReadinessActuator of(final String endpoint) {
+    final var target = new HardCodedTarget<>(UpgradeReadinessActuator.class, endpoint);
+    return Feign.builder()
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+
+  @RequestLine("GET")
+  @Headers("Accept: application/json")
+  UpgradeReadinessResponse get();
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record UpgradeReadinessResponse(
+      boolean upgradeable, Map<String, Map<String, MigrationConditionStatus>> physicalTenants) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record MigrationConditionStatus(String state, String detail) {}
+}


### PR DESCRIPTION
This pull request introduces a new upgrade-readiness condition reporting mechanism.

- introduced new Actuator-API `UpgradeReadinessEndpoint` at `/upgradeReadiness` to retrieve upgradeReadiness based on the completion of previous migrations
```json
{
  "upgradeable": false,
  "physicalTenants": {
    "default": {
      "rdbmsSchemaMigrated": {
        "state": "MIGRATED",
        "detail": "schema version 8.10 matches the application version"
      },
      "rocksDbMigrated": {
        "state": "MIGRATION_IN_PROGRESS",
        "detail": "partition 1: migrated to 8.10 but not yet snapshotted"
      }
    }
  }
}
```
- introduces new OC internal interface `MigrationStatusProvider`. Any component in OC can provide implementations of this interface

First implementation: `RdbmsSchemaMigrationStatusProvider`
- called once for each physical tenant with a relational database connected
- reads the current schema version and compares it by compatibility with the current application version
  - With liquibase this test basically is always `true` because Liquibase will always execute missing migrations on startup and the application will not be "ready" before
  - with external scripts it actually can make a difference and relies on the DBA when he executes the manual scripts

closes #59847 
