### PR TITLE
pg/scaleup-await-group-redistribution

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.fail;
 
+import com.sun.management.HotSpotDiagnosticMXBean;
+import com.sun.management.HotSpotDiagnosticMXBean.ThreadDumpFormat;
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.CreateGroupResponse;
@@ -45,6 +47,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -53,7 +56,10 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -84,6 +90,9 @@ public class ScaleUpPartitionsTest {
   private static final String JOB_TYPE = "job";
   private static final String PROCESS_ID = DEFAULT_PROCESS_ID;
   private static final MemberId MEMBER_0 = MemberId.from("0");
+  // Restoring the three brokers takes seconds; keep the bound well inside the method timeout so a
+  // broker that hangs is reported with a thread dump instead of the method timing out first.
+  private static final Duration RESTORE_TIMEOUT = Duration.ofMinutes(2);
   @AutoClose CamundaClient camundaClient;
   private ClusterActuator clusterActuator;
   private BackupActuator backupActuator;
@@ -614,9 +623,53 @@ public class ScaleUpPartitionsTest {
       try (final var restoreApp =
           new TestRestoreApp(getRestoreConfig(broker.unifiedConfig(), workingDirectory))
               .withBackupId(backupId)) {
-        assertThatNoException().isThrownBy(restoreApp::start);
+        awaitRestored(restoreApp, broker.nodeId());
       }
       FileUtil.flushDirectory(dataFolder);
+    }
+  }
+
+  /**
+   * Restoring is unbounded, so a partition that never finishes leaves the caller blocked forever.
+   * The class-level {@link Timeout} does not help: it only compares elapsed time once the test
+   * method returns, so a blocked restore takes down the whole CI job without a single test result.
+   * Run the restore on its own thread instead, and report where it got stuck if it overruns.
+   */
+  private void awaitRestored(final TestRestoreApp restoreApp, final MemberId nodeId) {
+    final var restoreExecutor =
+        Executors.newSingleThreadExecutor(
+            command -> Thread.ofPlatform().daemon().name("restore-" + nodeId).unstarted(command));
+    try {
+      CompletableFuture.runAsync(restoreApp::start, restoreExecutor)
+          .get(RESTORE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (final TimeoutException e) {
+      fail(
+          "Expected broker %s to be restored within %s, but it is still restoring. Thread dump:%n%s"
+              .formatted(nodeId, RESTORE_TIMEOUT, threadDump()));
+    } catch (final ExecutionException e) {
+      fail("Failed to restore broker %s".formatted(nodeId), e.getCause());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      fail("Interrupted while restoring broker %s".formatted(nodeId), e);
+    } finally {
+      restoreExecutor.shutdownNow();
+    }
+  }
+
+  /**
+   * Partitions are restored on virtual threads, which {@link Thread#getAllStackTraces()} does not
+   * report, so take a JVM thread dump that covers them.
+   */
+  private static String threadDump() {
+    try {
+      final var dumpFile = Files.createTempFile("restore-thread-dump", ".txt");
+      // dumpThreads refuses to write to a file that already exists
+      Files.delete(dumpFile);
+      ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class)
+          .dumpThreads(dumpFile.toAbsolutePath().toString(), ThreadDumpFormat.TEXT_PLAIN);
+      return Files.readString(dumpFile);
+    } catch (final IOException e) {
+      return "Failed to capture a thread dump: " + e;
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -33,6 +33,8 @@ import io.camunda.zeebe.management.cluster.RoutingState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.AbstractStartEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
@@ -40,6 +42,7 @@ import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -161,6 +164,7 @@ public class ScaleUpPartitionsTest {
   @Test
   void shouldScaleWhenGlobalStateIsLarge() {
     // given
+    final int totalCount = 1000;
     final var desiredPartitionCount = PARTITIONS_COUNT + 1;
     cluster.awaitHealthyTopology();
 
@@ -185,10 +189,9 @@ public class ScaleUpPartitionsTest {
 
     processDefinitionId.forEach(process -> deployProcessModel(camundaClient, process, false));
 
-    // Create a total of 1000 users in batch of 100
-    for (int b = 0; b < 10; b++) {
+    final int batches = totalCount / 100;
+    for (int b = 0; b < batches; b++) {
       final var batchId = b;
-      // create users in batches of 10 concurrently
       final var futures =
           IntStream.range(0, 100)
               .mapToObj(i -> createGroupWithIdx(i * 100 + batchId))
@@ -196,6 +199,8 @@ public class ScaleUpPartitionsTest {
               .toArray(CompletableFuture[]::new);
       CompletableFuture.allOf(futures).join();
     }
+
+    awaitAllGroupsDistributed(totalCount);
 
     // when
     executeScaling(desiredPartitionCount);
@@ -218,6 +223,18 @@ public class ScaleUpPartitionsTest {
         .name("Group#" + userIdx)
         .send()
         .toCompletableFuture();
+  }
+
+  private void awaitAllGroupsDistributed(final int count) {
+    RecordingExporter.await(Duration.ofMinutes(2))
+        .until(
+            () ->
+                RecordingExporter.commandDistributionRecords()
+                        .withDistributionIntent(GroupIntent.CREATE)
+                        .withIntent(CommandDistributionIntent.FINISHED)
+                        .limit(count)
+                        .count()
+                    == count);
   }
 
   @ParameterizedTest
@@ -398,8 +415,7 @@ public class ScaleUpPartitionsTest {
   }
 
   @Test
-  public void shouldBePossibleToRestoreFromBackupTakenAfterScaleup()
-      throws IOException, InterruptedException {
+  public void shouldBePossibleToRestoreFromBackupTakenAfterScaleup() throws IOException {
     // given
     final var desiredPartitionCount = PARTITIONS_COUNT + 1;
     cluster.awaitHealthyTopology();

--- a/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,12 +50,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.jspecify.annotations.NullMarked;
@@ -67,8 +64,6 @@ import org.slf4j.LoggerFactory;
 @NullMarked
 public class RestoreManager implements CloseableSilently {
   private static final Logger LOG = LoggerFactory.getLogger(RestoreManager.class);
-  private static final Duration PARTITION_RESTORE_TIMEOUT = Duration.ofMinutes(20);
-
   private final BrokerCfg configuration;
   private final BackupStore backupStore;
   private final BackupMetadataSyncer metadataSyncer;
@@ -243,7 +238,6 @@ public class RestoreManager implements CloseableSilently {
 
     try {
       final var partitionsToRestore = collectPartitions();
-      final var inProgressPartitions = ConcurrentHashMap.<Integer>newKeySet();
       final var tasks = new ArrayList<Callable<Void>>(partitionsToRestore.size());
       for (final var partition : partitionsToRestore) {
         final var partitionId = partition.partition().id().number();
@@ -253,27 +247,12 @@ public class RestoreManager implements CloseableSilently {
         }
         tasks.add(
             () -> {
-              inProgressPartitions.add(partitionId);
-              try {
-                restorePartition(partition, backupIds, validateConfig);
-              } finally {
-                inProgressPartitions.remove(partitionId);
-              }
+              restorePartition(partition, backupIds, validateConfig);
               return null;
             });
       }
-
-      for (final var result :
-          executor.invokeAll(tasks, PARTITION_RESTORE_TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
-        if (!result.isCancelled()) {
-          result.get(); // throw exception if the task failed
-        }
-      }
-      if (!inProgressPartitions.isEmpty()) {
-        throw new ExecutionException(
-            "Restoring partition(s) %s did not complete within %s"
-                .formatted(inProgressPartitions, PARTITION_RESTORE_TIMEOUT),
-            new TimeoutException());
+      for (final var result : executor.invokeAll(tasks)) {
+        result.get(); // throw exception if any of the tasks failed
       }
 
       if (configuration.getCluster().getNodeId() == 0) {

--- a/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,10 +51,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.jspecify.annotations.NullMarked;
@@ -64,6 +67,8 @@ import org.slf4j.LoggerFactory;
 @NullMarked
 public class RestoreManager implements CloseableSilently {
   private static final Logger LOG = LoggerFactory.getLogger(RestoreManager.class);
+  private static final Duration PARTITION_RESTORE_TIMEOUT = Duration.ofMinutes(20);
+
   private final BrokerCfg configuration;
   private final BackupStore backupStore;
   private final BackupMetadataSyncer metadataSyncer;
@@ -238,6 +243,7 @@ public class RestoreManager implements CloseableSilently {
 
     try {
       final var partitionsToRestore = collectPartitions();
+      final var inProgressPartitions = ConcurrentHashMap.<Integer>newKeySet();
       final var tasks = new ArrayList<Callable<Void>>(partitionsToRestore.size());
       for (final var partition : partitionsToRestore) {
         final var partitionId = partition.partition().id().number();
@@ -247,12 +253,27 @@ public class RestoreManager implements CloseableSilently {
         }
         tasks.add(
             () -> {
-              restorePartition(partition, backupIds, validateConfig);
+              inProgressPartitions.add(partitionId);
+              try {
+                restorePartition(partition, backupIds, validateConfig);
+              } finally {
+                inProgressPartitions.remove(partitionId);
+              }
               return null;
             });
       }
-      for (final var result : executor.invokeAll(tasks)) {
-        result.get(); // throw exception if any of the tasks failed
+
+      for (final var result :
+          executor.invokeAll(tasks, PARTITION_RESTORE_TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
+        if (!result.isCancelled()) {
+          result.get(); // throw exception if the task failed
+        }
+      }
+      if (!inProgressPartitions.isEmpty()) {
+        throw new ExecutionException(
+            "Restoring partition(s) %s did not complete within %s"
+                .formatted(inProgressPartitions, PARTITION_RESTORE_TIMEOUT),
+            new TimeoutException());
       }
 
       if (configuration.getCluster().getNodeId() == 0) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Await the redistribution of created groups to all  partitoins before initiating the cluster scale up.

Introduce a timeout on partition restore from the `RestoreApp` to help identify issues on CI related to these tests. The timeout could be removed afterwards, however based on previous timed restore runs 15min should be enough.

Attempt to resolve flakes on CI alert, ref #inc-7201-unsuccessful-job-ci-integration-testszeebe-ds-integration-scaleup

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
