### PR TITLE
ci: add stable/8.10 to release dry-run workflow

### DIFF
--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -87,6 +87,7 @@ jobs:
       # Uses fake tag for dry run testing without affecting real releases
       releaseVersion: 0.0.0-dryrun-810
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
+      # 8.10 is the latest stable minor, so it is the only one flagged as latest
       isLatest: true
       dryRun: true
       includeOptimize: true
@@ -102,7 +103,8 @@ jobs:
       # Uses fake tag for dry run testing without affecting real releases
       releaseVersion: 0.0.0-dryrun-89
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
-      isLatest: true
+      # Only the latest stable minor is the latest release; older minors set false
+      isLatest: false
       dryRun: true
       includeOptimize: true
   dry-run-release-88:
@@ -117,7 +119,8 @@ jobs:
       # Uses fake tag for dry run testing without affecting real releases
       releaseVersion: 0.0.0-dryrun-88
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
-      isLatest: true
+      # Only the latest stable minor is the latest release; older minors set false
+      isLatest: false
       dryRun: true
       includeOptimize: true
   dry-run-release-87:
@@ -132,7 +135,8 @@ jobs:
       # Uses fake tag for dry run testing without affecting real releases
       releaseVersion: 0.0.0-dryrun-87
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
-      isLatest: true
+      # Only the latest stable minor is the latest release; older minors set false
+      isLatest: false
       dryRun: true
   # Always run cleanup. Delete refs for successful dry runs and keep failed
   # ones available for targeted reruns.

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ steps.github-token.outputs.token }}
       - name: Create branches
         run: |
-          for version in 8.7 8.8 8.9; do
+          for version in 8.7 8.8 8.9 8.10; do
             branch_name="tmp-dryrun-${version}-${{ github.run_id }}"
             git checkout "origin/stable/${version}"
             git checkout -b "${branch_name}"
@@ -55,9 +55,10 @@ jobs:
             [8.7]=0.0.0-dryrun-87
             [8.8]=0.0.0-dryrun-88
             [8.9]=0.0.0-dryrun-89
+            [8.10]=0.0.0-dryrun-810
           )
 
-          for version in 8.7 8.8 8.9; do
+          for version in 8.7 8.8 8.9 8.10; do
             tag_name="${tags[$version]}"
             git checkout "origin/stable/${version}"
             git tag -f "${tag_name}"
@@ -74,6 +75,21 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  dry-run-release-810:
+    name: "Release from stable/8.10"
+    needs: create-dry-run-branches
+    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.10
+    secrets: inherit
+    strategy:
+      fail-fast: false
+    with:
+      releaseBranch: tmp-dryrun-8.10-${{ github.run_id }}
+      # Uses fake tag for dry run testing without affecting real releases
+      releaseVersion: 0.0.0-dryrun-810
+      nextDevelopmentVersion: 0.0.0-SNAPSHOT
+      isLatest: true
+      dryRun: true
+      includeOptimize: true
   dry-run-release-89:
     name: "Release from stable/8.9"
     needs: create-dry-run-branches
@@ -123,7 +139,7 @@ jobs:
   cleanup-dry-run-branches:
     name: Delete temporary dry-run branches
     runs-on: ubuntu-slim
-    needs: [dry-run-release-87, dry-run-release-88, dry-run-release-89]
+    needs: [dry-run-release-87, dry-run-release-88, dry-run-release-89, dry-run-release-810]
     if: always()
     timeout-minutes: 5
     permissions: {}  # Uses GitHub App token instead of GITHUB_TOKEN
@@ -145,6 +161,12 @@ jobs:
         # zizmor: ignore[artipacked]
         with:
           token: ${{ steps.github-token.outputs.token }}
+      - name: Delete temporary dryrun 8.10 branch and tag
+        if: ${{ needs.dry-run-release-810.result == 'success' }}
+        run: |
+          branch_name="tmp-dryrun-8.10-${{ github.run_id }}"
+          git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
+          git push origin --delete "refs/tags/0.0.0-dryrun-810" 2>/dev/null || echo "::warning::Failed to delete 0.0.0-dryrun-810, it may have already been deleted"
       - name: Delete temporary dryrun 8.9 branch and tag
         if: ${{ needs.dry-run-release-89.result == 'success' }}
         run: |
@@ -175,7 +197,7 @@ jobs:
   notify-camunda:
     name: Send Slack notification for 8.7+
     runs-on: ubuntu-latest
-    needs: [dry-run-release-87, dry-run-release-88, dry-run-release-89, cleanup-dry-run-branches]
+    needs: [dry-run-release-87, dry-run-release-88, dry-run-release-89, dry-run-release-810, cleanup-dry-run-branches]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -194,7 +216,7 @@ jobs:
 
       - name: Send failure Slack notification
         uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
-        if: ${{ (needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success' || needs.dry-run-release-89.result != 'success') && github.event_name == 'schedule' }}
+        if: ${{ (needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success' || needs.dry-run-release-89.result != 'success' || needs.dry-run-release-810.result != 'success') && github.event_name == 'schedule' }}
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Description

Adds `stable/8.10` to the scheduled release dry-run workflow
(`.github/workflows/zeebe-release-stable-dry-run.yml`) so the monorepo
release pipeline is exercised against 8.10 alongside 8.7, 8.8, and 8.9.

A symmetric 8.10 entry is added at all four per-version touchpoints,
mirroring the existing 8.9 wiring exactly (`includeOptimize: true`):

1. `create-dry-run-branches` — `8.10` added to the branch-creation loop, the
   `tags` map (`0.0.0-dryrun-810`), and the tag loop.
2. A new `dry-run-release-810` job pinned to
   `...camunda-platform-release.yml@stable/8.10`
   (`releaseBranch: tmp-dryrun-8.10-…`, `releaseVersion: 0.0.0-dryrun-810`).
3. `cleanup-dry-run-branches` — added to `needs` plus a new 8.10 branch/tag
   deletion step.
4. `notify-camunda` — added to `needs` and the failure condition.

The 8.7/8.8/8.9 blocks are untouched. `actionlint` (with shellcheck) passes.

## Precedent

Equivalent to #46499 (which added 8.9), adapted to the current
`create-dry-run-branches` / `tmp-dryrun-*` structure.

Actual dry-run https://github.com/camunda/camunda/actions/runs/32760360202

Relate to #60298