### PR TITLE
feat: apply a zone migration to every physical tenant

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
@@ -153,10 +153,11 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
 
   /**
    * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
-   * partition group alone. Every caller has moved to {@code phases} except {@link
-   * ZoneMigrationRequestTransformer}, which still plans through here, so this cannot be dropped
-   * until <a href="https://github.com/camunda/camunda/issues/60341">zone migration</a> is planned
-   * across every physical tenant too.
+   * partition group alone. Nothing in production plans through here anymore: what remains are the
+   * {@code operations} overrides of {@link ClusterScaleRequestTransformer}, {@link
+   * ClusterPatchRequestTransformer} and {@link ZoneMigrationRequestTransformer}, which exist for
+   * the tests that assert on the flat operation list. Retiring all four needs a test simulator that
+   * applies phases.
    */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.util.Either;
@@ -45,17 +46,38 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
-    final var partitionDistribution = currentConfiguration.partitionDistributorConfig();
+    return stageTargetMembers(
+            currentConfiguration.members().keySet(),
+            currentConfiguration.partitionDistributorConfig())
+        .flatMap(
+            targetMembers ->
+                new ScaleRequestTransformer(
+                        targetMembers, Optional.empty(), Optional.empty(), Optional.of(zoneName))
+                    .operations(currentConfiguration));
+  }
+
+  /**
+   * Validates the request and returns the member set the cluster has to reach at the end of this
+   * stage: the current members with the bare ids belonging to this stage's zone replaced by their
+   * zoned ids.
+   *
+   * <p>Reads nothing but the two pieces of global state it takes, rather than the whole
+   * configuration: which bare id becomes which zoned id, and in which order the zones migrate, is
+   * decided by the member set and the persisted zone plan alone.
+   */
+  private Either<Exception, Set<MemberId>> stageTargetMembers(
+      final Set<MemberId> currentMembers,
+      final Optional<PartitionDistributorConfig> partitionDistributorConfig) {
     final ZoneAwareConfig zoneAwareConfig;
-    if (partitionDistribution.isPresent()
-        && partitionDistribution.get() instanceof final ZoneAwareConfig cfg) {
+    if (partitionDistributorConfig.isPresent()
+        && partitionDistributorConfig.get() instanceof final ZoneAwareConfig cfg) {
       zoneAwareConfig = cfg;
     } else {
       return Either.left(
           new InvalidRequest(
               "Zone migration requires a persisted zone-aware partition distribution config, but was %s. Update the partition distribution before migrating brokers."
                   .formatted(
-                      partitionDistribution
+                      partitionDistributorConfig
                           .map(c -> c.getClass().getSimpleName())
                           .orElse("not set"))));
     }
@@ -69,18 +91,13 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
                   + "'. Configure it first via the persisted partition distribution."));
     }
 
-    final var stageReplacements = stageReplacements(currentConfiguration, zones);
-    final var validation = validate(currentConfiguration, zones, stageReplacements);
+    final var stageReplacements = stageReplacements(currentMembers, zones);
+    final var validation = validate(currentMembers, zones, stageReplacements);
     if (validation.isLeft()) {
       return Either.left(validation.getLeft());
     }
 
