### PR TITLE
fix: only load process definitions from selected tenant

### DIFF
--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/FieldsModal.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/FieldsModal.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Fragment} from 'react';
+import {Fragment, useCallback} from 'react';
 import {
   Button,
   DatePicker,
@@ -28,6 +28,7 @@ import {FieldArray} from 'react-final-form-arrays';
 import arrayMutators from 'final-form-arrays';
 import set from 'lodash/set';
 import {MultitenancySelect} from 'common/multitenancy/MultitenancySelect';
+import {DEFAULT_TENANT_ID} from 'common/multitenancy/constants';
 import {useCurrentUser} from 'common/api/useCurrentUser.query';
 import {useIsMultitenancyEnabled} from 'common/multitenancy/useIsMultitenancyEnabled';
 import {
@@ -39,6 +40,7 @@ import styles from './fieldsModal.module.scss';
 import cn from 'classnames';
 import {Modal} from 'common/components/Modal';
 import {useTranslation} from 'react-i18next';
+import {getClientConfig} from 'common/config/getClientConfig';
 
 type FormValues = NamedCustomFilters & {
   areAdvancedFiltersEnabled: boolean;
@@ -88,9 +90,37 @@ const FieldsModal: React.FC<Props> = ({
 }) => {
   const {t, i18n} = useTranslation();
   const label = t('customFiltersModalAdvancedFiltersLabel');
-  const {isMultitenancyEnabled} = useIsMultitenancyEnabled();
+  const {isMultitenancyEnabled: isTenantSelectEnabled} =
+    useIsMultitenancyEnabled();
   const {data: currentUser} = useCurrentUser();
+  const {clientMode, isMultiTenancyEnabled} = getClientConfig();
   const groups = currentUser?.groups ?? [];
+  const getTenantId = useCallback(
+    (formTenant: string | undefined) => {
+      if (!isMultiTenancyEnabled) {
+        return undefined;
+      }
+
+      if (clientMode === 'v1') {
+        return DEFAULT_TENANT_ID;
+      }
+
+      if (formTenant !== undefined && formTenant !== '') {
+        return formTenant;
+      }
+
+      if (formTenant === '') {
+        return undefined;
+      }
+
+      if (currentUser?.tenants.length === 1) {
+        return currentUser.tenants[0]?.tenantId;
+      }
+
+      return undefined;
+    },
+    [clientMode, currentUser, isMultiTenancyEnabled],
+  );
 
   return (
     <Modal
@@ -283,15 +313,18 @@ const FieldsModal: React.FC<Props> = ({
                       <ProcessesSelect
                         {...input}
                         id={input.name}
-                        tenantId={values?.tenant}
-                        disabled={!isOpen}
+                        tenantId={getTenantId(values?.tenant)}
+                        disabled={
+                          !isOpen ||
+                          (isMultiTenancyEnabled && currentUser === undefined)
+                        }
                         labelText={t(
                           'customFiltersModalLatestProcessVersionLabel',
                         )}
                       />
                     )}
                   </Field>
-                  {isMultitenancyEnabled ? (
+                  {isTenantSelectEnabled ? (
                     <Field name="tenant">
                       {({input}) => (
                         <MultitenancySelect

--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/ProcessesSelect.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/ProcessesSelect.tsx
@@ -7,7 +7,6 @@
  */
 
 import {Select, SelectItem} from '@carbon/react';
-import {DEFAULT_TENANT_ID} from 'common/multitenancy/constants';
 import {useProcesses} from 'v1/api/useProcesses.query';
 import {useAllProcessDefinitions} from 'v2/api/useAllProcessDefinitions.query';
 import {useTranslation} from 'react-i18next';
@@ -62,21 +61,13 @@ type Props = {
   tenantId?: string;
 } & React.ComponentProps<typeof Select>;
 
-const ProcessesSelect: React.FC<Props> = ({
-  tenantId = DEFAULT_TENANT_ID,
-  disabled,
-  ...props
-}) => {
+const ProcessesSelect: React.FC<Props> = ({tenantId, disabled, ...props}) => {
   const {t} = useTranslation();
-  const {data} = useMultiModeProcesses(
-    {
-      tenantId,
-    },
-    {
-      enabled: !disabled,
-      refetchInterval: false,
-    },
-  );
+  const tenantFilter = tenantId === undefined ? {} : {tenantId};
+  const {data} = useMultiModeProcesses(tenantFilter, {
+    enabled: !disabled,
+    refetchInterval: false,
+  });
 
   const processes = normalizeProcesses(
     (isV2Result(data) ? data.items : data?.processes) ?? [],

--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/index.v1.test.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/index.v1.test.tsx
@@ -15,6 +15,7 @@ import {HttpResponse, http} from 'msw';
 import * as userMocks from 'common/mocks/current-user';
 import {createMockProcess} from 'v1/api/useProcesses.query';
 import {getStateLocally, storeStateLocally} from 'common/local-storage';
+import * as clientConfig from 'common/config/getClientConfig';
 
 const getWrapper = () => {
   const mockClient = getMockQueryClient();
@@ -183,6 +184,144 @@ describe('<CustomFiltersModal />', () => {
     expect(
       within(dialog).getByRole('textbox', {name: /in a group/i}),
     ).toBeInTheDocument();
+  });
+
+  it('should load default-tenant processes for a user with one accessible tenant', async () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      clientMode: 'v1',
+      isMultiTenancyEnabled: true,
+    });
+    nodeMockServer.use(
+      http.get('/v2/authentication/me', () =>
+        HttpResponse.json({
+          ...userMocks.currentUser,
+          tenants: [{tenantId: 'staging', name: 'Staging', description: null}],
+        }),
+      ),
+      http.get('/v1/internal/processes', ({request}) => {
+        if (new URL(request.url).searchParams.get('tenantId') !== '<default>') {
+          return HttpResponse.json(null, {status: 400});
+        }
+
+        return HttpResponse.json([createMockProcess('process-0')]);
+      }),
+    );
+
+    render(
+      <CustomFiltersModal
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
+    );
+    expect(
+      screen.queryByRole('combobox', {name: /tenant/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should load default-tenant processes for a user with multiple accessible tenants', async () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      clientMode: 'v1',
+      isMultiTenancyEnabled: true,
+    });
+    nodeMockServer.use(
+      http.get('/v2/authentication/me', () =>
+        HttpResponse.json(userMocks.currentUserWithTenants),
+      ),
+      http.get('/v1/internal/processes', ({request}) => {
+        if (new URL(request.url).searchParams.get('tenantId') !== '<default>') {
+          return HttpResponse.json(null, {status: 400});
+        }
+
+        return HttpResponse.json([createMockProcess('process-0')]);
+      }),
+    );
+
+    render(
+      <CustomFiltersModal
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
+    );
+  });
+
+  it('should load default-tenant processes when another tenant is selected', async () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      clientMode: 'v1',
+      isMultiTenancyEnabled: true,
+    });
+    storeStateLocally('customFilters', {
+      custom: {assignee: 'all', status: 'all', tenant: 'tenantB'},
+    });
+    nodeMockServer.use(
+      http.get('/v2/authentication/me', () =>
+        HttpResponse.json(userMocks.currentUserWithTenants),
+      ),
+      http.get('/v1/internal/processes', ({request}) => {
+        if (new URL(request.url).searchParams.get('tenantId') !== '<default>') {
+          return HttpResponse.json(null, {status: 400});
+        }
+
+        return HttpResponse.json([createMockProcess('process-0')]);
+      }),
+    );
+
+    render(
+      <CustomFiltersModal
+        isOpen
+        filterId="custom"
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
+    );
+  });
+
+  it('should load processes without a tenant when multi-tenancy is disabled', async () => {
+    nodeMockServer.use(
+      http.get('/v1/internal/processes', ({request}) => {
+        if (new URL(request.url).searchParams.has('tenantId')) {
+          return HttpResponse.json(null, {status: 400});
+        }
+
+        return HttpResponse.json([createMockProcess('process-0')]);
+      }),
+    );
+
+    render(
+      <CustomFiltersModal
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
+    );
   });
 
   it('should render advanced filters', async () => {

--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/index.v2.test.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/index.v2.test.tsx
@@ -14,11 +14,15 @@ import {nodeMockServer} from 'common/testing/nodeMockServer';
 import {HttpResponse, http} from 'msw';
 import * as userMocks from 'common/mocks/current-user';
 import {getStateLocally, storeStateLocally} from 'common/local-storage';
-import {endpoints} from '@camunda/camunda-api-zod-schemas/8.9';
+import {
+  endpoints,
+  type QueryProcessDefinitionsRequestBody,
+} from '@camunda/camunda-api-zod-schemas/8.9';
 import {
   getProcessDefinitionMock,
   getQueryProcessDefinitionsResponseMock,
 } from 'v2/mocks/processDefinitions';
+import * as clientConfig from 'common/config/getClientConfig';
 
 const definitionsMock = getQueryProcessDefinitionsResponseMock([
   getProcessDefinitionMock(),
@@ -336,6 +340,167 @@ describe('<CustomFiltersModal />', () => {
     expect(
       await within(dialog).findByRole('combobox', {name: /in a group/i}),
     ).toBeInTheDocument();
+  });
+
+  it('should load processes from the only accessible tenant', async () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      isMultiTenancyEnabled: true,
+    });
+    nodeMockServer.use(
+      http.get('/v2/authentication/me', () =>
+        HttpResponse.json({
+          ...userMocks.currentUser,
+          tenants: [{tenantId: 'staging', name: 'Staging', description: null}],
+        }),
+      ),
+      http.post(
+        endpoints.queryProcessDefinitions.getUrl(),
+        async ({request}) => {
+          const {filter} =
+            (await request.json()) as QueryProcessDefinitionsRequestBody;
+          if (
+            filter?.tenantId !== 'staging' ||
+            Object.keys(filter).length !== 1
+          ) {
+            return HttpResponse.json(null, {status: 400});
+          }
+
+          return HttpResponse.json(definitionsMock);
+        },
+      ),
+    );
+
+    render(
+      <CustomFiltersModal
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
+    );
+    expect(
+      screen.queryByRole('combobox', {name: /tenant/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should load processes from all accessible tenants', async () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      isMultiTenancyEnabled: true,
+    });
+    nodeMockServer.use(
+      http.get('/v2/authentication/me', () =>
+        HttpResponse.json(userMocks.currentUserWithTenants),
+      ),
+      http.post(
+        endpoints.queryProcessDefinitions.getUrl(),
+        async ({request}) => {
+          const {filter} =
+            (await request.json()) as QueryProcessDefinitionsRequestBody;
+          if (filter === undefined || Object.keys(filter).length !== 0) {
+            return HttpResponse.json(null, {status: 400});
+          }
+
+          return HttpResponse.json(definitionsMock);
+        },
+      ),
+    );
+
+    render(
+      <CustomFiltersModal
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
+    );
+  });
+
+  it('should load processes from the explicitly selected tenant', async () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      isMultiTenancyEnabled: true,
+    });
+    storeStateLocally('customFilters', {
+      custom: {assignee: 'all', status: 'all', tenant: 'tenantB'},
+    });
+    nodeMockServer.use(
+      http.get('/v2/authentication/me', () =>
+        HttpResponse.json(userMocks.currentUserWithTenants),
+      ),
+      http.post(
+        endpoints.queryProcessDefinitions.getUrl(),
+        async ({request}) => {
+          const {filter} =
+            (await request.json()) as QueryProcessDefinitionsRequestBody;
+          if (
+            filter?.tenantId !== 'tenantB' ||
+            Object.keys(filter).length !== 1
+          ) {
+            return HttpResponse.json(null, {status: 400});
+          }
+
+          return HttpResponse.json(definitionsMock);
+        },
+      ),
+    );
+
+    render(
+      <CustomFiltersModal
+        isOpen
+        filterId="custom"
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
+    );
+  });
+
+  it('should load processes without a tenant when multi-tenancy is disabled', async () => {
+    nodeMockServer.use(
+      http.post(
+        endpoints.queryProcessDefinitions.getUrl(),
+        async ({request}) => {
+          const {filter} =
+            (await request.json()) as QueryProcessDefinitionsRequestBody;
+          if (filter === undefined || Object.keys(filter).length !== 0) {
+            return HttpResponse.json(null, {status: 400});
+          }
+
+          return HttpResponse.json(definitionsMock);
+        },
+      ),
+    );
+
+    render(
+      <CustomFiltersModal
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
+    );
   });
 
   it('should load from previously saved filters', async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Same as https://github.com/camunda/camunda/pull/60359

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/60339
