### PR TITLE
build: Apply skip.fe.build property from parent

### DIFF
--- a/testing/camunda-process-test-coverage/pom.xml
+++ b/testing/camunda-process-test-coverage/pom.xml
@@ -17,7 +17,6 @@
 
   <properties>
     <version.java>8</version.java>
-    <skip.fe.build>false</skip.fe.build>
     <!--
       Maven resource root – everything placed here becomes a classpath resource.
       The Webpack build writes to <fe.output.dir>/coverage/ so the JAR contains:


### PR DESCRIPTION
## Description

Removed the `skip.fe.build` property to resolve it from the parent. Skip the NPM build if the `quickly` property is `true`.  

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

[Slack thread](https://camunda.slack.com/archives/C08F5RD5X8B/p1785752737183989) 
