### PR TITLE
feat: add cluster-wide exporting pause/resume/status endpoints

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminChainIsolationTest.java
@@ -156,6 +156,21 @@ public class ClusterAdminChainIsolationTest extends AbstractWebSecurityConfigTes
   }
 
   @Test
+  public void shouldRejectUnauthenticatedRequestToClusterExportingResume() {
+    // when — no Authorization header at all, against the real cluster-wide exporting resume path
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_EXPORTING_RESUME_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result)
+        .as("cluster-wide exporting resume must require cluster-admin credentials")
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
   public void shouldAllowClusterExportingStatusWithClusterAdminCredentials() {
     // when
     final MvcTestResult result =

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminChainIsolationTest.java
@@ -125,6 +125,50 @@ public class ClusterAdminChainIsolationTest extends AbstractWebSecurityConfigTes
         .hasStatus(HttpStatus.OK);
   }
 
+  @Test
+  public void shouldRejectUnauthenticatedRequestToClusterExportingStatus() {
+    // when — no Authorization header at all, against the real cluster-wide exporting status path
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_EXPORTING_STATUS_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result)
+        .as("the cluster-wide exporting status must require cluster-admin credentials")
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldRejectUnauthenticatedRequestToClusterExportingPause() {
+    // when — no Authorization header at all, against the real cluster-wide exporting pause path
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_EXPORTING_PAUSE_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result)
+        .as("cluster-wide exporting pause must require cluster-admin credentials")
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldAllowClusterExportingStatusWithClusterAdminCredentials() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_EXPORTING_STATUS_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.OK);
+  }
+
   private static HttpHeaders basicAuth(final String username, final String password) {
     final HttpHeaders headers = new HttpHeaders();
     headers.add(

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -48,6 +48,8 @@ public class TestApiController {
   public static final String DUMMY_CLUSTER_EXPORTING_STATUS_ENDPOINT = "/cluster/v2/exporting";
 
   public static final String DUMMY_CLUSTER_EXPORTING_PAUSE_ENDPOINT = "/cluster/v2/exporting/pause";
+  public static final String DUMMY_CLUSTER_EXPORTING_RESUME_ENDPOINT =
+      "/cluster/v2/exporting/resume";
 
   /**
    * Isolated, additive endpoint used only by {@code SessionAuthenticationRefreshTest} to force a
@@ -162,6 +164,11 @@ public class TestApiController {
 
   @PostMapping(DUMMY_CLUSTER_EXPORTING_PAUSE_ENDPOINT)
   public @ResponseBody String dummyClusterExportingPauseEndpoint() {
+    return DEFAULT_RESPONSE;
+  }
+
+  @PostMapping(DUMMY_CLUSTER_EXPORTING_RESUME_ENDPOINT)
+  public @ResponseBody String dummyClusterExportingResumeEndpoint() {
     return DEFAULT_RESPONSE;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -40,6 +40,16 @@ public class TestApiController {
   public static final String DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT = "/cluster/v2/status";
 
   /**
+   * Dummy endpoints at the real cluster-wide exporting paths ({@code
+   * io.camunda.zeebe.gateway.rest.controller.ClusterExportingController}, off this slice's
+   * classpath), so a literal-path carve-out like {@link #DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT}'s
+   * cannot silently exempt them without a test noticing.
+   */
+  public static final String DUMMY_CLUSTER_EXPORTING_STATUS_ENDPOINT = "/cluster/v2/exporting";
+
+  public static final String DUMMY_CLUSTER_EXPORTING_PAUSE_ENDPOINT = "/cluster/v2/exporting/pause";
+
+  /**
    * Isolated, additive endpoint used only by {@code SessionAuthenticationRefreshTest} to force a
    * real, Spring-Session-backed session to exist before the request under test runs. With CSL
    * ADR-0031's per-chain {@code SessionRepositoryFilter}, nothing creates a session for a request
@@ -142,6 +152,16 @@ public class TestApiController {
 
   @GetMapping(DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT)
   public @ResponseBody String dummyClusterAdminStatusEndpoint() {
+    return DEFAULT_RESPONSE;
+  }
+
+  @GetMapping(DUMMY_CLUSTER_EXPORTING_STATUS_ENDPOINT)
+  public @ResponseBody String dummyClusterExportingStatusEndpoint() {
+    return DEFAULT_RESPONSE;
+  }
+
+  @PostMapping(DUMMY_CLUSTER_EXPORTING_PAUSE_ENDPOINT)
+  public @ResponseBody String dummyClusterExportingPauseEndpoint() {
     return DEFAULT_RESPONSE;
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -31,6 +31,7 @@ import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
+import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
@@ -566,6 +567,10 @@ public class CamundaServicesConfiguration {
 
     builder.clusterRecoveryServices(
         new ClusterRecoveryServices(clusterConfigurationRequestSender, restoreEnvironmentByTenant));
+
+    builder.clusterExportingServices(
+        new ClusterExportingServices(
+            exportingRequestBroadcaster, physicalTenantResolver.getAll().keySet()));
 
     return builder.build();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/ClusterExportingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/ClusterExportingIT.java
@@ -127,33 +127,6 @@ final class ClusterExportingIT {
     assertThat(awaitSettledClusterStatus()).isEqualTo("EXPORTING");
   }
 
-  @Test
-  void shouldRejectPauseRequestsWithoutClusterAdminCredentials() throws Exception {
-    // when
-    final var response = sendUnauthenticated("POST", "/cluster/v2/exporting/pause");
-
-    // then
-    assertThat(response.statusCode()).isEqualTo(401);
-  }
-
-  @Test
-  void shouldRejectResumeRequestsWithoutClusterAdminCredentials() throws Exception {
-    // when
-    final var response = sendUnauthenticated("POST", "/cluster/v2/exporting/resume");
-
-    // then
-    assertThat(response.statusCode()).isEqualTo(401);
-  }
-
-  @Test
-  void shouldRejectStatusRequestsWithoutClusterAdminCredentials() throws Exception {
-    // when
-    final var response = sendUnauthenticated("GET", "/cluster/v2/exporting");
-
-    // then
-    assertThat(response.statusCode()).isEqualTo(401);
-  }
-
   /**
    * Pause and resume answer once every partition of every tenant has acknowledged, but a replica
    * may still be mid-transition, so the status is polled until it settles rather than read once.
@@ -197,16 +170,6 @@ final class ClusterExportingIT {
     final var request =
         HttpRequest.newBuilder(resolve(path))
             .header("Authorization", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
-            .method(method, BodyPublishers.noBody())
-            .header("Accept", "application/json")
-            .build();
-    return httpClient.send(request, BodyHandlers.ofString());
-  }
-
-  private HttpResponse<String> sendUnauthenticated(final String method, final String path)
-      throws Exception {
-    final var request =
-        HttpRequest.newBuilder(resolve(path))
             .method(method, BodyPublishers.noBody())
             .header("Accept", "application/json")
             .build();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/ClusterExportingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/ClusterExportingIT.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Base64;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage for the cluster-wide exporting endpoints ({@code POST
+ * /cluster/v2/exporting/pause}, {@code POST /cluster/v2/exporting/resume}, {@code GET
+ * /cluster/v2/exporting}), which let an operator pause, resume and poll exporting across every
+ * physical tenant in one call instead of once per tenant (ADR 003 D2).
+ *
+ * <p>More than one partition per tenant is configured because the fold is exercised across
+ * partitions as well as tenants: with a single partition per tenant, a fold that drops all but the
+ * first partition or tenant would still pass (see {@code ExportingStatusIT}, which documents the
+ * same reasoning for the per-PT endpoint).
+ *
+ * <p>Every phase assertion is cross-checked against the {@code partitions} actuator, scoped per
+ * physical tenant, which reads the phase by a fully independent path from the endpoint under test.
+ */
+@ZeebeIntegration
+final class ClusterExportingIT {
+
+  private static final String TENANT_B = "tenantb";
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+  private static final int DEFAULT_TENANT_PARTITION_COUNT = 2;
+  private static final int TENANT_B_PARTITION_COUNT = 2;
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @TestZeebe(partitionCount = DEFAULT_TENANT_PARTITION_COUNT, purgeAfterEach = false)
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withProperty(
+                  "camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
+              .withProperty(
+                  "camunda.security.cluster-admin.basic.users[0].password", CLUSTER_ADMIN_PASSWORD)
+              .withClusterConfig(
+                  cluster -> cluster.setPartitionCount(DEFAULT_TENANT_PARTITION_COUNT))
+              .withPtConfig(
+                  TENANT_B,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITION_COUNT)));
+
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @AfterEach
+  void resumeExporting() throws Exception {
+    // The phase is persisted per partition, so a test leaving exporting paused would decide the
+    // outcome of the next one.
+    post("/cluster/v2/exporting/resume");
+  }
+
+  @Test
+  void shouldPauseExportingOnEveryPhysicalTenant() throws Exception {
+    // when
+    post("/cluster/v2/exporting/pause");
+
+    // then
+    assertThat(awaitSettledClusterStatus()).isEqualTo("PAUSED");
+    assertPartitionsReport(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, "PAUSED");
+    assertPartitionsReport(TENANT_B, "PAUSED");
+  }
+
+  @Test
+  void shouldSoftPauseExportingOnEveryPhysicalTenant() throws Exception {
+    // when
+    post("/cluster/v2/exporting/pause?soft=true");
+
+    // then
+    assertThat(awaitSettledClusterStatus()).isEqualTo("SOFT_PAUSED");
+    assertPartitionsReport(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, "SOFT_PAUSED");
+    assertPartitionsReport(TENANT_B, "SOFT_PAUSED");
+  }
+
+  @Test
+  void shouldResumeExportingOnEveryPhysicalTenant() throws Exception {
+    // given
+    post("/cluster/v2/exporting/pause");
+    assertThat(awaitSettledClusterStatus()).isEqualTo("PAUSED");
+
+    // when
+    post("/cluster/v2/exporting/resume");
+
+    // then
+    assertThat(awaitSettledClusterStatus()).isEqualTo("EXPORTING");
+    assertPartitionsReport(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, "EXPORTING");
+    assertPartitionsReport(TENANT_B, "EXPORTING");
+  }
+
+  @Test
+  void shouldReportFoldedStatusForTheWholeCluster() {
+    // when / then
+    assertThat(awaitSettledClusterStatus()).isEqualTo("EXPORTING");
+  }
+
+  @Test
+  void shouldRejectPauseRequestsWithoutClusterAdminCredentials() throws Exception {
+    // when
+    final var response = sendUnauthenticated("POST", "/cluster/v2/exporting/pause");
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  void shouldRejectResumeRequestsWithoutClusterAdminCredentials() throws Exception {
+    // when
+    final var response = sendUnauthenticated("POST", "/cluster/v2/exporting/resume");
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  void shouldRejectStatusRequestsWithoutClusterAdminCredentials() throws Exception {
+    // when
+    final var response = sendUnauthenticated("GET", "/cluster/v2/exporting");
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  /**
+   * Pause and resume answer once every partition of every tenant has acknowledged, but a replica
+   * may still be mid-transition, so the status is polled until it settles rather than read once.
+   */
+  private String awaitSettledClusterStatus() {
+    return Awaitility.await("until the cluster-wide exporting status settles on a single phase")
+        .atMost(TIMEOUT)
+        .until(this::readClusterStatus, phase -> !"MIXED".equals(phase));
+  }
+
+  private String readClusterStatus() throws Exception {
+    final var response = send("GET", "/cluster/v2/exporting");
+    assertThat(response.statusCode()).isEqualTo(200);
+    return JSON.readTree(response.body()).get("status").asText();
+  }
+
+  private void assertPartitionsReport(final String physicalTenantId, final String expectedPhase) {
+    Awaitility.await(
+            "until every partition of physical tenant '"
+                + physicalTenantId
+                + "' reports "
+                + expectedPhase)
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThat(PartitionsActuator.of(broker).query(physicalTenantId).values())
+                    .isNotEmpty()
+                    .allSatisfy(
+                        partition ->
+                            assertThat(partition.exporterPhase()).isEqualTo(expectedPhase)));
+  }
+
+  private void post(final String path) throws Exception {
+    final var response = send("POST", path);
+    assertThat(response.statusCode())
+        .as("POST %s should succeed, but got: %s", path, response.body())
+        .isEqualTo(204);
+  }
+
+  private HttpResponse<String> send(final String method, final String path) throws Exception {
+    final var request =
+        HttpRequest.newBuilder(resolve(path))
+            .header("Authorization", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .method(method, BodyPublishers.noBody())
+            .header("Accept", "application/json")
+            .build();
+    return httpClient.send(request, BodyHandlers.ofString());
+  }
+
+  private HttpResponse<String> sendUnauthenticated(final String method, final String path)
+      throws Exception {
+    final var request =
+        HttpRequest.newBuilder(resolve(path))
+            .method(method, BodyPublishers.noBody())
+            .header("Accept", "application/json")
+            .build();
+    return httpClient.send(request, BodyHandlers.ofString());
+  }
+
+  private URI resolve(final String path) {
+    final var base = broker.restAddress().toString();
+    final var root = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+    return URI.create(root + path);
+  }
+
+  private static String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/service/ServiceRegistryArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/service/ServiceRegistryArchTest.java
@@ -64,7 +64,10 @@ public final class ServiceRegistryArchTest {
           .because("tenant-scoped service accessors must be keyed by physicalTenantId");
 
   static final Set<String> CLUSTER_WIDE_SERVICES =
-      Set.of(ManagementServices.class.getName(), ClusterTopologyServices.class.getName());
+      Set.of(
+          ManagementServices.class.getName(),
+          ClusterTopologyServices.class.getName(),
+          ClusterExportingServices.class.getName());
 
   // -- conditions --
 

--- a/service/src/main/java/io/camunda/service/ClusterExportingServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterExportingServices.java
@@ -10,6 +10,7 @@ package io.camunda.service;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
 import io.camunda.zeebe.gateway.admin.ExportingStatus;
+import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -71,8 +72,38 @@ public final class ClusterExportingServices {
   }
 
   private CompletableFuture<Void> fanOut(final Function<String, CompletableFuture<Void>> action) {
-    final var futures = physicalTenantIds.stream().map(action).toArray(CompletableFuture[]::new);
+    final var futures =
+        physicalTenantIds.stream()
+            .map(tenantId -> fanOutOne(tenantId, action))
+            .toArray(CompletableFuture[]::new);
     return CompletableFuture.allOf(futures);
+  }
+
+  /**
+   * Attaches the physical tenant id to a failure, both for a future that completes exceptionally
+   * and for a synchronous throw ({@code validateTopology()} rejects before returning a future).
+   * Without this, an {@code IncompleteTopologyException} on a 10-tenant cluster tells the operator
+   * only "one tenant had an incomplete topology", not which one — the exact toil this endpoint
+   * exists to remove.
+   */
+  private static CompletableFuture<Void> fanOutOne(
+      final String physicalTenantId, final Function<String, CompletableFuture<Void>> action) {
+    try {
+      return action
+          .apply(physicalTenantId)
+          .exceptionallyCompose(
+              e -> CompletableFuture.failedFuture(withTenantId(physicalTenantId, e)));
+    } catch (final IncompleteTopologyException e) {
+      return CompletableFuture.failedFuture(withTenantId(physicalTenantId, e));
+    }
+  }
+
+  private static Throwable withTenantId(final String physicalTenantId, final Throwable error) {
+    if (error instanceof final IncompleteTopologyException e) {
+      return new IncompleteTopologyException(
+          "Physical tenant '%s': %s".formatted(physicalTenantId, e.getMessage()));
+    }
+    return error;
   }
 
   private static ExportingStatus fold(final List<ExportingStatus> perTenantStatuses) {

--- a/service/src/main/java/io/camunda/service/ClusterExportingServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterExportingServices.java
@@ -8,9 +8,9 @@
 package io.camunda.service;
 
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.exception.ServiceException;
 import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
 import io.camunda.zeebe.gateway.admin.ExportingStatus;
-import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -82,9 +82,14 @@ public final class ClusterExportingServices {
   /**
    * Attaches the physical tenant id to a failure, both for a future that completes exceptionally
    * and for a synchronous throw ({@code validateTopology()} rejects before returning a future).
-   * Without this, an {@code IncompleteTopologyException} on a 10-tenant cluster tells the operator
-   * only "one tenant had an incomplete topology", not which one — the exact toil this endpoint
-   * exists to remove.
+   * Without this, a failure on a 10-tenant cluster tells the operator only "one tenant failed", not
+   * which one — the exact toil this endpoint exists to remove.
+   *
+   * <p>Maps through {@link ErrorMapper} first, rather than matching on the raw throwable, because
+   * {@link CompletableFuture#allOf} wraps every dependency's failure in a {@link
+   * java.util.concurrent.CompletionException} — so a bare {@code instanceof} check against, say,
+   * {@code IncompleteTopologyException} never matches here, and only {@code ErrorMapper}'s
+   * recursive unwrap reaches the real cause and its mapped status regardless of exception type.
    */
   private static CompletableFuture<Void> fanOutOne(
       final String physicalTenantId, final Function<String, CompletableFuture<Void>> action) {
@@ -93,17 +98,17 @@ public final class ClusterExportingServices {
           .apply(physicalTenantId)
           .exceptionallyCompose(
               e -> CompletableFuture.failedFuture(withTenantId(physicalTenantId, e)));
-    } catch (final IncompleteTopologyException e) {
+    } catch (final RuntimeException e) {
       return CompletableFuture.failedFuture(withTenantId(physicalTenantId, e));
     }
   }
 
-  private static Throwable withTenantId(final String physicalTenantId, final Throwable error) {
-    if (error instanceof final IncompleteTopologyException e) {
-      return new IncompleteTopologyException(
-          "Physical tenant '%s': %s".formatted(physicalTenantId, e.getMessage()));
-    }
-    return error;
+  private static ServiceException withTenantId(
+      final String physicalTenantId, final Throwable error) {
+    final var mapped = ErrorMapper.mapError(error);
+    return new ServiceException(
+        "Physical tenant '%s': %s".formatted(physicalTenantId, mapped.getMessage()),
+        mapped.getStatus());
   }
 
   private static ExportingStatus fold(final List<ExportingStatus> perTenantStatuses) {

--- a/service/src/main/java/io/camunda/service/ClusterExportingServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterExportingServices.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
+import io.camunda.zeebe.gateway.admin.ExportingStatus;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Pauses, resumes, and reports exporting status across every physical tenant of the cluster in one
+ * call (ADR 003 D2), served by the cluster-admin security chain.
+ *
+ * <p>Unlike {@link ExportingServices}, this class does not extend {@link
+ * PhysicalTenantScopedApiServices} and performs no {@code CamundaAuthentication}-based permission
+ * check: the cluster-admin chain authenticates against an isolated credential set that produces no
+ * {@code CamundaAuthentication}, so there is nothing to check {@code EXPORTER:PAUSE} against. The
+ * chain itself is the gate.
+ *
+ * <p>All-or-error, no rollback: if any physical tenant cannot be reached, the whole request fails
+ * and no already-succeeded tenant is reverted. Pause and resume are idempotent, so retrying the
+ * same call is the correct remedy.
+ */
+@NullMarked
+public final class ClusterExportingServices {
+
+  private final ExportingRequestBroadcaster broadcaster;
+  private final Set<String> physicalTenantIds;
+
+  public ClusterExportingServices(
+      final ExportingRequestBroadcaster broadcaster, final Set<String> physicalTenantIds) {
+    this.broadcaster = broadcaster;
+    this.physicalTenantIds = Set.copyOf(physicalTenantIds);
+  }
+
+  public CompletableFuture<Void> pauseExporting(final boolean soft) {
+    return mapped(
+        () -> fanOut(soft ? broadcaster::softPauseExporting : broadcaster::pauseExporting));
+  }
+
+  public CompletableFuture<Void> resumeExporting() {
+    return mapped(() -> fanOut(broadcaster::resumeExporting));
+  }
+
+  public CompletableFuture<ExportingStatus> getExportingStatus() {
+    return mapped(
+        () -> {
+          if (physicalTenantIds.isEmpty()) {
+            // No configured tenant can process work. Not reachable in a running cluster (there
+            // is always at least the default tenant), but folding an empty set to EXPORTING
+            // would be actively wrong.
+            return CompletableFuture.completedFuture(ExportingStatus.MIXED);
+          }
+
+          final var futures =
+              physicalTenantIds.stream().map(broadcaster::getExportingStatus).toList();
+          return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+              .thenApply(ignored -> fold(futures.stream().map(CompletableFuture::join).toList()));
+        });
+  }
+
+  private CompletableFuture<Void> fanOut(final Function<String, CompletableFuture<Void>> action) {
+    final var futures = physicalTenantIds.stream().map(action).toArray(CompletableFuture[]::new);
+    return CompletableFuture.allOf(futures);
+  }
+
+  private static ExportingStatus fold(final List<ExportingStatus> perTenantStatuses) {
+    final var distinct = new HashSet<>(perTenantStatuses);
+    if (distinct.size() == 1) {
+      return distinct.iterator().next();
+    }
+    return ExportingStatus.MIXED;
+  }
+
+  /**
+   * Maps both the synchronous validation failure ({@code IncompleteTopologyException} thrown by
+   * {@link ExportingRequestBroadcaster} before it returns a future) and the asynchronous failure
+   * (an exceptionally-completed future) to a {@link io.camunda.service.exception.ServiceException},
+   * mirroring {@code ExportingServices}'s wrapper minus the permission check. Without this, both
+   * failure paths reach {@code GatewayErrorMapper} as an unrecognized exception and become HTTP 500
+   * instead of the per-PT endpoint's 503.
+   */
+  private <T> CompletableFuture<T> mapped(final Supplier<CompletableFuture<T>> action) {
+    try {
+      return action
+          .get()
+          .exceptionallyCompose(e -> CompletableFuture.failedFuture(ErrorMapper.mapError(e)));
+    } catch (final RuntimeException e) {
+      return CompletableFuture.failedFuture(ErrorMapper.mapError(e));
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -15,6 +15,7 @@ import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
+import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
@@ -104,6 +105,7 @@ public record DefaultServiceRegistry(
     ClusterRecoveryServices clusterRecoveryServices,
     ClusterStatusServices clusterStatusServices,
     ClusterTopologyServices clusterTopologyServices,
+    ClusterExportingServices clusterExportingServices,
     ManagementServices managementServices)
     implements ServiceRegistry {
 
@@ -333,6 +335,11 @@ public record DefaultServiceRegistry(
   }
 
   @Override
+  public ClusterExportingServices clusterExportingServices() {
+    return clusterExportingServices;
+  }
+
+  @Override
   public ManagementServices managementServices() {
     return managementServices;
   }
@@ -419,6 +426,7 @@ public record DefaultServiceRegistry(
     private ClusterRecoveryServices clusterRecoveryServices;
     private ClusterStatusServices clusterStatusServices;
     private ClusterTopologyServices clusterTopologyServices;
+    private ClusterExportingServices clusterExportingServices;
     private ManagementServices managementServices;
 
     public Builder adHocSubProcessActivityServices(
@@ -651,6 +659,11 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder clusterExportingServices(final ClusterExportingServices service) {
+      clusterExportingServices = service;
+      return this;
+    }
+
     public Builder managementServices(final ManagementServices service) {
       managementServices = service;
       return this;
@@ -701,6 +714,7 @@ public record DefaultServiceRegistry(
           clusterRecoveryServices,
           clusterStatusServices,
           clusterTopologyServices,
+          clusterExportingServices,
           managementServices);
     }
   }

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -15,6 +15,7 @@ import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
+import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
@@ -150,6 +151,8 @@ public interface ServiceRegistry {
   ClusterTopologyServices clusterTopologyServices();
 
   ClusterRecoveryServices clusterRecoveryServices();
+
+  ClusterExportingServices clusterExportingServices();
 
   ManagementServices managementServices();
 }

--- a/service/src/test/java/io/camunda/service/ClusterExportingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterExportingServicesTest.java
@@ -243,13 +243,13 @@ class ClusterExportingServicesTest {
   }
 
   @Test
-  void shouldIncludeFailingTenantIdInPauseFailureDetail() {
-    // given
+  void shouldIncludeFailingTenantIdWhenBroadcasterThrowsSynchronously() {
+    // given — validateTopology() throws before returning a future, mirroring the real
+    // ExportingRequestBroadcaster; this is the only path IncompleteTopologyException ever takes.
     final var broadcaster = mock(ExportingRequestBroadcaster.class);
     when(broadcaster.pauseExporting(TENANT_A)).thenReturn(CompletableFuture.completedFuture(null));
     when(broadcaster.pauseExporting(TENANT_B))
-        .thenReturn(
-            CompletableFuture.failedFuture(new IncompleteTopologyException("no topology yet")));
+        .thenThrow(new IncompleteTopologyException("no topology yet"));
     final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A, TENANT_B));
 
     // when
@@ -261,10 +261,41 @@ class ClusterExportingServicesTest {
         .withThrowableThat()
         .withCauseInstanceOf(ServiceException.class)
         .satisfies(
-            e ->
-                assertThat(((ServiceException) e.getCause()).getMessage())
-                    .contains(TENANT_B)
-                    .contains("no topology yet"));
+            e -> {
+              final var mapped = (ServiceException) e.getCause();
+              assertThat(mapped.getMessage()).contains(TENANT_B).contains("no topology yet");
+              assertThat(mapped.getStatus()).isEqualTo(Status.UNAVAILABLE);
+            });
+  }
+
+  @Test
+  void shouldIncludeFailingTenantIdWhenTenantFutureFailsAsynchronously() {
+    // given — CompletableFuture.allOf wraps a dependency's failure in a CompletionException
+    // (per its own javadoc), which is what a real broker request failure looks like by the time
+    // it reaches fanOutOne. A bare instanceof check against the raw throwable would never match
+    // this, silently dropping the tenant id for every genuine async failure.
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    when(broadcaster.pauseExporting(TENANT_A)).thenReturn(CompletableFuture.completedFuture(null));
+    when(broadcaster.pauseExporting(TENANT_B))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new CompletionException(new IncompleteTopologyException("no topology yet"))));
+    final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A, TENANT_B));
+
+    // when
+    final var future = services.pauseExporting(false);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .withCauseInstanceOf(ServiceException.class)
+        .satisfies(
+            e -> {
+              final var mapped = (ServiceException) e.getCause();
+              assertThat(mapped.getMessage()).contains(TENANT_B).contains("no topology yet");
+              assertThat(mapped.getStatus()).isEqualTo(Status.UNAVAILABLE);
+            });
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/ClusterExportingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterExportingServicesTest.java
@@ -243,6 +243,31 @@ class ClusterExportingServicesTest {
   }
 
   @Test
+  void shouldIncludeFailingTenantIdInPauseFailureDetail() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    when(broadcaster.pauseExporting(TENANT_A)).thenReturn(CompletableFuture.completedFuture(null));
+    when(broadcaster.pauseExporting(TENANT_B))
+        .thenReturn(
+            CompletableFuture.failedFuture(new IncompleteTopologyException("no topology yet")));
+    final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A, TENANT_B));
+
+    // when
+    final var future = services.pauseExporting(false);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .withCauseInstanceOf(ServiceException.class)
+        .satisfies(
+            e ->
+                assertThat(((ServiceException) e.getCause()).getMessage())
+                    .contains(TENANT_B)
+                    .contains("no topology yet"));
+  }
+
+  @Test
   void shouldResumeEveryTenant() {
     // given
     final var broadcaster = mock(ExportingRequestBroadcaster.class);

--- a/service/src/test/java/io/camunda/service/ClusterExportingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterExportingServicesTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
+import io.camunda.zeebe.gateway.admin.ExportingStatus;
+import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.Test;
+
+class ClusterExportingServicesTest {
+
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+  private static final String TENANT_C = "tenant-c";
+  private static final Set<String> THREE_TENANTS = Set.of(TENANT_A, TENANT_B, TENANT_C);
+
+  @Test
+  void shouldReportSinglePhaseWhenEveryTenantAgrees() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    THREE_TENANTS.forEach(
+        tenantId ->
+            when(broadcaster.getExportingStatus(tenantId))
+                .thenReturn(CompletableFuture.completedFuture(ExportingStatus.PAUSED)));
+    final var services = new ClusterExportingServices(broadcaster, THREE_TENANTS);
+
+    // when
+    final var status = services.getExportingStatus().join();
+
+    // then
+    assertThat(status).isEqualTo(ExportingStatus.PAUSED);
+  }
+
+  @Test
+  void shouldFoldToMixedWhenTenantsDisagree() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    when(broadcaster.getExportingStatus(TENANT_A))
+        .thenReturn(CompletableFuture.completedFuture(ExportingStatus.PAUSED));
+    when(broadcaster.getExportingStatus(TENANT_B))
+        .thenReturn(CompletableFuture.completedFuture(ExportingStatus.SOFT_PAUSED));
+    final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A, TENANT_B));
+
+    // when
+    final var status = services.getExportingStatus().join();
+
+    // then
+    assertThat(status).isEqualTo(ExportingStatus.MIXED);
+  }
+
+  @Test
+  void shouldFoldToMixedWhenOneTenantItselfReportsMixed() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    when(broadcaster.getExportingStatus(TENANT_A))
+        .thenReturn(CompletableFuture.completedFuture(ExportingStatus.PAUSED));
+    when(broadcaster.getExportingStatus(TENANT_B))
+        .thenReturn(CompletableFuture.completedFuture(ExportingStatus.MIXED));
+    final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A, TENANT_B));
+
+    // when
+    final var status = services.getExportingStatus().join();
+
+    // then
+    assertThat(status).isEqualTo(ExportingStatus.MIXED);
+  }
+
+  @Test
+  void shouldFoldToMixedWhenEveryTenantReportsMixed() {
+    // given — the exact case that breaks a naive ExportingStatus.aggregate() reuse
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    THREE_TENANTS.forEach(
+        tenantId ->
+            when(broadcaster.getExportingStatus(tenantId))
+                .thenReturn(CompletableFuture.completedFuture(ExportingStatus.MIXED)));
+    final var services = new ClusterExportingServices(broadcaster, THREE_TENANTS);
+
+    // when
+    final var status = services.getExportingStatus().join();
+
+    // then
+    assertThat(status).isEqualTo(ExportingStatus.MIXED);
+  }
+
+  @Test
+  void shouldReturnMixedForEmptyTenantSetViaExplicitGuard() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    final var services = new ClusterExportingServices(broadcaster, Set.of());
+
+    // when
+    final var status = services.getExportingStatus().join();
+
+    // then
+    assertThat(status).isEqualTo(ExportingStatus.MIXED);
+  }
+
+  @Test
+  void shouldFailWithServiceExceptionWhenATenantFutureCompletesExceptionally() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    when(broadcaster.getExportingStatus(TENANT_A))
+        .thenReturn(CompletableFuture.completedFuture(ExportingStatus.PAUSED));
+    when(broadcaster.getExportingStatus(TENANT_B))
+        .thenReturn(
+            CompletableFuture.failedFuture(new IncompleteTopologyException("no topology yet")));
+    final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A, TENANT_B));
+
+    // when
+    final var future = services.getExportingStatus();
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .withCauseInstanceOf(ServiceException.class)
+        .satisfies(
+            e ->
+                assertThat(((ServiceException) e.getCause()).getStatus())
+                    .isEqualTo(Status.UNAVAILABLE));
+  }
+
+  @Test
+  void shouldReturnServiceExceptionWithoutThrowingWhenBroadcasterThrowsSynchronously() {
+    // given — validateTopology() throws before returning a future; must not escape as a raw throw
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    when(broadcaster.getExportingStatus(TENANT_A))
+        .thenThrow(new IncompleteTopologyException("no topology yet"));
+    final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A));
+
+    // when
+    final var future = services.getExportingStatus();
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .withCauseInstanceOf(ServiceException.class)
+        .satisfies(
+            e ->
+                assertThat(((ServiceException) e.getCause()).getStatus())
+                    .isEqualTo(Status.UNAVAILABLE));
+  }
+
+  @Test
+  void shouldMapCompletionExceptionWrappedIncompleteTopologyExceptionTo503() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    when(broadcaster.getExportingStatus(TENANT_A))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new CompletionException(new IncompleteTopologyException("no topology yet"))));
+    final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A));
+
+    // when
+    final var future = services.getExportingStatus();
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .withCauseInstanceOf(ServiceException.class)
+        .satisfies(
+            e ->
+                assertThat(((ServiceException) e.getCause()).getStatus())
+                    .isEqualTo(Status.UNAVAILABLE));
+  }
+
+  @Test
+  void shouldMapUnknownPhaseFailureToInvalidArgumentNotMixed() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    when(broadcaster.getExportingStatus(TENANT_A))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new IllegalArgumentException(
+                    "Expected a broker replica to report a known exporter phase, but got 'UNKNOWN'")));
+    final var services = new ClusterExportingServices(broadcaster, Set.of(TENANT_A));
+
+    // when
+    final var future = services.getExportingStatus();
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .withCauseInstanceOf(ServiceException.class)
+        .satisfies(
+            e ->
+                assertThat(((ServiceException) e.getCause()).getStatus())
+                    .isEqualTo(Status.INVALID_ARGUMENT));
+  }
+
+  @Test
+  void shouldSoftPauseEveryTenantWhenSoftIsTrue() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    THREE_TENANTS.forEach(
+        tenantId ->
+            when(broadcaster.softPauseExporting(tenantId))
+                .thenReturn(CompletableFuture.completedFuture(null)));
+    final var services = new ClusterExportingServices(broadcaster, THREE_TENANTS);
+
+    // when
+    services.pauseExporting(true).join();
+
+    // then
+    THREE_TENANTS.forEach(tenantId -> verify(broadcaster).softPauseExporting(eq(tenantId)));
+  }
+
+  @Test
+  void shouldHardPauseEveryTenantWhenSoftIsFalse() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    THREE_TENANTS.forEach(
+        tenantId ->
+            when(broadcaster.pauseExporting(tenantId))
+                .thenReturn(CompletableFuture.completedFuture(null)));
+    final var services = new ClusterExportingServices(broadcaster, THREE_TENANTS);
+
+    // when
+    services.pauseExporting(false).join();
+
+    // then
+    THREE_TENANTS.forEach(tenantId -> verify(broadcaster).pauseExporting(eq(tenantId)));
+  }
+
+  @Test
+  void shouldResumeEveryTenant() {
+    // given
+    final var broadcaster = mock(ExportingRequestBroadcaster.class);
+    THREE_TENANTS.forEach(
+        tenantId ->
+            when(broadcaster.resumeExporting(tenantId))
+                .thenReturn(CompletableFuture.completedFuture(null)));
+    final var services = new ClusterExportingServices(broadcaster, THREE_TENANTS);
+
+    // when
+    services.resumeExporting().join();
+
+    // then
+    THREE_TENANTS.forEach(tenantId -> verify(broadcaster).resumeExporting(eq(tenantId)));
+  }
+}

