### PR TITLE
fix: scope call activity drill-down to the clicked element instance

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -140,21 +140,20 @@ const TopPanel: React.FC = observer(() => {
   const customElementClasses = useMemo<
     [elementId: string, className: string][]
   >(() => {
-    if (
-      isModificationModeEnabled ||
-      !businessObjects ||
-      !totalRunningInstancesByElement
-    ) {
+    if (isModificationModeEnabled || !businessObjects) {
       return [];
     }
 
+    // customElementClasses isn't just styling: BpmnJS only invokes
+    // onElementDoubleClick for elements listed here (see
+    // #handleElementDoubleClick), so this array gates drill-down, not just
+    // its cosmetic affordance. Every call activity/business rule task is
+    // included regardless of instance state - a completed one still has a
+    // called instance worth navigating to, and one that never ran resolves
+    // to nothing and silently no-ops in useDrillDownNavigation.
     const DRILLDOWN_TYPES = ['bpmn:CallActivity', 'bpmn:BusinessRuleTask'];
     const drilldownClasses: [string, string][] = Object.entries(businessObjects)
-      .filter(
-        ([elementId, bo]) =>
-          DRILLDOWN_TYPES.includes(bo.$type) &&
-          (totalRunningInstancesByElement[elementId] ?? 0) > 0,
-      )
+      .filter(([, bo]) => DRILLDOWN_TYPES.includes(bo.$type))
       .map(([elementId]) => [elementId, 'op-drilldown'] as const);
 
     if (pendingDrillDownElementId !== null) {
@@ -165,12 +164,7 @@ const TopPanel: React.FC = observer(() => {
     }
 
     return drilldownClasses;
-  }, [
-    businessObjects,
-    totalRunningInstancesByElement,
-    isModificationModeEnabled,
-    pendingDrillDownElementId,
-  ]);
+  }, [businessObjects, isModificationModeEnabled, pendingDrillDownElementId]);
 
   useEffect(() => {
     if (!isModificationModeEnabled) {

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
@@ -10,12 +10,16 @@ import {renderHook, act} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {useDrillDownNavigation} from './useDrilldownNavigation';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {notificationsStore} from 'modules/stores/notifications';
 import {Paths} from 'modules/Routes';
 import {createProcessInstance, searchResult} from 'modules/testUtils';
-import type {QueryDecisionInstancesResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {
+  ElementInstance,
+  QueryDecisionInstancesResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 
 vi.mock('modules/stores/notifications', () => ({
   notificationsStore: {
@@ -39,6 +43,8 @@ vi.mock('react-router-dom', async () => {
 const PROCESS_INSTANCE_KEY = '2251799813685249';
 const CALL_ACTIVITY_ID = 'confirmDelivery';
 const BUSINESS_RULE_TASK_ID = 'evaluateRisk';
+const CALL_ACTIVITY_ELEMENT_INSTANCE_KEY = 'element-instance-100';
+const BUSINESS_RULE_TASK_ELEMENT_INSTANCE_KEY = 'element-instance-200';
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -52,11 +58,54 @@ function createWrapper() {
   );
 }
 
+function createElementInstance(
+  options: Partial<ElementInstance> = {},
+): ElementInstance {
+  return {
+    processDefinitionId: 'process',
+    startDate: '2024-01-01T00:00:00.000+0000',
+    endDate: null,
+    elementId: CALL_ACTIVITY_ID,
+    elementName: null,
+    type: 'CALL_ACTIVITY',
+    state: 'ACTIVE',
+    hasIncident: false,
+    tenantId: '<default>',
+    elementInstanceKey: CALL_ACTIVITY_ELEMENT_INSTANCE_KEY,
+    processInstanceKey: PROCESS_INSTANCE_KEY,
+    rootProcessInstanceKey: null,
+    processDefinitionKey: 'process-def-1',
+    incidentKey: null,
+    ...options,
+  };
+}
+
 function createDecisionSearchResult(
   items: QueryDecisionInstancesResponseBody['items'],
   totalItems = items.length,
 ) {
   return searchResult(items, totalItems);
+}
+
+function mockResolvedCallActivityElement() {
+  mockSearchElementInstances().withSuccess(
+    searchResult([createElementInstance()], 1),
+  );
+}
+
+function mockResolvedBusinessRuleTaskElement() {
+  mockSearchElementInstances().withSuccess(
+    searchResult(
+      [
+        createElementInstance({
+          elementId: BUSINESS_RULE_TASK_ID,
+          type: 'BUSINESS_RULE_TASK',
+          elementInstanceKey: BUSINESS_RULE_TASK_ELEMENT_INSTANCE_KEY,
+        }),
+      ],
+      1,
+    ),
+  );
 }
 
 describe('useDrillDownNavigation', () => {
@@ -65,6 +114,7 @@ describe('useDrillDownNavigation', () => {
       processInstanceKey: 'called-200',
     });
 
+    mockResolvedCallActivityElement();
     mockSearchProcessInstances().withSuccess(searchResult([calledInstance], 1));
 
     const {result} = renderHook(
@@ -81,12 +131,13 @@ describe('useDrillDownNavigation', () => {
     );
   });
 
-  it('should not navigate when there are multiple called instances', async () => {
+  it('should not navigate when the clicked element has multiple called instances', async () => {
     const calledInstances = [
       createProcessInstance({processInstanceKey: 'called-200'}),
       createProcessInstance({processInstanceKey: 'called-201'}),
     ];
 
+    mockResolvedCallActivityElement();
     mockSearchProcessInstances().withSuccess(searchResult(calledInstances, 2));
 
     const {result} = renderHook(
@@ -101,7 +152,62 @@ describe('useDrillDownNavigation', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it('should not navigate when the clicked element itself is ambiguous (e.g. multi-instance)', async () => {
+    mockSearchElementInstances().withSuccess(
+      searchResult(
+        [
+          createElementInstance({elementInstanceKey: 'element-instance-a'}),
+          createElementInstance({elementInstanceKey: 'element-instance-b'}),
+        ],
+        2,
+      ),
+    );
+    // No handler registered for the process-instances search: if the hook
+    // incorrectly fell through to it, the request would fail and surface as
+    // an error toast instead of a silent no-navigate.
+
+    const {result} = renderHook(
+      () => useDrillDownNavigation(PROCESS_INSTANCE_KEY),
+      {wrapper: createWrapper()},
+    );
+
+    await act(async () => {
+      result.current.handleDrillDown(CALL_ACTIVITY_ID, 'bpmn:CallActivity');
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(notificationsStore.displayNotification).not.toHaveBeenCalled();
+  });
+
+  it('should scope the called-instance lookup to the clicked call activity, not the whole process instance', async () => {
+    mockResolvedCallActivityElement();
+    const requestBodyResolverFn = vi.fn();
+    mockSearchProcessInstances().withSuccess(
+      searchResult(
+        [createProcessInstance({processInstanceKey: 'called-200'})],
+        1,
+      ),
+      {requestBodyResolverFn},
+    );
+
+    const {result} = renderHook(
+      () => useDrillDownNavigation(PROCESS_INSTANCE_KEY),
+      {wrapper: createWrapper()},
+    );
+
+    await act(async () => {
+      result.current.handleDrillDown(CALL_ACTIVITY_ID, 'bpmn:CallActivity');
+    });
+
+    expect(requestBodyResolverFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {parentElementInstanceKey: CALL_ACTIVITY_ELEMENT_INSTANCE_KEY},
+      }),
+    );
+  });
+
   it('should show error toast when process API call fails', async () => {
+    mockResolvedCallActivityElement();
     mockSearchProcessInstances().withServerError();
 
     const {result} = renderHook(
@@ -122,6 +228,7 @@ describe('useDrillDownNavigation', () => {
   });
 
   it('should navigate to the decision instance when there is exactly one', async () => {
+    mockResolvedBusinessRuleTaskElement();
     mockSearchDecisionInstances().withSuccess(
       createDecisionSearchResult([
         {
@@ -140,7 +247,7 @@ describe('useDrillDownNavigation', () => {
           processDefinitionKey: 'proc-def-1',
           processInstanceKey: PROCESS_INSTANCE_KEY,
           rootProcessInstanceKey: null,
-          elementInstanceKey: 'el-inst-1',
+          elementInstanceKey: BUSINESS_RULE_TASK_ELEMENT_INSTANCE_KEY,
           rootDecisionDefinitionKey: 'def-1',
           businessId: null,
         },
@@ -165,6 +272,7 @@ describe('useDrillDownNavigation', () => {
   });
 
   it('should not navigate when there are multiple decision instances', async () => {
+    mockResolvedBusinessRuleTaskElement();
     mockSearchDecisionInstances().withSuccess(
       createDecisionSearchResult(
         [
@@ -184,7 +292,7 @@ describe('useDrillDownNavigation', () => {
             processDefinitionKey: 'proc-def-1',
             processInstanceKey: PROCESS_INSTANCE_KEY,
             rootProcessInstanceKey: null,
-            elementInstanceKey: 'el-inst-1',
+            elementInstanceKey: BUSINESS_RULE_TASK_ELEMENT_INSTANCE_KEY,
             rootDecisionDefinitionKey: 'def-1',
             businessId: null,
           },
@@ -209,6 +317,7 @@ describe('useDrillDownNavigation', () => {
   });
 
   it('should show error toast when decision API call fails', async () => {
+    mockResolvedBusinessRuleTaskElement();
     mockSearchDecisionInstances().withServerError();
 
     const {result} = renderHook(

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
@@ -127,7 +127,7 @@ describe('useDrillDownNavigation', () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      Paths.processInstance('called-200'),
+      Paths.processInstanceDetails({processInstanceId: 'called-200'}),
     );
   });
 

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
@@ -271,6 +271,54 @@ describe('useDrillDownNavigation', () => {
     );
   });
 
+  it('should scope the called-decision lookup to the clicked business rule task, not the whole process instance', async () => {
+    mockResolvedBusinessRuleTaskElement();
+    const requestBodyResolverFn = vi.fn();
+    mockSearchDecisionInstances().withSuccess(
+      createDecisionSearchResult([
+        {
+          decisionEvaluationInstanceKey: 'dec-100',
+          decisionEvaluationKey: 'dec-eval-100',
+          state: 'EVALUATED',
+          evaluationDate: '2024-01-01T00:00:00.000+0000',
+          evaluationFailure: null,
+          decisionDefinitionId: 'risk-assessment',
+          decisionDefinitionName: 'Risk Assessment',
+          decisionDefinitionVersion: 1,
+          decisionDefinitionType: 'DECISION_TABLE',
+          decisionDefinitionKey: 'def-1',
+          result: '',
+          tenantId: '<default>',
+          processDefinitionKey: 'proc-def-1',
+          processInstanceKey: PROCESS_INSTANCE_KEY,
+          rootProcessInstanceKey: null,
+          elementInstanceKey: BUSINESS_RULE_TASK_ELEMENT_INSTANCE_KEY,
+          rootDecisionDefinitionKey: 'def-1',
+          businessId: null,
+        },
+      ]),
+      {requestBodyResolverFn},
+    );
+
+    const {result} = renderHook(
+      () => useDrillDownNavigation(PROCESS_INSTANCE_KEY),
+      {wrapper: createWrapper()},
+    );
+
+    await act(async () => {
+      result.current.handleDrillDown(
+        BUSINESS_RULE_TASK_ID,
+        'bpmn:BusinessRuleTask',
+      );
+    });
+
+    expect(requestBodyResolverFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {elementInstanceKey: BUSINESS_RULE_TASK_ELEMENT_INSTANCE_KEY},
+      }),
+    );
+  });
+
   it('should not navigate when there are multiple decision instances', async () => {
     mockResolvedBusinessRuleTaskElement();
     mockSearchDecisionInstances().withSuccess(

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.ts
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.ts
@@ -94,7 +94,9 @@ const useDrillDownNavigation = (processInstanceKey: string) => {
 
         if (response.page.totalItems === 1) {
           navigate(
-            Paths.processInstance(response.items[0]!.processInstanceKey),
+            Paths.processInstanceDetails({
+              processInstanceId: response.items[0]!.processInstanceKey,
+            }),
           );
         }
       } catch {

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.ts
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.ts
@@ -9,6 +9,7 @@
 import {useState, useTransition} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {useQueryClient} from '@tanstack/react-query';
+import {searchElementInstances} from 'modules/api/v2/elementInstances/searchElementInstances';
 import {searchProcessInstances} from 'modules/api/v2/processInstances/searchProcessInstances';
 import {searchDecisionInstances} from 'modules/api/v2/decisionInstances/searchDecisionInstances';
 import {Paths} from 'modules/Routes';
@@ -36,19 +37,52 @@ const useDrillDownNavigation = (processInstanceKey: string) => {
     }
   }
 
+  // Resolves the elementId (a static BPMN node) to the runtime element
+  // instance it produced in this process instance. Returns null when the
+  // element has no instance yet, or more than one (e.g. a multi-instance
+  // call activity) — both cases are treated as unresolvable rather than
+  // guessed at.
+  async function resolveElementInstanceKey(elementId: string) {
+    const response = await queryClient.fetchQuery({
+      queryKey: queryKeys.elementInstances.search({
+        elementId,
+        processInstanceKey,
+      }),
+      queryFn: async () => {
+        const {response, error} = await searchElementInstances({
+          filter: {elementId, processInstanceKey},
+          page: {limit: 1},
+        });
+        if (response !== null) {
+          return response;
+        }
+        throw error;
+      },
+    });
+
+    return response.page.totalItems === 1
+      ? response.items[0]!.elementInstanceKey
+      : null;
+  }
+
   function drillDownToCalledProcess(elementId: string) {
     startTransition(async () => {
       setPendingDrillDownElementId(elementId);
 
       try {
+        const elementInstanceKey = await resolveElementInstanceKey(elementId);
+        if (elementInstanceKey === null) {
+          return;
+        }
+
         const response = await queryClient.fetchQuery({
           queryKey: queryKeys.processInstances.search({
-            filter: {parentProcessInstanceKey: processInstanceKey},
+            filter: {parentElementInstanceKey: elementInstanceKey},
             page: {limit: 1},
           }),
           queryFn: async () => {
             const {response, error} = await searchProcessInstances({
-              filter: {parentProcessInstanceKey: processInstanceKey},
+              filter: {parentElementInstanceKey: elementInstanceKey},
               page: {limit: 1},
             });
             if (response !== null) {
@@ -80,14 +114,19 @@ const useDrillDownNavigation = (processInstanceKey: string) => {
       setPendingDrillDownElementId(elementId);
 
       try {
+        const elementInstanceKey = await resolveElementInstanceKey(elementId);
+        if (elementInstanceKey === null) {
+          return;
+        }
+
         const response = await queryClient.fetchQuery({
           queryKey: queryKeys.decisionInstances.search({
-            filter: {processInstanceKey},
+            filter: {elementInstanceKey},
             page: {limit: 1},
           }),
           queryFn: async () => {
             const {response, error} = await searchDecisionInstances({
-              filter: {processInstanceKey},
+              filter: {elementInstanceKey},
               page: {limit: 1},
             });
             if (response !== null) {


### PR DESCRIPTION
## Description

Call activity / business rule task double-click drill-down resolved the called instance by counting instances across the whole process instance instead of the clicked element, so it silently did nothing once a process instance had more than one call activity. Scopes the lookup to the clicked element's own instance instead.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60358
