### PR TITLE
feat: accept $or in the user task search API zod schema

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -21,7 +21,7 @@
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
 		"@bpmn-io/form-js-carbon-styles": "1.24.1",
 		"@bpmn-io/form-js-viewer": "1.24.1",
-		"@camunda/camunda-api-zod-schemas": "0.0.90",
+		"@camunda/camunda-api-zod-schemas": "0.0.91",
 		"@camunda/camunda-composite-components": "0.25.4",
 		"@camunda/design-system": "0.46.1",
 		"@camunda/session-heartbeat": "0.0.1",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -32,7 +32,7 @@
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
 				"@bpmn-io/form-js-carbon-styles": "1.24.1",
 				"@bpmn-io/form-js-viewer": "1.24.1",
-				"@camunda/camunda-api-zod-schemas": "0.0.90",
+				"@camunda/camunda-api-zod-schemas": "0.0.91",
 				"@camunda/camunda-composite-components": "0.25.4",
 				"@camunda/design-system": "0.46.1",
 				"@camunda/session-heartbeat": "0.0.1",
@@ -15027,7 +15027,7 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.90",
+				"@camunda/camunda-api-zod-schemas": "0.0.91",
 				"typescript": "7.0.2"
 			}
 		},
@@ -15068,7 +15068,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.90",
+			"version": "0.0.91",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "26.2.0",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.90",
+		"@camunda/camunda-api-zod-schemas": "0.0.91",
 		"typescript": "7.0.2"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.91
+
+### 🚀 Enhancements
+
+- Accept a top-level `$or` clause in the 8.10 user task search filter, matching the other search endpoints ([#59998](https://github.com/camunda/camunda/issues/59998))
+
+### ❤️ Contributors
+
+- Aleksander Dytko ([@aleksander-dytko](https://github.com/aleksander-dytko))
+
 ## v0.0.90
 
 ### 🩹 Fixes

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/user-task.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/user-task.ts
@@ -13,6 +13,7 @@ import {
 	advancedStringFilterSchema,
 	API_VERSION,
 	getEnumFilterSchema,
+	getOrFilterSchema,
 	getQueryRequestBodySchema,
 	getQueryResponseBodySchema,
 	type Endpoint,
@@ -74,32 +75,34 @@ const getUserTask = {
 
 const queryUserTasksRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: ['creationDate', 'completionDate', 'followUpDate', 'dueDate', 'priority', 'businessId'] as const,
-	filter: userTaskSchema
-		.pick({
-			state: true,
-			elementId: true,
-			tenantId: true,
-			processDefinitionId: true,
-			userTaskKey: true,
-			processDefinitionKey: true,
-			processInstanceKey: true,
-			elementInstanceKey: true,
-		})
-		.extend({
-			assignee: advancedStringFilterSchema,
-			businessId: advancedStringFilterSchema,
-			priority: advancedIntegerFilterSchema,
-			candidateGroup: advancedStringFilterSchema,
-			candidateUser: advancedStringFilterSchema,
-			creationDate: advancedDateTimeFilterSchema,
-			completionDate: advancedDateTimeFilterSchema,
-			followUpDate: advancedDateTimeFilterSchema,
-			dueDate: advancedDateTimeFilterSchema,
-			localVariables: z.array(userTaskVariableFilterSchema),
-			processInstanceVariables: z.array(userTaskVariableFilterSchema),
-			state: getEnumFilterSchema(userTaskStateSchema),
-		})
-		.partial(),
+	filter: getOrFilterSchema(
+		userTaskSchema
+			.pick({
+				state: true,
+				elementId: true,
+				tenantId: true,
+				processDefinitionId: true,
+				userTaskKey: true,
+				processDefinitionKey: true,
+				processInstanceKey: true,
+				elementInstanceKey: true,
+			})
+			.extend({
+				assignee: advancedStringFilterSchema,
+				businessId: advancedStringFilterSchema,
+				priority: advancedIntegerFilterSchema,
+				candidateGroup: advancedStringFilterSchema,
+				candidateUser: advancedStringFilterSchema,
+				creationDate: advancedDateTimeFilterSchema,
+				completionDate: advancedDateTimeFilterSchema,
+				followUpDate: advancedDateTimeFilterSchema,
+				dueDate: advancedDateTimeFilterSchema,
+				localVariables: z.array(userTaskVariableFilterSchema),
+				processInstanceVariables: z.array(userTaskVariableFilterSchema),
+				state: getEnumFilterSchema(userTaskStateSchema),
+			})
+			.partial(),
+	),
 });
 type QueryUserTasksRequestBody = z.infer<typeof queryUserTasksRequestBodySchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.90",
+	"version": "0.0.91",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

Wraps the user task search filter in `getOrFilterSchema`, so the frontend API contract accepts the top-level `$or` filter. Same one-line change #52701 made for element instances.

Without it a `$or` clause would not type-check against `queryUserTasksRequestBodySchema` and would be stripped by schema parsing.

The backend counterpart (#59999) is merged, so this now targets `main` directly.

## TODO

- [ ] Release package — cut `v0.0.91` (changelog + version bump + workspace dependency bumps), then dispatch [Publish Zod Schemas to npm](https://github.com/camunda/camunda/actions/workflows/publish-zod-schemas.yml) from `main` once this merges.

## Related issues

relates to #59998
