### PR TITLE
fix: make the journal safe to read from another thread than the writer

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -123,11 +123,26 @@ public interface Journal extends AutoCloseable {
   void flush() throws FlushException;
 
   /**
-   * Opens a new {@link JournalReader}
+   * Opens a new {@link JournalReader} for a consumer that reads on the same thread that writes to
+   * this journal. Records it returns point directly into the journal, and stay valid until the next
+   * call on the reader.
    *
    * @return a journal reader
    */
   JournalReader openReader();
+
+  /**
+   * Opens a new {@link JournalReader} for a consumer that reads on another thread than the one that
+   * writes to this journal. Records such a reader returned stay valid until the next call on the
+   * reader, even if they are deleted in the meantime: deleting them does not overwrite them, and
+   * does not unmap the segment they are in.
+   *
+   * <p>This costs a new segment per deletion that leaves records this reader read behind, so only
+   * use it for consumers that really do read on another thread.
+   *
+   * @return a journal reader
+   */
+  JournalReader openConcurrentReader();
 
   /**
    * Check if the journal is open

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/FrameUtil.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/FrameUtil.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 
 final class FrameUtil {
@@ -26,6 +27,10 @@ final class FrameUtil {
   private FrameUtil() {}
 
   static void writeVersion(final ByteBuffer buffer, final int offset) {
+    // The version is what makes a record visible to readers, and a reader may run on another
+    // thread than the writer. Without this fence, such a reader can observe the version before the
+    // record it belongs to, and read a record that is still being written.
+    VarHandle.releaseFence();
     write(buffer, offset, VERSION);
   }
 
@@ -48,7 +53,13 @@ final class FrameUtil {
     if (buffer.capacity() < buffer.position() + LENGTH) {
       return false;
     }
-    return buffer.get(buffer.position()) != IGNORE;
+    if (buffer.get(buffer.position()) == IGNORE) {
+      return false;
+    }
+    // Pairs with the release fence in writeVersion: having seen the version, we may now read the
+    // record it publishes.
+    VarHandle.acquireFence();
+    return true;
   }
 
   static int getLength() {

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -313,6 +313,19 @@ final class SegmentWriter {
     FrameUtil.markAsIgnored(buffer, position);
   }
 
+  /**
+   * Flushes the invalidated frame that marks where this segment's records end, so that a restart
+   * cannot read whatever follows it. Only needed when the segment stops being written before it is
+   * full, as the records after the invalidated frame are otherwise overwritten anyway.
+   *
+   * <p>Expects the position to be at that frame, which is where truncating leaves it. A caller that
+   * flushes a segment whose records end at its capacity fails here, rather than silently skipping a
+   * marker that recovery relies on.
+   */
+  void flushEndOfRecords() {
+    buffer.force(buffer.position(), FrameUtil.getLength());
+  }
+
   private void jumpToLastEntry(final int lastPosition, final long lastIndex) {
     try {
       buffer.position(lastPosition);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -110,8 +110,7 @@ public final class SegmentedJournal implements Journal {
           final var stamp = rwlock.writeLock();
           try {
             writer.deleteAfter(indexExclusive);
-            // Reset segment readers.
-            resetAdvancedReaders(indexExclusive + 1);
+            readers.forEach(reader -> reader.onTruncatedAfter(indexExclusive));
           } finally {
             rwlock.unlockWrite(stamp);
           }
@@ -309,19 +308,6 @@ public final class SegmentedJournal implements Journal {
 
   void closeReader(final SegmentedJournalReader segmentedJournalReader) {
     readers.remove(segmentedJournalReader);
-  }
-
-  /**
-   * Resets journal readers to the given index, if they are at a larger index.
-   *
-   * @param index The index at which to reset readers.
-   */
-  private void resetAdvancedReaders(final long index) {
-    for (final SegmentedJournalReader reader : readers) {
-      if (reader.getNextIndex() > index) {
-        reader.unsafeSeek(index);
-      }
-    }
   }
 
   JournalIndex getJournalIndex() {

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -109,7 +109,7 @@ public final class SegmentedJournal implements Journal {
         () -> {
           final var stamp = rwlock.writeLock();
           try {
-            writer.deleteAfter(indexExclusive);
+            writer.deleteAfter(indexExclusive, hasConcurrentReaderPast(indexExclusive));
             readers.forEach(reader -> reader.onTruncatedAfter(indexExclusive));
           } finally {
             rwlock.unlockWrite(stamp);
@@ -187,9 +187,18 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public JournalReader openReader() {
+    return openReader(false);
+  }
+
+  @Override
+  public JournalReader openConcurrentReader() {
+    return openReader(true);
+  }
+
+  private JournalReader openReader(final boolean readsConcurrently) {
     final var stamped = acquireReadlock();
     try {
-      final var reader = new SegmentedJournalReader(this, journalMetrics);
+      final var reader = new SegmentedJournalReader(this, journalMetrics, readsConcurrently);
       readers.add(reader);
       return reader;
     } finally {
@@ -308,6 +317,21 @@ public final class SegmentedJournal implements Journal {
 
   void closeReader(final SegmentedJournalReader segmentedJournalReader) {
     readers.remove(segmentedJournalReader);
+  }
+
+  /**
+   * Whether any reader that reads on another thread has already read a record after the given
+   * index. Such a reader handed that record to a consumer that may still be reading it straight
+   * from the segment, so the records after the given index must stay where they are instead of
+   * being overwritten. Readers that read on the writer's thread need no such care: this truncation
+   * runs on that thread, so their consumer is not reading a record right now.
+   *
+   * <p>Reading the reader positions here is safe: readers only move while holding the read lock,
+   * which the write lock held during a truncation excludes.
+   */
+  private boolean hasConcurrentReaderPast(final long index) {
+    return readers.stream()
+        .anyMatch(reader -> reader.readsConcurrently() && reader.getNextIndex() > index + 1);
   }
 
   JournalIndex getJournalIndex() {

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
@@ -24,10 +24,19 @@ import java.util.NoSuchElementException;
 
 class SegmentedJournalReader implements JournalReader {
 
+  private static final long NO_TRUNCATION = Long.MIN_VALUE;
+
   private final SegmentedJournal journal;
   private Segment currentSegment;
   private SegmentReader currentReader;
   private final JournalMetrics metrics;
+
+  /**
+   * The index a truncation deleted after, set by the truncating thread and applied by this reader's
+   * own thread. Written while holding the journal's write lock and read while holding its read
+   * lock, so the lock orders the two threads.
+   */
+  private long pendingTruncationIndex = NO_TRUNCATION;
 
   SegmentedJournalReader(final SegmentedJournal journal, final JournalMetrics journalMetrics) {
     this.journal = journal;
@@ -189,6 +198,7 @@ class SegmentedJournalReader implements JournalReader {
   }
 
   long unsafeSeek(final long index) {
+    discardPendingTruncation();
     if (!currentSegment.isOpen()) {
       unsafeSeekToFirst();
     }
@@ -205,8 +215,14 @@ class SegmentedJournalReader implements JournalReader {
   }
 
   private long unsafeSeekToFirst() {
+    discardPendingTruncation();
     replaceCurrentSegment(journal.getFirstSegment());
     return journal.getFirstIndex();
+  }
+
+  /** An explicit seek positions the reader itself, so there is nothing left to rewind. */
+  private void discardPendingTruncation() {
+    pendingTruncationIndex = NO_TRUNCATION;
   }
 
   private long unsafeSeekToLast() {
@@ -242,7 +258,36 @@ class SegmentedJournalReader implements JournalReader {
     currentReader.seek(index);
   }
 
+  /**
+   * Records that everything after the given index was deleted. The reader position is left
+   * untouched: it is only ever moved by the thread that reads, in {@link
+   * #applyPendingTruncation()}. Moving it here would close the segment reader that keeps the
+   * truncated records mapped, while the thread that reads may still be using them.
+   */
+  void onTruncatedAfter(final long index) {
+    pendingTruncationIndex = index;
+  }
+
+  /**
+   * Seeks this reader back to the truncation point if it is positioned after it. Records above that
+   * point are gone, so a reader that read past it must not continue where it was, and a reader that
+   * sits at the start of a segment the truncation deleted has to re-attach to a live segment.
+   */
+  private void applyPendingTruncation() {
+    final var truncationIndex = pendingTruncationIndex;
+    if (truncationIndex == NO_TRUNCATION) {
+      return;
+    }
+
+    pendingTruncationIndex = NO_TRUNCATION;
+    if (getNextIndex() > truncationIndex) {
+      unsafeSeek(truncationIndex + 1);
+    }
+  }
+
   private boolean unsafeHasNext() {
+    applyPendingTruncation();
+
     if (!currentReader.hasNext()) {
       if (!currentSegment.isOpen()) {
         // When the segment has been deleted concurrently, we do not want to allow the readers to

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
@@ -30,6 +30,7 @@ class SegmentedJournalReader implements JournalReader {
   private Segment currentSegment;
   private SegmentReader currentReader;
   private final JournalMetrics metrics;
+  private final boolean readsConcurrently;
 
   /**
    * The index a truncation deleted after, set by the truncating thread and applied by this reader's
@@ -38,10 +39,19 @@ class SegmentedJournalReader implements JournalReader {
    */
   private long pendingTruncationIndex = NO_TRUNCATION;
 
-  SegmentedJournalReader(final SegmentedJournal journal, final JournalMetrics journalMetrics) {
+  SegmentedJournalReader(
+      final SegmentedJournal journal,
+      final JournalMetrics journalMetrics,
+      final boolean readsConcurrently) {
     this.journal = journal;
     metrics = journalMetrics;
+    this.readsConcurrently = readsConcurrently;
     initialize();
+  }
+
+  /** Whether this reader is read by another thread than the one writing to the journal. */
+  boolean readsConcurrently() {
+    return readsConcurrently;
   }
 
   /** Initializes the reader to the given index. */

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -113,7 +113,18 @@ final class SegmentedJournalWriter {
     currentWriter = currentSegment.writer();
   }
 
-  void deleteAfter(final long index) {
+  /**
+   * Deletes all records after the given index.
+   *
+   * @param index the index to delete after, inclusive
+   * @param preserveDeletedRecords when true, the deleted records are left in place instead of being
+   *     overwritten by the records appended next. Deleting records only unmaps a segment once the
+   *     last reader let go of it, but the records deleted from the middle of a segment are unmapped
+   *     by nobody: the next append simply writes over them. Callers that hand out records to be
+   *     read straight from a segment have to preserve them, or a reader can end up reading memory
+   *     that was overwritten while it was reading.
+   */
+  void deleteAfter(final long index, final boolean preserveDeletedRecords) {
     // reset the last flushed index first to avoid corruption on restart in case of partial
     // truncation (e.g. the node crashed while deleting segments)
     lastFlushedIndex = index;
@@ -126,12 +137,34 @@ final class SegmentedJournalWriter {
       currentWriter = currentSegment.writer();
     }
 
+    // Only records in the middle of a segment are overwritten by the next append; if the segment
+    // already ends at the given index, everything after it was in the segments deleted above.
+    final var overwritesDeletedRecords = index < currentWriter.getLastIndex();
+
     // Reset last entry position in descriptor to 0, to ensure that after a restart it is not using
     // the old truncated entry.
     currentSegment.resetLastEntryInDescriptor();
     // Truncate down to the current index, such that the last index is `index`, and the next index
     // `index + 1`
     currentWriter.truncate(index);
+
+    if (overwritesDeletedRecords && preserveDeletedRecords) {
+      LOGGER.debug(
+          "Continuing in a new segment after deleting records after index {}, to keep the deleted records readable",
+          index);
+      if (currentWriter.getLastIndex() < currentSegment.index()) {
+        // Nothing is left of this segment, so replacing it is enough: a deleted segment is only
+        // unmapped once the last reader let go of it.
+        currentSegment = segments.resetSegments(index + 1);
+      } else {
+        // Recovery finds the end of a segment's records by the invalidated frame that truncating
+        // left behind. Flush it before the next segment exists, or a restart can find records after
+        // it and resurrect the records deleted here.
+        currentWriter.flushEndOfRecords();
+        journalMetrics.observeSegmentCreation(this::createNewSegment);
+      }
+      currentWriter = currentSegment.writer();
+    }
   }
 
   void flush() throws FlushException {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -400,6 +400,25 @@ class SegmentedJournalTest {
   }
 
   @Test
+  void shouldNotOverwriteDeletedRecordsThatAReaderRead() {
+    // given - a reader that read a record which is deleted afterwards
+    journal = openJournal("aaaa", 4);
+    final var reader = journal.openConcurrentReader();
+    journal.append(1, journalFactory.entry());
+    final var deletedIndex = journal.append(2, journalFactory.entry()).index();
+    reader.next();
+    final var deletedRecord = reader.next();
+
+    // when - a new record is written at the index of the deleted one
+    journal.deleteAfter(deletedIndex - 1);
+    final var newRecord = journal.append(2, entry("bbbb"));
+
+    // then - the record the reader is still holding is unchanged
+    assertThat(newRecord.index()).isEqualTo(deletedIndex);
+    assertThat(BufferUtil.bufferAsString(deletedRecord.data())).isEqualTo("aaaa");
+  }
+
+  @Test
   void shouldKeepDeletedSegmentReadableForAReaderThatReadFromIt() {
     // given - a reader that read a record from a segment which is deleted afterwards
     journal = openJournal("aaaa", 1);
@@ -455,6 +474,53 @@ class SegmentedJournalTest {
     // then
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(newRecord.index());
+  }
+
+  @Test
+  void shouldOverwriteDeletedRecordsThatOnlyANonConcurrentReaderRead() {
+    // given - a reader on the writer's thread that read a record which is deleted afterwards
+    journal = openJournal("aaaa", 4);
+    final var reader = journal.openReader();
+    final var keptIndex = journal.append(1, journalFactory.entry()).index();
+    journal.append(2, journalFactory.entry());
+    reader.next();
+    reader.next();
+    final var segment = journal.getLastSegment();
+
+    // when
+    journal.deleteAfter(keptIndex);
+    journal.append(2, entry("bbbb"));
+
+    // then - the deleted record is overwritten in place instead of in a new segment
+    assertThat(journal.getLastSegment()).isSameAs(segment);
+  }
+
+  @Test
+  void shouldNotReadDeletedRecordsAfterRestart() {
+    // given - records deleted while a reader was holding them
+    journal = openJournal("aaaa", 8);
+    final var reader = journal.openConcurrentReader();
+    journal.append(1, journalFactory.entry());
+    final var deletedIndex = journal.append(2, journalFactory.entry()).index();
+    journal.append(3, journalFactory.entry());
+    reader.next();
+    reader.next();
+    reader.next();
+    journal.deleteAfter(deletedIndex - 1);
+    journal.append(2, entry("bbbb"));
+
+    // when
+    journal.close();
+    journal = openJournal("aaaa", 8);
+
+    // then - the deleted records are gone, and what replaced them is not
+    assertThat(journal.getLastIndex()).isEqualTo(deletedIndex);
+    final var records = new ArrayList<String>();
+    final var reopenedReader = journal.openReader();
+    while (reopenedReader.hasNext()) {
+      records.add(BufferUtil.bufferAsString(reopenedReader.next().data()));
+    }
+    assertThat(records).containsExactly("aaaa", "bbbb");
   }
 
   @Test

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -400,6 +400,64 @@ class SegmentedJournalTest {
   }
 
   @Test
+  void shouldKeepDeletedSegmentReadableForAReaderThatReadFromIt() {
+    // given - a reader that read a record from a segment which is deleted afterwards
+    journal = openJournal("aaaa", 1);
+    final var reader = journal.openReader();
+    final var keptIndex = journal.append(1, journalFactory.entry()).index();
+    journal.append(2, entry("bbbb"));
+    reader.next();
+    final var deletedRecord = reader.next();
+
+    // when - the whole segment holding that record is deleted
+    journal.deleteAfter(keptIndex);
+
+    // then - the record the reader is still holding is readable, i.e. the segment is still mapped
+    assertThat(BufferUtil.bufferAsString(deletedRecord.data())).isEqualTo("bbbb");
+  }
+
+  @Test
+  void shouldReadRecordsWrittenAfterTheReaderReadDeletedRecords() {
+    // given - a reader that read a record which is deleted afterwards
+    journal = openJournal("aaaa", 4);
+    final var reader = journal.openReader();
+    journal.append(1, journalFactory.entry());
+    final var deletedIndex = journal.append(2, journalFactory.entry()).index();
+    reader.next();
+    reader.next();
+
+    // when
+    journal.deleteAfter(deletedIndex - 1);
+    journal.append(2, entry("bbbb"));
+
+    // then - the reader reads the new record instead of the deleted one
+    assertThat(reader.hasNext()).isTrue();
+    final var record = reader.next();
+    assertThat(record.index()).isEqualTo(deletedIndex);
+    assertThat(BufferUtil.bufferAsString(record.data())).isEqualTo("bbbb");
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  void shouldReadRecordsWrittenAfterTheSegmentAReaderReadFromIsDeleted() {
+    // given - a reader that read a record from a segment which is deleted afterwards
+    journal = openJournal(1);
+    final var reader = journal.openReader();
+    final var keptIndex = journal.append(1, journalFactory.entry()).index();
+    journal.append(2, journalFactory.entry());
+    reader.next();
+    reader.next();
+
+    // when
+    journal.deleteAfter(keptIndex);
+    final var newRecord = journal.append(2, journalFactory.entry());
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().index()).isEqualTo(newRecord.index());
+  }
+
+  @Test
   void shouldCompactUpToStartOfSegment() {
     final int entryPerSegment = 2;
     journal = openJournal(entryPerSegment);
@@ -1102,6 +1160,11 @@ class SegmentedJournalTest {
 
   private SegmentedJournal openJournal(final int entriesPerSegment) {
     return openJournal("test", entriesPerSegment);
+  }
+
+  /** An entry with custom data, of the same size as {@link TestJournalFactory#entry()}. */
+  private DirectBufferWriter entry(final String data) {
+    return new DirectBufferWriter(BufferUtil.wrapString(data));
   }
 
   private SegmentedJournal openJournal(final String data, final int entriesPerSegment) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -74,7 +74,7 @@ final class SegmentedJournalWriterTest {
     writer.flush();
 
     // when
-    writer.deleteAfter(2);
+    writer.deleteAfter(2, false);
 
     // then
     assertThat(writer.getLastFlushedIndex()).isEqualTo(2L);
@@ -147,7 +147,7 @@ final class SegmentedJournalWriterTest {
   void shouldInvalidateNextEntryAfterAppend() {
     try (final SegmentedJournalReader reader =
         new SegmentedJournalReader(
-            journalFactory.journal(segments), new JournalMetrics(meterRegistry))) {
+            journalFactory.journal(segments), new JournalMetrics(meterRegistry), false)) {
       // when
       writer.append(-1, journalFactory.entry());
 
@@ -172,7 +172,9 @@ final class SegmentedJournalWriterTest {
 
     try (final SegmentedJournalReader reader =
         new SegmentedJournalReader(
-            followerJournalFactory.journal(followerSegments), new JournalMetrics(meterRegistry))) {
+            followerJournalFactory.journal(followerSegments),
+            new JournalMetrics(meterRegistry),
+            false)) {
       // when
       final byte[] serializedRecord = BufferUtil.bufferAsArray(writtenRecord.serializedRecord());
       followerWriter.append(writtenRecord.checksum(), serializedRecord);


### PR DESCRIPTION
Prerequisite for #59206, which lets the stream processor read uncommitted records. Its processing reader reads on the stream processor's thread while raft appends and truncates on its own, and the journal is not safe for that today. Three separate problems, one commit each.

**A truncation frees memory a reader is using.** Truncating [seeks every reader that read past the truncation point](https://github.com/camunda/camunda/blob/630164937d53763531c2d620c6718a3647c9a763/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java#L319-L325), from the thread that truncates. That seek closes the segment reader keeping the segment mapped, and for a reader whose segment the same truncation deleted, it drops the last reference and unmaps immediately — under a consumer that is reading a record from it, so a SIGSEGV rather than an exception. A truncation now [only records the index on each reader](https://github.com/camunda/camunda/blob/49c87f51db5dadf2387ac1b401d694f9d699b94f/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java#L277), and the reader seeks itself on its own thread before its next read.

**Records deleted from the middle of a segment get overwritten while they are read.** They stay mapped, but the next append writes over them, which no reference count guards against. Readers can now be opened with `openConcurrentReader` to declare they read on another thread; a truncation that deletes records such a reader already read [continues in a new segment](https://github.com/camunda/camunda/blob/49c87f51db5dadf2387ac1b401d694f9d699b94f/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java#L151) instead of overwriting them. Opt-in because it costs a segment per truncation: raft's readers all read on the thread that writes, so every truncation raft does today still truncates in place.

**A record can be observed before it is fully written.** The frame version byte that publishes a record is a plain write, unordered against the body, so a reader on another thread can see the frame first and read a torn record — reported as a corrupted journal, or decoded as garbage. [Release/acquire fences](https://github.com/camunda/camunda/blob/49c87f51db5dadf2387ac1b401d694f9d699b94f/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/FrameUtil.java#L33) around it now order the two. Free on x86, which orders the stores anyway.

Nothing here changes behavior for any current caller, so there is nothing to backport; #59206 opts in.

Two things worth a reviewer's attention:

- Preserving records means the seal that ends a segment's records has to reach disk before the new segment can hold records, or a restart reads past it and resurrects deleted entries. The flush is ordered for that, but no test can reproduce a lost seal: an unflushed page is still visible to every reader in the process.
- A truncation that leaves nothing in its segment replaces the segment instead of adding one, because the records to preserve start where a new segment would begin.

Adjacent, not fixed here: raft holds `currentEntry` from its per-follower replication readers across calls, and a truncation on its own thread can overwrite it. Same thread, so no race, and the [replication path copies](https://github.com/camunda/camunda/blob/630164937d53763531c2d620c6718a3647c9a763/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java#L52-L56) before sending, but it reads a record that may no longer be there.
