### PR TITLE
ci: add 8.11 to preview-env smoke test matrix (8.11/8.10/8.9/8.8)

### DIFF
--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -15,6 +15,7 @@ on:
         type: choice
         options:
         - all
+        - '8.11'
         - '8.10'
         - '8.9'
         - '8.8'
@@ -27,8 +28,8 @@ on:
         default: false
       existing-host:
         description: |
-          Iteration shortcut (8.10 only): reuse an already-deployed preview env
-          (host FQDN, e.g. smoke810-123.camunda.camunda.cloud) instead of
+          Iteration shortcut (8.11 only): reuse an already-deployed preview env
+          (host FQDN, e.g. smoke811-123.camunda.camunda.cloud) instead of
           building images and deploying. Chart changes reach the existing env
           via ArgoCD branch tracking, so a push + this input skips ~20min of
           build/deploy per iteration.
@@ -60,13 +61,22 @@ on:
         required: false
         type: string
         default: 'stable/8.9'
+      ref-8-10:
+        description: |
+          Git ref to build and deploy the 8.10 preview from. Lets stable-branch
+          chart changes be smoke-tested pre-merge from their PR branch. The
+          reusable deploy workflow itself still runs from stable/8.10 (static
+          `uses:` ref).
+        required: false
+        type: string
+        default: 'stable/8.10'
 
 env:
   TEST_OWNER: '@camunda/engineering-operations'
   E2E_DIR: e2e-tests
 
 jobs:
-  # Gate for the free-form ref-8-8/ref-8-9 dispatch inputs: they are forwarded
+  # Gate for the free-form ref-8-8/ref-8-9/ref-8-10 dispatch inputs: they are forwarded
   # as `ref` into the reusable deploy/teardown workflows, where they end up in
   # shell-built ArgoCD arguments (--revision, --helm-set), so restrict them to
   # git-ref characters before anything consumes them. Always runs (trivially
@@ -83,8 +93,9 @@ jobs:
         env:
           REF_8_8: ${{ inputs.ref-8-8 }}
           REF_8_9: ${{ inputs.ref-8-9 }}
+          REF_8_10: ${{ inputs.ref-8-10 }}
         run: |
-          for ref in "$REF_8_8" "$REF_8_9"; do
+          for ref in "$REF_8_8" "$REF_8_9" "$REF_8_10"; do
             if [[ -n "$ref" && ! "$ref" =~ ^[A-Za-z0-9._/-]+$ ]]; then
               echo "::error::Invalid ref override (allowed: A-Z a-z 0-9 . _ / -): ${ref}"
               exit 1
@@ -145,15 +156,31 @@ jobs:
 
   deploy-8-10:
     name: Deploy 8.10 Preview Environment
-    if: contains(fromJSON('["all", "8.10", ""]'), inputs.version) && inputs.existing-host == ''
-    uses: ./.github/workflows/preview-env-build-and-deploy.yml
+    if: contains(fromJSON('["all", "8.10", ""]'), inputs.version)
+    needs: validate-ref-inputs
+    uses: camunda/camunda/.github/workflows/preview-env-build-and-deploy.yml@stable/8.10
     secrets: inherit
     with:
       app-name: smoke810-${{ github.run_number }}
+      ref: ${{ inputs.ref-8-10 || 'stable/8.10' }}
       labels: |
         preview=smoke-test
         repo=camunda_camunda
         version=8.10
+      helm-extra-args: |
+        --helm-set global.preview.ingress.internalAuthBypass.enabled=true
+
+  deploy-8-11:
+    name: Deploy 8.11 Preview Environment
+    if: contains(fromJSON('["all", "8.11", ""]'), inputs.version) && inputs.existing-host == ''
+    uses: ./.github/workflows/preview-env-build-and-deploy.yml
+    secrets: inherit
+    with:
+      app-name: smoke811-${{ github.run_number }}
+      labels: |
+        preview=smoke-test
+        repo=camunda_camunda
+        version=8.11
       helm-extra-args: |
         --helm-set global.preview.ingress.internalAuthBypass.enabled=true
 
@@ -163,9 +190,10 @@ jobs:
     - deploy-8-8
     - deploy-8-9
     - deploy-8-10
