### PR TITLE
Load tests: Increase default disk capacity 160 -> 256

### DIFF
--- a/load-tests/setup/charts/load-test-setup/values.yaml
+++ b/load-tests/setup/charts/load-test-setup/values.yaml
@@ -125,7 +125,7 @@ elasticsearch:
     # -- Kubernetes StorageClass for the PersistentVolumeClaim.
     storageClassName: benchmark-ssd-zonal-v1
     # -- Storage capacity requested per Elasticsearch node.
-    requests: 160Gi
+    requests: 256Gi
 
   # -- Node selector labels for Elasticsearch pod scheduling.
   # The top-level `topologyZone` value is also applied as `topology.kubernetes.io/zone`.
@@ -304,7 +304,7 @@ opensearch:
 
   persistence:
     enabled: true
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   nodeSelector:
@@ -394,7 +394,7 @@ postgresql:
 
   # -- Persistent storage configuration for the PostgreSQL cluster.
   storage:
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   # -- The PostgreSQL database and user used by Camunda to connect to this cluster.

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "160Gi"
+          storage: "256Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "160Gi"
+          storage: "256Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "160Gi"
+          storage: "256Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "160Gi"
+          storage: "256Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "160Gi"
+          storage: "256Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "160Gi"
+          storage: "256Gi"
       storageClassName: "benchmark-ssd-zonal-v1"
   template:
     metadata:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/postgresql.yaml
@@ -22,7 +22,7 @@ spec:
       memory: 8Gi
 
   storage:
-    size: 160Gi
+    size: 256Gi
     storageClass: benchmark-ssd-zonal-v1
 
   affinity:

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -69,7 +69,7 @@ spec:
         accessModes: [ReadWriteOnce]
         resources:
           requests:
-            storage: 160Gi
+            storage: 256Gi
 
   http:
     tls:


### PR DESCRIPTION
## Description

Release load tests failed in the morning, after accumulating state over the weekend. The reduced disk size isn't enough, it [seems](https://camunda.slack.com/archives/C0BQL528L94/p1786959145282779).

Looking back at history, using a value of 256 should be rather safe. Be aware that the spikes for 8.7 were actually misbehaving, and importing wasn't working in these cases.

<img width="3333" height="1097" alt="2026-08-17_11-30" src="https://github.com/user-attachments/assets/3f489fc7-d90f-42b6-a943-3e834d4236b3" />

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

- Related incident https://app.slack.com/client/T0PM0P1SA/C0BQL528L94?skip_today=1
- closes https://github.com/camunda/camunda/issues/59330
