### PR TITLE
feat: report referenced secrets from the expression evaluation endpoint

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/EvaluateExpressionResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/EvaluateExpressionResponse.java
@@ -40,4 +40,15 @@ public interface EvaluateExpressionResponse {
    * @return the list of warnings, or an empty list if none
    */
   List<EvaluationWarning> getWarnings();
+
+  /**
+   * Returns the secret references resolved from trusted sources while evaluating the expression: a
+   * {@code camunda.secrets.<name>} reference used directly in the expression, or one carried by a
+   * {@code SECRET_REFERENCE}-kind cluster variable the expression read. References appearing only
+   * in request-body variables or plain cluster variables are excluded, so callers may safely
+   * resolve exactly the references reported here.
+   *
+   * @return the list of referenced secrets, or an empty list if none
+   */
+  List<SecretReference> getReferencedSecrets();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/SecretReference.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/SecretReference.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+/**
+ * A {@code camunda.secrets.<name>} reference that was resolved from a trusted source while
+ * evaluating an expression: a reference used directly in the expression, or one carried by a {@code
+ * SECRET_REFERENCE}-kind cluster variable the expression read. Callers use this to know which
+ * references in the result they may safely resolve.
+ */
+public interface SecretReference {
+
+  /**
+   * Returns the identifier of the secret store that holds the referenced secret.
+   *
+   * @return the secret store identifier, e.g. {@code "default"}
+   */
+  String getStoreId();
+
+  /**
+   * Returns the secret name.
+   *
+   * @return the secret name, e.g. {@code "token"} for {@code "camunda.secrets.token"}
+   */
+  String getSecretName();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateExpressionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateExpressionResponseImpl.java
@@ -17,7 +17,9 @@ package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.client.api.response.EvaluationWarning;
+import io.camunda.client.api.response.SecretReference;
 import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,6 +28,7 @@ public class EvaluateExpressionResponseImpl implements EvaluateExpressionRespons
   private final String expression;
   private final Object result;
   private final List<EvaluationWarning> warnings;
+  private final List<SecretReference> referencedSecrets;
 
   public EvaluateExpressionResponseImpl(final ExpressionEvaluationResult response) {
     expression = response.getExpression();
@@ -34,6 +37,13 @@ public class EvaluateExpressionResponseImpl implements EvaluateExpressionRespons
         response.getWarnings().stream()
             .map(EvaluationWarningImpl::new)
             .collect(Collectors.toList());
+    // referencedSecrets is added in 8.10; an older gateway may omit it, leaving the field null
+    referencedSecrets =
+        response.getReferencedSecrets() == null
+            ? Collections.emptyList()
+            : response.getReferencedSecrets().stream()
+                .map(SecretReferenceImpl::new)
+                .collect(Collectors.toList());
   }
 
   @Override
@@ -49,5 +59,10 @@ public class EvaluateExpressionResponseImpl implements EvaluateExpressionRespons
   @Override
   public List<EvaluationWarning> getWarnings() {
     return warnings;
+  }
+
+  @Override
+  public List<SecretReference> getReferencedSecrets() {
+    return referencedSecrets;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/SecretReferenceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/SecretReferenceImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.SecretReference;
+import io.camunda.client.protocol.rest.ExpressionSecretReferenceItem;
+
+public class SecretReferenceImpl implements SecretReference {
+
+  private final String storeId;
+  private final String secretName;
+
+  public SecretReferenceImpl(final ExpressionSecretReferenceItem item) {
+    storeId = item.getStoreId();
+    secretName = item.getSecretName();
+  }
+
+  @Override
+  public String getStoreId() {
+    return storeId;
+  }
+
+  @Override
+  public String getSecretName() {
+    return secretName;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
@@ -18,13 +18,16 @@ package io.camunda.client.expression;
 import static io.camunda.client.util.assertions.LoggedRequestAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.client.api.response.EvaluationWarning;
+import io.camunda.client.api.response.SecretReference;
 import io.camunda.client.protocol.rest.ExpressionEvaluationRequest;
 import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
 import io.camunda.client.protocol.rest.ExpressionEvaluationWarningItem;
+import io.camunda.client.protocol.rest.ExpressionSecretReferenceItem;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
@@ -211,6 +214,33 @@ public final class EvaluateExpressionTest extends ClientRestTest {
     assertThat(response.getExpression()).isEqualTo(expression);
     assertThat(response.getResult()).isEqualTo(resultValue);
     assertThat(response.getWarnings()).isEmpty();
+    assertThat(response.getReferencedSecrets()).isEmpty();
+  }
+
+  @Test
+  void shouldReceiveExpressionEvaluationResultWithReferencedSecrets() {
+    // given
+    final String expression = "=camunda.secrets.token";
+    final Object resultValue = "camunda.secrets.token";
+    final List<ExpressionSecretReferenceItem> referencedSecrets =
+        Arrays.asList(
+            new ExpressionSecretReferenceItem().storeId("default").secretName("token"),
+            new ExpressionSecretReferenceItem().storeId("vault").secretName("apiKey"));
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult()
+            .expression(expression)
+            .result(resultValue)
+            .warnings(Collections.emptyList())
+            .referencedSecrets(referencedSecrets));
+
+    // when
+    final EvaluateExpressionResponse response =
+        client.newEvaluateExpressionCommand().expression(expression).send().join();
+
+    // then
+    assertThat(response.getReferencedSecrets())
+        .extracting(SecretReference::getStoreId, SecretReference::getSecretName)
+        .containsExactly(tuple("default", "token"), tuple("vault", "apiKey"));
   }
 
   @Test

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -54,6 +54,7 @@ import io.camunda.gateway.protocol.model.EvaluatedDecisionOutputItem;
 import io.camunda.gateway.protocol.model.EvaluatedDecisionResult;
 import io.camunda.gateway.protocol.model.ExpressionEvaluationResult;
 import io.camunda.gateway.protocol.model.ExpressionEvaluationWarningItem;
+import io.camunda.gateway.protocol.model.ExpressionSecretReferenceItem;
 import io.camunda.gateway.protocol.model.GroupCreateResult;
 import io.camunda.gateway.protocol.model.GroupUpdateResult;
 import io.camunda.gateway.protocol.model.JobKindEnum;
@@ -928,6 +929,15 @@ public final class ResponseMapper {
                 .map(
                     warning ->
                         ExpressionEvaluationWarningItem.Builder.create().message(warning).build())
+                .toList())
+        .referencedSecrets(
+            expressionRecord.getReferencedSecrets().stream()
+                .map(
+                    reference ->
+                        ExpressionSecretReferenceItem.Builder.create()
+                            .storeId(reference.getStoreId())
+                            .secretName(reference.getSecretReference())
+                            .build())
                 .toList())
         .build();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -9,12 +9,15 @@ package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientHttpException;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.client.api.response.EvaluationWarning;
+import io.camunda.client.api.response.SecretReference;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
@@ -326,6 +329,65 @@ public class ExpressionEvaluationIT {
     assertThat(response).isNotNull();
     assertThat(response.getResult()).isEqualTo("camunda.secrets.TEST");
     assertThat(response.getWarnings()).isEmpty();
+    // a reference used directly in the expression is trusted, so the endpoint reports it, letting
+    // an inbound connector safely resolve it in the result
+    assertThat(response.getReferencedSecrets())
+        .extracting(SecretReference::getStoreId, SecretReference::getSecretName)
+        .containsExactly(tuple("default", "TEST"));
+  }
+
+  @Test
+  void shouldReportReferencedSecretFromSecretReferenceClusterVariable() {
+    // given a SECRET_REFERENCE-kind cluster variable whose value carries a secret reference
+    final String variableName = "secretRefVar_" + UUID.randomUUID().toString().replace("-", "");
+    final String secretName = "clusterToken_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, Map.of("apiToken", "camunda.secrets." + secretName))
+        .kind(ClusterVariableKind.SECRET_REFERENCE)
+        .send()
+        .join();
+
+    // when the expression reads the reference through the cluster variable
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName + ".apiToken")
+            .send()
+            .join();
+
+    // then the reference is resolved to its placeholder and reported as trusted
+    assertThat(response.getResult()).isEqualTo("camunda.secrets." + secretName);
+    assertThat(response.getReferencedSecrets())
+        .extracting(SecretReference::getStoreId, SecretReference::getSecretName)
+        .containsExactly(tuple("default", secretName));
+  }
+
+  @Test
+  void shouldNotReportSecretLookingValueFromJsonClusterVariable() {
+    // given a plain JSON cluster variable whose value merely looks like a secret reference
+    final String variableName = "jsonSecretVar_" + UUID.randomUUID().toString().replace("-", "");
+    final String injected =
+        "camunda.secrets.INJECTED_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, injected)
+        .kind(ClusterVariableKind.JSON)
+        .send()
+        .join();
+
+    // when the expression reads it
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName)
+            .send()
+            .join();
+
+    // then the reference-looking value is not treated as a trusted secret: resolving it would
+    // reintroduce the secret-injection vulnerability, so it must not be reported
+    assertThat(response.getResult()).isEqualTo(injected);
+    assertThat(response.getReferencedSecrets()).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.processing.expression.ExpressionBehavior;
 import io.camunda.zeebe.engine.processing.expression.GlobalScopeClusterVariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.NamespacedEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.ProcessInstanceContextEvaluationContext;
+import io.camunda.zeebe.engine.processing.expression.ReferencedSecretCollector;
 import io.camunda.zeebe.engine.processing.expression.TenantScopeClusterVariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.VariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -42,6 +43,7 @@ import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import java.time.InstantSource;
+import org.jspecify.annotations.Nullable;
 
 public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
@@ -96,35 +98,13 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final CslTenantCheck tenantCheck,
       final SecretStoreRegistry secretStoreRegistry) {
 
-    final var tenantClusterScope =
-        new TenantScopeClusterVariableEvaluationContext(processingState.getClusterVariableState());
-    final var globalClusterScope =
-        new GlobalScopeClusterVariableEvaluationContext(processingState.getClusterVariableState());
-    final var mergedClusterScope =
-        CombinedEvaluationContext.withContexts(tenantClusterScope, globalClusterScope);
-
-    final var namespacedTenantClusterScope =
-        NamespacedEvaluationContext.create().register("tenant", tenantClusterScope);
-    final var namespacedGlobalClusterScope =
-        NamespacedEvaluationContext.create().register("cluster", globalClusterScope);
-    final var namespacedMergedClusterScope =
-        NamespacedEvaluationContext.create().register("env", mergedClusterScope);
-
-    final var processInstanceContext =
-        new ProcessInstanceContextEvaluationContext(processingState.getElementInstanceState());
-
-    final var namespaceFullClusterContext =
-        NamespacedEvaluationContext.create()
-            .register(
-                "camunda",
-                NamespacedEvaluationContext.create()
-                    .register(
-                        "vars",
-                        CombinedEvaluationContext.withContexts(
-                            namespacedMergedClusterScope,
-                            namespacedTenantClusterScope,
-                            namespacedGlobalClusterScope))
-                    .register("processInstance", processInstanceContext));
+    // The expression endpoint reports which trusted secrets an evaluation touched; only its
+    // contexts record into the collector. The BPMN path uses collector-free contexts, so its
+    // (much more frequent) evaluations never accumulate anything.
+    final var referencedSecretCollector = new ReferencedSecretCollector();
+    final var bpmnClusterContext = buildClusterEvaluationContext(processingState, null);
+    final var endpointClusterContext =
+        buildClusterEvaluationContext(processingState, referencedSecretCollector);
 
     final var processVariableContext =
         new VariableEvaluationContext(processingState.getVariableState());
@@ -136,16 +116,16 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     expressionProcessor =
         new ExpressionProcessor(
             expressionLanguage,
-            CombinedEvaluationContext.withContexts(
-                processVariableContext, namespaceFullClusterContext),
+            CombinedEvaluationContext.withContexts(processVariableContext, bpmnClusterContext),
             config.getExpressionEvaluationTimeout());
 
     expressionBehavior =
         new ExpressionBehavior(
-            namespaceFullClusterContext,
+            endpointClusterContext,
             expressionLanguage,
             config.getExpressionEvaluationTimeout(),
-            processingState.getVariableState());
+            processingState.getVariableState(),
+            referencedSecretCollector);
 
     conditionalBehavior =
         new BpmnConditionalBehavior(
@@ -326,6 +306,47 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             writers.state(),
             processingState.getKeyGenerator(),
             processDefinitionMetrics);
+  }
+
+  /**
+   * Builds the {@code camunda.vars.*} / {@code camunda.processInstance} cluster evaluation context
+   * tree. Passing a non-null {@code collector} makes the cluster-variable contexts record the
+   * trusted secret references they resolve (used by the expression endpoint); passing {@code null}
+   * yields collector-free contexts for the BPMN path, which must not accumulate references.
+   */
+  private static NamespacedEvaluationContext buildClusterEvaluationContext(
+      final MutableProcessingState processingState,
+      final @Nullable ReferencedSecretCollector collector) {
+    final var tenantClusterScope =
+        new TenantScopeClusterVariableEvaluationContext(
+            processingState.getClusterVariableState(), collector);
+    final var globalClusterScope =
+        new GlobalScopeClusterVariableEvaluationContext(
+            processingState.getClusterVariableState(), collector);
+    final var mergedClusterScope =
+        CombinedEvaluationContext.withContexts(tenantClusterScope, globalClusterScope);
+
+    final var namespacedTenantClusterScope =
+        NamespacedEvaluationContext.create().register("tenant", tenantClusterScope);
+    final var namespacedGlobalClusterScope =
+        NamespacedEvaluationContext.create().register("cluster", globalClusterScope);
+    final var namespacedMergedClusterScope =
+        NamespacedEvaluationContext.create().register("env", mergedClusterScope);
+
+    final var processInstanceContext =
+        new ProcessInstanceContextEvaluationContext(processingState.getElementInstanceState());
+
+    return NamespacedEvaluationContext.create()
+        .register(
+            "camunda",
+            NamespacedEvaluationContext.create()
+                .register(
+                    "vars",
+                    CombinedEvaluationContext.withContexts(
+                        namespacedMergedClusterScope,
+                        namespacedTenantClusterScope,
+                        namespacedGlobalClusterScope))
+                .register("processInstance", processInstanceContext));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.expression.CombinedEvaluationContext;
+import io.camunda.zeebe.engine.processing.expression.ReferencedSecretCollector;
 import io.camunda.zeebe.engine.processing.expression.ScopedEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.SecretReferenceEvaluationContext;
 import io.camunda.zeebe.model.bpmn.util.time.Interval;
@@ -101,9 +102,23 @@ public final class ExpressionProcessor {
    * @see SecretReferenceEvaluationContext
    */
   public ExpressionProcessor withSecretReferenceContext() {
+    return withSecretReferenceContext(null);
+  }
+
+  /**
+   * Like {@link #withSecretReferenceContext()}, but additionally records into {@code collector}
+   * every {@code camunda.secrets.<name>} reference resolved directly from the expression, so a
+   * caller (e.g. the expression endpoint) can report which secrets the evaluation touched.
+   *
+   * @param collector the collector to record referenced secrets into, or {@code null} to record
+   *     nothing
+   * @return a new secret-aware processor; this one is left unchanged
+   * @see SecretReferenceEvaluationContext
+   */
+  public ExpressionProcessor withSecretReferenceContext(final ReferencedSecretCollector collector) {
     return new ExpressionProcessor(
         expressionLanguage,
-        new SecretReferenceEvaluationContext(scopedEvaluationContext),
+        new SecretReferenceEvaluationContext(scopedEvaluationContext, collector),
         expressionEvaluationTimeout);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
@@ -25,20 +25,24 @@ public class ExpressionBehavior {
 
   private final ExpressionProcessor clusterExpressionProcessor;
   private final VariableState variableState;
+  private final ReferencedSecretCollector referencedSecretCollector;
 
   public ExpressionBehavior(
       final NamespacedEvaluationContext namespaceFullClusterContext,
       final ExpressionLanguage expressionLanguage,
       final Duration expressionEvaluationTimeout,
-      final VariableState variableState) {
+      final VariableState variableState,
+      final ReferencedSecretCollector referencedSecretCollector) {
+    this.referencedSecretCollector = referencedSecretCollector;
     // Resolve camunda.secrets.<name> references to their own placeholder string (as the engine
     // does for input mappings), so callers of the expression endpoint — e.g. inbound connectors,
     // which have no job to trigger job-activation resolution — receive the reference text instead
     // of null. Only that path is affected; camunda.vars.* and every other lookup forward unchanged.
+    // The collector records references resolved from trusted sources so they can be reported.
     clusterExpressionProcessor =
         new ExpressionProcessor(
                 expressionLanguage, namespaceFullClusterContext, expressionEvaluationTimeout)
-            .withSecretReferenceContext();
+            .withSecretReferenceContext(referencedSecretCollector);
     this.variableState = variableState;
   }
 
@@ -55,6 +59,11 @@ public class ExpressionBehavior {
    */
   public Either<Rejection, ExpressionRecord> resolveExpression(
       final Expression expression, final ExpressionRecord expressionRecord) {
+    // A single collector instance is reused across evaluations (stream processing is
+    // single-threaded per partition). Only the endpoint's contexts hold a collector — the BPMN
+    // path uses collector-free contexts — so a fresh reset here is enough to isolate this
+    // evaluation's references.
+    referencedSecretCollector.reset();
     final long scopeKey = expressionRecord.getScopeKey();
     final var variables = expressionRecord.getVariables();
     final var bodyContext =
@@ -95,13 +104,20 @@ public class ExpressionBehavior {
 
   private ExpressionRecord mapSuccess(
       final EvaluationResult evaluationResult, final ExpressionRecord expressionRecord) {
-    return new ExpressionRecord()
-        .setTenantId(expressionRecord.getTenantId())
-        .setExpression(expressionRecord.getExpression())
-        .setVariables(expressionRecord.getVariablesBuffer())
-        .setScopeKey(expressionRecord.getScopeKey())
-        .setWarnings(
-            evaluationResult.getWarnings().stream().map(EvaluationWarning::getMessage).toList())
-        .setResultValue(evaluationResult.toBuffer());
+    final var mapped =
+        new ExpressionRecord()
+            .setTenantId(expressionRecord.getTenantId())
+            .setExpression(expressionRecord.getExpression())
+            .setVariables(expressionRecord.getVariablesBuffer())
+            .setScopeKey(expressionRecord.getScopeKey())
+            .setWarnings(
+                evaluationResult.getWarnings().stream().map(EvaluationWarning::getMessage).toList())
+            .setResultValue(evaluationResult.toBuffer());
+    referencedSecretCollector
+        .drain()
+        .forEach(
+            reference ->
+                mapped.addReferencedSecret(reference.storeId(), reference.secretReference()));
+    return mapped;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/GlobalScopeClusterVariableEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/GlobalScopeClusterVariableEvaluationContext.java
@@ -13,13 +13,17 @@ import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public final class GlobalScopeClusterVariableEvaluationContext implements ScopedEvaluationContext {
   private final ClusterVariableState clusterVariableState;
+  private final @Nullable ReferencedSecretCollector referencedSecretCollector;
 
   public GlobalScopeClusterVariableEvaluationContext(
-      final ClusterVariableState clusterVariableState) {
+      final ClusterVariableState clusterVariableState,
+      final @Nullable ReferencedSecretCollector referencedSecretCollector) {
     this.clusterVariableState = clusterVariableState;
+    this.referencedSecretCollector = referencedSecretCollector;
   }
 
   @Override
@@ -27,8 +31,16 @@ public final class GlobalScopeClusterVariableEvaluationContext implements Scoped
     return Either.left(
         clusterVariableState
             .getGloballyScopedClusterVariable(BufferUtil.wrapString(variableName))
+            .filter(instance -> instance.getValueBuffer().capacity() > 0)
+            .map(this::recordSecretReferences)
             .map(ClusterVariableInstance::getValueBuffer)
-            .filter(value -> value.capacity() > 0)
             .orElse(null));
+  }
+
+  private ClusterVariableInstance recordSecretReferences(final ClusterVariableInstance instance) {
+    if (referencedSecretCollector != null) {
+      referencedSecretCollector.addClusterVariableReferences(instance);
+    }
+    return instance;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ReferencedSecretCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ReferencedSecretCollector.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import io.camunda.zeebe.engine.state.clustervariable.ClusterVariableInstance;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Accumulates, for a single expression evaluation, the {@code camunda.secrets.<name>} references
+ * that were resolved from <em>trusted</em> sources: a reference used directly in the expression
+ * (see {@link SecretReferenceEvaluationContext}) or one carried by a {@code SECRET_REFERENCE}-kind
+ * cluster variable the expression read (see {@code TenantScopeClusterVariableEvaluationContext} and
+ * {@code GlobalScopeClusterVariableEvaluationContext}).
+ *
+ * <p>This collector is the single authority on what counts as a trusted reference: references that
+ * appear in request-body variables or plain (JSON-kind) cluster variables never reach it, so
+ * callers can safely resolve exactly the references it reports without reintroducing a
+ * secret-injection vector.
+ *
+ * <p>Only the expression-endpoint path ({@code ExpressionBehavior}) wires a collector into its
+ * evaluation contexts; the BPMN input-mapping contexts are built without one and never record. The
+ * engine's stream processing is single-threaded per partition, so a single mutable instance is
+ * reused across endpoint evaluations: {@code ExpressionBehavior} {@link #reset() resets} it before
+ * each evaluation and {@link #drain() drains} it afterwards.
+ */
+@NullMarked
+public final class ReferencedSecretCollector {
+
+  private final Set<ReferencedSecret> references = new LinkedHashSet<>();
+
+  /** Records a reference used directly in the expression (against the given store). */
+  public void add(final String storeId, final String secretReference) {
+    references.add(new ReferencedSecret(storeId, secretReference));
+  }
+
+  /**
+   * Records the references a resolved cluster variable brought into the evaluation, but only when
+   * its kind is {@link ClusterVariableKind#SECRET_REFERENCE}. A JSON-kind variable contributes
+   * nothing, even if its value happens to contain a {@code camunda.secrets.<name>}-looking string:
+   * only references the engine detected and pinned at write time are trusted.
+   */
+  public void addClusterVariableReferences(final ClusterVariableInstance instance) {
+    if (instance.getRecord().getKind() != ClusterVariableKind.SECRET_REFERENCE) {
+      return;
+    }
+    instance
+        .getRecord()
+        .getSecretReferences()
+        .forEach(reference -> add(reference.getStoreId(), reference.getSecretReference()));
+  }
+
+  /** Starts a fresh collection, discarding anything a previous evaluation left behind. */
+  public void reset() {
+    references.clear();
+  }
+
+  /**
+   * Returns a snapshot of the collected references (insertion order, deduplicated) and clears them.
+   */
+  public List<ReferencedSecret> drain() {
+    final var snapshot = List.copyOf(references);
+    references.clear();
+    return snapshot;
+  }
+
+  public record ReferencedSecret(String storeId, String secretReference) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.zeebe.engine.processing.expression;
 
+import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.el.EvaluationContext;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A {@link ScopedEvaluationContext} that resolves a {@code camunda.secrets.<name>} reference used
@@ -35,9 +37,17 @@ public final class SecretReferenceEvaluationContext implements ScopedEvaluationC
   static final String NAMESPACE = "secrets";
 
   private final ScopedEvaluationContext delegate;
+  private final @Nullable ReferencedSecretCollector referencedSecretCollector;
 
   public SecretReferenceEvaluationContext(final ScopedEvaluationContext delegate) {
+    this(delegate, null);
+  }
+
+  public SecretReferenceEvaluationContext(
+      final ScopedEvaluationContext delegate,
+      final @Nullable ReferencedSecretCollector referencedSecretCollector) {
     this.delegate = delegate;
+    this.referencedSecretCollector = referencedSecretCollector;
   }
 
   @Override
@@ -53,30 +63,34 @@ public final class SecretReferenceEvaluationContext implements ScopedEvaluationC
     }
     // wrap the delegate's `camunda` context (or absence) so `secrets` resolves while every other
     // key — e.g. cluster variables under `vars` — keeps forwarding to the delegate
-    return Either.right(new CamundaNamespaceContext(camunda));
+    return Either.right(new CamundaNamespaceContext(camunda, referencedSecretCollector));
   }
 
   @Override
   public ScopedEvaluationContext processScoped(final long scopeKey) {
-    return new SecretReferenceEvaluationContext(delegate.processScoped(scopeKey));
+    return new SecretReferenceEvaluationContext(
+        delegate.processScoped(scopeKey), referencedSecretCollector);
   }
 
   @Override
   public ScopedEvaluationContext tenantScoped(final String tenantId) {
-    return new SecretReferenceEvaluationContext(delegate.tenantScoped(tenantId));
+    return new SecretReferenceEvaluationContext(
+        delegate.tenantScoped(tenantId), referencedSecretCollector);
   }
 
   /**
    * The {@code camunda} namespace: resolves {@code secrets} to the secret-reference leaf and
    * forwards every other key to the delegate's {@code camunda} content (e.g. {@code vars}).
    */
-  private record CamundaNamespaceContext(Either<DirectBuffer, EvaluationContext> delegateCamunda)
+  private record CamundaNamespaceContext(
+      Either<DirectBuffer, EvaluationContext> delegateCamunda,
+      @Nullable ReferencedSecretCollector referencedSecretCollector)
       implements EvaluationContext {
 
     @Override
     public Either<DirectBuffer, EvaluationContext> getVariable(final String variableName) {
       if (NAMESPACE.equals(variableName)) {
-        return Either.right(SecretLeafContext.INSTANCE);
+        return Either.right(new SecretLeafContext(referencedSecretCollector));
       }
       final var camunda = delegateCamunda.isRight() ? delegateCamunda.get() : null;
       return camunda != null ? camunda.getVariable(variableName) : notFound();
@@ -90,14 +104,19 @@ public final class SecretReferenceEvaluationContext implements ScopedEvaluationC
 
   /**
    * The {@code camunda.secrets} namespace: every name resolves to its own reference string literal
-   * {@code "camunda.secrets.<name>"}.
+   * {@code "camunda.secrets.<name>"} and, when a collector is present, is recorded as a referenced
+   * secret so the expression endpoint can report it.
    */
-  private static final class SecretLeafContext implements EvaluationContext {
-
-    private static final SecretLeafContext INSTANCE = new SecretLeafContext();
+  private record SecretLeafContext(@Nullable ReferencedSecretCollector referencedSecretCollector)
+      implements EvaluationContext {
 
     @Override
     public Either<DirectBuffer, EvaluationContext> getVariable(final String name) {
+      if (referencedSecretCollector != null) {
+        // a reference used directly in the expression names no store, so it resolves against the
+        // default one
+        referencedSecretCollector.add(SecretStoreRegistry.DEFAULT_STORE_ID, name);
+      }
       final String reference = ROOT + "." + NAMESPACE + "." + name;
       // cast to Object to serialize the string as a MessagePack string value, not parse it as JSON
       return Either.left(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/TenantScopeClusterVariableEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/TenantScopeClusterVariableEvaluationContext.java
@@ -13,22 +13,27 @@ import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public final class TenantScopeClusterVariableEvaluationContext implements ScopedEvaluationContext {
 
   private final ClusterVariableState clusterVariableState;
   private final String tenantId;
+  private final @Nullable ReferencedSecretCollector referencedSecretCollector;
 
   public TenantScopeClusterVariableEvaluationContext(
-      final ClusterVariableState clusterVariableState) {
-    this.clusterVariableState = clusterVariableState;
-    tenantId = "";
+      final ClusterVariableState clusterVariableState,
+      final @Nullable ReferencedSecretCollector referencedSecretCollector) {
+    this(clusterVariableState, "", referencedSecretCollector);
   }
 
-  public TenantScopeClusterVariableEvaluationContext(
-      final ClusterVariableState clusterVariableState, final String tenantId) {
+  private TenantScopeClusterVariableEvaluationContext(
+      final ClusterVariableState clusterVariableState,
+      final String tenantId,
+      final @Nullable ReferencedSecretCollector referencedSecretCollector) {
     this.clusterVariableState = clusterVariableState;
     this.tenantId = tenantId;
+    this.referencedSecretCollector = referencedSecretCollector;
   }
 
   @Override
@@ -36,13 +41,22 @@ public final class TenantScopeClusterVariableEvaluationContext implements Scoped
     return Either.left(
         clusterVariableState
             .getTenantScopedClusterVariable(BufferUtil.wrapString(variableName), tenantId)
+            .filter(instance -> instance.getValueBuffer().capacity() > 0)
+            .map(this::recordSecretReferences)
             .map(ClusterVariableInstance::getValueBuffer)
-            .filter(value -> value.capacity() > 0)
             .orElse(null));
   }
 
   @Override
   public ScopedEvaluationContext tenantScoped(final String tenantId) {
-    return new TenantScopeClusterVariableEvaluationContext(clusterVariableState, tenantId);
+    return new TenantScopeClusterVariableEvaluationContext(
+        clusterVariableState, tenantId, referencedSecretCollector);
+  }
+
+  private ClusterVariableInstance recordSecretReferences(final ClusterVariableInstance instance) {
+    if (referencedSecretCollector != null) {
+      referencedSecretCollector.addClusterVariableReferences(instance);
+    }
+    return instance;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ExpressionReferencedSecretsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ExpressionReferencedSecretsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
+import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue.ExpressionSecretReferenceValue;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies the expression endpoint reports which {@code camunda.secrets.<name>} references it
+ * resolved from trusted sources — a reference used directly in the expression, or one carried by a
+ * {@code SECRET_REFERENCE}-kind cluster variable — while never reporting references that only
+ * appear in untrusted input (request-body variables or plain, JSON-kind cluster variables). The
+ * latter is the security invariant: reporting them would let a caller resolve an injected secret.
+ */
+public class ExpressionReferencedSecretsTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldReportSecretReferenceUsedDirectlyInExpression() {
+    // when
+    final var record = ENGINE.expression().withExpression("=camunda.secrets.token").resolve();
+
+    // then the reference resolves to its placeholder and is reported
+    assertThat(record.getValue().getResultValue()).isEqualTo("camunda.secrets.token");
+    assertThat(record.getValue().getReferencedSecrets())
+        .extracting(
+            ExpressionSecretReferenceValue::getStoreId,
+            ExpressionSecretReferenceValue::getSecretReference)
+        .containsExactly(tuple("default", "token"));
+  }
+
+  @Test
+  public void shouldReportSecretReferenceCarriedByClusterVariable() {
+    // given a SECRET_REFERENCE-kind cluster variable
+    ENGINE
+        .clusterVariables()
+        .withName("SECRET_CLUSTER_VAR")
+        .setGlobalScope()
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("auth", "camunda.secrets.dbPassword"))
+        .create();
+
+    // when the expression reads it
+    final var record =
+        ENGINE.expression().withExpression("=camunda.vars.cluster.SECRET_CLUSTER_VAR").resolve();
+
+    // then the cluster variable's secret reference is reported
+    assertThat(record.getValue().getReferencedSecrets())
+        .extracting(
+            ExpressionSecretReferenceValue::getStoreId,
+            ExpressionSecretReferenceValue::getSecretReference)
+        .containsExactly(tuple("default", "dbPassword"));
+  }
+
+  @Test
+  public void shouldReportSecretReferenceFromNestedClusterVariableAccess() {
+    // given a SECRET_REFERENCE-kind cluster variable holding a nested reference
+    ENGINE
+        .clusterVariables()
+        .withName("NESTED_SECRET_CLUSTER_VAR")
+        .setGlobalScope()
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("auth", "camunda.secrets.dbPassword"))
+        .create();
+
+    // when the expression reads only a nested member of it
+    final var record =
+        ENGINE
+            .expression()
+            .withExpression("=camunda.vars.cluster.NESTED_SECRET_CLUSTER_VAR.auth")
+            .resolve();
+
+    // then the nested reference resolves to its placeholder and is still reported
+    assertThat(record.getValue().getResultValue()).isEqualTo("camunda.secrets.dbPassword");
+    assertThat(record.getValue().getReferencedSecrets())
+        .extracting(
+            ExpressionSecretReferenceValue::getStoreId,
+            ExpressionSecretReferenceValue::getSecretReference)
+        .containsExactly(tuple("default", "dbPassword"));
+  }
+
+  @Test
+  public void shouldNotReportSecretReferenceFromPlainClusterVariable() {
+    // given a plain (JSON-kind) cluster variable whose value merely looks like a reference
+    ENGINE
+        .clusterVariables()
+        .withName("PLAIN_CLUSTER_VAR")
+        .setGlobalScope()
+        .withValue("\"camunda.secrets.evil\"")
+        .create();
+
+    // when the expression reads it
+    final var record =
+        ENGINE.expression().withExpression("=camunda.vars.cluster.PLAIN_CLUSTER_VAR").resolve();
+
+    // then nothing is reported — resolving it would leak an injected secret
+    assertThat(record.getValue().getResultValue()).isEqualTo("camunda.secrets.evil");
+    assertThat(record.getValue().getReferencedSecrets()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotReportSecretReferenceFromRequestBodyVariable() {
+    // when an untrusted request-body variable holds a reference-looking string
+    final var record =
+        ENGINE
+            .expression()
+            .withExpression("=injected")
+            .withVariables(Map.of("injected", "camunda.secrets.evil"))
+            .resolve();
+
+    // then nothing is reported
+    assertThat(record.getValue().getResultValue()).isEqualTo("camunda.secrets.evil");
+    assertThat(record.getValue().getReferencedSecrets()).isEmpty();
+  }
+
+  @Test
+  public void shouldReportNoSecretsForExpressionWithoutReferences() {
+    // when
+    final var record = ENGINE.expression().withExpression("=1 + 2").resolve();
+
+    // then
+    assertThat(record.getValue().getReferencedSecrets()).isEmpty();
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -84,6 +84,7 @@ components:
         - expression
         - result
         - warnings
+        - referencedSecrets
       properties:
         expression:
           type: string
@@ -100,6 +101,35 @@ components:
           items:
             $ref: '#/components/schemas/ExpressionEvaluationWarningItem'
           example: [ ]
+        referencedSecrets:
+          type: array
+          description: |
+            The secret references resolved from trusted sources while evaluating the expression: a
+            `camunda.secrets.<name>` reference used directly in the expression, or a reference
+            carried by a `SECRET_REFERENCE`-kind cluster variable the expression read. References
+            appearing only in request-body variables or plain cluster variables are excluded.
+            Callers use this to know which `camunda.secrets.<name>` occurrences in the result they
+            may safely resolve.
+          items:
+            $ref: '#/components/schemas/ExpressionSecretReferenceItem'
+          example: [ ]
+      x-properties-added-in-version:
+        - propertyName: referencedSecrets
+          addedInVersion: "8.10"
+    ExpressionSecretReferenceItem:
+      type: object
+      required:
+        - storeId
+        - secretName
+      properties:
+        storeId:
+          type: string
+          description: The identifier of the secret store that holds the referenced secret
+          example: "default"
+        secretName:
+          type: string
+          description: The secret name, e.g. "token" for "camunda.secrets.token"
+          example: "token"
     ExpressionEvaluationWarningItem:
       type: object
       required:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
@@ -89,7 +89,8 @@ public class ExpressionControllerTest extends RestControllerTest {
             {
                 "expression": "=x + y",
                 "result": "10",
-                "warnings": []
+                "warnings": [],
+                "referencedSecrets": []
             }""",
             JsonCompareMode.STRICT);
 
@@ -138,7 +139,8 @@ public class ExpressionControllerTest extends RestControllerTest {
             {
                 "expression": "=x + y",
                 "result": "10",
-                "warnings": []
+                "warnings": [],
+                "referencedSecrets": []
             }""",
             JsonCompareMode.STRICT);
 
@@ -188,7 +190,8 @@ public class ExpressionControllerTest extends RestControllerTest {
                     {
                         "message": "No function found with name 'invalid_function' and 0 parameters"
                     }
-                ]
+                ],
+                "referencedSecrets": []
             }""",
             JsonCompareMode.STRICT);
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue.ExpressionSecretReferenceValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue SCOPE_KEY_KEY = new StringValue("scopeKey");
+  private static final StringValue REFERENCED_SECRETS_KEY = new StringValue("referencedSecrets");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -47,14 +49,18 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
 
+  private final ArrayProperty<ExpressionSecretReference> referencedSecretsProp =
+      new ArrayProperty<>(REFERENCED_SECRETS_KEY, ExpressionSecretReference::new);
+
   public ExpressionRecord() {
-    super(6);
+    super(7);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(scopeKeyProp);
+        .declareProperty(scopeKeyProp)
+        .declareProperty(referencedSecretsProp);
   }
 
   @Override
@@ -125,6 +131,25 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setScopeKey(final long scopeKey) {
     scopeKeyProp.setValue(scopeKey);
+    return this;
+  }
+
+  @Override
+  public List<ExpressionSecretReferenceValue> getReferencedSecrets() {
+    // copy each element out of the reusable backing array so the returned list stays valid after
+    // the record is reset or another element is added
+    return referencedSecretsProp.stream()
+        .map(
+            reference ->
+                (ExpressionSecretReferenceValue)
+                    new ExpressionSecretReference()
+                        .setStoreId(reference.getStoreId())
+                        .setSecretReference(reference.getSecretReference()))
+        .collect(Collectors.toList());
+  }
+
+  public ExpressionRecord addReferencedSecret(final String storeId, final String secretReference) {
+    referencedSecretsProp.add().setStoreId(storeId).setSecretReference(secretReference);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionSecretReference.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionSecretReference.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.expression;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue.ExpressionSecretReferenceValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+@JsonIgnoreProperties({
+  /* Inherited from ObjectValue. They have no purpose in exported JSON records. */
+  "encodedLength",
+  "empty"
+})
+public final class ExpressionSecretReference extends ObjectValue
+    implements ExpressionSecretReferenceValue {
+
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue STORE_ID_KEY = new StringValue("storeId");
+  private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
+
+  // mirrors io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID: the record layer stays
+  // free of the secret store API, so the value is repeated here. An unset store ID names the
+  // default store, not no store at all.
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "default");
+  private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
+
+  public ExpressionSecretReference() {
+    super(2);
+    declareProperty(storeIdProp).declareProperty(secretReferenceProp);
+  }
+
+  @Override
+  public String getStoreId() {
+    return BufferUtil.bufferAsString(storeIdProp.getValue());
+  }
+
+  public ExpressionSecretReference setStoreId(final String storeId) {
+    storeIdProp.setValue(storeId);
+    return this;
+  }
+
+  @Override
+  public String getSecretReference() {
+    return BufferUtil.bufferAsString(secretReferenceProp.getValue());
+  }
+
+  public ExpressionSecretReference setSecretReference(final String secretReference) {
+    secretReferenceProp.setValue(secretReference);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -682,7 +682,8 @@ final class JsonSerializableToJsonTest {
                   .setScopeKey(1)
                   .setTenantId("test-tenant")
                   .setWarnings(List.of("warning1", "warning2"))
-                  .setVariables(VARIABLES_MSGPACK);
+                  .setVariables(VARIABLES_MSGPACK)
+                  .addReferencedSecret("default", "token");
               return record;
             },
         """
@@ -694,7 +695,13 @@ final class JsonSerializableToJsonTest {
                   "warnings":["warning1","warning2"],
                   "variables":{
                     "foo":"bar"
-                  }
+                  },
+                  "referencedSecrets":[
+                    {
+                      "storeId":"default",
+                      "secretReference":"token"
+                    }
+                  ]
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue.ExpressionSecretReferenceValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue SCOPE_KEY_KEY = new StringValue("scopeKey");
+  private static final StringValue REFERENCED_SECRETS_KEY = new StringValue("referencedSecrets");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -47,14 +49,18 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
 
+  private final ArrayProperty<ExpressionSecretReference> referencedSecretsProp =
+      new ArrayProperty<>(REFERENCED_SECRETS_KEY, ExpressionSecretReference::new);
+
   public ExpressionRecord() {
-    super(6);
+    super(7);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(scopeKeyProp);
+        .declareProperty(scopeKeyProp)
+        .declareProperty(referencedSecretsProp);
   }
 
   @Override
@@ -125,6 +131,25 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setScopeKey(final long scopeKey) {
     scopeKeyProp.setValue(scopeKey);
+    return this;
+  }
+
+  @Override
+  public List<ExpressionSecretReferenceValue> getReferencedSecrets() {
+    // copy each element out of the reusable backing array so the returned list stays valid after
+    // the record is reset or another element is added
+    return referencedSecretsProp.stream()
+        .map(
+            reference ->
+                (ExpressionSecretReferenceValue)
+                    new ExpressionSecretReference()
+                        .setStoreId(reference.getStoreId())
+                        .setSecretReference(reference.getSecretReference()))
+        .collect(Collectors.toList());
+  }
+
+  public ExpressionRecord addReferencedSecret(final String storeId, final String secretReference) {
+    referencedSecretsProp.add().setStoreId(storeId).setSecretReference(secretReference);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionSecretReference.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionSecretReference.golden
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.expression;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue.ExpressionSecretReferenceValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+@JsonIgnoreProperties({
+  /* Inherited from ObjectValue. They have no purpose in exported JSON records. */
+  "encodedLength",
+  "empty"
+})
+public final class ExpressionSecretReference extends ObjectValue
+    implements ExpressionSecretReferenceValue {
+
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue STORE_ID_KEY = new StringValue("storeId");
+  private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
+
+  // mirrors io.camunda.secretstore.SecretStoreRegistry#DEFAULT_STORE_ID: the record layer stays
+  // free of the secret store API, so the value is repeated here. An unset store ID names the
+  // default store, not no store at all.
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "default");
+  private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
+
+  public ExpressionSecretReference() {
+    super(2);
+    declareProperty(storeIdProp).declareProperty(secretReferenceProp);
+  }
+
+  @Override
+  public String getStoreId() {
+    return BufferUtil.bufferAsString(storeIdProp.getValue());
+  }
+
+  public ExpressionSecretReference setStoreId(final String storeId) {
+    storeIdProp.setValue(storeId);
+    return this;
+  }
+
+  @Override
+  public String getSecretReference() {
+    return BufferUtil.bufferAsString(secretReferenceProp.getValue());
+  }
+
+  public ExpressionSecretReference setSecretReference(final String secretReference) {
+    secretReferenceProp.setValue(secretReference);
+    return this;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
@@ -74,4 +74,37 @@ public interface ExpressionRecordValue extends RecordValue, TenantOwned, RecordV
    * @return the scope key, or {@code -1} if not set
    */
   long getScopeKey();
+
+  /**
+   * Returns the secret references that were resolved from trusted sources while evaluating the
+   * expression: a {@code camunda.secrets.<name>} reference used directly in the expression, or a
+   * reference carried by a {@code SECRET_REFERENCE}-kind cluster variable the expression read.
+   *
+   * <p>References that merely appear in request-body variables or in plain (JSON-kind) cluster
+   * variables are deliberately excluded — they are untrusted input and resolving them would
+   * reintroduce a secret-injection vector. Callers (e.g. the connector runtime) use this list to
+   * know which {@code camunda.secrets.<name>} occurrences in the result they may safely resolve.
+   *
+   * @return the referenced secrets (never {@code null}, but can be empty)
+   */
+  List<ExpressionSecretReferenceValue> getReferencedSecrets();
+
+  /**
+   * A secret reference resolved from a trusted source during expression evaluation. Carries the
+   * reference identifier only, never the resolved secret value.
+   */
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableExpressionSecretReferenceValue.Builder.class)
+  interface ExpressionSecretReferenceValue {
+
+    /**
+     * @return the identifier of the secret store that holds the referenced secret
+     */
+    String getStoreId();
+
+    /**
+     * @return the secret name, e.g. {@code token} for {@code camunda.secrets.token}; not the value
+     */
+    String getSecretReference();
+  }
 }


### PR DESCRIPTION
## Description

Inbound connectors resolve FEEL fields through `POST /v2/expression/evaluation`
and then run a second secret-resolution pass. A `camunda.secrets.<name>`
reference can enter the evaluation result from a **trusted** source — the
expression itself, or a `SECRET_REFERENCE`-kind cluster variable — or from
**untrusted** input (request-body variables, or a plain JSON-kind cluster
variable whose value merely looks like a reference). The endpoint returns only a
value, so the connector cannot tell them apart; resolving every occurrence would
reintroduce the secret-injection vulnerability closed in #60240.

This PR reports the trusted references on the endpoint response so the connector
resolves exactly those. The engine records them **where the source kind is
known — inside the evaluation contexts, not by post-scanning the result** — which
is what keeps untrusted references out:

- a `camunda.secrets.<name>` reference used directly in the expression is
  recorded (the placeholder it already produces);
- a cluster variable's references are recorded only when its kind is
  `SECRET_REFERENCE`; a JSON-kind variable contributes nothing.

A single `ReferencedSecretCollector` is shared per partition (stream processing
is single-threaded): `ExpressionBehavior` resets it before each evaluation and
drains it into the record afterwards. The BPMN path shares the same cluster
contexts and also records, but never resets or drains, so its writes are
harmless — avoiding a duplicated context tree just to isolate the endpoint. The
response exposes `referencedSecrets` as `{storeId, secretName}` identifiers
(added in 8.10), surfaced through the Java client.

**Alternative considered:** having the connector runtime pre-fetch cluster
variables to learn their kind. Rejected — it pushes complexity into the runtime
and loses the kind information the engine already has at evaluation time.

The three commits are split by layer (protocol → engine → REST/client), each
building on its predecessor.

## Related issues

closes #60384
depends on #60240
