### PR TITLE
Fix flaky M2 assertion in MessageStartProcessInstanceCrossPartitionMetricsTest

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionMetricsTest.java
@@ -140,18 +140,19 @@ public final class MessageStartProcessInstanceCrossPartitionMetricsTest {
         .publish();
 
     // and the handshake completes: the PI is started on P_B and P_K processes the STARTED reply
+    final int pK = partitionFor(CORRELATION_KEY);
+    final int pB = partitionFor(BUSINESS_ID);
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
         .withElementType(BpmnElementType.PROCESS)
         .withBpmnProcessId(PROCESS_ID)
         .getFirst();
     RecordingExporter.messageStartProcessInstanceRequestRecords(
             MessageStartProcessInstanceRequestIntent.STARTED)
+        .withPartitionId(pK)
         .getFirst();
 
     // then the ask is counted on P_K (M3), the REQUEST is counted as started on P_B (M1), and the
     // STARTED reply is counted on P_K (M2)
-    final int pK = partitionFor(CORRELATION_KEY);
-    final int pB = partitionFor(BUSINESS_ID);
     assertThat(counter(pK, ASKS_METRIC, null, null))
         .as("M3: the cross-partition ask is dispatched from P_K")
         .isEqualTo(1.0);


### PR DESCRIPTION
## Description

`shouldRecordAskRequestAndReplyMetricsForCleanCrossPartitionStart` waited for `MessageStartProcessInstanceRequestIntent.STARTED` before asserting the M2 reply-metric counter. That intent is written by two different processors: `P_B` writes it locally the moment it decides to start (before it even sends the reply), and `P_K` writes it again after it finishes processing that reply, right before the M2 counter is incremented.

`RecordingExporter` merges both partitions into one ordered stream, and the wait had no partition filter, so it was always satisfied by `P_B`'s record, which is written first every time. That gave no real guarantee that `P_K` had processed the reply, so the M2 assertion raced the actual increment. On a slow/busy CI machine that race occasionally lost — see the issue for the observed CI failure.

Filtering the wait to `P_K`'s partition fixes the race: `P_B`'s and `P_K`'s writes are structurally on different partitions in the cross-partition handshake, so scoping to `P_K`'s partition unambiguously waits for `P_K`'s own write, not `P_B`'s.

## Checklist

- [x] Enable backports when necessary — not needed, test-only fix on `main`.

## Related issues

closes #60309