### PR TITLE
fix: prevent runtime-directory collisions across physical tenants

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.partitioning.startup;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.cluster.PartitionId;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -74,9 +75,11 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -243,20 +246,8 @@ public final class ZeebePartitionFactory {
       final ZeebeDbFactory<ZbColumnFamilies> zeebeRocksDbFactory,
       final ConstructableSnapshotStore snapshotStore,
       final ConcurrencyControl concurrencyControl) {
-    final Path runtimeDirectory;
-    final var partitionId = raftPartition.id().number();
-    if (brokerCfg.getData().useSeparateRuntimeDirectory()) {
-      final Path rootRuntimeDirectory = Paths.get(brokerCfg.getData().getRuntimeDirectory());
-      try {
-        FileUtil.ensureDirectoryExists(rootRuntimeDirectory);
-      } catch (final IOException e) {
-        throw new UncheckedIOException(
-            "Runtime directory %s does not exist".formatted(rootRuntimeDirectory), e);
-      }
-      runtimeDirectory = rootRuntimeDirectory.resolve(String.valueOf(partitionId));
-    } else {
-      runtimeDirectory = raftPartition.dataDirectory().toPath().resolve(DEFAULT_RUNTIME_DIRECTORY);
-    }
+    final Path runtimeDirectory =
+        resolveRuntimeDirectory(brokerCfg, raftPartition.id(), raftPartition.dataDirectory());
 
     final var continuousBackup = brokerCfg.getData().getBackup().isContinuous();
     return new StateControllerImpl(
@@ -266,6 +257,31 @@ public final class ZeebePartitionFactory {
         new AtomixRecordEntrySupplierImpl(raftPartition.getServer()),
         zeebeDb -> new DbPositionSupplier(zeebeDb, continuousBackup),
         concurrencyControl);
+  }
+
+  /**
+   * Resolves the runtime directory for one partition. When {@code
+   * data.primary-storage.runtime-directory} is not overridden per physical tenant, every tenant's
+   * {@code BrokerCfg} resolves to the same root runtime directory, and partition numbers restart at
+   * 1 per partition group — so the partition-group name must be part of the path, or two tenants'
+   * same-numbered partitions collide on the same on-disk runtime directory.
+   */
+  @VisibleForTesting
+  static Path resolveRuntimeDirectory(
+      final BrokerCfg brokerCfg, final PartitionId partitionId, final File partitionDataDirectory) {
+    if (!brokerCfg.getData().useSeparateRuntimeDirectory()) {
+      return partitionDataDirectory.toPath().resolve(DEFAULT_RUNTIME_DIRECTORY);
+    }
+
+    final Path rootRuntimeDirectory =
+        Paths.get(brokerCfg.getData().getRuntimeDirectory()).resolve(partitionId.group());
+    try {
+      FileUtil.ensureDirectoryExists(rootRuntimeDirectory);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(
+          "Runtime directory %s does not exist".formatted(rootRuntimeDirectory), e);
+    }
+    return rootRuntimeDirectory.resolve(String.valueOf(partitionId.number()));
   }
 
   private TypedRecordProcessorsFactory createFactory(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactoryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ZeebePartitionFactoryTest {
+
+  @Test
+  void shouldAppendPartitionGroupToSeparateRuntimeDirectory(@TempDir final Path runtimeRoot) {
+    // given a broker configured with a separate root runtime directory
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getData().setRuntimeDirectory(runtimeRoot.toString());
+    final var partitionId = new PartitionId("tenanta", 1);
+
+    // when
+    final Path resolved =
+        ZeebePartitionFactory.resolveRuntimeDirectory(brokerCfg, partitionId, runtimeRoot.toFile());
+
+    // then the partition group is part of the resolved path
+    assertThat(resolved).isEqualTo(runtimeRoot.resolve("tenanta").resolve("1"));
+  }
+
+  @Test
+  void shouldNotCollideForDifferentPartitionGroupsWithTheSamePartitionNumber(
+      @TempDir final Path runtimeRoot) {
+    // given two physical tenants (partition groups) that do not override the runtime directory,
+    // so both resolve the same root runtime directory from the shared BrokerCfg, and partition
+    // numbers restart at 1 per group
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getData().setRuntimeDirectory(runtimeRoot.toString());
+    final var tenantAPartitionOne = new PartitionId("tenanta", 1);
+    final var tenantBPartitionOne = new PartitionId("tenantb", 1);
+
+    // when
+    final Path tenantARuntimeDirectory =
+        ZeebePartitionFactory.resolveRuntimeDirectory(
+            brokerCfg, tenantAPartitionOne, runtimeRoot.toFile());
+    final Path tenantBRuntimeDirectory =
+        ZeebePartitionFactory.resolveRuntimeDirectory(
+            brokerCfg, tenantBPartitionOne, runtimeRoot.toFile());
+
+    // then each tenant's same-numbered partition gets a distinct runtime directory
+    assertThat(tenantARuntimeDirectory).isNotEqualTo(tenantBRuntimeDirectory);
+  }
+
+  @Test
+  void shouldCreateTheGroupScopedRuntimeRootDirectory(@TempDir final Path runtimeRoot) {
+    // given a broker configured with a separate root runtime directory
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getData().setRuntimeDirectory(runtimeRoot.toString());
+    final var partitionId = new PartitionId("tenanta", 2);
+
+    // when
+    ZeebePartitionFactory.resolveRuntimeDirectory(brokerCfg, partitionId, runtimeRoot.toFile());
+
+    // then the group-scoped parent directory was created on disk
+    assertThat(runtimeRoot.resolve("tenanta")).isDirectory();
+  }
+
+  @Test
+  void shouldResolveRuntimeDirectoryUnderPartitionDataDirectoryWhenNotUsingSeparateDirectory(
+      @TempDir final Path partitionDataDirectory) {
+    // given a broker that does not configure a separate runtime directory
+    final var brokerCfg = new BrokerCfg();
+    final var partitionId = new PartitionId("default", 3);
+
+    // when
+    final Path resolved =
+        ZeebePartitionFactory.resolveRuntimeDirectory(
+            brokerCfg, partitionId, partitionDataDirectory.toFile());
+
+    // then it falls back to a fixed subdirectory of the partition's own (already
+    // group-scoped) data directory, unaffected by this fix
+    assertThat(resolved)
+        .isEqualTo(partitionDataDirectory.resolve(ZeebePartitionFactory.DEFAULT_RUNTIME_DIRECTORY));
+  }
+
+  @Test
+  void shouldThrowWhenRuntimeDirectoryCannotBeCreated(@TempDir final Path runtimeRoot) {
+    // given a root runtime directory path that is actually a regular file, so it cannot be
+    // turned into a directory
+    final File blockingFile = runtimeRoot.resolve("not-a-directory").toFile();
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getData().setRuntimeDirectory(blockingFile.getPath());
+    final var partitionId = new PartitionId("tenanta", 1);
+
+    try {
+      assertThat(blockingFile.createNewFile()).isTrue();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    // when / then
+    assertThat(
+            catchThrowable(
+                () ->
+                    ZeebePartitionFactory.resolveRuntimeDirectory(
+                        brokerCfg, partitionId, runtimeRoot.toFile())))
+        .isInstanceOf(UncheckedIOException.class);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerDifferentRuntimeDirectoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerDifferentRuntimeDirectoryTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,7 +28,14 @@ public class BrokerDifferentRuntimeDirectoryTest {
 
   @Test
   public void shouldUseConfiguredRuntimeDirectory() {
-    final var runtimeDirectory = brokerRule.getBrokerBase().resolve(STATE);
+    // the partition-group name is part of the resolved path (see
+    // ZeebePartitionFactory#resolveRuntimeDirectory) so that different physical tenants sharing
+    // the same root runtime directory cannot collide on the same on-disk partition directory
+    final var runtimeDirectory =
+        brokerRule
+            .getBrokerBase()
+            .resolve(STATE)
+            .resolve(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(runtimeDirectory).isNotEmptyDirectory();


### PR DESCRIPTION
## Summary
- `ZeebePartitionFactory.createStateController` resolved the RocksDB runtime directory as `<runtime-directory>/<partitionNumber>` whenever `data.primary-storage.runtime-directory` was configured.
- Partition numbers restart at 1 per partition group (physical tenant). When the runtime directory is **not** overridden per tenant, every tenant's `BrokerCfg` resolves to the same root path, so two tenants' same-numbered partitions (e.g. `tenanta` partition 1 and `tenantb` partition 1) silently opened their RocksDB state in the same on-disk directory.
- Fix: resolve the directory as `<runtime-directory>/<group>/<partitionNumber>` instead, mirroring the group-then-number layout `RaftPartitionFactory` already uses for the primary data directory.
- The resolution logic is extracted into a small static, unit-tested helper (`ZeebePartitionFactory.resolveRuntimeDirectory`) instead of left inline, since the previous shape had no test coverage.

related to #56648 

🤖 Generated with [Claude Code](https://claude.com/claude-code)