### PR TITLE
docs: update routing info for CI medic delegation

### DIFF
--- a/docs/monorepo-docs/processes.md
+++ b/docs/monorepo-docs/processes.md
@@ -127,9 +127,12 @@ The DRI for an open Renovate PR is responsible for addressing the dependency upg
 - Escalate to Legal when license terms or obligations require clarification
   - Open a Jira ticket directly from the corresponding FOSSA issue
   - e.g. [issue](https://app.fossa.com/projects/custom%2B50756%2Fcamunda%2Fcamunda%40single-app/refs/branch/main/a23e32efeadc45545ae17ce70ed3908e3b9c5f7a/issues/licensing/10591187?revisionScanId=91861742) & [Jira ticket](https://jira.camunda.com/browse/OSS-24)
-- Delegate to the responsible team medics when Engineering actions are needed: use either of the 4 medics:
-  - **@core-features-medic** (Operate, Optimize, Tasklist)
-  - **@zeebe-medic** (Zeebe Engine)
+- Delegate to the responsible team medics when Engineering actions are needed: use either of the below medics:
+  - **@pod-operate-medic** (Operate Frontend)
+  - **@pod-employee-engagement-tasklist-medic** (Tasklist Frontend)
+  - **@bi-pod-medic** (Optimize Frontend)
+  - **@core-features-medic** (Operate, Tasklist, Optimize Backend)
+  - **@distributed-systems-medic** (Zeebe Engine)
   - **@data-layer-medic** (Elasticsearch, Opensearch, RDBMS layer)
   - **@identity-medic** (Identity) to delegate.
   - *If you're not sure about which medic to choose, pick the one that makes most sense to you. They will reroute you to the right one.*
@@ -141,14 +144,16 @@ The DRI for an open Renovate PR is responsible for addressing the dependency upg
 - Follow the [CI incident management process](#ci-incident-management).
 - Debug problems on GitHub Actions level yourself, involve the stakeholder teams (via their medic) or subject-matter experts for advice on technical details in certain sub-areas:
   - CI Knowledge Base: https://camunda.github.io/camunda/ci
-  - Core Features: **@core-features-medic** on Slack (e.g. issues with Operate, Optimize, Tasklist)
-  - Core Foundations:
-    - Data Layer: **@data-layer-medic** on Slack (e.g. issues with OpenSearch/Elasticsearch tests)
-    - Identity: **@identity-medic** on Slack (e.g. issues with Identity and Identity Management)
-    - Zeebe: **@zeebe-medic** on Slack
-  - Self-Managed:
-    - Distro **@distro-medic** on Slack (e.g. Helm chart integration tests)
-  - Infra: **@infra-medic** on Slack (e.g. self-hosted runner problems, Vault issues)
+  - Core Features: **@core-features-medic** on Slack (e.g. issues with backend/Java code of Operate, Optimize, Tasklist)
+  - Data Layer: **@data-layer-medic** on Slack (e.g. issues with OpenSearch/Elasticsearch tests)
+  - Distributed Systems: **@distributed-systems-medic** on Slack
+  - Distribution: **@distro-medic** on Slack (e.g. Helm chart integration tests, C8run)
+  - Identity: **@identity-medic** on Slack (e.g. issues with Identity and Identity Management)
+  - Infra: **@infra-medic** on Slack (e.g. self-hosted runner problems, Vault issues, Harbor issues)
+  - Operate frontend: **@pod-operate-medic** on Slack
+  - Optimize frontend: **@bi-pod-medic** on Slack
+  - Reliability testing: **@reliability-testing-medic** on Slack (e.g. load test CI or benchmark infra issues)
+  - Tasklist frontend: **@pod-employee-engagement-tasklist-medic** on Slack
 - Try to identify a (limited) workaround to unblock users.
 
 ## CI Incident Management


### PR DESCRIPTION
## Description

As [discussed on Slack](https://camunda.slack.com/archives/CHY2S7KDJ/p1786630886833179), after the re-org we need to update which team/medic to contact about what.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

None
