### PR TITLE
fix: fix process definition filtering with multi-tenancy

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/custom-filters/FieldsModal.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/custom-filters/FieldsModal.test.tsx
@@ -9,6 +9,7 @@
 import {HttpResponse} from 'msw';
 import {it} from '#/vitest-modules/test-extend';
 import {afterEach, beforeEach, describe, expect, vi} from 'vitest';
+import {z} from 'zod';
 import {userEvent} from 'vitest/browser';
 import {mockCurrentUserEndpoint, mockQueryProcessDefinitionsEndpoint} from '#/shared-test-modules/mock-handlers';
 import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
@@ -22,6 +23,18 @@ import {FieldsModal} from './FieldsModal';
 import {renderWithRouter} from '#/vitest-modules/render-with-router';
 
 const DEFAULT_VALUES: NamedCustomFilters = {assignee: 'all', status: 'all'};
+
+const allTenantsRequestSchema = z.object({
+	filter: z.object({isLatestVersion: z.literal(true)}).strict(),
+	page: z.object({limit: z.literal(1000)}),
+});
+
+function getTenantRequestSchema(tenantId: string) {
+	return z.object({
+		filter: z.object({isLatestVersion: z.literal(true), tenantId: z.literal(tenantId)}).strict(),
+		page: z.object({limit: z.literal(1000)}),
+	});
+}
 
 function getMocks(overrides?: {groups?: string[]}) {
 	return [
@@ -283,6 +296,154 @@ describe('<FieldsModal />', () => {
 		);
 
 		await expect.element(screen.getByRole('dialog', {name: /custom filters modal/i})).toBeVisible();
+		await expect.element(screen.getByRole('combobox', {name: /process/i})).toBeVisible();
+	});
+
+	it('should load processes from the only accessible tenant', async ({worker}) => {
+		sessionStorage.setItem(
+			'clientConfig',
+			JSON.stringify(createSystemConfiguration({deployment: {isMultiTenancyEnabled: true, maxRequestSize: 0}})),
+		);
+		worker.use(
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(
+					createCurrentUser({
+						tenants: [{tenantId: 'staging', name: 'Staging', description: null}],
+					}),
+				),
+			}),
+			mockQueryProcessDefinitionsEndpoint({
+				schema: getTenantRequestSchema('staging'),
+				failureResponse: HttpResponse.json(null, {status: 400}),
+				successResponse: HttpResponse.json(createQueryProcessDefinitionsResponse({items: []})),
+			}),
+		);
+
+		const screen = await renderWithRouter(
+			() => (
+				<FieldsModal
+					isOpen
+					initialValues={DEFAULT_VALUES}
+					onClose={() => {}}
+					onApply={() => {}}
+					onSave={() => {}}
+					onEdit={() => {}}
+					onDelete={() => {}}
+				/>
+			),
+			{path: '/tasklist'},
+		);
+
+		await expect.element(screen.getByRole('combobox', {name: /process/i})).toBeVisible();
+	});
+
+	it('should load processes from all accessible tenants', async ({worker}) => {
+		sessionStorage.setItem(
+			'clientConfig',
+			JSON.stringify(createSystemConfiguration({deployment: {isMultiTenancyEnabled: true, maxRequestSize: 0}})),
+		);
+		worker.use(
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(
+					createCurrentUser({
+						tenants: [
+							{tenantId: 'staging', name: 'Staging', description: null},
+							{tenantId: 'production', name: 'Production', description: null},
+						],
+					}),
+				),
+			}),
+			mockQueryProcessDefinitionsEndpoint({
+				schema: allTenantsRequestSchema,
+				failureResponse: HttpResponse.json(null, {status: 400}),
+				successResponse: HttpResponse.json(createQueryProcessDefinitionsResponse({items: []})),
+			}),
+		);
+
+		const screen = await renderWithRouter(
+			() => (
+				<FieldsModal
+					isOpen
+					initialValues={{...DEFAULT_VALUES, tenant: ''}}
+					onClose={() => {}}
+					onApply={() => {}}
+					onSave={() => {}}
+					onEdit={() => {}}
+					onDelete={() => {}}
+				/>
+			),
+			{path: '/tasklist'},
+		);
+
+		await expect.element(screen.getByRole('combobox', {name: /process/i})).toBeVisible();
+	});
+
+	it('should load processes from the explicitly selected tenant', async ({worker}) => {
+		sessionStorage.setItem(
+			'clientConfig',
+			JSON.stringify(createSystemConfiguration({deployment: {isMultiTenancyEnabled: true, maxRequestSize: 0}})),
+		);
+		worker.use(
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(
+					createCurrentUser({
+						tenants: [
+							{tenantId: 'staging', name: 'Staging', description: null},
+							{tenantId: 'production', name: 'Production', description: null},
+						],
+					}),
+				),
+			}),
+			mockQueryProcessDefinitionsEndpoint({
+				schema: getTenantRequestSchema('staging'),
+				failureResponse: HttpResponse.json(null, {status: 400}),
+				successResponse: HttpResponse.json(createQueryProcessDefinitionsResponse({items: []})),
+			}),
+		);
+
+		const screen = await renderWithRouter(
+			() => (
+				<FieldsModal
+					isOpen
+					initialValues={{...DEFAULT_VALUES, tenant: 'staging'}}
+					onClose={() => {}}
+					onApply={() => {}}
+					onSave={() => {}}
+					onEdit={() => {}}
+					onDelete={() => {}}
+				/>
+			),
+			{path: '/tasklist'},
+		);
+
+		await expect.element(screen.getByRole('combobox', {name: /process/i})).toBeVisible();
+	});
+
+	it('should load processes without a tenant when multi-tenancy is disabled', async ({worker}) => {
+		worker.use(
+			mockCurrentUserEndpoint({successResponse: HttpResponse.json(createCurrentUser())}),
+			mockQueryProcessDefinitionsEndpoint({
+				schema: allTenantsRequestSchema,
+				failureResponse: HttpResponse.json(null, {status: 400}),
+				successResponse: HttpResponse.json(createQueryProcessDefinitionsResponse({items: []})),
+			}),
+		);
+
+		const screen = await renderWithRouter(
+			() => (
+				<FieldsModal
+					isOpen
+					initialValues={DEFAULT_VALUES}
+					onClose={() => {}}
+					onApply={() => {}}
+					onSave={() => {}}
+					onEdit={() => {}}
+					onDelete={() => {}}
+				/>
+			),
+			{path: '/tasklist'},
+		);
+
 		await expect.element(screen.getByRole('combobox', {name: /process/i})).toBeVisible();
 	});
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/custom-filters/FieldsModal.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/custom-filters/FieldsModal.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Fragment, Suspense} from 'react';
+import {Fragment, Suspense, useCallback} from 'react';
 import {
 	Button,
 	ComposedModal,
@@ -90,7 +90,30 @@ const FieldsModal: React.FC<Props> = ({isOpen, onClose, onApply, onSave, onEdit,
 	const {t, i18n} = useTranslation();
 	const label = t('tasklist.customFiltersModalAdvancedFiltersLabel');
 	const {data: currentUser} = useSuspenseQuery(queries.getCurrentUser());
+	const isMultiTenancyEnabled = getClientConfig().deployment.isMultiTenancyEnabled;
 	const groups = currentUser?.groups ?? [];
+	const getTenantId = useCallback(
+		(formTenant: string | undefined) => {
+			if (!isMultiTenancyEnabled) {
+				return undefined;
+			}
+
+			if (formTenant !== undefined && formTenant !== '') {
+				return formTenant;
+			}
+
+			if (formTenant === '') {
+				return undefined;
+			}
+
+			if (currentUser.tenants.length === 1) {
+				return currentUser.tenants[0]?.tenantId;
+			}
+
+			return undefined;
+		},
+		[currentUser, isMultiTenancyEnabled],
+	);
 
 	return (
 		<ComposedModal
@@ -256,14 +279,14 @@ const FieldsModal: React.FC<Props> = ({isOpen, onClose, onApply, onSave, onEdit,
 													<ProcessesSelect
 														{...input}
 														id={input.name}
-														tenantId={values?.tenant}
+														tenantId={getTenantId(values?.tenant)}
 														labelText={t('tasklist.customFiltersModalLatestProcessVersionLabel')}
 													/>
 												</Suspense>
 											</ErrorBoundary>
 										)}
 									</Field>
-									{getClientConfig().deployment.isMultiTenancyEnabled ? (
+									{isMultiTenancyEnabled ? (
 										<Field name="tenant">
 											{({input}) => (
 												<MultitenancySelect

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/custom-filters/ProcessesSelect.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/custom-filters/ProcessesSelect.tsx
@@ -11,18 +11,16 @@ import {useSuspenseQuery} from '@tanstack/react-query';
 import {useTranslation} from 'react-i18next';
 import {queries} from '#/shared/http/queries';
 
-const DEFAULT_TENANT_ID = '<default>';
-
 type Props = {
 	tenantId?: string;
 } & Omit<React.ComponentProps<typeof Select>, 'disabled'>;
 
-const ProcessesSelect: React.FC<Props> = ({tenantId = DEFAULT_TENANT_ID, ...props}) => {
+const ProcessesSelect: React.FC<Props> = ({tenantId, ...props}) => {
 	const {t} = useTranslation();
 
 	const {data: processes} = useSuspenseQuery({
 		...queries.queryProcessDefinitions({
-			filter: {isLatestVersion: true, tenantId},
+			filter: {isLatestVersion: true, ...(tenantId === undefined ? {} : {tenantId})},
 			page: {limit: 1000},
 		}),
 		select({items}) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Properly correlate the user tenant to the process definitions dropdown.
It also correlate the tenant selection with the process definition fetching

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #60339
