### PR TITLE
refactor: remove legacy single-group code path from cluster config manager

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -79,9 +79,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private final TopologyManagerMetrics topologyMetrics;
   private final boolean useNewConfig;
 
-  private final @Nullable PersistedCurrentClusterConfiguration persistedCurrentConfiguration;
+  private final PersistedCurrentClusterConfiguration persistedCurrentConfiguration;
   private @Nullable Consumer<CurrentClusterConfiguration> currentConfigurationGossiper;
-  private final @Nullable ClusterConfigurationCoordinatorSupplier coordinatorSupplier;
+  private final ClusterConfigurationCoordinatorSupplier coordinatorSupplier;
   private @Nullable GlobalConfigurationChangeAppliers globalChangeAppliers;
   private final Map<String, PartitionGroupConfigurationChangeAppliers>
       partitionGroupChangeAppliers = new HashMap<>();
@@ -171,6 +171,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
    * Not supported on the multi-partition-group model — the legacy single-group configuration cannot
    * be mutated in isolation. Use {@link #updateMultiConfiguration} instead.
    */
+  @Deprecated
   @Override
   public ActorFuture<ClusterConfiguration> updateClusterConfiguration(
       final UnaryOperator<ClusterConfiguration> configUpdater) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -9,17 +9,14 @@ package io.camunda.zeebe.dynamic.config;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
-import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliers;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliers;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics.OperationObserver;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
-import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
@@ -65,7 +62,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>When a member receives a configuration with pending changes, it applies the change if it is
  * applicable to the member. Only a member can make changes to its own state in the configuration.
- * See {@link ConfigurationChangeAppliers} to see how a change is applied locally.
+ * See {@link GlobalConfigurationChangeAppliers} and {@link
+ * PartitionGroupConfigurationChangeAppliers} to see how a change is applied locally.
  */
 public final class ClusterConfigurationManagerImpl implements ClusterConfigurationManager {
 
@@ -73,21 +71,14 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private static final Duration MIN_RETRY_DELAY = Duration.ofSeconds(10);
   private static final Duration MAX_RETRY_DELAY = Duration.ofMinutes(1);
   private final ConcurrencyControl executor;
-  private final PersistedClusterConfiguration persistedClusterConfiguration;
-  private Consumer<ClusterConfiguration> configurationGossiper;
   private final ActorFuture<Void> startFuture;
-  private ConfigurationChangeAppliers changeAppliers;
   private InconsistentConfigurationListener onInconsistentConfigurationDetected;
   private final MemberId localMemberId;
-  // Indicates whether there is a configuration change operation in progress on this member.
-  private boolean onGoingConfigurationChangeOperation = false;
-  private boolean shouldRetry = false;
   private final ExponentialBackoffRetryDelay backoffRetry;
   private boolean initialized = false;
   private final TopologyManagerMetrics topologyMetrics;
   private final boolean useNewConfig;
 
-  // New-model state, only used when useNewConfig is true.
   private final @Nullable PersistedCurrentClusterConfiguration persistedCurrentConfiguration;
   private @Nullable Consumer<CurrentClusterConfiguration> currentConfigurationGossiper;
   private final @Nullable ClusterConfigurationCoordinatorSupplier coordinatorSupplier;
@@ -105,47 +96,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private final Map<Long, ScheduledTimer> advancePhaseRetryTimers = new HashMap<>();
   private final int completedChangeHistoryLimit;
 
-  ClusterConfigurationManagerImpl(
-      final ConcurrencyControl executor,
-      final MemberId localMemberId,
-      final PersistedClusterConfiguration persistedClusterConfiguration,
-      final TopologyManagerMetrics topologyMetrics) {
-    this(
-        executor,
-        localMemberId,
-        persistedClusterConfiguration,
-        topologyMetrics,
-        MIN_RETRY_DELAY,
-        MAX_RETRY_DELAY);
-  }
-
-  @VisibleForTesting
-  ClusterConfigurationManagerImpl(
-      final ConcurrencyControl executor,
-      final MemberId localMemberId,
-      final PersistedClusterConfiguration persistedClusterConfiguration,
-      final TopologyManagerMetrics topologyMetrics,
-      final Duration minRetryDelay,
-      final Duration maxRetryDelay) {
-    this.executor = executor;
-    this.persistedClusterConfiguration = persistedClusterConfiguration;
-    startFuture = executor.createFuture();
-    this.localMemberId = localMemberId;
-    this.topologyMetrics = topologyMetrics;
-    this.minRetryDelay = minRetryDelay;
-    this.maxRetryDelay = maxRetryDelay;
-    backoffRetry = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
-    useNewConfig = false;
-    persistedCurrentConfiguration = null;
-    coordinatorSupplier = null;
-    completedChangeHistoryLimit = PhasedChangeState.DEFAULT_HISTORY_LIMIT;
-  }
-
-  /**
-   * Constructs a manager operating on the new multi-partition-group model. Used when {@link
-   * ClusterConfigurationManagerService#USE_NEW_CONFIG} is enabled. The legacy {@code
-   * PersistedClusterConfiguration} is not used in this mode.
-   */
+  /** Constructs a manager operating on the multi-partition-group model. */
   ClusterConfigurationManagerImpl(
       final ConcurrencyControl executor,
       final MemberId localMemberId,
@@ -192,7 +143,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
       final Duration maxRetryDelay,
       final int completedChangeHistoryLimit) {
     this.executor = executor;
-    persistedClusterConfiguration = null;
     this.persistedCurrentConfiguration = persistedCurrentConfiguration;
     startFuture = executor.createFuture();
     this.localMemberId = localMemberId;
@@ -208,41 +158,24 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
             () -> this.persistedCurrentConfiguration.getConfiguration());
   }
 
+  /** Legacy single-group projection of the multi-partition-group configuration. */
   @Override
   public ActorFuture<ClusterConfiguration> getClusterConfiguration() {
     final var future = executor.<ClusterConfiguration>createFuture();
     executor.run(
-        () ->
-            future.complete(
-                useNewConfig
-                    ? persistedCurrentConfiguration.getConfiguration().toLegacyDefault()
-                    : persistedClusterConfiguration.getConfiguration()));
+        () -> future.complete(persistedCurrentConfiguration.getConfiguration().toLegacyDefault()));
     return future;
   }
 
