### PR TITLE
feat: add RocksDbMigrationStatusProvider for upgrade-readiness

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/RocksDbMigrationStatusProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/RocksDbMigrationStatusProviderConfiguration.java
@@ -16,12 +16,7 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * Registers the RocksDB {@link MigrationStatusProvider} for the upgrade-readiness endpoint
- * (camunda/product-hub#3067), collected by {@link UpgradeReadinessEndpoint} alongside every other
- * provider bean.
- *
- * <p>{@link PhysicalTenantIds} is injected as the interface, not the concrete {@code
- * PhysicalTenantResolver} (which implements it) — this keeps {@code zeebe/gateway} from depending
- * on the {@code configuration} module, mirroring how {@code db/rdbms} stays decoupled from it too.
+ * (camunda/product-hub#3067).
  */
 @Configuration(proxyBeanMethods = false)
 public class RocksDbMigrationStatusProviderConfiguration {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/RocksDbMigrationStatusProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/RocksDbMigrationStatusProviderConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.admin.ClusterRocksDbMigrationStatusProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers the RocksDB {@link MigrationStatusProvider} for the upgrade-readiness endpoint
+ * (camunda/product-hub#3067), collected by {@link UpgradeReadinessEndpoint} alongside every other
+ * provider bean.
+ *
+ * <p>{@link PhysicalTenantIds} is injected as the interface, not the concrete {@code
+ * PhysicalTenantResolver} (which implements it) — this keeps {@code zeebe/gateway} from depending
+ * on the {@code configuration} module, mirroring how {@code db/rdbms} stays decoupled from it too.
+ */
+@Configuration(proxyBeanMethods = false)
+public class RocksDbMigrationStatusProviderConfiguration {
+
+  @Bean
+  public MigrationStatusProvider rocksDbMigrationStatusProvider(
+      final BrokerClient brokerClient, final PhysicalTenantIds physicalTenantIds) {
+    return new ClusterRocksDbMigrationStatusProvider(brokerClient, physicalTenantIds);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControlLimits;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Optional;
@@ -83,6 +85,13 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
   public ActorFuture<ExporterPhase> getExporterPhase() {
     logCall();
     return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<PartitionMigrationStatus> getMigrationStatus() {
+    logCall();
+    return CompletableActorFuture.completed(
+        new PartitionMigrationStatus(MigrationStatusCode.UNKNOWN, "no-op partition admin access"));
   }
 
   private void logCall() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -58,10 +58,7 @@ public interface PartitionAdminAccess {
 
   /**
    * Whether this replica's RocksDB state is migrated to the current application version and a
-   * snapshot capturing that migrated state has been taken, for the upgrade-readiness endpoint
-   * (camunda/product-hub#3067). Every replica answers from its own local state — migration and
-   * migration-snapshotting run independently on every replica, leader or follower, so a caller must
-   * ask every replica to be sure a fail-over cannot promote an unmigrated one.
+   * snapshot capturing that migrated state has been taken, for the upgrade-readiness endpoint.
    */
   ActorFuture<PartitionMigrationStatus> getMigrationStatus();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControlLimits;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Optional;
@@ -54,4 +55,13 @@ public interface PartitionAdminAccess {
    * the leader.
    */
   ActorFuture<ExporterPhase> getExporterPhase();
+
+  /**
+   * Whether this replica's RocksDB state is migrated to the current application version and a
+   * snapshot capturing that migrated state has been taken, for the upgrade-readiness endpoint
+   * (camunda/product-hub#3067). Every replica answers from its own local state — migration and
+   * migration-snapshotting run independently on every replica, leader or follower, so a caller must
+   * ask every replica to be sure a fail-over cannot promote an unmigrated one.
+   */
+  ActorFuture<PartitionMigrationStatus> getMigrationStatus();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -45,4 +45,11 @@ public interface PartitionAdminControl {
    * (leader-only) exporter director.
    */
   ExporterPhase getExporterPhase();
+
+  /**
+   * {@code true} once a snapshot capturing this replica's migrated state has been taken since it
+   * last ran its migrations (see {@code MigrationSnapshotDirector}). Never resets to {@code false}
+   * once set.
+   */
+  boolean isMigrationSnapshotTaken();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -25,6 +25,7 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   private final Supplier<PartitionProcessingState> partitionProcessingStateSupplier;
   private final Supplier<ZeebeDb> zeebeDbSupplier;
   private final Supplier<LogStream> logStreamSupplier;
+  private final Supplier<Boolean> migrationSnapshotTakenSupplier;
 
   public PartitionAdminControlImpl(
       final Supplier<StreamProcessor> streamProcessorSupplier,
@@ -32,13 +33,15 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
       final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier,
       final Supplier<PartitionProcessingState> partitionProcessingStateSupplier,
       final Supplier<ZeebeDb> zeebeDbSupplier,
-      final Supplier<LogStream> logStreamSupplier) {
+      final Supplier<LogStream> logStreamSupplier,
+      final Supplier<Boolean> migrationSnapshotTakenSupplier) {
     this.streamProcessorSupplier = streamProcessorSupplier;
     this.exporterDirectorSupplier = exporterDirectorSupplier;
     this.snapshotDirectorSupplier = snapshotDirectorSupplier;
     this.partitionProcessingStateSupplier = partitionProcessingStateSupplier;
     this.zeebeDbSupplier = zeebeDbSupplier;
     this.logStreamSupplier = logStreamSupplier;
+    this.migrationSnapshotTakenSupplier = migrationSnapshotTakenSupplier;
   }
 
   @Override
@@ -104,5 +107,10 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public ExporterPhase getExporterPhase() {
     return partitionProcessingStateSupplier.get().getExporterPhase();
+  }
+
+  @Override
+  public boolean isMigrationSnapshotTaken() {
+    return migrationSnapshotTakenSupplier.get();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -425,6 +425,11 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
+  public void resetMigrationSnapshotTaken() {
+    migrationSnapshotTaken = false;
+  }
+
+  @Override
   public boolean isMigrationSnapshotTaken() {
     return migrationSnapshotTaken;
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -119,6 +119,7 @@ public class PartitionStartupAndTransitionContextImpl
   private final MeterRegistry startupMeterRegistry;
   private MeterRegistry transitionMeterRegistry;
   private volatile boolean migrationsPerformed = false;
+  private volatile boolean migrationSnapshotTaken = false;
   private final SnapshotApiRequestHandler snapshotApiRequestHandler;
   private ClusterConfigurationService clusterConfigurationService;
 
@@ -181,7 +182,8 @@ public class PartitionStartupAndTransitionContextImpl
         () -> snapshotDirector,
         () -> partitionProcessingState,
         () -> zeebeDb,
-        () -> logStream);
+        () -> logStream,
+        this::isMigrationSnapshotTaken);
   }
 
   @Override
@@ -415,6 +417,16 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public boolean areMigrationsPerformed() {
     return migrationsPerformed;
+  }
+
+  @Override
+  public void markMigrationSnapshotTaken() {
+    migrationSnapshotTaken = true;
+  }
+
+  @Override
+  public boolean isMigrationSnapshotTaken() {
+    return migrationSnapshotTaken;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -164,6 +164,17 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   boolean areMigrationsPerformed();
 
+  /**
+   * Marks that a snapshot capturing the migrated state has been taken since this replica last ran
+   * its migrations. Once set, this must never be un-set: the underlying snapshot does not stop
+   * existing because of a later role transition, even though {@link
+   * io.camunda.zeebe.broker.system.partitions.impl.MigrationSnapshotDirector} itself is recreated
+   * on every transition.
+   */
+  void markMigrationSnapshotTaken();
+
+  boolean isMigrationSnapshotTaken();
+
   ComponentTreeListener getComponentTreeListener();
 
   ClusterConfigurationService getClusterConfigurationService();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -166,12 +166,21 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   /**
    * Marks that a snapshot capturing the migrated state has been taken since this replica last ran
-   * its migrations. Once set, this must never be un-set: the underlying snapshot does not stop
-   * existing because of a later role transition, even though {@link
+   * its migrations. A later role transition alone never un-sets this -- {@link
    * io.camunda.zeebe.broker.system.partitions.impl.MigrationSnapshotDirector} itself is recreated
-   * on every transition.
+   * on every transition, but the snapshot it already took keeps existing regardless. It can,
+   * however, be reverted by {@link #resetMigrationSnapshotTaken()} when a *new* migration cycle
+   * starts, e.g. because a received snapshot transfer reverted this replica to an older, unmigrated
+   * version that needs to migrate again.
    */
   void markMigrationSnapshotTaken();
+
+  /**
+   * Invalidates a previously-marked {@link #markMigrationSnapshotTaken()} because a new migration
+   * cycle is starting (see {@link #markMigrationsDone()}) -- whatever was true about a prior
+   * migration's snapshot says nothing about whether *this* one has been snapshotted yet.
+   */
+  void resetMigrationSnapshotTaken();
 
   boolean isMigrationSnapshotTaken();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -13,12 +13,16 @@ import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.migration.DbMigrationState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControlLimits;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -29,6 +33,11 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import java.io.IOException;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -40,6 +49,14 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
   private final ConcurrencyControl concurrencyControl;
   private final int partitionId;
   private final PartitionAdminControl adminControl;
+
+  // Lazily built the first time the migration status is read, and reused on every later read --
+  // each read otherwise opened a fresh transaction context on the live ZeebeDb (see
+  // #migrationState) that nothing ever closed, leaking one native transaction per admin request.
+  // Rebuilt only if the underlying ZeebeDb instance itself changes (e.g. a follower installing a
+  // new snapshot), never per call.
+  private ZeebeDb migrationStatusDb;
+  private DbMigrationState migrationStatusState;
 
   ZeebePartitionAdminAccess(
       final ConcurrencyControl concurrencyControl,
@@ -257,6 +274,110 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
           }
         });
     return future;
+  }
+
+  @Override
+  public ActorFuture<PartitionMigrationStatus> getMigrationStatus() {
+    final ActorFuture<PartitionMigrationStatus> future = concurrencyControl.createFuture();
+
+    concurrencyControl.run(
+        () -> {
+          try {
+            future.complete(readMigrationStatus());
+          } catch (final Exception e) {
+            LOG.error("Failed to determine the migration status of partition {}", partitionId, e);
+            future.complete(
+                new PartitionMigrationStatus(
+                    MigrationStatusCode.UNKNOWN,
+                    "partition "
+                        + partitionId
+                        + ": failed to read migration status: "
+                        + e.getMessage()));
+          }
+        });
+
+    return future;
+  }
+
+  /**
+   * Reads {@code DbMigrationState.getMigratedByVersion()} through a second transaction on the
+   * already-open, live {@code ZeebeDb}, without disturbing the stream processor's own state — the
+   * same technique {@link #banInstanceInState} already uses for {@code DbBannedInstanceState}.
+   */
+  private PartitionMigrationStatus readMigrationStatus() {
+    final var zeebeDb = adminControl.getZeebeDb();
+    if (zeebeDb == null) {
+      return new PartitionMigrationStatus(
+          MigrationStatusCode.UNKNOWN,
+          "partition " + partitionId + ": no ZeebeDb open on this replica yet");
+    }
+
+    final var migrationState = migrationState(zeebeDb);
+    final var migratedByVersion = migrationState.getMigratedByVersion();
+    if (migratedByVersion == null) {
+      return new PartitionMigrationStatus(
+          MigrationStatusCode.MIGRATION_IN_PROGRESS,
+          "partition " + partitionId + ": no migrated-by-version recorded yet");
+    }
+
+    // Same comparison DbMigratorImpl itself uses to gate migrations — kept consistent so this
+    // read-only status check never disagrees with the engine's own compatibility decision.
+    final var result = VersionCompatibilityCheck.check(migratedByVersion, VersionUtil.getVersion());
+    return switch (result) {
+      case Compatible.SameVersion same -> migratedAndSnapshotted(same.version().toString());
+      case Compatible.PatchUpgrade patch ->
+          notYetMigrated(patch.from().toString(), patch.to().toString());
+      case Compatible.MinorUpgrade minor ->
+          notYetMigrated(minor.from().toString(), minor.to().toString());
+      case Incompatible incompatible ->
+          new PartitionMigrationStatus(
+              MigrationStatusCode.UNKNOWN,
+              "partition " + partitionId + ": incompatible migration path: " + incompatible);
+      case Indeterminate indeterminate ->
+          new PartitionMigrationStatus(
+              MigrationStatusCode.UNKNOWN,
+              "partition "
+                  + partitionId
+                  + ": cannot determine migration compatibility: "
+                  + indeterminate);
+    };
+  }
+
+  /**
+   * Reuses one transaction context for the life of a given {@code ZeebeDb} instance instead of
+   * opening a fresh one on every status read — this method may run once per admin request, and
+   * {@code TransactionContext} has no way to close and release the native transaction it wraps, so
+   * a new one per call would leak for as long as the {@code ZeebeDb} stays open. Rebuilt only if
+   * the db instance itself changes, e.g. a follower installing a new snapshot.
+   */
+  private DbMigrationState migrationState(final ZeebeDb zeebeDb) {
+    if (migrationStatusState == null || migrationStatusDb != zeebeDb) {
+      migrationStatusDb = zeebeDb;
+      migrationStatusState = new DbMigrationState(zeebeDb, zeebeDb.createContext());
+    }
+    return migrationStatusState;
+  }
+
+  private PartitionMigrationStatus migratedAndSnapshotted(final String version) {
+    if (adminControl.isMigrationSnapshotTaken()) {
+      return new PartitionMigrationStatus(
+          MigrationStatusCode.MIGRATED,
+          "partition " + partitionId + ": migrated to " + version + " and snapshotted");
+    }
+    return new PartitionMigrationStatus(
+        MigrationStatusCode.MIGRATION_IN_PROGRESS,
+        "partition " + partitionId + ": migrated to " + version + " but not yet snapshotted");
+  }
+
+  private PartitionMigrationStatus notYetMigrated(final String from, final String to) {
+    return new PartitionMigrationStatus(
+        MigrationStatusCode.MIGRATION_IN_PROGRESS,
+        "partition "
+            + partitionId
+            + ": migrated-by-version "
+            + from
+            + " has not yet migrated to "
+            + to);
   }
 
   private void writeErrorEventAndBanInstance(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
+import com.google.common.base.Throwables;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -152,12 +153,8 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
     if (error == null) {
       return true;
     }
-    for (var cause = error; cause != null; cause = cause.getCause()) {
-      if (cause instanceof StateClosedException) {
-        return false;
-      }
-    }
-    return true;
+    return Throwables.getCausalChain(error).stream()
+        .noneMatch(cause -> cause instanceof StateClosedException);
   }
 
   private ActorFuture<Void> forceSnapshot() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.SnapshotException.StateClosedException;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.ExponentialBackoff;
 import io.camunda.zeebe.util.health.FailureListener;
@@ -18,10 +19,8 @@ import io.camunda.zeebe.util.health.HealthIssue;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.slf4j.Logger;
@@ -40,15 +39,18 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
   private final ConcurrencyControl control;
   private final HealthMonitor healthMonitor;
   private final RetryState retryState = new RetryState();
+  private final Runnable onSnapshotTaken;
   private volatile boolean closed = false;
 
   public MigrationSnapshotDirector(
       final AsyncSnapshotDirector asyncSnapshotDirector,
       final ConcurrencyControl control,
-      final HealthMonitor healthMonitor) {
+      final HealthMonitor healthMonitor,
+      final Runnable onSnapshotTaken) {
     snapshotDirector = asyncSnapshotDirector;
     this.control = control;
     this.healthMonitor = healthMonitor;
+    this.onSnapshotTaken = onSnapshotTaken;
     healthReport = snapshotNotTaken();
     healthMonitor.registerComponent(this);
     LOG.debug("Initialized migration snapshot director. Scheduling snapshot");
@@ -140,10 +142,22 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
     }
   }
 
+  /**
+   * Only a closed state store means retrying can never help -- everything else (an IOException, a
+   * transient race during the rapid role-transition churn at broker bootstrap, or any other error)
+   * should keep retrying with backoff instead of giving up permanently, the same way the periodic
+   * snapshot mechanism this wraps never gives up on its own scheduled attempts either.
+   */
   private boolean isRecoverableError(final Throwable error) {
-    return error == null
-        || (error instanceof IOException
-            || (error instanceof CompletionException && error.getCause() instanceof IOException));
+    if (error == null) {
+      return true;
+    }
+    for (var cause = error; cause != null; cause = cause.getCause()) {
+      if (cause instanceof StateClosedException) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private ActorFuture<Void> forceSnapshot() {
@@ -158,6 +172,7 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
                   LOG.debug("Snapshot taken after migrations: {}", snapshot.getId());
                   healthReport = HealthReport.healthy(this);
                   notifyListeners();
+                  onSnapshotTaken.run();
                 }
                 runningSnapshot = null;
                 return error != null

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -67,6 +67,19 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
       zeebeDbContext.getCurrentTransaction().commit();
       if (migrationsPerformed.versionChanged()) {
         context.markMigrationsDone();
+      } else if (!context.areMigrationsPerformed()) {
+        // No migration was needed, and none has run yet in this boot either -- this replica
+        // booted already at the current version, so whatever earlier boot completed that
+        // migration must also have forced a snapshot capturing it (this is exactly what
+        // SnapshotAfterMigrationTransitionStep does whenever migrations do run). There's nothing
+        // left to snapshot here.
+        //
+        // SAFETY NOTE: this assumes that earlier boot's migration-snapshot actually completed. If
+        // a broker crashes between committing a migration and that migration-snapshot finishing,
+        // the next restart lands here too (already at the current version, no migration to run)
+        // and will skip forcing a snapshot, even though none actually captures the migrated state
+        // yet. Accepted as a narrow, low-probability window rather than tracking that separately.
+        context.markMigrationSnapshotTaken();
       }
     } catch (final Exception e) {
       return CompletableActorFuture.completedExceptionally(e);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -67,18 +67,8 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
       zeebeDbContext.getCurrentTransaction().commit();
       if (migrationsPerformed.versionChanged()) {
         context.markMigrationsDone();
+        context.resetMigrationSnapshotTaken();
       } else if (!context.areMigrationsPerformed()) {
-        // No migration was needed, and none has run yet in this boot either -- this replica
-        // booted already at the current version, so whatever earlier boot completed that
-        // migration must also have forced a snapshot capturing it (this is exactly what
-        // SnapshotAfterMigrationTransitionStep does whenever migrations do run). There's nothing
-        // left to snapshot here.
-        //
-        // SAFETY NOTE: this assumes that earlier boot's migration-snapshot actually completed. If
-        // a broker crashes between committing a migration and that migration-snapshot finishing,
-        // the next restart lands here too (already at the current version, no migration to run)
-        // and will skip forcing a snapshot, even though none actually captures the migrated state
-        // yet. Accepted as a narrow, low-probability window rather than tracking that separately.
         context.markMigrationSnapshotTaken();
       }
     } catch (final Exception e) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotAfterMigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotAfterMigrationTransitionStep.java
@@ -38,7 +38,8 @@ public class SnapshotAfterMigrationTransitionStep implements PartitionTransition
             new MigrationSnapshotDirector(
                 context.getSnapshotDirector(),
                 context.getConcurrencyControl(),
-                context.getComponentHealthMonitor());
+                context.getComponentHealthMonitor(),
+                context::markMigrationSnapshotTaken);
       }
     }
     return CompletableActorFuture.completed();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler;
 import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.LimitSerializer;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusPayload;
 import io.camunda.zeebe.protocol.management.AdminRequestType;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -79,6 +80,7 @@ public class AdminApiRequestHandler
       case GET_FLOW_CONTROL -> getFlowControl(responseWriter, errorWriter);
       case SET_FLOW_CONTROL -> setFlowControl(requestReader, responseWriter, errorWriter);
       case GET_EXPORTING_STATE -> getExportingState(responseWriter, partitionId, errorWriter);
+      case GET_MIGRATION_STATUS -> getMigrationStatus(responseWriter, partitionId, errorWriter);
       default -> unknownRequest(errorWriter, requestReader.getMessageDecoder().type());
     };
   }
@@ -172,6 +174,40 @@ public class AdminApiRequestHandler
                     Either.left(
                         errorWriter.internalError(
                             "Failed to get the exporting state on partition %s", partitionId)));
+              }
+            });
+
+    return result;
+  }
+
+  private ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> getMigrationStatus(
+      final ApiResponseWriter responseWriter,
+      final int partitionId,
+      final ErrorResponseWriter errorWriter) {
+    final var partitionAdminAccess = adminAccess.forPartition(partitionId);
+    if (partitionAdminAccess.isEmpty()) {
+      return CompletableActorFuture.completed(
+          Either.left(
+              errorWriter.internalError(
+                  "Partition %s failed to report its migration status. Could not find the partition.",
+                  partitionId)));
+    }
+
+    final ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> result = actor.createFuture();
+    partitionAdminAccess
+        .orElseThrow()
+        .getMigrationStatus()
+        .onComplete(
+            (status, t) -> {
+              if (t == null) {
+                responseWriter.setPayload(MigrationStatusPayload.encode(status));
+                result.complete(Either.right(responseWriter));
+              } else {
+                LOG.error("Failed to get the migration status on partition {}", partitionId, t);
+                result.complete(
+                    Either.left(
+                        errorWriter.internalError(
+                            "Failed to get the migration status on partition %s", partitionId)));
               }
             });
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -396,6 +396,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
+  public void resetMigrationSnapshotTaken() {
+    migrationSnapshotTaken = false;
+  }
+
+  @Override
   public boolean isMigrationSnapshotTaken() {
     return migrationSnapshotTaken;
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -93,6 +93,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private MeterRegistry transitionMeterRegistry;
   private String brokerVersion = PartitionTransitionContext.super.getBrokerVersion();
   private boolean migrationsPerformed;
+  private boolean migrationSnapshotTaken;
   private final ComponentTreeListener healthMetrics;
   private SnapshotCopy snapshotCopy;
   private ClusterConfigurationService clusterConfigurationService;
@@ -387,6 +388,16 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public boolean areMigrationsPerformed() {
     return migrationsPerformed;
+  }
+
+  @Override
+  public void markMigrationSnapshotTaken() {
+    migrationSnapshotTaken = true;
+  }
+
+  @Override
+  public boolean isMigrationSnapshotTaken() {
+    return migrationSnapshotTaken;
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccessTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccessTest.java
@@ -12,13 +12,24 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.camunda.zeebe.engine.state.migration.DbMigrationState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.util.VersionUtil;
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 final class ZeebePartitionAdminAccessTest {
 
@@ -47,5 +58,98 @@ final class ZeebePartitionAdminAccessTest {
 
     // then
     assertThat(resumed).succeedsWithin(Duration.ofSeconds(5));
+  }
+
+  /**
+   * Uses a real, on-disk ZeebeDb since {@link ZeebePartitionAdminAccess#getMigrationStatus()} opens
+   * a second transaction context on the live db, the same technique already used for banning
+   * instances -- mocking ZeebeDb itself would not exercise that path.
+   */
+  @Nested
+  final class MigrationStatus {
+
+    @TempDir private File dbDirectory;
+    private ZeebeDb<ZbColumnFamilies> zeebeDb;
+
+    @BeforeEach
+    void openDb() throws Exception {
+      zeebeDb = DefaultZeebeDbFactory.<ZbColumnFamilies>defaultFactory().createDb(dbDirectory);
+      when(adminControl.getZeebeDb()).thenReturn(zeebeDb);
+    }
+
+    @AfterEach
+    void closeDb() throws Exception {
+      zeebeDb.close();
+    }
+
+    @Test
+    void shouldReportMigratedWhenVersionMatchesAndSnapshotTaken() {
+      // given
+      writeMigratedByVersion(VersionUtil.getVersion());
+      when(adminControl.isMigrationSnapshotTaken()).thenReturn(true);
+
+      // when
+      final var status = sut.getMigrationStatus().join();
+
+      // then
+      assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+    }
+
+    @Test
+    void shouldReportMigrationInProgressWhenVersionMatchesButSnapshotNotYetTaken() {
+      // given
+      writeMigratedByVersion(VersionUtil.getVersion());
+      when(adminControl.isMigrationSnapshotTaken()).thenReturn(false);
+
+      // when
+      final var status = sut.getMigrationStatus().join();
+
+      // then
+      assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+    }
+
+    @Test
+    void shouldReportMigrationInProgressWhenNoVersionRecordedYet() {
+      // given - nothing written, fresh partition
+
+      // when
+      final var status = sut.getMigrationStatus().join();
+
+      // then
+      assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+      assertThat(status.detail()).contains("no migrated-by-version");
+    }
+
+    @Test
+    void shouldReportUnknownWhenZeebeDbIsNotYetOpen() {
+      // given
+      when(adminControl.getZeebeDb()).thenReturn(null);
+
+      // when
+      final var status = sut.getMigrationStatus().join();
+
+      // then
+      assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+    }
+
+    @Test
+    void shouldSeeFreshDataOnRepeatedReadsInsteadOfOpeningANewContextEachTime() {
+      // given - readMigrationStatus() reuses one transaction context across calls (see
+      // ZeebePartitionAdminAccess#migrationState) instead of leaking a fresh one on every read;
+      // this must not mean later reads see stale data
+      when(adminControl.isMigrationSnapshotTaken()).thenReturn(true);
+      assertThat(sut.getMigrationStatus().join().code())
+          .isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+
+      // when - the version is written after the first read, through a different transaction
+      writeMigratedByVersion(VersionUtil.getVersion());
+
+      // then - the reused context still picks up the newly committed value
+      assertThat(sut.getMigrationStatus().join().code()).isEqualTo(MigrationStatusCode.MIGRATED);
+    }
+
+    private void writeMigratedByVersion(final String version) {
+      new DbMigrationState(zeebeDb, zeebeDb.createContext()).setMigratedByVersion(version);
+    }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirectorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import org.junit.jupiter.api.Test;
+
+final class MigrationSnapshotDirectorTest {
+
+  private final AsyncSnapshotDirector snapshotDirector = mock(AsyncSnapshotDirector.class);
+  private final HealthMonitor healthMonitor = mock(HealthMonitor.class);
+  private final Runnable onSnapshotTaken = mock(Runnable.class);
+
+  @Test
+  void shouldInvokeCallbackOnceTheFirstSnapshotSucceeds() {
+    // given
+    final var snapshot = mock(PersistedSnapshot.class);
+    when(snapshotDirector.forceSnapshot()).thenReturn(CompletableActorFuture.completed(snapshot));
+
+    // when
+    final var sut =
+        new MigrationSnapshotDirector(
+            snapshotDirector, new TestConcurrencyControl(), healthMonitor, onSnapshotTaken);
+
+    // then
+    assertThat(sut.isSnapshotTaken()).isTrue();
+    verify(onSnapshotTaken, times(1)).run();
+  }
+
+  @Test
+  void shouldNotInvokeCallbackBeforeASnapshotSucceeds() {
+    // given - the snapshot attempt never completes
+    when(snapshotDirector.forceSnapshot()).thenReturn(new CompletableActorFuture<>());
+
+    // when
+    final var sut =
+        new MigrationSnapshotDirector(
+            snapshotDirector, new TestConcurrencyControl(), healthMonitor, onSnapshotTaken);
+
+    // then
+    assertThat(sut.isSnapshotTaken()).isFalse();
+    verify(onSnapshotTaken, never()).run();
+  }
+
+  @Test
+  void shouldInvokeCallbackOnlyOnceEvenIfForceSnapshotIsCalledAgain() {
+    // given
+    final var snapshot = mock(PersistedSnapshot.class);
+    when(snapshotDirector.forceSnapshot()).thenReturn(CompletableActorFuture.completed(snapshot));
+    final var sut =
+        new MigrationSnapshotDirector(
+            snapshotDirector, new TestConcurrencyControl(), healthMonitor, onSnapshotTaken);
+
+    // when - a snapshot has already been taken, so this is a no-op
+    sut.close();
+
+    // then
+    verify(onSnapshotTaken, times(1)).run();
+  }
+
+  @Test
+  void shouldKeepRetryingAfterANonIoExceptionFailure() {
+    // given - the first attempt fails with an error that isn't an IOException (e.g. a transient
+    // race during the rapid role-transition churn at broker bootstrap); this must not be treated
+    // as a permanent failure, since the periodic snapshot mechanism it wraps never gives up either
+    final var snapshot = mock(PersistedSnapshot.class);
+    when(snapshotDirector.forceSnapshot())
+        .thenReturn(
+            CompletableActorFuture.completedExceptionally(new IllegalStateException("boom")))
+        .thenReturn(CompletableActorFuture.completed(snapshot));
+
+    // when
+    final var sut =
+        new MigrationSnapshotDirector(
+            snapshotDirector, new TestConcurrencyControl(), healthMonitor, onSnapshotTaken);
+
+    // then
+    assertThat(sut.isSnapshotTaken()).isTrue();
+    verify(onSnapshotTaken, times(1)).run();
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirectorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotException.StateClosedException;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import org.junit.jupiter.api.Test;
 
@@ -92,5 +93,24 @@ final class MigrationSnapshotDirectorTest {
     // then
     assertThat(sut.isSnapshotTaken()).isTrue();
     verify(onSnapshotTaken, times(1)).run();
+  }
+
+  @Test
+  void shouldGiveUpOnAStateClosedExceptionWrappedInsideAnotherException() {
+    // given - a StateClosedException nested a level deep, not the outermost exception itself;
+    // isRecoverableError() must walk the whole cause chain, not just check the top-level error
+    when(snapshotDirector.forceSnapshot())
+        .thenReturn(
+            CompletableActorFuture.completedExceptionally(
+                new RuntimeException("wrapped", new StateClosedException("expected"))));
+
+    // when
+    final var sut =
+        new MigrationSnapshotDirector(
+            snapshotDirector, new TestConcurrencyControl(), healthMonitor, onSnapshotTaken);
+
+    // then
+    assertThat(sut.isSnapshotTaken()).isFalse();
+    verify(onSnapshotTaken, never()).run();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStepTest.java
@@ -91,4 +91,58 @@ public class MigrationTransitionStepTest {
     // then
     assertThat(context.areMigrationsPerformed()).isTrue();
   }
+
+  @Test
+  public void shouldMarkMigrationSnapshotTakenWhenAlreadyAtCurrentVersionOnBoot() {
+    // given - a restart with no version change: this replica was already fully migrated in an
+    // earlier boot, so no migration runs in this one either
+    migrationState.setMigratedByVersion("8.8.0");
+    context.setBrokerCfg(new BrokerCfg());
+    context.setBrokerVersion("8.8.0");
+    final var step = new MigrationTransitionStep();
+
+    // when
+    step.transitionTo(context, 0, Role.FOLLOWER).join();
+
+    // then
+    assertThat(context.areMigrationsPerformed()).isFalse();
+    assertThat(context.isMigrationSnapshotTaken()).isTrue();
+  }
+
+  @Test
+  public void shouldNotMarkMigrationSnapshotTakenWhenMigrationsActuallyRun() {
+    // given - a genuine migration this boot; the real MigrationSnapshotDirector is responsible
+    // for eventually marking the snapshot taken, not this step
+    migrationState.setMigratedByVersion("8.7.0");
+    context.setBrokerCfg(new BrokerCfg());
+    context.setBrokerVersion("8.8.0");
+    final var step = new MigrationTransitionStep();
+
+    // when
+    step.transitionTo(context, 0, Role.FOLLOWER).join();
+
+    // then
+    assertThat(context.areMigrationsPerformed()).isTrue();
+    assertThat(context.isMigrationSnapshotTaken()).isFalse();
+  }
+
+  @Test
+  public void shouldNotMarkMigrationSnapshotTakenOnALaterTransitionWithinTheSameBoot() {
+    // given - migrations already ran on an earlier transition in this same boot; a later
+    // transition seeing the version already match must not short-circuit the still-pending
+    // snapshot requirement for that earlier migration
+    migrationState.setMigratedByVersion("8.7.0");
+    context.setBrokerCfg(new BrokerCfg());
+    context.setBrokerVersion("8.8.0");
+    final var step = new MigrationTransitionStep();
+    step.transitionTo(context, 0, Role.FOLLOWER).join();
+    assertThat(context.areMigrationsPerformed()).isTrue();
+    assertThat(context.isMigrationSnapshotTaken()).isFalse();
+
+    // when - a second transition within the same boot; the version already matches now
+    step.transitionTo(context, 1, Role.LEADER).join();
+
+    // then
+    assertThat(context.isMigrationSnapshotTaken()).isFalse();
+  }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStepTest.java
@@ -127,6 +127,26 @@ public class MigrationTransitionStepTest {
   }
 
   @Test
+  public void shouldResetMigrationSnapshotTakenWhenAMigrationRerunsAfterAnEarlierCycle() {
+    // given - an earlier migration cycle already had its snapshot taken (e.g. by the real
+    // MigrationSnapshotDirector), but this replica has since been reverted to an older,
+    // unmigrated version -- e.g. by installing a received snapshot from a lagging peer -- so a
+    // fresh migration cycle is about to start
+    migrationState.setMigratedByVersion("8.7.0");
+    context.setBrokerCfg(new BrokerCfg());
+    context.setBrokerVersion("8.8.0");
+    context.markMigrationSnapshotTaken();
+    final var step = new MigrationTransitionStep();
+
+    // when
+    step.transitionTo(context, 0, Role.FOLLOWER).join();
+
+    // then - the stale flag from the earlier cycle must not survive into the new one
+    assertThat(context.areMigrationsPerformed()).isTrue();
+    assertThat(context.isMigrationSnapshotTaken()).isFalse();
+  }
+
+  @Test
   public void shouldNotMarkMigrationSnapshotTakenOnALaterTransitionWithinTheSameBoot() {
     // given - migrations already ran on an earlier transition in this same boot; a later
     // transition seeing the version already match must not short-circuit the still-pending

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotMigrationTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotMigrationTransitionStepTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.health.CriticalComponentsHealthMonitor;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotException;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
@@ -300,6 +301,23 @@ public class SnapshotMigrationTransitionStepTest {
     assertThat(concurrencyControl.scheduledTasks()).isNotZero();
   }
 
+  @ParameterizedTest
+  @EnumSource(
+      value = Role.class,
+      mode = Mode.EXCLUDE,
+      names = {"INACTIVE"})
+  public void shouldRetryErrorsThatAreNotAClosedState(final Role role) {
+    // given - only a closed state store means retrying can never help; every other error,
+    // including one that isn't an IOException, must still be retried
+    final var exception = new RuntimeException("expected");
+    setupCommonCase(role, CompletableActorFuture.completedExceptionally(exception));
+    // when
+    concurrencyControl.runAll();
+    // then
+    verify(snapshotDirector, atLeast(2)).forceSnapshot();
+    assertThat(concurrencyControl.scheduledTasks()).isNotZero();
+  }
+
   private void setupCommonCase(
       final Role role, final ActorFuture<PersistedSnapshot> snapshotResult) {
     // given
@@ -322,7 +340,9 @@ public class SnapshotMigrationTransitionStepTest {
       names = {"INACTIVE"})
   public void shouldCloseItselfIfExceptionIsNotRetriable(final Role role) {
     setupCommonCase(
-        role, CompletableActorFuture.completedExceptionally(new RuntimeException("expected")));
+        role,
+        CompletableActorFuture.completedExceptionally(
+            new SnapshotException.StateClosedException("expected")));
 
     Awaitility.await("Until report does not contain the component")
         .untilAsserted(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -23,6 +23,9 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusPayload;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
 import io.camunda.zeebe.protocol.management.AdminRequestType;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -361,6 +364,97 @@ final class AdminApiRequestHandlerTest {
           .thenReturn(
               CompletableActorFuture.completedExceptionally(
                   new RuntimeException("Exporting fails")));
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertErrorCode(responseFuture, ErrorCode.INTERNAL_ERROR);
+    }
+
+    @Test
+    void shouldRespondWithFailureIfPartitionNotFound() {
+      // given
+      request.setPartitionId(5);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertErrorCode(responseFuture, ErrorCode.INTERNAL_ERROR);
+    }
+  }
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
+  final class GetMigrationStatusRequest {
+    @RegisterExtension
+    final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+
+    private final PartitionAdminAccess adminAccess;
+    private final AdminApiRequestHandler handler;
+    private final AdminRequest request;
+
+    public GetMigrationStatusRequest(
+        @Mock final PartitionAdminAccess adminAccess,
+        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
+        @Mock final AtomixServerTransport transport,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
+      this.adminAccess = adminAccess;
+      final int partitionId = 1;
+      when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
+      handler =
+          new AdminApiRequestHandler(
+              null,
+              transport,
+              adminAccess,
+              raftPartition,
+              clusterConfigurationService,
+              BrokerMemberId.from(1));
+
+      request = new AdminRequest();
+      request.setPartitionId(partitionId);
+      request.setType(AdminRequestType.GET_MIGRATION_STATUS);
+    }
+
+    @BeforeEach
+    void startHandler() {
+      scheduler.submitActor(handler);
+      scheduler.workUntilDone();
+    }
+
+    @Test
+    void shouldReportMigrationStatusForGivenPartition() {
+      // given
+      final var status =
+          new PartitionMigrationStatus(
+              MigrationStatusCode.MIGRATED, "migrated to 8.10.0 and snapshotted");
+      when(adminAccess.getMigrationStatus()).thenReturn(CompletableActorFuture.completed(status));
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(adminAccess).forPartition(request.getPartitionId());
+      final var decoded =
+          responseFuture
+              .thenApply(Either::get)
+              .thenApply(response -> MigrationStatusPayload.decode(response.getPayload()))
+              .join();
+      assertThat(decoded).isEqualTo(status);
+    }
+
+    @Test
+    void shouldRespondWithFailureIfReadingStatusFails() {
+      // given
+      when(adminAccess.getMigrationStatus())
+          .thenReturn(
+              CompletableActorFuture.completedExceptionally(
+                  new RuntimeException("Migration status read fails")));
 
       // when
       final var responseFuture = handleRequest(request, handler);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -49,6 +49,10 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
     request.setType(AdminRequestType.GET_EXPORTING_STATE);
   }
 
+  public void getMigrationStatus() {
+    request.setType(AdminRequestType.GET_MIGRATION_STATUS);
+  }
+
   public void getFLowControlConfiguration() {
     request.setType(AdminRequestType.GET_FLOW_CONTROL);
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterMigrationStatusReader.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterMigrationStatusReader.java
@@ -23,15 +23,6 @@ import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 
-/**
- * The tenant-fan-out-with-shared-timeout skeleton for a distributed {@link
- * io.camunda.cluster.migration.MigrationStatusProvider} (e.g. {@link
- * ClusterRocksDbMigrationStatusProvider}), kept separate from that provider so a future,
- * differently-distributed migration-status condition can reuse the same shape: resolve every known
- * physical tenant concurrently, under one shared timeout budget, and report each tenant's best
- * available answer independently — a tenant whose fan-out doesn't finish in time reports {@code
- * UNKNOWN} on its own, without holding back tenants that did finish.
- */
 @NullMarked
 final class ClusterMigrationStatusReader {
 
@@ -105,12 +96,6 @@ final class ClusterMigrationStatusReader {
    * Combines every queried replica/partition's status with {@code UNKNOWN > MIGRATION_IN_PROGRESS >
    * MIGRATED} precedence: any one we can't confidently assess makes the whole tenant's condition
    * {@code UNKNOWN} rather than silently reporting a partial answer as though it were complete.
-   *
-   * <p>The combined detail only ever names the ones still behind -- on a cluster with many
-   * partitions (or, for a condition that queries every replica, many partition-replica pairs),
-   * echoing every single one's detail back, migrated or not, would make this unreadable. Once every
-   * one is confidently {@code MIGRATED}, this reports one summary line instead of {@code
-   * statuses.size()} near-identical ones.
    */
   static PartitionMigrationStatus aggregate(final List<PartitionMigrationStatus> statuses) {
     if (statuses.isEmpty()) {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterMigrationStatusReader.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterMigrationStatusReader.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+
+/**
+ * The tenant-fan-out-with-shared-timeout skeleton for a distributed {@link
+ * io.camunda.cluster.migration.MigrationStatusProvider} (e.g. {@link
+ * ClusterRocksDbMigrationStatusProvider}), kept separate from that provider so a future,
+ * differently-distributed migration-status condition can reuse the same shape: resolve every known
+ * physical tenant concurrently, under one shared timeout budget, and report each tenant's best
+ * available answer independently — a tenant whose fan-out doesn't finish in time reports {@code
+ * UNKNOWN} on its own, without holding back tenants that did finish.
+ */
+@NullMarked
+final class ClusterMigrationStatusReader {
+
+  private ClusterMigrationStatusReader() {}
+
+  static Map<String, MigrationConditionStatus> resolveTenants(
+      final PhysicalTenantIds physicalTenantIds,
+      final Duration fetchTimeout,
+      final Function<String, CompletableFuture<PartitionMigrationStatus>> fetchTenantStatus,
+      final Logger log,
+      final String conditionDescription) {
+    final var futuresByPhysicalTenant =
+        new LinkedHashMap<String, CompletableFuture<PartitionMigrationStatus>>();
+    for (final var physicalTenantId : physicalTenantIds.known()) {
+      futuresByPhysicalTenant.put(physicalTenantId, fetchTenantStatus.apply(physicalTenantId));
+    }
+
+    // One shared timeout budget for every tenant's fan-out, run concurrently -- not one timeout
+    // per tenant, which would let a large multi-tenant cluster's total latency grow with the
+    // tenant count.
+    try {
+      CompletableFuture.allOf(futuresByPhysicalTenant.values().toArray(CompletableFuture<?>[]::new))
+          .get(fetchTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (final InterruptedException e) {
+      // Restore the interrupt so callers on this thread (e.g. during a graceful shutdown) still
+      // observe it -- swallowing it here would hide the signal from whatever cancellation logic
+      // is waiting on it, even though the resolution below still proceeds on a best-effort basis.
+      Thread.currentThread().interrupt();
+      log.warn(
+          "Interrupted while waiting for every physical tenant's {} to be determined.",
+          conditionDescription,
+          e);
+    } catch (final Exception e) {
+      log.warn(
+          "Not every physical tenant's {} could be determined within {}.",
+          conditionDescription,
+          fetchTimeout,
+          e);
+    }
+
+    final var statuses = new LinkedHashMap<String, MigrationConditionStatus>();
+    futuresByPhysicalTenant.forEach(
+        (physicalTenantId, future) ->
+            statuses.put(physicalTenantId, resolve(physicalTenantId, future)));
+    return statuses;
+  }
+
+  /**
+   * Reports each tenant's best available answer independently: a tenant whose fan-out finished
+   * (successfully or not) reports its actual result; a tenant still pending when the shared budget
+   * ran out reports {@code UNKNOWN} on its own, without holding back tenants that did finish.
+   */
+  private static MigrationConditionStatus resolve(
+      final String physicalTenantId, final CompletableFuture<PartitionMigrationStatus> future) {
+    if (future.isDone() && !future.isCompletedExceptionally()) {
+      return toConditionStatus(future.join());
+    }
+    if (future.isCompletedExceptionally()) {
+      return new MigrationConditionStatus(
+          MigrationState.UNKNOWN,
+          "physical tenant '" + physicalTenantId + "': failed to determine migration status");
+    }
+    return new MigrationConditionStatus(
+        MigrationState.UNKNOWN,
+        "physical tenant '"
+            + physicalTenantId
+            + "': timed out waiting for every partition replica to respond");
+  }
+
+  /**
+   * Combines every queried replica/partition's status with {@code UNKNOWN > MIGRATION_IN_PROGRESS >
+   * MIGRATED} precedence: any one we can't confidently assess makes the whole tenant's condition
+   * {@code UNKNOWN} rather than silently reporting a partial answer as though it were complete.
+   *
+   * <p>The combined detail only ever names the ones still behind -- on a cluster with many
+   * partitions (or, for a condition that queries every replica, many partition-replica pairs),
+   * echoing every single one's detail back, migrated or not, would make this unreadable. Once every
+   * one is confidently {@code MIGRATED}, this reports one summary line instead of {@code
+   * statuses.size()} near-identical ones.
+   */
+  static PartitionMigrationStatus aggregate(final List<PartitionMigrationStatus> statuses) {
+    if (statuses.isEmpty()) {
+      return new PartitionMigrationStatus(
+          MigrationStatusCode.UNKNOWN, "no partitions found in the topology");
+    }
+
+    final var notMigrated =
+        statuses.stream().filter(status -> status.code() != MigrationStatusCode.MIGRATED).toList();
+    if (notMigrated.isEmpty()) {
+      return new PartitionMigrationStatus(MigrationStatusCode.MIGRATED, "All partitions migrated");
+    }
+
+    final var overallCode =
+        notMigrated.stream().anyMatch(status -> status.code() == MigrationStatusCode.UNKNOWN)
+            ? MigrationStatusCode.UNKNOWN
+            : MigrationStatusCode.MIGRATION_IN_PROGRESS;
+    final var detail =
+        notMigrated.stream()
+            .map(PartitionMigrationStatus::detail)
+            .collect(Collectors.joining("; "));
+    return new PartitionMigrationStatus(overallCode, detail);
+  }
+
+  /** Maps the wire-level protocol type to the upgrade-readiness API/SPI type. */
+  static MigrationConditionStatus toConditionStatus(final PartitionMigrationStatus status) {
+    final var state =
+        switch (status.code()) {
+          case MIGRATED -> MigrationState.MIGRATED;
+          case MIGRATION_IN_PROGRESS -> MigrationState.MIGRATION_IN_PROGRESS;
+          case UNKNOWN -> MigrationState.UNKNOWN;
+        };
+    return new MigrationConditionStatus(state, status.detail());
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterRocksDbMigrationStatusProvider.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterRocksDbMigrationStatusProvider.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.gateway.admin;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.cluster.migration.MigrationConditionStatus;
-import io.camunda.cluster.migration.MigrationState;
 import io.camunda.cluster.migration.MigrationStatusProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
@@ -26,28 +25,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Reports whether every partition replica's RocksDB state has migrated to the current application
- * version and been captured in a snapshot, per physical tenant, for the upgrade-readiness endpoint
- * (camunda/product-hub#3067).
+ * version and been captured in a snapshot, per physical tenant.
  *
  * <p>Every replica of every partition, of every known physical tenant, is queried — leader,
  * followers, and inactive members — not just the leader: migration runs independently on every
  * replica, so a follower that has not yet migrated could still be promoted to leader after a
  * fail-over.
- *
- * <p>Talks to brokers using {@link PartitionMigrationStatus}/{@link MigrationStatusCode} — the
- * wire-level protocol types, kept deliberately separate from {@link MigrationConditionStatus}/
- * {@link MigrationState}, which are the upgrade-readiness API/SPI types. This class is the boundary
- * between the two: it aggregates every replica's wire-level status internally, per tenant, then
- * maps each tenant's final result to the API type only in {@link #getMigrationStatus()}, so the
- * broker/gateway RPC layer never needs to depend on the {@code cluster} API module for this.
- *
- * <p>Unlike {@link ExportingRequestBroadcaster}, which callers invoke asynchronously with an
- * explicit physical tenant, this implements the synchronous {@link MigrationStatusProvider} SPI so
- * it can be collected alongside every other upgrade-readiness condition. All known physical tenants
- * are fetched concurrently under one shared timeout budget; a tenant whose fan-out does not finish
- * within that budget is reported as {@link MigrationState#UNKNOWN} on its own, without holding back
- * tenants that did finish in time — per the distributed-condition contract described in {@code
- * docs/adr/management/004-upgrade-readiness-actuator-solution-proposal.md}.
  */
 @NullMarked
 public class ClusterRocksDbMigrationStatusProvider implements MigrationStatusProvider {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterRocksDbMigrationStatusProvider.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterRocksDbMigrationStatusProvider.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusPayload;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reports whether every partition replica's RocksDB state has migrated to the current application
+ * version and been captured in a snapshot, per physical tenant, for the upgrade-readiness endpoint
+ * (camunda/product-hub#3067).
+ *
+ * <p>Every replica of every partition, of every known physical tenant, is queried — leader,
+ * followers, and inactive members — not just the leader: migration runs independently on every
+ * replica, so a follower that has not yet migrated could still be promoted to leader after a
+ * fail-over.
+ *
+ * <p>Talks to brokers using {@link PartitionMigrationStatus}/{@link MigrationStatusCode} — the
+ * wire-level protocol types, kept deliberately separate from {@link MigrationConditionStatus}/
+ * {@link MigrationState}, which are the upgrade-readiness API/SPI types. This class is the boundary
+ * between the two: it aggregates every replica's wire-level status internally, per tenant, then
+ * maps each tenant's final result to the API type only in {@link #getMigrationStatus()}, so the
+ * broker/gateway RPC layer never needs to depend on the {@code cluster} API module for this.
+ *
+ * <p>Unlike {@link ExportingRequestBroadcaster}, which callers invoke asynchronously with an
+ * explicit physical tenant, this implements the synchronous {@link MigrationStatusProvider} SPI so
+ * it can be collected alongside every other upgrade-readiness condition. All known physical tenants
+ * are fetched concurrently under one shared timeout budget; a tenant whose fan-out does not finish
+ * within that budget is reported as {@link MigrationState#UNKNOWN} on its own, without holding back
+ * tenants that did finish in time — per the distributed-condition contract described in {@code
+ * docs/adr/management/004-upgrade-readiness-actuator-solution-proposal.md}.
+ */
+@NullMarked
+public class ClusterRocksDbMigrationStatusProvider implements MigrationStatusProvider {
+
+  public static final String CONDITION_NAME = "rocksDbMigrated";
+  private static final Duration DEFAULT_FETCH_TIMEOUT = Duration.ofSeconds(5);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ClusterRocksDbMigrationStatusProvider.class);
+
+  private final BrokerClient brokerClient;
+  private final PhysicalTenantIds physicalTenantIds;
+  private final Duration fetchTimeout;
+
+  public ClusterRocksDbMigrationStatusProvider(
+      final BrokerClient brokerClient, final PhysicalTenantIds physicalTenantIds) {
+    this(brokerClient, physicalTenantIds, DEFAULT_FETCH_TIMEOUT);
+  }
+
+  @VisibleForTesting
+  ClusterRocksDbMigrationStatusProvider(
+      final BrokerClient brokerClient,
+      final PhysicalTenantIds physicalTenantIds,
+      final Duration fetchTimeout) {
+    this.brokerClient = brokerClient;
+    this.physicalTenantIds = physicalTenantIds;
+    this.fetchTimeout = fetchTimeout;
+  }
+
+  @Override
+  public String conditionName() {
+    return CONDITION_NAME;
+  }
+
+  @Override
+  public Map<String, MigrationConditionStatus> getMigrationStatus() {
+    return ClusterMigrationStatusReader.resolveTenants(
+        physicalTenantIds, fetchTimeout, this::fetchTenantStatus, LOG, "RocksDB migration status");
+  }
+
+  private CompletableFuture<PartitionMigrationStatus> fetchTenantStatus(
+      final String physicalTenantId) {
+    final var topology = brokerClient.getTopologyManager().getTopology(physicalTenantId);
+
+    // A partition (or one of its members) that the topology doesn't know about yet -- during
+    // startup, a reconfiguration, or a transient gossip gap -- would otherwise be silently
+    // skipped rather than counted against the aggregate: PartitionReplicas.allOf can only query
+    // members the topology actually reports, so a not-yet-known partition contributes nothing,
+    // and a tenant where every known partition happens to report MIGRATED would then be reported
+    // as fully migrated even though one partition was never actually checked.
+    try {
+      ExportingRequestBroadcaster.validateTopology(topology);
+    } catch (final IncompleteTopologyException e) {
+      return CompletableFuture.completedFuture(
+          new PartitionMigrationStatus(
+              MigrationStatusCode.UNKNOWN,
+              "physical tenant '"
+                  + physicalTenantId
+                  + "': incomplete topology: "
+                  + e.getMessage()));
+    }
+
+    final var responses =
+        topology.getPartitions().stream()
+            .flatMap(
+                partitionId ->
+                    PartitionReplicas.allOf(topology, partitionId).stream()
+                        .map(brokerId -> requestStatus(physicalTenantId, partitionId, brokerId)))
+            .toList();
+
+    return CompletableFuture.allOf(responses.toArray(CompletableFuture<?>[]::new))
+        .thenApply(
+            ignored ->
+                ClusterMigrationStatusReader.aggregate(
+                    responses.stream().map(CompletableFuture::join).toList()));
+  }
+
+  private CompletableFuture<PartitionMigrationStatus> requestStatus(
+      final String physicalTenantId, final Integer partitionId, final BrokerMemberId brokerId) {
+    final var request = new BrokerAdminRequest();
+    request.setPartitionGroup(physicalTenantId);
+    request.setBrokerId(brokerId);
+    request.setPartitionId(partitionId);
+    request.getMigrationStatus();
+    return brokerClient
+        .sendRequest(request)
+        .thenApply(
+            response -> MigrationStatusPayload.decode(response.getResponseOrThrow().getPayload()));
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcaster.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ExportingRequestBroadcaster.java
@@ -153,7 +153,12 @@ public class ExportingRequestBroadcaster {
     return members;
   }
 
-  private void validateTopology(final BrokerClusterState topology) {
+  /**
+   * Throws {@link IncompleteTopologyException} unless every partition of the topology, and every
+   * one of its members, is known -- shared with {@link ClusterRocksDbMigrationStatusProvider},
+   * which needs the same guarantee before fanning out to every partition replica.
+   */
+  static void validateTopology(final BrokerClusterState topology) {
     final var replicationFactor = topology.getReplicationFactor();
     final var expectedPartitions = topology.getPartitionsCount();
     final var partitions = topology.getPartitions();

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/PartitionReplicas.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/PartitionReplicas.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import java.util.HashSet;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Resolves the replicas of a partition from a {@link BrokerClusterState}, for callers that need to
+ * query every partition replica directly over the admin API (e.g. {@link
+ * ClusterRocksDbMigrationStatusProvider}).
+ */
+@NullMarked
+final class PartitionReplicas {
+
+  private PartitionReplicas() {}
+
+  /**
+   * Every replica of a partition: leader, followers, and inactive members. Inactive members keep
+   * their data and can be promoted back once they recover, so they are as relevant as any other
+   * replica for a condition that genuinely differs per replica (e.g. RocksDB migration state).
+   */
+  static Set<BrokerMemberId> allOf(final BrokerClusterState topology, final int partitionId) {
+    final var leader = topology.getLeaderForPartition(partitionId);
+    final var followers = topology.getFollowersForPartition(partitionId);
+    final var inactive = topology.getInactiveNodesForPartition(partitionId);
+
+    final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
+    if (leader != null) {
+      members.add(leader);
+    }
+    members.addAll(followers);
+    members.addAll(inactive);
+    return members;
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterMigrationStatusReaderTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterMigrationStatusReaderTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+final class ClusterMigrationStatusReaderTest {
+
+  @Test
+  void shouldReportOneConciseSummaryWhenEveryEntryIsMigrated() {
+    // given - a large partition count would otherwise echo one near-identical detail per entry
+    final var statuses =
+        List.of(
+            migrated("partition 1: migrated to 8.10"),
+            migrated("partition 2: migrated to 8.10"),
+            migrated("partition 3: migrated to 8.10"));
+
+    // when
+    final var aggregated = ClusterMigrationStatusReader.aggregate(statuses);
+
+    // then
+    assertThat(aggregated.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+    assertThat(aggregated.detail()).isEqualTo("All partitions migrated");
+  }
+
+  @Test
+  void shouldOnlyListEntriesThatAreNotYetMigrated() {
+    // given
+    final var statuses =
+        List.of(
+            migrated("partition 1: migrated to 8.10"),
+            inProgress("partition 2: not yet caught up to 8.10"),
+            migrated("partition 3: migrated to 8.10"));
+
+    // when
+    final var aggregated = ClusterMigrationStatusReader.aggregate(statuses);
+
+    // then
+    assertThat(aggregated.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+    assertThat(aggregated.detail())
+        .contains("partition 2")
+        .doesNotContain("partition 1", "partition 3");
+  }
+
+  @Test
+  void shouldOnlyListEntriesThatAreNotYetMigratedWhenSomeAreUnknown() {
+    // given - UNKNOWN still takes precedence in the overall code, but the migrated entries are
+    // still dropped from the detail
+    final var statuses =
+        List.of(
+            migrated("partition 1: migrated to 8.10"),
+            inProgress("partition 2: not yet caught up to 8.10"),
+            unknown("partition 3: unreachable"));
+
+    // when
+    final var aggregated = ClusterMigrationStatusReader.aggregate(statuses);
+
+    // then
+    assertThat(aggregated.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+    assertThat(aggregated.detail())
+        .contains("partition 2", "partition 3")
+        .doesNotContain("partition 1");
+  }
+
+  @Test
+  void shouldReportUnknownWhenNoPartitionsAreFoundAtAll() {
+    // when
+    final var aggregated = ClusterMigrationStatusReader.aggregate(List.of());
+
+    // then
+    assertThat(aggregated.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+  }
+
+  @Test
+  void shouldRestoreInterruptStatusWhenInterruptedWhileWaiting() throws InterruptedException {
+    // given - a fetch that never completes, so resolveTenants blocks on the shared timeout's
+    // get() until either the timeout elapses or the waiting thread is interrupted
+    final var enteredFanOut = new CountDownLatch(1);
+    final var neverCompletes = new CompletableFuture<PartitionMigrationStatus>();
+    final var interruptedInsideResolveTenants = new AtomicBoolean();
+    final var worker =
+        new Thread(
+            () -> {
+              ClusterMigrationStatusReader.resolveTenants(
+                  singleTenant("tenantA"),
+                  Duration.ofSeconds(30),
+                  tenantId -> {
+                    enteredFanOut.countDown();
+                    return neverCompletes;
+                  },
+                  LoggerFactory.getLogger(ClusterMigrationStatusReaderTest.class),
+                  "test condition");
+              interruptedInsideResolveTenants.set(Thread.currentThread().isInterrupted());
+            });
+
+    // when - interrupt the worker once it has dispatched its fetch and is about to wait
+    worker.start();
+    assertThat(enteredFanOut.await(5, TimeUnit.SECONDS)).isTrue();
+    worker.interrupt();
+    worker.join(Duration.ofSeconds(5).toMillis());
+
+    // then - the interrupt status is restored rather than silently swallowed
+    assertThat(interruptedInsideResolveTenants.get()).isTrue();
+  }
+
+  private static PhysicalTenantIds singleTenant(final String physicalTenantId) {
+    return () -> Set.of(physicalTenantId);
+  }
+
+  private static PartitionMigrationStatus migrated(final String detail) {
+    return new PartitionMigrationStatus(MigrationStatusCode.MIGRATED, detail);
+  }
+
+  private static PartitionMigrationStatus inProgress(final String detail) {
+    return new PartitionMigrationStatus(MigrationStatusCode.MIGRATION_IN_PROGRESS, detail);
+  }
+
+  private static PartitionMigrationStatus unknown(final String detail) {
+    return new PartitionMigrationStatus(MigrationStatusCode.UNKNOWN, detail);
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterRocksDbMigrationStatusProviderTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterRocksDbMigrationStatusProviderTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusPayload;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+final class ClusterRocksDbMigrationStatusProviderTest {
+
+  private static final String DEFAULT = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
+  private static final BrokerClusterState TOPOLOGY =
+      ofTopology(
+          Map.of(
+              1,
+              List.of(BrokerMemberId.from(1), BrokerMemberId.from(2), BrokerMemberId.from(3)),
+              2,
+              List.of(BrokerMemberId.from(2), BrokerMemberId.from(1), BrokerMemberId.from(3))));
+
+  @Test
+  void shouldReportConditionName() {
+    final var provider =
+        new ClusterRocksDbMigrationStatusProvider(mock(BrokerClient.class), singleTenant(DEFAULT));
+    assertThat(provider.conditionName())
+        .isEqualTo(ClusterRocksDbMigrationStatusProvider.CONDITION_NAME);
+  }
+
+  @Test
+  void shouldQueryEveryReplicaOfEveryPartitionForTheKnownTenant() {
+    // given
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "ok"));
+    final var provider = new ClusterRocksDbMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    provider.getMigrationStatus();
+
+    // then - leader and every follower of every partition, not just leaders
+    for (final var partition : TOPOLOGY.getPartitions()) {
+      verify(client)
+          .sendRequest(
+              argThatTargets(DEFAULT, partition, TOPOLOGY.getLeaderForPartition(partition)));
+      for (final var follower : TOPOLOGY.getFollowersForPartition(partition)) {
+        verify(client).sendRequest(argThatTargets(DEFAULT, partition, follower));
+      }
+    }
+  }
+
+  @Test
+  void shouldQueryEveryKnownPhysicalTenantIndependently() {
+    // given - two tenants, each with their own topology and their own leader
+    final var topologyB =
+        ofTopology(Map.of(1, List.of(BrokerMemberId.from(4), BrokerMemberId.from(5))));
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY, "tenantB", topologyB));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "ok"));
+    final var provider =
+        new ClusterRocksDbMigrationStatusProvider(client, multiTenant(DEFAULT, "tenantB"));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses).containsOnlyKeys(DEFAULT, "tenantB");
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(statuses.get("tenantB").state()).isEqualTo(MigrationState.MIGRATED);
+    verify(client).sendRequest(argThatTargets("tenantB", 1, BrokerMemberId.from(4)));
+    verify(client).sendRequest(argThatTargets("tenantB", 1, BrokerMemberId.from(5)));
+  }
+
+  @Test
+  void shouldReportMigratedWhenEveryReplicaIsMigrated() {
+    // given
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "migrated"));
+    final var provider = new ClusterRocksDbMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressWhenOneReplicaIsBehind() {
+    // given
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "migrated"));
+    when(client.sendRequest(argThatTargets(DEFAULT, 1, TOPOLOGY.getLeaderForPartition(1))))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATION_IN_PROGRESS, "behind"));
+    final var provider = new ClusterRocksDbMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportUnknownWhenAnyReplicaIsUnknownEvenIfOthersAreMigrated() {
+    // given - UNKNOWN takes precedence: we must not claim a confident answer when part of the
+    // picture is missing.
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "migrated"));
+    when(client.sendRequest(argThatTargets(DEFAULT, 1, TOPOLOGY.getLeaderForPartition(1))))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.UNKNOWN, "unreachable"));
+    final var provider = new ClusterRocksDbMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownWhenARequestFails() {
+    // given
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unreachable")));
+    final var provider = new ClusterRocksDbMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then - a failed fan-out must never throw out of getMigrationStatus()
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownWhenTheFanOutTimesOut() {
+    // given - a request that never completes, and a short timeout so the test itself stays fast
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any())).thenReturn(new CompletableFuture<>());
+    final var provider =
+        new ClusterRocksDbMigrationStatusProvider(
+            client, singleTenant(DEFAULT), Duration.ofMillis(200));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(statuses.get(DEFAULT).detail()).contains("timed out");
+  }
+
+  @Test
+  void shouldReportEachTenantIndependentlyWhenOnlyOneTimesOut() {
+    // given - "default" resolves quickly, "tenantB" never responds; both share one timeout budget
+    final var topologyB =
+        ofTopology(Map.of(1, List.of(BrokerMemberId.from(4), BrokerMemberId.from(5))));
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY, "tenantB", topologyB));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "migrated"));
+    when(client.sendRequest(argThatTargetsTenant("tenantB"))).thenReturn(new CompletableFuture<>());
+    final var provider =
+        new ClusterRocksDbMigrationStatusProvider(
+            client, multiTenant(DEFAULT, "tenantB"), Duration.ofMillis(200));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then - the slow tenant does not hold back the fast one
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(statuses.get("tenantB").state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownWithoutQueryingAnyReplicaWhenTopologyIsIncomplete() {
+    // given - partition 2's leader is not known yet (e.g. gossip hasn't caught up), so the
+    // topology doesn't yet reflect every partition's full replica set
+    final var incompleteTopology =
+        ofTopology(
+            Map.of(
+                1, List.of(BrokerMemberId.from(1), BrokerMemberId.from(2)),
+                2, List.of()));
+    final var client = setupBrokerClient(Map.of(DEFAULT, incompleteTopology));
+    final var provider = new ClusterRocksDbMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then - reported unknown rather than silently aggregating only the partitions that are known
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(statuses.get(DEFAULT).detail()).contains("incomplete topology");
+    verify(client, never()).sendRequest(any());
+  }
+
+  private static CompletableFuture<BrokerResponse<AdminResponse>> respondWith(
+      final MigrationStatusCode code, final String detail) {
+    final var response = mock(AdminResponse.class);
+    when(response.getPayload())
+        .thenReturn(MigrationStatusPayload.encode(new PartitionMigrationStatus(code, detail)));
+    return CompletableFuture.completedFuture(new BrokerResponse<>(response));
+  }
+
+  private static PhysicalTenantIds singleTenant(final String physicalTenantId) {
+    return () -> Set.of(physicalTenantId);
+  }
+
+  private static PhysicalTenantIds multiTenant(final String... physicalTenantIds) {
+    return () -> Set.of(physicalTenantIds);
+  }
+
+  private static BrokerClient setupBrokerClient(
+      final Map<String, BrokerClusterState> topologyByTenant) {
+    final var client = mock(BrokerClient.class);
+    final var topologyManager = mock(BrokerTopologyManager.class);
+    topologyByTenant.forEach(
+        (tenantId, topology) -> when(topologyManager.getTopology(tenantId)).thenReturn(topology));
+    when(client.getTopologyManager()).thenReturn(topologyManager);
+    return client;
+  }
+
+  private static io.camunda.zeebe.broker.client.api.dto.BrokerRequest<AdminResponse> argThatTargets(
+      final String physicalTenantId, final int partitionId, final BrokerMemberId brokerId) {
+    return argThat(
+        request ->
+            request != null
+                && request.getPartitionGroup().equals(physicalTenantId)
+                && request.getPartitionId() == partitionId
+                && request.getBrokerId().orElseThrow().equals(brokerId));
+  }
+
+  private static io.camunda.zeebe.broker.client.api.dto.BrokerRequest<AdminResponse>
+      argThatTargetsTenant(final String physicalTenantId) {
+    return argThat(
+        request -> request != null && request.getPartitionGroup().equals(physicalTenantId));
+  }
+
+  private static BrokerClusterState ofTopology(final Map<Integer, List<BrokerMemberId>> topology) {
+    return new BrokerClusterState() {
+      @Override
+      public boolean isInitialized() {
+        return true;
+      }
+
+      @Override
+      public int getClusterSize() {
+        return (int) topology.values().stream().flatMap(Collection::stream).distinct().count();
+      }
+
+      @Override
+      public int getPartitionsCount() {
+        return topology.size();
+      }
+
+      @Override
+      public int getReplicationFactor() {
+        return topology.values().stream().map(List::size).max(Integer::compareTo).orElse(1);
+      }
+
+      @Override
+      public @Nullable BrokerMemberId getLeaderForPartition(final int partition) {
+        return Optional.ofNullable(topology.get(partition))
+            .filter(brokers -> !brokers.isEmpty())
+            .map(List::getFirst)
+            .orElse(null);
+      }
+
+      @Override
+      public Set<BrokerMemberId> getFollowersForPartition(final int partition) {
+        return topology.getOrDefault(partition, List.of()).stream()
+            .skip(1)
+            .collect(Collectors.toSet());
+      }
+
+      @Override
+      public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
+        return Set.of();
+      }
+
+      @Override
+      public @Nullable BrokerMemberId getRandomBroker() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public List<Integer> getPartitions() {
+        return new ArrayList<>(topology.keySet());
+      }
+
+      @Override
+      public List<BrokerMemberId> getBrokers() {
+        return topology.values().stream().flatMap(Collection::stream).distinct().toList();
+      }
+
+      @Override
+      public @Nullable String getBrokerAddress(final @NonNull BrokerMemberId brokerId) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public @Nullable String getBrokerVersion(final @NonNull BrokerMemberId brokerId) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public PartitionHealthStatus getPartitionHealth(
+          final @NonNull BrokerMemberId brokerId, final int partition) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public State getPartitionState(final BrokerMemberId brokerId, final int partition) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public long getLastCompletedChangeId() {
+        return 0;
+      }
+
+      @Override
+      public String getClusterId() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusCode.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusCode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+/**
+ * The migration status of a single partition replica, as reported over the {@code
+ * GET_MIGRATION_STATUS} admin request/response wire protocol (see {@link PartitionMigrationStatus},
+ * {@link MigrationStatusPayload}).
+ *
+ * <p>Deliberately distinct from {@code io.camunda.cluster.MigrationState}: that type is the
+ * upgrade-readiness API/SPI's condition state, used by every {@code MigrationStatusProvider} and
+ * the actuator endpoint that aggregates them. This one is the wire-level status a broker reports
+ * for one partition replica. Keeping them separate means the broker/gateway RPC layer does not
+ * depend on the {@code cluster} API module, and the API-level enum can evolve independently of the
+ * wire format. Providers map between the two at the boundary (e.g. {@code
+ * ClusterRocksDbMigrationStatusProvider}, once it has aggregated across every replica).
+ */
+public enum MigrationStatusCode {
+  MIGRATED,
+  MIGRATION_IN_PROGRESS,
+  UNKNOWN
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusCode.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusCode.java
@@ -11,14 +11,6 @@ package io.camunda.zeebe.protocol.impl.encoding;
  * The migration status of a single partition replica, as reported over the {@code
  * GET_MIGRATION_STATUS} admin request/response wire protocol (see {@link PartitionMigrationStatus},
  * {@link MigrationStatusPayload}).
- *
- * <p>Deliberately distinct from {@code io.camunda.cluster.MigrationState}: that type is the
- * upgrade-readiness API/SPI's condition state, used by every {@code MigrationStatusProvider} and
- * the actuator endpoint that aggregates them. This one is the wire-level status a broker reports
- * for one partition replica. Keeping them separate means the broker/gateway RPC layer does not
- * depend on the {@code cluster} API module, and the API-level enum can evolve independently of the
- * wire format. Providers map between the two at the boundary (e.g. {@code
- * ClusterRocksDbMigrationStatusProvider}, once it has aggregated across every replica).
  */
 public enum MigrationStatusCode {
   MIGRATED,

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusPayload.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusPayload.java
@@ -11,12 +11,7 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Encodes/decodes a {@link PartitionMigrationStatus} into the {@code payload} byte blob of an
- * {@code AdminRequest}/{@code AdminResponse} ({@code GET_MIGRATION_STATUS}), the same way {@code
- * GET_EXPORTING_STATE} stuffs an {@code ExporterPhase} name into the same field — no dedicated SBE
- * message is needed for a value this small.
- *
- * <p>Wire format: {@code <code name>\n<detail>}, UTF-8. The detail is everything after the first
- * newline, so it may itself contain newlines.
+ * {@code AdminRequest}/{@code AdminResponse} ({@code GET_MIGRATION_STATUS}).
  */
 public final class MigrationStatusPayload {
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusPayload.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusPayload.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Encodes/decodes a {@link PartitionMigrationStatus} into the {@code payload} byte blob of an
+ * {@code AdminRequest}/{@code AdminResponse} ({@code GET_MIGRATION_STATUS}), the same way {@code
+ * GET_EXPORTING_STATE} stuffs an {@code ExporterPhase} name into the same field — no dedicated SBE
+ * message is needed for a value this small.
+ *
+ * <p>Wire format: {@code <code name>\n<detail>}, UTF-8. The detail is everything after the first
+ * newline, so it may itself contain newlines.
+ */
+public final class MigrationStatusPayload {
+
+  private static final String DELIMITER = "\n";
+
+  private MigrationStatusPayload() {}
+
+  public static byte[] encode(final PartitionMigrationStatus status) {
+    return (status.code().name() + DELIMITER + status.detail()).getBytes(StandardCharsets.UTF_8);
+  }
+
+  public static PartitionMigrationStatus decode(final byte[] payload) {
+    final var decoded = new String(payload, StandardCharsets.UTF_8);
+    final var parts = decoded.split(DELIMITER, 2);
+    final var code = MigrationStatusCode.valueOf(parts[0]);
+    final var detail = parts.length > 1 ? parts[1] : "";
+    return new PartitionMigrationStatus(code, detail);
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/PartitionMigrationStatus.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/PartitionMigrationStatus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+/**
+ * A single partition replica's migration status, reported by {@code
+ * PartitionAdminAccess#getMigrationStatus()} and carried over the wire by {@link
+ * MigrationStatusPayload}.
+ *
+ * @param code whether this replica is migrated, confidently not yet migrated, or unknown
+ * @param detail a short, human-readable explanation
+ */
+public record PartitionMigrationStatus(MigrationStatusCode code, String detail) {}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusPayloadTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusPayloadTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+final class MigrationStatusPayloadTest {
+
+  @ParameterizedTest
+  @EnumSource(MigrationStatusCode.class)
+  void shouldRoundTripEveryCode(final MigrationStatusCode code) {
+    // given
+    final var status = new PartitionMigrationStatus(code, "some detail text");
+
+    // when
+    final var decoded = MigrationStatusPayload.decode(MigrationStatusPayload.encode(status));
+
+    // then
+    assertThat(decoded).isEqualTo(status);
+  }
+
+  @Test
+  void shouldRoundTripEmptyDetail() {
+    // given
+    final var status = new PartitionMigrationStatus(MigrationStatusCode.MIGRATED, "");
+
+    // when
+    final var decoded = MigrationStatusPayload.decode(MigrationStatusPayload.encode(status));
+
+    // then
+    assertThat(decoded).isEqualTo(status);
+  }
+
+  @Test
+  void shouldPreserveNewlinesInDetail() {
+    // given - the detail is everything after the first delimiter, so it may contain more of them
+    final var status =
+        new PartitionMigrationStatus(MigrationStatusCode.UNKNOWN, "line one\nline two");
+
+    // when
+    final var decoded = MigrationStatusPayload.decode(MigrationStatusPayload.encode(status));
+
+    // then
+    assertThat(decoded).isEqualTo(status);
+  }
+}

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -16,6 +16,7 @@
       <validValue name="SET_FLOW_CONTROL">5</validValue>
       <validValue name="GET_FLOW_CONTROL">6</validValue>
       <validValue name="GET_EXPORTING_STATE">7</validValue>
+      <validValue name="GET_MIGRATION_STATUS">8</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterRocksDbMigrationStatusProviderIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterRocksDbMigrationStatusProviderIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.management;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.admin.ClusterRocksDbMigrationStatusProvider;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real multi-broker coverage for {@link ClusterRocksDbMigrationStatusProvider}
+ * (camunda/product-hub#3067), constructed directly against a live {@link BrokerClient} rather than
+ * through the {@code upgradeReadiness} actuator endpoint.
+ *
+ * <p>{@link io.camunda.zeebe.it.cluster.management.UpgradeReadinessEndpointIT} already covers the
+ * endpoint end-to-end, but on a single broker every partition has only a leader — it never
+ * exercises the part of this provider that broadcasts to every partition *replica*, including
+ * followers, over the real network. A replication factor equal to the broker count spreads leader
+ * and follower roles for every partition across all three brokers, so this test genuinely forces
+ * the fan-out to cross real broker process boundaries, hitting the real wire encoding ({@code
+ * io.camunda.zeebe.protocol.impl.encoding.MigrationStatusPayload}) and the real broker-side handler
+ * ({@code AdminApiRequestHandler.getMigrationStatus}) — none of which the provider's own unit test
+ * (fully mocked {@code BrokerClient}/{@code BrokerTopologyManager}) can exercise.
+ */
+@ZeebeIntegration
+final class ClusterRocksDbMigrationStatusProviderIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+  @TestZeebe
+  private static final TestCluster CLUSTER =
+      TestCluster.builder()
+          .withBrokersCount(3)
+          .withPartitionsCount(3)
+          .withReplicationFactor(3)
+          // Inter-broker replication and the RocksDB provider's fan-out both go over the internal
+          // API. Relying on each broker's auto-detected LAN address makes that depend on the
+          // environment's network/firewall setup; loopback is always valid for a local cluster.
+          .withBrokerConfig(
+              broker ->
+                  broker.withClusterConfig(
+                      cluster -> {
+                        cluster.getNetwork().setAdvertisedHost("127.0.0.1");
+                        cluster.getNetwork().getInternalApi().setAdvertisedHost("127.0.0.1");
+                      }))
+          .build();
+
+  @Test
+  void shouldReportMigratedAcrossAllPartitionReplicasIncludingFollowers() {
+    final var brokerClient = CLUSTER.anyGateway().bean(BrokerClient.class);
+    final var provider =
+        new ClusterRocksDbMigrationStatusProvider(brokerClient, PhysicalTenantIds.DEFAULT);
+
+    Awaitility.await("until every partition replica, including followers, reports MIGRATED")
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var status = provider.getMigrationStatus();
+
+              assertThat(status).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID);
+              assertThat(status.get(DEFAULT_PHYSICAL_TENANT_ID).state())
+                  .isEqualTo(MigrationState.MIGRATED);
+            });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterRocksDbMigrationStatusProviderIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterRocksDbMigrationStatusProviderIT.java
@@ -25,16 +25,6 @@ import org.junit.jupiter.api.Test;
  * Real multi-broker coverage for {@link ClusterRocksDbMigrationStatusProvider}
  * (camunda/product-hub#3067), constructed directly against a live {@link BrokerClient} rather than
  * through the {@code upgradeReadiness} actuator endpoint.
- *
- * <p>{@link io.camunda.zeebe.it.cluster.management.UpgradeReadinessEndpointIT} already covers the
- * endpoint end-to-end, but on a single broker every partition has only a leader — it never
- * exercises the part of this provider that broadcasts to every partition *replica*, including
- * followers, over the real network. A replication factor equal to the broker count spreads leader
- * and follower roles for every partition across all three brokers, so this test genuinely forces
- * the fan-out to cross real broker process boundaries, hitting the real wire encoding ({@code
- * io.camunda.zeebe.protocol.impl.encoding.MigrationStatusPayload}) and the real broker-side handler
- * ({@code AdminApiRequestHandler.getMigrationStatus}) — none of which the provider's own unit test
- * (fully mocked {@code BrokerClient}/{@code BrokerTopologyManager}) can exercise.
  */
 @ZeebeIntegration
 final class ClusterRocksDbMigrationStatusProviderIT {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
@@ -23,24 +23,39 @@ import org.junit.jupiter.api.Test;
 /**
  * End-to-end happy-path coverage for {@code GET /actuator/upgradeReadiness}
  * (camunda/product-hub#3067) with RDBMS as the secondary storage: on a normally-booted, healthy
- * broker — no chained-upgrade or migration scenario involved — the condition must settle on {@code
- * MIGRATED} for the default physical tenant, and the endpoint must report the cluster as
- * upgradeable.
+ * broker — no chained-upgrade or migration scenario involved — every registered condition must
+ * settle on {@code MIGRATED} for the default physical tenant, and the endpoint must report the
+ * cluster as upgradeable.
  *
- * <p>Covers {@code RdbmsSchemaMigrationStatusProvider} (schema-version check against the shared
- * RDBMS store) — the only provider wired for a single-node RDBMS broker today.
+ * <p>Covers both providers wired for a single-node RDBMS broker today: {@code
+ * RdbmsSchemaMigrationStatusProvider} (schema-version check against the shared RDBMS store) and
+ * {@code ClusterRocksDbMigrationStatusProvider} (per-partition-replica broadcast over the admin
+ * API). Three partitions are configured because the RocksDB condition folds over every partition's
+ * replicas — with a single partition, an aggregation that dropped every partition but the first
+ * would still pass.
  */
 @ZeebeIntegration
 final class UpgradeReadinessEndpointIT {
 
   private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static final int PARTITION_COUNT = 3;
   private static final String H2_URL =
       "jdbc:h2:mem:upgrade-readiness-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
 
-  @TestZeebe
+  @TestZeebe(partitionCount = PARTITION_COUNT)
   private static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker()
           .withSecondaryStorageType(SecondaryStorageType.rdbms)
+          .withClusterConfig(
+              cluster -> {
+                cluster.setPartitionCount(PARTITION_COUNT);
+                // The RocksDB provider broadcasts admin requests to every replica over the
+                // internal API, which for this single-node broker means connecting to itself.
+                // Advertising the host's auto-detected LAN address can make that self-connect
+                // depend on the environment's network/firewall setup; loopback is always valid.
+                cluster.getNetwork().setAdvertisedHost("127.0.0.1");
+                cluster.getNetwork().getInternalApi().setAdvertisedHost("127.0.0.1");
+              })
           .withUnifiedConfig(
               cfg -> {
                 final var rdbms = cfg.getData().getSecondaryStorage().getRdbms();
@@ -50,9 +65,8 @@ final class UpgradeReadinessEndpointIT {
               });
 
   @Test
-  void shouldReportRdbmsSchemaMigratedForTheDefaultPhysicalTenant() {
-    Awaitility.await(
-            "until the rdbmsSchemaMigrated condition settles on MIGRATED for the default tenant")
+  void shouldReportBothProvidersMigratedForTheDefaultPhysicalTenant() {
+    Awaitility.await("until every registered condition settles on MIGRATED for the default tenant")
         .atMost(TIMEOUT)
         .untilAsserted(
             () -> {
@@ -60,8 +74,9 @@ final class UpgradeReadinessEndpointIT {
 
               assertThat(response.physicalTenants()).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID);
               final var defaultTenant = response.physicalTenants().get(DEFAULT_PHYSICAL_TENANT_ID);
-              assertThat(defaultTenant).containsKey("rdbmsSchemaMigrated");
+              assertThat(defaultTenant).containsKeys("rdbmsSchemaMigrated", "rocksDbMigrated");
               assertThat(defaultTenant.get("rdbmsSchemaMigrated").state()).isEqualTo("MIGRATED");
+              assertThat(defaultTenant.get("rocksDbMigrated").state()).isEqualTo("MIGRATED");
               assertThat(response.upgradeable()).isTrue();
             });
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
@@ -26,13 +26,6 @@ import org.junit.jupiter.api.Test;
  * broker — no chained-upgrade or migration scenario involved — every registered condition must
  * settle on {@code MIGRATED} for the default physical tenant, and the endpoint must report the
  * cluster as upgradeable.
- *
- * <p>Covers both providers wired for a single-node RDBMS broker today: {@code
- * RdbmsSchemaMigrationStatusProvider} (schema-version check against the shared RDBMS store) and
- * {@code ClusterRocksDbMigrationStatusProvider} (per-partition-replica broadcast over the admin
- * API). Three partitions are configured because the RocksDB condition folds over every partition's
- * replicas — with a single partition, an aggregation that dropped every partition but the first
- * would still pass.
  */
 @ZeebeIntegration
 final class UpgradeReadinessEndpointIT {


### PR DESCRIPTION
## What

Adds the `ClusterRocksDbMigrationStatusProvider` upgrade-readiness condition (camunda/product-hub#3067): whether every partition **replica**'s RocksDB state has migrated to the current application version and been captured in a snapshot, per physical tenant.

- Every replica of every partition (leader, followers, inactive members) is queried independently over a new `GET_MIGRATION_STATUS` admin request — migration runs independently per replica, so a follower could still be promoted to leader while unmigrated.
- Broker-side (`ZeebePartitionAdminAccess.getMigrationStatus()`) reads `DbMigrationState.getMigratedByVersion()` via a second transaction on the live `ZeebeDb`, and only reports `MIGRATED` once the version matches **and** a post-migration snapshot has actually been taken — RocksDB's migrated state isn't durably safe until snapshotted. `MigrationSnapshotDirector`/`SnapshotAfterMigrationTransitionStep` already existed to force that snapshot; this PR adds the callback that lets the admin-access check observe when it actually succeeds, and invalidates that signal again if a later migration reruns (e.g. after a received snapshot reverts a replica to an older, unmigrated version).
- Gateway-side (`ClusterRocksDbMigrationStatusProvider`) fans out to every replica of every known physical tenant under one shared timeout, combining results with `UNKNOWN > MIGRATION_IN_PROGRESS > MIGRATED` precedence.
- `PartitionReplicas`/`ClusterMigrationStatusReader` extract the replica-resolution and tenant-fan-out logic out of the provider into small, stateless helpers — anticipating a future, differently-distributed migration-status condition that will need the same shape (tracked separately, not part of this PR).

## Tests

- Unit tests for the wire encoding, broker-side handler, and gateway-side provider (mocked `BrokerClient`).
- A dedicated multi-broker IT (`ClusterRocksDbMigrationStatusProviderIT`) against a real 3-broker/RF-3/3-partition cluster, proving the fan-out genuinely crosses broker process boundaries and exercises follower replicas.
- A single-broker happy-path IT (`UpgradeReadinessEndpointIT`) verifying the actuator endpoint end-to-end for both the RDBMS and RocksDB conditions together.

Closes #59851.
