### PR TITLE
feat: apply a broker count or membership change to every physical tenant

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -68,22 +68,39 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
                     + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
       }
     }
-    if (changesMembership || (newPartitionCount.isEmpty() && newReplicationFactor.isEmpty())) {
-      // Cluster membership has no tenant dimension, so a request carrying it is planned exactly the
-      // way it always was, against the default group. So is a request that changes neither
-      // membership nor a partition dimension, which has nothing to plan. That a membership change
-      // redistributes only the default tenant's partitions, rather than every tenant's, is a gap
-      // that predates physical tenants being scalable at all; closing it needs global and
-      // partition-group phases planned together, tracked in #60193.
-      return ConfigurationChangeRequest.super.phases(clusterConfiguration);
-    }
     // The replication factor of a zone-aware cluster follows from its zone specs, so it cannot be
     // set directly. Checked here as well as in operations(), because the new-model coordinator
-    // plans through phases() alone and never calls operations() at all.
+    // plans through phases() alone and never calls operations() at all — and checked before
+    // anything else that could plan, in the same order operations() checks it, so that a request
+    // combining a replication factor with a membership change is still answered with this rather
+    // than with whatever the zone-aware distributor raises about the resulting replica sum.
     if (newReplicationFactor.isPresent() && !clusterConfiguration.isUnzoned()) {
       return Either.left(
           new InvalidRequest(
               "Changing the replication factor is not supported on zone-aware clusters."));
+    }
+    if (changesMembership) {
+      // Checked here as well as in operations(), because the new-model coordinator plans through
+      // phases() alone and would otherwise admit a self-contradicting request.
+      if (membersToAdd.stream().anyMatch(membersToRemove::contains)) {
+        return Either.left(
+            new InvalidRequest(
+                new IllegalArgumentException(
+                    "Cannot add and remove the same member in the same request")));
+      }
+      // Membership has no tenant dimension, but the partitions it moves do: every tenant's
+      // partitions have to be redistributed over the new member set, not just the default
+      // tenant's. ScaleRequestTransformer plans that, the same way operations() delegates to it.
+      final var newSetOfMembers =
+          new HashSet<>(clusterConfiguration.globalConfiguration().members().keySet());
+      newSetOfMembers.addAll(membersToAdd);
+      newSetOfMembers.removeAll(membersToRemove);
+      return new ScaleRequestTransformer(newSetOfMembers, newReplicationFactor, newPartitionCount)
+          .phases(clusterConfiguration);
+    }
+    if (newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
+      // Changes neither membership nor a partition dimension, so there is nothing to plan.
+      return ConfigurationChangeRequest.super.phases(clusterConfiguration);
     }
 
     final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -100,7 +100,7 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
     }
     if (newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
       // Changes neither membership nor a partition dimension, so there is nothing to plan.
-      return ConfigurationChangeRequest.super.phases(clusterConfiguration);
+      return Either.right(List.of());
     }
 
     final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -73,7 +73,7 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
     }
     if (brokerCount.isEmpty() && newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
       // Changes neither membership nor a partition dimension, so there is nothing to plan.
-      return ConfigurationChangeRequest.super.phases(clusterConfiguration);
+      return Either.right(List.of());
     }
 
     final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -71,18 +71,28 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
                     + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
       }
     }
-    if (brokerCount.isPresent()
-        || (newPartitionCount.isEmpty() && newReplicationFactor.isEmpty())) {
-      // brokerCount changes cluster membership, which has no tenant dimension, so a request
-      // carrying it is planned exactly the way it always was, against the default group. So is a
-      // request that changes neither membership nor a partition dimension, which has nothing to
-      // plan. That a membership change redistributes only the default tenant's partitions, rather
-      // than every tenant's, is a gap that predates physical tenants being scalable at all;
-      // closing it needs global and partition-group phases planned together, tracked in #60193.
+    if (brokerCount.isEmpty() && newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
+      // Changes neither membership nor a partition dimension, so there is nothing to plan.
       return ConfigurationChangeRequest.super.phases(clusterConfiguration);
     }
 
     final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    final var invalidZone = validateZone(clusterConfiguration.toLegacy(groupId));
+    if (invalidZone.isPresent()) {
+      return Either.left(invalidZone.get());
+    }
+    if (brokerCount.isPresent()) {
+      // brokerCount has no tenant dimension, but the partitions it moves do: every tenant's
+      // partitions have to be redistributed over the new member set, not just the default
+      // tenant's. ScaleRequestTransformer plans that, the same way operations() delegates to it.
+      return new ScaleRequestTransformer(
+              newSetOfMembers(clusterConfiguration.toLegacy(groupId)),
+              newReplicationFactor,
+              newPartitionCount,
+              zone)
+          .phases(clusterConfiguration);
+    }
+
     // Only the partition count targets a group; the replication factor spans every tenant, so a
     // request carrying it alone has no group that has to exist.
     if (newPartitionCount.isPresent() && !clusterConfiguration.hasPartitionGroup(groupId)) {
@@ -90,10 +100,6 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
           new NotFound(
               "Expected to scale physical tenant '%s', but there's no such tenant"
                   .formatted(groupId)));
-    }
-    final var invalidZone = validateZone(clusterConfiguration.toLegacy(groupId));
-    if (invalidZone.isPresent()) {
-      return Either.left(invalidZone.get());
     }
     return PartitionGroupScalingPhases.phases(
         groupId, clusterConfiguration, newPartitionCount, newReplicationFactor);
@@ -112,26 +118,32 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
     }
 
     // replicationFactor and partitionCount is validated in the delegated transformer.
-    final Set<MemberId> newSetOfMembers;
-    if (zone.isPresent()) {
-      final var zoneName = zone.get();
-      newSetOfMembers =
-          clusterConfiguration.members().keySet().stream()
-              .filter(m -> !m.isInZone(zoneName))
-              .collect(Collectors.toSet());
-      final int currentZoneCount =
-          (int)
-              clusterConfiguration.members().keySet().stream()
-                  .filter(m -> m.isInZone(zoneName))
-                  .count();
-      final var targetZoneMembers = membersInZone(currentZoneCount);
-      newSetOfMembers.addAll(targetZoneMembers);
-    } else {
-      newSetOfMembers = membersInZone(clusterConfiguration.members().size());
-    }
     return new ScaleRequestTransformer(
-            newSetOfMembers, newReplicationFactor, newPartitionCount, zone)
+            newSetOfMembers(clusterConfiguration), newReplicationFactor, newPartitionCount, zone)
         .operations(clusterConfiguration);
+  }
+
+  /**
+   * The complete member set the cluster should have once this request is applied. A zoned request
+   * resizes only the named zone and leaves every other zone's members untouched; an unzoned one
+   * resizes the whole cluster.
+   */
+  private Set<MemberId> newSetOfMembers(final ClusterConfiguration clusterConfiguration) {
+    if (zone.isEmpty()) {
+      return membersInZone(clusterConfiguration.members().size());
+    }
+    final var zoneName = zone.get();
+    final Set<MemberId> newSetOfMembers =
+        clusterConfiguration.members().keySet().stream()
+            .filter(m -> !m.isInZone(zoneName))
+            .collect(Collectors.toSet());
+    final int currentZoneCount =
+        (int)
+            clusterConfiguration.members().keySet().stream()
+                .filter(m -> m.isInZone(zoneName))
+                .count();
+    newSetOfMembers.addAll(membersInZone(currentZoneCount));
+    return newSetOfMembers;
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
@@ -36,9 +36,11 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
- * Plans a change to where the cluster's partitions live, for {@link ClusterScaleRequestTransformer}
- * and {@link ClusterPatchRequestTransformer}: a partition-count scale-up of one physical tenant's
- * partition group, a change of the cluster-wide replication factor, or both at once.
+ * Plans a change to where the cluster's partitions live, for {@link
+ * ClusterScaleRequestTransformer}, {@link ClusterPatchRequestTransformer} and {@link
+ * ScaleRequestTransformer}: a partition-count scale-up of one physical tenant's partition group, a
+ * change of the cluster-wide replication factor, a change of the cluster's membership, or any
+ * combination of them.
  *
  * <p>Partitions are distributed across brokers considering every physical tenant's partitions at
  * once, not just those of the tenant being scaled: a tenant scaled on its own would be placed as if
