### PR TITLE
Physical-tenant dimension for the flowControl actuator

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlEndpoint.java
@@ -10,9 +10,15 @@ package io.camunda.zeebe.shared.management;
 import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
@@ -21,37 +27,100 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Component
 @RestControllerEndpoint(id = "flowControl")
 public class FlowControlEndpoint {
 
   final FlowControlService flowControlService;
+  private final PhysicalTenantIds physicalTenantIds;
 
   @Autowired
-  public FlowControlEndpoint(final FlowControlService flowControlService) {
+  public FlowControlEndpoint(
+      final FlowControlService flowControlService, final PhysicalTenantIds physicalTenantIds) {
     this.flowControlService = flowControlService;
+    this.physicalTenantIds = physicalTenantIds;
   }
 
+  /**
+   * Applies the given flow control configuration. Without a {@code physicalTenant} query parameter,
+   * it is applied to every known physical tenant, keeping the whole-cluster meaning the operation
+   * always had. With the parameter, only that physical tenant is configured.
+   *
+   * <p>The response reports the resulting configuration in the same shape {@link #get(String)}
+   * returns it.
+   */
   @PostMapping()
-  public ResponseEntity<?> post(@RequestBody final FlowControlCfg flowControlCfg) {
+  public ResponseEntity<?> post(
+      @RequestBody final FlowControlCfg flowControlCfg,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
+    return respond(physicalTenant, tenant -> flowControlService.set(flowControlCfg, tenant));
+  }
+
+  /**
+   * Returns the flow control configuration of every partition. With the {@code physicalTenant}
+   * query parameter, the result is scoped to that physical tenant and keyed by partition id,
+   * matching today's shape. Without it, every known physical tenant is reported, keyed by physical
+   * tenant id — unless there is at most one, in which case the flat single-tenant shape is kept.
+   *
+   * <p>Responds with 404 if the requested physical tenant is not configured on this node.
+   */
+  @GetMapping
+  public ResponseEntity<?> get(
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
+    return respond(physicalTenant, flowControlService::get);
+  }
+
+  private ResponseEntity<?> respond(
+      final @Nullable String physicalTenant,
+      final Function<String, CompletableFuture<Map<Integer, JsonNode>>> operation) {
+    final var requested = Optional.ofNullable(physicalTenant).filter(tenant -> !tenant.isBlank());
+    final var known = physicalTenantIds.known();
+
+    if (requested.isPresent() && !known.contains(requested.get())) {
+      return ResponseEntity.status(WebEndpointResponse.STATUS_NOT_FOUND)
+          .body(
+              Map.of(
+                  "error",
+                  "Physical tenant '%s' does not exist".formatted(requested.get()),
+                  "knownPhysicalTenants",
+                  known));
+    }
 
     try {
-      return ResponseEntity.status(WebEndpointResponse.STATUS_OK)
-          .body(flowControlService.set(flowControlCfg, DEFAULT_PHYSICAL_TENANT_ID).join());
+      final var body =
+          requested.isPresent()
+              ? operation.apply(requested.get()).join()
+              : applyToEveryPhysicalTenant(known, operation);
+      return ResponseEntity.status(WebEndpointResponse.STATUS_OK).body(body);
     } catch (final Exception e) {
       return ResponseEntity.internalServerError().body(e);
     }
   }
 
-  @GetMapping
-  public ResponseEntity<?> get() {
-    try {
-      return ResponseEntity.status(WebEndpointResponse.STATUS_OK)
-          .body(flowControlService.get(DEFAULT_PHYSICAL_TENANT_ID).join());
-    } catch (final Exception e) {
-      return ResponseEntity.internalServerError().body(e);
+  /**
+   * Applies the operation to every known physical tenant, in parallel. With at most one known
+   * tenant the result keeps today's flat, partition-keyed shape; beyond that it has to be keyed by
+   * physical tenant id, since partition ids alias across partition groups.
+   *
+   * <p>A tenant whose partitions cannot be reached fails the whole response rather than being
+   * reported as empty, the same all-or-nothing behavior a partially available cluster has always
+   * had.
+   */
+  private Object applyToEveryPhysicalTenant(
+      final Set<String> known,
+      final Function<String, CompletableFuture<Map<Integer, JsonNode>>> operation) {
+    if (known.size() <= 1) {
+      return operation.apply(known.stream().findFirst().orElse(DEFAULT_PHYSICAL_TENANT_ID)).join();
     }
+
+    final var pending = new LinkedHashMap<String, CompletableFuture<Map<Integer, JsonNode>>>();
+    known.stream().sorted().forEach(tenant -> pending.put(tenant, operation.apply(tenant)));
+
+    final var byPhysicalTenant = new LinkedHashMap<String, Map<Integer, JsonNode>>();
+    pending.forEach((tenant, configuration) -> byPhysicalTenant.put(tenant, configuration.join()));
+    return byPhysicalTenant;
   }
 
   interface FlowControlService {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlEndpoint.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import java.util.Map;
@@ -36,7 +38,7 @@ public class FlowControlEndpoint {
 
     try {
       return ResponseEntity.status(WebEndpointResponse.STATUS_OK)
-          .body(flowControlService.set(flowControlCfg).join());
+          .body(flowControlService.set(flowControlCfg, DEFAULT_PHYSICAL_TENANT_ID).join());
     } catch (final Exception e) {
       return ResponseEntity.internalServerError().body(e);
     }
@@ -46,15 +48,25 @@ public class FlowControlEndpoint {
   public ResponseEntity<?> get() {
     try {
       return ResponseEntity.status(WebEndpointResponse.STATUS_OK)
-          .body(flowControlService.get().join());
+          .body(flowControlService.get(DEFAULT_PHYSICAL_TENANT_ID).join());
     } catch (final Exception e) {
       return ResponseEntity.internalServerError().body(e);
     }
   }
 
   interface FlowControlService {
-    CompletableFuture<Map<Integer, JsonNode>> get();
 
-    CompletableFuture<Map<Integer, JsonNode>> set(FlowControlCfg flowControlCfg);
+    /**
+     * Returns the flow control configuration of every partition of the given physical tenant, keyed
+     * by partition id.
+     */
+    CompletableFuture<Map<Integer, JsonNode>> get(String physicalTenantId);
+
+    /**
+     * Applies the given configuration to every partition of the given physical tenant and returns
+     * the resulting configuration, keyed by partition id.
+     */
+    CompletableFuture<Map<Integer, JsonNode>> set(
+        FlowControlCfg flowControlCfg, String physicalTenantId);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
@@ -29,6 +29,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/**
+ * Every operation targets a single physical tenant (partition group). The {@code physicalTenantId}
+ * selects the partition set the operation enumerates and is stamped on every outgoing broker
+ * request so that routing resolves leaders from that group's topology: a bare partition id aliases
+ * across groups and would otherwise always resolve against the default one.
+ */
 @Component
 @NullMarked
 public class FlowControlServiceImpl implements FlowControlService {
@@ -41,11 +47,11 @@ public class FlowControlServiceImpl implements FlowControlService {
   }
 
   @Override
-  public CompletableFuture<Map<Integer, JsonNode>> get() {
-    final var topology = client.getTopologyManager().getTopology();
+  public CompletableFuture<Map<Integer, JsonNode>> get(final String physicalTenantId) {
+    final var topology = client.getTopologyManager().getTopology(physicalTenantId);
     final var futures =
         topology.getPartitions().stream()
-            .map(partition -> fetchFlowConfigOnPartition(topology, partition))
+            .map(partition -> fetchFlowConfigOnPartition(physicalTenantId, topology, partition))
             .toList();
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
         .thenApply(
@@ -58,8 +64,12 @@ public class FlowControlServiceImpl implements FlowControlService {
   }
 
   @Override
-  public CompletableFuture<Map<Integer, JsonNode>> set(final FlowControlCfg flowControlCfg) {
-    LOG.info("Setting flow control configuration to {}", flowControlCfg);
+  public CompletableFuture<Map<Integer, JsonNode>> set(
+      final FlowControlCfg flowControlCfg, final String physicalTenantId) {
+    LOG.info(
+        "Setting flow control configuration of physical tenant {} to {}",
+        physicalTenantId,
+        flowControlCfg);
 
     final byte[] configuration;
     try {
@@ -68,20 +78,22 @@ public class FlowControlServiceImpl implements FlowControlService {
       return CompletableFuture.failedFuture(e);
     }
 
-    final var topology = client.getTopologyManager().getTopology();
+    final var topology = client.getTopologyManager().getTopology(physicalTenantId);
     final var results =
         topology.getPartitions().stream()
             .map(
                 partition ->
                     broadcastOnPartition(
+                        physicalTenantId,
                         topology,
                         partition,
                         request -> request.setFlowControlConfiguration(configuration)))
             .toArray(CompletableFuture<?>[]::new);
-    return CompletableFuture.allOf(results).thenCompose(ignored -> get());
+    return CompletableFuture.allOf(results).thenCompose(ignored -> get(physicalTenantId));
   }
 
   private CompletableFuture<Void> broadcastOnPartition(
+      final String physicalTenantId,
       final BrokerClusterState topology,
       final Integer partitionId,
       final Consumer<BrokerAdminRequest> configureRequest) {
@@ -93,6 +105,7 @@ public class FlowControlServiceImpl implements FlowControlService {
             .map(
                 brokerId -> {
                   final var request = new BrokerAdminRequest();
+                  request.setPartitionGroup(physicalTenantId);
                   request.setBrokerId(brokerId);
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
@@ -105,13 +118,16 @@ public class FlowControlServiceImpl implements FlowControlService {
   }
 
   private CompletableFuture<FlowControlStatus> fetchFlowConfigOnPartition(
-      final BrokerClusterState topology, final Integer partitionId) {
+      final String physicalTenantId, final BrokerClusterState topology, final Integer partitionId) {
     final var brokerId = topology.getLeaderForPartition(partitionId);
     if (brokerId == null) {
       return CompletableFuture.failedFuture(
-          new IllegalStateException("No leader for partition " + partitionId));
+          new IllegalStateException(
+              "No leader for partition %s of physical tenant %s"
+                  .formatted(partitionId, physicalTenantId)));
     }
     final var request = new BrokerAdminRequest();
+    request.setPartitionGroup(physicalTenantId);
     request.setBrokerId(brokerId);
     request.setPartitionId(partitionId);
     request.getFLowControlConfiguration();

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/FlowControlEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/FlowControlEndpointTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
+import io.camunda.zeebe.shared.management.FlowControlEndpoint.FlowControlService;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.ResponseEntity;
+
+final class FlowControlEndpointTest {
+
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+
+  private final FlowControlService service = mock(FlowControlService.class);
+
+  @Test
+  void shouldKeepFlatShapeOnSingleTenantCluster() {
+    // given
+    final var endpoint = endpointFor(Set.of(DEFAULT_PHYSICAL_TENANT_ID));
+    when(service.get(DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(configuration(1, 50));
+
+    // when
+    final var response = endpoint.get(null);
+
+    // then - a single-tenant cluster sees the pre-existing, partition-keyed response
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(response.getBody()).isEqualTo(Map.of(1, limit(50)));
+  }
+
+  @Test
+  void shouldKeyByPhysicalTenantWhenSeveralAreKnown() {
+    // given
+    final var endpoint = endpointFor(Set.of(TENANT_B, TENANT_A));
+    when(service.get(TENANT_A)).thenReturn(configuration(1, 50));
+    when(service.get(TENANT_B)).thenReturn(configuration(1, 90));
+
+    // when
+    final var response = endpoint.get(null);
+
+    // then - partition 1 exists in both tenants, so the response has to distinguish them; tenants
+    // are reported in a stable order so that two reads of an unchanged cluster are diffable
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(bodyAsMap(response))
+        .containsExactly(
+            entry(TENANT_A, Map.of(1, limit(50))), entry(TENANT_B, Map.of(1, limit(90))));
+  }
+
+  @Test
+  void shouldFilterReadToRequestedPhysicalTenant() {
+    // given
+    final var endpoint = endpointFor(Set.of(TENANT_A, TENANT_B));
+    when(service.get(TENANT_B)).thenReturn(configuration(1, 90));
+
+    // when
+    final var response = endpoint.get(TENANT_B);
+
+    // then - scoping to one tenant makes the partition id unambiguous again, so the flat shape is
+    // returned instead of a single-entry nesting
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(response.getBody()).isEqualTo(Map.of(1, limit(90)));
+    verify(service, never()).get(TENANT_A);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", " "})
+  void shouldTreatMissingPhysicalTenantAsEveryPhysicalTenant(final String physicalTenant) {
+    // given
+    final var endpoint = endpointFor(Set.of(TENANT_A, TENANT_B));
+    when(service.get(TENANT_A)).thenReturn(configuration(1, 50));
+    when(service.get(TENANT_B)).thenReturn(configuration(1, 90));
+
+    // when
+    final var response = endpoint.get(physicalTenant);
+
+    // then
+    assertThat(bodyAsMap(response)).containsOnlyKeys(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  void shouldRejectReadOfUnknownPhysicalTenant() {
+    // given
+    final var endpoint = endpointFor(Set.of(DEFAULT_PHYSICAL_TENANT_ID));
+
+    // when
+    final var response = endpoint.get("nope");
+
+    // then - reporting an empty configuration would read as "this tenant has no partitions" rather
+    // than "there is no such tenant"
+    assertThat(response.getStatusCode().value()).isEqualTo(404);
+    assertThat(bodyAsMap(response))
+        .containsEntry("error", "Physical tenant 'nope' does not exist")
+        .containsEntry("knownPhysicalTenants", Set.of(DEFAULT_PHYSICAL_TENANT_ID));
+    verify(service, never()).get(any());
+  }
+
+  @Test
+  void shouldApplyConfigurationToEveryPhysicalTenant() {
+    // given
+    final var endpoint = endpointFor(Set.of(TENANT_A, TENANT_B));
+    final var flowControlCfg = new FlowControlCfg();
+    when(service.set(flowControlCfg, TENANT_A)).thenReturn(configuration(1, 50));
+    when(service.set(flowControlCfg, TENANT_B)).thenReturn(configuration(1, 50));
+
+    // when
+    final var response = endpoint.post(flowControlCfg, null);
+
+    // then - a write without a tenant keeps its whole-cluster meaning
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(bodyAsMap(response)).containsOnlyKeys(TENANT_A, TENANT_B);
+    verify(service).set(flowControlCfg, TENANT_A);
+    verify(service).set(flowControlCfg, TENANT_B);
+  }
+
+  @Test
+  void shouldScopeConfigurationToRequestedPhysicalTenant() {
+    // given
+    final var endpoint = endpointFor(Set.of(TENANT_A, TENANT_B));
+    final var flowControlCfg = new FlowControlCfg();
+    when(service.set(flowControlCfg, TENANT_A)).thenReturn(configuration(1, 50));
+
+    // when
+    final var response = endpoint.post(flowControlCfg, TENANT_A);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(response.getBody()).isEqualTo(Map.of(1, limit(50)));
+    verify(service, never()).set(flowControlCfg, TENANT_B);
+  }
+
+  @Test
+  void shouldRejectWriteToUnknownPhysicalTenant() {
+    // given
+    final var endpoint = endpointFor(Set.of(DEFAULT_PHYSICAL_TENANT_ID));
+    final var flowControlCfg = new FlowControlCfg();
+
+    // when
+    final var response = endpoint.post(flowControlCfg, "nope");
+
+    // then - the write must not silently fall back to another tenant
+    assertThat(response.getStatusCode().value()).isEqualTo(404);
+    verify(service, never()).set(any(), any());
+  }
+
+  @Test
+  void shouldReportInternalErrorWhenPhysicalTenantIsUnreachable() {
+    // given
+    final var endpoint = endpointFor(Set.of(TENANT_A, TENANT_B));
+    when(service.get(TENANT_A)).thenReturn(configuration(1, 50));
+    when(service.get(TENANT_B))
+        .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("no leader")));
+
+    // when
+    final var response = endpoint.get(null);
+
+    // then - a partially reachable cluster fails the read rather than under-reporting it
+    assertThat(response.getStatusCode().value()).isEqualTo(500);
+  }
+
+  private FlowControlEndpoint endpointFor(final Set<String> knownPhysicalTenants) {
+    final PhysicalTenantIds physicalTenantIds = () -> knownPhysicalTenants;
+    return new FlowControlEndpoint(service, physicalTenantIds);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> bodyAsMap(final ResponseEntity<?> response) {
+    return (Map<String, Object>) response.getBody();
+  }
+
+  private static CompletableFuture<Map<Integer, JsonNode>> configuration(
+      final int partitionId, final int limit) {
+    return CompletableFuture.completedFuture(Map.of(partitionId, limit(limit)));
+  }
+
+  private static JsonNode limit(final int limit) {
+    return JsonNodeFactory.instance.objectNode().put("limit", limit);
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/FlowControlServiceImplTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/FlowControlServiceImplTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.BrokerMemberId;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
+import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+final class FlowControlServiceImplTest {
+
+  private static final String TENANT_A = "tenant-a";
+  private static final BrokerMemberId LEADER = BrokerMemberId.from(0);
+  private static final BrokerMemberId FOLLOWER = BrokerMemberId.from(1);
+
+  private final BrokerClient client = mock(BrokerClient.class);
+  private final BrokerTopologyManager topologyManager = mock(BrokerTopologyManager.class);
+  private final BrokerClusterState topology = mock(BrokerClusterState.class);
+
+  @Test
+  void shouldReadFromThePartitionGroupOfThePhysicalTenant() {
+    // given
+    setupTopology(List.of(1, 2));
+    final var service = new FlowControlServiceImpl(client);
+
+    // when
+    final var configuration = service.get(TENANT_A).join();
+
+    // then - a bare partition id aliases across partition groups, so every request has to name the
+    // group it addresses, or it resolves against the default one
+    assertThat(configuration).containsOnlyKeys(1, 2);
+    assertThat(capturedRequests())
+        .extracting(BrokerRequest::getPartitionGroup)
+        .containsOnly(TENANT_A);
+  }
+
+  @Test
+  void shouldWriteToThePartitionGroupOfThePhysicalTenant() {
+    // given
+    setupTopology(List.of(1));
+    when(topology.getFollowersForPartition(1)).thenReturn(Set.of(FOLLOWER));
+    final var service = new FlowControlServiceImpl(client);
+
+    // when
+    service.set(new FlowControlCfg(), TENANT_A).join();
+
+    // then - the update is broadcast to every member of the partition, and the read it answers with
+    // is scoped the same way
+    assertThat(capturedRequests())
+        .hasSizeGreaterThan(1)
+        .extracting(BrokerRequest::getPartitionGroup)
+        .containsOnly(TENANT_A);
+  }
+
+  @Test
+  void shouldFailWhenThePhysicalTenantHasNoLeaderForAPartition() {
+    // given - a partition group that is configured but not led anywhere
+    setupTopology(List.of(1));
+    when(topology.getLeaderForPartition(1)).thenReturn(null);
+    final var service = new FlowControlServiceImpl(client);
+
+    // when / then - the error names the tenant, since the partition id alone does not identify it
+    assertThatThrownBy(() -> service.get(TENANT_A).join())
+        .isInstanceOf(CompletionException.class)
+        .hasMessageContaining("No leader for partition 1 of physical tenant " + TENANT_A);
+  }
+
+  private void setupTopology(final List<Integer> partitions) {
+    when(topology.getPartitions()).thenReturn(partitions);
+    partitions.forEach(
+        partition -> when(topology.getLeaderForPartition(partition)).thenReturn(LEADER));
+    when(topologyManager.getTopology(TENANT_A)).thenReturn(topology);
+    when(client.getTopologyManager()).thenReturn(topologyManager);
+
+    final var response = mock(AdminResponse.class);
+    when(response.getPayload()).thenReturn("{}".getBytes(StandardCharsets.UTF_8));
+    doReturn(CompletableFuture.completedFuture(new BrokerResponse<>(response)))
+        .when(client)
+        .sendRequest(any());
+  }
+
+  private List<BrokerRequest> capturedRequests() {
+    final ArgumentCaptor<BrokerRequest> captor = ArgumentCaptor.forClass(BrokerRequest.class);
+    verify(client, atLeastOnce()).sendRequest(captor.capture());
+    return captor.getAllValues();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantFlowControlActuatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantFlowControlActuatorIT.java
@@ -88,6 +88,30 @@ final class PhysicalTenantFlowControlActuatorIT {
   }
 
   @Test
+  void shouldApplyConfigurationToEveryPhysicalTenantWithoutParameter() {
+    // given - the tenants start out with limits of their own, so a write that reaches only one of
+    // them cannot be mistaken for one that reached both
+    awaitFlowControlReadable();
+    actuator.setFlowControlConfiguration(writeRateLimitOf(111), TENANT_A);
+    actuator.setFlowControlConfiguration(writeRateLimitOf(222), DEFAULT_TENANT);
+
+    // when - writing without a physicalTenant parameter
+    final var response =
+        actuator.setFlowControlConfigurationByPhysicalTenant(writeRateLimitOf(333));
+
+    // then - the write kept its whole-cluster meaning, and the response reports the result per
+    // tenant rather than aliasing the two partition 1s
+    assertThat(response).containsOnlyKeys(DEFAULT_TENANT, TENANT_A);
+    assertThat(writeRateLimitIn(response.get(TENANT_A))).isEqualTo(333);
+    assertThat(writeRateLimitIn(response.get(DEFAULT_TENANT))).isEqualTo(333);
+
+    // and - a subsequent read agrees, so the response was not merely echoing the request
+    assertThat(writeRateLimitIn(actuator.getFlowControlConfiguration(TENANT_A))).isEqualTo(333);
+    assertThat(writeRateLimitIn(actuator.getFlowControlConfiguration(DEFAULT_TENANT)))
+        .isEqualTo(333);
+  }
+
+  @Test
   void shouldRejectUnknownPhysicalTenant() {
     // given
     awaitFlowControlReadable();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantFlowControlActuatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantFlowControlActuatorIT.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import feign.FeignException;
+import io.camunda.zeebe.qa.util.actuator.FlowControlActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the {@code flowControl} actuator distinguishes the partitions of different physical
+ * tenants instead of aliasing them by numeric partition id, and that its {@code physicalTenant}
+ * query parameter scopes both the read and the write to one tenant (ADR 003 D3).
+ *
+ * <p>Every tenant here owns a partition 1, which is exactly the case the pre-existing, flat
+ * partition-keyed response could not represent.
+ */
+@ZeebeIntegration
+final class PhysicalTenantFlowControlActuatorIT {
+
+  private static final String DEFAULT_TENANT = PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+  private static final String TENANT_A = "tenanta";
+  private static final int PARTITION_ID = 1;
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(DEFAULT_TENANT, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  private final FlowControlActuator actuator = FlowControlActuator.of(broker);
+
+  @Test
+  void shouldReportEveryPhysicalTenantWithoutParameter() {
+    // given
+    awaitFlowControlReadable();
+
+    // when - reading without a physicalTenant parameter on a node serving more than one tenant
+    final var configurationByTenant = actuator.getFlowControlConfigurationByPhysicalTenant();
+
+    // then - both tenants are reported under their own key; a flat partition-keyed map could only
+    // have held one of the two partition 1s
+    assertThat(configurationByTenant).containsOnlyKeys(DEFAULT_TENANT, TENANT_A);
+    assertThat(configurationByTenant.get(DEFAULT_TENANT)).containsKey(PARTITION_ID);
+    assertThat(configurationByTenant.get(TENANT_A)).containsKey(PARTITION_ID);
+  }
+
+  @Test
+  void shouldScopeConfigurationToTargetedPhysicalTenant() {
+    // given - each tenant is given a write rate limit of its own, so neither assertion depends on
+    // what the default configuration happens to be
+    awaitFlowControlReadable();
+    actuator.setFlowControlConfiguration(writeRateLimitOf(111), TENANT_A);
+    actuator.setFlowControlConfiguration(writeRateLimitOf(222), DEFAULT_TENANT);
+
+    // when
+    final var tenantAConfiguration = actuator.getFlowControlConfiguration(TENANT_A);
+    final var defaultConfiguration = actuator.getFlowControlConfiguration(DEFAULT_TENANT);
+
+    // then - each tenant kept its own limit, so neither write leaked into the other's partition 1
+    assertThat(writeRateLimitIn(tenantAConfiguration)).isEqualTo(111);
+    assertThat(writeRateLimitIn(defaultConfiguration)).isEqualTo(222);
+
+    // and - the unscoped read reports the same two, distinguished by tenant
+    final var configurationByTenant = actuator.getFlowControlConfigurationByPhysicalTenant();
+    assertThat(writeRateLimitIn(configurationByTenant.get(TENANT_A))).isEqualTo(111);
+    assertThat(writeRateLimitIn(configurationByTenant.get(DEFAULT_TENANT))).isEqualTo(222);
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenant() {
+    // given
+    awaitFlowControlReadable();
+
+    // when / then - an unconfigured tenant is not an empty configuration
+    assertThatThrownBy(() -> actuator.getFlowControlConfiguration("nosuchtenant"))
+        .isInstanceOf(FeignException.NotFound.class)
+        .hasMessageContaining("Physical tenant 'nosuchtenant' does not exist");
+  }
+
+  // a partition's flow control is only readable once the partition has a leader, which happens
+  // asynchronously after startup for each tenant's partition group
+  private void awaitFlowControlReadable() {
+    await("every physical tenant has a leader for its partition")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(actuator.getFlowControlConfigurationByPhysicalTenant())
+                    .containsOnlyKeys(DEFAULT_TENANT, TENANT_A));
+  }
+
+  private static int writeRateLimitIn(final Map<Integer, JsonNode> configuration) {
+    return configuration.get(PARTITION_ID).get("writeRateLimit").get("limit").asInt();
+  }
+
+  private static String writeRateLimitOf(final int limit) {
+    // language=JSON
+    return """
+        {
+          "write": {
+            "enabled": true,
+            "rampUp": 0,
+            "limit": %d
+          }
+        }"""
+        .formatted(limit);
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/FlowControlActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/FlowControlActuator.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.Feign;
 import feign.Headers;
+import feign.Param;
 import feign.RequestLine;
 import feign.Retryer;
 import feign.Target.HardCodedTarget;
@@ -48,23 +49,40 @@ public interface FlowControlActuator {
   }
 
   public default Map<Integer, JsonNode> setFlowControlConfiguration(final String request) {
-    final FlowControlCfg flowControlCfg;
+    return setFlowControlConfiguration(deserialize(request));
+  }
+
+  public default Map<Integer, JsonNode> setFlowControlConfiguration(
+      final String request, final String physicalTenant) {
+    return setFlowControlConfiguration(deserialize(request), physicalTenant);
+  }
+
+  private static FlowControlCfg deserialize(final String request) {
     try {
-      flowControlCfg = FlowControlCfg.deserialize(request);
+      return FlowControlCfg.deserialize(request);
     } catch (final JsonProcessingException e) {
       throw new RuntimeException(e);
     }
-    return setFlowControlConfiguration(flowControlCfg);
   }
 
   /**
-   * Sets the flow control configuration.
+   * Sets the flow control configuration of every known physical tenant.
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("POST")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, JsonNode> setFlowControlConfiguration(@RequestBody FlowControlCfg flowControlCfg);
+
+  /**
+   * Sets the flow control configuration of the given physical tenant only.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST ?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Map<Integer, JsonNode> setFlowControlConfiguration(
+      @RequestBody FlowControlCfg flowControlCfg, @Param String physicalTenant);
 
   /**
    * Gets the flow control configuration.
@@ -74,4 +92,24 @@ public interface FlowControlActuator {
   @RequestLine("GET")
   @Headers({"Content-Type: application/json"})
   Map<Integer, JsonNode> getFlowControlConfiguration();
+
+  /**
+   * Same as {@link #getFlowControlConfiguration()}, but decodes the response as the shape returned
+   * when more than one physical tenant is known: a map keyed by physical tenant id, whose values
+   * are the usual per-partition configuration map.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("GET")
+  @Headers({"Content-Type: application/json"})
+  Map<String, Map<Integer, JsonNode>> getFlowControlConfigurationByPhysicalTenant();
+
+  /**
+   * Gets the flow control configuration of the given physical tenant only.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("GET ?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json"})
+  Map<Integer, JsonNode> getFlowControlConfiguration(@Param String physicalTenant);
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/FlowControlActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/FlowControlActuator.java
@@ -57,6 +57,11 @@ public interface FlowControlActuator {
     return setFlowControlConfiguration(deserialize(request), physicalTenant);
   }
 
+  public default Map<String, Map<Integer, JsonNode>> setFlowControlConfigurationByPhysicalTenant(
+      final String request) {
+    return setFlowControlConfigurationByPhysicalTenant(deserialize(request));
+  }
+
   private static FlowControlCfg deserialize(final String request) {
     try {
       return FlowControlCfg.deserialize(request);
@@ -73,6 +78,20 @@ public interface FlowControlActuator {
   @RequestLine("POST")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, JsonNode> setFlowControlConfiguration(@RequestBody FlowControlCfg flowControlCfg);
+
+  /**
+   * Same as {@link #setFlowControlConfiguration(FlowControlCfg)}, but decodes the response as the
+   * shape returned when more than one physical tenant is known: a map keyed by physical tenant id,
+   * whose values are the usual per-partition configuration map. Use this from a multi-tenant test —
+   * the flat method would apply the configuration and only then fail to decode the tenant ids as
+   * partition ids.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Map<String, Map<Integer, JsonNode>> setFlowControlConfigurationByPhysicalTenant(
+      @RequestBody FlowControlCfg flowControlCfg);
 
   /**
    * Sets the flow control configuration of the given physical tenant only.


### PR DESCRIPTION
## Description

The `flowControl` actuator keyed its response by bare numeric partition id. Partition ids are only unique within a partition group, so on a multi-physical-tenant cluster two tenants both own a partition 1 and the map aliased them: an operator could neither tell whose limits they were reading nor configure one tenant without touching the others.

Two related problems, in separate commits:

1. **Routing** — the service resolved its partition set from the no-arg topology and sent admin requests without a partition group, so leader lookup and routing always landed on the default group. This is the same defect ADR 003 records for `BackupRequestHandler` and `ExportingControlService`. The service now takes the physical tenant id and stamps `setPartitionGroup` on every request, as `ExportingRequestBroadcaster` already does. Structural only — the endpoint passes the default tenant, so the broker receives the same request as before.

2. **Response shape and tenant selection** — `GET` and `POST` accept `?physicalTenant={id}`, which filters the read and scopes the write to one tenant and answers with the flat, partition-keyed body the endpoint has always returned (unambiguous again, because the group is pinned). Without the parameter both keep their whole-cluster meaning and cover every known tenant, keying the response by physical tenant id. An unknown tenant is a 404 naming the known ones, rather than an empty configuration that would read as "this tenant has no partitions" and for a write would be a silent no-op.

## Related issues

closes #57379 