-    # Run if at least one deploy succeeded (or an existing 8.10 preview is
-    # reused; existing-host only applies when the version selection includes 8.10)
-    if: always() && (needs.deploy-8-10.result == 'success' || needs.deploy-8-9.result == 'success' || needs.deploy-8-8.result == 'success' || (inputs.existing-host != '' && contains(fromJSON('["all", "8.10", ""]'), inputs.version)))
+    - deploy-8-11
+    # Run if at least one deploy succeeded (or an existing 8.11 preview is
+    # reused; existing-host only applies when the version selection includes 8.11)
+    if: always() && (needs.deploy-8-11.result == 'success' || needs.deploy-8-10.result == 'success' || needs.deploy-8-9.result == 'success' || needs.deploy-8-8.result == 'success' || (inputs.existing-host != '' && contains(fromJSON('["all", "8.11", ""]'), inputs.version)))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -183,8 +211,11 @@ jobs:
           host: ${{ needs.deploy-8-9.outputs.host-name }}
           run: ${{ needs.deploy-8-9.result == 'success' }}
         - version: '8.10'
-          host: ${{ inputs.existing-host || needs.deploy-8-10.outputs.host-name }}
-          run: ${{ needs.deploy-8-10.result == 'success' || (inputs.existing-host != '' && contains(fromJSON('["all", "8.10", ""]'), inputs.version)) }}
+          host: ${{ needs.deploy-8-10.outputs.host-name }}
+          run: ${{ needs.deploy-8-10.result == 'success' }}
+        - version: '8.11'
+          host: ${{ inputs.existing-host || needs.deploy-8-11.outputs.host-name }}
+          run: ${{ needs.deploy-8-11.result == 'success' || (inputs.existing-host != '' && contains(fromJSON('["all", "8.11", ""]'), inputs.version)) }}
         exclude:
         - deployment:
             run: false
@@ -388,10 +419,26 @@ jobs:
     needs:
     - deploy-8-10
     - test
-    uses: ./.github/workflows/preview-env-teardown.yml
+    uses: camunda/camunda/.github/workflows/preview-env-teardown.yml@stable/8.10
     secrets: inherit
     with:
       app-name: smoke810-${{ github.run_number }}
+      ref: ${{ inputs.ref-8-10 || 'stable/8.10' }}
+
+  teardown-8-11:
+    name: Teardown 8.11 Preview Environment
+    if: >
+      always() &&
+      needs.deploy-8-11.result == 'success' &&
+      needs.test.result == 'success' &&
+      !inputs.skip-teardown
+    needs:
+    - deploy-8-11
+    - test
+    uses: ./.github/workflows/preview-env-teardown.yml
+    secrets: inherit
+    with:
+      app-name: smoke811-${{ github.run_number }}
 
   notify-failure:
     name: Notify on Failure
@@ -403,12 +450,14 @@ jobs:
         contains(fromJSON('["failure", "cancelled"]'), needs.deploy-8-8.result) ||
         contains(fromJSON('["failure", "cancelled"]'), needs.deploy-8-9.result) ||
         contains(fromJSON('["failure", "cancelled"]'), needs.deploy-8-10.result) ||
+        contains(fromJSON('["failure", "cancelled"]'), needs.deploy-8-11.result) ||
         contains(fromJSON('["failure", "cancelled"]'), needs.test.result)
       )
     needs:
     - deploy-8-8
     - deploy-8-9
     - deploy-8-10
+    - deploy-8-11
     - test
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## What

Adds **8.11** to the weekly preview-env smoke test matrix following the version
bump that makes `main` 8.11, and moves 8.10 onto its stable cross-ref now that it
has a `stable/8.10` branch.

**8.8 is intentionally retained** (still supported), so this expands coverage to
four minors: **8.11 / 8.10 / 8.9 / 8.8** — the `8.8` `version` option and its
`deploy-8-8` / `test` / `notify-failure` wiring are left in place on purpose.

Follows the same rotation pattern as #46532, applied one minor forward:

- **`deploy-8-10`** switches from the local reusable-workflow ref to the
  cross-ref `@stable/8.10`, gaining a `ref-8-10` dispatch input and the
  `validate-ref-inputs` dependency — exactly like `deploy-8-9` today.
- **`deploy-8-11`** is added on the **local** ref (main is now 8.11) — what
  `deploy-8-10` did before this change. No branch dependency.
- **`existing-host`** iteration shortcut follows the local-ref version from
  8.10 → 8.11, because its ArgoCD branch-tracking premise only holds for the
  preview built from the caller's checkout, not a static stable cross-ref.
- `test`, `notify-failure` and `teardown` extended for 8.11; `teardown-8-10`
  switched to the stable cross-ref. `deploy-8-8` and its wiring are unchanged.
- **Every version literal is quoted** (`'8.11'`, `'8.10'`) so GHA's YAML parser
  does not read them as truncated numbers — the defect that required the
  #46532 follow-up (#47325). No follow-up needed this time.

## Validation

- `actionlint` clean
- YAML parses

Related: #60298