+  /**
+   * Not supported on the multi-partition-group model — the legacy single-group configuration cannot
+   * be mutated in isolation. Use {@link #updateMultiConfiguration} instead.
+   */
   @Override
   public ActorFuture<ClusterConfiguration> updateClusterConfiguration(
       final UnaryOperator<ClusterConfiguration> configUpdater) {
-    final ActorFuture<ClusterConfiguration> future = executor.createFuture();
-    executor.run(
-        () -> {
-          try {
-            final ClusterConfiguration updatedConfiguration =
-                configUpdater.apply(persistedClusterConfiguration.getConfiguration());
-            updateLocalConfiguration(updatedConfiguration)
-                .ifRightOrLeft(
-                    updated -> {
-                      future.complete(updated);
-                      applyConfigurationChangeOperation(updatedConfiguration);
-                    },
-                    future::completeExceptionally);
-          } catch (final Exception e) {
-            LOG.error("Failed to update cluster configuration", e);
-            future.completeExceptionally(e);
-          }
-        });
-
-    return future;
+    throw new UnsupportedOperationException(
+        "updateClusterConfiguration is not supported; use updateMultiConfiguration instead");
   }
 
   @Override
@@ -286,7 +219,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   }
 
   ActorFuture<Void> start(
-      final ClusterConfigurationInitializer<? extends InitializableClusterConfiguration>
+      final ClusterConfigurationInitializer<CurrentClusterConfiguration>
           clusterConfigurationInitializer) {
     executor.run(
         () -> {
@@ -299,12 +232,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     return startFuture;
   }
 
-  public void setConfigurationGossiper(final Consumer<ClusterConfiguration> configurationGossiper) {
-    this.configurationGossiper = configurationGossiper;
-  }
-
   private void initialize(
-      final ClusterConfigurationInitializer<? extends InitializableClusterConfiguration>
+      final ClusterConfigurationInitializer<CurrentClusterConfiguration>
           clusterConfigurationInitializer) {
     clusterConfigurationInitializer
         .initialize()
@@ -319,43 +248,20 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
                 LOG.error(errorMessage);
                 startFuture.completeExceptionally(new IllegalStateException(errorMessage));
               } else {
-                // temporary workaround to support both legacy and new configuration models.
-                if (configuration instanceof final ClusterConfiguration clusterConfiguration) {
-                  try {
-                    // merge in case there was a concurrent update via gossip
-                    persistedClusterConfiguration.update(
-                        clusterConfiguration.merge(
-                            persistedClusterConfiguration.getConfiguration()));
-                    LOG.debug(
-                        "Initialized (legacy) cluster configuration '{}'",
-                        persistedClusterConfiguration.getConfiguration());
-                    configurationGossiper.accept(persistedClusterConfiguration.getConfiguration());
-                  } catch (final IOException e) {
-                    startFuture.completeExceptionally(
-                        "Failed to start update cluster configuration", e);
-                  }
-                } else if (configuration
-                    instanceof final CurrentClusterConfiguration currentClusterConfiguration) {
-                  try {
-                    // merge in case there was a concurrent update via gossip
-                    persistedCurrentConfiguration.update(
-                        currentClusterConfiguration.merge(
-                            persistedCurrentConfiguration.getConfiguration()));
-                    LOG.debug(
-                        "Initialized cluster configuration '{}'",
+                try {
+                  // merge in case there was a concurrent update via gossip
+                  persistedCurrentConfiguration.update(
+                      configuration.merge(persistedCurrentConfiguration.getConfiguration()));
+                  LOG.debug(
+                      "Initialized cluster configuration '{}'",
+                      persistedCurrentConfiguration.getConfiguration());
+                  if (currentConfigurationGossiper != null) {
+                    currentConfigurationGossiper.accept(
                         persistedCurrentConfiguration.getConfiguration());
-                    if (currentConfigurationGossiper != null) {
-                      currentConfigurationGossiper.accept(
-                          persistedCurrentConfiguration.getConfiguration());
-                    }
-                  } catch (final IOException e) {
-                    startFuture.completeExceptionally(
-                        "Failed to start update cluster configuration", e);
                   }
-                } else {
+                } catch (final IOException e) {
                   startFuture.completeExceptionally(
-                      new IllegalStateException(
-                          "Unexpected configuration type: " + configuration.getClass()));
+                      "Failed to start update cluster configuration", e);
                 }
                 setStarted();
               }
@@ -369,73 +275,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     }
   }
 
-  void onGossipReceived(final ClusterConfiguration receivedConfiguration) {
-    executor.run(
-        () -> {
-          if (!initialized) {
-            LOG.trace(
-                "Received configuration {} before ClusterConfigurationManager is initialized.",
-                receivedConfiguration);
-            // When not started, do not update the local configuration. This is to avoid any race
-            // condition between FileInitializer and concurrently received configuration via gossip.
-            configurationGossiper.accept(receivedConfiguration);
-            return;
-          }
-          try {
-            if (receivedConfiguration != null) {
-              final var mergedConfiguration =
-                  persistedClusterConfiguration.getConfiguration().merge(receivedConfiguration);
-              // If received configuration is an older version, the merged configuration will be
-              // same as the
-              // local one. In that case, we can skip the next steps.
-              if (!mergedConfiguration.equals(persistedClusterConfiguration.getConfiguration())) {
-                LOG.debug(
-                    "Received new configuration {}. Updating local configuration to {}",
-                    receivedConfiguration,
-                    mergedConfiguration);
-
-                final var oldConfiguration = persistedClusterConfiguration.getConfiguration();
-                final var isConflictingConfiguration =
-                    isConflictingConfiguration(mergedConfiguration, oldConfiguration);
-                persistedClusterConfiguration.update(mergedConfiguration);
-
-                if (isConflictingConfiguration && onInconsistentConfigurationDetected != null) {
-                  onInconsistentConfigurationDetected.onInconsistentConfiguration(
-                      mergedConfiguration, oldConfiguration);
-                }
-
-                configurationGossiper.accept(mergedConfiguration);
-                applyConfigurationChangeOperation(mergedConfiguration);
-              }
-            }
-          } catch (final IOException error) {
-            LOG.warn(
-                "Failed to process cluster configuration received via gossip. '{}'",
-                receivedConfiguration,
-                error);
-          }
-        });
-  }
-
-  private boolean isConflictingConfiguration(
-      final ClusterConfiguration mergedConfiguration, final ClusterConfiguration oldConfiguration) {
-    if (!mergedConfiguration.hasMember(localMemberId)
-        && oldConfiguration.hasMember(localMemberId)
-        && oldConfiguration.getMember(localMemberId).state() == State.LEFT) {
-      // If the member has left, it's state will be removed from the configuration by another
-      // member. See ClusterConfiguration#advance()
-      return false;
-    }
-    return !Objects.equals(
-        mergedConfiguration.getMember(localMemberId), oldConfiguration.getMember(localMemberId));
-  }
-
   /**
-   * New-model counterpart of {@link #isConflictingConfiguration(ClusterConfiguration,
-   * ClusterConfiguration)}. The legacy model has a single partition group, so the local member's
-   * state is checked once; the new model has one {@link PartitionGroupConfiguration} per physical
-   * tenant, so the local member's state is checked in every group it appears in, in either
-   * configuration.
+   * The local member's state is checked in every {@link PartitionGroupConfiguration} (physical
+   * tenant) it appears in, in either configuration.
    */
   private boolean isConflictingConfiguration(
       final CurrentClusterConfiguration mergedConfiguration,
@@ -461,11 +303,10 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
       // The member's zero-partition entry was pruned from this group as part of the current
       // plan's own operations targeting it (e.g. it is leaving this group as one of the plan's
       // steps). A faster peer's gossip can report that removal before the local apply catches up;
-      // that race is expected, not a forced/unexpected change, so it's not a conflict. Mirrors the
-      // LEFT-member exclusion in isConflictingConfiguration(ClusterConfiguration,
-      // ClusterConfiguration) above. A removal the member was never an operation-target for (e.g. a
-      // force-reconfigure applied by another member on its behalf) still falls through and
-      // conflicts, since {@code wasTargetedByCurrentPlan} only returns true for the former.
+      // that race is expected, not a forced/unexpected change, so it's not a conflict. A removal
+      // the member was never an operation-target for (e.g. a force-reconfigure applied by another
+      // member on its behalf) still falls through and conflicts, since {@code
+      // wasTargetedByCurrentPlan} only returns true for the former.
       return false;
     }
     return !Objects.equals(mergedMemberState, oldMemberState);
@@ -488,147 +329,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         .filter(Objects::nonNull)
         .flatMap(List::stream)
         .anyMatch(operation -> operation.memberId().equals(localMemberId));
-  }
-
-  private boolean shouldApplyConfigurationChangeOperation(
-      final ClusterConfiguration mergedConfiguration) {
-    // Configuration change operation should be applied only once. The operation is removed
-    // from the pending list only after the operation is completed. We should take care
-    // not to repeatedly trigger the same operation while it is in progress. This
-    // usually would not happen, because no other member will update the configuration while
-    // the current one is in progress. So the local configuration is not changed. The configuration
-    // change operation is triggered locally only when the local configuration is changes. However,
-    // as
-    // an extra precaution we check if there is an ongoing operation before applying one.
-    return (!onGoingConfigurationChangeOperation || shouldRetry)
-        && mergedConfiguration.pendingChangesFor(localMemberId).isPresent()
-        // changeApplier is registered only after PartitionManager in the Broker is started.
-        && changeAppliers != null;
-  }
-
-  private void applyConfigurationChangeOperation(final ClusterConfiguration mergedConfiguration) {
-    if (!shouldApplyConfigurationChangeOperation(mergedConfiguration)) {
-      return;
-    }
-
-    onGoingConfigurationChangeOperation = true;
-    shouldRetry = false;
-    final var operation = mergedConfiguration.pendingChangesFor(localMemberId).orElseThrow();
-    final var observer = topologyMetrics.observeOperation(operation);
-    LOG.info("Applying configuration change operation {}", operation);
-    final var operationApplier = changeAppliers.getApplier(operation);
-    final var operationInitialized =
-        operationApplier
-            .init(mergedConfiguration)
-            .map(transformer -> transformer.apply(mergedConfiguration))
-            .flatMap(this::updateLocalConfiguration);
-
-    if (operationInitialized.isLeft()) {
-      // TODO: Mark ClusterChangePlan as failed
-      observer.failed();
-      onGoingConfigurationChangeOperation = false;
-      LOG.error(
-          "Failed to initialize configuration change operation {}",
-          operation,
-          operationInitialized.getLeft());
-      return;
-    }
-
-    final var initializedConfiguration = operationInitialized.get();
-    operationApplier
-        .apply()
-        .onComplete(
-            (transformer, error) ->
-                onOperationApplied(
-                    initializedConfiguration, operation, transformer, error, observer));
-  }
-
-  private void logAndScheduleRetry(
-      final ClusterConfigurationChangeOperation operation, final Throwable error) {
-    shouldRetry = true;
-    final Duration delay = backoffRetry.nextDelay();
-    LOG.warn(
-        "Failed to apply configuration change operation {}. Will be retried in {}.",
-        operation,
-        delay,
-        error);
-    executor.schedule(
-        delay,
-        () -> {
-          LOG.debug("Retrying last applied operation");
-          applyConfigurationChangeOperation(persistedClusterConfiguration.getConfiguration());
-        });
-  }
-
-  private void onOperationApplied(
-      final ClusterConfiguration topologyOnWhichOperationIsApplied,
-      final ClusterConfigurationChangeOperation operation,
-      final UnaryOperator<ClusterConfiguration> transformer,
-      final Throwable error,
-      final OperationObserver observer) {
-    onGoingConfigurationChangeOperation = false;
-    if (error == null) {
-      observer.applied();
-      backoffRetry.reset();
-      if (persistedClusterConfiguration.getConfiguration().version()
-          != topologyOnWhichOperationIsApplied.version()) {
-        LOG.debug(
-            "Configuration changed while applying operation {}. Expected configuration is {}. Current configuration is {}. Most likely the change operation was cancelled.",
-            operation,
-            topologyOnWhichOperationIsApplied,
-            persistedClusterConfiguration.getConfiguration());
-        return;
-      }
-      updateLocalConfiguration(
-          persistedClusterConfiguration.getConfiguration().advanceConfigurationChange(transformer));
-      LOG.info(
-          "Operation {} applied. Updated local configuration to {}",
-          operation,
-          persistedClusterConfiguration.getConfiguration());
-
-      executor.run(
-          () -> {
-            // Continue applying configuration change, if the next operation is for the local member
-            applyConfigurationChangeOperation(persistedClusterConfiguration.getConfiguration());
-          });
-    } else {
-      observer.failed();
-      // Retry after a delay. The failure is most likely due to timeouts such
-      // as when joining a raft partition.
-      logAndScheduleRetry(operation, error);
-    }
-  }
-
-  private Either<Exception, ClusterConfiguration> updateLocalConfiguration(
-      final ClusterConfiguration configuration) {
-    if (configuration.equals(persistedClusterConfiguration.getConfiguration())) {
-      return Either.right(configuration);
-    }
-    try {
-      persistedClusterConfiguration.update(configuration);
-      configurationGossiper.accept(configuration);
-      return Either.right(configuration);
-    } catch (final Exception e) {
-      return Either.left(e);
-    }
-  }
-
-  void registerTopologyChangeAppliers(
-      final ConfigurationChangeAppliers configurationChangeAppliers) {
-    executor.run(
-        () -> {
-          changeAppliers = configurationChangeAppliers;
-          // Continue applying the configuration change operation, after a broker restart.
-          applyConfigurationChangeOperation(persistedClusterConfiguration.getConfiguration());
-        });
-  }
-
-  // ---------------------------------------------------------------------------
-  // New multi-partition-group model (used only when useNewConfig is true).
-  // ---------------------------------------------------------------------------
-
-  void removeTopologyChangeAppliers() {
-    executor.run(() -> changeAppliers = null);
   }
 
   void registerTopologyChangedListener(final InconsistentConfigurationListener listener) {
@@ -668,9 +368,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   /**
    * Merges a {@link CurrentClusterConfiguration} received via gossip into the local one. If the
    * merge changes the local configuration, it is persisted, re-gossiped, and local operation
-   * application is triggered. Mirrors the legacy {@code onGossipReceived} merge behaviour,
-   * including leaving local state unchanged until {@link #start} has completed, to avoid a race
-   * between the configuration initializer and a concurrently received gossip update.
+   * application is triggered. Leaves local state unchanged until {@link #start} has completed, to
+   * avoid a race between the configuration initializer and a concurrently received gossip update.
    */
   void onGossipReceivedCurrent(final CurrentClusterConfiguration receivedConfiguration) {
     executor.run(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -11,7 +11,6 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.cluster.PartitionId;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.FileInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.GossipInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.InitializerError.PersistedConfigurationIsBroken;
@@ -24,7 +23,6 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestServer;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestValidator;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
-import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
@@ -42,7 +40,6 @@ import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -50,7 +47,6 @@ import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.FileUtil;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -61,7 +57,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -72,22 +67,17 @@ public final class ClusterConfigurationManagerService
   public static final String TOPOLOGY_FILE_NAME = ".topology.meta";
 
   /**
-   * Static feature flag switching the manager between the legacy single-group model and the new
-   * multi-partition-group model. Kept {@code false} in production for now; the new path is
-   * exercised via the {@code useNewConfig} constructor parameter (see {@link #USE_NEW_CONFIG}).
-   * When {@code false}, the legacy code path runs completely unchanged.
+   * Static feature flag indicating that the manager operates on the multi-partition-group model.
+   * Kept as a named constant for callers outside this class that still branch on it explicitly
+   * (e.g. {@code BrokerTopologyManagerImpl}, {@code GatewayClusterConfigurationService}); within
+   * this class and {@link ClusterConfigurationManagerImpl}, the legacy single-group code path has
+   * been removed and the new model always runs.
    */
   public static final boolean USE_NEW_CONFIG = true;
 
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
-  // Exactly one of persistedClusterConfiguration (legacy model) /
-  // persistedCurrentClusterConfiguration
-  // (new model) is set, matching ClusterConfigurationManagerImpl.USE_NEW_CONFIG. Both classes read
-  // the same on-disk file, distinguished by an internal header version, so only one may ever open
-  // it.
-  private final @Nullable PersistedClusterConfiguration persistedClusterConfiguration;
-  private final @Nullable PersistedCurrentClusterConfiguration persistedCurrentClusterConfiguration;
+  private final PersistedCurrentClusterConfiguration persistedCurrentClusterConfiguration;
   private final Path configurationFile;
   private final ConfigurationChangeCoordinator configurationChangeCoordinator;
   private final ClusterConfigurationRequestServer configurationRequestServer;
@@ -100,9 +90,7 @@ public final class ClusterConfigurationManagerService
   private final ClusterMembershipService membershipService;
   private final MemberId localMemberId;
   private final RequestValidatorRegistry validators = new RequestValidatorRegistry();
-  private final boolean useNewConfig;
   private final Map<String, ModeChangeExecutor> modeChangeExecutorPerTenant = new HashMap<>();
-  private Set<String> knownGroups = Set.of();
 
   public ClusterConfigurationManagerService(
       final Path dataRootDirectory,
@@ -111,31 +99,6 @@ public final class ClusterConfigurationManagerService
       final ClusterConfigurationGossiperConfig config,
       final ClusterChangeExecutor clusterChangeExecutor,
       final MeterRegistry meterRegistry) {
-    this(
-        dataRootDirectory,
-        communicationService,
-        memberShipService,
-        config,
-        clusterChangeExecutor,
-        meterRegistry,
-        USE_NEW_CONFIG);
-  }
-
-  /**
-   * @param useNewConfig overrides {@link ClusterConfigurationManagerService#USE_NEW_CONFIG} for
-   *     testing; production code always goes through the constructor above, which uses the
-   *     compile-time flag.
-   */
-  @VisibleForTesting
-  ClusterConfigurationManagerService(
-      final Path dataRootDirectory,
-      final ClusterCommunicationService communicationService,
-      final ClusterMembershipService memberShipService,
-      final ClusterConfigurationGossiperConfig config,
-      final ClusterChangeExecutor clusterChangeExecutor,
-      final MeterRegistry meterRegistry,
-      final boolean useNewConfig) {
-    this.useNewConfig = useNewConfig;
     gossiperConfig = config;
     this.clusterChangeExecutor = clusterChangeExecutor;
     topologyMetrics = new TopologyMetrics(meterRegistry);
@@ -152,24 +115,14 @@ public final class ClusterConfigurationManagerService
     gossipActor = Actor.newActor().name("ClusterConfigGossip").build();
     managerActor = Actor.newActor().name("ClusterConfigManager").build();
 
-    if (useNewConfig) {
-      persistedClusterConfiguration = null;
-      persistedCurrentClusterConfiguration =
-          PersistedCurrentClusterConfiguration.ofFile(configurationFile, new ProtoBufSerializer());
-      clusterConfigurationManager =
-          new ClusterConfigurationManagerImpl(
-              managerActor,
-              localMemberId,
-              persistedCurrentClusterConfiguration,
-              topologyManagerMetrics);
-    } else {
-      persistedCurrentClusterConfiguration = null;
-      persistedClusterConfiguration =
-          PersistedClusterConfiguration.ofFile(configurationFile, new ProtoBufSerializer());
-      clusterConfigurationManager =
-          new ClusterConfigurationManagerImpl(
-              managerActor, localMemberId, persistedClusterConfiguration, topologyManagerMetrics);
-    }
+    persistedCurrentClusterConfiguration =
+        PersistedCurrentClusterConfiguration.ofFile(configurationFile, new ProtoBufSerializer());
+    clusterConfigurationManager =
+        new ClusterConfigurationManagerImpl(
+            managerActor,
+            localMemberId,
+            persistedCurrentClusterConfiguration,
+            topologyManagerMetrics);
 
     clusterConfigurationGossiper =
         new ClusterConfigurationGossiper(
@@ -178,10 +131,8 @@ public final class ClusterConfigurationManagerService
             memberShipService,
             new ProtoBufSerializer(),
             config,
-            // Dead on the new model: setCurrentConfigurationUpdateHandler (below) makes the
-            // gossiper prefer the new-model handler, so this legacy one is never invoked.
-            useNewConfig ? ignored -> {} : clusterConfigurationManager::onGossipReceived,
-            useNewConfig ? clusterConfigurationManager::onGossipReceivedCurrent : null,
+            ignored -> {},
+            clusterConfigurationManager::onGossipReceivedCurrent,
             topologyMetrics);
     configurationChangeCoordinator =
         new ConfigurationChangeCoordinatorImpl(
@@ -193,107 +144,16 @@ public final class ClusterConfigurationManagerService
             new ClusterConfigurationManagementRequestsHandler(
                 configurationChangeCoordinator, localMemberId, managerActor, validators));
 
-    if (useNewConfig) {
-      clusterConfigurationManager.setCurrentConfigurationGossiper(
-          clusterConfigurationGossiper::updateCurrentClusterConfiguration);
-    } else {
-      clusterConfigurationManager.setConfigurationGossiper(
-          clusterConfigurationGossiper::updateClusterConfiguration);
-    }
-  }
-
-  private ClusterConfigurationInitializer<ClusterConfiguration> getNonCoordinatorInitializer(
-      final StaticConfiguration staticConfiguration,
-      final Map<PartitionId, ExportingState> legacyExportingStates) {
-    final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
-    return FileInitializer.legacyFileInitializer(configurationFile, new ProtoBufSerializer())
-        // Recover via sync to ensure that we don't gossip an uninitialized configuration.
-        // This is important so that we don't silently revert to uninitialized configuration
-        // when
-        // multiple members have a broken configuration file at the same time, for example
-        // because
-        // of a serialization bug.
-        .recover(
-            PersistedConfigurationIsBroken.class,
-            new SyncInitializer<>(
-                gossiperConfig.syncInitializerDelay(),
-                clusterConfigurationGossiper,
-                otherKnownMembers,
-                managerActor,
-                clusterConfigurationGossiper::queryClusterConfiguration,
-                gossiperConfig.bootstrapTimeout(),
-                ClusterConfiguration.uninitialized()))
-        .orThen(
-            new GossipInitializer<>(
-                clusterConfigurationGossiper,
-                persistedClusterConfiguration::getConfiguration,
-                clusterConfigurationGossiper::updateClusterConfiguration,
-                managerActor,
-                ClusterConfiguration.uninitialized()))
-        .andThen(
-            new ExporterStateInitializer(
-                staticConfiguration
-                    .partitionConfigPerPhysicalTenant()
-                    .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
-                    .exporting()
-                    .exporters()
-                    .keySet(),
-                staticConfiguration.localMemberId(),
-                managerActor,
-                false))
-        .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()))
-        // Must be initialized by the coordinator only. However, we still define it here because
-        // the
-        // actual coordinator might be different from what is provided in the static
-        // configuration.
-        // These initializers will be skipped if they are not running on the latest coordinator
-        // based on the initialized configuration.
-        .andThen(
-            PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
-                staticConfiguration))
-        .andThen(new ClusterIdInitializer(staticConfiguration.clusterId(), localMemberId));
-  }
-
-  private ClusterConfigurationInitializer<ClusterConfiguration> getCoordinatorInitializer(
-      final StaticConfiguration staticConfiguration,
-      final Map<PartitionId, ExportingState> legacyExportingStates) {
-    final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
-    return FileInitializer.legacyFileInitializer(configurationFile, new ProtoBufSerializer())
-        .orThen(
-            new SyncInitializer<>(
-                gossiperConfig.syncInitializerDelay(),
-                clusterConfigurationGossiper,
-                otherKnownMembers,
-                managerActor,
-                clusterConfigurationGossiper::queryClusterConfiguration,
-                gossiperConfig.bootstrapTimeout(),
-                ClusterConfiguration.uninitialized()))
-        .orThen(new StaticInitializer<>(staticConfiguration::generateTopology))
-        .andThen(
-            new ExporterStateInitializer(
-                staticConfiguration
-                    .partitionConfigPerPhysicalTenant()
-                    .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
-                    .exporting()
-                    .exporters()
-                    .keySet(),
-                staticConfiguration.localMemberId(),
-                managerActor,
-                true))
-        .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()))
-        // Must be initialized by the coordinator only
-        .andThen(
-            PartitionDistributorInitializer.legacyPartitionDistributorInitializer(
-                staticConfiguration))
-        .andThen(new ClusterIdInitializer(staticConfiguration.clusterId(), localMemberId));
+    clusterConfigurationManager.setCurrentConfigurationGossiper(
+        clusterConfigurationGossiper::updateCurrentClusterConfiguration);
   }
 
   /**
-   * New-model counterpart of {@link #getNonCoordinatorInitializer}. Mirrors its shape exactly:
-   * recover a broken file via sync, then wait on gossip from the coordinator; the coordinator-only
-   * initializers below are still defined here (not skipped) because the actual coordinator, once
-   * the configuration is initialized, might differ from what {@code staticConfiguration} assumes —
-   * see {@link ClusterConfigurationModifier.CoordinatorOnly}'s self-filtering.
+   * Recovers a broken file via sync, then waits on gossip from the coordinator; the
+   * coordinator-only initializers below are still defined here (not skipped) because the actual
+   * coordinator, once the configuration is initialized, might differ from what {@code
+   * staticConfiguration} assumes — see {@link ClusterConfigurationModifier.CoordinatorOnly}'s
+   * self-filtering.
    */
   private ClusterConfigurationInitializer<CurrentClusterConfiguration>
       getCurrentClusterConfigurationNonCoordinatorInitializer(
@@ -330,9 +190,9 @@ public final class ClusterConfigurationManagerService
   }
 
   /**
-   * New-model counterpart of {@link #getCoordinatorInitializer}. Mirrors its shape exactly: sync
-   * from other members, and — unlike the non-coordinator chain — self-generate from static
-   * configuration as a last resort if sync times out uninitialized.
+   * Mirrors {@link #getCurrentClusterConfigurationNonCoordinatorInitializer}'s shape: sync from
+   * other members, and — unlike the non-coordinator chain — self-generate from static configuration
+   * as a last resort if sync times out uninitialized.
    */
   private ClusterConfigurationInitializer<CurrentClusterConfiguration>
       getCurrentClusterConfigurationCoordinatorInitializer(
@@ -408,11 +268,6 @@ public final class ClusterConfigurationManagerService
       final Map<PartitionId, ExportingState> legacyExportingStates) {
     final var result = new CompletableActorFuture<Void>();
 
-    knownGroups =
-        staticConfiguration.partitionIds().stream()
-            .map(PartitionId::group)
-            .collect(Collectors.toSet());
-
     configurationRequestServer.start();
 
     // Start gossiper first so that when ClusterConfigurationManager initializes the configuration,
@@ -423,43 +278,28 @@ public final class ClusterConfigurationManagerService
             (ok, error) -> {
               if (error != null) {
                 result.completeExceptionally(error);
-              } else if (useNewConfig) {
-                // Registered here rather than in the constructor: registerGlobalChangeAppliers goes
-                // through managerActor's executor.
-                clusterConfigurationManager.registerGlobalChangeAppliers(
-                    new GlobalConfigurationChangeAppliersImpl(
-                        new NoopClusterMembershipChangeExecutor(), clusterChangeExecutor));
-                final var coordinatorMemberId =
-                    ClusterConfigurationCoordinatorSupplier.ofMembers(
-                            staticConfiguration.clusterMembers())
-                        .getDefaultCoordinator();
-                final var isCoordinator = coordinatorMemberId.equals(localMemberId);
-                final ClusterConfigurationInitializer<CurrentClusterConfiguration>
-                    currentClusterConfigurationInitializer =
-                        isCoordinator
-                            ? getCurrentClusterConfigurationCoordinatorInitializer(
-                                staticConfiguration, legacyExportingStates)
-                            : getCurrentClusterConfigurationNonCoordinatorInitializer(
-                                staticConfiguration, legacyExportingStates);
-                clusterConfigurationManager
-                    .start(currentClusterConfigurationInitializer)
-                    .onComplete(result);
-              } else {
-                final var coordinatorMemberId =
-                    ClusterConfigurationCoordinatorSupplier.ofMembers(
-                            staticConfiguration.clusterMembers())
-                        .getDefaultCoordinator();
-                final var isCoordinator = coordinatorMemberId.equals(localMemberId);
-                final ClusterConfigurationInitializer<ClusterConfiguration>
-                    clusterConfigurationInitializer =
-                        isCoordinator
-                            ? getCoordinatorInitializer(staticConfiguration, legacyExportingStates)
-                            : getNonCoordinatorInitializer(
-                                staticConfiguration, legacyExportingStates);
-                clusterConfigurationManager
-                    .start(clusterConfigurationInitializer)
-                    .onComplete(result);
+                return;
               }
+              // Registered here rather than in the constructor: registerGlobalChangeAppliers goes
+              // through managerActor's executor.
+              clusterConfigurationManager.registerGlobalChangeAppliers(
+                  new GlobalConfigurationChangeAppliersImpl(
+                      new NoopClusterMembershipChangeExecutor(), clusterChangeExecutor));
+              final var coordinatorMemberId =
+                  ClusterConfigurationCoordinatorSupplier.ofMembers(
+                          staticConfiguration.clusterMembers())
+                      .getDefaultCoordinator();
+              final var isCoordinator = coordinatorMemberId.equals(localMemberId);
+              final ClusterConfigurationInitializer<CurrentClusterConfiguration>
+                  currentClusterConfigurationInitializer =
+                      isCoordinator
+                          ? getCurrentClusterConfigurationCoordinatorInitializer(
+                              staticConfiguration, legacyExportingStates)
+                          : getCurrentClusterConfigurationNonCoordinatorInitializer(
+                              staticConfiguration, legacyExportingStates);
+              clusterConfigurationManager
+                  .start(currentClusterConfigurationInitializer)
+                  .onComplete(result);
             });
     return result;
   }
