### PR TITLE
feat: apply a replication factor change to every physical tenant

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -80,7 +80,7 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
     // The replication factor of a zone-aware cluster follows from its zone specs, so it cannot be
     // set directly. Checked here as well as in operations(), because the new-model coordinator
     // plans through phases() alone and never calls operations() at all.
-    if (newReplicationFactor.isPresent() && !clusterConfiguration.toLegacyDefault().isUnzoned()) {
+    if (newReplicationFactor.isPresent() && !clusterConfiguration.isUnzoned()) {
       return Either.left(
           new InvalidRequest(
               "Changing the replication factor is not supported on zone-aware clusters."));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -68,18 +68,28 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
                     + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
       }
     }
-    if (changesMembership || newReplicationFactor.isPresent() || newPartitionCount.isEmpty()) {
-      // Cluster membership and the replication factor have no tenant dimension, so a request
-      // carrying either is planned exactly the way it always was, against the default group. So is
-      // a request that changes neither those nor the partition count, which has nothing to plan.
-      // That such a change redistributes only the default tenant's partitions, rather than every
-      // tenant's, is a gap that predates physical tenants being scalable at all; closing it needs
-      // global and partition-group phases planned together, tracked in #60192 and #60193.
+    if (changesMembership || (newPartitionCount.isEmpty() && newReplicationFactor.isEmpty())) {
+      // Cluster membership has no tenant dimension, so a request carrying it is planned exactly the
+      // way it always was, against the default group. So is a request that changes neither
+      // membership nor a partition dimension, which has nothing to plan. That a membership change
+      // redistributes only the default tenant's partitions, rather than every tenant's, is a gap
+      // that predates physical tenants being scalable at all; closing it needs global and
+      // partition-group phases planned together, tracked in #60193.
       return ConfigurationChangeRequest.super.phases(clusterConfiguration);
+    }
+    // The replication factor of a zone-aware cluster follows from its zone specs, so it cannot be
+    // set directly. Checked here as well as in operations(), because the new-model coordinator
+    // plans through phases() alone and never calls operations() at all.
+    if (newReplicationFactor.isPresent() && !clusterConfiguration.toLegacyDefault().isUnzoned()) {
+      return Either.left(
+          new InvalidRequest(
+              "Changing the replication factor is not supported on zone-aware clusters."));
     }
 
     final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
-    if (!clusterConfiguration.hasPartitionGroup(groupId)) {
+    // Only the partition count targets a group; the replication factor spans every tenant, so a
+    // request carrying it alone has no group that has to exist.
+    if (newPartitionCount.isPresent() && !clusterConfiguration.hasPartitionGroup(groupId)) {
       return Either.left(
           new NotFound(
               "Expected to patch physical tenant '%s', but there's no such tenant"

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -86,7 +86,7 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
                   .formatted(groupId)));
     }
     return PartitionGroupScalingPhases.phases(
-        groupId, clusterConfiguration, newPartitionCount.get());
+        groupId, clusterConfiguration, newPartitionCount, newReplicationFactor);
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -72,19 +72,20 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
       }
     }
     if (brokerCount.isPresent()
-        || newReplicationFactor.isPresent()
-        || newPartitionCount.isEmpty()) {
-      // Cluster membership and the replication factor have no tenant dimension, so a request
-      // carrying either is planned exactly the way it always was, against the default group. So is
-      // a request that changes neither those nor the partition count, which has nothing to plan.
-      // That such a change redistributes only the default tenant's partitions, rather than every
-      // tenant's, is a gap that predates physical tenants being scalable at all; closing it needs
-      // global and partition-group phases planned together, tracked in #60192 and #60193.
+        || (newPartitionCount.isEmpty() && newReplicationFactor.isEmpty())) {
+      // brokerCount changes cluster membership, which has no tenant dimension, so a request
+      // carrying it is planned exactly the way it always was, against the default group. So is a
+      // request that changes neither membership nor a partition dimension, which has nothing to
+      // plan. That a membership change redistributes only the default tenant's partitions, rather
+      // than every tenant's, is a gap that predates physical tenants being scalable at all;
+      // closing it needs global and partition-group phases planned together, tracked in #60193.
       return ConfigurationChangeRequest.super.phases(clusterConfiguration);
     }
 
     final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
