### PR TITLE
feat: apply a partition distribution or zone layout change to every physical tenant

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
@@ -29,20 +30,30 @@ public class AddMembersTransformer implements ConfigurationChangeRequest {
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    if (clusterConfiguration.isFullyZoneAware() && members.stream().anyMatch(MemberId::isBare)) {
+    return joins(clusterConfiguration.members().keySet(), clusterConfiguration.isFullyZoneAware())
+        .map(List::<ClusterConfigurationChangeOperation>copyOf);
+  }
+
+  /**
+   * The joins this request amounts to on a cluster with the given members.
+   *
+   * <p>Takes the member set rather than a configuration, because that is all the answer depends on:
+   * joining a broker is global, with no per-tenant dimension.
+   */
+  Either<Exception, List<GlobalChangeOperation>> joins(
+      final Set<MemberId> currentMembers, final boolean fullyZoneAware) {
+    if (fullyZoneAware && members.stream().anyMatch(MemberId::isBare)) {
       return Either.left(
           new InvalidRequest(
               "Members without a zone cannot be added to a zone-aware cluster: "
                   + members.stream().filter(MemberId::isBare).sorted().toList()));
     }
-    final var operations =
+    return Either.right(
         members.stream()
             // only add members that are not already part of the cluster
-            .filter(memberId -> !clusterConfiguration.hasMember(memberId))
-            .map(MemberJoinOperation::new)
-            .map(ClusterConfigurationChangeOperation.class::cast)
-            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
-            .toList();
-    return Either.right(operations);
+            .filter(memberId -> !currentMembers.contains(memberId))
+            .map(memberId -> (GlobalChangeOperation) new MemberJoinOperation(memberId))
+            .sorted(Comparator.comparing(GlobalChangeOperation::memberId))
+            .toList());
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformer.java
@@ -12,14 +12,19 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Restores a previously failed-over zone: re-adds the operator-supplied brokers to the member set,
@@ -44,6 +49,36 @@ public final class AddZoneTransformer implements ConfigurationChangeRequest {
     this.brokers = brokers;
   }
 
+  /**
+   * Places the returning zone's brokers into every physical tenant's partition group, by handing
+   * the re-included zone layout to {@link
+   * UpdatePartitionDistributionTransformer#phases(CurrentClusterConfiguration)}.
+   *
+   * <p>The brokers have to join before any partition can land on them, so their joins are folded
+   * into the leading global phase of that plan — the one that persists the layout — rather than
+   * emitted as a phase of their own. That is the same plan {@code toPhases} derives from the flat
+   * operation list {@link #operations(ClusterConfiguration)} produces, where the joins and the
+   * layout are one uninterrupted run of global operations.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    return zoneAddedConfig(configuration.globalConfiguration().partitionDistributorConfig())
+        .flatMap(
+            newConfig ->
+                new AddMembersTransformer(brokers)
+                    .joins(configuration.getMembers(), configuration.isFullyZoneAware())
+                    .flatMap(
+                        joins ->
+                            new UpdatePartitionDistributionTransformer(newConfig, brokers)
+                                .phases(configuration)
+                                .map(phases -> withJoinsFirst(joins, phases))));
+  }
+
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
@@ -68,6 +103,19 @@ public final class AddZoneTransformer implements ConfigurationChangeRequest {
                                       allOps.addAll(distributionOps);
                                       return allOps;
                                     })));
+  }
+
+  private static List<Phase> withJoinsFirst(
+      final List<GlobalChangeOperation> joins, final List<Phase> phases) {
+    if (joins.isEmpty()) {
+      return phases;
+    }
+    if (!phases.isEmpty() && phases.getFirst() instanceof final GlobalPhase leading) {
+      final var merged = new ArrayList<>(joins);
+      merged.addAll(leading.operations());
+      return Stream.concat(Stream.of(new GlobalPhase(merged)), phases.stream().skip(1)).toList();
+    }
+    return Stream.concat(Stream.of(new GlobalPhase(joins)), phases.stream()).toList();
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformer.java
@@ -12,11 +12,13 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -45,7 +47,38 @@ public final class AddZoneTransformer implements ConfigurationChangeRequest {
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
-    final var partitionDistributorConfig = currentConfiguration.partitionDistributorConfig();
+    return zoneAddedConfig(currentConfiguration.partitionDistributorConfig())
+        .flatMap(
+            newConfig ->
+                // Join the returning brokers, then reuse the shared distribution transformer to
+                // persist the new config and reassign partitions over the current members plus the
+                // returning brokers.
+                new AddMembersTransformer(brokers)
+                    .operations(currentConfiguration)
+                    .flatMap(
+                        addMembersOps ->
+                            new UpdatePartitionDistributionTransformer(newConfig, brokers)
+                                .operations(currentConfiguration)
+                                .map(
+                                    distributionOps -> {
+                                      final var allOps =
+                                          new ArrayList<ClusterConfigurationChangeOperation>(
+                                              addMembersOps.size() + distributionOps.size());
+                                      allOps.addAll(addMembersOps);
+                                      allOps.addAll(distributionOps);
+                                      return allOps;
+                                    })));
+  }
+
+  /**
+   * Validates the request and answers with the zone layout it implies: the persisted one with the
+   * returning zone added back.
+   *
+   * <p>Takes the persisted layout rather than a configuration because that is all the answer
+   * depends on — the zone layout and the member set are global, with no per-tenant dimension.
+   */
+  private Either<Exception, ZoneAwareConfig> zoneAddedConfig(
+      final Optional<PartitionDistributorConfig> partitionDistributorConfig) {
     final List<ZoneSpec> currentZones;
     if (partitionDistributorConfig.isPresent()
         && partitionDistributorConfig.get() instanceof final ZoneAwareConfig cfg) {
@@ -99,24 +132,6 @@ public final class AddZoneTransformer implements ConfigurationChangeRequest {
       return Either.left(new InvalidRequest(e));
     }
     newZones.add(newZone);
-    final var newConfig = new ZoneAwareConfig(newZones);
-
-    // Join the returning brokers, then reuse the shared distribution transformer to persist the new
-    // config and reassign partitions over the current members plus the returning brokers.
-    return new AddMembersTransformer(brokers)
-        .operations(currentConfiguration)
-        .flatMap(
-            addMembersOps ->
-                new UpdatePartitionDistributionTransformer(newConfig, brokers)
-                    .operations(currentConfiguration)
-                    .map(
-                        distributionOps -> {
-                          final var allOps =
-                              new ArrayList<ClusterConfigurationChangeOperation>(
-                                  addMembersOps.size() + distributionOps.size());
-                          allOps.addAll(addMembersOps);
-                          allOps.addAll(distributionOps);
-                          return allOps;
-                        }));
+    return Either.right(new ZoneAwareConfig(newZones));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -57,7 +57,59 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
+    return validatedZoneAwareConfig(
+            currentConfiguration.minReplicationFactor(),
+            currentConfiguration.isFullyZoneAware(),
+            currentConfiguration.isPartiallyZoneAware())
+        .flatMap(zoneAwareConfig -> operations(currentConfiguration, zoneAwareConfig));
+  }
 
+  private Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration currentConfiguration, final ZoneAwareConfig zoneAwareConfig) {
+    final var coordinator =
+        ClusterConfigurationCoordinatorSupplier.of(() -> currentConfiguration)
+            .getDefaultCoordinator();
+
+    // Apply the new config to produce a temporary configuration whose partitionDistributor()
+    // returns the new ZoneAwarePartitionDistributor. This is only used for distribution
+    // computation; the real version bump happens when the config-set operation is applied.
+    final var updatedConfiguration = currentConfiguration.setPartitionDistributorConfig(newConfig);
+
+    return new PartitionReassignRequestTransformer(
+            targetMembers(currentConfiguration.members().keySet()),
+            Optional.of(zoneAwareConfig.replicationFactor()),
+            Optional.empty())
+        .operations(updatedConfiguration)
+        .map(
+            ops -> {
+              final var allOps = new ArrayList<ClusterConfigurationChangeOperation>(ops.size() + 1);
+              allOps.add(new UpdatePartitionDistributorConfigOperation(coordinator, newConfig));
+              allOps.addAll(ops);
+              return allOps;
+            });
+  }
+
+  private Set<MemberId> targetMembers(final Set<MemberId> currentMembers) {
+    final var members = new HashSet<>(currentMembers);
+    members.addAll(extraMembers);
+    return members;
+  }
+
+  /**
+   * Checks the request against the cluster it would apply to and answers with the requested config
+   * once it is known to be applicable.
+   *
+   * <p>Takes what it checks rather than a configuration, because the answer does not depend on
+   * which partition groups the cluster runs: whether a zone layout can be adopted follows from the
+   * layout itself, from how far the cluster has come in adopting zone-awareness, and from the
+   * replication factor it runs today.
+   *
+   * @param currentReplicationFactor the lowest replication factor any partition currently has
+   */
+  private Either<Exception, ZoneAwareConfig> validatedZoneAwareConfig(
+      final int currentReplicationFactor,
+      final boolean fullyZoneAware,
+      final boolean partiallyZoneAware) {
     if (!(newConfig instanceof final ZoneAwareConfig zoneAwareConfig)) {
       return Either.left(
           new InvalidRequest(
@@ -80,9 +132,7 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
     }
 
     final int targetReplicationFactor = zoneAwareConfig.replicationFactor();
-    final int currentReplicationFactor = currentConfiguration.minReplicationFactor();
-    if (!currentConfiguration.isFullyZoneAware()
-        && targetReplicationFactor != currentReplicationFactor) {
+    if (!fullyZoneAware && targetReplicationFactor != currentReplicationFactor) {
       return Either.left(
           new InvalidRequest(
               String.format(
@@ -91,36 +141,13 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
                   targetReplicationFactor, currentReplicationFactor)));
     }
 
-    final var coordinator =
-        ClusterConfigurationCoordinatorSupplier.of(() -> currentConfiguration)
-            .getDefaultCoordinator();
-
-    if (currentConfiguration.isPartiallyZoneAware()) {
+    if (partiallyZoneAware) {
       return Either.left(
           new InvalidRequest(
               "Partition distribution changes are only supported on fully zone-aware clusters or "
                   + "on fully bare clusters before zone migration starts."));
     }
 
-    // Apply the new config to produce a temporary configuration whose partitionDistributor()
-    // returns the new ZoneAwarePartitionDistributor. This is only used for distribution
-    // computation; the real version bump happens when the config-set operation is applied.
-    final var updatedConfiguration = currentConfiguration.setPartitionDistributorConfig(newConfig);
-
-    final var members = new HashSet<>(currentConfiguration.members().keySet());
-    members.addAll(extraMembers);
-
-    return new PartitionReassignRequestTransformer(
-            members, Optional.of(zoneAwareConfig.replicationFactor()), Optional.empty())
-        .operations(updatedConfiguration)
-        .map(
-            ops -> {
-              final var allOps = new ArrayList<ClusterConfigurationChangeOperation>(ops.size() + 1);
-              final var updateConfigOperation =
-                  new UpdatePartitionDistributorConfigOperation(coordinator, newConfig);
-              allOps.add(updateConfigOperation);
-              allOps.addAll(ops);
-              return allOps;
-            });
+    return Either.right(zoneAwareConfig);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -12,11 +12,15 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.CollectionUtil;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -24,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Computes the operations needed to apply a new {@link ZoneAwareConfig}. It persists the new config
@@ -54,6 +59,29 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
     this.extraMembers = Set.copyOf(extraMembers);
   }
 
+  /**
+   * Plans the redistribution over every physical tenant's partition group, rather than the default
+   * one only: the new config is persisted by a leading global phase, and the placement it implies
+   * is then planned for every group at once.
+   *
+   * <p>On a zone-aware cluster the replication factor is derived from the zone layout, so this is
+   * also how a layout change reaches each tenant's replication factor — planning the default group
+   * alone left every other tenant at the replication factor of the layout it replaced.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    return validatedZoneAwareConfig(
+            configuration.minReplicationFactor(),
+            configuration.isFullyZoneAware(),
+            configuration.isPartiallyZoneAware())
+        .flatMap(zoneAwareConfig -> phases(configuration, zoneAwareConfig));
+  }
+
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer and the two that delegate to it assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
@@ -62,6 +90,31 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
             currentConfiguration.isFullyZoneAware(),
             currentConfiguration.isPartiallyZoneAware())
         .flatMap(zoneAwareConfig -> operations(currentConfiguration, zoneAwareConfig));
+  }
+
+  private Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration configuration, final ZoneAwareConfig zoneAwareConfig) {
+    final List<GlobalChangeOperation> persistConfig =
+        List.of(
+            new UpdatePartitionDistributorConfigOperation(
+                ClusterConfigurationCoordinatorSupplier.from(() -> configuration)
+                    .getDefaultCoordinator(),
+                newConfig));
+
+    // The placement must be computed with the new distributor, and the planner resolves it from the
+    // configuration it is handed — so hand it a copy that already carries the new config. Only the
+    // operation above really persists it.
+    return PartitionGroupScalingPhases.phases(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            configuration.updateGlobalConfiguration(
+                global -> global.setPartitionDistributorConfig(newConfig)),
+            targetMembers(configuration.getMembers()),
+            Optional.empty(),
+            Optional.of(zoneAwareConfig.replicationFactor()))
+        .map(
+            partitionPhases ->
+                Stream.concat(Stream.of(new GlobalPhase(persistConfig)), partitionPhases.stream())
+                    .toList());
   }
 
   private Either<Exception, List<ClusterConfigurationChangeOperation>> operations(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
@@ -11,9 +11,11 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.CollectionUtil;
 import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
@@ -39,6 +41,25 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
     this.sortedZoneNames = List.copyOf(sortedZoneNames);
   }
 
+  /**
+   * Re-prioritizes every physical tenant's partitions, by handing the re-prioritized layout to
+   * {@link UpdatePartitionDistributionTransformer#phases(CurrentClusterConfiguration)}. Which zone
+   * is preferred for leadership is global, so the layout is computed once and applied to every
+   * group.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    return reprioritized(configuration.globalConfiguration().partitionDistributorConfig())
+        .flatMap(
+            newConfig ->
+                new UpdatePartitionDistributionTransformer(newConfig).phases(configuration));
+  }
+
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.util.CollectionUtil;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -40,7 +42,22 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
-    final var partitionDistributorConfig = currentConfiguration.partitionDistributorConfig();
+    return reprioritized(currentConfiguration.partitionDistributorConfig())
+        .flatMap(
+            newConfig ->
+                new UpdatePartitionDistributionTransformer(newConfig)
+                    .operations(currentConfiguration));
+  }
+
+  /**
+   * Validates the requested order and answers with the layout it implies: the existing priorities
+   * re-assigned to zones by that order.
+   *
+   * <p>Takes the persisted layout rather than a configuration because that is all the answer
+   * depends on — zone priorities are global, with no per-tenant dimension.
+   */
+  private Either<Exception, ZoneAwareConfig> reprioritized(
+      final Optional<PartitionDistributorConfig> partitionDistributorConfig) {
     final ZoneAwareConfig zoneAwareConfig;
     if (partitionDistributorConfig.isPresent()
         && partitionDistributorConfig.get() instanceof final ZoneAwareConfig cfg) {
@@ -89,7 +106,6 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
             .map(t -> t.getRight().withPriority(t.getLeft()))
             .toList();
 
-    final var newConfig = new ZoneAwareConfig(reprioritized);
-    return new UpdatePartitionDistributionTransformer(newConfig).operations(currentConfiguration);
+    return Either.right(new ZoneAwareConfig(reprioritized));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -141,6 +141,60 @@ public record CurrentClusterConfiguration(
   }
 
   /**
+   * Whether the cluster is between the two modes: some but not all brokers are assigned to a zone,
+   * or every broker is but the partition distributor is not zone-aware yet.
+   *
+   * <p>Both are global state, so this reads the same fields {@link
+   * ClusterConfiguration#isPartiallyZoneAware()} does — the projection through {@link
+   * #toLegacyDefault()} that method needs is not.
+   */
+  public boolean isPartiallyZoneAware() {
+    final var members = globalConfiguration.members().keySet();
+    if (members.isEmpty()) {
+      return false;
+    }
+    final var zonedCount = members.stream().filter(member -> member.zone() != null).count();
+    final var distributorIsNotZoneAware =
+        globalConfiguration
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .isEmpty();
+    return (zonedCount > 0 && zonedCount < members.size())
+        || (zonedCount == members.size() && distributorIsNotZoneAware);
+  }
+
+  /**
+   * The lowest number of replicas any partition of any physical tenant currently has. Taken across
+   * every group because the replication factor is a cluster-wide setting: a request that has to
+   * match what the cluster runs today has to match it for every tenant, not only the default one.
+   *
+   * <p>Read as the minimum rather than a configured value, mirroring {@link
+   * ClusterConfiguration#minReplicationFactor()}: during a configuration change a partition can
+   * temporarily hold more replicas than the cluster is configured for.
+   *
+   * <p>Answers 0 for a cluster that runs no partitions at all, which is what makes an equality
+   * check against it fail rather than pass. {@code PartitionGroupScalingPhases} asks a different
+   * question — the replication factor to plan with when the request names none — and defaults to 1
+   * there for the same reason.
+   */
+  public int minReplicationFactor() {
+    final var countingBrokers = liveMembers();
+    return partitionGroups.values().stream()
+        .flatMap(
+            group ->
+                group.members().entrySet().stream()
+                    .filter(member -> countingBrokers.contains(member.getKey()))
+                    .flatMap(member -> member.getValue().partitions().keySet().stream())
+                    .collect(
+                        Collectors.groupingBy(partitionId -> partitionId, Collectors.counting()))
+                    .values()
+                    .stream())
+        .mapToInt(Long::intValue)
+        .min()
+        .orElse(0);
+  }
+
+  /**
    * Creates an empty configuration with an initial global configuration and no partition groups.
    */
   public static CurrentClusterConfiguration init() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformerTest.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
@@ -21,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwar
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
@@ -28,6 +33,7 @@ import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class AddZoneTransformerTest {
@@ -207,5 +213,110 @@ final class AddZoneTransformerTest {
     assertThat(result.getLeft())
         .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
         .hasMessageContaining("ZoneSpec: priority must be > 0, got -1");
+  }
+
+  @Nested
+  class Phases {
+
+    private static final ZoneAwareConfig RESTORED_CONFIG =
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 500)));
+
+    /**
+     * A single-tenant cluster must plan exactly the change it planned before {@code phases()}
+     * existed, so this compares the two directly rather than re-deriving an expected plan. It is
+     * also what pins the phase boundary: the returning broker's join and the layout it comes back
+     * into are one uninterrupted run of global operations, so they belong in one phase.
+     */
+    @Test
+    void shouldPlanTheSameChangeAsTheLegacyPath() {
+      // given
+      final var topology = buildTopology(SINGLE_ZONE_CONFIG, SINGLE_ZONE_MEMBERS);
+      final var transformer = new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_0));
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(topology));
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(CurrentClusterConfiguration.toPhases(transformer.operations(topology).get()));
+    }
+
+    /**
+     * A zone comes back to serve the whole cluster, so its brokers have to take partitions of every
+     * tenant — a tenant left out gains no replica in the returning zone and stays exposed to the
+     * failure of the one that carried it alone.
+     */
+    @Test
+    void shouldPlacePartitionsOfEveryTenantInTheReturningZone() {
+      // given — two tenants left on zone-a alone after zone-b failed over
+      final var configuration =
+          withMirroredTenant(buildTopology(SINGLE_ZONE_CONFIG, SINGLE_ZONE_MEMBERS));
+
+      // when — zone-b comes back with one broker
+      final var phases =
+          new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_0)).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(partitionGroupPhase(phases.get()).groupOperations())
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+          .allSatisfy(
+              (groupId, operations) ->
+                  assertThat(operations)
+                      .describedAs("tenant '%s' replicates every partition into zone-b", groupId)
+                      .filteredOn(PartitionJoinOperation.class::isInstance)
+                      .hasSize(PARTITION_IDS.size())
+                      .allSatisfy(
+                          join ->
+                              assertThat(((PartitionJoinOperation) join).memberId())
+                                  .isEqualTo(ZONE_B_0)));
+    }
+
+    /**
+     * The returning brokers must be members before any tenant's partition is placed on them, and
+     * the layout must be persisted before a partition placed by the new distributor is applied — so
+     * both come first, in one global phase.
+     */
+    @Test
+    void shouldJoinTheReturningBrokersAndPersistTheLayoutBeforeAnyTenantIsReplanned() {
+      // given
+      final var configuration =
+          withMirroredTenant(buildTopology(SINGLE_ZONE_CONFIG, SINGLE_ZONE_MEMBERS));
+
+      // when
+      final var phases =
+          new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_0)).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get()).hasSize(2);
+      assertThat(((GlobalPhase) phases.get().getFirst()).operations())
+          .containsExactly(
+              new MemberJoinOperation(ZONE_B_0),
+              new UpdatePartitionDistributorConfigOperation(ZONE_A_0, RESTORED_CONFIG));
+    }
+
+    @Test
+    void shouldRejectAnInvalidRequestBeforePlanningAnyTenant() {
+      // given — a zone that is already part of the layout
+      final var configuration =
+          withMirroredTenant(buildTopology(RESTORED_CONFIG, Set.of(ZONE_A_0, ZONE_B_0)));
+
+      // when
+      final var phases =
+          new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_1)).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+          .satisfies(
+              e ->
+                  assertThat(e)
+                      .hasMessageContaining(
+                          "Cannot add back zone 'zone-b' because it is already present"));
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -7,20 +7,26 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
@@ -28,6 +34,7 @@ import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class UpdatePartitionDistributionTransformerTest {
@@ -221,5 +228,120 @@ class UpdatePartitionDistributionTransformerTest {
         .isLeft()
         .left()
         .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+  }
+
+  @Nested
+  class Phases {
+
+    private static final ZoneAwareConfig HIGHER_REPLICATION_FACTOR =
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 2, 1000), new ZoneSpec(ZONE_B, 1, 500)));
+
+    /**
+     * A single-tenant cluster must plan exactly the change it planned before {@code phases()}
+     * existed, so this compares the two directly rather than re-deriving an expected plan: the
+     * phases the multi-group path builds against the phases {@code toPhases} derives from the
+     * legacy flat operation list. Any divergence in operation content, ordering, or phase
+     * boundaries fails it.
+     */
+    @Test
+    void shouldPlanTheSameReplicationFactorChangeAsTheLegacyPath() {
+      shouldPlanTheSameChangeAsTheLegacyPath(HIGHER_REPLICATION_FACTOR);
+    }
+
+    /** The layout change an operator makes to move leadership, which changes no placement. */
+    @Test
+    void shouldPlanTheSamePriorityChangeAsTheLegacyPath() {
+      shouldPlanTheSameChangeAsTheLegacyPath(
+          new ZoneAwareConfig(
+              List.of(new ZoneSpec(ZONE_A, 1, 500), new ZoneSpec(ZONE_B, 1, 1000))));
+    }
+
+    private void shouldPlanTheSameChangeAsTheLegacyPath(final ZoneAwareConfig newConfig) {
+      // given
+      final var topology = buildTopology(INITIAL_CONFIG, MEMBERS);
+      final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(topology));
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(CurrentClusterConfiguration.toPhases(transformer.operations(topology).get()));
+    }
+
+    /**
+     * The replication factor of a zone-aware cluster is derived from its zone layout, so this is
+     * both the placement check and the replication-factor one: a tenant left out of the plan keeps
+     * the replication factor of the layout being replaced.
+     */
+    @Test
+    void shouldApplyTheDerivedReplicationFactorToEveryTenant() {
+      // given — two tenants at replication factor 2, and a layout that raises it to 3
+      final var configuration = withMirroredTenant(buildTopology(INITIAL_CONFIG, MEMBERS));
+
+      // when
+      final var phases =
+          new UpdatePartitionDistributionTransformer(HIGHER_REPLICATION_FACTOR)
+              .phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(partitionGroupPhase(phases.get()).groupOperations())
+          .describedAs("every tenant's partitions are replanned, not only the default tenant's")
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+          .allSatisfy(
+              (groupId, operations) ->
+                  assertThat(operations)
+                      .describedAs(
+                          "tenant '%s' gains the third replica of every partition", groupId)
+                      .filteredOn(PartitionJoinOperation.class::isInstance)
+                      .hasSize(PARTITION_IDS.size()));
+    }
+
+    /**
+     * The layout is global state, so it is persisted once for the whole cluster and before any
+     * partition moves — a partition placed by the new distributor must not be applied while the old
+     * layout is still the persisted one.
+     */
+    @Test
+    void shouldPersistTheLayoutOnceBeforeAnyTenantIsReplanned() {
+      // given
+      final var configuration = withMirroredTenant(buildTopology(INITIAL_CONFIG, MEMBERS));
+
+      // when
+      final var phases =
+          new UpdatePartitionDistributionTransformer(HIGHER_REPLICATION_FACTOR)
+              .phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get()).hasSize(2);
+      assertThat(((GlobalPhase) phases.get().getFirst()).operations())
+          .containsExactly(
+              new UpdatePartitionDistributorConfigOperation(
+                  COORDINATOR, HIGHER_REPLICATION_FACTOR));
+    }
+
+    @Test
+    void shouldRejectAnInvalidRequestBeforePlanningAnyTenant() {
+      // given — a request body the endpoint does not support
+      final var configuration = withMirroredTenant(buildTopology(INITIAL_CONFIG, MEMBERS));
+
+      // when
+      final var phases =
+          new UpdatePartitionDistributionTransformer(new RoundRobinConfig()).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+          .satisfies(
+              e ->
+                  assertThat(e)
+                      .hasMessageContaining(
+                          "Only ZONE_AWARE partition distribution config is supported."));
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +17,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
@@ -25,6 +29,7 @@ import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class UpdateZonePrioritiesTransformerTest {
@@ -128,5 +133,55 @@ final class UpdateZonePrioritiesTransformerTest {
         .isInstanceOf(InvalidRequest.class)
         .hasMessageContaining(
             "Updating zone priorities requires a persisted zone-aware partition distribution config, but was not set");
+  }
+
+  @Nested
+  class Phases {
+
+    /**
+     * A single-tenant cluster must plan exactly the change it planned before {@code phases()}
+     * existed, so this compares the two directly rather than re-deriving an expected plan.
+     */
+    @Test
+    void shouldPlanTheSameChangeAsTheLegacyPath() {
+      // given
+      final var topology = zoneAwareCluster(new ZoneSpec(ZONE_A, 1, 3), new ZoneSpec(ZONE_B, 1, 1));
+      final var transformer = new UpdateZonePrioritiesTransformer(List.of(ZONE_B, ZONE_A));
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(topology));
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(CurrentClusterConfiguration.toPhases(transformer.operations(topology).get()));
+    }
+
+    /**
+     * Leadership follows the Raft priorities of each partition, so moving it to another zone means
+     * reconfiguring the priorities of every tenant's partitions — a tenant left out keeps its
+     * leaders where they were.
+     */
+    @Test
+    void shouldReconfigurePrioritiesForEveryTenant() {
+      // given — two tenants on a cluster where zone-a leads
+      final var configuration =
+          withMirroredTenant(
+              zoneAwareCluster(new ZoneSpec(ZONE_A, 1, 3), new ZoneSpec(ZONE_B, 1, 1)));
+
+      // when — zone-b takes over leadership
+      final var phases =
+          new UpdateZonePrioritiesTransformer(List.of(ZONE_B, ZONE_A)).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(partitionGroupPhase(phases.get()).groupOperations())
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+          .allSatisfy(
+              (groupId, operations) ->
+                  assertThat(operations)
+                      .describedAs("tenant '%s' moves its leaders to zone-b", groupId)
+                      .anyMatch(PartitionReconfigurePriorityOperation.class::isInstance));
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PhysicalTenantFixtures.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PhysicalTenantFixtures.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import java.util.List;
+import java.util.Map;
+
+public final class PhysicalTenantFixtures {
+
+  public static final String TENANT_A = "tenant-a";
+
+  private PhysicalTenantFixtures() {}
+
+  /**
+   * The given single-group topology as a multi-group configuration whose two partition groups are
+   * mirror images: the default tenant and {@link #TENANT_A} run the same partitions over the same
+   * brokers.
+   *
+   * <p>Mirroring rather than varying the two is what makes a plan easy to read: whatever a request
+   * does to the default tenant it must do to the other one as well, so a plan that only ever saw
+   * the default group is distinguishable by the group it is missing, not by a placement difference
+   * that has to be derived.
+   */
+  public static CurrentClusterConfiguration withMirroredTenant(
+      final ClusterConfiguration topology) {
+    final var single = CurrentClusterConfiguration.fromLegacy(topology);
+    return new CurrentClusterConfiguration(
+        single.version(),
+        single.globalConfiguration(),
+        Map.of(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+            TENANT_A,
+            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
+        single.phasedChangeState());
+  }
+
+  /**
+   * The phase of a plan that carries the per-tenant work, which is where a plan that only ever saw
+   * the default partition group differs from one that saw every tenant's.
+   */
+  public static PartitionGroupParallelPhase partitionGroupPhase(final List<Phase> phases) {
+    return phases.stream()
+        .filter(PartitionGroupParallelPhase.class::isInstance)
+        .map(PartitionGroupParallelPhase.class::cast)
+        .findFirst()
+        .orElseThrow(
+            () -> new AssertionError("expected the plan to contain partition work: " + phases));
+  }
+}


### PR DESCRIPTION
Plans a change to the persisted partition distribution across every physical tenant's partition group instead of the default one only. Three operator-facing endpoints are affected, because all three funnel through `UpdatePartitionDistributionTransformer`: `PUT /actuator/cluster/partition-distribution` with a new zone layout, the same endpoint with `zonePriorities`, and `POST /actuator/cluster/zones/{zoneId}`.

On a zone-aware cluster the replication factor is derived from the zone layout — the sum of the per-zone replica counts — and this transformer is how that reaches the partitions. So a layout change also left every tenant but the default one at the replication factor of the layout it replaced, the same class of gap #60192 closed for a request that names a replication factor outright. Together that meant a multi-tenant zone-aware cluster could not change its zone layout, could not move leadership between zones, and could not take a zone back after a failover. The cause is the one #60192 and #60193 already fixed elsewhere: none of the three transformers overrode `phases()`, so all of them fell through to the default implementation, which plans against the default group's projection.

`UpdatePartitionDistributionTransformer` now composes the phases itself — a global phase carrying the layout, then the placement it implies planned for every group at once by `PartitionGroupScalingPhases`. The planner resolves its distributor from the configuration it is handed, so it is handed a copy that already carries the new layout; only the operation in the global phase really persists it. The other two delegate to it, as their `operations()` already do, and `AddZoneTransformer` folds the returning brokers' joins into that leading global phase rather than emitting one of their own — which is the plan `toPhases` derives from the flat operation list it produces today. Deciding whether a layout can be adopted needs the replication factor the cluster runs, so `CurrentClusterConfiguration` answers that across every tenant's partitions; it also gains `isPartiallyZoneAware` so the mid-migration guard reads global state without projecting a group.

The validate-and-derive half of each transformer is extracted first, in a separate `refactor:` commit. A single-tenant cluster plans exactly the same change for all three, which the tests assert by comparing `phases()` against `toPhases(operations(...))` rather than re-deriving an expected plan.

Stacked on #60420, which is itself stacked on #60348; review those first, and the base moves down the stack as they merge.

closes #60342