### PR TITLE
fix codeowners of oc webapps

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -426,7 +426,7 @@ optimize.Dockerfile         @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml @camunda/core-features
 /.github/workflows/ci-database-integration-tests-reusable.yml @camunda/data-layer
-/.github/workflows/frontend-sbom-snyk-nightly.yml @camunda/hub-frontend
+/.github/workflows/frontend-sbom-snyk-nightly.yml @camunda/orchestration-cluster-webapps
 /.github/workflows/zeebe-release-stable-dry-run.yml @camunda/engineering-operations
 /.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml    @camunda/test-automation-team
 /.github/workflows/c8-orchestration-cluster-nightly-8.7-api-es.yml                 @camunda/test-automation-team

--- a/.github/workflows/frontend-sbom-snyk-nightly.yml
+++ b/.github/workflows/frontend-sbom-snyk-nightly.yml
@@ -1,7 +1,7 @@
 # description: Nightly frontend SBOM vulnerability scan using Snyk.
-#              Reports failures to #team-core-features-frontend on Slack.
+#              Reports failures to #team-orchestration-cluster-webapps on Slack.
 # type: CI
-# owner: @camunda/core-features
+# owner: @camunda/orchestration-cluster-webapps
 ---
 name: Frontend SBOM Snyk Nightly
 run-name: Frontend SBOM Snyk (${{ inputs.branch }})
@@ -38,7 +38,7 @@ permissions:
   contents: read
 
 env:
-  TEST_OWNER: '@camunda/hub-frontend'
+  TEST_OWNER: '@camunda/orchestration-cluster-webapps'
 
 jobs:
   identity-fe-sbom-snyk:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,7 +41,7 @@
 /.github/workflows/assign-urgency-to-issues-cron.yml                          @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-nightly-metrics-report.yml        @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-responses-regenerate.yml          @camunda/core-features
-/.github/workflows/frontend-sbom-snyk-nightly.yml                             @camunda/core-features
+/.github/workflows/frontend-sbom-snyk-nightly.yml                             @camunda/orchestration-cluster-webapps
 /.github/workflows/optimize-release-optimize-c8-only.yml                      @camunda/core-features
 /.github/workflows/publish-zod-schemas.yml                                    @camunda/core-features
 /.github/workflows/verify-x-added-in-version-annotations.yml                 @camunda/core-features


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix codeowners of oc webapps.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

See https://camunda.slack.com/archives/C0BQ5GJGZ7X/p1786962446827289