-    if (!clusterConfiguration.hasPartitionGroup(groupId)) {
+    // Only the partition count targets a group; the replication factor spans every tenant, so a
+    // request carrying it alone has no group that has to exist.
+    if (newPartitionCount.isPresent() && !clusterConfiguration.hasPartitionGroup(groupId)) {
       return Either.left(
           new NotFound(
               "Expected to scale physical tenant '%s', but there's no such tenant"
@@ -134,11 +135,10 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
   }
 
   /**
-   * The zone rules this request has to satisfy, shared by {@link #operations} and the tenant-scoped
-   * {@link #phases} path: a zone may only be named on a zone-aware cluster and must be one the
-   * cluster knows, an unzoned request is only valid while no broker is zoned at all, and the
-   * replication factor of a zone-aware cluster is derived from its zone specs rather than set
-   * directly.
+   * The zone rules this request has to satisfy, shared by {@link #operations} and the {@link
+   * #phases} path: a zone may only be named on a zone-aware cluster and must be one the cluster
+   * knows, an unzoned request is only valid while no broker is zoned at all, and the replication
+   * factor of a zone-aware cluster is derived from its zone specs rather than set directly.
    *
    * @return the rejection to answer with, or empty if the request is valid
    */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -95,7 +95,7 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
       return Either.left(invalidZone.get());
     }
     return PartitionGroupScalingPhases.phases(
-        groupId, clusterConfiguration, newPartitionCount.get());
+        groupId, clusterConfiguration, newPartitionCount, newReplicationFactor);
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -35,8 +36,9 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
- * Plans a partition-count scale-up of one physical tenant's partition group, for {@link
- * ClusterScaleRequestTransformer} and {@link ClusterPatchRequestTransformer}.
+ * Plans a change to where the cluster's partitions live, for {@link ClusterScaleRequestTransformer}
+ * and {@link ClusterPatchRequestTransformer}: a partition-count scale-up of one physical tenant's
+ * partition group, a change of the cluster-wide replication factor, or both at once.
  *
  * <p>Partitions are distributed across brokers considering every physical tenant's partitions at
  * once, not just those of the tenant being scaled: a tenant scaled on its own would be placed as if
@@ -44,7 +46,9 @@ import java.util.stream.Stream;
  * tenant's partitions. This is why the change cannot be planned through {@code
  * ConfigurationChangeRequest#operations(ClusterConfiguration)} — the legacy configuration that
  * takes projects a single partition group, so a distribution computed from it can only ever see the
- * partitions of the group being scaled.
+ * partitions of the group being scaled. The replication factor is why this matters even when no
+ * partition count changes: it is a cluster-wide setting, so it has to reach every group's
+ * partitions rather than only the default group's.
  *
  * <p>The distribution itself is the cluster's configured {@link
  * io.camunda.zeebe.dynamic.config.PartitionDistributor} — the same round-robin (or zone-aware) one
@@ -62,35 +66,64 @@ final class PartitionGroupScalingPhases {
   private PartitionGroupScalingPhases() {}
 
   /**
-   * @param targetGroupId the partition group to scale; must exist in {@code clusterConfiguration}
+   * @param targetGroupId the partition group whose partition count changes; must exist in {@code
+   *     clusterConfiguration} whenever {@code newPartitionCount} is present, and is unused
+   *     otherwise — the replication factor has no target group
    * @param clusterConfiguration the current multi-group configuration
-   * @param newPartitionCount the partition count {@code targetGroupId} should reach
+   * @param newPartitionCount the partition count {@code targetGroupId} should reach, or empty to
+   *     leave every group's partition count as it is
+   * @param newReplicationFactor the replication factor every partition of every group should reach,
+   *     or empty to keep the one currently in use
    * @return a single {@link PartitionGroupParallelPhase} covering every group whose partitions have
-   *     to change, or no phase at all when the group already has {@code newPartitionCount}
-   *     partitions. Left if the target count is below the group's current one — partitions can only
-   *     be scaled up — or if no valid distribution exists for it.
+   *     to change, or no phase at all when the cluster already has the requested placement. Left if
+   *     the target count is below the group's current one — partitions can only be scaled up — if
+   *     the live brokers cannot satisfy the replication factor, or if no valid distribution exists.
    */
   static Either<Exception, List<Phase>> phases(
       final String targetGroupId,
       final CurrentClusterConfiguration clusterConfiguration,
-      final int newPartitionCount) {
+      final Optional<Integer> newPartitionCount,
+      final Optional<Integer> newReplicationFactor) {
     final var distributionByGroup =
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration);
     final var currentPartitionCount =
         distributionByGroup.getOrDefault(targetGroupId, Set.of()).size();
+    final int targetPartitionCount = newPartitionCount.orElse(currentPartitionCount);
 
-    if (newPartitionCount < currentPartitionCount) {
+    if (targetPartitionCount < currentPartitionCount) {
       return Either.left(
           new InvalidRequest(
               "New partition count [%d] of physical tenant '%s' must be greater than or equal to its current partition count [%d]"
-                  .formatted(newPartitionCount, targetGroupId, currentPartitionCount)));
+                  .formatted(targetPartitionCount, targetGroupId, currentPartitionCount)));
     }