@@ -71,6 +73,9 @@ final class PartitionGroupScalingPhases {
   private PartitionGroupScalingPhases() {}
 
   /**
+   * Plans the placement over the cluster's live members, for a request that does not change
+   * membership.
+   *
    * @param targetGroupId the partition group whose partition count changes; must exist in {@code
    *     clusterConfiguration} whenever {@code newPartitionCount} is present, and is unused
    *     otherwise — the replication factor has no target group
@@ -89,29 +94,55 @@ final class PartitionGroupScalingPhases {
       final CurrentClusterConfiguration clusterConfiguration,
       final Optional<Integer> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
-    final var distributionByGroup =
-        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration);
-    final var currentPartitionCount =
-        distributionByGroup.getOrDefault(targetGroupId, Set.of()).size();
-    final int targetPartitionCount = newPartitionCount.orElse(currentPartitionCount);
-
-    if (newReplicationFactor.isEmpty() && targetPartitionCount == currentPartitionCount) {
+    final var currentPartitionCount = currentPartitionCount(clusterConfiguration, targetGroupId);
+    if (newReplicationFactor.isEmpty()
+        && newPartitionCount.orElse(currentPartitionCount) == currentPartitionCount) {
       // Nothing is asked for that the cluster does not already have. Returning before the
       // distributor runs is what keeps such a request a no-op: a placement that has drifted from
       // what the distributor would compute now — after a manual reassignment through
       // /partition-distribution, say — would otherwise be rebalanced by a request that asked for
       // no change at all. It also keeps a request that asks for nothing answerable while the
       // cluster cannot satisfy its own replication factor, e.g. with a broker down.
+      //
+      // The guard belongs to this entry point alone: a membership change does ask for something
+      // even when neither partition dimension moves, and running the distributor is then exactly
+      // right.
       return Either.right(List.of());
     }
+    return phases(
+        targetGroupId,
+        clusterConfiguration,
+        clusterConfiguration.liveMembers(),
+        newPartitionCount,
+        newReplicationFactor);
+  }
+
+  /**
+   * As {@link #phases(String, CurrentClusterConfiguration, Optional, Optional)}, but places the
+   * partitions on {@code targetMembers} rather than on whichever members are currently live, and
+   * always runs the distributor.
+   *
+   * @param targetMembers the members every partition of every group should end up on — the complete
+   *     desired member set, so a member being removed from the cluster is simply absent from it
+   */
+  static Either<Exception, List<Phase>> phases(
+      final String targetGroupId,
+      final CurrentClusterConfiguration clusterConfiguration,
+      final Set<MemberId> targetMembers,
+      final Optional<Integer> newPartitionCount,
+      final Optional<Integer> newReplicationFactor) {
+    final var distributionByGroup =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration);
+    final var currentPartitionCount =
+        distributionByGroup.getOrDefault(targetGroupId, Set.of()).size();
+    final int targetPartitionCount = newPartitionCount.orElse(currentPartitionCount);
 
     final int replicationFactor =
         newReplicationFactor.orElseGet(() -> currentReplicationFactor(distributionByGroup));
-    final var liveMembers = clusterConfiguration.liveMembers();
     final var rejection =
         reject(
             targetGroupId,
-            liveMembers,
+            targetMembers,
             currentPartitionCount,
             targetPartitionCount,
             replicationFactor);
@@ -135,7 +166,7 @@ final class PartitionGroupScalingPhases {
     try {
       final var targetDistribution =
           targetDistribution(
-              clusterConfiguration, liveMembers, targetPartitionIds, replicationFactor);
+              clusterConfiguration, targetMembers, targetPartitionIds, replicationFactor);
       operationsByGroup =
           new LinkedHashMap<>(
               PartitionReassignmentOperationsGenerator.generateOperations(
@@ -180,7 +211,7 @@ final class PartitionGroupScalingPhases {
    */
   private static Optional<Exception> reject(
       final String targetGroupId,
-      final Set<MemberId> liveMembers,
+      final Set<MemberId> targetMembers,
       final int currentPartitionCount,
       final int targetPartitionCount,
       final int replicationFactor) {
@@ -195,13 +226,20 @@ final class PartitionGroupScalingPhases {
           new InvalidRequest(
               "Replication factor [%d] must be greater than 0".formatted(replicationFactor)));
     }
-    if (liveMembers.size() < replicationFactor) {
+    if (targetMembers.size() < replicationFactor) {
       return Optional.of(
           new InvalidRequest(
               "Number of brokers [%d] is less than the replication factor [%d]"
-                  .formatted(liveMembers.size(), replicationFactor)));
+                  .formatted(targetMembers.size(), replicationFactor)));
     }
     return Optional.empty();
+  }
+
+  private static int currentPartitionCount(
+      final CurrentClusterConfiguration clusterConfiguration, final String groupId) {
+    return ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration)
+        .getOrDefault(groupId, Set.of())
+        .size();
   }
 
   private static Set<PartitionMetadata> targetDistribution(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
@@ -94,7 +94,9 @@ final class PartitionGroupScalingPhases {
       final CurrentClusterConfiguration clusterConfiguration,
       final Optional<Integer> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
-    final var currentPartitionCount = currentPartitionCount(clusterConfiguration, targetGroupId);
+    final var distributionByGroup =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration);
+    final var currentPartitionCount = currentPartitionCount(distributionByGroup, targetGroupId);
     if (newReplicationFactor.isEmpty()
         && newPartitionCount.orElse(currentPartitionCount) == currentPartitionCount) {
       // Nothing is asked for that the cluster does not already have. Returning before the
@@ -112,6 +114,7 @@ final class PartitionGroupScalingPhases {
     return phases(
         targetGroupId,
         clusterConfiguration,
+        distributionByGroup,
         clusterConfiguration.liveMembers(),
         newPartitionCount,
         newReplicationFactor);
@@ -131,10 +134,28 @@ final class PartitionGroupScalingPhases {
       final Set<MemberId> targetMembers,
       final Optional<Integer> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
-    final var distributionByGroup =
-        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration);
-    final var currentPartitionCount =
-        distributionByGroup.getOrDefault(targetGroupId, Set.of()).size();
+    return phases(
+        targetGroupId,
+        clusterConfiguration,
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration),
+        targetMembers,
+        newPartitionCount,
+        newReplicationFactor);
+  }
+
+  /**
+   * Takes the current per-tenant distribution rather than scanning it out of {@code
+   * clusterConfiguration}: the entry point above needs it to decide whether the request asks for
+   * anything at all, and passes on what it already scanned.
+   */
+  private static Either<Exception, List<Phase>> phases(
+      final String targetGroupId,
+      final CurrentClusterConfiguration clusterConfiguration,
+      final Map<String, Set<PartitionMetadata>> distributionByGroup,
+      final Set<MemberId> targetMembers,
+      final Optional<Integer> newPartitionCount,
+      final Optional<Integer> newReplicationFactor) {
+    final var currentPartitionCount = currentPartitionCount(distributionByGroup, targetGroupId);
     final int targetPartitionCount = newPartitionCount.orElse(currentPartitionCount);
 
     final int replicationFactor =
@@ -236,10 +257,8 @@ final class PartitionGroupScalingPhases {
   }
 
   private static int currentPartitionCount(
-      final CurrentClusterConfiguration clusterConfiguration, final String groupId) {
-    return ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration)
-        .getOrDefault(groupId, Set.of())
-        .size();
+      final Map<String, Set<PartitionMetadata>> distributionByGroup, final String groupId) {
+    return distributionByGroup.getOrDefault(groupId, Set.of()).size();
   }
 
   private static Set<PartitionMetadata> targetDistribution(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
@@ -8,11 +8,18 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +61,95 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
     this.newReplicationFactor = newReplicationFactor;
     this.newPartitionCount = newPartitionCount;
     this.zone = zone;
+  }
+
+  /**
+   * The same composition {@link #operations(ClusterConfiguration)} produces — pre-scaling and
+   * member joins, then the partition placement, then member leaves and post-scaling — but planned
+   * across every physical tenant's partition group instead of the default one only.
+   *
+   * <p>Only the partition half differs: {@link PartitionGroupScalingPhases} distributes every
+   * group's partitions together over {@link #members}, where {@code operations} distributes the
+   * default group's alone. The member operations have no tenant dimension, so they are unchanged.
+   *
+   * <p>The resulting phases are the same three {@code toPhases} derives from the flat operation
+   * list today — a global phase, a partition-group phase, a global phase — with the two global runs
+   * merged when there is no partition work, since {@code toPhases} would then see one uninterrupted
+   * run of global operations. A single-tenant cluster therefore plans exactly what it planned
+   * before.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    if (members.isEmpty()) {
+      return Either.left(
+          new InvalidRequest(
+              new IllegalArgumentException(
+                  "Cannot reassign partitions if no brokers are provided")));
+    }
+    final var legacy = configuration.toLegacyDefault();
+    if (legacy.isFullyZoneAware() && members.stream().anyMatch(MemberId::isBare)) {
+      return Either.left(
+          new InvalidRequest(
+              "Members without a zone cannot be added to a zone-aware cluster: "
+                  + members.stream().filter(MemberId::isBare).sorted().toList()));
+    }
+
+    final var currentMembers = legacy.members().keySet();
+    final var joining =
+        members.stream()
+            .filter(member -> !legacy.hasMember(member))
+            .sorted()
+            .map(member -> (GlobalChangeOperation) new MemberJoinOperation(member))
+            .toList();
+    final var leaving =
+        currentMembers.stream()
+            .filter(member -> !members.contains(member))
+            .sorted()
+            .map(member -> (GlobalChangeOperation) new MemberLeaveOperation(member))
+            .toList();
+
+    // Same rule as operations(): the callbacks act on the node-id state of the zone being scaled,
+    // and there is nothing to prepare when the member set is unchanged.
+    final var scalingExecutor =
+        currentMembers.equals(members)
+            ? Optional.<MemberId>empty()
+            : selectPrePostScalingExecutor(legacy);
+
+    final var before = new ArrayList<GlobalChangeOperation>();
+    scalingExecutor.ifPresent(id -> before.add(new PreScalingOperation(id, members)));
+    before.addAll(joining);
+    final var after = new ArrayList<GlobalChangeOperation>(leaving);
+    scalingExecutor.ifPresent(id -> after.add(new PostScalingOperation(id, members)));
+
+    return PartitionGroupScalingPhases.phases(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            configuration,
+            members,
+            newPartitionCount,
+            newReplicationFactor)
+        .map(partitionPhases -> assemble(before, partitionPhases, after));
+  }
+
+  private static List<Phase> assemble(
+      final List<GlobalChangeOperation> before,
+      final List<Phase> partitionPhases,
+      final List<GlobalChangeOperation> after) {
+    if (partitionPhases.isEmpty()) {
+      // Nothing separates the two runs of global operations, so they are one phase — exactly what
+      // toPhases yields for the equivalent flat operation list.
+      final var merged = new ArrayList<>(before);
+      merged.addAll(after);
+      return merged.isEmpty() ? List.of() : List.of(new GlobalPhase(List.copyOf(merged)));
+    }
+    final var phases = new ArrayList<Phase>();
+    if (!before.isEmpty()) {
+      phases.add(new GlobalPhase(List.copyOf(before)));
+    }
+    phases.addAll(partitionPhases);
+    if (!after.isEmpty()) {
+      phases.add(new GlobalPhase(List.copyOf(after)));
+    }
+    return phases;
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
@@ -86,18 +86,17 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
               new IllegalArgumentException(
                   "Cannot reassign partitions if no brokers are provided")));
     }
-    final var legacy = configuration.toLegacyDefault();
-    if (legacy.isFullyZoneAware() && members.stream().anyMatch(MemberId::isBare)) {
+    if (configuration.isFullyZoneAware() && members.stream().anyMatch(MemberId::isBare)) {
       return Either.left(
           new InvalidRequest(
               "Members without a zone cannot be added to a zone-aware cluster: "
                   + members.stream().filter(MemberId::isBare).sorted().toList()));
     }
 
-    final var currentMembers = legacy.members().keySet();
+    final var currentMembers = configuration.getMembers();
     final var joining =
         members.stream()
-            .filter(member -> !legacy.hasMember(member))
+            .filter(member -> !currentMembers.contains(member))
             .sorted()
             .map(member -> (GlobalChangeOperation) new MemberJoinOperation(member))
             .toList();
@@ -113,7 +112,7 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
     final var scalingExecutor =
         currentMembers.equals(members)
             ? Optional.<MemberId>empty()
-            : selectPrePostScalingExecutor(legacy);
+            : selectPrePostScalingExecutor(currentMembers);
 
     final var before = new ArrayList<GlobalChangeOperation>();
     scalingExecutor.ifPresent(id -> before.add(new PreScalingOperation(id, members)));
@@ -152,6 +151,13 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
     return phases;
   }
 
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Every caller has moved to {@code phases} except {@link
+   * ZoneMigrationRequestTransformer}, which still plans through here, so this cannot be dropped
+   * until <a href="https://github.com/camunda/camunda/issues/60341">zone migration</a> is planned
+   * across every physical tenant too.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
@@ -206,17 +212,19 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
 
   private Optional<MemberId> selectPrePostScalingExecutor(
       final ClusterConfiguration clusterConfiguration) {
+    return selectPrePostScalingExecutor(clusterConfiguration.members().keySet());
+  }
+
+  private Optional<MemberId> selectPrePostScalingExecutor(final Set<MemberId> currentMembers) {
     final var coordinatorSupplier =
-        ClusterConfigurationCoordinatorSupplier.of(() -> clusterConfiguration);
+        ClusterConfigurationCoordinatorSupplier.ofMembers(currentMembers);
     if (zone.isEmpty()) {
       return Optional.of(coordinatorSupplier.getDefaultCoordinator());
     }
     final var zoneName = zone.get();
     final var membersInZone =
         // pick a member from the current set of members
-        clusterConfiguration.members().keySet().stream()
-            .filter(m -> m.isInZone(zoneName))
-            .collect(Collectors.toSet());
+        currentMembers.stream().filter(m -> m.isInZone(zoneName)).collect(Collectors.toSet());
     if (membersInZone.isEmpty()) {
       // New zone with no existing brokers: the callbacks cannot run in the correct zone and the
       // new zone's brokers create their node-id leases on startup, so skip pre/post scaling.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -124,6 +124,23 @@ public record CurrentClusterConfiguration(
   }
 
   /**
+   * Whether the cluster uses zone awareness throughout: every broker is assigned to a zone and the
+   * partition distributor is zone-aware. A cluster where only one of the two holds is mid-migration
+   * between the two modes rather than fully zone-aware.
+   *
+   * <p>Both are global state, so this reads the same fields {@link
+   * ClusterConfiguration#isFullyZoneAware()} does — the projection through {@link
+   * #toLegacyDefault()} that method needs is not.
+   */
+  public boolean isFullyZoneAware() {
+    return globalConfiguration.members().keySet().stream().allMatch(member -> member.zone() != null)
+        && globalConfiguration
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .isPresent();
+  }
+
+  /**
    * Creates an empty configuration with an initial global configuration and no partition groups.
    */
   public static CurrentClusterConfiguration init() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.ClusterConfig;
@@ -93,6 +94,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
@@ -1223,6 +1225,109 @@ abstract class ClusterConfigurationManagementApiTestBase {
                 .getMember(coordinatorId)
                 .mode())
         .isEqualTo(Mode.PROCESSING);
+  }
+
+  /**
+   * Before every physical tenant was considered when planning a membership change, this request was
+   * rejected during validation: the plan moved only the default tenant's partitions, so {@code
+   * MemberLeaveApplier} — which checks every partition group — refused to let the departing member
+   * leave while it still held the other tenant's partition. The whole request failed with "the
+   * member still has partitions assigned", leaving the operator no way to remove the broker at all.
+   */
+  @Test
+  void shouldMoveANonDefaultTenantsPartitionOffARemovedBroker() {
+    // given — a third member that holds nothing but tenant-b's partition
+    final var removedMember = memberFactory.apply(2);
+    wireNonDefaultTenantOnLastMember(removedMember);
+
+    // when — that member is removed from the cluster
+    final var changeStatus =
+        clientApi
+            .patchCluster(
+                new ClusterPatchRequest(
+                    Set.of(), Set.of(removedMember), Optional.empty(), Optional.empty(), false))
+            .join()
+            .get();
+
+    // then — the request is answered with a plan at all, which is the regression: validation
+    // simulates every phase through the same appliers the manager uses, so a plan means
+    // MemberLeaveApplier no longer refuses the leave
+    final var expected = changeStatus.response().expectedConfiguration();
+    assertThat(expected.getMembers()).doesNotContain(removedMember);
+    assertThat(expected.partitionGroup(TENANT_B).members())
+        .describedAs("tenant-b's partition is reassigned to a retained broker, not dropped")
+        .isNotEmpty()
+        .doesNotContainKey(removedMember);
+
+    // and the partitions move before the member leaves, not after
+    final var phases = changeStatus.response().phases();
+    assertThat(phases).hasSize(3);
+    assertThat(phases.get(1))
+        .asInstanceOf(type(PartitionGroupParallelPhase.class))
+        .satisfies(
+            phase -> {
+              assertThat(phase.groupOperations()).containsKey(TENANT_B);
+              assertThat(phase.groupOperations().get(TENANT_B))
+                  .contains(new PartitionLeaveOperation(removedMember, 1, 1))
+                  .anySatisfy(
+                      operation ->
+                          assertThat(operation)
+                              .asInstanceOf(type(PartitionJoinOperation.class))
+                              .extracting(PartitionJoinOperation::memberId)
+                              .isNotEqualTo(removedMember));
+            });
+    assertThat(phases.get(2))
+        .asInstanceOf(type(GlobalPhase.class))
+        .satisfies(
+            phase ->
+                assertThat(phase.operations()).contains(new MemberLeaveOperation(removedMember)));
+  }
+
+  /**
+   * Wires a three-member cluster where the default tenant's only partition sits on {@link
+   * #coordinatorId} and {@link #TENANT_B}'s only partition on {@code lastMember}, so that member
+   * holds nothing but a non-default tenant's partition.
+   *
+   * <p>Deliberately left without a zone-aware distributor config, unlike {@link
+   * #wireTwoPhysicalTenants()}: round robin places three members in either variant of this suite,
+   * where a zone spec written for a single broker could not.
+   */
+  private void wireNonDefaultTenantOnLastMember(final MemberId lastMember) {
+    setCurrentTopology(
+        initialTopology
+            .updateMember(
+                coordinatorId, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of()))
+            .addMember(lastMember, MemberState.initializeAsActive(Map.of())));
+    manager.registerPartitionGroupChangeAppliers(
+        TENANT_B,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+    manager
+        .updateMultiConfiguration(
+            current ->
+                new CurrentClusterConfiguration(
+                    current.version(),
+                    current.globalConfiguration(),
+                    Map.of(
+                        CurrentClusterConfiguration.DEFAULT_GROUP,
+                        current.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+                        TENANT_B,
+                        new PartitionGroupConfiguration(
+                            1,
+                            0,
+                            Map.of(
+                                lastMember,
+                                BrokerPartitionState.initialize(
+                                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty())),
+                    current.phasedChangeState()))
+        .join();
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -8,10 +8,12 @@
 package io.camunda.zeebe.dynamic.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterPatchRequestTransformer;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
@@ -35,6 +37,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOp
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
@@ -65,6 +68,8 @@ final class NewModelConfigurationChangeCoordinatorTest {
 
   private static final MemberId MEMBER_0 = MemberId.from("0");
   private static final MemberId MEMBER_1 = MemberId.from("1");
+  private static final MemberId MEMBER_2 = MemberId.from("2");
+  private static final String TENANT_A = "tenanta";
   private final TestConcurrencyControl executor = new TestConcurrencyControl();
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
@@ -89,13 +94,19 @@ final class NewModelConfigurationChangeCoordinatorTest {
     manager.registerGlobalChangeAppliers(
         new GlobalConfigurationChangeAppliersImpl(
             new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
-    manager.registerPartitionGroupChangeAppliers(
-        CurrentClusterConfiguration.DEFAULT_GROUP,
-        new PartitionGroupConfigurationChangeAppliersImpl(
-            new NoopPartitionChangeExecutor(),
-            new NoopPartitionScalingChangeExecutor(),
-            new NoopModeChangeExecutor(),
-            new NoopRestoreChangeExecutor()));
+    // Every broker registers appliers for every physical tenant it is configured with, so a seed
+    // with more than one partition group needs more than one registration here too.
+    seed.partitionGroups()
+        .keySet()
+        .forEach(
+            groupId ->
+                manager.registerPartitionGroupChangeAppliers(
+                    groupId,
+                    new PartitionGroupConfigurationChangeAppliersImpl(
+                        new NoopPartitionChangeExecutor(),
+                        new NoopPartitionScalingChangeExecutor(),
+                        new NoopModeChangeExecutor(),
+                        new NoopRestoreChangeExecutor())));
     coordinator = new ConfigurationChangeCoordinatorImpl(manager, localMemberId, executor);
     manager.updateMultiConfiguration(ignored -> seed).join();
   }
@@ -159,8 +170,96 @@ final class NewModelConfigurationChangeCoordinatorTest {
         base.phasedChangeState());
   }
 
+  /**
+   * Three active members, replication factor 1. The default tenant runs partition 1 on member 0;
+   * "tenanta" runs its partition 1 on member 2, so member 2 holds nothing but a non-default
+   * tenant's partition.
+   */
+  private CurrentClusterConfiguration twoTenantCluster() {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_2, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
+        Map.of(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            singlePartitionGroup(MEMBER_0),
+            TENANT_A,
+            singlePartitionGroup(MEMBER_2)),
+        PhasedChangeState.empty());
+  }
+
+  private PartitionGroupConfiguration singlePartitionGroup(final MemberId member) {
+    return new PartitionGroupConfiguration(
+        1,
+        0,
+        Map.of(
+            member,
+            BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, partitionConfig)))),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
   private CurrentClusterConfiguration configuration() {
     return manager.getMultiConfiguration().join();
+  }
+
+  /**
+   * Before every physical tenant was considered when planning a membership change, this request was
+   * rejected during validation: the plan moved only the default tenant's partitions, so {@code
+   * MemberLeaveApplier} — which checks every partition group — refused to let member 2 leave while
+   * it still held tenanta's partition. The whole request failed with "the member still has
+   * partitions assigned", leaving the operator no way to remove the broker at all.
+   */
+  @Test
+  void shouldMoveANonDefaultTenantsPartitionOffARemovedBroker() {
+    // given — member 2 holds only tenanta's partition
+    wire(MEMBER_0, twoTenantCluster());
+
+    // when — member 2 is removed from the cluster
+    final var result =
+        coordinator
+            .applyOperations(
+                new ClusterPatchRequestTransformer(
+                    Set.of(), Set.of(MEMBER_2), Optional.empty(), Optional.empty()))
+            .join();
+
+    // then — the request is admitted at all, which is the regression: validation simulates every
+    // phase through the same appliers the manager uses, so reaching a pending plan proves
+    // MemberLeaveApplier no longer refuses the leave.
+    assertThat(configuration().phasedChangeState().pending()).containsKey(result.changeId());
+
+    // and the plan moves tenanta's partition to a retained broker, before member 2 leaves. It is
+    // not drained here: its operations target members 1 and 2, and this harness runs a single
+    // manager for member 0 — a real cluster applying every phase is covered by
+    // PhysicalTenantBrokerScalingIT.
+    assertThat(result.phases()).hasSize(3);
+    assertThat(result.phases().get(1))
+        .asInstanceOf(type(PartitionGroupParallelPhase.class))
+        .satisfies(
+            phase -> {
+              assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
+              assertThat(phase.groupOperations().get(TENANT_A))
+                  .contains(new PartitionLeaveOperation(MEMBER_2, 1, 1))
+                  .anySatisfy(
+                      operation ->
+                          assertThat(operation)
+                              .asInstanceOf(type(PartitionJoinOperation.class))
+                              .extracting(PartitionJoinOperation::memberId)
+                              .isNotEqualTo(MEMBER_2));
+            });
+    assertThat(result.phases().get(2))
+        .asInstanceOf(type(GlobalPhase.class))
+        .satisfies(
+            phase -> assertThat(phase.operations()).contains(new MemberLeaveOperation(MEMBER_2)));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -8,12 +8,10 @@
 package io.camunda.zeebe.dynamic.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterPatchRequestTransformer;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
@@ -37,7 +35,6 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOp
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
@@ -68,8 +65,6 @@ final class NewModelConfigurationChangeCoordinatorTest {
 
   private static final MemberId MEMBER_0 = MemberId.from("0");
   private static final MemberId MEMBER_1 = MemberId.from("1");
-  private static final MemberId MEMBER_2 = MemberId.from("2");
-  private static final String TENANT_A = "tenanta";
   private final TestConcurrencyControl executor = new TestConcurrencyControl();
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
@@ -94,19 +89,13 @@ final class NewModelConfigurationChangeCoordinatorTest {
     manager.registerGlobalChangeAppliers(
         new GlobalConfigurationChangeAppliersImpl(
             new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
-    // Every broker registers appliers for every physical tenant it is configured with, so a seed
-    // with more than one partition group needs more than one registration here too.
-    seed.partitionGroups()
-        .keySet()
-        .forEach(
-            groupId ->
-                manager.registerPartitionGroupChangeAppliers(
-                    groupId,
-                    new PartitionGroupConfigurationChangeAppliersImpl(
-                        new NoopPartitionChangeExecutor(),
-                        new NoopPartitionScalingChangeExecutor(),
-                        new NoopModeChangeExecutor(),
-                        new NoopRestoreChangeExecutor())));
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
     coordinator = new ConfigurationChangeCoordinatorImpl(manager, localMemberId, executor);
     manager.updateMultiConfiguration(ignored -> seed).join();
   }
@@ -170,96 +159,8 @@ final class NewModelConfigurationChangeCoordinatorTest {
         base.phasedChangeState());
   }
 
-  /**
-   * Three active members, replication factor 1. The default tenant runs partition 1 on member 0;
-   * "tenanta" runs its partition 1 on member 2, so member 2 holds nothing but a non-default
-   * tenant's partition.
-   */
-  private CurrentClusterConfiguration twoTenantCluster() {
-    return new CurrentClusterConfiguration(
-        CurrentClusterConfiguration.INITIAL_VERSION,
-        new GlobalConfiguration(
-            1,
-            Optional.empty(),
-            Map.of(
-                MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
-                MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
-                MEMBER_2, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty()),
-        Map.of(
-            CurrentClusterConfiguration.DEFAULT_GROUP,
-            singlePartitionGroup(MEMBER_0),
-            TENANT_A,
-            singlePartitionGroup(MEMBER_2)),
-        PhasedChangeState.empty());
-  }
-
-  private PartitionGroupConfiguration singlePartitionGroup(final MemberId member) {
-    return new PartitionGroupConfiguration(
-        1,
-        0,
-        Map.of(
-            member,
-            BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, partitionConfig)))),
-        Optional.empty(),
-        Optional.empty(),
-        Optional.empty());
-  }
-
   private CurrentClusterConfiguration configuration() {
     return manager.getMultiConfiguration().join();
-  }
-
-  /**
-   * Before every physical tenant was considered when planning a membership change, this request was
-   * rejected during validation: the plan moved only the default tenant's partitions, so {@code
-   * MemberLeaveApplier} — which checks every partition group — refused to let member 2 leave while
-   * it still held tenanta's partition. The whole request failed with "the member still has
-   * partitions assigned", leaving the operator no way to remove the broker at all.
-   */
-  @Test
-  void shouldMoveANonDefaultTenantsPartitionOffARemovedBroker() {
-    // given — member 2 holds only tenanta's partition
-    wire(MEMBER_0, twoTenantCluster());
-
-    // when — member 2 is removed from the cluster
-    final var result =
-        coordinator
-            .applyOperations(
-                new ClusterPatchRequestTransformer(
-                    Set.of(), Set.of(MEMBER_2), Optional.empty(), Optional.empty()))
-            .join();
-
-    // then — the request is admitted at all, which is the regression: validation simulates every
-    // phase through the same appliers the manager uses, so reaching a pending plan proves
-    // MemberLeaveApplier no longer refuses the leave.
-    assertThat(configuration().phasedChangeState().pending()).containsKey(result.changeId());
-
-    // and the plan moves tenanta's partition to a retained broker, before member 2 leaves. It is
-    // not drained here: its operations target members 1 and 2, and this harness runs a single
-    // manager for member 0 — a real cluster applying every phase is covered by
-    // PhysicalTenantBrokerScalingIT.
-    assertThat(result.phases()).hasSize(3);
-    assertThat(result.phases().get(1))
-        .asInstanceOf(type(PartitionGroupParallelPhase.class))
-        .satisfies(
-            phase -> {
-              assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
-              assertThat(phase.groupOperations().get(TENANT_A))
-                  .contains(new PartitionLeaveOperation(MEMBER_2, 1, 1))
-                  .anySatisfy(
-                      operation ->
-                          assertThat(operation)
-                              .asInstanceOf(type(PartitionJoinOperation.class))
-                              .extracting(PartitionJoinOperation::memberId)
-                              .isNotEqualTo(MEMBER_2));
-            });
-    assertThat(result.phases().get(2))
-        .asInstanceOf(type(GlobalPhase.class))
-        .satisfies(
-            phase -> assertThat(phase.operations()).contains(new MemberLeaveOperation(MEMBER_2)));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
@@ -29,8 +30,10 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -619,6 +622,64 @@ final class ClusterPatchRequestTransformerTest {
     // that may have drifted from what the distributor would compute now
     assertThat(result).isRight();
     Assertions.assertThat(result.get()).isEmpty();
+  }
+
+  @Test
+  void shouldRedistributeEveryPhysicalTenantWhenRemovingABroker() {
+    // given — id2 holds only tenant-b's partition, so the whole partition half of this plan is work
+    // the default-group projection could never have produced
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(id2), Optional.empty(), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isRight();
+    Assertions.assertThat(result.get()).hasSize(3);
+    final var partitionPhase = (PartitionGroupParallelPhase) result.get().get(1);
+    Assertions.assertThat(partitionPhase.groupOperations()).containsOnlyKeys(TENANT_B);
+    Assertions.assertThat(partitionPhase.groupOperations().get(TENANT_B))
+        .describedAs("tenant-b gives up the partition on the departing broker")
+        .contains(new PartitionLeaveOperation(id2, 1, 1));
+    Assertions.assertThat(((GlobalPhase) result.get().get(2)).operations())
+        .describedAs("the broker leaves only after the partition work")
+        .contains(new MemberLeaveOperation(id2));
+  }
+
+  @Test
+  void shouldRejectReplicationFactorOnZoneAwareClusterEvenWhenChangingMembership() {
+    // given — a request that both adds a broker and raises the replication factor
+    final var transformer =
+        new ClusterPatchRequestTransformer(Set.of(id3), Set.of(), Optional.empty(), Optional.of(2));
+
+    // when
+    final var result = transformer.phases(zoneAwareTwoTenantCluster());
+
+    // then — answered with the zone-aware rejection, not with whatever the zone-aware distributor
+    // raises about the resulting replica sum once a placement is attempted
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("zone-aware");
+  }
+
+  @Test
+  void shouldRejectAddingAndRemovingTheSameMemberWhenPlanningPhases() {
+    // given
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(id3), Set.of(id3), Optional.empty(), Optional.empty());
+
+    // when — the new-model coordinator plans through phases() alone, so the check has to hold there
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("Cannot add and remove the same member");
   }
 
   /** {@link #twoTenantCluster()} with a zone-aware partition distributor. */

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
@@ -30,8 +31,10 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -681,6 +684,35 @@ final class ClusterScaleRequestTransformerTest {
     Assertions.assertThat(result.getLeft())
         .isInstanceOf(InvalidRequest.class)
         .hasMessageContaining("Number of brokers [3] is less than the replication factor [4]");
+  }
+
+  @Test
+  void shouldRedistributeEveryPhysicalTenantWhenChangingTheBrokerCount() {
+    // given — the cluster shrinks from three brokers to two. Only broker id2 holds anything that
+    // has to move, and what it holds belongs to tenant-b, so the whole partition half of this plan
+    // is work the default-group projection could never have produced.
+    final var transformer =
+        new ClusterScaleRequestTransformer(
+            Optional.of(2), Optional.empty(), Optional.empty(), Optional.empty());
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isRight();
+    Assertions.assertThat(result.get()).hasSize(3);
+    final var partitionPhase = (PartitionGroupParallelPhase) result.get().get(1);
+    Assertions.assertThat(partitionPhase.groupOperations()).containsOnlyKeys(TENANT_B);
+    Assertions.assertThat(joins(partitionPhase, TENANT_B))
+        .describedAs("tenant-b's partition is placed on a retained broker")
+        .extracting(PartitionJoinOperation::memberId)
+        .containsExactly(id0);
+    Assertions.assertThat(partitionPhase.groupOperations().get(TENANT_B))
+        .describedAs("tenant-b gives up the partition on the departing broker")
+        .contains(new PartitionLeaveOperation(id2, 1, 1));
+    Assertions.assertThat(((GlobalPhase) result.get().get(2)).operations())
+        .describedAs("the broker leaves only after the partition work")
+        .contains(new MemberLeaveOperation(id2));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -12,23 +12,40 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.PartitionDistributor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.util.Either;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -44,10 +61,47 @@ import net.jqwik.api.constraints.IntRange;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ScaleRequestTransformerTest {
 
+  private static final String TENANT_A = "tenant-a";
+
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  static List<Arguments> singleTenantScenarios() {
+    final var two = members(2);
+    final var three = members(3);
+    return List.of(
+        Arguments.of("scale up", two, three, Optional.empty(), Optional.empty()),
+        Arguments.of("scale down", three, two, Optional.empty(), Optional.empty()),
+        Arguments.of(
+            "add and remove",
+            three,
+            Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("3")),
+            Optional.empty(),
+            Optional.empty()),
+        Arguments.of("unchanged members", three, three, Optional.empty(), Optional.empty()),
+        Arguments.of(
+            "scale up with replication factor", two, three, Optional.of(2), Optional.empty()),
+        Arguments.of("scale up with partition count", two, three, Optional.empty(), Optional.of(5)),
+        Arguments.of("scale up with both", two, three, Optional.of(2), Optional.of(5)));
+  }
+
+  private static Set<MemberId> members(final int count) {
+    return IntStream.range(0, count)
+        .mapToObj(Integer::toString)
+        .map(MemberId::from)
+        .collect(Collectors.toSet());
+  }
+
+  private static List<PartitionId> sortedPartitionIds(final int partitionCount) {
+    return IntStream.rangeClosed(1, partitionCount)
+        .mapToObj(id -> new PartitionId(CurrentClusterConfiguration.DEFAULT_GROUP, id))
+        .toList();
+  }
 
   @Property(tries = 10)
   void shouldScaleAndReassignWithReplicationFactor1(
@@ -313,6 +367,287 @@ class ScaleRequestTransformerTest {
   }
 
   @Nested
+  class PhasesOnASingleTenantCluster {
+
+    /**
+     * A single-tenant cluster must plan exactly the change it planned before {@code phases()}
+     * existed, so this compares the two directly: the phases the new path builds against the phases
+     * {@code toPhases} derives from the legacy flat operation list. Asserting equality rather than
+     * re-deriving an expected plan is what makes it a regression test — any divergence in operation
+     * content, ordering, or phase boundaries fails it.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(
+        "io.camunda.zeebe.dynamic.config.api.ScaleRequestTransformerTest#singleTenantScenarios")
+    void shouldPlanTheSameChangeAsTheLegacyPath(
+        final String name,
+        final Set<MemberId> oldMembers,
+        final Set<MemberId> newMembers,
+        final Optional<Integer> newReplicationFactor,
+        final Optional<Integer> newPartitionCount) {
+      // given
+      final var legacy =
+          ConfigurationUtil.getClusterConfigFrom(
+              new RoundRobinPartitionDistributor()
+                  .distributePartitions(oldMembers, sortedPartitionIds(3), 1),
+              DynamicPartitionConfig.init(),
+              "clusterId");
+      final var transformer =
+          new ScaleRequestTransformer(newMembers, newReplicationFactor, newPartitionCount);
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(legacy));
+
+      // then
+      final var legacyPhases =
+          CurrentClusterConfiguration.toPhases(transformer.operations(legacy).get());
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get()).isEqualTo(legacyPhases);
+    }
+  }
+
+  @Nested
+  class PhasesAcrossPhysicalTenants {
+
+    /**
+     * Two brokers, replication factor 1, and two tenants each running partitions 1-3 spread over
+     * both brokers. Six joint partitions over three brokers give the third broker one partition of
+     * each tenant, so a plan that only ever saw the default group is plainly distinguishable from
+     * one that saw both.
+     */
+    private CurrentClusterConfiguration twoTenantCluster() {
+      return twoTenantCluster(Set.of(MemberId.from("0"), MemberId.from("1")));
+    }
+
+    private CurrentClusterConfiguration twoTenantCluster(final Set<MemberId> members) {
+      final var legacy =
+          ConfigurationUtil.getClusterConfigFrom(
+              new RoundRobinPartitionDistributor()
+                  .distributePartitions(members, sortedPartitionIds(3), 1),
+              DynamicPartitionConfig.init(),
+              "clusterId");
+      final var single = CurrentClusterConfiguration.fromLegacy(legacy);
+      return new CurrentClusterConfiguration(
+          single.version(),
+          single.globalConfiguration(),
+          Map.of(
+              CurrentClusterConfiguration.DEFAULT_GROUP,
+              single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+              TENANT_A,
+              single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
+          single.phasedChangeState());
+    }
+
+    @Test
+    void shouldPlacePartitionsOfEveryTenantOnAnAddedBroker() {
+      // given
+      final var configuration = twoTenantCluster();
+
+      // when — broker 2 joins
+      final var phases =
+          new ScaleRequestTransformer(
+                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")))
+              .phases(configuration);
+
+      // then — the joining broker receives a partition of both tenants
+      final var partitionPhase = partitionPhase(phases);
+      assertThat(joinedPartitions(partitionPhase, CurrentClusterConfiguration.DEFAULT_GROUP))
+          .describedAs("the default tenant places a partition on broker 2")
+          .isNotEmpty()
+          .allSatisfy(join -> assertThat(join.memberId()).isEqualTo(MemberId.from("2")));
+      assertThat(joinedPartitions(partitionPhase, TENANT_A))
+          .describedAs("tenant-a places a partition on broker 2")
+          .isNotEmpty()
+          .allSatisfy(join -> assertThat(join.memberId()).isEqualTo(MemberId.from("2")));
+    }
+
+    @Test
+    void shouldMoveEveryTenantsPartitionsOffARemovedBroker() {
+      // given
+      final var configuration =
+          twoTenantCluster(Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
+
+      // when — broker 2 leaves
+      final var phases =
+          new ScaleRequestTransformer(Set.of(MemberId.from("0"), MemberId.from("1")))
+              .phases(configuration);
+
+      // then — both tenants give up the partitions broker 2 held, and it receives nothing. The
+      // distributor recomputes the whole placement, so partitions also move between the two
+      // surviving brokers; what matters is that neither tenant leaves anything behind on the
+      // departing one.
+      final var partitionPhase = partitionPhase(phases);
+      for (final var groupId : List.of(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)) {
+        assertThat(leftPartitions(partitionPhase, groupId))
+            .describedAs("tenant '%s' moves its partitions off broker 2", groupId)
+            .extracting(PartitionLeaveOperation::memberId)
+            .contains(MemberId.from("2"));
+        assertThat(joinedPartitions(partitionPhase, groupId))
+            .describedAs("tenant '%s' places nothing on the departing broker 2", groupId)
+            .extracting(PartitionJoinOperation::memberId)
+            .doesNotContain(MemberId.from("2"));
+      }
+      assertThat(phases.get())
+          .describedAs("the member leaves only after the partition work")
+          .last()
+          .isInstanceOf(GlobalPhase.class);
+      assertThat(((GlobalPhase) phases.get().getLast()).operations())
+          .contains(new MemberLeaveOperation(MemberId.from("2")));
+    }
+
+    @Test
+    void shouldOrderMemberJoinsBeforeAndMemberLeavesAfterThePartitionWork() {
+      // given
+      final var configuration =
+          twoTenantCluster(Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
+
+      // when — broker 3 joins as broker 2 leaves
+      final var phases =
+          new ScaleRequestTransformer(
+                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("3")))
+              .phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .hasSize(3)
+          .satisfies(
+              list -> {
+                assertThat(((GlobalPhase) list.get(0)).operations())
+                    .contains(new MemberJoinOperation(MemberId.from("3")))
+                    .doesNotContain(new MemberLeaveOperation(MemberId.from("2")));
+                assertThat(list.get(1)).isInstanceOf(PartitionGroupParallelPhase.class);
+                assertThat(((GlobalPhase) list.get(2)).operations())
+                    .contains(new MemberLeaveOperation(MemberId.from("2")))
+                    .doesNotContain(new MemberJoinOperation(MemberId.from("3")));
+              });
+    }
+
+    @Test
+    void shouldApplyAReplicationFactorChangeToEveryTenantWhileScaling() {
+      // given
+      final var configuration = twoTenantCluster();
+
+      // when — broker 2 joins and the replication factor is raised at the same time
+      final var phases =
+          new ScaleRequestTransformer(
+                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")),
+                  Optional.of(2))
+              .phases(configuration);
+
+      // then — every partition of every tenant gains a replica
+      final var partitionPhase = partitionPhase(phases);
+      assertThat(partitionPhase.groupOperations())
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A);
+      assertThat(joinedPartitions(partitionPhase, CurrentClusterConfiguration.DEFAULT_GROUP))
+          .hasSize(3);
+      assertThat(joinedPartitions(partitionPhase, TENANT_A)).hasSize(3);
+    }
+
+    @Test
+    void shouldPlanASingleGlobalPhaseWhenThereIsNoPartitionWork() {
+      // given — one partition per tenant, already sitting where round robin over three brokers puts
+      // it, so adding the third broker has nothing to move for either tenant
+      final var configuration =
+          cluster(
+              Set.of(MemberId.from("0"), MemberId.from("1")),
+              Map.of(
+                  CurrentClusterConfiguration.DEFAULT_GROUP,
+                  Map.of(MemberId.from("0"), 1),
+                  TENANT_A,
+                  Map.of(MemberId.from("1"), 1)));
+
+      // when
+      final var phases =
+          new ScaleRequestTransformer(
+                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")))
+              .phases(configuration);
+
+      // then — nothing separates the member join from the scaling callbacks, so one uninterrupted
+      // run of global operations is one phase, exactly as toPhases would produce
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get()).singleElement().isInstanceOf(GlobalPhase.class);
+    }
+
+    /** A configuration with explicit per-tenant placement: group id to member to partition id. */
+    private CurrentClusterConfiguration cluster(
+        final Set<MemberId> members, final Map<String, Map<MemberId, Integer>> placement) {
+      final var brokers =
+          members.stream()
+              .collect(
+                  Collectors.toMap(
+                      member -> member,
+                      member -> new BrokerState(1, Instant.EPOCH, BrokerState.State.ACTIVE)));
+      final var groups =
+          placement.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey,
+                      group ->
+                          new PartitionGroupConfiguration(
+                              1,
+                              0,
+                              group.getValue().entrySet().stream()
+                                  .collect(
+                                      Collectors.toMap(
+                                          Map.Entry::getKey,
+                                          member ->
+                                              BrokerPartitionState.initialize(
+                                                  Map.of(
+                                                      member.getValue(),
+                                                      PartitionState.active(
+                                                          1, DynamicPartitionConfig.init()))))),
+                              Optional.empty(),
+                              Optional.empty(),
+                              Optional.empty())));
+      return new CurrentClusterConfiguration(
+          CurrentClusterConfiguration.INITIAL_VERSION,
+          new GlobalConfiguration(
+              1, Optional.empty(), brokers, Optional.empty(), Optional.empty(), Optional.empty()),
+          groups,
+          PhasedChangeState.empty());
+    }
+
+    @Test
+    void shouldRejectARequestWithoutAnyBroker() {
+      // when
+      final var phases = new ScaleRequestTransformer(Set.of()).phases(twoTenantCluster());
+
+      // then
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+    }
+
+    private PartitionGroupParallelPhase partitionPhase(
+        final Either<Exception, List<Phase>> phases) {
+      EitherAssert.assertThat(phases).isRight();
+      return (PartitionGroupParallelPhase)
+          phases.get().stream()
+              .filter(PartitionGroupParallelPhase.class::isInstance)
+              .findFirst()
+              .orElseThrow(() -> new AssertionError("no partition group phase in " + phases.get()));
+    }
+
+    private List<PartitionJoinOperation> joinedPartitions(
+        final PartitionGroupParallelPhase phase, final String groupId) {
+      return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
+          .filter(PartitionJoinOperation.class::isInstance)
+          .map(PartitionJoinOperation.class::cast)
+          .toList();
+    }
+
+    private List<PartitionLeaveOperation> leftPartitions(
+        final PartitionGroupParallelPhase phase, final String groupId) {
+      return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
+          .filter(PartitionLeaveOperation.class::isInstance)
+          .map(PartitionLeaveOperation.class::cast)
+          .toList();
+    }
+  }
+
+  @Nested
   class ZoneAwareScaling {
     static final Set<MemberId> SCALED_MEMBERS =
         Set.of(
@@ -376,6 +711,78 @@ class ScaleRequestTransformerTest {
           .filteredOn(PostScalingOperation.class::isInstance)
           .extracting(op -> ((PostScalingOperation) op).memberId())
           .containsExactly(expectedCoordinator);
+    }
+
+    /**
+     * A zone-aware cluster reaches the same planner: it resolves the distributor from the persisted
+     * {@link ZoneAwareConfig}, so zone-awareness needs no separate path to cover every tenant.
+     */
+    @Test
+    void shouldScaleAZoneAcrossEveryPhysicalTenant() {
+      // given — two tenants on a zone-aware cluster
+      final var configuration = twoTenantZoneAwareCluster(UNSCALED_MEMBERS);
+      final Set<MemberId> newMembers = new HashSet<>(UNSCALED_MEMBERS);
+      newMembers.add(MemberId.from("zone-b", 1));
+
+      // when — zone-b grows from one broker to two
+      final var phases =
+          new ScaleRequestTransformer(
+                  newMembers, Optional.empty(), Optional.empty(), Optional.of("zone-b"))
+              .phases(configuration);
+
+      // then — both tenants' partitions are replanned, and the callbacks still run in zone-b
+      EitherAssert.assertThat(phases).isRight();
+      final var partitionPhase =
+          phases.get().stream()
+              .filter(PartitionGroupParallelPhase.class::isInstance)
+              .map(PartitionGroupParallelPhase.class::cast)
+              .findFirst()
+              .orElseThrow();
+      assertThat(partitionPhase.groupOperations())
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A);
+      assertThat(((GlobalPhase) phases.get().getFirst()).operations())
+          .filteredOn(PreScalingOperation.class::isInstance)
+          .extracting(op -> ((PreScalingOperation) op).memberId())
+          .containsExactly(MemberId.from("zone-b", 0));
+    }
+
+    @Test
+    void shouldRejectABareMemberJoiningAZoneAwareCluster() {
+      // given
+      final var configuration = twoTenantZoneAwareCluster(UNSCALED_MEMBERS);
+      final Set<MemberId> newMembers = new HashSet<>(UNSCALED_MEMBERS);
+      newMembers.add(MemberId.from("3"));
+
+      // when
+      final var phases = new ScaleRequestTransformer(newMembers).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+    }
+
+    private CurrentClusterConfiguration twoTenantZoneAwareCluster(final Set<MemberId> members) {
+      final var legacy =
+          ConfigurationUtil.getClusterConfigFrom(
+                  ZONE_AWARE_CONFIG
+                      .toDistributor()
+                      .distributePartitions(
+                          members, sortedPartitionIds(3), ZONE_AWARE_CONFIG.replicationFactor()),
+                  DynamicPartitionConfig.init(),
+                  "clusterId")
+              .setPartitionDistributorConfig(ZONE_AWARE_CONFIG);
+      final var single = CurrentClusterConfiguration.fromLegacy(legacy);
+      return new CurrentClusterConfiguration(
+          single.version(),
+          single.globalConfiguration(),
+          Map.of(
+              CurrentClusterConfiguration.DEFAULT_GROUP,
+              single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+              TENANT_A,
+              single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
+          single.phasedChangeState());
     }
 
     @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantBrokerScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantBrokerScalingIT.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a broker count change through {@code POST /actuator/cluster/brokers} reaches every
+ * physical tenant's partition group (issue #60193), not only the default one.
+ *
+ * <p>Before this, adding a broker gave capacity only the default tenant could use, and removing one
+ * was rejected outright — the plan moved only the default tenant's partitions off the departing
+ * broker, so the member leave was refused because the broker still held another tenant's
+ * partitions.
+ *
+ * <p>Both tenants deliberately run the same number of partitions. Six partitions spread over three
+ * brokers by a single cluster-wide round robin put one partition of *each* tenant on every broker,
+ * so a plan that only ever saw the default group leaves the third broker without any {@code
+ * tenanta} partition — visible in the per-tenant topology rather than only in a plan.
+ */
+@ZeebeIntegration
+final class PhysicalTenantBrokerScalingIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int INITIAL_BROKERS_COUNT = 2;
+  private static final int PARTITIONS_PER_TENANT = 3;
+  private static final int REPLICATION_FACTOR = 1;
+  // TestClusterBuilder sizes the actor threads as (partitions * replicationFactor) / brokers, which
+  // counts one tenant's partitions only and rounds down to 0 at replication factor 1 — and a
+  // scheduler with no threads cannot start a broker. Size them for every partition of both tenants.
+  private static final int ACTOR_THREAD_COUNT = 2 * PARTITIONS_PER_TENANT;
+
+  // Routing through PhysicalTenantsITHelper both supplies a real config diff (secondary storage =
+  // none) so the tenant is discovered and bootstrapped, and declares the per-tenant
+  // security.initialization block that PhysicalTenantRequiredOverrideValidation requires once a
+  // non-default tenant exists.
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(INITIAL_BROKERS_COUNT)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withPartitionsCount(PARTITIONS_PER_TENANT)
+          .withBrokerConfig(broker -> configureTenants(broker, INITIAL_BROKERS_COUNT))
+          .build();
+
+  private TestStandaloneBroker addedBroker;
+
+  @AfterEach
+  void closeAddedBroker() {
+    if (addedBroker != null) {
+      addedBroker.close();
+      addedBroker = null;
+    }
+  }
+
+  @Test
+  void shouldPlacePartitionsOfEveryTenantOnAnAddedBroker() {
+    // given — both tenants run their partitions on the two initial brokers
+    awaitTopology(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, INITIAL_BROKERS_COUNT);
+    awaitTopology(TENANT_A, INITIAL_BROKERS_COUNT);
+
+    // when — a third broker joins the cluster
+    final int newBrokerId = INITIAL_BROKERS_COUNT;
+    final int newClusterSize = INITIAL_BROKERS_COUNT + 1;
+    addedBroker = startBroker(newBrokerId, newClusterSize);
+    scaleBrokers(newClusterSize);
+
+    // then — every tenant places a partition on it, not just the default one. isComplete alone
+    // would not catch this: with three partitions at replication factor one it holds even when the
+    // new broker sits empty and all three stay on the original two.
+    awaitTopology(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, newClusterSize);
+    awaitTopology(TENANT_A, newClusterSize);
+    awaitHoldsAPartition(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, newBrokerId);
+    awaitHoldsAPartition(TENANT_A, newBrokerId);
+  }
+
+  @Test
+  void shouldMoveEveryTenantsPartitionsOffARemovedBroker() {
+    // given — a third broker holding a partition of each tenant
+    final int removedBrokerId = INITIAL_BROKERS_COUNT;
+    final int grownClusterSize = INITIAL_BROKERS_COUNT + 1;
+    addedBroker = startBroker(removedBrokerId, grownClusterSize);
+    scaleBrokers(grownClusterSize);
+    awaitHoldsAPartition(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, removedBrokerId);
+    awaitHoldsAPartition(TENANT_A, removedBrokerId);
+
+    // when — that broker is removed again
+    scaleBrokers(INITIAL_BROKERS_COUNT);
+    awaitLeftTheCluster(removedBrokerId);
+    // Stop it only once it has left, so it no longer gossips its broker info into the gateway's
+    // topology — mirroring what ScaleDownBrokersTest does for a decommissioned broker.
+    addedBroker.close();
+    addedBroker = null;
+
+    // then — every partition of both tenants is healthy on the two remaining brokers, which is only
+    // true if each tenant moved what the departing broker held
+    awaitTopology(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, INITIAL_BROKERS_COUNT);
+    awaitTopology(TENANT_A, INITIAL_BROKERS_COUNT);
+  }
+
+  private void awaitLeftTheCluster(final int brokerId) {
+    final var actuator = ClusterActuator.of(cluster.availableGateway());
+    await("broker %d has left the cluster configuration".formatted(brokerId))
+        .atMost(Duration.ofMinutes(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(actuator.getTopology().getBrokers())
+                    .extracting(brokerState -> brokerState.getId().toString())
+                    .doesNotContain(String.valueOf(brokerId)));
+  }
+
+  /**
+   * Submits the broker set through {@code POST /actuator/cluster/brokers}. Completion is not
+   * awaited here but through each tenant's own topology, which is what shows the partitions really
+   * moved rather than only that a plan finished.
+   *
+   * <p>A retry is needed because the cluster can still be applying its own initial configuration
+   * change when the test starts, and rejects a second change while one is in progress. The request
+   * either returns or throws a {@link feign.FeignException}, so it cannot be handed to {@code
+   * untilAsserted}, which only retries on {@link AssertionError}.
+   */
+  private void scaleBrokers(final int newClusterSize) {
+    final var actuator = ClusterActuator.of(cluster.availableGateway());
+    final var brokerIds = IntStream.range(0, newClusterSize).boxed().toList();
+    final var response = new PlannedOperationsResponse[1];
+    await("the cluster accepts the broker set %s".formatted(brokerIds))
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              response[0] = actuator.scaleBrokers(brokerIds);
+              return true;
+            });
+    assertThat(response[0].getPlannedChanges()).isNotEmpty();
+  }
+
+  /**
+   * Asserts through the tenant's own client that its partitions are healthy on {@code size}
+   * brokers.
+   */
+  private void awaitTopology(final String physicalTenantId, final int clusterSize) {
+    try (final var client =
+        TENANTS.newClientBuilder(cluster.availableGateway(), physicalTenantId).build()) {
+      await(
+              "physical tenant '%s' has a complete topology over %d brokers"
+                  .formatted(physicalTenantId, clusterSize))
+          .atMost(Duration.ofMinutes(2))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                      .isComplete(clusterSize, PARTITIONS_PER_TENANT, REPLICATION_FACTOR));
+    }
+  }
+
+  private void awaitHoldsAPartition(final String physicalTenantId, final int brokerId) {
+    try (final var client =
+        TENANTS.newClientBuilder(cluster.availableGateway(), physicalTenantId).build()) {
+      await(
+              "physical tenant '%s' holds a partition on broker %d"
+                  .formatted(physicalTenantId, brokerId))
+          .atMost(Duration.ofMinutes(1))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  assertThat(client.newTopologyRequest().send().join().getBrokers())
+                      .filteredOn(broker -> broker.getNodeId() == brokerId)
+                      .singleElement()
+                      .satisfies(
+                          broker ->
+                              assertThat(broker.getPartitions())
+                                  .describedAs(
+                                      "partitions of tenant '%s' on broker %d",
+                                      physicalTenantId, brokerId)
+                                  .isNotEmpty()));
+    }
+  }
+
+  /** Starts a broker outside the {@link TestCluster}, configured like the ones inside it. */
+  private TestStandaloneBroker startBroker(final int nodeId, final int clusterSize) {
+    final var contactPoint =
+        cluster.brokers().get(MemberId.from("0")).address(TestZeebePort.CLUSTER);
+    final var broker =
+        configureTenants(new TestStandaloneBroker(), clusterSize)
+            .withUnifiedConfig(
+                camunda -> {
+                  camunda.getCluster().setName(cluster.name());
+                  camunda.getCluster().setNodeId(nodeId);
+                  camunda.getCluster().setInitialContactPoints(List.of(contactPoint));
+                });
+    broker.start();
+    return broker;
+  }
+
+  private static TestStandaloneBroker configureTenants(
+      final TestStandaloneBroker broker, final int clusterSize) {
+    return TENANTS.configure(
+        broker
+            .withUnauthenticatedAccess()
+            .withPtConfig(
+                TENANT_A, camunda -> camunda.getCluster().setPartitionCount(PARTITIONS_PER_TENANT))
+            .withUnifiedConfig(
+                camunda -> {
+                  camunda.getCluster().setSize(clusterSize);
+                  camunda.getSystem().setCpuThreadCount(ACTOR_THREAD_COUNT);
+                  camunda.getSystem().setIoThreadCount(ACTOR_THREAD_COUNT);
+                }));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantBrokerScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantBrokerScalingIT.java
@@ -50,8 +50,8 @@ final class PhysicalTenantBrokerScalingIT {
   private static final int PARTITIONS_PER_TENANT = 3;
   private static final int REPLICATION_FACTOR = 1;
   // TestClusterBuilder sizes the actor threads as (partitions * replicationFactor) / brokers, which
-  // counts one tenant's partitions only and rounds down to 0 at replication factor 1 — and a
-  // scheduler with no threads cannot start a broker. Size them for every partition of both tenants.
+  // counts one tenant's partitions only: here that is a single thread, for the partitions of both
+  // tenants a broker ends up hosting. Size them for every partition of both tenants instead.
   private static final int ACTOR_THREAD_COUNT = 2 * PARTITIONS_PER_TENANT;
 
   // Routing through PhysicalTenantsITHelper both supplies a real config diff (secondary storage =


### PR DESCRIPTION
Adding or removing brokers moved only the default physical tenant's partitions, so on a multi-tenant cluster adding a broker gave capacity only the default tenant could use, and removing one could not be done at all — the plan moved only the default tenant's partitions off the departing broker, so `MemberLeaveApplier`, which checks every partition group, refused the leave and the whole request was rejected during validation with "the member still has partitions assigned".

`ScaleRequestTransformer` now composes the phases itself, mirroring what its `operations()` already does — pre-scaling and member joins, then the partition placement, then member leaves and post-scaling ([`ScaleRequestTransformer.java#L82-L131`](https://github.com/camunda/camunda/blob/1f3121118ae2e1a46e0e4635a081d240a82d141b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java#L82-L131)). Only the partition half changes: `PartitionGroupScalingPhases` distributes every group's partitions together over the request's member set, via a new overload that takes the target members explicitly ([`PartitionGroupScalingPhases.java#L120-L133`](https://github.com/camunda/camunda/blob/1f3121118ae2e1a46e0e4635a081d240a82d141b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java#L120-L133)) rather than the cluster's live members. Both request transformers delegate to it for membership changes, exactly as their `operations()` already delegate.

The joint distribution is what makes this work rather than merely tidier: placing each tenant independently would leave a new broker empty, because round robin over one tenant's partitions alone need not reach it.

Zone-aware clusters need no separate path — the planner resolves its distributor from the persisted `ZoneAwareConfig`, so a zoned cluster is planned by `ZoneAwarePartitionDistributor` over every tenant's partitions, and that distributor's own validations surface as request rejections. One ordering detail mattered here: the zone-aware replication-factor rejection had to move ahead of the membership branch ([`ClusterPatchRequestTransformer.java#L71-L81`](https://github.com/camunda/camunda/blob/1f3121118ae2e1a46e0e4635a081d240a82d141b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java#L71-L81)), matching the order `operations()` checks it in, so a request combining a replication factor with a membership change is still answered with "not supported on zone-aware clusters" instead of whatever the distributor raises about the resulting replica sum. `ZoneAwareClusterEndpointIT.shouldRequestClusterPatch` caught that.

### On the first acceptance criterion

The behaviour of removing a broker that still holds a non-default tenant's partitions is recorded in [a comment on the issue](https://github.com/camunda/camunda/issues/60193): the request is rejected up front and the configuration is left untouched, so there is no silent replication loss — the operation is simply unavailable. The forced path is blocked identically, and adding a broker succeeds but plans nothing for any tenant but the default one. All three were established by driving the real coordinator against a two-tenant configuration.

### Verification

`phases()` reproducing today's plan is asserted directly rather than by re-deriving an expected one: for a single-tenant cluster the new path is compared against `toPhases(operations(...))` across scale-up, scale-down, add-and-remove, an unchanged member set, and each combined with a replication-factor and a partition-count change. The acceptance IT was checked against a negative control — with the routing reverted, both tests fail on "tenant a holds a partition on the added broker", and only after the equivalent assertion for the default tenant has passed.

`NonZoneAwareClusterEndpointIT`, `ZoneAwareClusterEndpointIT`, `ScaleUpBrokersTest`, `ScaleDownBrokersTest`, `ForceScaleDownBrokersTest`, `CancelChangeTest`, `PhysicalTenantPartitionScalingIT` and `PhysicalTenantReplicationFactorIT` all pass.

### Follow-ups

This does not finish zone-awareness with physical tenants. Every zone operation funnels through the legacy single-group distribution step, and only some reach it via `ScaleRequestTransformer`. In particular `PUT /actuator/cluster/zones` is knowingly left on the legacy path: `ZoneMigrationRequestTransformer` delegates to `operations()`, so after this PR it becomes the one caller of `ScaleRequestTransformer` that does not get multi-group planning. Follow-ups filed: #60341 (zone migration), #60342 (`UpdatePartitionDistributionTransformer`, which unlocks `PUT /partition-distribution` and `POST /zones/{id}`), #60343 (the force family), #60344 (a disabled physical tenant still blocks broker removal).

closes #60193

