### PR TITLE
Share AI customizations across Claude and Copilot

### DIFF
--- a/.claude/agents/agentic-workflows.md
+++ b/.claude/agents/agentic-workflows.md
@@ -1,0 +1,6 @@
+---
+name: agentic-workflows
+description: Create, debug, and upgrade GitHub Agentic Workflows.
+---
+
+Read `.github/agents/agentic-workflows.md`, ignore only its YAML frontmatter, and follow its body.

--- a/.claude/agents/ci.md
+++ b/.claude/agents/ci.md
@@ -1,0 +1,6 @@
+---
+name: ci-agent
+description: Create, refactor, and validate GitHub Actions workflows for this monorepo.
+---
+
+Read `.github/agents/ci.agent.md`, ignore only its YAML frontmatter, and follow its body.

--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -1,0 +1,6 @@
+---
+name: frontend-agent
+description: Build, test, debug, and migrate Camunda frontend code.
+---
+
+Read `.github/agents/frontend.agent.md`, ignore only its YAML frontmatter, and follow its body.

--- a/.claude/skills/ci-flood-triage/SKILL.md
+++ b/.claude/skills/ci-flood-triage/SKILL.md
@@ -36,7 +36,7 @@ handle cross-incident merging.
 
 ### Step 1 — Parse the time window
 
-Read `$ARGUMENTS`. Supported forms:
+Read the time window from the user's request. Supported forms:
 
 | Argument | Meaning |
 |---|---|

--- a/.claude/skills/ci-incident/SKILL.md
+++ b/.claude/skills/ci-incident/SKILL.md
@@ -29,8 +29,8 @@ stop and ask for the incident ID.
 
 ### Step 1 — Parse the incident ID
 
-The incident ID comes from `$ARGUMENTS`. If empty, ask the user for it before proceeding. Do not
-guess from recent context.
+Read the incident ID from the user's request. If it is missing, ask the user for it before
+proceeding. Do not guess from recent context.
 
 ### Step 2 — Pull incident state
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,11 +254,14 @@ Load extra context on demand — only when relevant, only if the files exist.
 
 **When editing these areas**, read the corresponding instruction file:
 
+- CI/release MCP configuration (`.vscode/mcp.json`) →
+  `.github/instructions/ci-mcp-tooling.instructions.md`
 - Frontend code (`client/` directories) → `.github/instructions/frontend.instructions.md`
 - MCP gateway (`gateways/gateway-mcp/`) → `gateways/gateway-mcp/AGENTS.md`
 - Load tests (`load-tests/`, load test workflows) →
   `.github/instructions/load-tests.instructions.md`
-- Testing libraries / Camunda Process Test (`testing/`) → `testing/AGENTS.md`
+- Testing libraries / Camunda Process Test (`testing/`) →
+  `.github/instructions/testing.instructions.md` and `testing/AGENTS.md`
 
 **When working inside a specific module**:
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
               YamlFrontMatter flexmark extension
               -->
               <exclude>.github/instructions/**/*.md</exclude>
+              <exclude>.claude/agents/**/*.md</exclude>
               <exclude>.claude/skills/**/*.md</exclude>
               <exclude>.github/agents/**/*.md</exclude>
               <exclude>.github/workflows/**/*.md</exclude>


### PR DESCRIPTION
## Summary

- add Claude custom-agent adapters that delegate to the existing Copilot agent bodies
- route Claude to the existing path-scoped instructions
- make shared skill input parsing vendor-neutral

This keeps behavioral guidance single-sourced while preserving each tool's native discovery format.