-    if (newPartitionCount == currentPartitionCount) {
+    if (newReplicationFactor.isEmpty() && targetPartitionCount == currentPartitionCount) {
+      // Nothing is asked for that the cluster does not already have. Returning before the
+      // distributor runs is what keeps such a request a no-op: a placement that has drifted from
+      // what the distributor would compute now — after a manual reassignment through
+      // /partition-distribution, say — would otherwise be rebalanced by a request that asked for
+      // no change at all.
       return Either.right(List.of());
     }
 
+    final int replicationFactor =
+        newReplicationFactor.orElseGet(() -> currentReplicationFactor(distributionByGroup));
+    final var liveMembers = clusterConfiguration.liveMembers();
+    // Rejected here rather than left to the distributor so that the operator sees why the request
+    // is impossible, with the same wording PartitionReassignRequestTransformer answers with.
+    if (replicationFactor <= 0) {
+      return Either.left(
+          new InvalidRequest(
+              "Replication factor [%d] must be greater than 0".formatted(replicationFactor)));
+    }
+    if (liveMembers.size() < replicationFactor) {
+      return Either.left(
+          new InvalidRequest(
+              "Number of brokers [%d] is less than the replication factor [%d]"
+                  .formatted(liveMembers.size(), replicationFactor)));
+    }
+
     final var newPartitionIds =
-        IntStream.rangeClosed(currentPartitionCount + 1, newPartitionCount)
+        IntStream.rangeClosed(currentPartitionCount + 1, targetPartitionCount)
             .mapToObj(number -> new PartitionId(targetGroupId, number))
             .toList();
     final var targetPartitionIds =
@@ -100,38 +133,40 @@ final class PartitionGroupScalingPhases {
                     .map(PartitionMetadata::id),
                 newPartitionIds.stream())
             .toList();
-    final var replicationFactor = replicationFactor(distributionByGroup);
 
     final Map<String, List<PartitionGroupOperation>> operationsByGroup;
     try {
       final var targetDistribution =
           targetDistribution(
-              clusterConfiguration,
-              clusterConfiguration.liveMembers(),
-              targetPartitionIds,
-              replicationFactor);
+              clusterConfiguration, liveMembers, targetPartitionIds, replicationFactor);
       operationsByGroup =
           new LinkedHashMap<>(
               PartitionReassignmentOperationsGenerator.generateOperations(
                   clusterConfiguration, targetDistribution, Map.of()));
     } catch (final RuntimeException e) {
       // What the distributor and the generator raise is a rejection of the request, not an internal
-      // failure: too few live brokers for the replication factor, a distributor that cannot place
-      // these partitions, a distribution that would drop one.
+      // failure: a distributor that cannot place these partitions, a distribution that would drop
+      // one.
       return Either.left(new InvalidRequest(e));
     }
 
-    final var newPartitionNumbers =
-        new TreeSet<>(newPartitionIds.stream().map(PartitionId::number).toList());
-    operationsByGroup.put(
-        targetGroupId,
-        withScaleUpOperations(
-            operationsByGroup.getOrDefault(targetGroupId, List.of()),
-            ClusterConfigurationCoordinatorSupplier.from(() -> clusterConfiguration)
-                .getDefaultCoordinator(),
-            newPartitionCount,
-            newPartitionNumbers));
+    if (!newPartitionIds.isEmpty()) {
+      final var newPartitionNumbers =
+          new TreeSet<>(newPartitionIds.stream().map(PartitionId::number).toList());
+      operationsByGroup.put(
+          targetGroupId,
+          withScaleUpOperations(
+              operationsByGroup.getOrDefault(targetGroupId, List.of()),
+              ClusterConfigurationCoordinatorSupplier.from(() -> clusterConfiguration)
+                  .getDefaultCoordinator(),
+              targetPartitionCount,
+              newPartitionNumbers));
+    }
 
