### PR TITLE
refactor: drop target prefix from job registry entity fields

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
@@ -10,10 +10,10 @@ package io.camunda.optimize.service.db.reader;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import java.time.OffsetDateTime;
@@ -44,7 +44,7 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
     // given
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, "2251799813685251");
 
     // when
     final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
@@ -63,7 +63,7 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
   void shouldNotFindQueuedJobsWhenNoneAreQueued() {
     // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
 
     // when
@@ -91,11 +91,11 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
     // could land in the same millisecond and the sort-by-oldest assertion would be flaky.
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
     final JobRegistryEntryDto olderEntry =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
 
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
     final JobRegistryEntryDto newerEntry =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
 
     // when
     final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
@@ -111,10 +111,10 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
     // given
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
     final JobRegistryEntryDto olderEntry =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
 
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
-    jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
 
     // when
     final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(1);
@@ -129,11 +129,11 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
   void shouldSkipCompletedEntryAndReturnTheQueuedOne() {
     // given
     final JobRegistryEntryDto completedEntry =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
     jobRegistryWriter.updateJobStatus(completedEntry.getId(), JobStatus.COMPLETED, null);
 
     final JobRegistryEntryDto queuedEntry =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
 
     // when
     final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
@@ -152,11 +152,11 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
   void shouldSkipFailedEntryAndReturnTheQueuedOne() {
     // given
     final JobRegistryEntryDto failedEntry =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
     jobRegistryWriter.updateJobStatus(failedEntry.getId(), JobStatus.FAILED, "boom");
 
     final JobRegistryEntryDto queuedEntry =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
 
     // when
     final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
@@ -172,27 +172,24 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
-  void shouldFindLastJobByJobTypeAndTargetEntityId() {
-    final String targetEntityId = "2251799813685251";
+  void shouldFindLastJobByJobTypeAndEntityId() {
+    final String entityId = "2251799813685251";
     // given
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
-    jobRegistryWriter.createJobEntry(
-        JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, targetEntityId);
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, entityId);
 
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:02.000+00:00"));
     final JobRegistryEntryDto lastEntry =
-        jobRegistryWriter.createJobEntry(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, targetEntityId);
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, entityId);
 
     // not the last but persisted after the last one
     LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
-    jobRegistryWriter.createJobEntry(
-        JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, targetEntityId);
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, entityId);
 
     // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findLastByJobTypeAndTargetEntityId(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, targetEntityId);
+        jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, entityId);
 
     // then
     assertThat(found).isPresent();
@@ -200,16 +197,16 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
-  void shouldFindLastJobByJobTypeAndTargetEntityIdRegardlessOfStatus() {
+  void shouldFindLastJobByJobTypeAndEntityIdRegardlessOfStatus() {
     // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
 
     // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findLastByJobTypeAndTargetEntityId(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
 
     // then
     assertThat(found).isPresent();
@@ -217,14 +214,14 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
-  void shouldNotFindJobForUnknownTargetEntityId() {
+  void shouldNotFindJobForUnknownEntityId() {
     // given
-    jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
 
     // when
     final Optional<JobRegistryEntryDto> found =
-        jobRegistryReader.findLastByJobTypeAndTargetEntityId(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "does-not-exist");
+        jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, "does-not-exist");
 
     // then
     assertThat(found).isEmpty();

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/writer/JobRegistryWriterIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/writer/JobRegistryWriterIT.java
@@ -11,10 +11,10 @@ import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDE
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
     // given
     final JobRegistryEntryDto created =
         jobRegistryWriter.createJobEntry(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, "2251799813685251");
 
     // when
     final List<JobRegistryEntryDto> stored =
@@ -47,9 +47,8 @@ public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
             jobRegistry -> {
               assertThat(jobRegistry.getId()).isEqualTo(created.getId());
               assertThat(jobRegistry.getJobType()).isEqualTo(JobType.DELETE);
-              assertThat(jobRegistry.getTargetEntityType())
-                  .isEqualTo(TargetEntityType.PROCESS_DEFINITION);
-              assertThat(jobRegistry.getTargetEntityId()).isEqualTo("2251799813685251");
+              assertThat(jobRegistry.getEntityType()).isEqualTo(EntityType.PROCESS_DEFINITION);
+              assertThat(jobRegistry.getEntityId()).isEqualTo("2251799813685251");
               assertThat(jobRegistry.getStatus()).isEqualTo(JobStatus.QUEUED);
               assertThat(jobRegistry.getUpdatedAt()).isNull();
             });
@@ -59,7 +58,7 @@ public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
   void shouldUpdateJobStatusToCompletedWithCompletionTimestamp() {
     // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
 
     // when
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.COMPLETED, null);
@@ -82,7 +81,7 @@ public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
   void shouldUpdateJobStatusToFailedWithErrorMessage() {
     // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
 
     // when
     jobRegistryWriter.updateJobStatus(created.getId(), JobStatus.FAILED, "boom");
@@ -105,7 +104,7 @@ public class JobRegistryWriterIT extends AbstractBrokerlessZeebeCCSMIT {
   void shouldClearErrorMessageWhenRetryCompletesSuccessfully() {
     // given
     final JobRegistryEntryDto created =
-        jobRegistryWriter.createJobEntry(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
 
     // Move the entry into a FAILED state first, so errorMessage is populated. A retry that
     // completes successfully must clear it back to null -- the JobRegistryEntryUpdateDto relies

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/EntityType.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/EntityType.java
@@ -7,6 +7,6 @@
  */
 package io.camunda.optimize.dto.optimize.query.job;
 
-public enum TargetEntityType {
+public enum EntityType {
   PROCESS_DEFINITION
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDto.java
@@ -15,19 +15,19 @@ public class JobRegistryEntryDto {
 
   private String id;
   private JobType jobType;
-  private TargetEntityType targetEntityType;
-  private String targetEntityId;
+  private EntityType entityType;
+  private String entityId;
   private JobStatus status;
   private String errorMessage;
   private OffsetDateTime createdAt;
   private OffsetDateTime updatedAt;
 
   public JobRegistryEntryDto(
-      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+      final JobType jobType, final EntityType entityType, final String entityId) {
     id = IdGenerator.getNextId();
     this.jobType = jobType;
-    this.targetEntityType = targetEntityType;
-    this.targetEntityId = targetEntityId;
+    this.entityType = entityType;
+    this.entityId = entityId;
     status = JobStatus.QUEUED;
     createdAt = LocalDateUtil.getCurrentDateTime();
   }
@@ -50,20 +50,20 @@ public class JobRegistryEntryDto {
     this.jobType = jobType;
   }
 
-  public TargetEntityType getTargetEntityType() {
-    return targetEntityType;
+  public EntityType getEntityType() {
+    return entityType;
   }
 
-  public void setTargetEntityType(final TargetEntityType targetEntityType) {
-    this.targetEntityType = targetEntityType;
+  public void setEntityType(final EntityType entityType) {
+    this.entityType = entityType;
   }
 
-  public String getTargetEntityId() {
-    return targetEntityId;
+  public String getEntityId() {
+    return entityId;
   }
 
-  public void setTargetEntityId(final String targetEntityId) {
-    this.targetEntityId = targetEntityId;
+  public void setEntityId(final String entityId) {
+    this.entityId = entityId;
   }
 
   public JobStatus getStatus() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -14,10 +14,10 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
 import io.camunda.optimize.service.db.reader.JobRegistryReader;
@@ -77,13 +77,13 @@ public class JobRegistryReaderES implements JobRegistryReader {
   }
 
   @Override
-  public Optional<JobRegistryEntryDto> findLastByJobTypeAndTargetEntityId(
-      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+  public Optional<JobRegistryEntryDto> findLastByJobTypeAndEntityId(
+      final JobType jobType, final EntityType entityType, final String entityId) {
     LOG.debug(
         "Fetching job registry entry for [{}] target type [{}] target [{}].",
         jobType,
-        targetEntityType,
-        targetEntityId);
+        entityType,
+        entityId);
     final Query query =
         Query.of(
             q ->
@@ -99,14 +99,13 @@ public class JobRegistryReaderES implements JobRegistryReader {
                                 m ->
                                     m.term(
                                         t ->
-                                            t.field(JobRegistryIndex.TARGET_ENTITY_TYPE)
-                                                .value(targetEntityType.name())))
+                                            t.field(JobRegistryIndex.ENTITY_TYPE)
+                                                .value(entityType.name())))
                             .must(
                                 m ->
                                     m.term(
                                         t ->
-                                            t.field(JobRegistryIndex.TARGET_ENTITY_ID)
-                                                .value(targetEntityId)))));
+                                            t.field(JobRegistryIndex.ENTITY_ID).value(entityId)))));
 
     final SearchRequest searchRequest =
         OptimizeSearchRequestBuilderES.of(
@@ -131,7 +130,7 @@ public class JobRegistryReaderES implements JobRegistryReader {
       final String message =
           String.format(
               "Was not able to fetch job registry entry for [%s] target type [%s] target [%s].",
-              jobType, targetEntityType, targetEntityId);
+              jobType, entityType, entityId);
       LOG.error(message, e);
       throw new OptimizeRuntimeException(message, e);
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -80,7 +80,7 @@ public class JobRegistryReaderES implements JobRegistryReader {
   public Optional<JobRegistryEntryDto> findLastByJobTypeAndEntityId(
       final JobType jobType, final EntityType entityType, final String entityId) {
     LOG.debug(
-        "Fetching job registry entry for [{}] target type [{}] target [{}].",
+        "Fetching job registry entry for [{}] entity type [{}] entity [{}].",
         jobType,
         entityType,
         entityId);
@@ -129,7 +129,7 @@ public class JobRegistryReaderES implements JobRegistryReader {
     } catch (final IOException e) {
       final String message =
           String.format(
-              "Was not able to fetch job registry entry for [%s] target type [%s] target [%s].",
+              "Was not able to fetch job registry entry for [%s] entity type [%s] entity [%s].",
               jobType, entityType, entityId);
       LOG.error(message, e);
       throw new OptimizeRuntimeException(message, e);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
@@ -46,7 +46,7 @@ public class JobRegistryWriterES implements JobRegistryWriter {
       final JobType jobType, final EntityType entityType, final String entityId) {
     final JobRegistryEntryDto entry = new JobRegistryEntryDto(jobType, entityType, entityId);
     LOG.debug(
-        "Creating job registry entry with id [{}] for [{}] target [{}].",
+        "Creating job registry entry with id [{}] for [{}] entity [{}].",
         entry.getId(),
         jobType,
         entityId);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/JobRegistryWriterES.java
@@ -14,11 +14,11 @@ import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch.core.IndexResponse;
 import co.elastic.clients.elasticsearch.core.UpdateResponse;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryUpdateDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.es.builders.OptimizeIndexRequestBuilderES;
 import io.camunda.optimize.service.db.es.builders.OptimizeUpdateRequestBuilderES;
@@ -43,14 +43,13 @@ public class JobRegistryWriterES implements JobRegistryWriter {
 
   @Override
   public JobRegistryEntryDto createJobEntry(
-      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
-    final JobRegistryEntryDto entry =
-        new JobRegistryEntryDto(jobType, targetEntityType, targetEntityId);
+      final JobType jobType, final EntityType entityType, final String entityId) {
+    final JobRegistryEntryDto entry = new JobRegistryEntryDto(jobType, entityType, entityId);
     LOG.debug(
         "Creating job registry entry with id [{}] for [{}] target [{}].",
         entry.getId(),
         jobType,
-        targetEntityId);
+        entityId);
     try {
       final IndexResponse indexResponse =
           esClient.index(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -73,7 +73,7 @@ public class JobRegistryReaderOS implements JobRegistryReader {
   public Optional<JobRegistryEntryDto> findLastByJobTypeAndEntityId(
       final JobType jobType, final EntityType entityType, final String entityId) {
     LOG.debug(
-        "Fetching job registry entry for [{}] target type [{}] target [{}].",
+        "Fetching job registry entry for [{}] entity type [{}] entity [{}].",
         jobType,
         entityType,
         entityId);
@@ -96,7 +96,7 @@ public class JobRegistryReaderOS implements JobRegistryReader {
 
     final String errorMessage =
         String.format(
-            "Was not able to fetch job registry entry for [%s] target type [%s] target [%s].",
+            "Was not able to fetch job registry entry for [%s] entity type [%s] entity [%s].",
             jobType, entityType, entityId);
     final SearchResponse<JobRegistryEntryDto> searchResponse =
         osClient.search(searchReqBuilder, JobRegistryEntryDto.class, errorMessage);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -9,10 +9,10 @@ package io.camunda.optimize.service.db.os.reader;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
 
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.client.dsl.QueryDSL;
 import io.camunda.optimize.service.db.reader.JobRegistryReader;
@@ -70,18 +70,18 @@ public class JobRegistryReaderOS implements JobRegistryReader {
   }
 
   @Override
-  public Optional<JobRegistryEntryDto> findLastByJobTypeAndTargetEntityId(
-      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
+  public Optional<JobRegistryEntryDto> findLastByJobTypeAndEntityId(
+      final JobType jobType, final EntityType entityType, final String entityId) {
     LOG.debug(
         "Fetching job registry entry for [{}] target type [{}] target [{}].",
         jobType,
-        targetEntityType,
-        targetEntityId);
+        entityType,
+        entityId);
     final BoolQuery boolQuery =
         new BoolQuery.Builder()
             .must(QueryDSL.term(JobRegistryIndex.JOB_TYPE, jobType.name()))
-            .must(QueryDSL.term(JobRegistryIndex.TARGET_ENTITY_TYPE, targetEntityType.name()))
-            .must(QueryDSL.term(JobRegistryIndex.TARGET_ENTITY_ID, targetEntityId))
+            .must(QueryDSL.term(JobRegistryIndex.ENTITY_TYPE, entityType.name()))
+            .must(QueryDSL.term(JobRegistryIndex.ENTITY_ID, entityId))
             .build();
 
     final SearchRequest.Builder searchReqBuilder =
@@ -97,7 +97,7 @@ public class JobRegistryReaderOS implements JobRegistryReader {
     final String errorMessage =
         String.format(
             "Was not able to fetch job registry entry for [%s] target type [%s] target [%s].",
-            jobType, targetEntityType, targetEntityId);
+            jobType, entityType, entityId);
     final SearchResponse<JobRegistryEntryDto> searchResponse =
         osClient.search(searchReqBuilder, JobRegistryEntryDto.class, errorMessage);
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
@@ -46,7 +46,7 @@ public class JobRegistryWriterOS implements JobRegistryWriter {
       final JobType jobType, final EntityType entityType, final String entityId) {
     final JobRegistryEntryDto entry = new JobRegistryEntryDto(jobType, entityType, entityId);
     LOG.debug(
-        "Creating job registry entry with id [{}] for [{}] target [{}].",
+        "Creating job registry entry with id [{}] for [{}] entity [{}].",
         entry.getId(),
         jobType,
         entityId);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/JobRegistryWriterOS.java
@@ -10,11 +10,11 @@ package io.camunda.optimize.service.db.os.writer;
 import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
 
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryUpdateDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
@@ -43,14 +43,13 @@ public class JobRegistryWriterOS implements JobRegistryWriter {
 
   @Override
   public JobRegistryEntryDto createJobEntry(
-      final JobType jobType, final TargetEntityType targetEntityType, final String targetEntityId) {
-    final JobRegistryEntryDto entry =
-        new JobRegistryEntryDto(jobType, targetEntityType, targetEntityId);
+      final JobType jobType, final EntityType entityType, final String entityId) {
+    final JobRegistryEntryDto entry = new JobRegistryEntryDto(jobType, entityType, entityId);
     LOG.debug(
         "Creating job registry entry with id [{}] for [{}] target [{}].",
         entry.getId(),
         jobType,
-        targetEntityId);
+        entityId);
 
     final IndexRequest.Builder<JobRegistryEntryDto> request =
         new IndexRequest.Builder<JobRegistryEntryDto>()

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.optimize.service.db.reader;
 
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,9 +22,9 @@ public interface JobRegistryReader {
   List<JobRegistryEntryDto> findOldestQueuedJobs(int limit);
 
   /**
-   * Returns the most recent job registry entry for the given jobType, targetEntityType, and
-   * targetEntityId, if one exists (in any status).
+   * Returns the most recent job registry entry for the given jobType, entityType, and entityId, if
+   * one exists (in any status).
    */
-  Optional<JobRegistryEntryDto> findLastByJobTypeAndTargetEntityId(
-      JobType jobType, TargetEntityType targetEntityType, String targetEntityId);
+  Optional<JobRegistryEntryDto> findLastByJobTypeAndEntityId(
+      JobType jobType, EntityType entityType, String entityId);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/JobRegistryWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/JobRegistryWriter.java
@@ -7,15 +7,14 @@
  */
 package io.camunda.optimize.service.db.writer;
 
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
-import io.camunda.optimize.dto.optimize.query.job.TargetEntityType;
 
 public interface JobRegistryWriter {
 
-  JobRegistryEntryDto createJobEntry(
-      JobType jobType, TargetEntityType targetEntityType, String targetEntityId);
+  JobRegistryEntryDto createJobEntry(JobType jobType, EntityType entityType, String entityId);
 
   void updateJobStatus(String id, JobStatus status, String errorMessage);
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDtoTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDtoTest.java
@@ -16,13 +16,12 @@ class JobRegistryEntryDtoTest {
   @Test
   void shouldInitializeQueuedEntryWithGeneratedIdAndCreationTimestamp() {
     final JobRegistryEntryDto entry =
-        new JobRegistryEntryDto(
-            JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2251799813685251");
+        new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2251799813685251");
 
     assertThat(entry.getId()).isNotBlank();
     assertThat(entry.getJobType()).isEqualTo(JobType.DELETE);
-    assertThat(entry.getTargetEntityType()).isEqualTo(TargetEntityType.PROCESS_DEFINITION);
-    assertThat(entry.getTargetEntityId()).isEqualTo("2251799813685251");
+    assertThat(entry.getEntityType()).isEqualTo(EntityType.PROCESS_DEFINITION);
+    assertThat(entry.getEntityId()).isEqualTo("2251799813685251");
     assertThat(entry.getStatus()).isEqualTo(JobStatus.QUEUED);
     assertThat(entry.getErrorMessage()).isNull();
     assertThat(entry.getCreatedAt()).isNotNull();
@@ -32,9 +31,9 @@ class JobRegistryEntryDtoTest {
   @Test
   void shouldGenerateDifferentIdsForEachEntry() {
     final JobRegistryEntryDto first =
-        new JobRegistryEntryDto(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "1");
+        new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
     final JobRegistryEntryDto second =
-        new JobRegistryEntryDto(JobType.DELETE, TargetEntityType.PROCESS_DEFINITION, "2");
+        new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
 
     assertThat(first.getId()).isNotEqualTo(second.getId());
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
@@ -20,8 +20,8 @@ public abstract class JobRegistryIndex<TBuilder> extends DefaultIndexMappingCrea
 
   public static final String ID = "id";
   public static final String JOB_TYPE = "jobType";
-  public static final String TARGET_ENTITY_TYPE = "targetEntityType";
-  public static final String TARGET_ENTITY_ID = "targetEntityId";
+  public static final String ENTITY_TYPE = "entityType";
+  public static final String ENTITY_ID = "entityId";
   public static final String STATUS = "status";
   public static final String ERROR_MESSAGE = "errorMessage";
   public static final String CREATED_AT = "createdAt";
@@ -32,8 +32,8 @@ public abstract class JobRegistryIndex<TBuilder> extends DefaultIndexMappingCrea
     return builder
         .properties(ID, p -> p.keyword(k -> k))
         .properties(JOB_TYPE, p -> p.keyword(k -> k))
-        .properties(TARGET_ENTITY_TYPE, p -> p.keyword(k -> k))
-        .properties(TARGET_ENTITY_ID, p -> p.keyword(k -> k))
+        .properties(ENTITY_TYPE, p -> p.keyword(k -> k))
+        .properties(ENTITY_ID, p -> p.keyword(k -> k))
         .properties(STATUS, p -> p.keyword(k -> k))
         .properties(ERROR_MESSAGE, p -> p.keyword(k -> k.ignoreAbove(IGNORE_ABOVE_CHAR_LIMIT)))
         .properties(CREATED_AT, p -> p.date(d -> d.format(OPTIMIZE_DATE_FORMAT)))


### PR DESCRIPTION
## Summary
- Rename `targetEntityType`/`targetEntityId` to `entityType`/`entityId` across `JobRegistryEntryDto`, the ES/OS index, and readers/writers
- Rename the `TargetEntityType` enum to `EntityType`

## Why
Field names implied a "target" distinction that doesn't exist — a job registry entry only ever refers to one entity. Safe to rename now since the job-registry index is unreleased (no migration needed).

## Test plan
- [x] `./mvnw install -pl optimize/util/optimize-commons -am -T1C -DskipTests` — green
- [x] `JobRegistryEntryDtoTest` — passes