### PR TITLE
fix: prevent Argument list too long in build-platform-docker retries

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -87,7 +87,13 @@ runs:
       # which answers 502 often enough to be the most frequent way an image build fails on healthy
       # code. It's a `uses:` step, so nick-fields/retry (our usual retry action, shell-command only)
       # can't wrap it.
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      #
+      # Pinned to `_js_action`, not the documented `v3.8.0` composite, so github_context/env_context/
+      # job_context/matrix_context below can be overridden -- see
+      # https://github.com/Wandalen/wretry.action/issues/182. Blanked out because
+      # docker/setup-buildx-action's action.yml has no `${{ }}` expressions of its own; re-check this
+      # if that's still true when its pin next bumps.
+      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       with:
         action: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         # wretry cannot inspect the wrapped action's error -- `retry_condition` only sees contexts
@@ -97,6 +103,10 @@ runs:
         attempt_delay: 10000
         # wretry clones the wrapped action at runtime; without a token that clone gets HTTP 403
         github_token: ${{ github.token }}
+        github_context: '{}'
+        env_context: '{}'
+        job_context: '{}'
+        matrix_context: '{}'
         with: |
           # to be able to push to local registry, which we use in our tests, we need to use host network
           driver-opts: network=host
@@ -188,7 +198,11 @@ runs:
       # Wrapped for the same reason as the buildx setup above: BuildKit resolves the Dockerfile
       # frontend and the base images through Docker Hub, whose token endpoint answers 5xx or drops
       # the connection often enough to fail the build before a single layer is built.
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      #
+      # Pinned to `_js_action` for the same reason as the buildx step above. build-push-action's only
+      # `${{ }}` expression is its `github-token` default, set explicitly below instead since the
+      # context that would resolve it is blanked out; re-check on future version bumps.
+      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       env:
         DOCKER_BUILD_SUMMARY: false
         DOCKER_BUILD_RECORD_UPLOAD: false
@@ -202,6 +216,10 @@ runs:
         attempt_delay: 10000
         # wretry clones the wrapped action at runtime; without a token that clone gets HTTP 403
         github_token: ${{ github.token }}
+        github_context: '{}'
+        env_context: '{}'
+        job_context: '{}'
+        matrix_context: '{}'
         # wretry re-parses this block as YAML, so the indentation below is significant: it has to
         # stay valid after the expressions expand. Keep every interpolated value single-line -- a
         # multi-line one would have its later lines land at column 0 and break the nested scalar.
@@ -214,6 +232,7 @@ runs:
           platforms: ${{ inputs.platforms }}
           provenance: false
           outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false,push=true' || '' }}
+          github-token: ${{ github.token }}
           build-args: |
             DISTBALL=${{ steps.get-distball.outputs.result }}
             DATE=${{ steps.get-date.outputs.result }}


### PR DESCRIPTION
## Summary

CI job `Tasklist / Integration / Docker ITs` (and any other job using `build-platform-docker`) failed with:

```
An error occurred trying to start process '.../node24/bin/node' ... Argument list too long
```

**Root cause**: `Wandalen/wretry.action`'s `v3.8.0` composite entry point hardcodes `github_context: ${{ toJSON(github) }}` (plus env/job/matrix contexts) on the internal call it makes, with no way for a caller to override it. The triggering merge included a Renovate PR whose full body (dependency table + changelogs) landed as the merge commit message — measured at ~59KB, duplicated across `github.event.commits[]` and `github.event.head_commit`, so ~118KB in `github.event` alone. Once GitHub injects that as `INPUT_GITHUB_CONTEXT` for the node process wretry spawns, the job's combined environment exceeds the runner's `ARG_MAX`.

This is a known, still-open upstream bug: [Wandalen/wretry.action#182](https://github.com/Wandalen/wretry.action/issues/182). The action hasn't released since `v3.8.0` (Jan 2025).

Full incident writeup: [INC-7226](https://app.incident.io/camunda/incidents/7226).

**Fix**: both retried steps in `build-platform-docker/action.yml` now pin to the `_js_action` tag instead of the `v3.8.0` composite — that tag exposes `github_context`/`env_context`/`job_context`/`matrix_context` as ordinary, overridable inputs — and blank them out. Verified neither wrapped action (`docker/setup-buildx-action`, `docker/build-push-action`) depends on those contexts internally, except `build-push-action`'s own `github-token` default, which is now set explicitly instead. The retry mechanism itself (exit code, `retry_condition`) never consulted these contexts, so retry behavior is unchanged.

No backport needed (confirmed with the reporting engineer) — this only affects `main`'s copy of the action file.

## Test plan

- [ ] `zizmor 1.24.1` run locally against the changed file — no new findings, SHA pin compliant with `.github/zizmor.yml` policy
- [ ] `./mvnw license:format spotless:apply` — no diff beyond the intended change
- [ ] Exercise a job that uses `build-platform-docker` on this PR (`pull_request` trigger) and confirm both wretry-wrapped steps ("Set up Docker Buildx", "Build Docker image") still succeed
- [ ] Confirm no `INPUT_*` leakage regression in the existing "Clear ... leaked into the job environment by wretry" cleanup steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)