### PR TITLE
fix: reconcile draining definitions on newly bootstrapped partitions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
@@ -24,9 +24,18 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 /**
- * Finalizes local deletion of a {@link PersistedProcessState#DRAINING} definition once its last
- * active instance completes or terminates. Banned instances are excluded from the active-instance
- * check, as they never complete or terminate.
+ * Finalizes local deletion of {@link PersistedProcessState#DRAINING} definitions. A definition is
+ * finalized either when
+ *
+ * <ul>
+ *   <li>its last active instance completes or terminates ({@link #finalizeDeletionIfDraining})
+ *   <li>for a definition inherited by a freshly bootstrapped partition that holds none of its
+ *       instances, when that partition finishes bootstrapping ({@link
+ *       #finalizeDrainingDefinitionsWithoutLocalInstances})
+ * </ul>
+ *
+ * <p>Banned instances are excluded from the active-instance check, as they never complete or
+ * terminate.
  */
 public final class BpmnProcessDeletionBehavior {
 
@@ -87,12 +96,31 @@ public final class BpmnProcessDeletionBehavior {
   }
 
   /**
+   * Reconciles every {@code DRAINING} definition on this partition that has no local active
+   * instances, finalizing its drain. A freshly bootstrapped partition inherits {@code DRAINING}
+   * definitions through the snapshot but holds none of their instances.
+   */
+  public void finalizeDrainingDefinitionsWithoutLocalInstances() {
+    final var bannedInstances = bannedInstanceState.getBannedProcessInstanceKeys();
+    processState.forEachProcess(
+        null,
+        process -> {
+          if (process.getState() == PersistedProcessState.DRAINING
+              && !elementInstanceState.hasActiveProcessInstances(
+                  process.getKey(), bannedInstances)) {
+            finalizeDrain(process);
+          }
+          return true;
+        });
+  }
+
+  /**
    * Removes the definition from local state ({@link ProcessIntent#DELETING} / {@link
    * ProcessIntent#DELETED}) and reports the drain to the deployment partition ({@link
    * ProcessIntent#DELETE_COMPLETE}). Callers must ensure the definition is {@code DRAINING} and has
    * no remaining active instances on this partition.
    */
-  public void finalizeDrain(final PersistedProcess process) {
+  private void finalizeDrain(final PersistedProcess process) {
     final var processRecord =
         new ProcessRecord()
             .setBpmnProcessId(process.getBpmnProcessId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
 import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.AgentDefinitionState;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
@@ -82,6 +83,16 @@ public final class BpmnProcessDeletionBehavior {
       return;
     }
 
+    finalizeDrain(process.getPersistedProcess());
+  }
+
+  /**
+   * Removes the definition from local state ({@link ProcessIntent#DELETING} / {@link
+   * ProcessIntent#DELETED}) and reports the drain to the deployment partition ({@link
+   * ProcessIntent#DELETE_COMPLETE}). Callers must ensure the definition is {@code DRAINING} and has
+   * no remaining active instances on this partition.
+   */
+  public void finalizeDrain(final PersistedProcess process) {
     final var processRecord =
         new ProcessRecord()
             .setBpmnProcessId(process.getBpmnProcessId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleMarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleMarkPartitionBootstrappedProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.scaling;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnProcessDeletionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.resource.StartEventSubscriptions;
@@ -43,6 +44,7 @@ public class ScaleMarkPartitionBootstrappedProcessor
   private final CommandDistributionBehavior distributionBehavior;
   private final ProcessState processState;
   private final StartEventSubscriptions startEventSubscriptions;
+  private final BpmnProcessDeletionBehavior processDeletionBehavior;
 
   public ScaleMarkPartitionBootstrappedProcessor(
       final KeyGenerator keyGenerator,
@@ -64,6 +66,7 @@ public class ScaleMarkPartitionBootstrappedProcessor
             bpmnBehaviors.expressionProcessor(),
             bpmnBehaviors.catchEventBehavior(),
             startEventSubscriptionManager);
+    processDeletionBehavior = bpmnBehaviors.processDeletionBehavior();
   }
 
   @Override
@@ -99,7 +102,16 @@ public class ScaleMarkPartitionBootstrappedProcessor
     final var scaleUp = command.getValue();
     final var scalingKey = command.getKey();
     final var wasAlreadyBootstrapped = areAllPartitionsBootstrapped();
+    final var isNewlyBootstrappedPartition =
+        scaleUp.getRedistributedPartitions().contains(command.getPartitionId())
+            && !routingState.currentPartitions().contains(command.getPartitionId());
+
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.PARTITION_BOOTSTRAPPED, scaleUp);
+
+    if (isNewlyBootstrappedPartition) {
+      // inherited draining definitions have no local instances here, so finalize their drain now
+      processDeletionBehavior.finalizeDrainingDefinitionsWithoutLocalInstances();
+    }
     // if the partition that has completed bootstrapping is the current one and the command was
     // not already processed, resubscribe to all message start events and signals
     if (scaleUp.getRedistributedPartitions().contains(command.getPartitionId())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehaviorTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link
+ * BpmnProcessDeletionBehavior#finalizeDrainingDefinitionsWithoutLocalInstances()}.
+ */
+@ExtendWith(ProcessingStateExtension.class)
+final class BpmnProcessDeletionBehaviorTest {
+
+  private static final String OTHER_TENANT = "other-tenant";
+
+  private MutableProcessingState processingState;
+
+  private final StateWriter stateWriter = mock(StateWriter.class);
+  private final TypedCommandWriter commandWriter = mock(TypedCommandWriter.class);
+  private BpmnProcessDeletionBehavior behavior;
+  private long nextKey = 1L;
+
+  @BeforeEach
+  void setUp() {
+    behavior =
+        new BpmnProcessDeletionBehavior(
+            processingState.getProcessState(),
+            processingState.getAgentDefinitionState(),
+            processingState.getElementInstanceState(),
+            processingState.getBannedInstanceState(),
+            commandWriter,
+            stateWriter,
+            processingState.getKeyGenerator(),
+            new ProcessDefinitionMetrics(
+                new SimpleMeterRegistry(), processingState.getProcessState()));
+  }
+
+  @Test
+  void shouldReportDrainForEveryDrainingDefinitionWithoutInstances() {
+    // given - several draining, instance-free definitions: two versions of one process id and one
+    // under a non-default tenant, covering the all-version/all-tenant scan
+    final long keyV1 = putProcess("process", 1, TenantOwned.DEFAULT_TENANT_IDENTIFIER, true);
+    final long keyV2 = putProcess("process", 2, TenantOwned.DEFAULT_TENANT_IDENTIFIER, true);
+    final long keyOtherTenant = putProcess("other-process", 1, OTHER_TENANT, true);
+
+    // when
+    behavior.finalizeDrainingDefinitionsWithoutLocalInstances();
+
+    // then - each definition is removed locally and its drain reported to the deployment partition
+    assertThat(reportedDrainKeys()).containsExactlyInAnyOrder(keyV1, keyV2, keyOtherTenant);
+    assertThat(appendedEventKeys(ProcessIntent.DELETING))
+        .containsExactlyInAnyOrder(keyV1, keyV2, keyOtherTenant);
+    assertThat(appendedEventKeys(ProcessIntent.DELETED))
+        .containsExactlyInAnyOrder(keyV1, keyV2, keyOtherTenant);
+  }
+
+  @Test
+  void shouldNotReportDrainForActiveDefinition() {
+    // given - one draining and one ACTIVE (non-draining) definition
+    final long drainingKey = putProcess("draining", 1, TenantOwned.DEFAULT_TENANT_IDENTIFIER, true);
+    putProcess("active", 1, TenantOwned.DEFAULT_TENANT_IDENTIFIER, false);
+
+    // when
+    behavior.finalizeDrainingDefinitionsWithoutLocalInstances();
+
+    // then - only the draining definition is finalized; the ACTIVE one is left untouched
+    assertThat(reportedDrainKeys()).containsExactly(drainingKey);
+  }
+
+  @Test
+  void shouldNotReportDrainWhileDrainingDefinitionStillHasActiveInstance() {
+    // given - a draining definition that still has a local active instance
+    final long drainingKey = putProcess("draining", 1, TenantOwned.DEFAULT_TENANT_IDENTIFIER, true);
+    putActiveProcessInstance(drainingKey, "draining");
+
+    // when
+    behavior.finalizeDrainingDefinitionsWithoutLocalInstances();
+
+    // then - the guard keeps it draining: nothing is reported or removed
+    verifyNoInteractions(commandWriter);
+    verifyNoInteractions(stateWriter);
+  }
+
+  private long putProcess(
+      final String processId, final int version, final String tenantId, final boolean draining) {
+    final long key = nextKey++;
+    final var processRecord =
+        new ProcessRecord()
+            .setKey(key)
+            .setBpmnProcessId(processId)
+            .setVersion(version)
+            .setResourceName(processId + ".bpmn")
+            .setResource(
+                wrapString(
+                    Bpmn.convertToString(
+                        Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())))
+            .setTenantId(tenantId)
+            .setDeleteHistory(false);
+    processingState.getProcessState().putProcess(key, processRecord);
+    if (draining) {
+      processingState.getProcessState().markDraining(processRecord);
+    }
+    return key;
+  }
+
+  private void putActiveProcessInstance(final long processDefinitionKey, final String processId) {
+    final long instanceKey = nextKey++;
+    final var record =
+        new ProcessInstanceRecord()
+            .setProcessInstanceKey(instanceKey)
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setBpmnProcessId(processId)
+            .setElementId(processId)
+            .setBpmnElementType(BpmnElementType.PROCESS);
+    processingState
+        .getElementInstanceState()
+        .newInstance(instanceKey, record, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+  }
+
+  private List<Long> reportedDrainKeys() {
+    final var captor = ArgumentCaptor.forClass(ProcessRecord.class);
+    verify(commandWriter, atLeast(0))
+        .appendFollowUpCommand(anyLong(), eq(ProcessIntent.DELETE_COMPLETE), captor.capture());
+    return captor.getAllValues().stream().map(ProcessRecord::getProcessDefinitionKey).toList();
+  }
+
+  private List<Long> appendedEventKeys(final ProcessIntent intent) {
+    final var captor = ArgumentCaptor.forClass(ProcessRecord.class);
+    verify(stateWriter, atLeast(0)).appendFollowUpEvent(anyLong(), eq(intent), captor.capture());
+    return captor.getAllValues().stream().map(ProcessRecord::getProcessDefinitionKey).toList();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ReconcileDrainingOnScaleUpTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ReconcileDrainingOnScaleUpTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering.dynamic;
+
+import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.DEFAULT_PROCESS_ID;
+import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.createInstanceOnAllPartitions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
+import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Reproduces <a href="https://github.com/camunda/camunda/issues/59881">#59881</a> with a real
+ * cluster scale-up: a partition added while a definition is {@code DRAINING} inherits it via the
+ * bootstrap snapshot with none of its instances, so the drain must be finalized on bootstrap rather
+ * than left {@code DRAINING} forever.
+ */
+@Testcontainers
+@ZeebeIntegration
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
+class ReconcileDrainingOnScaleUpTest {
+
+  private static final int INITIAL_PARTITIONS = 2;
+  private static final int NEW_PARTITION_ID = INITIAL_PARTITIONS + 1;
+  private static final String JOB_TYPE = "job";
+  private static final String PROCESS_ID = DEFAULT_PROCESS_ID;
+
+  @AutoClose private CamundaClient camundaClient;
+  private ClusterActuator clusterActuator;
+
+  @TestZeebe(awaitCompleteTopology = false)
+  private final TestCluster cluster;
+
+  ReconcileDrainingOnScaleUpTest(@TempDir final Path backupPath) {
+    cluster =
+        TestCluster.builder()
+            .useRecordingExporter(true)
+            .withEmbeddedGateway(true)
+            .withBrokersCount(3)
+            .withPartitionsCount(INITIAL_PARTITIONS)
+            .withReplicationFactor(3)
+            .withBrokerConfig(
+                b ->
+                    b.withUnifiedConfig(
+                        cfg -> {
+                          // Scale-up bootstraps the new partition from a backup store; without it
+                          // the bootstrap snapshot cannot be shared and scaling never completes.
+                          final var backup = cfg.getData().getPrimaryStorage().getBackup();
+                          backup.setStore(BackupStoreType.FILESYSTEM);
+                          backup.getFilesystem().setBasePath(backupPath.toString());
+
+                          final var membership = cfg.getCluster().getMembership();
+                          membership.setSyncInterval(Duration.ofSeconds(1));
+                          membership.setGossipInterval(Duration.ofMillis(500));
+
+                          final var distribution =
+                              cfg.getProcessing().getEngine().getDistribution();
+                          distribution.setMaxBackoffDuration(Duration.ofSeconds(1));
+                          distribution.setRedistributionInterval(Duration.ofMillis(200));
+                        }))
+            .build();
+  }
+
+  @BeforeEach
+  void createClient() {
+    camundaClient = cluster.availableGateway().newClientBuilder().build();
+    clusterActuator = ClusterActuator.of(cluster.availableGateway());
+  }
+
+  @Test
+  void shouldFinalizeDrainingDefinitionOnNewlyBootstrappedPartition() {
+    // given - a healthy cluster with a process that parks its instances on a pending job
+    cluster.awaitHealthyTopology();
+
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    final var deployResponse =
+        camundaClient
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .send()
+            .join();
+    final long processDefinitionKey =
+        deployResponse.getProcesses().getFirst().getProcessDefinitionKey();
+
+    // Instances on every existing partition keep a pending job, so the definition stays DRAINING
+    // (not immediately deleted) on each partition once the deletion is distributed. Crucially, the
+    // bootstrap source (partition 1) must have a local active instance, otherwise it deletes the
+    // definition immediately and the snapshot the new partition inherits carries no DRAINING state.
+    createInstanceOnAllPartitions(camundaClient, INITIAL_PARTITIONS, PROCESS_ID, Map::of);
+
+    // when - the definition is deleted while instances are still active and new partition is added
+    camundaClient.newDeleteResourceCommand(processDefinitionKey).send().join();
+
+    // the deletion has to land as DRAINING on the bootstrap source partition before we scale
+    RecordingExporter.await(Duration.ofMinutes(1))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.processRecords()
+                            .withIntent(ProcessIntent.DRAINING)
+                            .withProcessDefinitionKey(processDefinitionKey)
+                            .withPartitionId(1)
+                            .findFirst())
+                    .describedAs("definition is DRAINING on the bootstrap source partition")
+                    .isPresent());
+
+    scaleToPartitions(NEW_PARTITION_ID);
+    awaitScaleUpCompletion(NEW_PARTITION_ID);
+
+    // then - the newly bootstrapped partition deletes the inherited draining definition locally
+    assertThat(
+            RecordingExporter.processRecords()
+                .withProcessDefinitionKey(processDefinitionKey)
+                .withPartitionId(NEW_PARTITION_ID)
+                .withIntent(ProcessIntent.DELETED)
+                .exists())
+        .describedAs("draining definition is deleted on the newly bootstrapped partition")
+        .isTrue();
+  }
+
+  private void scaleToPartitions(
+      @SuppressWarnings("SameParameterValue") final int desiredPartitionCount) {
+    clusterActuator.patchCluster(
+        new ClusterConfigPatchRequest()
+            .partitions(
+                new ClusterConfigPatchRequestPartitions()
+                    .count(desiredPartitionCount)
+                    .replicationFactor(3)),
+        false,
+        false);
+  }
+
+  private void awaitScaleUpCompletion(
+      @SuppressWarnings("SameParameterValue") final int desiredPartitionCount) {
+    Awaitility.await("until scaling is done")
+        .atMost(Duration.ofMinutes(2))
+        .catchUncaughtExceptions()
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              final var topology = clusterActuator.getTopology();
+              assertThat(topology.getRouting()).isNotNull();
+              final var requestHandling = topology.getRouting().getRequestHandling();
+              assertThat(requestHandling).isInstanceOf(RequestHandlingAllPartitions.class);
+              final var allPartitions = (RequestHandlingAllPartitions) requestHandling;
+              assertThat(allPartitions.getPartitionCount()).isEqualTo(desiredPartitionCount);
+            });
+  }
+}


### PR DESCRIPTION
## Description

test: cover reconcile of draining definitions without local instances
fix: reconcile draining definitions on newly bootstrapped partitions
refactor: extract finalizeDrain helper in BpmnProcessDeletionBehavior

## Related issues

closes https://github.com/camunda/camunda/issues/59881