### PR TITLE
feat: add ExporterMigrationStatusProvider for upgrade-readiness

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Export.java
+++ b/configuration/src/main/java/io/camunda/configuration/Export.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import static io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.DEFAULT_DISTRIBUTION_INTERVAL;
+import static io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.DEFAULT_MIGRATION_STATUS_SCAN_MAX_RECORDS;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.time.Duration;
@@ -40,6 +41,17 @@ public class Export {
    */
   private Map<Integer, Set<Long>> skipRecords = Map.of();
 
+  /**
+   * The maximum number of not-yet-exported records to scan, starting from the oldest one still
+   * pending, when checking whether every pending record on a partition is on the current
+   * application version. This backs the {@code exporterMigrated} upgrade-readiness condition: if
+   * the backlog of not-yet-exported records is larger than this limit, the condition reports that
+   * it cannot verify all of them rather than risking an incorrect positive result. Scanning is
+   * bounded because its cost scales with the size of the backlog, which is exactly unbounded in the
+   * scenario this check exists to catch (e.g. a long soft-paused exporter).
+   */
+  private int migrationStatusScanMaxRecords = DEFAULT_MIGRATION_STATUS_SCAN_MAX_RECORDS;
+
   public Duration getDistributionInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".distribution-interval",
@@ -59,5 +71,18 @@ public class Export {
 
   public void setSkipRecords(final Map<Integer, Set<Long>> skipRecords) {
     this.skipRecords = skipRecords;
+  }
+
+  public int getMigrationStatusScanMaxRecords() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".migration-status-scan-max-records",
+        migrationStatusScanMaxRecords,
+        Integer.class,
+        BackwardsCompatibilityMode.NOT_SUPPORTED,
+        Set.of());
+  }
+
+  public void setMigrationStatusScanMaxRecords(final int migrationStatusScanMaxRecords) {
+    this.migrationStatusScanMaxRecords = migrationStatusScanMaxRecords;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -794,7 +794,10 @@ public class BrokerBasedPropertiesOverride {
       final BrokerBasedProperties override, final Camunda camunda) {
     final Export export = camunda.getData().getExport();
     final var exportingCfg =
-        new ExportingCfg(export.getSkipRecords(), export.getDistributionInterval());
+        new ExportingCfg(
+            export.getSkipRecords(),
+            export.getDistributionInterval(),
+            export.getMigrationStatusScanMaxRecords());
     override.setExporting(exportingCfg);
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/DataExportTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataExportTest.java
@@ -87,6 +87,24 @@ public class DataExportTest {
   @Nested
   @TestPropertySource(
       properties = {
+        "camunda.data.export.migration-status-scan-max-records=5",
+      })
+  class WithMigrationStatusScanMaxRecordsSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithMigrationStatusScanMaxRecordsSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMigrationStatusScanMaxRecords() {
+      assertThat(brokerCfg.getExporting().migrationStatusScanMaxRecords()).isEqualTo(5);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
         "camunda.data.export.skip-records.1=10,20",
         "camunda.data.export.skip-records.2=30",
       })

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -18,6 +18,7 @@ data.audit-log.unknown.excludes
 data.audit-log.user.categories
 data.audit-log.user.excludes
 data.export.distribution-interval
+data.export.migration-status-scan-max-records
 data.export.skip-records
 data.exporters
 data.extension-properties.inbound-connector-type-property

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -335,6 +335,14 @@ camunda: # Type: io.camunda.configuration.Camunda
       # need to replay and export everything. It can for example can start from the last exported position
       # it has received by the distribution mechanism.
       distribution-interval: null # Type: Duration, Env: CAMUNDA_DATA_EXPORT_DISTRIBUTIONINTERVAL
+      # The maximum number of not-yet-exported records to scan, starting from the oldest one still pending,
+      # when checking whether every pending record on a partition is on the current application version.
+      # This backs the `exporterMigrated` upgrade-readiness condition: if the backlog of not-yet-exported
+      # records is larger than this limit, the condition reports that it cannot verify all of them rather
+      # than risking an incorrect positive result. Scanning is bounded because its cost scales with the size
+      # of the backlog, which is exactly unbounded in the scenario this check exists to catch (e.g. a long
+      # soft-paused exporter).
+      migration-status-scan-max-records: null # Type: Integer, Env: CAMUNDA_DATA_EXPORT_MIGRATIONSTATUSSCANMAXRECORDS
       # Enable the exporters to skip record positions per partition. Allows to skip certain records by their
       # position for a specific partition. This is useful for debugging or skipping a record that is
       # preventing processing or exporting to continue. Record positions defined to skip in this definition

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BrokerVersionMigrationStatusProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BrokerVersionMigrationStatusProviderConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.admin.ClusterBrokerVersionMigrationStatusProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers the broker-version {@link MigrationStatusProvider} for the upgrade-readiness endpoint,
+ * collected by {@link UpgradeReadinessEndpoint} alongside every other provider bean. {@link
+ * PhysicalTenantIds} is injected as the interface, not the concrete {@code PhysicalTenantResolver}
+ * that implements it, so {@code zeebe/gateway} doesn't depend on the {@code configuration} module.
+ */
+@Configuration(proxyBeanMethods = false)
+public class BrokerVersionMigrationStatusProviderConfiguration {
+
+  @Bean
+  public MigrationStatusProvider brokerVersionMigrationStatusProvider(
+      final BrokerClient brokerClient, final PhysicalTenantIds physicalTenantIds) {
+    return new ClusterBrokerVersionMigrationStatusProvider(brokerClient, physicalTenantIds);
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExporterMigrationStatusProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExporterMigrationStatusProviderConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.admin.ClusterExporterMigrationStatusProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers the exporter {@link MigrationStatusProvider} for the upgrade-readiness endpoint,
+ * collected by {@link UpgradeReadinessEndpoint} alongside every other provider bean. {@link
+ * PhysicalTenantIds} is injected as the interface, not the concrete {@code PhysicalTenantResolver}
+ * that implements it, so {@code zeebe/gateway} doesn't depend on the {@code configuration} module.
+ */
+@Configuration(proxyBeanMethods = false)
+public class ExporterMigrationStatusProviderConfiguration {
+
+  @Bean
+  public MigrationStatusProvider exporterMigrationStatusProvider(
+      final BrokerClient brokerClient, final PhysicalTenantIds physicalTenantIds) {
+    return new ClusterExporterMigrationStatusProvider(brokerClient, physicalTenantIds);
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/MigrationStatusAggregator.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/MigrationStatusAggregator.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,9 +43,17 @@ public class MigrationStatusAggregator {
         providers.stream().map(MigrationStatusProvider::conditionName).toList();
     final var physicalTenants = new LinkedHashMap<String, Map<String, MigrationConditionStatus>>();
 
-    for (final var provider : providers) {
-      final var conditionName = provider.conditionName();
-      final var freshStatuses = safeGetMigrationStatus(provider);
+    // Poll every provider concurrently rather than one at a time, so a slow provider doesn't add
+    // its own timeout on top of every other provider's.
+    final var pendingStatusesByProvider =
+        providers.stream()
+            .map(provider -> CompletableFuture.supplyAsync(() -> safeGetMigrationStatus(provider)))
+            .toList();
+    CompletableFuture.allOf(pendingStatusesByProvider.toArray(CompletableFuture<?>[]::new)).join();
+
+    for (int i = 0; i < providers.size(); i++) {
+      final var conditionName = providers.get(i).conditionName();
+      final var freshStatuses = pendingStatusesByProvider.get(i).join();
       knownPhysicalTenantIds.addAll(freshStatuses.keySet());
       freshStatuses.forEach(
           (physicalTenantId, status) -> {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/MigrationStatusAggregator.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/MigrationStatusAggregator.java
@@ -22,16 +22,12 @@ import org.slf4j.LoggerFactory;
 /**
  * Collects every registered {@link MigrationStatusProvider} and combines their per-physical-tenant
  * statuses into an {@link UpgradeReadinessResponse}.
- *
- * <p>Keeps the last confirmed {@code MIGRATED} status per (physical tenant, condition) pair.
  */
 public class MigrationStatusAggregator {
 
   private static final Logger LOG = LoggerFactory.getLogger(MigrationStatusAggregator.class);
 
   private final List<MigrationStatusProvider> providers;
-  private final Map<TenantCondition, MigrationConditionStatus> lastConfirmedMigrated =
-      new ConcurrentHashMap<>();
   private final Set<String> knownPhysicalTenantIds = ConcurrentHashMap.newKeySet();
 
   public MigrationStatusAggregator(final List<MigrationStatusProvider> providers) {
@@ -56,12 +52,10 @@ public class MigrationStatusAggregator {
       final var freshStatuses = pendingStatusesByProvider.get(i).join();
       knownPhysicalTenantIds.addAll(freshStatuses.keySet());
       freshStatuses.forEach(
-          (physicalTenantId, status) -> {
-            final var resolved = resolveWithCache(physicalTenantId, conditionName, status);
-            physicalTenants
-                .computeIfAbsent(physicalTenantId, ignored -> new LinkedHashMap<>())
-                .put(conditionName, resolved);
-          });
+          (physicalTenantId, status) ->
+              physicalTenants
+                  .computeIfAbsent(physicalTenantId, ignored -> new LinkedHashMap<>())
+                  .put(conditionName, status));
     }
 
     backfillMissingPairs(physicalTenants, conditionNames);
@@ -90,25 +84,10 @@ public class MigrationStatusAggregator {
     }
   }
 
-  private MigrationConditionStatus resolveWithCache(
-      final String physicalTenantId,
-      final String conditionName,
-      final MigrationConditionStatus fresh) {
-    final var key = new TenantCondition(physicalTenantId, conditionName);
-    if (fresh.state() == MigrationState.MIGRATED) {
-      lastConfirmedMigrated.put(key, fresh);
-      return fresh;
-    }
-    final var cached = lastConfirmedMigrated.get(key);
-    return cached != null ? cached : fresh;
-  }
-
   /**
    * Fills in every (known physical tenant, registered condition) pair this poll did not freshly
    * report — whether because a whole provider call failed, or because that provider simply did not
-   * report that tenant this cycle. A pair once confirmed {@code MIGRATED} is restored from the
-   * cache rather than defaulting to {@code UNKNOWN}, preserving the same monotonicity guarantee as
-   * a fresh, successful lookup would.
+   * report that tenant this cycle — with {@code UNKNOWN}.
    */
   private void backfillMissingPairs(
       final Map<String, Map<String, MigrationConditionStatus>> physicalTenants,
@@ -119,17 +98,10 @@ public class MigrationStatusAggregator {
       for (final var conditionName : conditionNames) {
         conditions.computeIfAbsent(
             conditionName,
-            ignored -> {
-              final var cached =
-                  lastConfirmedMigrated.get(new TenantCondition(physicalTenantId, conditionName));
-              return cached != null
-                  ? cached
-                  : new MigrationConditionStatus(
-                      MigrationState.UNKNOWN, "no status reported for this poll");
-            });
+            ignored ->
+                new MigrationConditionStatus(
+                    MigrationState.UNKNOWN, "no status reported for this poll"));
       }
     }
   }
-
-  private record TenantCondition(String physicalTenantId, String conditionName) {}
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/MigrationStatusAggregatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/MigrationStatusAggregatorTest.java
@@ -14,9 +14,29 @@ import io.camunda.cluster.migration.MigrationState;
 import io.camunda.cluster.migration.MigrationStatusProvider;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 final class MigrationStatusAggregatorTest {
+
+  @Test
+  void shouldPollEveryProviderConcurrentlyRatherThanOneAtATime() {
+    // given - two slow providers, each blocking until the other has started
+    final var firstStarted = new CountDownLatch(1);
+    final var secondStarted = new CountDownLatch(1);
+    final var aggregator =
+        new MigrationStatusAggregator(
+            List.of(
+                blockingProvider("a", firstStarted, secondStarted),
+                blockingProvider("b", secondStarted, firstStarted)));
+
+    // when
+    final var response = aggregator.aggregate();
+
+    // then - both providers reported their status, so neither call was left waiting forever
+    assertThat(response.physicalTenants().get("default")).hasSize(2);
+  }
 
   @Test
   void shouldReportNotUpgradeableWhenNoProviderIsRegistered() {
@@ -162,6 +182,37 @@ final class MigrationStatusAggregatorTest {
 
   private static MigrationConditionStatus inProgress(final String detail) {
     return new MigrationConditionStatus(MigrationState.MIGRATION_IN_PROGRESS, detail);
+  }
+
+  /**
+   * A provider whose {@code getMigrationStatus()} signals {@code ownStart}, then blocks until
+   * {@code otherStart} is also signalled -- used in pairs to prove two providers' calls actually
+   * overlap, rather than the second one only starting once the first has already returned.
+   */
+  private static MigrationStatusProvider blockingProvider(
+      final String name, final CountDownLatch ownStart, final CountDownLatch otherStart) {
+    return new MigrationStatusProvider() {
+      @Override
+      public String conditionName() {
+        return name;
+      }
+
+      @Override
+      public Map<String, MigrationConditionStatus> getMigrationStatus() {
+        ownStart.countDown();
+        try {
+          if (!otherStart.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError(
+                "the other provider never started -- aggregate() is not polling providers"
+                    + " concurrently");
+          }
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(e);
+        }
+        return Map.of("default", migrated(name + " done"));
+      }
+    };
   }
 
   private static MigrationStatusProvider provider(

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/MigrationStatusAggregatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/MigrationStatusAggregatorTest.java
@@ -144,25 +144,26 @@ final class MigrationStatusAggregatorTest {
   }
 
   @Test
-  void shouldNeverRegressAConfirmedMigratedConditionWhenAProviderThrowsOnALaterPoll() {
+  void shouldReportUnknownOnANewPollWhenAPreviouslyMigratedProviderStartsThrowing() {
     // given - a provider that reports MIGRATED once, then throws entirely afterwards (e.g. a
     // later distributed fan-out breaking)
     final var flakyProvider = new FlakyProvider("a", migrated("done"));
     final var aggregator = new MigrationStatusAggregator(List.of(flakyProvider));
 
-    // when - first poll confirms MIGRATED, second poll would otherwise lose the entry entirely
+    // when - first poll confirms MIGRATED, second poll's provider call fails entirely
     final var firstResponse = aggregator.aggregate();
     final var secondResponse = aggregator.aggregate();
 
-    // then - monotonicity is preserved via the backfill, even under total provider failure
+    // then - each poll reflects only what it itself observed; a failure is reported as UNKNOWN
+    // rather than silently reusing the earlier MIGRATED result, since that could go stale
     assertThat(firstResponse.physicalTenants().get("default").get("a").state())
         .isEqualTo(MigrationState.MIGRATED);
     assertThat(secondResponse.physicalTenants().get("default").get("a").state())
-        .isEqualTo(MigrationState.MIGRATED);
+        .isEqualTo(MigrationState.UNKNOWN);
   }
 
   @Test
-  void shouldNotCacheANonMigratedStatus() {
+  void shouldReportUnknownOnANewPollWhenAProviderStopsRespondingAfterANonMigratedStatus() {
     // given - a provider that never reaches MIGRATED, then throws
     final var flakyProvider = new FlakyProvider("a", inProgress("not yet"));
     final var aggregator = new MigrationStatusAggregator(List.of(flakyProvider));
@@ -171,7 +172,7 @@ final class MigrationStatusAggregatorTest {
     aggregator.aggregate();
     final var secondResponse = aggregator.aggregate();
 
-    // then - nothing was ever confirmed MIGRATED, so the backfill falls back to UNKNOWN
+    // then - nothing from the first poll carries over; the backfill defaults to UNKNOWN
     assertThat(secondResponse.physicalTenants().get("default").get("a").state())
         .isEqualTo(MigrationState.UNKNOWN);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -906,9 +906,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   /**
-   * Peeks the version of the first not-yet-exported record, using its own throwaway reader
-   * instead of the {@link #logStreamReader} field the main export loop owns, since that one's
-   * cursor is actively advancing and isn't available at all in passive mode.
+   * Peeks the version of the first not-yet-exported record, using its own throwaway reader instead
+   * of the {@link #logStreamReader} field the main export loop owns, since that one's cursor is
+   * actively advancing and isn't available at all in passive mode.
    *
    * @return {@code null} if every record up to the log head has already been exported
    */

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -96,6 +96,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private final String clusterId;
   private final ExporterMode exporterMode;
   private final Duration distributionInterval;
+  private final int migrationStatusScanMaxRecords;
   private ExporterStateDistributionService exporterDistributionService;
   private ScheduledTimer exporterDistributionTimer;
   private final PartitionId partitionId;
@@ -160,6 +161,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
     exporterMode = context.getExporterMode();
     distributionInterval = context.getDistributionInterval();
+    migrationStatusScanMaxRecords = context.getMigrationStatusScanMaxRecords();
     positionsToSkipFilter = context.getPositionsToSkipFilter();
 
     // needs name to be initialized
@@ -854,11 +856,12 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   /**
    * Gathers the two already-durable facts {@link ExportingMigrationStatusCalculator} needs, reading
-   * the lowest exported position and peeking the next unexported record's version within a single,
-   * uninterrupted actor job so a compaction pass can't invalidate the position in between. Reports
-   * a failure to read either fact as {@link MigrationStatusCode#UNKNOWN} rather than letting the
-   * exception reach {@link #handleFailure(Throwable)} -- this is a best-effort diagnostic read for
-   * an actuator endpoint, and must not be able to take down the exporter actor itself.
+   * the lowest exported position and scanning the not-yet-exported records' versions within a
+   * single, uninterrupted actor job so a compaction pass can't invalidate the position in between.
+   * Reports a failure to read either fact as {@link MigrationStatusCode#UNKNOWN} rather than
+   * letting the exception reach {@link #handleFailure(Throwable)} -- this is a best-effort
+   * diagnostic read for an actuator endpoint, and must not be able to take down the exporter actor
+   * itself.
    */
   private PartitionMigrationStatus computeExportingMigrationStatus() {
     try {
@@ -868,11 +871,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       }
 
       final long lowestExportedPosition = state.getLowestPosition();
-      final String nextUnexportedRecordVersion =
-          peekNextUnexportedRecordVersion(lowestExportedPosition);
-      final var status =
-          ExportingMigrationStatusCalculator.compute(
-              partitionId.number(), true, nextUnexportedRecordVersion);
+      final var status = scanUnexportedRecordsForPreviousVersion(lowestExportedPosition);
       return explainIfPaused(status);
     } catch (final Exception e) {
       LOG.warn(
@@ -906,24 +905,42 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   /**
-   * Peeks the version of the first not-yet-exported record, using its own throwaway reader instead
-   * of the {@link #logStreamReader} field the main export loop owns, since that one's cursor is
-   * actively advancing and isn't available at all in passive mode.
+   * Scans not-yet-exported records after {@code lowestExportedPosition}, looking for one stamped
+   * with a previous application version. Stops the moment it finds a non-current-version record --
+   * already conclusive -- or reaches the log head, having verified every pending record.
    *
    * @return {@code null} if every record up to the log head has already been exported
    */
-  private @Nullable String peekNextUnexportedRecordVersion(final long lowestExportedPosition) {
+  private PartitionMigrationStatus scanUnexportedRecordsForPreviousVersion(
+      final long lowestExportedPosition) {
     try (final LogStreamReader reader = logStream.newLogStreamReader()) {
       if (!reader.seekToNextEvent(lowestExportedPosition)) {
         throw new IllegalStateException(
             "expected to find an event at or after position " + lowestExportedPosition);
       }
-      if (!reader.hasNext()) {
-        return null;
-      }
       final var metadata = new RecordMetadata();
-      reader.peekNext().readMetadata(metadata);
-      return metadata.getBrokerVersion().toString();
+      int scanned = 0;
+      while (reader.hasNext()) {
+        if (scanned >= migrationStatusScanMaxRecords) {
+          return new PartitionMigrationStatus(
+              MigrationStatusCode.UNKNOWN,
+              "partition "
+                  + partitionId.number()
+                  + ": more than "
+                  + migrationStatusScanMaxRecords
+                  + " unexported records pending, cannot verify all of them are on the current"
+                  + " version");
+        }
+        reader.next().readMetadata(metadata);
+        scanned++;
+        final var status =
+            ExportingMigrationStatusCalculator.compute(
+                partitionId.number(), true, metadata.getBrokerVersion().toString());
+        if (status.code() != MigrationStatusCode.MIGRATED) {
+          return status;
+        }
+      }
+      return ExportingMigrationStatusCalculator.compute(partitionId.number(), true, null);
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -868,17 +868,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       }
 
       final long lowestExportedPosition = state.getLowestPosition();
-      final String nextUnexportedRecordVersion;
-      try (final LogStreamReader reader = logStream.newLogStreamReader()) {
-        reader.seekToNextEvent(lowestExportedPosition);
-        if (reader.hasNext()) {
-          final var metadata = new RecordMetadata();
-          reader.peekNext().readMetadata(metadata);
-          nextUnexportedRecordVersion = metadata.getBrokerVersion().toString();
-        } else {
-          nextUnexportedRecordVersion = null;
-        }
-      }
+      final String nextUnexportedRecordVersion =
+          peekNextUnexportedRecordVersion(lowestExportedPosition);
       final var status =
           ExportingMigrationStatusCalculator.compute(
               partitionId.number(), true, nextUnexportedRecordVersion);
@@ -912,6 +903,28 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     return new PartitionMigrationStatus(
         MigrationStatusCode.MIGRATION_IN_PROGRESS,
         status.detail() + "; exporting is " + exporterPhase + ", resume it to continue");
+  }
+
+  /**
+   * Peeks the version of the first not-yet-exported record, using its own throwaway reader
+   * instead of the {@link #logStreamReader} field the main export loop owns, since that one's
+   * cursor is actively advancing and isn't available at all in passive mode.
+   *
+   * @return {@code null} if every record up to the log head has already been exported
+   */
+  private @Nullable String peekNextUnexportedRecordVersion(final long lowestExportedPosition) {
+    try (final LogStreamReader reader = logStream.newLogStreamReader()) {
+      if (!reader.seekToNextEvent(lowestExportedPosition)) {
+        throw new IllegalStateException(
+            "expected to find an event at or after position " + lowestExportedPosition);
+      }
+      if (!reader.hasNext()) {
+        return null;
+      }
+      final var metadata = new RecordMetadata();
+      reader.peekNext().readMetadata(metadata);
+      return metadata.getBrokerVersion().toString();
+    }
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -855,30 +855,44 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   /**
    * Gathers the two already-durable facts {@link ExportingMigrationStatusCalculator} needs, reading
    * the lowest exported position and peeking the next unexported record's version within a single,
-   * uninterrupted actor job so a compaction pass can't invalidate the position in between.
+   * uninterrupted actor job so a compaction pass can't invalidate the position in between. Reports
+   * a failure to read either fact as {@link MigrationStatusCode#UNKNOWN} rather than letting the
+   * exception reach {@link #handleFailure(Throwable)} -- this is a best-effort diagnostic read for
+   * an actuator endpoint, and must not be able to take down the exporter actor itself.
    */
   private PartitionMigrationStatus computeExportingMigrationStatus() {
-    final var hasExporters = state.hasExporters();
-    if (!hasExporters) {
-      return ExportingMigrationStatusCalculator.compute(partitionId.number(), false, null);
-    }
-
-    final long lowestExportedPosition = state.getLowestPosition();
-    final String nextUnexportedRecordVersion;
-    try (final LogStreamReader reader = logStream.newLogStreamReader()) {
-      reader.seekToNextEvent(lowestExportedPosition);
-      if (reader.hasNext()) {
-        final var metadata = new RecordMetadata();
-        reader.peekNext().readMetadata(metadata);
-        nextUnexportedRecordVersion = metadata.getBrokerVersion().toString();
-      } else {
-        nextUnexportedRecordVersion = null;
+    try {
+      final var hasExporters = state.hasExporters();
+      if (!hasExporters) {
+        return ExportingMigrationStatusCalculator.compute(partitionId.number(), false, null);
       }
+
+      final long lowestExportedPosition = state.getLowestPosition();
+      final String nextUnexportedRecordVersion;
+      try (final LogStreamReader reader = logStream.newLogStreamReader()) {
+        reader.seekToNextEvent(lowestExportedPosition);
+        if (reader.hasNext()) {
+          final var metadata = new RecordMetadata();
+          reader.peekNext().readMetadata(metadata);
+          nextUnexportedRecordVersion = metadata.getBrokerVersion().toString();
+        } else {
+          nextUnexportedRecordVersion = null;
+        }
+      }
+      final var status =
+          ExportingMigrationStatusCalculator.compute(
+              partitionId.number(), true, nextUnexportedRecordVersion);
+      return explainIfPaused(status);
+    } catch (final Exception e) {
+      LOG.warn(
+          "Failed to determine partition {}'s exporting migration status", partitionId.number(), e);
+      return new PartitionMigrationStatus(
+          MigrationStatusCode.UNKNOWN,
+          "partition "
+              + partitionId.number()
+              + ": failed to read exporting migration status: "
+              + e.getMessage());
     }
-    final var status =
-        ExportingMigrationStatusCalculator.compute(
-            partitionId.number(), true, nextUnexportedRecordVersion);
-    return explainIfPaused(status);
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -18,7 +18,10 @@ import io.camunda.zeebe.logstreams.log.LogRecordAwaiter;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
 import io.camunda.zeebe.protocol.impl.encoding.RecordMetadataBlock;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -833,6 +836,47 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       return CompletableActorFuture.completed(ExportersState.VALUE_NOT_FOUND);
     }
     return actor.call(() -> state.getLowestPosition());
+  }
+
+  /**
+   * Whether every exporter on this replica has finished exporting and acknowledging every record
+   * written under a previous application version, for the upgrade-readiness endpoint.
+   */
+  public ActorFuture<PartitionMigrationStatus> getExportingMigrationStatus() {
+    if (actor.isClosed()) {
+      return CompletableActorFuture.completed(
+          new PartitionMigrationStatus(
+              MigrationStatusCode.UNKNOWN,
+              "partition " + partitionId.number() + ": exporter director is closed"));
+    }
+    return actor.call(this::computeExportingMigrationStatus);
+  }
+
+  /**
+   * Gathers the two already-durable facts {@link ExportingMigrationStatusCalculator} needs, reading
+   * the lowest exported position and peeking the next unexported record's version within a single,
+   * uninterrupted actor job so a compaction pass can't invalidate the position in between.
+   */
+  private PartitionMigrationStatus computeExportingMigrationStatus() {
+    final var hasExporters = state.hasExporters();
+    if (!hasExporters) {
+      return ExportingMigrationStatusCalculator.compute(partitionId.number(), false, null);
+    }
+
+    final long lowestExportedPosition = state.getLowestPosition();
+    final String nextUnexportedRecordVersion;
+    try (final LogStreamReader reader = logStream.newLogStreamReader()) {
+      reader.seekToNextEvent(lowestExportedPosition);
+      if (reader.hasNext()) {
+        final var metadata = new RecordMetadata();
+        reader.peekNext().readMetadata(metadata);
+        nextUnexportedRecordVersion = metadata.getBrokerVersion().toString();
+      } else {
+        nextUnexportedRecordVersion = null;
+      }
+    }
+    return ExportingMigrationStatusCalculator.compute(
+        partitionId.number(), true, nextUnexportedRecordVersion);
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -875,8 +875,29 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         nextUnexportedRecordVersion = null;
       }
     }
-    return ExportingMigrationStatusCalculator.compute(
-        partitionId.number(), true, nextUnexportedRecordVersion);
+    final var status =
+        ExportingMigrationStatusCalculator.compute(
+            partitionId.number(), true, nextUnexportedRecordVersion);
+    return explainIfPaused(status);
+  }
+
+  /**
+   * Names a pause as the reason exporting hasn't caught up yet, since the operator's fix for that
+   * ({@code resume exporting}) is different from the fix for a genuine backlog. Left as-is for
+   * MIGRATED/UNKNOWN -- the peek that produced {@code status} already reflects the log's true
+   * content regardless of pause, so a pause never turns an otherwise-safe MIGRATED into something
+   * unsafe, and only naming it when the result is MIGRATION_IN_PROGRESS avoids reporting "not
+   * ready" for a pause that isn't actually blocking anything (e.g. nothing written since is on an
+   * old version).
+   */
+  private PartitionMigrationStatus explainIfPaused(final PartitionMigrationStatus status) {
+    if (status.code() != MigrationStatusCode.MIGRATION_IN_PROGRESS
+        || (exporterPhase != ExporterPhase.PAUSED && exporterPhase != ExporterPhase.SOFT_PAUSED)) {
+      return status;
+    }
+    return new PartitionMigrationStatus(
+        MigrationStatusCode.MIGRATION_IN_PROGRESS,
+        status.detail() + "; exporting is " + exporterPhase + ", resume it to continue");
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 public final class ExporterDirectorContext {
 
   public static final Duration DEFAULT_DISTRIBUTION_INTERVAL = Duration.ofSeconds(15);
+  public static final int DEFAULT_MIGRATION_STATUS_SCAN_MAX_RECORDS = 100_000;
 
   private int id;
   private PartitionId partitionId;
@@ -32,6 +33,7 @@ public final class ExporterDirectorContext {
   private PartitionMessagingService partitionMessagingService;
   private ExporterMode exporterMode = ExporterMode.ACTIVE; // per default we export records
   private Duration distributionInterval = DEFAULT_DISTRIBUTION_INTERVAL;
+  private int migrationStatusScanMaxRecords = DEFAULT_MIGRATION_STATUS_SCAN_MAX_RECORDS;
   private EventFilter positionsToSkipFilter;
   private MeterRegistry meterRegistry;
   private InstantSource clock;
@@ -66,6 +68,10 @@ public final class ExporterDirectorContext {
 
   public Duration getDistributionInterval() {
     return distributionInterval;
+  }
+
+  public int getMigrationStatusScanMaxRecords() {
+    return migrationStatusScanMaxRecords;
   }
 
   public EventFilter getPositionsToSkipFilter() {
@@ -135,6 +141,12 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext distributionInterval(final Duration distributionInterval) {
     this.distributionInterval = distributionInterval;
+    return this;
+  }
+
+  public ExporterDirectorContext migrationStatusScanMaxRecords(
+      final int migrationStatusScanMaxRecords) {
+    this.migrationStatusScanMaxRecords = migrationStatusScanMaxRecords;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportingMigrationStatusCalculator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportingMigrationStatusCalculator.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
+import io.camunda.zeebe.util.SemanticVersion;
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Computes whether every exporter on a partition has finished exporting and acknowledging every
+ * record written under a previous application version, for the upgrade-readiness endpoint. Only the
+ * minor version boundary matters: a patch-only difference, in either direction, is treated as
+ * {@code MIGRATED} since a patch release never changes the record format, while a minor-version gap
+ * means a real backlog is still in progress; the running version's pre-release suffix, if any, is
+ * stripped before comparing so a non-release build doesn't look incompatible with itself.
+ */
+final class ExportingMigrationStatusCalculator {
+
+  private ExportingMigrationStatusCalculator() {}
+
+  /**
+   * @param nextUnexportedRecordVersion the {@code brokerVersion} of the next record still waiting
+   *     to be exported, or {@code null} if every exporter is caught up to the log head
+   */
+  static PartitionMigrationStatus compute(
+      final int partitionId,
+      final boolean hasExporters,
+      final @Nullable String nextUnexportedRecordVersion) {
+    return compute(
+        partitionId, hasExporters, nextUnexportedRecordVersion, VersionUtil.getVersion());
+  }
+
+  /**
+   * @param currentVersion the version to compare {@code nextUnexportedRecordVersion} against,
+   *     exposed so tests can exercise every outcome deterministically.
+   */
+  @VisibleForTesting
+  static PartitionMigrationStatus compute(
+      final int partitionId,
+      final boolean hasExporters,
+      final @Nullable String nextUnexportedRecordVersion,
+      final String currentVersion) {
+    if (!hasExporters) {
+      return migrated(partitionId, "no exporters configured");
+    }
+    if (nextUnexportedRecordVersion == null) {
+      return migrated(partitionId, "every exporter is caught up to the log head");
+    }
+
+    final var result =
+        VersionCompatibilityCheck.check(
+            nextUnexportedRecordVersion, withoutPreReleaseSuffix(currentVersion));
+    return switch (result) {
+      case Compatible.SameVersion same ->
+          migrated(
+              partitionId,
+              "next unexported record is already on " + same.version().toMinorVersionString());
+      case Compatible.PatchUpgrade patch ->
+          migrated(
+              partitionId,
+              "next unexported record is already on " + patch.from().toMinorVersionString());
+      case Incompatible.PatchDowngrade patch ->
+          migrated(
+              partitionId,
+              "next unexported record is already on " + patch.from().toMinorVersionString());
+      case Compatible.MinorUpgrade minor ->
+          new PartitionMigrationStatus(
+              MigrationStatusCode.MIGRATION_IN_PROGRESS,
+              "partition "
+                  + partitionId
+                  + ": next unexported record is on "
+                  + minor.from().toMinorVersionString()
+                  + ", not yet caught up to "
+                  + minor.to().toMinorVersionString());
+      case Incompatible incompatible ->
+          unknown(
+              partitionId, "incompatible version path for next unexported record: " + incompatible);
+      case Indeterminate indeterminate ->
+          unknown(
+              partitionId,
+              "cannot determine version compatibility for next unexported record: "
+                  + indeterminate);
+    };
+  }
+
+  private static PartitionMigrationStatus migrated(final int partitionId, final String detail) {
+    return new PartitionMigrationStatus(
+        MigrationStatusCode.MIGRATED, "partition " + partitionId + ": " + detail);
+  }
+
+  private static PartitionMigrationStatus unknown(final int partitionId, final String detail) {
+    return new PartitionMigrationStatus(
+        MigrationStatusCode.UNKNOWN, "partition " + partitionId + ": " + detail);
+  }
+
+  /**
+   * @return {@code version} stripped of any pre-release/build-metadata suffix (e.g. {@code
+   *     8.10.0-SNAPSHOT} → {@code 8.10.0}), or the raw input if it can't be parsed.
+   */
+  private static String withoutPreReleaseSuffix(final String version) {
+    return SemanticVersion.parse(version)
+        .map(sv -> sv.major() + "." + sv.minor() + "." + sv.patch())
+        .orElse(version);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportingMigrationStatusCalculator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportingMigrationStatusCalculator.java
@@ -61,7 +61,7 @@ final class ExportingMigrationStatusCalculator {
 
     final var result =
         VersionCompatibilityCheck.check(
-            nextUnexportedRecordVersion, withoutPreReleaseSuffix(currentVersion));
+            nextUnexportedRecordVersion, SemanticVersion.withoutPreReleaseSuffix(currentVersion));
     return switch (result) {
       case Compatible.SameVersion same ->
           migrated(
@@ -103,15 +103,5 @@ final class ExportingMigrationStatusCalculator {
   private static PartitionMigrationStatus unknown(final int partitionId, final String detail) {
     return new PartitionMigrationStatus(
         MigrationStatusCode.UNKNOWN, "partition " + partitionId + ": " + detail);
-  }
-
-  /**
-   * @return {@code version} stripped of any pre-release/build-metadata suffix (e.g. {@code
-   *     8.10.0-SNAPSHOT} → {@code 8.10.0}), or the raw input if it can't be parsed.
-   */
-  private static String withoutPreReleaseSuffix(final String version) {
-    return SemanticVersion.parse(version)
-        .map(sv -> sv.major() + "." + sv.minor() + "." + sv.patch())
-        .orElse(version);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -69,6 +69,13 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
         new PartitionMigrationStatus(MigrationStatusCode.UNKNOWN, "no-op partition admin access"));
   }
 
+  @Override
+  public ActorFuture<PartitionMigrationStatus> getExportingMigrationStatus() {
+    logCall();
+    return CompletableActorFuture.completed(
+        new PartitionMigrationStatus(MigrationStatusCode.UNKNOWN, "no-op partition admin access"));
+  }
+
   private void logCall() {
     LOG.warn("Received call on NoOp implementation of PartitionAdminAccess");
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -33,4 +33,10 @@ public interface PartitionAdminAccess {
    * snapshot capturing that migrated state has been taken, for the upgrade-readiness endpoint.
    */
   ActorFuture<PartitionMigrationStatus> getMigrationStatus();
+
+  /**
+   * Whether every exporter on this replica has finished exporting and acknowledging every record
+   * written under a previous application version, for the upgrade-readiness endpoint.
+   */
+  ActorFuture<PartitionMigrationStatus> getExportingMigrationStatus();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExportingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExportingCfg.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import static io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.DEFAULT_DISTRIBUTION_INTERVAL;
+import static io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.DEFAULT_MIGRATION_STATUS_SCAN_MAX_RECORDS;
 
 import java.time.Duration;
 import java.util.Map;
@@ -20,16 +21,22 @@ import java.util.Set;
  * <p><b> Backwards compatibility with the legacy `zeebe.broker.exporting.skip-records` is broken
  * deliberately as this configuration should only be used for recovery purposes</b>
  */
-public record ExportingCfg(Map<Integer, Set<Long>> skipRecords, Duration distributionInterval) {
+public record ExportingCfg(
+    Map<Integer, Set<Long>> skipRecords,
+    Duration distributionInterval,
+    int migrationStatusScanMaxRecords) {
 
   public ExportingCfg(
-      final Map<Integer, Set<Long>> skipRecords, final Duration distributionInterval) {
+      final Map<Integer, Set<Long>> skipRecords,
+      final Duration distributionInterval,
+      final int migrationStatusScanMaxRecords) {
     this.skipRecords = skipRecords == null ? Map.of() : skipRecords;
     this.distributionInterval =
         distributionInterval == null ? DEFAULT_DISTRIBUTION_INTERVAL : distributionInterval;
+    this.migrationStatusScanMaxRecords = migrationStatusScanMaxRecords;
   }
 
   public static ExportingCfg defaultExportingCfg() {
-    return new ExportingCfg(null, null);
+    return new ExportingCfg(null, null, DEFAULT_MIGRATION_STATUS_SCAN_MAX_RECORDS);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
+import org.jspecify.annotations.Nullable;
 
 public interface PartitionAdminControl {
   StreamProcessor getStreamProcessor();
@@ -18,6 +20,13 @@ public interface PartitionAdminControl {
   ZeebeDb getZeebeDb();
 
   LogStream getLogStream();
+
+  /**
+   * The live exporter director on this replica, or {@code null} if it isn't open yet -- needed to
+   * read exporting-migration status directly from the running director (see {@link
+   * ZeebePartitionAdminAccess#getExportingMigrationStatus()}).
+   */
+  @Nullable ExporterDirector getExporterDirector();
 
   void triggerSnapshot();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -14,10 +15,12 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 
 public class PartitionAdminControlImpl implements PartitionAdminControl {
 
   private final Supplier<StreamProcessor> streamProcessorSupplier;
+  private final Supplier<@Nullable ExporterDirector> exporterDirectorSupplier;
   private final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier;
   private final Supplier<PartitionProcessingState> partitionProcessingStateSupplier;
   private final Supplier<ZeebeDb> zeebeDbSupplier;
@@ -26,12 +29,14 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
 
   public PartitionAdminControlImpl(
       final Supplier<StreamProcessor> streamProcessorSupplier,
+      final Supplier<@Nullable ExporterDirector> exporterDirectorSupplier,
       final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier,
       final Supplier<PartitionProcessingState> partitionProcessingStateSupplier,
       final Supplier<ZeebeDb> zeebeDbSupplier,
       final Supplier<LogStream> logStreamSupplier,
       final Supplier<Boolean> migrationSnapshotTakenSupplier) {
     this.streamProcessorSupplier = streamProcessorSupplier;
+    this.exporterDirectorSupplier = exporterDirectorSupplier;
     this.snapshotDirectorSupplier = snapshotDirectorSupplier;
     this.partitionProcessingStateSupplier = partitionProcessingStateSupplier;
     this.zeebeDbSupplier = zeebeDbSupplier;
@@ -52,6 +57,11 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public LogStream getLogStream() {
     return logStreamSupplier.get();
+  }
+
+  @Override
+  public @Nullable ExporterDirector getExporterDirector() {
+    return exporterDirectorSupplier.get();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -179,6 +179,7 @@ public class PartitionStartupAndTransitionContextImpl
   public PartitionAdminControl getPartitionAdminControl() {
     return new PartitionAdminControlImpl(
         () -> getPartitionContext().getStreamProcessor(),
+        () -> getPartitionContext().getExporterDirector(),
         () -> snapshotDirector,
         () -> partitionProcessingState,
         () -> zeebeDb,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -226,18 +226,32 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
 
     concurrencyControl.run(
         () -> {
-          final var exporterDirector = adminControl.getExporterDirector();
-          if (exporterDirector == null) {
+          try {
+            final var exporterDirector = adminControl.getExporterDirector();
+            if (exporterDirector == null) {
+              future.complete(
+                  new PartitionMigrationStatus(
+                      MigrationStatusCode.UNKNOWN,
+                      "partition "
+                          + partitionId
+                          + ": no exporter director running on this replica"
+                          + " yet"));
+              return;
+            }
+            exporterDirector.getExportingMigrationStatus().onComplete(future);
+          } catch (final Exception e) {
+            LOG.error(
+                "Failed to determine the exporting migration status of partition {}",
+                partitionId,
+                e);
             future.complete(
                 new PartitionMigrationStatus(
                     MigrationStatusCode.UNKNOWN,
                     "partition "
                         + partitionId
-                        + ": no exporter director running on this replica"
-                        + " yet"));
-            return;
+                        + ": failed to read exporting migration status: "
+                        + e.getMessage()));
           }
-          exporterDirector.getExportingMigrationStatus().onComplete(future);
         });
 
     return future;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -220,6 +220,29 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
     return future;
   }
 
+  @Override
+  public ActorFuture<PartitionMigrationStatus> getExportingMigrationStatus() {
+    final ActorFuture<PartitionMigrationStatus> future = concurrencyControl.createFuture();
+
+    concurrencyControl.run(
+        () -> {
+          final var exporterDirector = adminControl.getExporterDirector();
+          if (exporterDirector == null) {
+            future.complete(
+                new PartitionMigrationStatus(
+                    MigrationStatusCode.UNKNOWN,
+                    "partition "
+                        + partitionId
+                        + ": no exporter director running on this replica"
+                        + " yet"));
+            return;
+          }
+          exporterDirector.getExportingMigrationStatus().onComplete(future);
+        });
+
+    return future;
+  }
+
   /**
    * Reads {@code DbMigrationState.getMigratedByVersion()} through a second transaction on the
    * already-open, live {@code ZeebeDb}, without disturbing the stream processor's own state — the

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -125,6 +125,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .logStream(context.getLogStream())
             .zeebeDb(context.getZeebeDb())
             .distributionInterval(exportingCfg.distributionInterval())
+            .migrationStatusScanMaxRecords(exportingCfg.migrationStatusScanMaxRecords())
             .partitionMessagingService(context.getMessagingService())
             .descriptors(exporterDescriptors)
             .exporterMode(exporterMode)

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.Either;
 import java.io.IOException;
+import java.util.function.Function;
 
 public class AdminApiRequestHandler
     extends AsyncApiRequestHandler<ApiRequestReader, ApiResponseWriter> {
@@ -78,6 +79,8 @@ public class AdminApiRequestHandler
       case GET_FLOW_CONTROL -> getFlowControl(responseWriter, errorWriter);
       case SET_FLOW_CONTROL -> setFlowControl(requestReader, responseWriter, errorWriter);
       case GET_MIGRATION_STATUS -> getMigrationStatus(responseWriter, partitionId, errorWriter);
+      case GET_EXPORTING_MIGRATION_STATUS ->
+          getExportingMigrationStatus(responseWriter, partitionId, errorWriter);
       default -> unknownRequest(errorWriter, requestReader.getMessageDecoder().type());
     };
   }
@@ -152,30 +155,63 @@ public class AdminApiRequestHandler
       final ApiResponseWriter responseWriter,
       final int partitionId,
       final ErrorResponseWriter errorWriter) {
+    return getStatusFromPartition(
+        responseWriter,
+        partitionId,
+        errorWriter,
+        "migration status",
+        PartitionAdminAccess::getMigrationStatus,
+        MigrationStatusPayload::encode);
+  }
+
+  private ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> getExportingMigrationStatus(
+      final ApiResponseWriter responseWriter,
+      final int partitionId,
+      final ErrorResponseWriter errorWriter) {
+    return getStatusFromPartition(
+        responseWriter,
+        partitionId,
+        errorWriter,
+        "exporting migration status",
+        PartitionAdminAccess::getExportingMigrationStatus,
+        MigrationStatusPayload::encode);
+  }
+
+  /**
+   * Shared shape for "read one status value off a single partition and encode it as the response's
+   * payload", used by every admin request that reports a per-partition status ({@code
+   * getMigrationStatus}, {@code getExportingMigrationStatus}) rather than performing a mutation.
+   */
+  private <T> ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> getStatusFromPartition(
+      final ApiResponseWriter responseWriter,
+      final int partitionId,
+      final ErrorResponseWriter errorWriter,
+      final String description,
+      final Function<PartitionAdminAccess, ActorFuture<T>> fetchStatus,
+      final Function<T, byte[]> encode) {
     final var partitionAdminAccess = adminAccess.forPartition(partitionId);
     if (partitionAdminAccess.isEmpty()) {
       return CompletableActorFuture.completed(
           Either.left(
               errorWriter.internalError(
-                  "Partition %s failed to report its migration status. Could not find the partition.",
-                  partitionId)));
+                  "Partition %s failed to report its %s. Could not find the partition.",
+                  partitionId, description)));
     }
 
     final ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> result = actor.createFuture();
-    partitionAdminAccess
-        .orElseThrow()
-        .getMigrationStatus()
+    fetchStatus
+        .apply(partitionAdminAccess.orElseThrow())
         .onComplete(
             (status, t) -> {
               if (t == null) {
-                responseWriter.setPayload(MigrationStatusPayload.encode(status));
+                responseWriter.setPayload(encode.apply(status));
                 result.complete(Either.right(responseWriter));
               } else {
-                LOG.error("Failed to get the migration status on partition {}", partitionId, t);
+                LOG.error("Failed to get the {} on partition {}", description, partitionId, t);
                 result.complete(
                     Either.left(
                         errorWriter.internalError(
-                            "Failed to get the migration status on partition %s", partitionId)));
+                            "Failed to get the %s on partition %s", description, partitionId)));
               }
             });
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -30,6 +30,8 @@ import io.camunda.zeebe.broker.exporter.util.PojoConfigurationExporter.PojoExpor
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -41,6 +43,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
+import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -1047,6 +1050,106 @@ public final class ExporterDirectorTest {
     assertThat(exporter0.getExportedRecords())
         .extracting(Record::getPosition)
         .containsExactly(eventPosition1, eventPosition2, eventPosition3);
+  }
+
+  @Test
+  public void shouldReportExportingMigratedWhenNoExportersConfigured() {
+    // given - no exporters registered at all
+    startExporterDirector(Collections.emptyList());
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  public void shouldReportExportingMigratedWhenEveryExporterIsCaughtUpToLogHead() {
+    // given - both exporters acknowledge the only record written
+    startExporterDirector(exporterDescriptors);
+    final long eventPosition = writeEvent();
+    waitUntil(() -> exporters.get(0).getExportedRecords().size() == 1);
+    waitUntil(() -> exporters.get(1).getExportedRecords().size() == 1);
+    exporters.get(0).getController().updateLastExportedRecordPosition(eventPosition);
+    exporters.get(1).getController().updateLastExportedRecordPosition(eventPosition);
+    Awaitility.await("both exporters' positions are durably persisted")
+        .untilAsserted(
+            () -> {
+              assertThat(rule.getExportersState().getPosition(EXPORTER_ID_1))
+                  .isEqualTo(eventPosition);
+              assertThat(rule.getExportersState().getPosition(EXPORTER_ID_2))
+                  .isEqualTo(eventPosition);
+            });
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then - nothing remains unexported at all, so trivially no old-version backlog either
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  public void shouldReportExportingMigratedWhenNextUnexportedRecordIsAlreadyOnTheCurrentVersion() {
+    // given - a record on the current version is written but never acknowledged by either
+    // exporter; only a PREVIOUS-version backlog counts, so this must still report MIGRATED
+    startExporterDirector(exporterDescriptors);
+    writeEvent();
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  public void
+      shouldReportExportingMigrationInProgressWhenNextUnexportedRecordIsOnAPreviousVersion() {
+    // given - a record stamped with the last supported backwards-compatible version is written
+    // and never acknowledged
+    startExporterDirector(exporterDescriptors);
+    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow();
+    rule.writeEventWithBrokerVersion(
+        DeploymentIntent.CREATED,
+        new DeploymentRecord(),
+        new VersionInfo(previousVersion.major(), previousVersion.minor(), previousVersion.patch()));
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  public void shouldReportExportingMigrationUnknownWhenNextUnexportedRecordVersionIsIncompatible() {
+    // given - a record stamped with a version far ahead of the one actually running (as if this
+    // broker had been downgraded), never acknowledged
+    startExporterDirector(exporterDescriptors);
+    rule.writeEventWithBrokerVersion(
+        DeploymentIntent.CREATED, new DeploymentRecord(), new VersionInfo(99, 0, 0));
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+  }
+
+  @Test
+  public void shouldReportExportingMigrationStatusInPassiveModeUsingItsOwnFreshReader() {
+    // given - passive mode never opens the shared, ACTIVE-only logStreamReader field; this must
+    // still answer correctly using its own throwaway reader over the same log
+    passiveExporterRule.startExporterDirector(exporterDescriptors);
+    passiveExporterRule.writeEventWithBrokerVersion(
+        DeploymentIntent.CREATED, new DeploymentRecord(), new VersionInfo(99, 0, 0));
+
+    // when
+    final var status = passiveExporterRule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
   }
 
   private long writeEvent() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -1136,6 +1136,57 @@ public final class ExporterDirectorTest {
   }
 
   @Test
+  public void
+      shouldReportExportingMigrationInProgressWhenAPreviousVersionRecordIsQueuedBehindACurrentVersionRecord() {
+    // given - the immediate next unexported record is already on the current version, but a
+    // second one further back in the backlog is on a previous version (e.g. from a briefly
+    // re-elected not-yet-upgraded broker); a single-record peek would have missed this entirely
+    startExporterDirector(exporterDescriptors);
+    writeEvent();
+    rule.writeEventWithBrokerVersion(
+        DeploymentIntent.CREATED, new DeploymentRecord(), oneMinorBehindTheCurrentVersion());
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  public void shouldReportUnknownWhenTheBacklogExceedsTheConfiguredScanLimit() {
+    // given - two unexported records, both on the current version, but the scan budget only
+    // allows looking at one of them -- we cannot honestly claim the rest is fine without looking
+    rule.withExporterDirectorContextConfigurator(
+        context -> context.migrationStatusScanMaxRecords(1));
+    startExporterDirector(exporterDescriptors);
+    writeEvent();
+    writeEvent();
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+    assertThat(status.detail()).contains("more than 1 unexported records pending");
+  }
+
+  @Test
+  public void shouldReportMigratedWhenScanLimitIsZeroButNothingIsPending() {
+    // given - a scan budget of zero must not itself cause UNKNOWN when there is truly nothing to
+    // scan; the log head must be checked before the budget is
+    rule.withExporterDirectorContextConfigurator(
+        context -> context.migrationStatusScanMaxRecords(0));
+    startExporterDirector(exporterDescriptors);
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
   public void shouldReportExportingMigrationInProgressWithDetailWhenSoftPausedAndBehind() {
     // given - soft-paused exporting keeps running but never persists its position, freezing a
     // genuine previous-version backlog behind it -- the operator needs to know pausing, not an

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -1138,6 +1138,63 @@ public final class ExporterDirectorTest {
   }
 
   @Test
+  public void shouldReportExportingMigrationInProgressWithDetailWhenSoftPausedAndBehind() {
+    // given - soft-paused exporting keeps running but never persists its position, freezing a
+    // genuine previous-version backlog behind it -- the operator needs to know pausing, not an
+    // ongoing migration, is what's actually blocking progress
+    startExporterDirector(exporterDescriptors);
+    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow();
+    rule.writeEventWithBrokerVersion(
+        DeploymentIntent.CREATED,
+        new DeploymentRecord(),
+        new VersionInfo(previousVersion.major(), previousVersion.minor(), previousVersion.patch()));
+    rule.getDirector().softPauseExporting().join();
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+    assertThat(status.detail()).contains("SOFT_PAUSED").contains("resume it");
+  }
+
+  @Test
+  public void shouldReportExportingMigrationInProgressWithDetailWhenHardPausedAndBehind() {
+    // given - hard-paused exporting stops the export loop outright, freezing the same kind of
+    // backlog behind it as soft-pausing does, for the same reason: the operator needs to know why
+    startExporterDirector(exporterDescriptors);
+    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow();
+    rule.writeEventWithBrokerVersion(
+        DeploymentIntent.CREATED,
+        new DeploymentRecord(),
+        new VersionInfo(previousVersion.major(), previousVersion.minor(), previousVersion.patch()));
+    rule.getDirector().pauseExporting().join();
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+    assertThat(status.detail()).contains("PAUSED").contains("resume it");
+  }
+
+  @Test
+  public void shouldReportMigratedWhenPausedButNothingIsBehind() {
+    // given - pausing alone doesn't create a previous-version backlog; the peek that decides
+    // MIGRATED still reflects the log's true content, so a pause with nothing actually behind must
+    // not be reported as blocking readiness
+    startExporterDirector(exporterDescriptors);
+    writeEvent();
+    rule.getDirector().softPauseExporting().join();
+
+    // when
+    final var status = rule.getDirector().getExportingMigrationStatus().join();
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
   public void shouldReportExportingMigrationStatusInPassiveModeUsingItsOwnFreshReader() {
     // given - passive mode never opens the shared, ACTIVE-only logStreamReader field; this must
     // still answer correctly using its own throwaway reader over the same log

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
+import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Duration;
@@ -1106,14 +1107,11 @@ public final class ExporterDirectorTest {
   @Test
   public void
       shouldReportExportingMigrationInProgressWhenNextUnexportedRecordIsOnAPreviousVersion() {
-    // given - a record stamped with the last supported backwards-compatible version is written
-    // and never acknowledged
+    // given - a record stamped with a version one minor behind the one actually running is
+    // written and never acknowledged
     startExporterDirector(exporterDescriptors);
-    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow();
     rule.writeEventWithBrokerVersion(
-        DeploymentIntent.CREATED,
-        new DeploymentRecord(),
-        new VersionInfo(previousVersion.major(), previousVersion.minor(), previousVersion.patch()));
+        DeploymentIntent.CREATED, new DeploymentRecord(), oneMinorBehindTheCurrentVersion());
 
     // when
     final var status = rule.getDirector().getExportingMigrationStatus().join();
@@ -1143,11 +1141,8 @@ public final class ExporterDirectorTest {
     // genuine previous-version backlog behind it -- the operator needs to know pausing, not an
     // ongoing migration, is what's actually blocking progress
     startExporterDirector(exporterDescriptors);
-    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow();
     rule.writeEventWithBrokerVersion(
-        DeploymentIntent.CREATED,
-        new DeploymentRecord(),
-        new VersionInfo(previousVersion.major(), previousVersion.minor(), previousVersion.patch()));
+        DeploymentIntent.CREATED, new DeploymentRecord(), oneMinorBehindTheCurrentVersion());
     rule.getDirector().softPauseExporting().join();
 
     // when
@@ -1163,11 +1158,8 @@ public final class ExporterDirectorTest {
     // given - hard-paused exporting stops the export loop outright, freezing the same kind of
     // backlog behind it as soft-pausing does, for the same reason: the operator needs to know why
     startExporterDirector(exporterDescriptors);
-    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow();
     rule.writeEventWithBrokerVersion(
-        DeploymentIntent.CREATED,
-        new DeploymentRecord(),
-        new VersionInfo(previousVersion.major(), previousVersion.minor(), previousVersion.patch()));
+        DeploymentIntent.CREATED, new DeploymentRecord(), oneMinorBehindTheCurrentVersion());
     rule.getDirector().pauseExporting().join();
 
     // when
@@ -1212,6 +1204,17 @@ public final class ExporterDirectorTest {
   private long writeEvent() {
     final DeploymentRecord event = new DeploymentRecord();
     return rule.writeEvent(DeploymentIntent.CREATED, event);
+  }
+
+  /**
+   * A version exactly one minor behind whatever is actually running -- {@link
+   * VersionUtil#getPreviousSemanticVersion()} is a separately-configured backwards-compatibility
+   * baseline that only coincidentally stays one minor behind {@link VersionUtil#getVersion()}, so
+   * relying on it here would make this test depend on the two staying in lockstep.
+   */
+  private static VersionInfo oneMinorBehindTheCurrentVersion() {
+    final var current = SemanticVersion.parse(VersionUtil.getVersion()).orElseThrow();
+    return new VersionInfo(current.major(), current.minor() - 1, 0);
   }
 
   private Consumer<Context> withFilter(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.util.TestStreams;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
@@ -189,6 +190,18 @@ public final class ExporterRule implements TestRule {
         .recordType(recordType)
         .intent(intent)
         .event(value)
+        .write();
+  }
+
+  /** Writes an event as though it had been written by a broker running {@code brokerVersion}. */
+  public long writeEventWithBrokerVersion(
+      final Intent intent, final UnifiedRecordValue value, final VersionInfo brokerVersion) {
+    return streams
+        .newRecord(STREAM_NAME)
+        .recordType(RecordType.EVENT)
+        .intent(intent)
+        .event(value)
+        .brokerVersion(brokerVersion)
         .write();
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExportingMigrationStatusCalculatorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExportingMigrationStatusCalculatorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import org.junit.jupiter.api.Test;
+
+final class ExportingMigrationStatusCalculatorTest {
+
+  private static final int PARTITION_ID = 1;
+
+  @Test
+  void shouldReportMigratedWhenNoExportersConfigured() {
+    // when
+    final var status = ExportingMigrationStatusCalculator.compute(PARTITION_ID, false, "8.9.0");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigratedWhenCaughtUpToTheLogHead() {
+    // when - null means no next unexported record at all
+    final var status = ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, null);
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigratedWhenNextRecordIsOnTheCurrentVersion() {
+    // when
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.10.0", "8.10.0");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigratedWhenNextRecordIsOnlyAPatchBehind() {
+    // given - a patch release never changes the on-disk/wire record format, so a record one or
+    // more patches behind is not a "previous version" backlog either
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.10.0", "8.10.3");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigratedWhenNextRecordIsOnlyAPatchAhead() {
+    // given - the record was stamped by a newer patch than the one now running, e.g. right after
+    // a patch rollback
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.10.3", "8.10.1");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigratedWhenTheCurrentVersionHasAPreReleaseSuffix() {
+    // given - the running version's "-SNAPSHOT" suffix must not make an otherwise-identical
+    // version look incompatible
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.10.0", "8.10.0-SNAPSHOT");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressWhenOnAnOlderMinorEvenWithAPreReleaseSuffix() {
+    // given - the same asymmetry, but on a genuine minor-version gap: it must still be reported
+    // as in progress, not swallowed by stripping the suffix
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.9.0", "8.10.0-SNAPSHOT");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldNameOnlyTheMinorVersionInEveryDetailMessage() {
+    // when
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.10.3", "8.10.5-SNAPSHOT");
+
+    // then
+    assertThat(status.detail()).contains("8.10").doesNotContain("8.10.3", "8.10.5", "SNAPSHOT");
+  }
+
+  @Test
+  void shouldReportMigrationInProgressWhenNextRecordIsOnAnOlderMinorVersion() {
+    // when
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.9.0", "8.10.0");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.MIGRATION_IN_PROGRESS);
+    assertThat(status.detail()).contains("8.9").contains("8.10").doesNotContain("8.9.0", "8.10.0");
+  }
+
+  @Test
+  void shouldReportUnknownWhenNextRecordVersionSkipsAMinorVersion() {
+    // when - an illegal upgrade path (skipping a minor) is treated the same as any other
+    // incompatibility: we cannot confidently claim readiness
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.9.0", "8.11.0");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownWhenNextRecordVersionIsAheadOfTheCurrentVersion() {
+    // when - as if this broker had been downgraded; never a false "ready"
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.11.0", "8.10.0");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownWhenTheCurrentVersionCannotBeParsed() {
+    // when
+    final var status =
+        ExportingMigrationStatusCalculator.compute(PARTITION_ID, true, "8.9.0", "development");
+
+    // then
+    assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExporterConfigurationTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExporterConfigurationTest.java
@@ -27,6 +27,7 @@ class ExporterConfigurationTest {
     // then
     assertThat(exportingCfg.skipRecords()).isEqualTo(Map.of());
     assertThat(exportingCfg.distributionInterval()).isEqualTo(Duration.ofSeconds(15));
+    assertThat(exportingCfg.migrationStatusScanMaxRecords()).isEqualTo(100_000);
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccessTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccessTest.java
@@ -192,5 +192,20 @@ final class ZeebePartitionAdminAccessTest {
       assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
       assertThat(status.detail()).contains("no exporter director running");
     }
+
+    @Test
+    void shouldReportUnknownRatherThanHangWhenReadingTheStatusThrows() {
+      // given - a synchronous failure, e.g. before the exporter director's own future is even
+      // returned, must still complete this method's future rather than leave it hanging forever
+      when(adminControl.getExporterDirector())
+          .thenThrow(new RuntimeException("Exporter director lookup fails"));
+
+      // when
+      final var status = sut.getExportingMigrationStatus().join();
+
+      // then
+      assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+      assertThat(status.detail()).contains("Exporter director lookup fails");
+    }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccessTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccessTest.java
@@ -12,11 +12,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.migration.DbMigrationState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -150,6 +152,45 @@ final class ZeebePartitionAdminAccessTest {
 
     private void writeMigratedByVersion(final String version) {
       new DbMigrationState(zeebeDb, zeebeDb.createContext()).setMigratedByVersion(version);
+    }
+  }
+
+  /**
+   * The actual algorithm lives on {@link ExporterDirector} itself (it needs the partition's {@code
+   * LogStream}, not the {@code ZeebeDb}), so {@code ZeebePartitionAdminAccess}'s own responsibility
+   * here is pure delegation -- a mocked {@link ExporterDirector} is enough to verify it.
+   */
+  @Nested
+  final class ExportingMigrationStatus {
+
+    @Test
+    void shouldDelegateToTheExporterDirector() {
+      // given
+      final var exporterDirector = mock(ExporterDirector.class);
+      final var expectedStatus =
+          new PartitionMigrationStatus(MigrationStatusCode.MIGRATED, "caught up");
+      when(adminControl.getExporterDirector()).thenReturn(exporterDirector);
+      when(exporterDirector.getExportingMigrationStatus())
+          .thenReturn(CompletableActorFuture.completed(expectedStatus));
+
+      // when
+      final var status = sut.getExportingMigrationStatus().join();
+
+      // then
+      assertThat(status).isEqualTo(expectedStatus);
+    }
+
+    @Test
+    void shouldReportUnknownWhenNoExporterDirectorRunningYet() {
+      // given
+      when(adminControl.getExporterDirector()).thenReturn(null);
+
+      // when
+      final var status = sut.getExportingMigrationStatus().join();
+
+      // then
+      assertThat(status.code()).isEqualTo(MigrationStatusCode.UNKNOWN);
+      assertThat(status.detail()).contains("no exporter director running");
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -298,6 +298,98 @@ final class AdminApiRequestHandlerTest {
 
   @Nested
   @ExtendWith(MockitoExtension.class)
+  final class GetExportingMigrationStatusRequest {
+    @RegisterExtension
+    final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+
+    private final PartitionAdminAccess adminAccess;
+    private final AdminApiRequestHandler handler;
+    private final AdminRequest request;
+
+    public GetExportingMigrationStatusRequest(
+        @Mock final PartitionAdminAccess adminAccess,
+        @Mock(answer = RETURNS_MOCKS) final RaftPartition raftPartition,
+        @Mock final AtomixServerTransport transport,
+        @Mock final ClusterConfigurationService clusterConfigurationService) {
+      this.adminAccess = adminAccess;
+      final int partitionId = 1;
+      when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
+      handler =
+          new AdminApiRequestHandler(
+              null,
+              transport,
+              adminAccess,
+              raftPartition,
+              clusterConfigurationService,
+              BrokerMemberId.from(1));
+
+      request = new AdminRequest();
+      request.setPartitionId(partitionId);
+      request.setType(AdminRequestType.GET_EXPORTING_MIGRATION_STATUS);
+    }
+
+    @BeforeEach
+    void startHandler() {
+      scheduler.submitActor(handler);
+      scheduler.workUntilDone();
+    }
+
+    @Test
+    void shouldReportExportingMigrationStatusForGivenPartition() {
+      // given
+      final var status =
+          new PartitionMigrationStatus(
+              MigrationStatusCode.MIGRATED, "every exporter is caught up to the log head");
+      when(adminAccess.getExportingMigrationStatus())
+          .thenReturn(CompletableActorFuture.completed(status));
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(adminAccess).forPartition(request.getPartitionId());
+      final var decoded =
+          responseFuture
+              .thenApply(Either::get)
+              .thenApply(response -> MigrationStatusPayload.decode(response.getPayload()))
+              .join();
+      assertThat(decoded).isEqualTo(status);
+    }
+
+    @Test
+    void shouldRespondWithFailureIfReadingStatusFails() {
+      // given
+      when(adminAccess.getExportingMigrationStatus())
+          .thenReturn(
+              CompletableActorFuture.completedExceptionally(
+                  new RuntimeException("Exporting migration status read fails")));
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertErrorCode(responseFuture, ErrorCode.INTERNAL_ERROR);
+    }
+
+    @Test
+    void shouldRespondWithFailureIfPartitionNotFound() {
+      // given
+      request.setPartitionId(5);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertErrorCode(responseFuture, ErrorCode.INTERNAL_ERROR);
+    }
+  }
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
   final class StepdownRequest {
     @RegisterExtension
     final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -496,6 +497,15 @@ public final class TestStreams {
 
     public FluentLogWriter recordType(final RecordType recordType) {
       metadata.recordType(recordType);
+      return this;
+    }
+
+    /**
+     * Overrides the version stamped on this record, as if it had been written by a broker running
+     * that version — only needed to simulate a record written under a previous version.
+     */
+    public FluentLogWriter brokerVersion(final VersionInfo brokerVersion) {
+      metadata.brokerVersion(brokerVersion);
       return this;
     }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -54,6 +54,10 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
     request.setType(AdminRequestType.GET_MIGRATION_STATUS);
   }
 
+  public void getExportingMigrationStatus() {
+    request.setType(AdminRequestType.GET_EXPORTING_MIGRATION_STATUS);
+  }
+
   public void getFLowControlConfiguration() {
     request.setType(AdminRequestType.GET_FLOW_CONTROL);
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterBrokerVersionMigrationStatusProvider.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterBrokerVersionMigrationStatusProvider.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.util.SemanticVersion;
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reports whether every broker in the cluster is already running the current application version,
+ * for the upgrade-readiness endpoint. Complements {@link ClusterExporterMigrationStatusProvider}'s
+ * per-record check: that check alone only proves nothing written so far is behind, not that nothing
+ * behind ever will be -- a broker that hasn't upgraded yet could still regain leadership of a
+ * partition and append an old-version record afterward. Once every broker has upgraded, no such
+ * broker exists anymore to do that, closing the gap.
+ *
+ * <p>Broker membership and version are cluster-wide facts, not scoped to any one physical tenant,
+ * so this reports the same computed status under every known physical tenant, with no per-partition
+ * fan-out and no admin request needed -- unlike its sibling providers, everything it needs is
+ * already known locally from cluster topology gossip.
+ */
+@NullMarked
+public class ClusterBrokerVersionMigrationStatusProvider implements MigrationStatusProvider {
+
+  public static final String CONDITION_NAME = "brokerVersionMigrated";
+
+  private final BrokerClient brokerClient;
+  private final PhysicalTenantIds physicalTenantIds;
+
+  public ClusterBrokerVersionMigrationStatusProvider(
+      final BrokerClient brokerClient, final PhysicalTenantIds physicalTenantIds) {
+    this.brokerClient = brokerClient;
+    this.physicalTenantIds = physicalTenantIds;
+  }
+
+  @Override
+  public String conditionName() {
+    return CONDITION_NAME;
+  }
+
+  @Override
+  public Map<String, MigrationConditionStatus> getMigrationStatus() {
+    final var status = computeStatusSafely();
+    final var statusesByPhysicalTenant = new LinkedHashMap<String, MigrationConditionStatus>();
+    physicalTenantIds.known().forEach(tenantId -> statusesByPhysicalTenant.put(tenantId, status));
+    return statusesByPhysicalTenant;
+  }
+
+  private MigrationConditionStatus computeStatusSafely() {
+    try {
+      return computeStatus();
+    } catch (final Exception e) {
+      return new MigrationConditionStatus(
+          MigrationState.UNKNOWN,
+          "failed to determine broker-version migration status: " + e.getMessage());
+    }
+  }
+
+  private MigrationConditionStatus computeStatus() {
+    final var topology = brokerClient.getTopologyManager().getTopology();
+    if (topology == null) {
+      return new MigrationConditionStatus(MigrationState.UNKNOWN, "cluster topology not yet known");
+    }
+
+    final var brokers = topology.getBrokers();
+    if (brokers.isEmpty()) {
+      return new MigrationConditionStatus(
+          MigrationState.UNKNOWN, "no brokers known in the cluster topology yet");
+    }
+
+    final var currentVersion = VersionUtil.getVersion();
+    final var worst =
+        brokers.stream()
+            .map(
+                brokerId ->
+                    statusForBroker(brokerId, topology.getBrokerVersion(brokerId), currentVersion))
+            .max(Comparator.comparingInt(status -> precedence(status.state())))
+            .orElseThrow();
+    if (worst.state() == MigrationState.MIGRATED) {
+      // every broker individually reports MIGRATED; report one clean summary rather than an
+      // arbitrary single broker's detail
+      return new MigrationConditionStatus(
+          MigrationState.MIGRATED, "every broker is running " + currentVersion);
+    }
+    return worst;
+  }
+
+  /** {@code UNKNOWN > MIGRATION_IN_PROGRESS > MIGRATED}, matching every other condition here. */
+  private static int precedence(final MigrationState state) {
+    return switch (state) {
+      case UNKNOWN -> 2;
+      case MIGRATION_IN_PROGRESS -> 1;
+      case MIGRATED -> 0;
+    };
+  }
+
+  /**
+   * Only the minor version boundary matters, mirroring {@code ExportingMigrationStatusCalculator}:
+   * a patch-only difference, in either direction, doesn't mean this broker could still write in an
+   * incompatible format, while a minor-version gap means it hasn't upgraded yet. Every broker's
+   * gossiped version is its own raw {@code VersionUtil .getVersion()} (confirmed in {@code
+   * Broker#createBrokerInfo}), so a non-release build's pre-release suffix is stripped from both
+   * sides -- otherwise every broker in an all-SNAPSHOT cluster would look incompatible with itself.
+   */
+  private static MigrationConditionStatus statusForBroker(
+      final BrokerMemberId brokerId,
+      final @Nullable String brokerVersion,
+      final String currentVersion) {
+    if (brokerVersion == null) {
+      return new MigrationConditionStatus(
+          MigrationState.UNKNOWN, "broker " + brokerId + ": version not yet known");
+    }
+
+    final var result =
+        VersionCompatibilityCheck.check(
+            SemanticVersion.withoutPreReleaseSuffix(brokerVersion),
+            SemanticVersion.withoutPreReleaseSuffix(currentVersion));
+    return switch (result) {
+      case Compatible.SameVersion same ->
+          migrated(brokerId, "broker is on " + same.version().toMinorVersionString());
+      case Compatible.PatchUpgrade patch ->
+          migrated(brokerId, "broker is on " + patch.from().toMinorVersionString());
+      case Incompatible.PatchDowngrade patch ->
+          migrated(brokerId, "broker is on " + patch.from().toMinorVersionString());
+      case Compatible.MinorUpgrade minor ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "broker "
+                  + brokerId
+                  + " is on "
+                  + minor.from().toMinorVersionString()
+                  + ", not yet upgraded to "
+                  + minor.to().toMinorVersionString());
+      case Incompatible incompatible ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN,
+              "broker " + brokerId + ": incompatible version path: " + incompatible);
+      case Indeterminate indeterminate ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN,
+              "broker " + brokerId + ": cannot determine version compatibility: " + indeterminate);
+    };
+  }
+
+  private static MigrationConditionStatus migrated(
+      final BrokerMemberId brokerId, final String detail) {
+    return new MigrationConditionStatus(
+        MigrationState.MIGRATED, "broker " + brokerId + ": " + detail);
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterExporterMigrationStatusProvider.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/ClusterExporterMigrationStatusProvider.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusPayload;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reports whether every exporter on every partition, per physical tenant, has finished exporting
+ * and acknowledging every record written under a previous application version, for the
+ * upgrade-readiness endpoint. Queries one reachable replica per partition — preferring the leader,
+ * falling back to another replica on failure or timeout — since a follower's exporter position can
+ * only lag the leader's, never diverge from it.
+ */
+@NullMarked
+public class ClusterExporterMigrationStatusProvider implements MigrationStatusProvider {
+
+  public static final String CONDITION_NAME = "exporterMigrated";
+  private static final Duration DEFAULT_FETCH_TIMEOUT = Duration.ofSeconds(5);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ClusterExporterMigrationStatusProvider.class);
+
+  private final BrokerClient brokerClient;
+  private final PhysicalTenantIds physicalTenantIds;
+  private final Duration fetchTimeout;
+
+  public ClusterExporterMigrationStatusProvider(
+      final BrokerClient brokerClient, final PhysicalTenantIds physicalTenantIds) {
+    this(brokerClient, physicalTenantIds, DEFAULT_FETCH_TIMEOUT);
+  }
+
+  @VisibleForTesting
+  ClusterExporterMigrationStatusProvider(
+      final BrokerClient brokerClient,
+      final PhysicalTenantIds physicalTenantIds,
+      final Duration fetchTimeout) {
+    this.brokerClient = brokerClient;
+    this.physicalTenantIds = physicalTenantIds;
+    this.fetchTimeout = fetchTimeout;
+  }
+
+  @Override
+  public String conditionName() {
+    return CONDITION_NAME;
+  }
+
+  @Override
+  public Map<String, MigrationConditionStatus> getMigrationStatus() {
+    return ClusterMigrationStatusReader.resolveTenants(
+        physicalTenantIds, fetchTimeout, this::fetchTenantStatus, LOG, "exporter migration status");
+  }
+
+  private CompletableFuture<PartitionMigrationStatus> fetchTenantStatus(
+      final String physicalTenantId) {
+    // The topology manager may not know this physical tenant yet, so guard against a null
+    // topology rather than letting it fail every tenant's fan-out for this poll.
+    final var topology = brokerClient.getTopologyManager().getTopology(physicalTenantId);
+    if (topology == null) {
+      return CompletableFuture.completedFuture(
+          new PartitionMigrationStatus(
+              MigrationStatusCode.UNKNOWN,
+              "physical tenant '" + physicalTenantId + "': topology not yet known"));
+    }
+
+    final var responses =
+        topology.getPartitions().stream()
+            .map(
+                partitionId -> {
+                  final var candidates = PartitionReplicas.allOf(topology, partitionId);
+                  return requestStatusFromAnyReplica(
+                      physicalTenantId, partitionId, candidates, perCandidateTimeout(candidates));
+                })
+            .toList();
+
+    return CompletableFuture.allOf(responses.toArray(CompletableFuture<?>[]::new))
+        .thenApply(
+            ignored ->
+                ClusterMigrationStatusReader.aggregate(
+                    responses.stream().map(CompletableFuture::join).toList()));
+  }
+
+  /**
+   * Splits the shared per-tenant {@link #fetchTimeout} evenly across a partition's candidate
+   * replicas, so a single stalled candidate can't consume the whole shared budget by itself.
+   */
+  private Duration perCandidateTimeout(final List<BrokerMemberId> candidates) {
+    return candidates.isEmpty() ? fetchTimeout : fetchTimeout.dividedBy(candidates.size());
+  }
+
+  /**
+   * Tries every candidate replica of a partition in order — leader first — falling back to the next
+   * one only if the current one fails or times out, since the first replica that answers is already
+   * trustworthy.
+   */
+  private CompletableFuture<PartitionMigrationStatus> requestStatusFromAnyReplica(
+      final String physicalTenantId,
+      final int partitionId,
+      final List<BrokerMemberId> candidates,
+      final Duration perCandidateTimeout) {
+    if (candidates.isEmpty()) {
+      return CompletableFuture.completedFuture(
+          new PartitionMigrationStatus(
+              MigrationStatusCode.UNKNOWN,
+              "partition " + partitionId + ": no known replica to query"));
+    }
+
+    final var first = candidates.get(0);
+    final var rest = candidates.subList(1, candidates.size());
+    return requestStatus(physicalTenantId, partitionId, first, perCandidateTimeout)
+        .exceptionallyCompose(
+            ignored ->
+                requestStatusFromAnyReplica(
+                    physicalTenantId, partitionId, rest, perCandidateTimeout));
+  }
+
+  private CompletableFuture<PartitionMigrationStatus> requestStatus(
+      final String physicalTenantId,
+      final Integer partitionId,
+      final BrokerMemberId brokerId,
+      final Duration requestTimeout) {
+    final var request = new BrokerAdminRequest();
+    request.setPartitionGroup(physicalTenantId);
+    request.setBrokerId(brokerId);
+    request.setPartitionId(partitionId);
+    request.getExportingMigrationStatus();
+    return brokerClient
+        .sendRequest(request)
+        .orTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .thenApply(
+            response -> MigrationStatusPayload.decode(response.getResponseOrThrow().getPayload()));
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/PartitionReplicas.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/PartitionReplicas.java
@@ -9,14 +9,14 @@ package io.camunda.zeebe.gateway.admin;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import org.jspecify.annotations.NullMarked;
 
 /**
  * Resolves the replicas of a partition from a {@link BrokerClusterState}, for callers that need to
- * query every partition replica directly over the admin API (e.g. {@link
- * ClusterRocksDbMigrationStatusProvider}).
+ * query partition replicas directly over the admin API (e.g. {@link
+ * ClusterRocksDbMigrationStatusProvider}, {@link ClusterExporterMigrationStatusProvider}).
  */
 @NullMarked
 final class PartitionReplicas {
@@ -24,21 +24,21 @@ final class PartitionReplicas {
   private PartitionReplicas() {}
 
   /**
-   * Every replica of a partition: leader, followers, and inactive members. Inactive members keep
-   * their data and can be promoted back once they recover, so they are as relevant as any other
-   * replica for a condition that genuinely differs per replica (e.g. RocksDB migration state).
+   * Every replica of a partition, as a single ordered list — leader first, then followers, then
+   * inactive members. Inactive members are included because they keep their partition data and can
+   * be promoted back once they recover, so they are as relevant as any other replica for a
+   * condition that genuinely differs per replica (e.g. RocksDB migration state). The order lets a
+   * caller that only needs one reachable replica to answer prefer the leader and fall back through
+   * the rest; a caller that needs every replica can just iterate the whole list, ignoring order.
    */
-  static Set<BrokerMemberId> allOf(final BrokerClusterState topology, final int partitionId) {
+  static List<BrokerMemberId> allOf(final BrokerClusterState topology, final int partitionId) {
+    final var candidates = new ArrayList<BrokerMemberId>(topology.getReplicationFactor());
     final var leader = topology.getLeaderForPartition(partitionId);
-    final var followers = topology.getFollowersForPartition(partitionId);
-    final var inactive = topology.getInactiveNodesForPartition(partitionId);
-
-    final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
     if (leader != null) {
-      members.add(leader);
+      candidates.add(leader);
     }
-    members.addAll(followers);
-    members.addAll(inactive);
-    return members;
+    candidates.addAll(topology.getFollowersForPartition(partitionId));
+    candidates.addAll(topology.getInactiveNodesForPartition(partitionId));
+    return candidates;
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterBrokerVersionMigrationStatusProviderTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterBrokerVersionMigrationStatusProviderTest.java
@@ -62,7 +62,7 @@ final class ClusterBrokerVersionMigrationStatusProviderTest {
   void shouldReportMigrationInProgressWhenOneBrokerIsOnAnOlderMinorVersion() {
     // given - one broker hasn't restarted on the target version yet
     final var currentVersion = VersionUtil.getVersion();
-    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow().toString();
+    final var previousVersion = oneMinorBehind(currentVersion);
     final var client =
         setupBrokerClient(
             List.of(BROKER_1, BROKER_2),
@@ -149,7 +149,7 @@ final class ClusterBrokerVersionMigrationStatusProviderTest {
   @Test
   void shouldReportTheSameStatusUnderEveryKnownPhysicalTenant() {
     // given - broker membership/version is cluster-wide, not scoped to any one physical tenant
-    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow().toString();
+    final var previousVersion = oneMinorBehind(VersionUtil.getVersion());
     final var client = setupBrokerClient(List.of(BROKER_1), Map.of(BROKER_1, previousVersion));
     final var provider =
         new ClusterBrokerVersionMigrationStatusProvider(
@@ -162,6 +162,17 @@ final class ClusterBrokerVersionMigrationStatusProviderTest {
     assertThat(statuses).containsOnlyKeys("tenant-a", "tenant-b");
     assertThat(statuses.get("tenant-a")).isEqualTo(statuses.get("tenant-b"));
     assertThat(statuses.get("tenant-a").state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  /**
+   * A version exactly one minor behind {@code version} -- {@code VersionUtil
+   * .getPreviousSemanticVersion()} is a separately-configured backwards-compatibility baseline that
+   * only coincidentally stays one minor behind {@code VersionUtil.getVersion()}, so relying on it
+   * here would make this test depend on the two staying in lockstep.
+   */
+  private static String oneMinorBehind(final String version) {
+    final var semanticVersion = SemanticVersion.parse(version).orElseThrow();
+    return semanticVersion.major() + "." + (semanticVersion.minor() - 1) + ".0";
   }
 
   private static String withPatchOffset(final String version, final int offset) {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterBrokerVersionMigrationStatusProviderTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterBrokerVersionMigrationStatusProviderTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.util.SemanticVersion;
+import io.camunda.zeebe.util.VersionUtil;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class ClusterBrokerVersionMigrationStatusProviderTest {
+
+  private static final BrokerMemberId BROKER_1 = BrokerMemberId.from(1);
+  private static final BrokerMemberId BROKER_2 = BrokerMemberId.from(2);
+
+  @Test
+  void shouldReportConditionName() {
+    final var provider =
+        new ClusterBrokerVersionMigrationStatusProvider(
+            mock(BrokerClient.class), singleTenant(DEFAULT_PHYSICAL_TENANT_ID));
+    assertThat(provider.conditionName())
+        .isEqualTo(ClusterBrokerVersionMigrationStatusProvider.CONDITION_NAME);
+  }
+
+  @Test
+  void shouldReportMigratedWhenEveryBrokerIsOnTheCurrentVersion() {
+    // given
+    final var currentVersion = VersionUtil.getVersion();
+    final var client =
+        setupBrokerClient(
+            List.of(BROKER_1, BROKER_2),
+            Map.of(BROKER_1, currentVersion, BROKER_2, currentVersion));
+    final var provider =
+        new ClusterBrokerVersionMigrationStatusProvider(
+            client, singleTenant(DEFAULT_PHYSICAL_TENANT_ID));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT_PHYSICAL_TENANT_ID).state()).isEqualTo(MigrationState.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressWhenOneBrokerIsOnAnOlderMinorVersion() {
+    // given - one broker hasn't restarted on the target version yet
+    final var currentVersion = VersionUtil.getVersion();
+    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow().toString();
+    final var client =
+        setupBrokerClient(
+            List.of(BROKER_1, BROKER_2),
+            Map.of(BROKER_1, currentVersion, BROKER_2, previousVersion));
+    final var provider =
+        new ClusterBrokerVersionMigrationStatusProvider(
+            client, singleTenant(DEFAULT_PHYSICAL_TENANT_ID));
+
+    // when
+    final var status = provider.getMigrationStatus().get(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+    assertThat(status.detail()).contains(BROKER_2.toString());
+  }
+
+  @Test
+  void shouldReportMigratedWhenTheOnlyDifferenceIsAPatchVersion() {
+    // given - a patch-only difference never changes the wire/record format, so it doesn't count
+    final var currentVersion = VersionUtil.getVersion();
+    final var patchAhead = withPatchOffset(currentVersion, 1);
+    final var client = setupBrokerClient(List.of(BROKER_1), Map.of(BROKER_1, patchAhead));
+    final var provider =
+        new ClusterBrokerVersionMigrationStatusProvider(
+            client, singleTenant(DEFAULT_PHYSICAL_TENANT_ID));
+
+    // when
+    final var status = provider.getMigrationStatus().get(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATED);
+  }
+
+  @Test
+  void shouldReportUnknownWhenABrokerVersionIsNotYetKnown() {
+    // given - the topology has gossiped this broker's membership but not its version yet
+    final var client = setupBrokerClient(List.of(BROKER_1), Map.of());
+    final var provider =
+        new ClusterBrokerVersionMigrationStatusProvider(
+            client, singleTenant(DEFAULT_PHYSICAL_TENANT_ID));
+
+    // when
+    final var status = provider.getMigrationStatus().get(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("version not yet known");
+  }
+
+  @Test
+  void shouldReportUnknownWhenTopologyIsNotYetKnown() {
+    // given - an unstubbed mock's getTopology() already returns null, no explicit stub needed
+    final var client = mock(BrokerClient.class);
+    final var topologyManager = mock(BrokerTopologyManager.class);
+    when(client.getTopologyManager()).thenReturn(topologyManager);
+    final var provider =
+        new ClusterBrokerVersionMigrationStatusProvider(
+            client, singleTenant(DEFAULT_PHYSICAL_TENANT_ID));
+
+    // when
+    final var status = provider.getMigrationStatus().get(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("topology not yet known");
+  }
+
+  @Test
+  void shouldReportUnknownWhenNoBrokersAreKnownYet() {
+    // given
+    final var client = setupBrokerClient(List.of(), Map.of());
+    final var provider =
+        new ClusterBrokerVersionMigrationStatusProvider(
+            client, singleTenant(DEFAULT_PHYSICAL_TENANT_ID));
+
+    // when
+    final var status = provider.getMigrationStatus().get(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("no brokers known");
+  }
+
+  @Test
+  void shouldReportTheSameStatusUnderEveryKnownPhysicalTenant() {
+    // given - broker membership/version is cluster-wide, not scoped to any one physical tenant
+    final var previousVersion = VersionUtil.getPreviousSemanticVersion().orElseThrow().toString();
+    final var client = setupBrokerClient(List.of(BROKER_1), Map.of(BROKER_1, previousVersion));
+    final var provider =
+        new ClusterBrokerVersionMigrationStatusProvider(
+            client, multiTenant("tenant-a", "tenant-b"));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses).containsOnlyKeys("tenant-a", "tenant-b");
+    assertThat(statuses.get("tenant-a")).isEqualTo(statuses.get("tenant-b"));
+    assertThat(statuses.get("tenant-a").state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  private static String withPatchOffset(final String version, final int offset) {
+    final var semanticVersion = SemanticVersion.parse(version).orElseThrow();
+    return semanticVersion.major()
+        + "."
+        + semanticVersion.minor()
+        + "."
+        + (semanticVersion.patch() + offset);
+  }
+
+  private static PhysicalTenantIds singleTenant(final String physicalTenantId) {
+    return () -> Set.of(physicalTenantId);
+  }
+
+  private static PhysicalTenantIds multiTenant(final String... physicalTenantIds) {
+    return () -> Set.of(physicalTenantIds);
+  }
+
+  private static BrokerClient setupBrokerClient(
+      final List<BrokerMemberId> brokers, final Map<BrokerMemberId, String> versionsByBroker) {
+    final var topology = mock(BrokerClusterState.class);
+    when(topology.getBrokers()).thenReturn(brokers);
+    brokers.forEach(
+        brokerId ->
+            when(topology.getBrokerVersion(brokerId)).thenReturn(versionsByBroker.get(brokerId)));
+
+    final var client = mock(BrokerClient.class);
+    final var topologyManager = mock(BrokerTopologyManager.class);
+    when(topologyManager.getTopology()).thenReturn(topology);
+    when(client.getTopologyManager()).thenReturn(topologyManager);
+    return client;
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterExporterMigrationStatusProviderTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/admin/ClusterExporterMigrationStatusProviderTest.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusCode;
+import io.camunda.zeebe.protocol.impl.encoding.MigrationStatusPayload;
+import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+final class ClusterExporterMigrationStatusProviderTest {
+
+  private static final String DEFAULT = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
+  private static final BrokerClusterState TOPOLOGY =
+      ofTopology(
+          Map.of(
+              1,
+              List.of(BrokerMemberId.from(1), BrokerMemberId.from(2), BrokerMemberId.from(3)),
+              2,
+              List.of(BrokerMemberId.from(2), BrokerMemberId.from(1), BrokerMemberId.from(3))));
+
+  @Test
+  void shouldReportConditionName() {
+    final var provider =
+        new ClusterExporterMigrationStatusProvider(mock(BrokerClient.class), singleTenant(DEFAULT));
+    assertThat(provider.conditionName())
+        .isEqualTo(ClusterExporterMigrationStatusProvider.CONDITION_NAME);
+  }
+
+  @Test
+  void shouldQueryOnlyTheLeaderOfEveryPartitionWhenItAnswers() {
+    // given
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "ok"));
+    final var provider = new ClusterExporterMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    provider.getMigrationStatus();
+
+    // then - the leader answers, so no follower is ever queried
+    for (final var partition : TOPOLOGY.getPartitions()) {
+      verify(client)
+          .sendRequest(
+              argThatTargets(DEFAULT, partition, TOPOLOGY.getLeaderForPartition(partition)));
+      for (final var follower : TOPOLOGY.getFollowersForPartition(partition)) {
+        verify(client, never()).sendRequest(argThatTargets(DEFAULT, partition, follower));
+      }
+    }
+  }
+
+  @Test
+  void shouldFallBackToAFollowerWhenTheLeaderRequestFails() {
+    // given - register the catch-all first, then override for the leader specifically; Mockito's
+    // last-registered-matching-stub wins, so registering the specific override second is required
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "ok"));
+    when(client.sendRequest(argThatTargets(DEFAULT, 1, TOPOLOGY.getLeaderForPartition(1))))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("leader unreachable")));
+    final var provider = new ClusterExporterMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then - a follower answered instead, so the condition is still confidently MIGRATED
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+    verify(client).sendRequest(argThatTargets(DEFAULT, 1, TOPOLOGY.getLeaderForPartition(1)));
+    verify(client)
+        .sendRequest(
+            argThatTargets(DEFAULT, 1, TOPOLOGY.getFollowersForPartition(1).iterator().next()));
+  }
+
+  @Test
+  void shouldFallBackToAFollowerWhenTheLeaderStallsRatherThanFails() {
+    // given - the leader never responds at all (as opposed to failing outright)
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "ok"));
+    when(client.sendRequest(argThatTargets(DEFAULT, 1, TOPOLOGY.getLeaderForPartition(1))))
+        .thenReturn(new CompletableFuture<>());
+    final var provider =
+        new ClusterExporterMigrationStatusProvider(
+            client, singleTenant(DEFAULT), Duration.ofMillis(300));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then - the follower's prompt answer is used well before the shared budget expires
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+    verify(client)
+        .sendRequest(
+            argThatTargets(DEFAULT, 1, TOPOLOGY.getFollowersForPartition(1).iterator().next()));
+  }
+
+  @Test
+  void shouldReportMigratedWhenEveryPartitionIsMigrated() {
+    // given
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "migrated"));
+    final var provider = new ClusterExporterMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressWhenOnePartitionIsBehind() {
+    // given
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "migrated"));
+    when(client.sendRequest(argThatTargets(DEFAULT, 1, TOPOLOGY.getLeaderForPartition(1))))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATION_IN_PROGRESS, "behind"));
+    final var provider = new ClusterExporterMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportUnknownWhenAnyPartitionIsUnknownEvenIfOthersAreMigrated() {
+    // given - UNKNOWN takes precedence: we must not claim a confident answer when part of the
+    // picture is missing.
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "migrated"));
+    when(client.sendRequest(argThatTargets(DEFAULT, 1, TOPOLOGY.getLeaderForPartition(1))))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.UNKNOWN, "unreachable"));
+    final var provider = new ClusterExporterMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownWhenEveryReplicaOfAPartitionFails() {
+    // given - leader and every follower fail; there is no replica left to fall back to
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unreachable")));
+    final var provider = new ClusterExporterMigrationStatusProvider(client, singleTenant(DEFAULT));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then - a failed fan-out must never throw out of getMigrationStatus()
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownWhenTheFanOutTimesOut() {
+    // given - every replica of every partition never completes, and a short shared timeout so
+    // the test itself stays fast
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any())).thenReturn(new CompletableFuture<>());
+    final var provider =
+        new ClusterExporterMigrationStatusProvider(
+            client, singleTenant(DEFAULT), Duration.ofMillis(200));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(statuses.get(DEFAULT).detail()).contains("no known replica to query");
+  }
+
+  @Test
+  void shouldReportUnknownForATenantWithoutFailingOthersWhenTopologyIsNull() {
+    // given - the topology manager returns null for "tenantB" (not yet known)
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "ok"));
+    final var provider =
+        new ClusterExporterMigrationStatusProvider(client, multiTenant(DEFAULT, "tenantB"));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then - "tenantB" reports UNKNOWN on its own, without failing "default"'s fan-out too
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(statuses.get("tenantB").state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldQueryEveryKnownPhysicalTenantIndependently() {
+    // given - two tenants, each with their own topology and their own leader
+    final var topologyB =
+        ofTopology(Map.of(1, List.of(BrokerMemberId.from(4), BrokerMemberId.from(5))));
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY, "tenantB", topologyB));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "ok"));
+    final var provider =
+        new ClusterExporterMigrationStatusProvider(client, multiTenant(DEFAULT, "tenantB"));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then
+    assertThat(statuses).containsOnlyKeys(DEFAULT, "tenantB");
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(statuses.get("tenantB").state()).isEqualTo(MigrationState.MIGRATED);
+    verify(client).sendRequest(argThatTargets("tenantB", 1, BrokerMemberId.from(4)));
+  }
+
+  @Test
+  void shouldReportEachTenantIndependentlyWhenOnlyOneTimesOut() {
+    // given - "default" resolves quickly, "tenantB" never responds; both share one timeout budget
+    final var topologyB =
+        ofTopology(Map.of(1, List.of(BrokerMemberId.from(4), BrokerMemberId.from(5))));
+    final var client = setupBrokerClient(Map.of(DEFAULT, TOPOLOGY, "tenantB", topologyB));
+    when(client.sendRequest(any()))
+        .thenAnswer(invocation -> respondWith(MigrationStatusCode.MIGRATED, "migrated"));
+    when(client.sendRequest(argThatTargetsTenant("tenantB"))).thenReturn(new CompletableFuture<>());
+    final var provider =
+        new ClusterExporterMigrationStatusProvider(
+            client, multiTenant(DEFAULT, "tenantB"), Duration.ofMillis(200));
+
+    // when
+    final var statuses = provider.getMigrationStatus();
+
+    // then - the slow tenant does not hold back the fast one
+    assertThat(statuses.get(DEFAULT).state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(statuses.get("tenantB").state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  private static CompletableFuture<BrokerResponse<AdminResponse>> respondWith(
+      final MigrationStatusCode code, final String detail) {
+    final var response = mock(AdminResponse.class);
+    when(response.getPayload())
+        .thenReturn(MigrationStatusPayload.encode(new PartitionMigrationStatus(code, detail)));
+    return CompletableFuture.completedFuture(new BrokerResponse<>(response));
+  }
+
+  private static PhysicalTenantIds singleTenant(final String physicalTenantId) {
+    return () -> Set.of(physicalTenantId);
+  }
+
+  private static PhysicalTenantIds multiTenant(final String... physicalTenantIds) {
+    return () -> Set.of(physicalTenantIds);
+  }
+
+  private static BrokerClient setupBrokerClient(
+      final Map<String, BrokerClusterState> topologyByTenant) {
+    final var client = mock(BrokerClient.class);
+    final var topologyManager = mock(BrokerTopologyManager.class);
+    topologyByTenant.forEach(
+        (tenantId, topology) -> when(topologyManager.getTopology(tenantId)).thenReturn(topology));
+    when(client.getTopologyManager()).thenReturn(topologyManager);
+    return client;
+  }
+
+  private static BrokerRequest<AdminResponse> argThatTargets(
+      final String physicalTenantId, final int partitionId, final BrokerMemberId brokerId) {
+    return argThat(
+        request ->
+            request != null
+                && request.getPartitionGroup().equals(physicalTenantId)
+                && request.getPartitionId() == partitionId
+                && request.getBrokerId().orElseThrow().equals(brokerId));
+  }
+
+  private static BrokerRequest<AdminResponse> argThatTargetsTenant(final String physicalTenantId) {
+    return argThat(
+        request -> request != null && request.getPartitionGroup().equals(physicalTenantId));
+  }
+
+  private static BrokerClusterState ofTopology(final Map<Integer, List<BrokerMemberId>> topology) {
+    return new BrokerClusterState() {
+      @Override
+      public boolean isInitialized() {
+        return true;
+      }
+
+      @Override
+      public int getClusterSize() {
+        return (int) topology.values().stream().flatMap(Collection::stream).distinct().count();
+      }
+
+      @Override
+      public int getPartitionsCount() {
+        return topology.size();
+      }
+
+      @Override
+      public int getReplicationFactor() {
+        return topology.values().stream().map(List::size).max(Integer::compareTo).orElse(1);
+      }
+
+      @Override
+      public @Nullable BrokerMemberId getLeaderForPartition(final int partition) {
+        return Optional.ofNullable(topology.get(partition))
+            .filter(brokers -> !brokers.isEmpty())
+            .map(List::getFirst)
+            .orElse(null);
+      }
+
+      @Override
+      public Set<BrokerMemberId> getFollowersForPartition(final int partition) {
+        return topology.getOrDefault(partition, List.of()).stream()
+            .skip(1)
+            .collect(Collectors.toSet());
+      }
+
+      @Override
+      public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
+        return Set.of();
+      }
+
+      @Override
+      public @Nullable BrokerMemberId getRandomBroker() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public List<Integer> getPartitions() {
+        return new ArrayList<>(topology.keySet());
+      }
+
+      @Override
+      public List<BrokerMemberId> getBrokers() {
+        return topology.values().stream().flatMap(Collection::stream).distinct().toList();
+      }
+
+      @Override
+      public @Nullable String getBrokerAddress(final @NonNull BrokerMemberId brokerId) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public @Nullable String getBrokerVersion(final @NonNull BrokerMemberId brokerId) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public PartitionHealthStatus getPartitionHealth(
+          final @NonNull BrokerMemberId brokerId, final int partition) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public State getPartitionState(final BrokerMemberId brokerId, final int partition) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public long getLastCompletedChangeId() {
+        return 0;
+      }
+
+      @Override
+      public String getClusterId() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.logstreams.storage.LogStorage.AppendedListener;
 import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
 import io.camunda.zeebe.logstreams.storage.LogStorage.CommittedPositionListener;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
 import java.util.Collection;
@@ -190,9 +191,17 @@ public final class LogStreamImpl implements LogStream, CommitListener, AppendedL
   }
 
   private LogStreamReader createLogStreamReader(final Supplier<LogStorageReader> readerSupplier) {
-    final var newReader = new LogStreamReaderImpl(readerSupplier.get());
+    // Deregister on close instead of holding onto every reader ever created for the life of this
+    // LogStream -- a caller that opens and closes many short-lived readers (e.g. one per poll of a
+    // diagnostic endpoint) would otherwise leak one entry here per call.
+    final var newReader = new LogStreamReaderImpl(readerSupplier.get(), readers::remove);
     readers.add(newReader);
     return newReader;
+  }
+
+  @VisibleForTesting
+  int openReaderCount() {
+    return readers.size();
   }
 
   private long getWriteBuffersInitialPosition() {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 import net.jcip.annotations.NotThreadSafe;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -25,6 +26,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 @NotThreadSafe
 final class LogStreamReaderImpl implements LogStreamReader {
   private final LogStorageReader reader;
+  private final Consumer<LogStreamReader> onClose;
 
   private LoggedEventImpl currentEvent;
   private DirectBuffer currentEventBuffer;
@@ -35,7 +37,17 @@ final class LogStreamReaderImpl implements LogStreamReader {
   private int nextEventOffset;
 
   LogStreamReaderImpl(final LogStorageReader reader) {
+    this(reader, ignored -> {});
+  }
+
+  /**
+   * @param onClose notified with {@code this} when {@link #close()} runs, so a caller that tracks
+   *     every reader it creates (e.g. {@link LogStreamImpl}) can stop tracking this one instead of
+   *     holding onto it for the life of the process.
+   */
+  LogStreamReaderImpl(final LogStorageReader reader, final Consumer<LogStreamReader> onClose) {
     this.reader = reader;
+    this.onClose = onClose;
 
     reset();
     seekToFirstEvent();
@@ -154,6 +166,7 @@ final class LogStreamReaderImpl implements LogStreamReader {
   public void close() {
     reset();
     reader.close();
+    onClose.accept(this);
   }
 
   private long getCurrentPosition() {

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImplTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImplTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.logstreams.util.ListLogStorage;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.InstantSource;
+import org.junit.jupiter.api.Test;
+
+final class LogStreamImplTest {
+
+  private LogStreamImpl newLogStream() {
+    return (LogStreamImpl)
+        new LogStreamBuilderImpl()
+            .withLogStorage(new ListLogStorage())
+            .withClock(InstantSource.system())
+            .withMeterRegistry(new SimpleMeterRegistry())
+            .build();
+  }
+
+  @Test
+  void shouldStopTrackingAReaderOnceItIsClosed() {
+    // given
+    final var logStream = newLogStream();
+    final var reader = logStream.newLogStreamReader();
+    assertThat(logStream.openReaderCount()).isOne();
+
+    // when
+    reader.close();
+
+    // then
+    assertThat(logStream.openReaderCount()).isZero();
+  }
+
+  @Test
+  void shouldStopTrackingManyReadersIndependently() {
+    // given - a caller that opens and closes one reader per poll, as the upgrade-readiness
+    // endpoint's exporting-migration-status check used to before this was fixed
+    final var logStream = newLogStream();
+
+    // when
+    for (int i = 0; i < 1_000; i++) {
+      logStream.newLogStreamReader().close();
+    }
+
+    // then - none of them are still tracked
+    assertThat(logStream.openReaderCount()).isZero();
+  }
+
+  @Test
+  void shouldStillCloseAReaderThatWasNeverExplicitlyClosed() {
+    // given - LogStream#close() must still close out every reader still open when it happens,
+    // regardless of whether other readers already deregistered themselves in the meantime
+    final var logStream = newLogStream();
+    final var stillOpen = logStream.newLogStreamReader();
+    logStream.newLogStreamReader().close();
+    assertThat(logStream.openReaderCount()).isOne();
+
+    // when
+    logStream.close();
+
+    // then - closing the still-open reader again is safe (already exercised by LogStream#close())
+    stillOpen.close();
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusCode.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusCode.java
@@ -8,9 +8,10 @@
 package io.camunda.zeebe.protocol.impl.encoding;
 
 /**
- * The migration status of a single partition replica, as reported over the {@code
- * GET_MIGRATION_STATUS} admin request/response wire protocol (see {@link PartitionMigrationStatus},
- * {@link MigrationStatusPayload}).
+ * The migration status of a single partition replica, as reported over an admin request/response
+ * (see {@link PartitionMigrationStatus}, {@link MigrationStatusPayload}) — shared by every
+ * migration-status admin request ({@code GET_MIGRATION_STATUS}, {@code
+ * GET_EXPORTING_MIGRATION_STATUS}), not specific to one.
  */
 public enum MigrationStatusCode {
   MIGRATED,

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusPayload.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MigrationStatusPayload.java
@@ -11,7 +11,8 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Encodes/decodes a {@link PartitionMigrationStatus} into the {@code payload} byte blob of an
- * {@code AdminRequest}/{@code AdminResponse} ({@code GET_MIGRATION_STATUS}).
+ * {@code AdminRequest}/{@code AdminResponse} ({@code GET_MIGRATION_STATUS}, {@code
+ * GET_EXPORTING_MIGRATION_STATUS}).
  */
 public final class MigrationStatusPayload {
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/PartitionMigrationStatus.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/PartitionMigrationStatus.java
@@ -8,9 +8,9 @@
 package io.camunda.zeebe.protocol.impl.encoding;
 
 /**
- * A single partition replica's migration status, reported by {@code
- * PartitionAdminAccess#getMigrationStatus()} and carried over the wire by {@link
- * MigrationStatusPayload}.
+ * A single partition replica's migration status, reported by a {@code PartitionAdminAccess}
+ * migration-status method (e.g. {@code getMigrationStatus()}, {@code
+ * getExportingMigrationStatus()}) and carried over the wire by {@link MigrationStatusPayload}.
  *
  * @param code whether this replica is migrated, confidently not yet migrated, or unknown
  * @param detail a short, human-readable explanation

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -17,6 +17,7 @@
       <validValue name="GET_FLOW_CONTROL">6</validValue>
       <validValue name="GET_EXPORTING_STATE">7</validValue>
       <validValue name="GET_MIGRATION_STATUS">8</validValue>
+      <validValue name="GET_EXPORTING_MIGRATION_STATUS">9</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterExporterMigrationStatusProviderIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterExporterMigrationStatusProviderIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.management;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.admin.ClusterExporterMigrationStatusProvider;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real multi-broker coverage for {@link ClusterExporterMigrationStatusProvider}, constructed
+ * directly against a live {@link BrokerClient} rather than through the {@code upgradeReadiness}
+ * actuator endpoint — proving the leader-preferred replica selection actually resolves and queries
+ * the correct remote broker across real process boundaries, which a single-broker test can't.
+ */
+@ZeebeIntegration
+final class ClusterExporterMigrationStatusProviderIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+  @TestZeebe
+  private static final TestCluster CLUSTER =
+      TestCluster.builder()
+          .withBrokersCount(3)
+          .withPartitionsCount(3)
+          .withReplicationFactor(3)
+          // Loopback keeps inter-broker replication and this provider's fan-out independent of
+          // the environment's network/firewall setup.
+          .withBrokerConfig(
+              broker ->
+                  broker.withClusterConfig(
+                      cluster -> {
+                        cluster.getNetwork().setAdvertisedHost("127.0.0.1");
+                        cluster.getNetwork().getInternalApi().setAdvertisedHost("127.0.0.1");
+                      }))
+          .build();
+
+  @Test
+  void shouldReportMigratedByQueryingTheRealLeaderOfEveryPartition() {
+    final var brokerClient = CLUSTER.anyGateway().bean(BrokerClient.class);
+    final var provider =
+        new ClusterExporterMigrationStatusProvider(brokerClient, PhysicalTenantIds.DEFAULT);
+
+    Awaitility.await("until every partition's leader reports MIGRATED over the real network")
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var status = provider.getMigrationStatus();
+
+              assertThat(status).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID);
+              assertThat(status.get(DEFAULT_PHYSICAL_TENANT_ID).state())
+                  .isEqualTo(MigrationState.MIGRATED);
+            });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
@@ -58,7 +58,7 @@ final class UpgradeReadinessEndpointIT {
               });
 
   @Test
-  void shouldReportBothProvidersMigratedForTheDefaultPhysicalTenant() {
+  void shouldReportAllProvidersMigratedForTheDefaultPhysicalTenant() {
     Awaitility.await("until every registered condition settles on MIGRATED for the default tenant")
         .atMost(TIMEOUT)
         .untilAsserted(
@@ -67,9 +67,11 @@ final class UpgradeReadinessEndpointIT {
 
               assertThat(response.physicalTenants()).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID);
               final var defaultTenant = response.physicalTenants().get(DEFAULT_PHYSICAL_TENANT_ID);
-              assertThat(defaultTenant).containsKeys("rdbmsSchemaMigrated", "rocksDbMigrated");
+              assertThat(defaultTenant)
+                  .containsKeys("rdbmsSchemaMigrated", "rocksDbMigrated", "exporterMigrated");
               assertThat(defaultTenant.get("rdbmsSchemaMigrated").state()).isEqualTo("MIGRATED");
               assertThat(defaultTenant.get("rocksDbMigrated").state()).isEqualTo("MIGRATED");
+              assertThat(defaultTenant.get("exporterMigrated").state()).isEqualTo("MIGRATED");
               assertThat(response.upgradeable()).isTrue();
             });
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/UpgradeReadinessEndpointIT.java
@@ -68,10 +68,15 @@ final class UpgradeReadinessEndpointIT {
               assertThat(response.physicalTenants()).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID);
               final var defaultTenant = response.physicalTenants().get(DEFAULT_PHYSICAL_TENANT_ID);
               assertThat(defaultTenant)
-                  .containsKeys("rdbmsSchemaMigrated", "rocksDbMigrated", "exporterMigrated");
+                  .containsKeys(
+                      "rdbmsSchemaMigrated",
+                      "rocksDbMigrated",
+                      "exporterMigrated",
+                      "brokerVersionMigrated");
               assertThat(defaultTenant.get("rdbmsSchemaMigrated").state()).isEqualTo("MIGRATED");
               assertThat(defaultTenant.get("rocksDbMigrated").state()).isEqualTo("MIGRATED");
               assertThat(defaultTenant.get("exporterMigrated").state()).isEqualTo("MIGRATED");
+              assertThat(defaultTenant.get("brokerVersionMigrated").state()).isEqualTo("MIGRATED");
               assertThat(response.upgradeable()).isTrue();
             });
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
@@ -71,6 +71,10 @@ public record SemanticVersion(
     return preRelease != null;
   }
 
+  public String toMinorVersionString() {
+    return major + "." + minor;
+  }
+
   public static Optional<SemanticVersion> parse(final @Nullable String version) {
     if (version == null) {
       return Optional.empty();

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
@@ -75,12 +75,31 @@ public record SemanticVersion(
     return major + "." + minor;
   }
 
+  /**
+   * @return this version with its pre-release/build-metadata suffix stripped (e.g. {@code
+   *     8.10.0-SNAPSHOT} becomes {@code 8.10.0}), or this version unchanged if it has neither.
+   */
+  public SemanticVersion withoutPreRelease() {
+    if (preRelease == null && buildMetadata == null) {
+      return this;
+    }
+    return new SemanticVersion(major, minor, patch, null, null);
+  }
+
   public static Optional<SemanticVersion> parse(final @Nullable String version) {
     if (version == null) {
       return Optional.empty();
     }
 
     return Optional.ofNullable(CACHE.computeIfAbsent(version, SemanticVersion::doParse));
+  }
+
+  /**
+   * @return {@code version} stripped of any pre-release/build-metadata suffix, or the raw input
+   *     unchanged if it can't be parsed as a semantic version.
+   */
+  public static String withoutPreReleaseSuffix(final String version) {
+    return parse(version).map(sv -> sv.withoutPreRelease().toString()).orElse(version);
   }
 
   private static @Nullable SemanticVersion doParse(final String version) {

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/SemanticVersionTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/SemanticVersionTest.java
@@ -128,4 +128,11 @@ final class SemanticVersionTest {
                 "2.1.0-alpha3",
                 "2.1.0"));
   }
+
+  @Test
+  void shouldFormatOnlyMajorAndMinorAsAMinorVersionString() {
+    assertThat(new SemanticVersion(8, 10, 3, null, null).toMinorVersionString()).isEqualTo("8.10");
+    assertThat(new SemanticVersion(8, 10, 0, "SNAPSHOT", null).toMinorVersionString())
+        .isEqualTo("8.10");
+  }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/SemanticVersionTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/SemanticVersionTest.java
@@ -135,4 +135,21 @@ final class SemanticVersionTest {
     assertThat(new SemanticVersion(8, 10, 0, "SNAPSHOT", null).toMinorVersionString())
         .isEqualTo("8.10");
   }
+
+  @Test
+  void shouldStripThePreReleaseAndBuildMetadataSuffix() {
+    assertThat(new SemanticVersion(8, 10, 0, "SNAPSHOT", "build.1").withoutPreRelease())
+        .isEqualTo(new SemanticVersion(8, 10, 0, null, null));
+    assertThat(new SemanticVersion(8, 10, 0, null, null).withoutPreRelease())
+        .isEqualTo(new SemanticVersion(8, 10, 0, null, null));
+  }
+
+  @Test
+  void shouldStripThePreReleaseSuffixFromAVersionString() {
+    assertThat(SemanticVersion.withoutPreReleaseSuffix("8.10.0-SNAPSHOT")).isEqualTo("8.10.0");
+    assertThat(SemanticVersion.withoutPreReleaseSuffix("8.10.0")).isEqualTo("8.10.0");
+    assertThat(SemanticVersion.withoutPreReleaseSuffix("not-a-version"))
+        .describedAs("falls back to the raw input when it can't be parsed")
+        .isEqualTo("not-a-version");
+  }
 }


### PR DESCRIPTION
This pull request introduces a new mechanism to determine and report the migration status of exporter backlogs for upgrade-readiness. It adds an endpoint and supporting logic to check whether all exporters on a partition have finished exporting records from previous minor version.

**API and Endpoint Additions:**

* Added `getExportingMigrationStatus` method to the `PartitionAdminAccess` interface and its implementations (`ZeebePartitionAdminAccess`, `NoOpPartitionAdminAccess`, and `ExporterDirector`), enabling the system to report the exporter migration status for each partition.

**Migration Status Computation:**

* Introduced the `ExportingMigrationStatusCalculator` class, which determines if exporters are fully caught up with records from previous versions, using version compatibility checks and returning detailed status codes (`MIGRATED`, `MIGRATION_IN_PROGRESS`, `UNKNOWN`).

Closes #59852.
