### PR TITLE
Expose Agent Definition key as a reserved job header

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -260,7 +260,7 @@ public final class BpmnStreamProcessor
       final List<ExecutionListener> beforeAllListeners =
           multiInstanceBody.getBeforeAllExecutionListeners();
       if (!beforeAllListeners.isEmpty()) {
-        return createExecutionListenerJob(context, beforeAllListeners.getFirst());
+        return createExecutionListenerJob(context, element, beforeAllListeners.getFirst());
       }
     }
 
@@ -316,16 +316,19 @@ public final class BpmnStreamProcessor
       return finalizer.apply(element, context);
     }
 
-    return createExecutionListenerJob(context, listeners.getFirst());
+    return createExecutionListenerJob(context, element, listeners.getFirst());
   }
 
   private Either<Failure, ?> createExecutionListenerJob(
-      final BpmnElementContext context, final ExecutionListener listener) {
+      final BpmnElementContext context,
+      final ExecutableFlowElement element,
+      final ExecutionListener listener) {
     return jobBehavior
         .evaluateJobExpressions(listener.getJobWorkerProperties(), context)
         .thenDo(
             elJobProperties ->
-                jobBehavior.createNewExecutionListenerJob(context, elJobProperties, listener));
+                jobBehavior.createNewExecutionListenerJob(
+                    context, elJobProperties, listener, element));
   }
 
   /**
@@ -395,7 +398,7 @@ public final class BpmnStreamProcessor
     final Optional<ExecutionListener> nextListener =
         findNextExecutionListener(listeners, currentListenerIndex);
     return nextListener.isPresent()
-        ? createExecutionListenerJob(context, nextListener.get())
+        ? createExecutionListenerJob(context, element, nextListener.get())
         : finalizer.apply(element, context);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -293,6 +293,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             stateBehavior,
             processingState.getResourceState(),
             processingState.getFormState(),
+            processingState.getAgentDefinitionState(),
             incidentBehavior,
             jobActivationBehavior,
             jobMetrics,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
 import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
@@ -411,13 +412,15 @@ public final class BpmnJobBehavior {
         JobKind.BPMN_ELEMENT,
         JobListenerEventType.UNSPECIFIED,
         element.getJobWorkerProperties().getTaskHeaders(),
-        mergedSecretReferences(context, element));
+        mergedSecretReferences(context, element),
+        element);
   }
 
   public void createNewExecutionListenerJob(
       final BpmnElementContext context,
       final JobProperties jobProperties,
-      final ExecutionListener executionListener) {
+      final ExecutionListener executionListener,
+      final ExecutableFlowElement element) {
 
     final var jobListenerEventType =
         fromExecutionListenerEventType(executionListener.getEventType());
@@ -427,12 +430,14 @@ public final class BpmnJobBehavior {
         JobKind.EXECUTION_LISTENER,
         jobListenerEventType,
         executionListener.getJobWorkerProperties().getTaskHeaders(),
-        Map.of());
+        Map.of(),
+        element);
   }
 
   public void createNewTaskListenerJob(
       final BpmnElementContext context,
       final UserTaskRecord taskRecordValue,
+      final ExecutableFlowElement element,
       final TaskListener listener,
       final List<String> changedAttributes) {
     evaluateTaskListenerJobExpressions(listener.getJobWorkerProperties(), context, taskRecordValue)
@@ -445,7 +450,8 @@ public final class BpmnJobBehavior {
                     fromTaskListenerEventType(listener.getEventType()),
                     extractUserTaskHeaders(
                         taskRecordValue, changedAttributes, listener.getJobWorkerProperties()),
-                    Map.of()))
+                    Map.of(),
+                    element))
         .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
   }
 
@@ -459,7 +465,8 @@ public final class BpmnJobBehavior {
         JobKind.AD_HOC_SUB_PROCESS,
         JobListenerEventType.UNSPECIFIED,
         element.getJobWorkerProperties().getTaskHeaders(),
-        mergedSecretReferences(context, element));
+        mergedSecretReferences(context, element),
+        element);
   }
 
   /**
@@ -636,9 +643,10 @@ public final class BpmnJobBehavior {
       final JobKind jobKind,
       final JobListenerEventType jobListenerEventType,
       final Map<String, String> taskHeaders,
-      final Map<String, Set<SecretReference>> secretReferences) {
+      final Map<String, Set<SecretReference>> secretReferences,
+      final ExecutableFlowElement element) {
 
-    final var encodedHeaders = encodeHeaders(context, taskHeaders, props);
+    final var encodedHeaders = encodeHeaders(context, taskHeaders, props, element);
 
     jobRecord
         .setType(props.getType())
@@ -702,7 +710,8 @@ public final class BpmnJobBehavior {
   private DirectBuffer encodeHeaders(
       final BpmnElementContext context,
       final Map<String, String> taskHeaders,
-      final JobProperties props) {
+      final JobProperties props,
+      final ExecutableFlowElement element) {
     final var headers = new HashMap<>(taskHeaders);
     final String assignee = props.getAssignee();
     final String candidateGroups = props.getCandidateGroups();
@@ -740,11 +749,14 @@ public final class BpmnJobBehavior {
       }
     }
 
-    final var agentDefinitionKey =
-        agentDefinitionState.getAgentDefinitionKey(
-            context.getProcessDefinitionKey(), context.getElementId());
-    if (agentDefinitionKey != null) {
-      headers.put(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME, String.valueOf(agentDefinitionKey));
+    if (element instanceof final ExecutableJobWorkerElement jobWorkerElement
+        && jobWorkerElement.isAgentDefinition()) {
+      final var agentDefinitionKey =
+          agentDefinitionState.getAgentDefinitionKey(
+              context.getProcessDefinitionKey(), context.getElementId());
+      if (agentDefinitionKey != null) {
+        headers.put(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME, String.valueOf(agentDefinitionKey));
+      }
     }
     return headerEncoder.encode(headers);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWr
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
+import io.camunda.zeebe.engine.state.immutable.AgentDefinitionState;
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -130,6 +131,7 @@ public final class BpmnJobBehavior {
   private final BpmnStateBehavior stateBehavior;
   private final ResourceState resourceState;
   private final FormState formState;
+  private final AgentDefinitionState agentDefinitionState;
   private final BpmnIncidentBehavior incidentBehavior;
   private final JobProcessingMetrics jobMetrics;
   private final BpmnJobActivationBehavior jobActivationBehavior;
@@ -145,6 +147,7 @@ public final class BpmnJobBehavior {
       final BpmnStateBehavior stateBehavior,
       final ResourceState resourceState,
       final FormState formState,
+      final AgentDefinitionState agentDefinitionState,
       final BpmnIncidentBehavior incidentBehavior,
       final BpmnJobActivationBehavior jobActivationBehavior,
       final JobProcessingMetrics jobMetrics,
@@ -159,6 +162,7 @@ public final class BpmnJobBehavior {
     this.stateBehavior = stateBehavior;
     this.resourceState = resourceState;
     this.formState = formState;
+    this.agentDefinitionState = agentDefinitionState;
     this.incidentBehavior = incidentBehavior;
     this.jobMetrics = jobMetrics;
     this.jobActivationBehavior = jobActivationBehavior;
@@ -634,7 +638,7 @@ public final class BpmnJobBehavior {
       final Map<String, String> taskHeaders,
       final Map<String, Set<SecretReference>> secretReferences) {
 
-    final var encodedHeaders = encodeHeaders(taskHeaders, props);
+    final var encodedHeaders = encodeHeaders(context, taskHeaders, props);
 
     jobRecord
         .setType(props.getType())
@@ -696,7 +700,9 @@ public final class BpmnJobBehavior {
   }
 
   private DirectBuffer encodeHeaders(
-      final Map<String, String> taskHeaders, final JobProperties props) {
+      final BpmnElementContext context,
+      final Map<String, String> taskHeaders,
+      final JobProperties props) {
     final var headers = new HashMap<>(taskHeaders);
     final String assignee = props.getAssignee();
     final String candidateGroups = props.getCandidateGroups();
@@ -732,6 +738,13 @@ public final class BpmnJobBehavior {
         throw new IllegalArgumentException(
             "Failed to convert linked resource headers to json object", e);
       }
+    }
+
+    final var agentDefinitionKey =
+        agentDefinitionState.getAgentDefinitionKey(
+            context.getProcessDefinitionKey(), context.getElementId());
+    if (agentDefinitionKey != null) {
+      headers.put(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME, String.valueOf(agentDefinitionKey));
     }
     return headerEncoder.encode(headers);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
 import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.element.LinkedResource;
@@ -749,7 +750,15 @@ public final class BpmnJobBehavior {
       }
     }
 
-    if (element instanceof final ExecutableJobWorkerElement jobWorkerElement
+    // A multi-instance body is never itself agent-marked -- only the inner activity it
+    // wraps can be. Resolve to the inner activity here, or a `beforeAll` listener job on
+    // a multi-instance element would silently miss the agentDefinitionKey header.
+    final ExecutableFlowElement agentDefinitionElement =
+        element instanceof final ExecutableMultiInstanceBody multiInstanceBody
+            ? multiInstanceBody.getInnerActivity()
+            : element;
+
+    if (agentDefinitionElement instanceof final ExecutableJobWorkerElement jobWorkerElement
         && jobWorkerElement.isAgentDefinition()) {
       final var agentDefinitionKey =
           agentDefinitionState.getAgentDefinitionKey(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -147,6 +147,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
         jobBehavior.createNewTaskListenerJob(
             context,
             cancelingUserTask.get(),
+            element,
             firstCancelingListener.get(),
             Collections.emptyList());
         return TransitionOutcome.AWAIT;
@@ -203,7 +204,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             .findFirst();
     if (firstCreatingListener.isPresent()) {
       jobBehavior.createNewTaskListenerJob(
-          context, userTaskRecord, firstCreatingListener.get(), Collections.emptyList());
+          context, userTaskRecord, element, firstCreatingListener.get(), Collections.emptyList());
       lifecycleState = LifecycleState.CREATING;
     } else {
       userTaskRecord.unsetAssignee();
@@ -228,7 +229,11 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
         .ifPresentOrElse(
             listener ->
                 jobBehavior.createNewTaskListenerJob(
-                    context, userTaskRecord, listener, userTaskRecord.getChangedAttributes()),
+                    context,
+                    userTaskRecord,
+                    element,
+                    listener,
+                    userTaskRecord.getChangedAttributes()),
             () -> userTaskBehavior.userTaskAssigned(userTaskRecord, assignee));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -149,7 +149,11 @@ public class UserTaskProcessor
               final var changedAttributes =
                   intermediateUserTaskRecord.determineChangedAttributes(currentUserTask);
               jobBehavior.createNewTaskListenerJob(
-                  context, intermediateUserTaskRecord, listener, changedAttributes);
+                  context,
+                  intermediateUserTaskRecord,
+                  userTaskElement,
+                  listener,
+                  changedAttributes);
             },
             () -> finalizeCommand(command, lifecycleState, intermediateUserTaskRecord));
   }
@@ -226,7 +230,11 @@ public class UserTaskProcessor
       final var userTaskElementInstance = getUserTaskElementInstance(persistedRecord);
       final var context = buildContext(userTaskElementInstance);
       jobBehavior.createNewTaskListenerJob(
-          context, persistedRecord, listener, persistedRecord.getChangedAttributes());
+          context,
+          persistedRecord,
+          userTaskElement,
+          listener,
+          persistedRecord.getChangedAttributes());
     } else {
       processor.onFinalizeCommand(command, persistedRecord);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -100,7 +100,7 @@ public class UserTaskCreateProcessor implements UserTaskCommandProcessor {
         .ifPresentOrElse(
             listener ->
                 jobBehavior.createNewTaskListenerJob(
-                    context, userTaskRecord, listener, List.of(UserTaskRecord.ASSIGNEE)),
+                    context, userTaskRecord, element, listener, List.of(UserTaskRecord.ASSIGNEE)),
             () -> userTaskBehavior.userTaskAssigned(userTaskRecord, assignee));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -182,7 +182,11 @@ public final class VariableDocumentUpdateProcessor
       if (firstTaskListener.isPresent()) {
         final var listener = firstTaskListener.get();
         jobBehavior.createNewTaskListenerJob(
-            buildContext(scope), userTaskRecord, listener, userTaskRecord.getChangedAttributes());
+            buildContext(scope),
+            userTaskRecord,
+            userTaskElement,
+            listener,
+            userTaskRecord.getChangedAttributes());
         return;
       }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AgentDefinitionJobHeaderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AgentDefinitionJobHeaderTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -202,6 +203,58 @@ public class AgentDefinitionJobHeaderTest {
             .getFirst();
 
     assertThat(listenerJobCreated.getValue().getCustomHeaders())
+        .contains(
+            entry(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME, String.valueOf(agentDefinitionKey)));
+  }
+
+  @Test
+  public void
+      shouldIncludeAgentDefinitionKeyHeaderForBeforeAllListenerOnMultiInstanceAgentServiceTask() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    t ->
+                        t.zeebeJobType("jobType")
+                            .zeebeAiAgentTaskDefinition()
+                            .zeebeBeforeAllExecutionListener("beforeAllJobType")
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("items", List.of(1))
+            .create();
+
+    // then
+    final var agentDefinitionKey =
+        RecordingExporter.agentDefinitionRecords(AgentDefinitionIntent.CREATED)
+            .withBpmnProcessId(processId)
+            .getFirst()
+            .getValue()
+            .getAgentDefinitionKey();
+
+    final var beforeAllJobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("beforeAllJobType")
+            .getFirst();
+
+    assertThat(beforeAllJobCreated.getValue().getCustomHeaders())
         .contains(
             entry(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME, String.valueOf(agentDefinitionKey)));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AgentDefinitionJobHeaderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AgentDefinitionJobHeaderTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class AgentDefinitionJobHeaderTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldIncludeAgentDefinitionKeyHeaderForServiceTaskWithAgentDefinition() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("jobType").zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    final var agentDefinitionKey =
+        RecordingExporter.agentDefinitionRecords(AgentDefinitionIntent.CREATED)
+            .withBpmnProcessId(processId)
+            .getFirst()
+            .getValue()
+            .getAgentDefinitionKey();
+
+    final var jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getCustomHeaders())
+        .contains(
+            entry(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME, String.valueOf(agentDefinitionKey)));
+  }
+
+  @Test
+  public void shouldNotIncludeAgentDefinitionKeyHeaderForServiceTaskWithoutAgentDefinition() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("jobType"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    final var jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getCustomHeaders())
+        .doesNotContainKey(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME);
+  }
+
+  @Test
+  public void shouldIncludeAgentDefinitionKeyHeaderForAdHocSubProcessWithAgentDefinition() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .adHocSubProcess(
+                    "ad-hoc",
+                    ahsp ->
+                        ahsp.zeebeJobType("jobType")
+                            .zeebeAiAgentSubProcessDefinition()
+                            .task("inner"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    final var agentDefinitionKey =
+        RecordingExporter.agentDefinitionRecords(AgentDefinitionIntent.CREATED)
+            .withBpmnProcessId(processId)
+            .getFirst()
+            .getValue()
+            .getAgentDefinitionKey();
+
+    final var jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("ad-hoc")
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getCustomHeaders())
+        .contains(
+            entry(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME, String.valueOf(agentDefinitionKey)));
+  }
+
+  @Test
+  public void shouldNotIncludeAgentDefinitionKeyHeaderForAdHocSubProcessWithoutAgentDefinition() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .adHocSubProcess("ad-hoc", ahsp -> ahsp.zeebeJobType("jobType").task("inner"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    final var jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("ad-hoc")
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getCustomHeaders())
+        .doesNotContainKey(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME);
+  }
+
+  @Test
+  public void
+      shouldIncludeAgentDefinitionKeyHeaderForExecutionListenerJobOnAgentMarkedServiceTask() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    t ->
+                        t.zeebeJobType("jobType")
+                            .zeebeAiAgentTaskDefinition()
+                            .zeebeStartExecutionListener("listenerJobType"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    final var agentDefinitionKey =
+        RecordingExporter.agentDefinitionRecords(AgentDefinitionIntent.CREATED)
+            .withBpmnProcessId(processId)
+            .getFirst()
+            .getValue()
+            .getAgentDefinitionKey();
+
+    final var listenerJobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("listenerJobType")
+            .getFirst();
+
+    assertThat(listenerJobCreated.getValue().getCustomHeaders())
+        .contains(
+            entry(Protocol.AGENT_DEFINITION_KEY_HEADER_NAME, String.valueOf(agentDefinitionKey)));
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -110,6 +110,10 @@ public final class Protocol {
   public static final String USER_TASK_PRIORITY_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "priority";
 
+  /** Task header key used for the key of the Agent Definition. */
+  public static final String AGENT_DEFINITION_KEY_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "agentDefinitionKey";
+
   /** Linked resources header used in service task */
   public static final String LINKED_RESOURCES_HEADER_NAME = "linkedResources";
 


### PR DESCRIPTION
## Description

Connectors need to correlate an activated job back to the Agent Definition it belongs to, but jobs created for `zeebe:agentDefinition`-marked service tasks and ad-hoc sub-processes carried no such reference.

Jobs now carry the deployed Agent Definition's key under a new reserved header, `io.camunda.zeebe:agentDefinitionKey`, following the same convention as the existing reserved user-task headers. The header is added at the single shared header-encoding step used by both element kinds and their execution/task listener jobs, gated on the element's `isAgentDefinition()` flag so ordinary jobs don't pay for the extra state lookup.

**Out of scope**:
- Consuming the header on the Connector side.
- Documentation on https://docs.camunda.io.

## Checklist
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)). — not applicable, unreleased/net-new behavior.
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. — not applicable, this PR doesn't touch that suite.

## Related issues
closes #60319
