### PR TITLE
fix: prevent broker crash on long escaped FEEL string literals

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -47,14 +47,17 @@ final class SecretReferenceLiteralValidator<T extends ModelElementInstance>
     implements ModelElementValidator<T> {
 
   // Matches one whole double-quoted string literal, so only quoted text is scanned for a reference.
-  // As a regex (after Java unescaping): "(?:\\.|[^"\\])*"
-  //   "        an opening double quote
-  //   (?: )*   zero or more of, in order:
-  //     \\.      a backslash escape (backslash + any char), so \" does not end the literal
-  //     [^"\\]   any character that is not a double quote or a backslash
-  //   "        a closing double quote
+  // As a regex (after Java unescaping): "[^"\]*+(?:\\.[^"\]*+)*+"
+  //   "              opening double quote
+  //   [^"\]*+        a possessive run of non-quote, non-backslash chars
+  //   (?:\\.[^"\]*+)*+  zero or more: one escape (\\ + any char) then another safe run
+  //   "              closing double quote
+  // Unrolled + possessive: long safe runs avoid per-char alternation, and *+ / ++ prevent the
+  // recursive group-loop StackOverflowError that greedy * hit on multi-kilobyte escaped FEEL
+  // strings (e.g. embedded JSON with many \"). See #59121.
   // e.g. it matches "ab" and "a\"b".
-  private static final Pattern STRING_LITERAL = Pattern.compile("\"(?:\\\\.|[^\"\\\\])*\"");
+  private static final Pattern STRING_LITERAL =
+      Pattern.compile("\"[^\"\\\\]*+(?:\\\\.[^\"\\\\]*+)*+\"");
 
   private final Class<T> elementType;
   private final Function<T, @Nullable String> sourceExtractor;
@@ -130,6 +133,9 @@ final class SecretReferenceLiteralValidator<T extends ModelElementInstance>
    * Every double-quoted string literal in a FEEL expression body, joined by a separator so adjacent
    * literals cannot fuse into a spurious match. Text outside string literals (such as a {@code
    * camunda.secrets.token} path expression) is not matched, so only quoted usage is flagged.
+   *
+   * <p>Uses an unrolled possessive regex ({@link #STRING_LITERAL}) so multi-kilobyte escaped FEEL
+   * strings cannot overflow the stream-processor stack. See #59121.
    */
   private static String stringLiterals(final String feelBody) {
     return STRING_LITERAL

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
@@ -200,6 +200,60 @@ final class SecretReferenceLiteralValidatorTest {
     verify(collector).addError(eq(0), contains("camunda.secrets.token_2"));
   }
 
+  /**
+   * Regression for #59121: a multi-kilobyte FEEL string with many {@code \"} escapes (as in
+   * connector payloads that embed JSON) must not StackOverflow while scanning for secret-reference
+   * literals. A greedy string-literal regex recursed on the group loop and crashed the broker.
+   */
+  @ParameterizedTest(name = "[{0}] tolerates a long escaped FEEL string literal")
+  @MethodSource("validators")
+  void shouldTolerateLongEscapedFeelStringLiteral(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
+    // given - nested JSON-as-string with thousands of escaped quotes, no secret reference
+    final var escapedJson =
+        "{\\\"type\\\":\\\"AdaptiveCard\\\",\\\"body\\\":" + "\\\"x\\\"".repeat(2000) + "}";
+    final var source = "={\"content\": \"" + escapedJson + "\"}";
+
+    // when / then - must complete without StackOverflowError and accept the mapping
+    final var collector = validate(source, validate);
+    verifyNoInteractions(collector);
+  }
+
+  /**
+   * Escape sequences must not be collapsed (e.g. {@code \t} → {@code t}), or a string such as
+   * {@code camunda.secrets.\token} would be misread as the reference {@code camunda.secrets.token}.
+   */
+  @ParameterizedTest(name = "[{0}] does not treat FEEL escape as part of a secret reference name")
+  @MethodSource("validators")
+  void shouldNotRejectWhenEscapeBreaksSecretReferenceName(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
+    // when - \t is a FEEL tab escape, not the letter t in "token"
+    final var collector = validate("=\"camunda.secrets.\\token\"", validate);
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  /**
+   * Companion to {@link #shouldTolerateLongEscapedFeelStringLiteral}: the same long escaped payload
+   * must still reject a secret reference embedded as a quoted literal.
+   */
+  @ParameterizedTest(name = "[{0}] rejects secret reference inside a long escaped FEEL string")
+  @MethodSource("validators")
+  void shouldRejectSecretReferenceInsideLongEscapedFeelStringLiteral(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
+    // given
+    final var escapedJson =
+        "{\\\"auth\\\":\\\"camunda.secrets.token\\\",\\\"pad\\\":" + "\\\"x\\\"".repeat(2000) + "}";
+    final var source = "={\"content\": \"" + escapedJson + "\"}";
+
+    // when
+    final var collector = validate(source, validate);
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
   private ValidationResultCollector validate(
       final String source, final BiConsumer<String, ValidationResultCollector> validate) {
     final var collector = mock(ValidationResultCollector.class);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.SecretStoreRegistries;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.ClassRule;
@@ -218,6 +219,66 @@ public final class SecretReferenceInputMappingTest {
             .serviceTask(
                 "task",
                 t -> t.zeebeJobType("job").zeebeProperty("authToken", "=\"camunda.secrets.token\""))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejected = ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    assertThat(rejected.getRejectionReason())
+        .contains("camunda.secrets.token")
+        .contains("must be used as an expression");
+  }
+
+  /**
+   * Regression for #59121: deploying a process whose input mapping embeds a multi-kilobyte escaped
+   * JSON string must complete without a {@link StackOverflowError}. A greedy FEEL string-literal
+   * regex overflowed the stream-processor stack on such payloads; the scanner now uses an unrolled
+   * possessive pattern.
+   */
+  @Test
+  public void shouldDeployProcessWithLongEscapedStringInInputMapping() {
+    // given - FEEL object with a nested JSON-as-string full of \" escapes (no secret reference)
+    final var escapedJson =
+        "{\\\"type\\\":\\\"AdaptiveCard\\\",\\\"body\\\":" + "\\\"x\\\"".repeat(2000) + "}";
+    final var process =
+        Bpmn.createExecutableProcess("long-escaped-input")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("long-escaped-job")
+                        .zeebeInputExpression(
+                            "{\"content\": \"" + escapedJson + "\"}", "data.attachments"))
+            .endEvent()
+            .done();
+
+    // when / then - deployment must succeed; a StackOverflowError would kill the engine thread
+    final var deployment = ENGINE.deployment().withXmlResource(process).deploy();
+    assertThat(deployment.getIntent()).isEqualTo(DeploymentIntent.CREATED);
+    assertThat(deployment.getValue().getProcessesMetadata()).hasSize(1);
+  }
+
+  /**
+   * Companion to {@link #shouldDeployProcessWithLongEscapedStringInInputMapping}: the same long
+   * escaped payload must still reject a secret reference embedded as a quoted literal, without
+   * crashing the broker.
+   */
+  @Test
+  public void shouldRejectSecretReferenceInsideLongEscapedStringInInputMapping() {
+    // given
+    final var escapedJson =
+        "{\\\"auth\\\":\\\"camunda.secrets.token\\\",\\\"pad\\\":" + "\\\"x\\\"".repeat(2000) + "}";
+    final var process =
+        Bpmn.createExecutableProcess("long-escaped-secret-literal")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("job")
+                        .zeebeInputExpression(
+                            "{\"content\": \"" + escapedJson + "\"}", "data.attachments"))
             .endEvent()
             .done();
 


### PR DESCRIPTION
## Summary
- Deploying a BPMN with a multi-kilobyte escaped JSON string in a FEEL input mapping crashed every Zeebe broker with `StackOverflowError` (crash loop on recovery).
- Root cause: `SecretReferenceLiteralValidator` scanned FEEL string literals with a **greedy** Java regex whose group loop recurses per repetition. Introduced in #57291; **not** caused by #57504.
- Fix: unrolled **possessive** pattern `"[^"\]*+(?:\\.[^"\]*+)*+"` — long safe-char runs, no backtrack stack, keeps escapes as written (no `\t` → `t` false positive).
- Unit + engine-level regression tests for long escaped FEEL strings (including secret-literal rejection still works).

Closes #59121

## Test plan
- [x] `./mvnw verify -pl zeebe/engine -Dtest=SecretReferenceLiteralValidatorTest -DskipTests=false -DskipITs -Dquickly` — 34/34 passed
- [x] `./mvnw verify -pl zeebe/engine -Dtest=SecretReferenceInputMappingTest -DskipTests=false -DskipITs -Dquickly` — 10/10 passed
- [x] Standalone: greedy patterns SOE on MSTeams / multi-k escape payloads; unrolled possessive OK even at `-Xss512k`