@@ -469,38 +309,7 @@ public final class ClusterConfigurationManagerService
   }
 
   public ActorFuture<CurrentClusterConfiguration> getClusterConfiguration() {
-    if (useNewConfig) {
-      return clusterConfigurationManager.getMultiConfiguration();
-    } else {
-      return clusterConfigurationManager
-          .getClusterConfiguration()
-          .thenApply(
-              legacy -> {
-                if (legacy != null) {
-                  // the callers rely on having all physical tenants in the configuration. Until the
-                  // feature flag is enabled, use a fake config made from default physical tenant.
-                  // This aligns with the existing behavior in the broker where it derived the
-                  // config from default tenant.
-                  final var defaultGroupConfig = CurrentClusterConfiguration.fromLegacy(legacy);
-                  final Map<String, PartitionGroupConfiguration> groups =
-                      knownGroups.stream()
-                          .collect(
-                              Collectors.toMap(
-                                  id -> id,
-                                  id ->
-                                      Objects.requireNonNull(
-                                          defaultGroupConfig.partitionGroup(
-                                              PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))));
-                  return new CurrentClusterConfiguration(
-                      defaultGroupConfig.version(),
-                      defaultGroupConfig.globalConfiguration(),
-                      groups,
-                      defaultGroupConfig.phasedChangeState());
-                } else {
-                  return null;
-                }
-              });
-    }
+    return clusterConfigurationManager.getMultiConfiguration();
   }
 
   public Optional<ConfigurationChangeCoordinator> getTopologyChangeCoordinator() {
@@ -535,45 +344,23 @@ public final class ClusterConfigurationManagerService
       final RestoreChangeExecutor restoreChangeExecutor) {
     managerActor.run(
         () -> {
-          if (!useNewConfig && !PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(groupId)) {
-            return; // noop
-          }
-
           final ModeChangeExecutor modeChangeExecutor = modeChangeExecutorPerTenant.get(groupId);
           Objects.requireNonNull(
               modeChangeExecutor,
               "ModeChangeExecutor not set before registering topology appliers.");
 
-          if (!useNewConfig) {
-            clusterConfigurationManager.registerTopologyChangeAppliers(
-                new ConfigurationChangeAppliersImpl(
-                    partitionChangeExecutor,
-                    new NoopClusterMembershipChangeExecutor(),
-                    partitionScalingChangeExecutor,
-                    clusterChangeExecutor,
-                    modeChangeExecutor,
-                    restoreChangeExecutor));
-          } else {
-            clusterConfigurationManager.registerPartitionGroupChangeAppliers(
-                groupId,
-                new PartitionGroupConfigurationChangeAppliersImpl(
-                    partitionChangeExecutor,
-                    partitionScalingChangeExecutor,
-                    modeChangeExecutor,
-                    restoreChangeExecutor));
-          }
+          clusterConfigurationManager.registerPartitionGroupChangeAppliers(
+              groupId,
+              new PartitionGroupConfigurationChangeAppliersImpl(
+                  partitionChangeExecutor,
+                  partitionScalingChangeExecutor,
+                  modeChangeExecutor,
+                  restoreChangeExecutor));
         });
   }
 
   public void removePartitionChangeExecutor(final String groupId) {
-    if (!useNewConfig && !PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(groupId)) {
-      return; // noop
-    }
-    if (!useNewConfig) {
-      clusterConfigurationManager.removeTopologyChangeAppliers();
-    } else {
-      clusterConfigurationManager.removePartitionGroupChangeAppliers(groupId);
-    }
+    clusterConfigurationManager.removePartitionGroupChangeAppliers(groupId);
   }
 
   public void registerModeChangeExecutor(


### PR DESCRIPTION
## Summary
- Removes the legacy single-group `ClusterConfiguration` code path from `ClusterConfigurationManagerImpl` and `ClusterConfigurationManagerService`, which was dead weight now that `ClusterConfigurationManagerService#USE_NEW_CONFIG` runs the multi-partition-group model in production.
- `ClusterConfigurationManagerImpl` now always operates on `CurrentClusterConfiguration`; the legacy constructors, apply/retry loop, gossip handling, and per-tenant registration branches gated on `useNewConfig` are gone.
- `USE_NEW_CONFIG` itself is kept, since `BrokerTopologyManagerImpl` and `GatewayClusterConfigurationService` still branch on it directly and are out of scope for this change.

part of #56018.