### PR TITLE
fix: export process DRAINING only from the deployment partition

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -311,10 +311,6 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(),
                 processCache,
                 configuration.getExtensionProperties()),
-            new ProcessFullyDeletedHandler(
-                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
-            new ProcessDrainingHandler(
-                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
             new EmbeddedFormHandler(indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new FormHandler(
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName(), formCache),
@@ -445,6 +441,17 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(DeployedResourceIndex.class).getFullQualifiedName()),
             new ResourceDeletedHandler(
                 indexDescriptors.get(DeployedResourceIndex.class).getFullQualifiedName())));
+
+    // DRAINING is distributed to every partition, so register these on the deployment partition
+    // only: concurrent writes to the same process-definition document could otherwise race.
+    if (partitionId == PROCESS_DEFINITION_PARTITION) {
+      exportHandlers.add(
+          new ProcessDrainingHandler(
+              indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()));
+      exportHandlers.add(
+          new ProcessFullyDeletedHandler(
+              indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()));
+    }
 
     if (configuration.getAuditLog().isEnabled()) {
       addAuditLogHandlers(configuration.getAuditLog(), partitionId);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -18,6 +18,8 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.ProcessDrainingHandler;
+import io.camunda.exporter.handlers.ProcessFullyDeletedHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogCleanupHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
@@ -373,6 +375,46 @@ public class DefaultExporterResourceProviderTest {
                 .isEqualTo(expectedValueType);
           }
         });
+  }
+
+  @Test
+  void shouldRegisterProcessLifecycleHandlersOnlyOnDeploymentPartition() {
+    // given
+    final var config = new ExporterConfiguration();
+    final var provider = new DefaultExporterResourceProvider();
+    provider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new ExporterTestContext().setPartitionId(PROCESS_DEFINITION_PARTITION),
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
+
+    // when
+    final var handlers = provider.getExportHandlers();
+
+    // then
+    assertThat(handlers).anyMatch(ProcessDrainingHandler.class::isInstance);
+    assertThat(handlers).anyMatch(ProcessFullyDeletedHandler.class::isInstance);
+  }
+
+  @Test
+  void shouldNotRegisterProcessLifecycleHandlersOnNonDeploymentPartition() {
+    // given
+    final var config = new ExporterConfiguration();
+    final var provider = new DefaultExporterResourceProvider();
+    provider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new ExporterTestContext().setPartitionId(PROCESS_DEFINITION_PARTITION + 1),
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
+
+    // when
+    final var handlers = provider.getExportHandlers();
+
+    // then
+    assertThat(handlers).noneMatch(ProcessDrainingHandler.class::isInstance);
+    assertThat(handlers).noneMatch(ProcessFullyDeletedHandler.class::isInstance);
   }
 
   @Test


### PR DESCRIPTION
## Description

The camunda exporter registered ProcessDrainingHandler on every
partition. DRAINING is distributed to all partitions and written
locally on each, so the handler issued N identical process-index state
updates (one per partition) for a single logical deletion, all writing
the same DRAINING state to the same document.

Register ProcessDrainingHandler (and ProcessFullyDeletedHandler)
only on the deployment partition, gating them with
partitionId == PROCESS_DEFINITION_PARTITION in
DefaultExporterResourceProvider. This mirrors how the audit-log
handlers in the same class and the RDBMS exporter's ProcessExportHandler
are already scoped, and keeps the partition concern at registration
rather than in each handler's handlesRecord. The process index is now
updated once, from the main partition.

FULLY_DELETED is only ever written on the deployment partition
(ProcessDeleteCompleteProcessor is guarded by
currentPartitionId == DEPLOYMENT_PARTITION), so gating its handler is a
no-op for behavior; it is grouped with DRAINING for consistency and
defensiveness.

## Related issues

closes https://github.com/camunda/camunda/issues/60408