-    return new ScaleRequestTransformer(
-            stageTargetMembers(currentConfiguration, stageReplacements),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(zoneName))
-        .operations(currentConfiguration);
+    return Either.right(stageTargetMembers(currentMembers, stageReplacements));
   }
 
   /**
@@ -92,7 +109,7 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
    * zone-b_1}}.
    */
   private Map<MemberId, MemberId> stageReplacements(
-      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
+      final Set<MemberId> currentMembers, final List<ZoneSpec> zones) {
     final int zoneIndex = zoneIndex(zones);
 
     // Preserve the sorted bare-member order so replacements and the resulting operations are
@@ -100,7 +117,7 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
     final var stageReplacements = new LinkedHashMap<MemberId, MemberId>();
     int localNodeIndex = 0;
     for (final var memberId :
-        currentConfiguration.members().keySet().stream()
+        currentMembers.stream()
             .filter(candidate -> candidate.zone() == null)
             .filter(
                 candidate ->
@@ -114,22 +131,20 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
   }
 
   private Set<MemberId> stageTargetMembers(
-      final ClusterConfiguration currentConfiguration,
-      final Map<MemberId, MemberId> stageReplacements) {
+      final Set<MemberId> currentMembers, final Map<MemberId, MemberId> stageReplacements) {
     // Keep member iteration deterministic, e.g. for stable coordinator selection and test output.
-    final var stageTargetMembers = new LinkedHashSet<>(currentConfiguration.members().keySet());
+    final var stageTargetMembers = new LinkedHashSet<>(currentMembers);
     stageTargetMembers.removeAll(stageReplacements.keySet());
     stageTargetMembers.addAll(stageReplacements.values());
     return stageTargetMembers;
   }
 
   private Either<Exception, Void> validate(
-      final ClusterConfiguration currentConfiguration,
+      final Set<MemberId> currentMembers,
       final List<ZoneSpec> zones,
       final Map<MemberId, MemberId> stageReplacements) {
     final int zoneIndex = zoneIndex(zones);
-    if (currentConfiguration.members().keySet().stream()
-        .anyMatch(member -> zoneName.equals(member.zone()))) {
+    if (currentMembers.stream().anyMatch(member -> zoneName.equals(member.zone()))) {
       return Either.left(
           new InvalidRequest(
               "Zone migration request targets zone '"
@@ -137,7 +152,7 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
                   + "' which has already been migrated."));
     }
 
-    final int expectedNextZoneIndex = expectedNextZoneIndex(currentConfiguration, zones);
+    final int expectedNextZoneIndex = expectedNextZoneIndex(currentMembers, zones);
     if (zoneIndex != expectedNextZoneIndex) {
       return Either.left(
           new InvalidRequest(
@@ -159,13 +174,13 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
   }
 
   private int expectedNextZoneIndex(
-      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
+      final Set<MemberId> currentMembers, final List<ZoneSpec> zones) {
     // Bare members have no zone identity, so derive the next stage from the highest configured
     // zone that does not yet have a zoned member.
     return IntStream.range(0, zones.size())
         .filter(
             zoneIndex ->
-                currentConfiguration.members().keySet().stream()
+                currentMembers.stream()
                     .noneMatch(member -> zones.get(zoneIndex).name().equals(member.zone())))
         .max()
         .orElseThrow();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
@@ -13,9 +13,11 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -43,17 +45,42 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
     this.zoneName = zoneName;
   }
 
+  /**
+   * Plans the stage across every physical tenant's partition group, by handing the stage's target
+   * members to {@link ScaleRequestTransformer#phases(CurrentClusterConfiguration)}.
+   *
+   * <p>A stage replaces every broker of one zone, so a tenant left out does not merely miss out on
+   * capacity: its partitions stay on member ids the stage removes, and the member leave is then
+   * refused because the broker still holds partitions. Planning the default group alone — what
+   * {@link #operations(ClusterConfiguration)} does, and what this transformer inherited before —
+   * therefore made a zone migration impossible on a cluster with more than one tenant rather than
+   * only incomplete.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    return stageTargetMembers(
+            configuration.getMembers(),
+            configuration.globalConfiguration().partitionDistributorConfig())
+        .flatMap(targetMembers -> scaleRequest(targetMembers).phases(configuration));
+  }
+
+  /**
+   * Plans the same stage as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Kept because the tests around this transformer assert on the flat
+   * operation list; nothing in production plans through here anymore.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
     return stageTargetMembers(
             currentConfiguration.members().keySet(),
             currentConfiguration.partitionDistributorConfig())
-        .flatMap(
-            targetMembers ->
-                new ScaleRequestTransformer(
-                        targetMembers, Optional.empty(), Optional.empty(), Optional.of(zoneName))
-                    .operations(currentConfiguration));
+        .flatMap(targetMembers -> scaleRequest(targetMembers).operations(currentConfiguration));
+  }
+
+  private ScaleRequestTransformer scaleRequest(final Set<MemberId> stageTargetMembers) {
+    return new ScaleRequestTransformer(
+        stageTargetMembers, Optional.empty(), Optional.empty(), Optional.of(zoneName));
   }
 
   /**
@@ -61,9 +88,9 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
    * stage: the current members with the bare ids belonging to this stage's zone replaced by their
    * zoned ids.
    *
-   * <p>Reads nothing but the two pieces of global state it takes, rather than the whole
-   * configuration: which bare id becomes which zoned id, and in which order the zones migrate, is
-   * decided by the member set and the persisted zone plan alone.
+   * <p>Reads nothing but the two pieces of global state it takes, so the same validation and the
+   * same target member set serve both {@code phases} and {@code operations} — which bare id becomes
+   * which zoned id, and in which order the zones migrate, has no per-tenant dimension.
    */
   private Either<Exception, Set<MemberId>> stageTargetMembers(
       final Set<MemberId> currentMembers,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantZoneMigrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantZoneMigrationTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.BARE_0;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.BARE_2;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.DUAL_REGION;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_A;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_A_0;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_A_1;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_B;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_B_0;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_B_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.api.ZoneMigrationRequestTransformer;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A zone migration stage replaces every broker of one zone, so it has to move every physical
+ * tenant's partitions and not only the default tenant's. Planning the default group alone left the
+ * other tenants' partitions on the very brokers the stage removes, and the coordinator then refused
+ * the whole change while validating the member leave — a cluster with more than one tenant could
+ * not become zone-aware at all.
+ *
+ * <p>Driven through the coordinator rather than the transformer, because that is what makes the two
+ * stages real: the coordinator runs each stage's plan through the actual appliers — including the
+ * member leave that used to refuse it — and hands back the configuration the stage would leave
+ * behind, which is what the next stage is then planned against.
+ */
+final class PhysicalTenantZoneMigrationTest {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int PARTITIONS_PER_TENANT = 2;
+  private static final int REPLICATION_FACTOR = 4;
+
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @TempDir private Path tmp;
+
+  private ClusterConfigurationManagerImpl manager;
+  private ConfigurationChangeCoordinatorImpl coordinator;
+
+  @Test
+  void shouldMigrateEveryPhysicalTenantZoneByZone() {
+    // given — four bare brokers running two tenants, with the dual-region plan persisted. Brokers 1
+    // and 3 belong to zone-b under that plan, brokers 0 and 2 to zone-a.
+    wire(BARE_0, twoTenantBareCluster());
+
+    // when — zone-b migrates first, as the plan requires
+    migrate(ZONE_B);
+
+    // then — both tenants run on zone-b's new brokers and on the brokers zone-a has yet to replace
+    assertEveryTenantRunsOn(Set.of(BARE_0, BARE_2, ZONE_B_0, ZONE_B_1));
+
+    // when — zone-a follows
+    migrate(ZONE_A);
+
+    // then — no bare broker is left holding a partition of any tenant
+    assertEveryTenantRunsOn(Set.of(ZONE_A_0, ZONE_A_1, ZONE_B_0, ZONE_B_1));
+  }
+
+  /**
+   * Runs one stage and leaves the cluster in the configuration it produced, so the next stage is
+   * planned against it.
+   *
+   * <p>A dry run rather than a real apply: applying would need every member of the plan to be
+   * running, since each operation is executed by the broker it names, and a stage introduces
+   * brokers that do not exist yet. The dry run still puts the whole plan through the real appliers
+   * — the member leave among them — and returns the configuration it produced.
+   */
+  private void migrate(final String zone) {
+    final var result =
+        coordinator.simulateOperations(new ZoneMigrationRequestTransformer(zone)).join();
+    manager.updateMultiConfiguration(ignored -> result.finalMultiConfiguration()).join();
+  }
+
+  /**
+   * Asserts that every tenant's partitions are replicated over exactly {@code expectedMembers}.
+   * With the replication factor equal to the cluster size every broker holds every partition, so a
+   * tenant that was left out of a stage shows up as a broker that should have been replaced still
+   * holding partitions.
+   */
+  private void assertEveryTenantRunsOn(final Set<MemberId> expectedMembers) {
+    final var configuration = manager.getMultiConfiguration().join();
+    assertThat(configuration.globalConfiguration().members())
+        .describedAs("brokers left in the cluster")
+        .containsOnlyKeys(expectedMembers);
+    assertThat(configuration.partitionGroups())
+        .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+        .allSatisfy(
+            (groupId, group) ->
+                assertThat(
+                        group.members().entrySet().stream()
+                            .filter(member -> !member.getValue().partitions().isEmpty())
+                            .collect(
+                                Collectors.toMap(
+                                    Map.Entry::getKey,
+                                    member -> member.getValue().partitions().keySet())))
+                    .describedAs("partitions of physical tenant '%s' per broker", groupId)
+                    .hasSize(REPLICATION_FACTOR)
+                    .containsOnlyKeys(expectedMembers)
+                    .allSatisfy(
+                        (member, partitions) ->
+                            assertThat(partitions).hasSize(PARTITIONS_PER_TENANT)));
+  }
+
+  /**
+   * Both tenants deliberately run the same partitions over the same brokers: what distinguishes a
+   * plan that covered every tenant from one that only saw the default group is then which brokers
+   * are left holding partitions, not how the two tenants differ.
+   */
+  private CurrentClusterConfiguration twoTenantBareCluster() {
+    final var legacy =
+        unzonedTopology(4, PARTITIONS_PER_TENANT, REPLICATION_FACTOR)
+            .setPartitionDistributorConfig(new ZoneAwareConfig(DUAL_REGION));
+    final var single = CurrentClusterConfiguration.fromLegacy(legacy);
+    return new CurrentClusterConfiguration(
+        single.version(),
+        single.globalConfiguration(),
+        Map.of(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+            TENANT_A,
+            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
+        single.phasedChangeState());
+  }
+
+  private ClusterConfiguration unzonedTopology(
+      final int clusterSize, final int partitionCount, final int replicationFactor) {
+    final Set<MemberId> members =
+        IntStream.range(0, clusterSize).mapToObj(MemberId::from).collect(Collectors.toSet());
+    final var distribution =
+        new RoundRobinConfig()
+            .toDistributor()
+            .distributePartitions(
+                members,
+                IntStream.rangeClosed(1, partitionCount)
+                    .mapToObj(
+                        number ->
+                            new PartitionId(CurrentClusterConfiguration.DEFAULT_GROUP, number))
+                    .toList(),
+                replicationFactor);
+    var topology =
+        ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "clusterId");
+    for (final MemberId member : members) {
+      if (!topology.hasMember(member)) {
+        topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
+      }
+    }
+    return topology;
+  }
+
+  private void wire(final MemberId localMemberId, final CurrentClusterConfiguration seed) {
+    manager =
+        new ClusterConfigurationManagerImpl(
+            executor,
+            localMemberId,
+            PersistedCurrentClusterConfiguration.ofFile(
+                tmp.resolve("config.meta"), new ProtoBufSerializer()),
+            new TopologyManagerMetrics(new SimpleMeterRegistry()),
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+    manager.setCurrentConfigurationGossiper(ignored -> {});
+    manager.registerGlobalChangeAppliers(
+        new GlobalConfigurationChangeAppliersImpl(
+            new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
+    seed.partitionGroups()
+        .keySet()
+        .forEach(
+            groupId ->
+                manager.registerPartitionGroupChangeAppliers(
+                    groupId,
+                    new PartitionGroupConfigurationChangeAppliersImpl(
+                        new NoopPartitionChangeExecutor(),
+                        new NoopPartitionScalingChangeExecutor(),
+                        new NoopModeChangeExecutor(),
+                        new NoopRestoreChangeExecutor())));
+    coordinator = new ConfigurationChangeCoordinatorImpl(manager, localMemberId, executor);
+    manager.updateMultiConfiguration(ignored -> seed).join();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -18,6 +18,7 @@ import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.ZoneLayout;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
@@ -27,6 +28,9 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwar
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.HashMap;
 import java.util.List;
@@ -34,9 +38,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class ZoneMigrationRequestTransformerTest {
+
+  private static final String TENANT_A = "tenant-a";
 
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
@@ -296,6 +303,24 @@ final class ZoneMigrationRequestTransformerTest {
     return TestTopologyChangeSimulator.apply(oldTopology, result.get());
   }
 
+  /**
+   * The given topology with its single partition group mirrored under a second physical tenant, so
+   * every broker holds partitions of both tenants. Enough to tell a plan that saw every tenant's
+   * partition group from one that only ever saw the default group.
+   */
+  private CurrentClusterConfiguration twoTenantCluster(final ClusterConfiguration topology) {
+    final var single = CurrentClusterConfiguration.fromLegacy(topology);
+    return new CurrentClusterConfiguration(
+        single.version(),
+        single.globalConfiguration(),
+        Map.of(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+            TENANT_A,
+            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
+        single.phasedChangeState());
+  }
+
   private ClusterConfiguration setZoneAwareConfig(
       final ClusterConfiguration topology, final List<ZoneSpec> zones) {
     final var result =
@@ -383,5 +408,134 @@ final class ZoneMigrationRequestTransformerTest {
           MemberId.from(zones.get(zoneIdx), ZoneLayout.localNodeIdxForBareNodeIdx(i, 2)));
     }
     return nodeMapping;
+  }
+
+  @Nested
+  class Phases {
+
+    /**
+     * A single-tenant cluster must plan exactly the migration it planned before {@code phases()}
+     * existed, so this compares the two directly rather than re-deriving an expected plan: the
+     * phases the multi-group path builds against the phases {@code toPhases} derives from the
+     * legacy flat operation list. Any divergence in operation content, ordering, or phase
+     * boundaries fails it.
+     */
+    @Test
+    void shouldPlanTheSameSingleRegionMigrationAsTheLegacyPath() {
+      shouldPlanTheSameMigrationAsTheLegacyPath(unzonedTopology(3, 3, 3), SINGLE_REGION, ZONE_A);
+    }
+
+    @Test
+    void shouldPlanTheSameDualRegionStageAsTheLegacyPath() {
+      shouldPlanTheSameMigrationAsTheLegacyPath(unzonedTopology(4, 2, 4), DUAL_REGION, ZONE_B);
+    }
+
+    private void shouldPlanTheSameMigrationAsTheLegacyPath(
+        final ClusterConfiguration topology,
+        final List<ZoneSpec> zones,
+        final String migratedZone) {
+      // given
+      final var legacy = setZoneAwareConfig(topology, zones);
+      final var transformer = new ZoneMigrationRequestTransformer(migratedZone);
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(legacy));
+
+      // then
+      assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(CurrentClusterConfiguration.toPhases(transformer.operations(legacy).get()));
+    }
+
+    /**
+     * A stage replaces every broker of one zone, so leaving a tenant out does not merely deny it
+     * the new brokers: its partitions stay on the member ids the stage removes. Both tenants
+     * therefore have to move off both replaced brokers.
+     */
+    @Test
+    void shouldMoveEveryTenantsPartitionsOffTheStagesBrokers() {
+      // given — two tenants on a four-broker cluster staged for a dual-region migration, where
+      // brokers 1 and 3 are the ones zone-b replaces
+      final var configuration =
+          twoTenantCluster(setZoneAwareConfig(unzonedTopology(4, 2, 4), DUAL_REGION));
+
+      // when
+      final var phases = new ZoneMigrationRequestTransformer(ZONE_B).phases(configuration);
+
+      // then
+      assertThat(phases).isRight();
+      final var groupOperations = partitionPhase(phases.get()).groupOperations();
+      assertThat(groupOperations)
+          .describedAs("every tenant's partitions are replanned, not only the default tenant's")
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A);
+      assertThat(groupOperations)
+          .allSatisfy(
+              (groupId, operations) -> {
+                assertThat(operations)
+                    .describedAs("tenant '%s' leaves both brokers zone-b replaces", groupId)
+                    .filteredOn(PartitionLeaveOperation.class::isInstance)
+                    .extracting(operation -> ((PartitionLeaveOperation) operation).memberId())
+                    .contains(BARE_1, BARE_3)
+                    .doesNotContain(BARE_0, BARE_2);
+                assertThat(operations)
+                    .describedAs("tenant '%s' places partitions on zone-b's new brokers", groupId)
+                    .filteredOn(PartitionJoinOperation.class::isInstance)
+                    .extracting(operation -> ((PartitionJoinOperation) operation).memberId())
+                    .containsOnly(ZONE_B_0, ZONE_B_1);
+              });
+    }
+
+    /**
+     * The zoned ids a stage introduces are global state, so a plan that covers every tenant must
+     * still join and leave each broker exactly once, around the partition work rather than
+     * interleaved with it — a partition can only move onto a broker that has joined, and a broker
+     * can only leave once it holds nothing.
+     */
+    @Test
+    void shouldJoinAndLeaveEachBrokerOnceAroundThePartitionWork() {
+      // given
+      final var configuration =
+          twoTenantCluster(setZoneAwareConfig(unzonedTopology(4, 2, 4), DUAL_REGION));
+
+      // when
+      final var phases = new ZoneMigrationRequestTransformer(ZONE_B).phases(configuration);
+
+      // then
+      assertThat(phases).isRight();
+      assertThat(phases.get()).hasSize(3);
+      assertThat(((GlobalPhase) phases.get().getFirst()).operations())
+          .containsExactly(new MemberJoinOperation(ZONE_B_0), new MemberJoinOperation(ZONE_B_1));
+      assertThat(((GlobalPhase) phases.get().getLast()).operations())
+          .containsExactly(new MemberLeaveOperation(BARE_1), new MemberLeaveOperation(BARE_3));
+    }
+
+    @Test
+    void shouldRejectAnInvalidRequestBeforePlanningAnyTenant() {
+      // given — no zone-aware config persisted, so no stage can be derived
+      final var configuration = twoTenantCluster(unzonedTopology(4, 2, 4));
+
+      // when
+      final var phases = new ZoneMigrationRequestTransformer(ZONE_B).phases(configuration);
+
+      // then
+      assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+          .satisfies(
+              e ->
+                  assertThat(e)
+                      .hasMessageContaining(
+                          "Zone migration requires a persisted zone-aware partition distribution config, but was not set."));
+    }
+
+    private PartitionGroupParallelPhase partitionPhase(final List<Phase> phases) {
+      return phases.stream()
+          .filter(PartitionGroupParallelPhase.class::isInstance)
+          .map(PartitionGroupParallelPhase.class::cast)
+          .findFirst()
+          .orElseThrow(
+              () -> new AssertionError("expected the plan to contain partition work: " + phases));
+    }
   }
 }


### PR DESCRIPTION
Plans a zone migration stage across every physical tenant's partition group instead of the default one only.

A stage replaces every broker of one zone, so leaving the other tenants out did not merely deny them the new brokers — their partitions stayed on the very member ids the stage removes, and `MemberLeaveApplier`'s all-groups check then refused the leave. The whole request was rejected during validation with "the member still has partitions assigned", so a cluster with more than one tenant could not become zone-aware at all: the staged migration is the only supported way to adopt zone-awareness on a cluster that already holds data. The cause is that `ZoneMigrationRequestTransformer` only implements `operations()` and so inherited the default `phases()`, which plans against the default group's projection.

#60193 gave `ScaleRequestTransformer` a `phases()` that plans a membership change across every partition group, and a stage is exactly such a membership change — the bare ids of one zone swapped for their zoned ids. Deciding the stage has no per-tenant dimension, so the validate-and-compute-target-members half of `operations()` is extracted first (separate `refactor:` commit) and the stage is then handed to whichever planner the caller reached. A single-tenant cluster plans exactly the migration it planned before, which the tests assert by comparing `phases()` against `toPhases(operations(...))` rather than re-deriving an expected plan.

`operations()` stays for now. Nothing in production plans through it anymore — here or in `ClusterScaleRequestTransformer` and `ClusterPatchRequestTransformer` — but the tests around all three assert on the flat operation list, and retiring them needs a test simulator that applies phases instead.

Stacked on #60348; review that one first, and the base moves to `main` once it merges.

closes #60341