+    if (operationsByGroup.isEmpty()) {
+      // Every partition already sits where the requested distribution puts it.
+      return Either.right(List.of());
+    }
     return Either.right(List.of(new PartitionGroupParallelPhase(operationsByGroup)));
   }
 
@@ -150,12 +185,13 @@ final class PartitionGroupScalingPhases {
   }
 
   /**
-   * The replication factor every partition should keep. Taken as the minimum currently in use
-   * rather than a configured value, mirroring {@code ClusterConfiguration#minReplicationFactor}:
-   * during a configuration change a partition can temporarily hold more replicas than the cluster
-   * is configured for, and treating that as the target would permanently widen it.
+   * The replication factor every partition should keep when the request does not ask for one. Taken
+   * as the minimum currently in use rather than a configured value, mirroring {@code
+   * ClusterConfiguration#minReplicationFactor}: during a configuration change a partition can
+   * temporarily hold more replicas than the cluster is configured for, and treating that as the
+   * target would permanently widen it.
    */
-  private static int replicationFactor(
+  private static int currentReplicationFactor(
       final Map<String, Set<PartitionMetadata>> distributionByGroup) {
     return distributionByGroup.values().stream()
         .flatMap(Set::stream)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
@@ -60,6 +60,11 @@ import java.util.stream.Stream;
  *
  * <p>{@link PartitionReassignmentOperationsGenerator} turns the resulting distribution into
  * operations per group, emitting them only where a partition's placement actually changed.
+ *
+ * <p>Every group of the given configuration is planned for, disabled physical tenants included —
+ * the coordinator removes those before it calls {@code ConfigurationChangeRequest#phases} (see
+ * {@code ConfigurationChangeRequest#applyToDisabledTenants}), so a group that reaches this planner
+ * is one that runs on a broker and can apply an operation. No filter is needed here.
  */
 final class PartitionGroupScalingPhases {
 
@@ -90,36 +95,28 @@ final class PartitionGroupScalingPhases {
         distributionByGroup.getOrDefault(targetGroupId, Set.of()).size();
     final int targetPartitionCount = newPartitionCount.orElse(currentPartitionCount);
 
-    if (targetPartitionCount < currentPartitionCount) {
-      return Either.left(
-          new InvalidRequest(
-              "New partition count [%d] of physical tenant '%s' must be greater than or equal to its current partition count [%d]"
-                  .formatted(targetPartitionCount, targetGroupId, currentPartitionCount)));
-    }
     if (newReplicationFactor.isEmpty() && targetPartitionCount == currentPartitionCount) {
       // Nothing is asked for that the cluster does not already have. Returning before the
       // distributor runs is what keeps such a request a no-op: a placement that has drifted from
       // what the distributor would compute now — after a manual reassignment through
       // /partition-distribution, say — would otherwise be rebalanced by a request that asked for
-      // no change at all.
+      // no change at all. It also keeps a request that asks for nothing answerable while the
+      // cluster cannot satisfy its own replication factor, e.g. with a broker down.
       return Either.right(List.of());
     }
 
     final int replicationFactor =
         newReplicationFactor.orElseGet(() -> currentReplicationFactor(distributionByGroup));
     final var liveMembers = clusterConfiguration.liveMembers();
-    // Rejected here rather than left to the distributor so that the operator sees why the request
-    // is impossible, with the same wording PartitionReassignRequestTransformer answers with.
-    if (replicationFactor <= 0) {
-      return Either.left(
-          new InvalidRequest(
-              "Replication factor [%d] must be greater than 0".formatted(replicationFactor)));
-    }
-    if (liveMembers.size() < replicationFactor) {
-      return Either.left(
-          new InvalidRequest(
-              "Number of brokers [%d] is less than the replication factor [%d]"
-                  .formatted(liveMembers.size(), replicationFactor)));
+    final var rejection =
+        reject(
+            targetGroupId,
+            liveMembers,
+            currentPartitionCount,
+            targetPartitionCount,
+            replicationFactor);
+    if (rejection.isPresent()) {
+      return Either.left(rejection.get());
     }
 
     final var newPartitionIds =
@@ -168,6 +165,43 @@ final class PartitionGroupScalingPhases {
       return Either.right(List.of());
     }
     return Either.right(List.of(new PartitionGroupParallelPhase(operationsByGroup)));
+  }
+
+  /**
+   * The rejections that can be decided from the request and the current configuration alone, before
+   * a distribution is computed. What the distributor itself rejects — a placement it cannot produce
+   * for these members and zones — surfaces separately, as the {@code RuntimeException} it raises.
+   *
+   * <p>Both bounds on the replication factor are checked here rather than left to the distributor
+   * so that the operator sees why the request is impossible, with the same wording {@code
+   * PartitionReassignRequestTransformer} answers with.
+   *
+   * @return the rejection to answer with, or empty if the request can be planned
+   */
+  private static Optional<Exception> reject(
+      final String targetGroupId,
+      final Set<MemberId> liveMembers,
+      final int currentPartitionCount,
+      final int targetPartitionCount,
+      final int replicationFactor) {
+    if (targetPartitionCount < currentPartitionCount) {
+      return Optional.of(
+          new InvalidRequest(
+              "New partition count [%d] of physical tenant '%s' must be greater than or equal to its current partition count [%d]"
+                  .formatted(targetPartitionCount, targetGroupId, currentPartitionCount)));
+    }
+    if (replicationFactor <= 0) {
+      return Optional.of(
+          new InvalidRequest(
+              "Replication factor [%d] must be greater than 0".formatted(replicationFactor)));
+    }
+    if (liveMembers.size() < replicationFactor) {
+      return Optional.of(
+          new InvalidRequest(
+              "Number of brokers [%d] is less than the replication factor [%d]"
+                  .formatted(liveMembers.size(), replicationFactor)));
+    }
+    return Optional.empty();
   }
 
   private static Set<PartitionMetadata> targetDistribution(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.state;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.InitializableClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
@@ -103,6 +104,23 @@ public record CurrentClusterConfiguration(
 
   public Optional<String> clusterId() {
     return globalConfiguration.clusterId();
+  }
+
+  /**
+   * Whether the cluster does not use zone awareness at all: no broker is assigned to a zone and the
+   * partition distributor is not zone-aware. A cluster where only some of the two holds is
+   * mid-migration between the two modes rather than unzoned.
+   *
+   * <p>Both are global state, so this reads the same fields {@link
+   * ClusterConfiguration#isUnzoned()} does — the projection through {@link #toLegacyDefault()} that
+   * method needs is not.
+   */
+  public boolean isUnzoned() {
+    return globalConfiguration.members().keySet().stream().allMatch(member -> member.zone() == null)
+        && globalConfiguration
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .isEmpty();
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -24,6 +24,8 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
@@ -359,6 +361,14 @@ final class ClusterPatchRequestTransformerTest {
         .toList();
   }
 
+  private static List<PartitionJoinOperation> joins(
+      final PartitionGroupParallelPhase phase, final String groupId) {
+    return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
+        .filter(PartitionJoinOperation.class::isInstance)
+        .map(PartitionJoinOperation.class::cast)
+        .toList();
+  }
+
   @Test
   void shouldTargetOnlyTheRequestedPhysicalTenantsPartitionGroup() {
     // given — tenant-b currently has 1 partition; scale it to 2
@@ -493,5 +503,138 @@ final class ClusterPatchRequestTransformerTest {
 
     // then
     assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  // -- cluster-wide replication factor (phases()) --
+
+  @Test
+  void shouldApplyReplicationFactorToEveryPhysicalTenant() {
+    // given — every partition of both tenants is currently held by a single broker
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.empty(), Optional.of(2), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — every partition of every tenant gains a second replica. Planning this against the
+    // default group's projection alone, as an unscoped request used to, would have left tenant-b
+    // at a replication factor nobody chose for it.
+    final var phase = singlePhase(result);
+    Assertions.assertThat(phase.groupOperations()).containsOnlyKeys(DEFAULT_GROUP, TENANT_B);
+    Assertions.assertThat(joins(phase, DEFAULT_GROUP))
+        .extracting(PartitionJoinOperation::partitionId)
+        .containsExactlyInAnyOrder(1, 2);
+    Assertions.assertThat(joins(phase, TENANT_B))
+        .extracting(PartitionJoinOperation::partitionId)
+        .containsExactly(1);
+  }
+
+  @Test
+  void shouldNotRunScaleUpOperationsForAReplicationFactorChange() {
+    // given
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.empty(), Optional.of(2), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — no partition is added, so the engine never has to be told about a new partition count
+    // nor awaited for redistribution and relocation
+    Assertions.assertThat(singlePhase(result).groupOperations().values())
+        .allSatisfy(
+            operations ->
+                Assertions.assertThat(operations).noneMatch(ScaleUpOperation.class::isInstance));
+  }
+
+  @Test
+  void shouldApplyReplicationFactorAndPartitionCountTogether() {
+    // given — the default tenant is scaled from 2 partitions to 3 and the replication factor from
+    // 1 to 2 in one request
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.of(3), Optional.of(2), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — only the default tenant gains a partition, but both tenants reach the new replication
+    // factor: the partition count targets one group, the replication factor spans all of them
+    final var phase = singlePhase(result);
+    Assertions.assertThat(bootstraps(phase, DEFAULT_GROUP))
+        .singleElement()
+        .satisfies(op -> Assertions.assertThat(op.partitionId()).isEqualTo(3));
+    Assertions.assertThat(bootstraps(phase, TENANT_B)).isEmpty();
+    Assertions.assertThat(joins(phase, TENANT_B)).isNotEmpty();
+  }
+
+  @Test
+  void shouldRejectReplicationFactorAboveTheNumberOfBrokers() {
+    // given — three brokers cannot hold four replicas of a partition
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.empty(), Optional.of(4), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("Number of brokers [3] is less than the replication factor [4]");
+  }
+
+  @Test
+  void shouldRejectReplicationFactorOnZoneAwareCluster() {
+    // given — a zone-aware cluster derives its replication factor from its zone specs, so it
+    // cannot be set directly
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.empty(), Optional.of(2), Optional.empty());
+
+    // when
+    final var result = transformer.phases(zoneAwareTwoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("not supported on zone-aware clusters");
+  }
+
+  @Test
+  void shouldPlanNothingWhenOnlyThePartitionCountIsGivenAndUnchanged() {
+    // given — the default tenant already has the requested 2 partitions, and no replication factor
+    // is requested
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(), Optional.of(2), Optional.empty(), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — a request that asks for nothing plans nothing, rather than rebalancing a placement
+    // that may have drifted from what the distributor would compute now
+    assertThat(result).isRight();
+    Assertions.assertThat(result.get()).isEmpty();
+  }
+
+  /** {@link #twoTenantCluster()} with a zone-aware partition distributor. */
+  private CurrentClusterConfiguration zoneAwareTwoTenantCluster() {
+    final var cluster = twoTenantCluster();
+    final var global = cluster.globalConfiguration();
+    return new CurrentClusterConfiguration(
+        cluster.version(),
+        new GlobalConfiguration(
+            global.version(),
+            global.clusterId(),
+            global.members(),
+            Optional.of(new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1)))),
+            global.pendingChanges(),
+            global.lastChange()),
+        cluster.partitionGroups(),
+        cluster.phasedChangeState());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -468,6 +468,14 @@ final class ClusterScaleRequestTransformerTest {
         .toList();
   }
 
+  private static List<PartitionJoinOperation> joins(
+      final PartitionGroupParallelPhase phase, final String groupId) {
+    return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
+        .filter(PartitionJoinOperation.class::isInstance)
+        .map(PartitionJoinOperation.class::cast)
+        .toList();
+  }
+
   @Test
   void shouldTargetOnlyTheRequestedPhysicalTenantsPartitionGroup() {
     // given — tenant-b currently has 1 partition; scale it to 2
@@ -630,5 +638,63 @@ final class ClusterScaleRequestTransformerTest {
 
     // then
     assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  // -- cluster-wide replication factor (phases()) --
+
+  private ClusterScaleRequestTransformer replicationFactorTransformer(
+      final int newReplicationFactor, final Optional<String> zone) {
+    return new ClusterScaleRequestTransformer(
+        Optional.empty(), Optional.empty(), Optional.of(newReplicationFactor), zone);
+  }
+
+  @Test
+  void shouldApplyReplicationFactorToEveryPhysicalTenant() {
+    // given — every partition of both tenants is currently held by a single broker
+    final var transformer = replicationFactorTransformer(2, Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — every partition of every tenant gains a second replica, rather than only the default
+    // tenant's, which is what planning against the default group's projection alone produced
+    final var phase = singlePhase(result);
+    Assertions.assertThat(phase.groupOperations()).containsOnlyKeys(DEFAULT_GROUP, TENANT_B);
+    Assertions.assertThat(joins(phase, DEFAULT_GROUP))
+        .extracting(PartitionJoinOperation::partitionId)
+        .containsExactlyInAnyOrder(1, 2);
+    Assertions.assertThat(joins(phase, TENANT_B))
+        .extracting(PartitionJoinOperation::partitionId)
+        .containsExactly(1);
+  }
+
+  @Test
+  void shouldRejectReplicationFactorAboveTheNumberOfBrokers() {
+    // given — three brokers cannot hold four replicas of a partition
+    final var transformer = replicationFactorTransformer(4, Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("Number of brokers [3] is less than the replication factor [4]");
+  }
+
+  @Test
+  void shouldRejectReplicationFactorWithZone() {
+    // given — the replication factor of a zone-aware cluster follows from its zone specs
+    final var transformer = replicationFactorTransformer(2, Optional.of(ZONE_A));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("/partition-distribution");
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantReplicationFactorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantReplicationFactorIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a replication factor change through {@code PATCH /actuator/cluster} reaches every
+ * physical tenant's partition group (issue #60192), not only the default one.
+ *
+ * <p>The replication factor is a cluster-wide setting — it cannot be scoped to a tenant, and
+ * combining it with {@code physicalTenant} is rejected — so a change that reached only the default
+ * tenant left the others at a durability level nobody chose, with nothing in the response saying
+ * so.
+ *
+ * <p>The two tenants are deliberately given different partition counts. A wrong-group write would
+ * otherwise be hard to see: if both ran the same number of partitions, replicating the wrong one
+ * would still leave every count looking plausible.
+ */
+@ZeebeIntegration
+final class PhysicalTenantReplicationFactorIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int BROKERS_COUNT = 3;
+  private static final int DEFAULT_TENANT_PARTITIONS_COUNT = 1;
+  private static final int TENANT_A_PARTITIONS_COUNT = 2;
+  private static final int INITIAL_REPLICATION_FACTOR = 1;
+  private static final int TARGET_REPLICATION_FACTOR = 3;
+  private static final int ACTOR_THREAD_COUNT =
+      DEFAULT_TENANT_PARTITIONS_COUNT + TENANT_A_PARTITIONS_COUNT;
+
+  // Routing through PhysicalTenantsITHelper both supplies a real config diff (secondary storage =
+  // none) so the tenant is discovered and bootstrapped, and declares the per-tenant
+  // security.initialization block that PhysicalTenantRequiredOverrideValidation requires once a
+  // non-default tenant exists.
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(BROKERS_COUNT)
+          .withReplicationFactor(INITIAL_REPLICATION_FACTOR)
+          .withPartitionsCount(DEFAULT_TENANT_PARTITIONS_COUNT)
+          .withBrokerConfig(
+              broker ->
+                  TENANTS.configure(
+                      broker
+                          .withUnauthenticatedAccess()
+                          .withPtConfig(
+                              TENANT_A,
+                              camunda ->
+                                  camunda.getCluster().setPartitionCount(TENANT_A_PARTITIONS_COUNT))
+                          // TestClusterBuilder sizes the actor threads as
+                          // (partitions * replicationFactor) / brokers, which is 0 for a cluster
+                          // that starts at replication factor 1 — and a scheduler with no threads
+                          // cannot start a broker at all. Size them for what the brokers hold once
+                          // every partition of both tenants is fully replicated.
+                          .withUnifiedConfig(
+                              camunda -> {
+                                camunda.getSystem().setCpuThreadCount(ACTOR_THREAD_COUNT);
+                                camunda.getSystem().setIoThreadCount(ACTOR_THREAD_COUNT);
+                              })))
+          .build();
+
+  @Test
+  void shouldReplicateEveryPhysicalTenantsPartitions() {
+    // given — every partition of both tenants is held by a single broker
+    awaitReplicationFactor(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, INITIAL_REPLICATION_FACTOR);
+    awaitReplicationFactor(TENANT_A, INITIAL_REPLICATION_FACTOR);
+
+    // when — the replication factor is raised, naming no tenant
+    awaitAccepted(
+        "the cluster accepts the replication factor change",
+        () ->
+            ClusterActuator.of(cluster.availableGateway())
+                .patchCluster(
+                    new ClusterConfigPatchRequest()
+                        .partitions(
+                            new ClusterConfigPatchRequestPartitions()
+                                .replicationFactor(TARGET_REPLICATION_FACTOR)),
+                    false,
+                    false));
+
+    // then — every partition of every tenant really gained its replicas. Asserting through each
+    // tenant's own client topology, rather than the cluster configuration, is what shows the
+    // replicas joined and are healthy instead of only being planned.
+    awaitReplicationFactor(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, TARGET_REPLICATION_FACTOR);
+    awaitReplicationFactor(TENANT_A, TARGET_REPLICATION_FACTOR);
+  }
+
+  private void awaitReplicationFactor(
+      final String physicalTenantId, final int expectedReplicationFactor) {
+    final var partitionCount =
+        PhysicalTenantsITHelper.DEFAULT_TENANT_ID.equals(physicalTenantId)
+            ? DEFAULT_TENANT_PARTITIONS_COUNT
+            : TENANT_A_PARTITIONS_COUNT;
+    try (final var client =
+        TENANTS.newClientBuilder(cluster.availableGateway(), physicalTenantId).build()) {
+      await(
+              "physical tenant '%s' replicates its %d partitions %d times"
+                  .formatted(physicalTenantId, partitionCount, expectedReplicationFactor))
+          .atMost(Duration.ofSeconds(120))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                      .isComplete(BROKERS_COUNT, partitionCount, expectedReplicationFactor));
+    }
+  }
+
+  /**
+   * Retries {@code request} until the cluster accepts it. The request is not an assertion — it
+   * either returns or throws a {@link feign.FeignException} — so it cannot be handed to {@code
+   * untilAsserted}, which only retries on {@link AssertionError}. A retry is needed because the
+   * cluster can still be applying its own initial configuration change when the test starts, and
+   * rejects a second change while one is in progress.
+   */
+  private void awaitAccepted(final String alias, final Runnable request) {
+    await(alias)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              request.run();
+              return true;
+            });
+  }
+}


### PR DESCRIPTION
Makes a replication factor change through `PATCH /actuator/cluster` reach every physical tenant's partition group instead of only the default one.

Both transformers now plan through `PartitionGroupScalingPhases` whenever the request does not change cluster membership, whether it carries a replication factor, a partition count, or [both](https://github.com/camunda/camunda/blob/0aa468ac28b0f7a8c3be3017a6352e2aa8b73d7d/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java#L71). That planner, added by #60098, already computes a distribution over every group's partitions and turns it into operations per group, so it only needed the replication factor as an input rather than deriving it from the existing distribution. No global phases are involved: membership does not change, so a single `PartitionGroupParallelPhase` covers every tenant, the same shape a partition-count scale-up already produces. Going slightly beyond the issue, a request combining a replication factor with a partition count is planned this way too — the condition is simpler than singling out the replication-factor-only case, and it stops that combination from staying default-tenant-only. A request that does change membership keeps the old path and so still reaches the default tenant alone; closing that needs global and partition-group phases planned together, tracked in #60193.

Two validations move onto the `phases()` path, because the new-model coordinator plans through `phases()` alone and never calls `operations()`: the rejection of a replication factor change on a zone-aware cluster, where the factor follows from the zone specs, and the bounds on the factor itself. The latter live in the planner and repeat the wording `PartitionReassignRequestTransformer` answers with, so the error an operator sees does not depend on which path produced it. The tenant-existence check is now only made when a partition count is requested, since only the partition count targets a group.

Rebased onto `main` now that #60188 has landed, which is what the third commit overlapped with, so that commit is gone: the coordinator hands `phases()` a configuration with disabled physical tenants already removed unless the request opts into seeing them, which covers both halves of what that commit did — placing a disabled tenant's partitions, and counting them as load when placing another tenant's. The planner's [javadoc](https://github.com/camunda/camunda/blob/0aa468ac28b0f7a8c3be3017a6352e2aa8b73d7d/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java#L64-L67) records where the filter now lives, since a planner that fans out over every group it is given otherwise looks like it is missing one.

The last two commits are review feedback. [`CurrentClusterConfiguration#isUnzoned`](https://github.com/camunda/camunda/blob/0aa468ac28b0f7a8c3be3017a6352e2aa8b73d7d/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java#L109-L124) answers the zone question from the new model — zones are global state, so the legacy projection the check used to go through was never needed — and the planner's rejections move into [one method](https://github.com/camunda/camunda/blob/0aa468ac28b0f7a8c3be3017a6352e2aa8b73d7d/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java#L170-L205) so the planning steps read in sequence.

closes #60192