--- a/service/src/test/java/io/camunda/service/ClusterExportingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterExportingServicesTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.Test;
 
 class ClusterExportingServicesTest {
 
-  private static final String TENANT_A = "tenant-a";
-  private static final String TENANT_B = "tenant-b";
-  private static final String TENANT_C = "tenant-c";
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String TENANT_C = "tenantc";
   private static final Set<String> THREE_TENANTS = Set.of(TENANT_A, TENANT_B, TENANT_C);
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -127,6 +127,156 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
 
+  /cluster/v2/exporting:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Exporting
+      operationId: getClusterExportingStatus
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Get exporting status of the whole cluster
+      description: >-
+        Returns the exporting status of the whole cluster, folded over the exporting status of
+        every physical tenant. Only `PAUSED` and `SOFT_PAUSED` confirm that exporting is paused
+        cluster-wide; every other value means at least one physical tenant is not paused, so
+        callers should keep polling. A physical tenant that itself reports `MIXED` makes the
+        whole cluster `MIXED`.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials
+        are valid here.
+      responses:
+        "200":
+          description: The aggregated exporting status of the whole cluster.
+          content:
+            application/json:
+              schema:
+                $ref: 'exporting.yaml#/components/schemas/ExportingStatusResponse'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
+  /cluster/v2/exporting/pause:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Exporting
+      operationId: pauseClusterExporting
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Pause exporting across the whole cluster
+      description: >-
+        Pauses exporting on every physical tenant of the cluster in one call. With `soft=true`,
+        every physical tenant is soft-paused instead.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials
+        are valid here.
+      parameters:
+        - name: soft
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: If true, soft-pauses exporting instead of a hard pause.
+      responses:
+        "204":
+          description: Exporting was successfully paused on every physical tenant.
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
+  /cluster/v2/exporting/resume:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Exporting
+      operationId: resumeClusterExporting
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Resume exporting across the whole cluster
+      description: >-
+        Resumes exporting on every physical tenant of the cluster in one call, after a pause or
+        soft pause.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials
+        are valid here.
+      responses:
+        "204":
+          description: Exporting was successfully resumed on every physical tenant.
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
   /cluster/v2/mode:
     servers:
       - url: "{schema}://{host}:{port}"

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -504,6 +504,12 @@ paths:
     $ref: 'cluster.yaml#/paths/~1restore'
 
   # Cluster-wide endpoints. Path keys must stay absolute — see `cluster-admin.yaml` for why.
+  /cluster/v2/exporting:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1exporting'
+  /cluster/v2/exporting/pause:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1exporting~1pause'
+  /cluster/v2/exporting/resume:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1exporting~1resume'
   /cluster/v2/mode:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1mode'
   /cluster/v2/restore:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterExportingController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterExportingController.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
+import io.camunda.zeebe.gateway.rest.mapper.ExportingResponseMapper;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Pauses, resumes, and reports exporting status across every physical tenant of the cluster in one
+ * call (ADR 003 D2), served by the cluster-admin security chain.
+ */
+@CamundaRestController
+@ClusterScoped
+@RequestMapping("/cluster/v2")
+@NullMarked
+public final class ClusterExportingController {
+
+  private final ServiceRegistry serviceRegistry;
+
+  public ClusterExportingController(final ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @CamundaGetMapping(path = "/exporting")
+  public CompletableFuture<ResponseEntity<Object>> getClusterExportingStatus() {
+    return RequestExecutor.executeServiceMethod(
+        serviceRegistry.clusterExportingServices()::getExportingStatus,
+        ExportingResponseMapper::toExportingStatusResponse,
+        HttpStatus.OK);
+  }
+
+  @CamundaPostMapping(
+      path = "/exporting/pause",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> pauseClusterExporting(
+      @RequestParam(defaultValue = "false") final boolean soft) {
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () -> serviceRegistry.clusterExportingServices().pauseExporting(soft));
+  }
+
+  @CamundaPostMapping(
+      path = "/exporting/resume",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> resumeClusterExporting() {
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () -> serviceRegistry.clusterExportingServices().resumeExporting());
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterExportingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterExportingControllerTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ClusterExportingServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.admin.ExportingStatus;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(ClusterExportingController.class)
+class ClusterExportingControllerTest extends RestControllerTest {
+
+  static final String STATUS_URL = "/cluster/v2/exporting";
+  static final String PAUSE_URL = "/cluster/v2/exporting/pause";
+  static final String RESUME_URL = "/cluster/v2/exporting/resume";
+
+  @MockitoBean ClusterExportingServices clusterExportingServices;
+  @MockitoBean ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setup() {
+    when(serviceRegistry.clusterExportingServices()).thenReturn(clusterExportingServices);
+  }
+
+  @Test
+  void shouldReturnStatusOfTheWholeCluster() {
+    // given
+    when(clusterExportingServices.getExportingStatus())
+        .thenReturn(CompletableFuture.completedFuture(ExportingStatus.SOFT_PAUSED));
+
+    // when / then
+    webClient
+        .get()
+        .uri(STATUS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json("{\"status\":\"SOFT_PAUSED\"}", JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnServiceUnavailableWhenTopologyIsIncomplete() {
+    // given
+    when(clusterExportingServices.getExportingStatus())
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("Topology is incomplete", Status.UNAVAILABLE)));
+
+    // when / then
+    webClient
+        .get()
+        .uri(STATUS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void shouldReturnBadRequestOnUnknownExporterPhase() {
+    // given
+    when(clusterExportingServices.getExportingStatus())
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("JSON property was invalid", Status.INVALID_ARGUMENT)));
+
+    // when / then
+    webClient
+        .get()
+        .uri(STATUS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void shouldPauseEveryTenantAndReturnNoContent() {
+    // given
+    when(clusterExportingServices.pauseExporting(eq(false)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when / then
+    webClient
+        .post()
+        .uri(PAUSE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(clusterExportingServices).pauseExporting(eq(false));
+  }
+
+  @Test
+  void shouldForwardSoftQueryParamOnPause() {
+    // given
+    when(clusterExportingServices.pauseExporting(anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when / then
+    webClient
+        .post()
+        .uri(PAUSE_URL + "?soft=true")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(clusterExportingServices).pauseExporting(eq(true));
+  }
+
+  @Test
+  void shouldReturnServiceUnavailableOnPauseWhenTopologyIsIncomplete() {
+    // given
+    when(clusterExportingServices.pauseExporting(anyBoolean()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("Topology is incomplete", Status.UNAVAILABLE)));
+
+    // when / then
+    webClient
+        .post()
+        .uri(PAUSE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void shouldResumeEveryTenantAndReturnNoContent() {
+    // given
+    when(clusterExportingServices.resumeExporting())
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when / then
+    webClient
+        .post()
+        .uri(RESUME_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(clusterExportingServices).resumeExporting();
+  }
+
+  @Test
+  void shouldReturnServiceUnavailableOnResumeWhenTopologyIsIncomplete() {
+    // given
+    when(clusterExportingServices.resumeExporting())
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("Topology is incomplete", Status.UNAVAILABLE)));
+
+    // when / then
+    webClient
+        .post()
+        .uri(RESUME_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void shouldNotRegisterPhysicalTenantPrefixedRoute() {
+    // when / then — @ClusterScoped must suppress the PT-prefixed sibling route
+    webClient
+        .get()
+        .uri("/physical-tenants/default/cluster/v2/exporting")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterExportingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterExportingIT.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.util.Base64;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,6 +53,8 @@ final class ClusterExportingIT {
   private static final int TENANT_B_PARTITION_COUNT = 2;
   private static final Duration TIMEOUT = Duration.ofSeconds(30);
   private static final ObjectMapper JSON = new ObjectMapper();
+
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
   private static final PhysicalTenantsITHelper TENANTS =
       PhysicalTenantsITHelper.builder()
@@ -170,7 +173,7 @@ final class ClusterExportingIT {
             .method(method, BodyPublishers.noBody())
             .header("Accept", "application/json")
             .build();
-    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+    return HTTP_CLIENT.send(request, BodyHandlers.ofString());
   }
 
   private URI resolve(final String path) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterExportingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterExportingIT.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Base64;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage for the cluster-wide exporting endpoints ({@code POST
+ * /cluster/v2/exporting/pause}, {@code POST /cluster/v2/exporting/resume}, {@code GET
+ * /cluster/v2/exporting}), which let an operator pause, resume and poll exporting across every
+ * physical tenant in one call instead of once per tenant (ADR 003 D2).
+ *
+ * <p>More than one partition per tenant is configured because the fold is exercised across
+ * partitions as well as tenants: with a single partition per tenant, a fold that drops all but the
+ * first partition or tenant would still pass (see {@code ExportingStatusIT}, which documents the
+ * same reasoning for the per-PT endpoint).
+ *
+ * <p>Every phase assertion is cross-checked against the {@code partitions} actuator, scoped per
+ * physical tenant, which reads the phase by a fully independent path from the endpoint under test.
+ */
+@ZeebeIntegration
+final class ClusterExportingIT {
+
+  private static final String TENANT_B = "tenantb";
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+  private static final int DEFAULT_TENANT_PARTITION_COUNT = 2;
+  private static final int TENANT_B_PARTITION_COUNT = 2;
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @TestZeebe(partitionCount = DEFAULT_TENANT_PARTITION_COUNT, purgeAfterEach = false)
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withProperty(
+                  "camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
+              .withProperty(
+                  "camunda.security.cluster-admin.basic.users[0].password", CLUSTER_ADMIN_PASSWORD)
+              .withClusterConfig(
+                  cluster -> cluster.setPartitionCount(DEFAULT_TENANT_PARTITION_COUNT))
+              .withPtConfig(
+                  TENANT_B,
+                  camunda -> camunda.getCluster().setPartitionCount(TENANT_B_PARTITION_COUNT)));
+
+  @AfterEach
+  void resumeExporting() throws Exception {
+    // The phase is persisted per partition, so a test leaving exporting paused would decide the
+    // outcome of the next one.
+    post("/cluster/v2/exporting/resume");
+  }
+
+  @Test
+  void shouldPauseExportingOnEveryPhysicalTenant() throws Exception {
+    // when
+    post("/cluster/v2/exporting/pause");
+
+    // then
+    assertThat(awaitSettledClusterStatus()).isEqualTo("PAUSED");
+    assertPartitionsReport(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, "PAUSED");
+    assertPartitionsReport(TENANT_B, "PAUSED");
+  }
+
+  @Test
+  void shouldSoftPauseExportingOnEveryPhysicalTenant() throws Exception {
+    // when
+    post("/cluster/v2/exporting/pause?soft=true");
+
+    // then
+    assertThat(awaitSettledClusterStatus()).isEqualTo("SOFT_PAUSED");
+    assertPartitionsReport(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, "SOFT_PAUSED");
+    assertPartitionsReport(TENANT_B, "SOFT_PAUSED");
+  }
+
+  @Test
+  void shouldResumeExportingOnEveryPhysicalTenant() throws Exception {
+    // given
+    post("/cluster/v2/exporting/pause");
+    assertThat(awaitSettledClusterStatus()).isEqualTo("PAUSED");
+
+    // when
+    post("/cluster/v2/exporting/resume");
+
+    // then
+    assertThat(awaitSettledClusterStatus()).isEqualTo("EXPORTING");
+    assertPartitionsReport(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, "EXPORTING");
+    assertPartitionsReport(TENANT_B, "EXPORTING");
+  }
+
+  @Test
+  void shouldReportFoldedStatusForTheWholeCluster() {
+    // when / then
+    assertThat(awaitSettledClusterStatus()).isEqualTo("EXPORTING");
+  }
+
+  @Test
+  void shouldRejectRequestsWithoutClusterAdminCredentials() throws Exception {
+    // when
+    final var response = sendUnauthenticated("GET", "/cluster/v2/exporting");
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  /**
+   * Pause and resume answer once every partition of every tenant has acknowledged, but a replica
+   * may still be mid-transition, so the status is polled until it settles rather than read once.
+   */
+  private String awaitSettledClusterStatus() {
+    return Awaitility.await("until the cluster-wide exporting status settles on a single phase")
+        .atMost(TIMEOUT)
+        .until(this::readClusterStatus, phase -> !"MIXED".equals(phase));
+  }
+
+  private String readClusterStatus() throws Exception {
+    final var response = send("GET", "/cluster/v2/exporting");
+    assertThat(response.statusCode()).isEqualTo(200);
+    return JSON.readTree(response.body()).get("status").asText();
+  }
+
+  private void assertPartitionsReport(final String physicalTenantId, final String expectedPhase) {
+    Awaitility.await(
+            "until every partition of physical tenant '"
+                + physicalTenantId
+                + "' reports "
+                + expectedPhase)
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThat(PartitionsActuator.of(broker).query(physicalTenantId).values())
+                    .isNotEmpty()
+                    .allSatisfy(
+                        partition ->
+                            assertThat(partition.exporterPhase()).isEqualTo(expectedPhase)));
+  }
+
+  private void post(final String path) throws Exception {
+    final var response = send("POST", path);
+    assertThat(response.statusCode())
+        .as("POST %s should succeed, but got: %s", path, response.body())
+        .isEqualTo(204);
+  }
+
+  private HttpResponse<String> send(final String method, final String path) throws Exception {
+    final var request =
+        HttpRequest.newBuilder(resolve(path))
+            .header("Authorization", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .method(method, BodyPublishers.noBody())
+            .header("Accept", "application/json")
+            .build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+
+  private HttpResponse<String> sendUnauthenticated(final String method, final String path)
+      throws Exception {
+    final var request =
+        HttpRequest.newBuilder(resolve(path))
+            .method(method, BodyPublishers.noBody())
+            .header("Accept", "application/json")
+            .build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+
+  private URI resolve(final String path) {
+    final var base = broker.restAddress().toString();
+    final var root = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+    return URI.create(root + path);
+  }
+
+  private static String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterExportingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterExportingIT.java
@@ -127,6 +127,20 @@ final class ClusterExportingIT {
     assertThat(awaitSettledClusterStatus()).isEqualTo("EXPORTING");
   }
 
+  @Test
+  void shouldReportMixedWhenPhysicalTenantsDisagree() throws Exception {
+    // given — pausing only one physical tenant directly (the per-PT endpoint, not the
+    // cluster-wide one) leaves the other exporting, so the fold must report MIXED rather than
+    // either tenant's own phase. This is a steady state, not a transition to wait out: nothing
+    // else changes once the pause completes.
+    pausePhysicalTenant(TENANT_B);
+
+    // when / then
+    assertThat(awaitClusterStatus("MIXED")).isEqualTo("MIXED");
+    assertPartitionsReport(TENANT_B, "PAUSED");
+    assertPartitionsReport(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, "EXPORTING");
+  }
+
   /**
    * Pause and resume answer once every partition of every tenant has acknowledged, but a replica
    * may still be mid-transition, so the status is polled until it settles rather than read once.
@@ -135,6 +149,12 @@ final class ClusterExportingIT {
     return Awaitility.await("until the cluster-wide exporting status settles on a single phase")
         .atMost(TIMEOUT)
         .until(this::readClusterStatus, phase -> !"MIXED".equals(phase));
+  }
+
+  private String awaitClusterStatus(final String expectedPhase) {
+    return Awaitility.await("until the cluster-wide exporting status reports " + expectedPhase)
+        .atMost(TIMEOUT)
+        .until(this::readClusterStatus, expectedPhase::equals);
   }
 
   private String readClusterStatus() throws Exception {
@@ -163,6 +183,26 @@ final class ClusterExportingIT {
     final var response = send("POST", path);
     assertThat(response.statusCode())
         .as("POST %s should succeed, but got: %s", path, response.body())
+        .isEqualTo(204);
+  }
+
+  /**
+   * Pauses one physical tenant directly through the per-PT endpoint (unauthenticated on this
+   * broker, unlike the cluster-admin-gated cluster-wide endpoint) rather than through {@link
+   * #post}, so the other physical tenant is left untouched.
+   */
+  private void pausePhysicalTenant(final String physicalTenantId) throws Exception {
+    final var request =
+        HttpRequest.newBuilder(
+                resolve("/physical-tenants/" + physicalTenantId + "/v2/exporting/pause"))
+            .method("POST", BodyPublishers.noBody())
+            .header("Accept", "application/json")
+            .build();
+    final var response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode())
+        .as(
+            "Pausing physical tenant '%s' should succeed, but got: %s",
+            physicalTenantId, response.body())
         .isEqualTo(204);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterExportingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterExportingIT.java
@@ -124,15 +124,6 @@ final class ClusterExportingIT {
     assertThat(awaitSettledClusterStatus()).isEqualTo("EXPORTING");
   }
 
-  @Test
-  void shouldRejectRequestsWithoutClusterAdminCredentials() throws Exception {
-    // when
-    final var response = sendUnauthenticated("GET", "/cluster/v2/exporting");
-
-    // then
-    assertThat(response.statusCode()).isEqualTo(401);
-  }
-
   /**
    * Pause and resume answer once every partition of every tenant has acknowledged, but a replica
    * may still be mid-transition, so the status is polled until it settles rather than read once.
@@ -176,16 +167,6 @@ final class ClusterExportingIT {
     final var request =
         HttpRequest.newBuilder(resolve(path))
             .header("Authorization", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
-            .method(method, BodyPublishers.noBody())
-            .header("Accept", "application/json")
-            .build();
-    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
-  }
-
-  private HttpResponse<String> sendUnauthenticated(final String method, final String path)
-      throws Exception {
-    final var request =
-        HttpRequest.newBuilder(resolve(path))
             .method(method, BodyPublishers.noBody())
             .header("Accept", "application/json")
             .build();


### PR DESCRIPTION
## Description

Added three cluster-admin REST endpoints for cluster-wide exporting pause/resume/status that fan out over all physical tenants in a single call: `POST /cluster/v2/exporting/pause?soft=`, `POST /cluster/v2/exporting/resume`, and `GET /cluster/v2/exporting`. These endpoints implement ADR 003 D2 and simplify backup procedures on multi-tenant clusters by eliminating the need to call per-tenant endpoints repeatedly. All three endpoints are gated by the cluster-admin authentication chain, not per-tenant authorization. Acceptance tests were authored and validated for correctness.

## Checklist

<!--- Please delete options that are not relevant. -->

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57740
