### PR TITLE
ci: run Optimize E2E smoke test on Optimize back-end changes

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -16,6 +16,11 @@ on:
         description: "Set to true if Optimize back-end code was changed"
         type: boolean
         required: true
+      runE2eTests:
+        description: "Set to true if Optimize front-end or back-end code was changed"
+        type: boolean
+        required: false
+        default: true
       runDockerfileChecks:
         description: "Set to true if optimize.Dockerfile was changed"
         type: boolean
@@ -36,6 +41,11 @@ on:
         description: "Set to true if Optimize back-end code was changed"
         type: boolean
         required: true
+      runE2eTests:
+        description: "Set to true if Optimize front-end or back-end code was changed"
+        type: boolean
+        required: false
+        default: true
       runDockerfileChecks:
         description: "Set to true if optimize.Dockerfile was changed"
         type: boolean
@@ -431,7 +441,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   optimize-e2e-smoke:
     name: "E2E / Self-Managed (Smoke)"
-    if: inputs.runFeTests
+    if: inputs.runE2eTests
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 45
     permissions: { }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2249,6 +2249,7 @@ jobs:
     with:
       runFeTests: ${{ needs.detect-changes.outputs.optimize-frontend-changes == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.optimize-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
+      runE2eTests: ${{ needs.detect-changes.outputs.optimize-frontend-changes == 'true' || needs.detect-changes.outputs.optimize-backend-changes == 'true' }}
       runDockerfileChecks: ${{ needs.detect-changes.outputs.optimize-dockerfile-changes == 'true' }}
       # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
       # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.


### PR DESCRIPTION
## Why

`Optimize / E2E / Self-Managed (Smoke)` was gated on `runFeTests`, so it only ran when `optimize/client/**` (or the localization resources) changed. The smoke test drives the real UI against a running Optimize back end, so a back-end-only change can break it just as easily.

That is what happened with #60049: a change to the HTTP status code Optimize returns for a rejected request touched only Java sources, the job was skipped on the PR *and* in the merge queue, and it then failed on main — INC-7189.

Worth being explicit about the mechanism, since "a PR runs the same tests as main" is the assumption that broke: every `paths-filter` output is hardcoded to `true` on `push`, so the job always runs on main while being path-gated on `pull_request`/`merge_group`. Any job whose filter is narrower than its true blast radius is therefore a green-PR-then-red-main waiting to happen.

## What changed

New `runE2eTests` input on `ci-optimize.yml`, gating `optimize-e2e-smoke`. `ci.yml` sets it from `optimize-frontend-changes || optimize-backend-changes`.

`inputs.runFeTests || inputs.runBeTests` would have been a one-liner with no new input, but `runBeTests` also carries `zeebe-changes` — that would put this 45-minute 8-core job on nearly every Java PR in the monorepo. A dedicated input keeps the E2E scope decoupled from the unit-test scope. It defaults to `true`, so a future caller that forgets to pass it runs the test rather than silently skipping it.

## Scope note

This fixes the one job the incident hit. The same front-end-only gating exists on the E2E jobs in `ci-operate.yml` and `ci-tasklist.yml`; deliberately not touched here — different owners, and each needs its own cost call on how wide to open the filter.

## Verification

`actionlint` on both files reports only pre-existing findings (unknown self-hosted runner labels, `queue` under `concurrency`) — nothing from this change. The real check is this PR itself: it touches no Optimize code, so `E2E / Self-Managed (Smoke)` should be **skipped** here. Confirming it now runs on a back-end-only change needs a follow-up PR touching `optimize/backend/**`.
