### PR TITLE
feat: scope partition join, leave and priority changes to a physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.Error;
 import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
+import io.camunda.zeebe.management.cluster.PartitionJoinRequest;
 import io.camunda.zeebe.management.cluster.RequestHandlingActivePartitions;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
 import io.camunda.zeebe.management.cluster.RoutingState;
@@ -410,9 +411,11 @@ public class ClusterEndpoint {
       @PathVariable final String resourceId,
       @PathVariable("subResource") final Resource subResource,
       @PathVariable final String subResourceId,
-      @RequestBody final PartitionAddRequest request,
+      @RequestBody final PartitionJoinRequest request,
       @RequestParam(defaultValue = "false") final boolean dryRun) {
-    final int priority = request.priority();
+    // The generated body type makes priority nullable even though the schema requires it;
+    // an omitted priority has always meant the lowest one, so keep answering that way.
+    final int priority = Optional.ofNullable(request.getPriority()).orElse(0);
     return switch (resource) {
       case brokers ->
           switch (subResource) {
@@ -677,8 +680,6 @@ public class ClusterEndpoint {
   private static Optional<String> nonBlank(final @Nullable String value) {
     return Optional.ofNullable(value).filter(v -> !v.isBlank());
   }
-
-  public record PartitionAddRequest(int priority) {}
 
   private static final class UnknownRequestParameterException extends RuntimeException {
     private UnknownRequestParameterException(final String message) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -403,6 +403,12 @@ public class ClusterEndpoint {
         });
   }
 
+  /**
+   * Adds a broker to a partition's replication group, or changes the priority it replicates that
+   * partition with. Partition ids restart at 1 in every physical tenant, so without a {@code
+   * physicalTenant} query parameter the partition is resolved in the default physical tenant; with
+   * it, in that tenant's partition group.
+   */
   @PostMapping(
       path = "/{resource}/{resourceId}/{subResource}/{subResourceId}",
       consumes = "application/json")
@@ -412,10 +418,12 @@ public class ClusterEndpoint {
       @PathVariable("subResource") final Resource subResource,
       @PathVariable final String subResourceId,
       @RequestBody final PartitionJoinRequest request,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
     // The generated body type makes priority nullable even though the schema requires it;
     // an omitted priority has always meant the lowest one, so keep answering that way.
     final int priority = Optional.ofNullable(request.getPriority()).orElse(0);
+    final Optional<String> tenant = nonBlank(physicalTenant);
     return switch (resource) {
       case brokers ->
           switch (subResource) {
@@ -428,7 +436,11 @@ public class ClusterEndpoint {
                             requestSender
                                 .joinPartition(
                                     new JoinPartitionRequest(
-                                        member, Integer.parseInt(subResourceId), priority, dryRun))
+                                        member,
+                                        Integer.parseInt(subResourceId),
+                                        priority,
+                                        tenant,
+                                        dryRun))
                                 .join()));
             case brokers, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
           };
@@ -443,7 +455,11 @@ public class ClusterEndpoint {
                             requestSender
                                 .joinPartition(
                                     new JoinPartitionRequest(
-                                        member, Integer.parseInt(resourceId), priority, dryRun))
+                                        member,
+                                        Integer.parseInt(resourceId),
+                                        priority,
+                                        tenant,
+                                        dryRun))
                                 .join()));
             case partitions, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
           };
@@ -451,6 +467,11 @@ public class ClusterEndpoint {
     };
   }
 
+  /**
+   * Removes a broker from a partition's replication group. Partition ids restart at 1 in every
+   * physical tenant, so without a {@code physicalTenant} query parameter the partition is resolved
+   * in the default physical tenant; with it, in that tenant's partition group.
+   */
   @DeleteMapping(
       path = "/{resource}/{resourceId}/{subResource}/{subResourceId}",
       consumes = "application/json")
@@ -459,7 +480,9 @@ public class ClusterEndpoint {
       @PathVariable final String resourceId,
       @PathVariable("subResource") final Resource subResource,
       @PathVariable final String subResourceId,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
+    final Optional<String> tenant = nonBlank(physicalTenant);
     return switch (resource) {
       case brokers ->
           switch (subResource) {
@@ -471,7 +494,7 @@ public class ClusterEndpoint {
                             requestSender
                                 .leavePartition(
                                     new LeavePartitionRequest(
-                                        member, Integer.parseInt(subResourceId), dryRun))
+                                        member, Integer.parseInt(subResourceId), tenant, dryRun))
                                 .join()));
             case brokers, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
           };
@@ -485,7 +508,7 @@ public class ClusterEndpoint {
                             requestSender
                                 .leavePartition(
                                     new LeavePartitionRequest(
-                                        member, Integer.parseInt(resourceId), dryRun))
+                                        member, Integer.parseInt(resourceId), tenant, dryRun))
                                 .join()));
             case partitions, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
           };

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -63,10 +63,14 @@ paths:
       description: Adds the broker to the replication group of the given partition, replicating it
         with the requested priority. If the broker already replicates the partition, only its
         priority is changed. The broker must be running to complete the operation.
+        Partition ids restart at 1 in every physical tenant, so the partition is resolved within
+        the physical tenant named by physicalTenant, or within the default physical tenant when
+        the parameter is absent.
       parameters:
         - $ref: '#/components/parameters/BrokerId'
         - $ref: '#/components/parameters/PartitionId'
         - $ref: '#/components/parameters/DryRunParameter'
+        - $ref: '#/components/parameters/DefaultingPhysicalTenantParameter'
       requestBody:
         required: true
         content:
@@ -78,6 +82,8 @@ paths:
           $ref: '#/components/responses/JoinPartitionResponse'
         '400':
           $ref: 'components.yaml#/responses/InvalidRequest'
+        '404':
+          $ref: 'components.yaml#/responses/NotFound'
         '409':
           $ref: 'components.yaml#/responses/ConcurrentChangeError'
         '500':
@@ -91,15 +97,21 @@ paths:
       description: Removes the broker from the replication group of the given partition. The
         partition must keep at least one replica, so the last remaining replica cannot be removed.
         The broker must be running to complete the operation.
+        Partition ids restart at 1 in every physical tenant, so the partition is resolved within
+        the physical tenant named by physicalTenant, or within the default physical tenant when
+        the parameter is absent.
       parameters:
         - $ref: '#/components/parameters/BrokerId'
         - $ref: '#/components/parameters/PartitionId'
         - $ref: '#/components/parameters/DryRunParameter'
+        - $ref: '#/components/parameters/DefaultingPhysicalTenantParameter'
       responses:
         '202':
           $ref: '#/components/responses/LeavePartitionResponse'
         '400':
           $ref: 'components.yaml#/responses/InvalidRequest'
+        '404':
+          $ref: 'components.yaml#/responses/NotFound'
         '409':
           $ref: 'components.yaml#/responses/ConcurrentChangeError'
         '500':
@@ -279,7 +291,7 @@ paths:
               $ref: "components.yaml#/schemas/RoutingState"
       parameters:
         - $ref: '#/components/parameters/DryRunParameter'
-        - $ref: '#/components/parameters/RoutingStatePhysicalTenantParameter'
+        - $ref: '#/components/parameters/DefaultingPhysicalTenantParameter'
       responses:
         '202':
           description: Accepted
@@ -480,7 +492,7 @@ components:
       required: false
       schema:
         $ref: 'components.yaml#/schemas/PhysicalTenantId'
-    RoutingStatePhysicalTenantParameter:
+    DefaultingPhysicalTenantParameter:
       name: physicalTenant
       description: Id of the physical tenant to target. If not specified, the default physical tenant is targeted,
         not every physical tenant - unlike the other operations taking this parameter.

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -57,6 +57,58 @@ paths:
           $ref: 'components.yaml#/responses/GatewayError'
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
+  /brokers/{brokerId}/partitions/{partitionId}:
+    post:
+      summary: Add a broker to a partition's replication group, or change its priority
+      description: Adds the broker to the replication group of the given partition, replicating it
+        with the requested priority. If the broker already replicates the partition, only its
+        priority is changed. The broker must be running to complete the operation.
+      parameters:
+        - $ref: '#/components/parameters/BrokerId'
+        - $ref: '#/components/parameters/PartitionId'
+        - $ref: '#/components/parameters/DryRunParameter'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "components.yaml#/schemas/PartitionJoinRequest"
+      responses:
+        '202':
+          $ref: '#/components/responses/JoinPartitionResponse'
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+    delete:
+      summary: Remove a broker from a partition's replication group
+      description: Removes the broker from the replication group of the given partition. The
+        partition must keep at least one replica, so the last remaining replica cannot be removed.
+        The broker must be running to complete the operation.
+      parameters:
+        - $ref: '#/components/parameters/BrokerId'
+        - $ref: '#/components/parameters/PartitionId'
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          $ref: '#/components/responses/LeavePartitionResponse'
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
   /brokers:
     post:
       summary: Reconfigure the cluster with the given brokers.
@@ -397,6 +449,13 @@ components:
       description: Name of the zone
       schema:
         type: string
+    PartitionId:
+      name: partitionId
+      required: true
+      in: path
+      description: Id of the partition
+      schema:
+        $ref: 'components.yaml#/schemas/PartitionId'
     ChangeId:
       name: changeId
       required: true
@@ -472,6 +531,20 @@ components:
 
     ClusterConfigPurgeResponse:
       description: Request to purge cluster data is accepted.
+      content:
+        application/json:
+          schema:
+            $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+
+    JoinPartitionResponse:
+      description: Request for the broker to join the partition is accepted.
+      content:
+        application/json:
+          schema:
+            $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+
+    LeavePartitionResponse:
+      description: Request for the broker to leave the partition is accepted.
       content:
         application/json:
           schema:

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -303,6 +303,19 @@ schemas:
         items:
           $ref: "components.yaml#/schemas/BrokerId"
 
+  PartitionJoinRequest:
+    description: Request body for adding a broker to a partition's replication group. The broker
+      and the partition are given in the path.
+    type: object
+    required:
+      - priority
+    properties:
+      priority:
+        type: integer
+        format: int32
+        description: Preferred-leader ranking of the broker within the partition; higher value wins
+        example: 1
+
   ClusterZoneMigrationRequest:
     description: >
       Request to migrate one zone from a bare or partially zoned cluster. The complete zone order,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
@@ -29,20 +30,30 @@ public class AddMembersTransformer implements ConfigurationChangeRequest {
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    if (clusterConfiguration.isFullyZoneAware() && members.stream().anyMatch(MemberId::isBare)) {
+    return joins(clusterConfiguration.members().keySet(), clusterConfiguration.isFullyZoneAware())
+        .map(List::<ClusterConfigurationChangeOperation>copyOf);
+  }
+
+  /**
+   * The joins this request amounts to on a cluster with the given members.
+   *
+   * <p>Takes the member set rather than a configuration, because that is all the answer depends on:
+   * joining a broker is global, with no per-tenant dimension.
+   */
+  Either<Exception, List<GlobalChangeOperation>> joins(
+      final Set<MemberId> currentMembers, final boolean fullyZoneAware) {
+    if (fullyZoneAware && members.stream().anyMatch(MemberId::isBare)) {
       return Either.left(
           new InvalidRequest(
               "Members without a zone cannot be added to a zone-aware cluster: "
                   + members.stream().filter(MemberId::isBare).sorted().toList()));
     }
-    final var operations =
+    return Either.right(
         members.stream()
             // only add members that are not already part of the cluster
-            .filter(memberId -> !clusterConfiguration.hasMember(memberId))
-            .map(MemberJoinOperation::new)
-            .map(ClusterConfigurationChangeOperation.class::cast)
-            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
-            .toList();
-    return Either.right(operations);
+            .filter(memberId -> !currentMembers.contains(memberId))
+            .map(memberId -> (GlobalChangeOperation) new MemberJoinOperation(memberId))
+            .sorted(Comparator.comparing(GlobalChangeOperation::memberId))
+            .toList());
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformer.java
@@ -12,14 +12,19 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Restores a previously failed-over zone: re-adds the operator-supplied brokers to the member set,
@@ -44,6 +49,36 @@ public final class AddZoneTransformer implements ConfigurationChangeRequest {
     this.brokers = brokers;
   }
 
+  /**
+   * Places the returning zone's brokers into every physical tenant's partition group, by handing
+   * the re-included zone layout to {@link
+   * UpdatePartitionDistributionTransformer#phases(CurrentClusterConfiguration)}.
+   *
+   * <p>The brokers have to join before any partition can land on them, so their joins are folded
+   * into the leading global phase of that plan — the one that persists the layout — rather than
+   * emitted as a phase of their own. That is the same plan {@code toPhases} derives from the flat
+   * operation list {@link #operations(ClusterConfiguration)} produces, where the joins and the
+   * layout are one uninterrupted run of global operations.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    return zoneAddedConfig(configuration.globalConfiguration().partitionDistributorConfig())
+        .flatMap(
+            newConfig ->
+                new AddMembersTransformer(brokers)
+                    .joins(configuration.getMembers(), configuration.isFullyZoneAware())
+                    .flatMap(
+                        joins ->
+                            new UpdatePartitionDistributionTransformer(newConfig, brokers)
+                                .phases(configuration)
+                                .map(phases -> withJoinsFirst(joins, phases))));
+  }
+
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
@@ -68,6 +103,19 @@ public final class AddZoneTransformer implements ConfigurationChangeRequest {
                                       allOps.addAll(distributionOps);
                                       return allOps;
                                     })));
+  }
+
+  private static List<Phase> withJoinsFirst(
+      final List<GlobalChangeOperation> joins, final List<Phase> phases) {
+    if (joins.isEmpty()) {
+      return phases;
+    }
+    if (!phases.isEmpty() && phases.getFirst() instanceof final GlobalPhase leading) {
+      final var merged = new ArrayList<>(joins);
+      merged.addAll(leading.operations());
+      return Stream.concat(Stream.of(new GlobalPhase(merged)), phases.stream().skip(1)).toList();
+    }
+    return Stream.concat(Stream.of(new GlobalPhase(joins)), phases.stream()).toList();
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformer.java
@@ -12,11 +12,13 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -45,7 +47,38 @@ public final class AddZoneTransformer implements ConfigurationChangeRequest {
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
-    final var partitionDistributorConfig = currentConfiguration.partitionDistributorConfig();
+    return zoneAddedConfig(currentConfiguration.partitionDistributorConfig())
+        .flatMap(
+            newConfig ->
+                // Join the returning brokers, then reuse the shared distribution transformer to
+                // persist the new config and reassign partitions over the current members plus the
+                // returning brokers.
+                new AddMembersTransformer(brokers)
+                    .operations(currentConfiguration)
+                    .flatMap(
+                        addMembersOps ->
+                            new UpdatePartitionDistributionTransformer(newConfig, brokers)
+                                .operations(currentConfiguration)
+                                .map(
+                                    distributionOps -> {
+                                      final var allOps =
+                                          new ArrayList<ClusterConfigurationChangeOperation>(
+                                              addMembersOps.size() + distributionOps.size());
+                                      allOps.addAll(addMembersOps);
+                                      allOps.addAll(distributionOps);
+                                      return allOps;
+                                    })));
+  }
+
+  /**
+   * Validates the request and answers with the zone layout it implies: the persisted one with the
+   * returning zone added back.
+   *
+   * <p>Takes the persisted layout rather than a configuration because that is all the answer
+   * depends on — the zone layout and the member set are global, with no per-tenant dimension.
+   */
+  private Either<Exception, ZoneAwareConfig> zoneAddedConfig(
+      final Optional<PartitionDistributorConfig> partitionDistributorConfig) {
     final List<ZoneSpec> currentZones;
     if (partitionDistributorConfig.isPresent()
         && partitionDistributorConfig.get() instanceof final ZoneAwareConfig cfg) {
@@ -99,24 +132,6 @@ public final class AddZoneTransformer implements ConfigurationChangeRequest {
       return Either.left(new InvalidRequest(e));
     }
     newZones.add(newZone);
-    final var newConfig = new ZoneAwareConfig(newZones);
-
-    // Join the returning brokers, then reuse the shared distribution transformer to persist the new
-    // config and reassign partitions over the current members plus the returning brokers.
-    return new AddMembersTransformer(brokers)
-        .operations(currentConfiguration)
-        .flatMap(
-            addMembersOps ->
-                new UpdatePartitionDistributionTransformer(newConfig, brokers)
-                    .operations(currentConfiguration)
-                    .map(
-                        distributionOps -> {
-                          final var allOps =
-                              new ArrayList<ClusterConfigurationChangeOperation>(
-                                  addMembersOps.size() + distributionOps.size());
-                          allOps.addAll(addMembersOps);
-                          allOps.addAll(distributionOps);
-                          return allOps;
-                        }));
+    return Either.right(new ZoneAwareConfig(newZones));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -39,11 +39,48 @@ public sealed interface ClusterConfigurationManagementRequest {
   record RemoveMembersRequest(Set<MemberId> members, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record JoinPartitionRequest(MemberId memberId, int partitionId, int priority, boolean dryRun)
-      implements ClusterConfigurationManagementRequest {}
+  /**
+   * Adds a member to one partition's replication group, or changes the priority it already
+   * replicates that partition with.
+   *
+   * @param partitionId the partition within {@code physicalTenantId}'s partition group. Partition
+   *     ids restart at 1 in every physical tenant, so this identifies a partition only together
+   *     with the tenant.
+   * @param physicalTenantId the physical tenant whose partition to join, or empty for the default
+   *     physical tenant. A single partition belongs to exactly one tenant, so an absent id cannot
+   *     mean "every tenant" here, unlike the requests that address a whole cluster.
+   */
+  record JoinPartitionRequest(
+      MemberId memberId,
+      int partitionId,
+      int priority,
+      Optional<String> physicalTenantId,
+      boolean dryRun)
+      implements ClusterConfigurationManagementRequest {
 
-  record LeavePartitionRequest(MemberId memberId, int partitionId, boolean dryRun)
-      implements ClusterConfigurationManagementRequest {}
+    public JoinPartitionRequest {
+      physicalTenantId.ifPresent(assertNonEmpty("physicalTenantId"));
+    }
+  }
+
+  /**
+   * Removes a member from one partition's replication group.
+   *
+   * @param partitionId the partition within {@code physicalTenantId}'s partition group. Partition
+   *     ids restart at 1 in every physical tenant, so this identifies a partition only together
+   *     with the tenant.
+   * @param physicalTenantId the physical tenant whose partition to leave, or empty for the default
+   *     physical tenant. A single partition belongs to exactly one tenant, so an absent id cannot
+   *     mean "every tenant" here, unlike the requests that address a whole cluster.
+   */
+  record LeavePartitionRequest(
+      MemberId memberId, int partitionId, Optional<String> physicalTenantId, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {
+
+    public LeavePartitionRequest {
+      physicalTenantId.ifPresent(assertNonEmpty("physicalTenantId"));
+    }
+  }
 
   record ReassignPartitionsRequest(Set<MemberId> members, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -88,7 +88,8 @@ public final class ClusterConfigurationManagementRequestsHandler
         new JoinPartitionRequestTransformer(
             joinPartitionRequest.memberId(),
             joinPartitionRequest.partitionId(),
-            joinPartitionRequest.priority()));
+            joinPartitionRequest.priority(),
+            joinPartitionRequest.physicalTenantId()));
   }
 
   @Override
@@ -97,7 +98,9 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         leavePartitionRequest.dryRun(),
         new LeavePartitionRequestTransformer(
-            leavePartitionRequest.memberId(), leavePartitionRequest.partitionId()));
+            leavePartitionRequest.memberId(),
+            leavePartitionRequest.partitionId(),
+            leavePartitionRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -36,14 +36,10 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeResult;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.util.Either;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -89,13 +85,10 @@ public final class ClusterConfigurationManagementRequestsHandler
       final JoinPartitionRequest joinPartitionRequest) {
     return handleRequest(
         joinPartitionRequest.dryRun(),
-        ignore ->
-            Either.right(
-                List.of(
-                    new PartitionJoinOperation(
-                        joinPartitionRequest.memberId(),
-                        joinPartitionRequest.partitionId(),
-                        joinPartitionRequest.priority()))));
+        new JoinPartitionRequestTransformer(
+            joinPartitionRequest.memberId(),
+            joinPartitionRequest.partitionId(),
+            joinPartitionRequest.priority()));
   }
 
   @Override
@@ -103,13 +96,8 @@ public final class ClusterConfigurationManagementRequestsHandler
       final LeavePartitionRequest leavePartitionRequest) {
     return handleRequest(
         leavePartitionRequest.dryRun(),
-        ignore ->
-            Either.right(
-                List.of(
-                    new PartitionLeaveOperation(
-                        leavePartitionRequest.memberId(),
-                        leavePartitionRequest.partitionId(),
-                        1))));
+        new LeavePartitionRequestTransformer(
+            leavePartitionRequest.memberId(), leavePartitionRequest.partitionId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adds a broker to one partition's replication group, or changes the priority it already replicates
+ * that partition with.
+ */
+public final class JoinPartitionRequestTransformer implements ConfigurationChangeRequest {
+
+  private final MemberId memberId;
+  private final int partitionId;
+  private final int priority;
+
+  public JoinPartitionRequestTransformer(
+      final MemberId memberId, final int partitionId, final int priority) {
+    this.memberId = memberId;
+    this.partitionId = partitionId;
+    this.priority = priority;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    throw new UnsupportedOperationException(
+        "JoinPartitionRequestTransformer builds its change plan via "
+            + "phases(CurrentClusterConfiguration); the new-model coordinator path never calls "
+            + "operations(ClusterConfiguration)");
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    final List<PartitionGroupOperation> operations =
+        List.of(new PartitionJoinOperation(memberId, partitionId, priority));
+    return Either.right(
+        List.of(
+            new PartitionGroupParallelPhase(
+                Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, operations))));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
@@ -56,21 +56,16 @@ public final class JoinPartitionRequestTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
-    if (physicalTenantId.isPresent()
-        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    if (!clusterConfiguration.hasPartitionGroup(groupId)) {
       return Either.left(
           new NotFound(
               "Expected to join partition %d of physical tenant '%s', but the physical tenant does not exist"
-                  .formatted(partitionId, physicalTenantId.get())));
+                  .formatted(partitionId, groupId)));
     }
 
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionJoinOperation(memberId, partitionId, priority));
-    return Either.right(
-        List.of(
-            new PartitionGroupParallelPhase(
-                Map.of(
-                    physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP),
-                    operations))));
+    return Either.right(List.of(new PartitionGroupParallelPhase(Map.of(groupId, operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Adds a broker to one partition's replication group, or changes the priority it already replicates
@@ -29,12 +31,17 @@ public final class JoinPartitionRequestTransformer implements ConfigurationChang
   private final MemberId memberId;
   private final int partitionId;
   private final int priority;
+  private final Optional<String> physicalTenantId;
 
   public JoinPartitionRequestTransformer(
-      final MemberId memberId, final int partitionId, final int priority) {
+      final MemberId memberId,
+      final int partitionId,
+      final int priority,
+      final Optional<String> physicalTenantId) {
     this.memberId = memberId;
     this.partitionId = partitionId;
     this.priority = priority;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
@@ -49,11 +56,21 @@ public final class JoinPartitionRequestTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to join partition %d of physical tenant '%s', but the physical tenant does not exist"
+                  .formatted(partitionId, physicalTenantId.get())));
+    }
+
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionJoinOperation(memberId, partitionId, priority));
     return Either.right(
         List.of(
             new PartitionGroupParallelPhase(
-                Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, operations))));
+                Map.of(
+                    physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP),
+                    operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
@@ -57,21 +57,16 @@ public final class LeavePartitionRequestTransformer implements ConfigurationChan
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
-    if (physicalTenantId.isPresent()
-        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    if (!clusterConfiguration.hasPartitionGroup(groupId)) {
       return Either.left(
           new NotFound(
               "Expected to leave partition %d of physical tenant '%s', but the physical tenant does not exist"
-                  .formatted(partitionId, physicalTenantId.get())));
+                  .formatted(partitionId, groupId)));
     }
 
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionLeaveOperation(memberId, partitionId, MINIMUM_ALLOWED_REPLICAS));
-    return Either.right(
-        List.of(
-            new PartitionGroupParallelPhase(
-                Map.of(
-                    physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP),
-                    operations))));
+    return Either.right(List.of(new PartitionGroupParallelPhase(Map.of(groupId, operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+
+/** Removes a broker from one partition's replication group. */
+public final class LeavePartitionRequestTransformer implements ConfigurationChangeRequest {
+
+  /**
+   * An operator-driven leave must not take a partition below one replica; only a cluster purge is
+   * allowed to empty it.
+   */
+  private static final int MINIMUM_ALLOWED_REPLICAS = 1;
+
+  private final MemberId memberId;
+  private final int partitionId;
+
+  public LeavePartitionRequestTransformer(final MemberId memberId, final int partitionId) {
+    this.memberId = memberId;
+    this.partitionId = partitionId;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    throw new UnsupportedOperationException(
+        "LeavePartitionRequestTransformer builds its change plan via "
+            + "phases(CurrentClusterConfiguration); the new-model coordinator path never calls "
+            + "operations(ClusterConfiguration)");
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    final List<PartitionGroupOperation> operations =
+        List.of(new PartitionLeaveOperation(memberId, partitionId, MINIMUM_ALLOWED_REPLICAS));
+    return Either.right(
+        List.of(
+            new PartitionGroupParallelPhase(
+                Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, operations))));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -19,8 +20,12 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-/** Removes a broker from one partition's replication group. */
+/**
+ * Removes a broker from one partition's replication group, in a single physical tenant's partition
+ * group.
+ */
 public final class LeavePartitionRequestTransformer implements ConfigurationChangeRequest {
 
   /**
@@ -31,10 +36,13 @@ public final class LeavePartitionRequestTransformer implements ConfigurationChan
 
   private final MemberId memberId;
   private final int partitionId;
+  private final Optional<String> physicalTenantId;
 
-  public LeavePartitionRequestTransformer(final MemberId memberId, final int partitionId) {
+  public LeavePartitionRequestTransformer(
+      final MemberId memberId, final int partitionId, final Optional<String> physicalTenantId) {
     this.memberId = memberId;
     this.partitionId = partitionId;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
@@ -49,11 +57,21 @@ public final class LeavePartitionRequestTransformer implements ConfigurationChan
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to leave partition %d of physical tenant '%s', but the physical tenant does not exist"
+                  .formatted(partitionId, physicalTenantId.get())));
+    }
+
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionLeaveOperation(memberId, partitionId, MINIMUM_ALLOWED_REPLICAS));
     return Either.right(
         List.of(
             new PartitionGroupParallelPhase(
-                Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, operations))));
+                Map.of(
+                    physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP),
+                    operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -57,7 +57,59 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
+    return validatedZoneAwareConfig(
+            currentConfiguration.minReplicationFactor(),
+            currentConfiguration.isFullyZoneAware(),
+            currentConfiguration.isPartiallyZoneAware())
+        .flatMap(zoneAwareConfig -> operations(currentConfiguration, zoneAwareConfig));
+  }
 
+  private Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration currentConfiguration, final ZoneAwareConfig zoneAwareConfig) {
+    final var coordinator =
+        ClusterConfigurationCoordinatorSupplier.of(() -> currentConfiguration)
+            .getDefaultCoordinator();
+
+    // Apply the new config to produce a temporary configuration whose partitionDistributor()
+    // returns the new ZoneAwarePartitionDistributor. This is only used for distribution
+    // computation; the real version bump happens when the config-set operation is applied.
+    final var updatedConfiguration = currentConfiguration.setPartitionDistributorConfig(newConfig);
+
+    return new PartitionReassignRequestTransformer(
+            targetMembers(currentConfiguration.members().keySet()),
+            Optional.of(zoneAwareConfig.replicationFactor()),
+            Optional.empty())
+        .operations(updatedConfiguration)
+        .map(
+            ops -> {
+              final var allOps = new ArrayList<ClusterConfigurationChangeOperation>(ops.size() + 1);
+              allOps.add(new UpdatePartitionDistributorConfigOperation(coordinator, newConfig));
+              allOps.addAll(ops);
+              return allOps;
+            });
+  }
+
+  private Set<MemberId> targetMembers(final Set<MemberId> currentMembers) {
+    final var members = new HashSet<>(currentMembers);
+    members.addAll(extraMembers);
+    return members;
+  }
+
+  /**
+   * Checks the request against the cluster it would apply to and answers with the requested config
+   * once it is known to be applicable.
+   *
+   * <p>Takes what it checks rather than a configuration, because the answer does not depend on
+   * which partition groups the cluster runs: whether a zone layout can be adopted follows from the
+   * layout itself, from how far the cluster has come in adopting zone-awareness, and from the
+   * replication factor it runs today.
+   *
+   * @param currentReplicationFactor the lowest replication factor any partition currently has
+   */
+  private Either<Exception, ZoneAwareConfig> validatedZoneAwareConfig(
+      final int currentReplicationFactor,
+      final boolean fullyZoneAware,
+      final boolean partiallyZoneAware) {
     if (!(newConfig instanceof final ZoneAwareConfig zoneAwareConfig)) {
       return Either.left(
           new InvalidRequest(
@@ -80,9 +132,7 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
     }
 
     final int targetReplicationFactor = zoneAwareConfig.replicationFactor();
-    final int currentReplicationFactor = currentConfiguration.minReplicationFactor();
-    if (!currentConfiguration.isFullyZoneAware()
-        && targetReplicationFactor != currentReplicationFactor) {
+    if (!fullyZoneAware && targetReplicationFactor != currentReplicationFactor) {
       return Either.left(
           new InvalidRequest(
               String.format(
@@ -91,36 +141,13 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
                   targetReplicationFactor, currentReplicationFactor)));
     }
 
-    final var coordinator =
-        ClusterConfigurationCoordinatorSupplier.of(() -> currentConfiguration)
-            .getDefaultCoordinator();
-
-    if (currentConfiguration.isPartiallyZoneAware()) {
+    if (partiallyZoneAware) {
       return Either.left(
           new InvalidRequest(
               "Partition distribution changes are only supported on fully zone-aware clusters or "
                   + "on fully bare clusters before zone migration starts."));
     }
 
-    // Apply the new config to produce a temporary configuration whose partitionDistributor()
-    // returns the new ZoneAwarePartitionDistributor. This is only used for distribution
-    // computation; the real version bump happens when the config-set operation is applied.
-    final var updatedConfiguration = currentConfiguration.setPartitionDistributorConfig(newConfig);
-
-    final var members = new HashSet<>(currentConfiguration.members().keySet());
-    members.addAll(extraMembers);
-
-    return new PartitionReassignRequestTransformer(
-            members, Optional.of(zoneAwareConfig.replicationFactor()), Optional.empty())
-        .operations(updatedConfiguration)
-        .map(
-            ops -> {
-              final var allOps = new ArrayList<ClusterConfigurationChangeOperation>(ops.size() + 1);
-              final var updateConfigOperation =
-                  new UpdatePartitionDistributorConfigOperation(coordinator, newConfig);
-              allOps.add(updateConfigOperation);
-              allOps.addAll(ops);
-              return allOps;
-            });
+    return Either.right(zoneAwareConfig);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -12,11 +12,15 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.CollectionUtil;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -24,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Computes the operations needed to apply a new {@link ZoneAwareConfig}. It persists the new config
@@ -54,6 +59,29 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
     this.extraMembers = Set.copyOf(extraMembers);
   }
 
+  /**
+   * Plans the redistribution over every physical tenant's partition group, rather than the default
+   * one only: the new config is persisted by a leading global phase, and the placement it implies
+   * is then planned for every group at once.
+   *
+   * <p>On a zone-aware cluster the replication factor is derived from the zone layout, so this is
+   * also how a layout change reaches each tenant's replication factor — planning the default group
+   * alone left every other tenant at the replication factor of the layout it replaced.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    return validatedZoneAwareConfig(
+            configuration.minReplicationFactor(),
+            configuration.isFullyZoneAware(),
+            configuration.isPartiallyZoneAware())
+        .flatMap(zoneAwareConfig -> phases(configuration, zoneAwareConfig));
+  }
+
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer and the two that delegate to it assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
@@ -62,6 +90,31 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
             currentConfiguration.isFullyZoneAware(),
             currentConfiguration.isPartiallyZoneAware())
         .flatMap(zoneAwareConfig -> operations(currentConfiguration, zoneAwareConfig));
+  }
+
+  private Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration configuration, final ZoneAwareConfig zoneAwareConfig) {
+    final List<GlobalChangeOperation> persistConfig =
+        List.of(
+            new UpdatePartitionDistributorConfigOperation(
+                ClusterConfigurationCoordinatorSupplier.from(() -> configuration)
+                    .getDefaultCoordinator(),
+                newConfig));
+
+    // The placement must be computed with the new distributor, and the planner resolves it from the
+    // configuration it is handed — so hand it a copy that already carries the new config. Only the
+    // operation above really persists it.
+    return PartitionGroupScalingPhases.phases(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            configuration.updateGlobalConfiguration(
+                global -> global.setPartitionDistributorConfig(newConfig)),
+            targetMembers(configuration.getMembers()),
+            Optional.empty(),
+            Optional.of(zoneAwareConfig.replicationFactor()))
+        .map(
+            partitionPhases ->
+                Stream.concat(Stream.of(new GlobalPhase(persistConfig)), partitionPhases.stream())
+                    .toList());
   }
 
   private Either<Exception, List<ClusterConfigurationChangeOperation>> operations(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
@@ -11,9 +11,11 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.CollectionUtil;
 import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
@@ -39,6 +41,25 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
     this.sortedZoneNames = List.copyOf(sortedZoneNames);
   }
 
+  /**
+   * Re-prioritizes every physical tenant's partitions, by handing the re-prioritized layout to
+   * {@link UpdatePartitionDistributionTransformer#phases(CurrentClusterConfiguration)}. Which zone
+   * is preferred for leadership is global, so the layout is computed once and applied to every
+   * group.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    return reprioritized(configuration.globalConfiguration().partitionDistributorConfig())
+        .flatMap(
+            newConfig ->
+                new UpdatePartitionDistributionTransformer(newConfig).phases(configuration));
+  }
+
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.util.CollectionUtil;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -40,7 +42,22 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
-    final var partitionDistributorConfig = currentConfiguration.partitionDistributorConfig();
+    return reprioritized(currentConfiguration.partitionDistributorConfig())
+        .flatMap(
+            newConfig ->
+                new UpdatePartitionDistributionTransformer(newConfig)
+                    .operations(currentConfiguration));
+  }
+
+  /**
+   * Validates the requested order and answers with the layout it implies: the existing priorities
+   * re-assigned to zones by that order.
+   *
+   * <p>Takes the persisted layout rather than a configuration because that is all the answer
+   * depends on — zone priorities are global, with no per-tenant dimension.
+   */
+  private Either<Exception, ZoneAwareConfig> reprioritized(
+      final Optional<PartitionDistributorConfig> partitionDistributorConfig) {
     final ZoneAwareConfig zoneAwareConfig;
     if (partitionDistributorConfig.isPresent()
         && partitionDistributorConfig.get() instanceof final ZoneAwareConfig cfg) {
@@ -89,7 +106,6 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
             .map(t -> t.getRight().withPriority(t.getLeft()))
             .toList();
 
-    final var newConfig = new ZoneAwareConfig(reprioritized);
-    return new UpdatePartitionDistributionTransformer(newConfig).operations(currentConfiguration);
+    return Either.right(new ZoneAwareConfig(reprioritized));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1017,23 +1017,25 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodeJoinPartitionRequest(final JoinPartitionRequest req) {
-    return Requests.JoinPartitionRequest.newBuilder()
-        .setMemberId(req.memberId().id())
-        .setPartitionId(req.partitionId())
-        .setPriority(req.priority())
-        .setDryRun(req.dryRun())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.JoinPartitionRequest.newBuilder()
+            .setMemberId(req.memberId().id())
+            .setPartitionId(req.partitionId())
+            .setPriority(req.priority())
+            .setDryRun(req.dryRun());
+    req.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+    return builder.build().toByteArray();
   }
 
   @Override
   public byte[] encodeLeavePartitionRequest(final LeavePartitionRequest req) {
-    return Requests.LeavePartitionRequest.newBuilder()
-        .setMemberId(req.memberId().id())
-        .setPartitionId(req.partitionId())
-        .setDryRun(req.dryRun())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.LeavePartitionRequest.newBuilder()
+            .setMemberId(req.memberId().id())
+            .setPartitionId(req.partitionId())
+            .setDryRun(req.dryRun());
+    req.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+    return builder.build().toByteArray();
   }
 
   @Override
@@ -1251,6 +1253,9 @@ public class ProtoBufSerializer
           MemberId.from(joinPartitionRequest.getMemberId()),
           joinPartitionRequest.getPartitionId(),
           joinPartitionRequest.getPriority(),
+          joinPartitionRequest.hasPhysicalTenantId()
+              ? Optional.of(joinPartitionRequest.getPhysicalTenantId())
+              : Optional.empty(),
           joinPartitionRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
@@ -1264,6 +1269,9 @@ public class ProtoBufSerializer
       return new LeavePartitionRequest(
           MemberId.from(leavePartitionRequest.getMemberId()),
           leavePartitionRequest.getPartitionId(),
+          leavePartitionRequest.hasPhysicalTenantId()
+              ? Optional.of(leavePartitionRequest.getPhysicalTenantId())
+              : Optional.empty(),
           leavePartitionRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -141,6 +141,60 @@ public record CurrentClusterConfiguration(
   }
 
   /**
+   * Whether the cluster is between the two modes: some but not all brokers are assigned to a zone,
+   * or every broker is but the partition distributor is not zone-aware yet.
+   *
+   * <p>Both are global state, so this reads the same fields {@link
+   * ClusterConfiguration#isPartiallyZoneAware()} does — the projection through {@link
+   * #toLegacyDefault()} that method needs is not.
+   */
+  public boolean isPartiallyZoneAware() {
+    final var members = globalConfiguration.members().keySet();
+    if (members.isEmpty()) {
+      return false;
+    }
+    final var zonedCount = members.stream().filter(member -> member.zone() != null).count();
+    final var distributorIsNotZoneAware =
+        globalConfiguration
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .isEmpty();
+    return (zonedCount > 0 && zonedCount < members.size())
+        || (zonedCount == members.size() && distributorIsNotZoneAware);
+  }
+
+  /**
+   * The lowest number of replicas any partition of any physical tenant currently has. Taken across
+   * every group because the replication factor is a cluster-wide setting: a request that has to
+   * match what the cluster runs today has to match it for every tenant, not only the default one.
+   *
+   * <p>Read as the minimum rather than a configured value, mirroring {@link
+   * ClusterConfiguration#minReplicationFactor()}: during a configuration change a partition can
+   * temporarily hold more replicas than the cluster is configured for.
+   *
+   * <p>Answers 0 for a cluster that runs no partitions at all, which is what makes an equality
+   * check against it fail rather than pass. {@code PartitionGroupScalingPhases} asks a different
+   * question — the replication factor to plan with when the request names none — and defaults to 1
+   * there for the same reason.
+   */
+  public int minReplicationFactor() {
+    final var countingBrokers = liveMembers();
+    return partitionGroups.values().stream()
+        .flatMap(
+            group ->
+                group.members().entrySet().stream()
+                    .filter(member -> countingBrokers.contains(member.getKey()))
+                    .flatMap(member -> member.getValue().partitions().keySet().stream())
+                    .collect(
+                        Collectors.groupingBy(partitionId -> partitionId, Collectors.counting()))
+                    .values()
+                    .stream())
+        .mapToInt(Long::intValue)
+        .min()
+        .orElse(0);
+  }
+
+  /**
    * Creates an empty configuration with an initial global configuration and no partition groups.
    */
   public static CurrentClusterConfiguration init() {

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -20,6 +20,9 @@ message JoinPartitionRequest {
   int32 partitionId = 2;
   int32 priority = 3;
   bool dryRun = 4;
+  // The physical tenant the partition belongs to; the default tenant if not set. Partition ids
+  // restart at 1 in every tenant, so partitionId identifies a partition only together with this.
+  optional string physicalTenantId = 5;
 }
 
 message PurgeRequest {
@@ -33,6 +36,9 @@ message LeavePartitionRequest {
   string memberId = 1;
   int32 partitionId = 2;
   bool dryRun = 3;
+  // The physical tenant the partition belongs to; the default tenant if not set. Partition ids
+  // restart at 1 in every tenant, so partitionId identifies a partition only together with this.
+  optional string physicalTenantId = 4;
 }
 
 message BrokerScaleRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
@@ -410,7 +410,8 @@ abstract class ClusterConfigurationManagementApiTestBase {
             .updateMember(
                 coordinatorId, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of())));
-    final var request = new JoinPartitionRequest(memberFactory.apply(1), 1, 3, false);
+    final var request =
+        new JoinPartitionRequest(memberFactory.apply(1), 1, 3, Optional.empty(), false);
 
     // when
     final var changeStatus = clientApi.joinPartition(request).join().get();
@@ -432,7 +433,8 @@ abstract class ClusterConfigurationManagementApiTestBase {
                 memberFactory.apply(1),
                 MemberState.initializeAsActive(
                     Map.of(1, PartitionState.active(1, partitionConfig)))));
-    final var request = new LeavePartitionRequest(memberFactory.apply(1), 1, false);
+    final var request =
+        new LeavePartitionRequest(memberFactory.apply(1), 1, Optional.empty(), false);
 
     // when
     final var changeStatus = clientApi.leavePartition(request).join().get();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
@@ -1286,6 +1286,164 @@ abstract class ClusterConfigurationManagementApiTestBase {
   }
 
   /**
+   * Partition ids restart at 1 in every physical tenant, so before the request named a tenant this
+   * join was planned into the default tenant's group — the operator asked for one tenant's
+   * partition 1 and got another's.
+   */
+  @Test
+  void shouldJoinAPartitionOfANonDefaultPhysicalTenant() {
+    // given — both tenants run a partition numbered 1, held by the coordinator alone
+    final var joiningMember = memberFactory.apply(1);
+    wireTwoTenantsSharingPartitionOne(Set.of(coordinatorId), joiningMember);
+
+    // when — the member joins partition 1 of tenant-b
+    final var changeStatus =
+        clientApi
+            .joinPartition(
+                new JoinPartitionRequest(joiningMember, 1, 3, Optional.of(TENANT_B), false))
+            .join()
+            .get();
+
+    // then — it replicates tenant-b's partition 1, and the default tenant's identically numbered
+    // partition is left alone
+    final var expected = changeStatus.response().expectedConfiguration();
+    assertThat(expected.partitionGroup(TENANT_B).members()).containsKey(joiningMember);
+    assertThat(expected.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).members())
+        .doesNotContainKey(joiningMember);
+  }
+
+  /**
+   * The counterpart of {@link #shouldJoinAPartitionOfANonDefaultPhysicalTenant()}: an unscoped
+   * leave used to be the only leave there was, so asking for another tenant's partition 1 removed
+   * the replica from the default tenant instead — data loss on a tenant the operator never named.
+   */
+  @Test
+  void shouldLeaveAPartitionOfANonDefaultPhysicalTenant() {
+    // given — both tenants run a partition numbered 1, replicated by both members
+    final var leavingMember = memberFactory.apply(1);
+    wireTwoTenantsSharingPartitionOne(Set.of(coordinatorId, leavingMember), memberFactory.apply(2));
+
+    // when — the member leaves partition 1 of tenant-b
+    final var changeStatus =
+        clientApi
+            .leavePartition(
+                new LeavePartitionRequest(leavingMember, 1, Optional.of(TENANT_B), false))
+            .join()
+            .get();
+
+    // then — it stops replicating tenant-b's partition 1 and keeps the default tenant's
+    final var expected = changeStatus.response().expectedConfiguration();
+    assertThat(expected.partitionGroup(TENANT_B).members()).doesNotContainKey(leavingMember);
+    assertThat(expected.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).members())
+        .containsKey(leavingMember);
+  }
+
+  @Test
+  void shouldRejectAJoinForAnUnknownPhysicalTenant() {
+    // given
+    final var joiningMember = memberFactory.apply(1);
+    wireTwoTenantsSharingPartitionOne(Set.of(coordinatorId), joiningMember);
+
+    // when
+    final var changeStatus =
+        clientApi
+            .joinPartition(
+                new JoinPartitionRequest(joiningMember, 1, 3, Optional.of("does-not-exist"), false))
+            .join();
+
+    // then
+    EitherAssert.assertThat(changeStatus)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldRejectALeaveForAnUnknownPhysicalTenant() {
+    // given
+    final var leavingMember = memberFactory.apply(1);
+    wireTwoTenantsSharingPartitionOne(Set.of(coordinatorId, leavingMember), memberFactory.apply(2));
+
+    // when
+    final var changeStatus =
+        clientApi
+            .leavePartition(
+                new LeavePartitionRequest(leavingMember, 1, Optional.of("does-not-exist"), false))
+            .join();
+
+    // then
+    EitherAssert.assertThat(changeStatus)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.NOT_FOUND);
+  }
+
+  /**
+   * Wires a cluster where the default tenant and {@link #TENANT_B} each run a partition numbered 1,
+   * both replicated by exactly {@code replicas}. The two groups are deliberately identical: a
+   * request that resolves the partition in the wrong group would still find a partition 1 there, so
+   * only which group changed can tell the two apart.
+   *
+   * <p>{@code idleMember} joins the cluster without replicating anything, so it is available to
+   * join either partition.
+   *
+   * <p>Left without a zone-aware distributor config, unlike {@link #wireTwoPhysicalTenants()}:
+   * nothing here asks for a placement to be computed, and a zone spec sized for a single broker
+   * could not describe this cluster.
+   */
+  private void wireTwoTenantsSharingPartitionOne(
+      final Set<MemberId> replicas, final MemberId idleMember) {
+    var topology = initialTopology.addMember(idleMember, MemberState.initializeAsActive(Map.of()));
+    for (final var replica : replicas) {
+      topology =
+          topology.hasMember(replica)
+              ? topology.updateMember(
+                  replica, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+              : topology.addMember(
+                  replica,
+                  MemberState.initializeAsActive(
+                      Map.of(1, PartitionState.active(1, partitionConfig))));
+    }
+    setCurrentTopology(topology);
+    manager.registerPartitionGroupChangeAppliers(
+        TENANT_B,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+    manager
+        .updateMultiConfiguration(
+            current ->
+                new CurrentClusterConfiguration(
+                    current.version(),
+                    current.globalConfiguration(),
+                    Map.of(
+                        CurrentClusterConfiguration.DEFAULT_GROUP,
+                        current.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+                        TENANT_B,
+                        new PartitionGroupConfiguration(
+                            1,
+                            0,
+                            replicas.stream()
+                                .collect(
+                                    Collectors.toMap(
+                                        replica -> replica,
+                                        replica ->
+                                            BrokerPartitionState.initialize(
+                                                Map.of(
+                                                    1,
+                                                    PartitionState.active(1, partitionConfig))))),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty())),
+                    current.phasedChangeState()))
+        .join();
+  }
+
+  /**
    * Wires a three-member cluster where the default tenant's only partition sits on {@link
    * #coordinatorId} and {@link #TENANT_B}'s only partition on {@code lastMember}, so that member
    * holds nothing but a non-default tenant's partition.

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformerTest.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
@@ -21,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwar
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
@@ -28,6 +33,7 @@ import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class AddZoneTransformerTest {
@@ -207,5 +213,110 @@ final class AddZoneTransformerTest {
     assertThat(result.getLeft())
         .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
         .hasMessageContaining("ZoneSpec: priority must be > 0, got -1");
+  }
+
+  @Nested
+  class Phases {
+
+    private static final ZoneAwareConfig RESTORED_CONFIG =
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 500)));
+
+    /**
+     * A single-tenant cluster must plan exactly the change it planned before {@code phases()}
+     * existed, so this compares the two directly rather than re-deriving an expected plan. It is
+     * also what pins the phase boundary: the returning broker's join and the layout it comes back
+     * into are one uninterrupted run of global operations, so they belong in one phase.
+     */
+    @Test
+    void shouldPlanTheSameChangeAsTheLegacyPath() {
+      // given
+      final var topology = buildTopology(SINGLE_ZONE_CONFIG, SINGLE_ZONE_MEMBERS);
+      final var transformer = new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_0));
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(topology));
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(CurrentClusterConfiguration.toPhases(transformer.operations(topology).get()));
+    }
+
+    /**
+     * A zone comes back to serve the whole cluster, so its brokers have to take partitions of every
+     * tenant — a tenant left out gains no replica in the returning zone and stays exposed to the
+     * failure of the one that carried it alone.
+     */
+    @Test
+    void shouldPlacePartitionsOfEveryTenantInTheReturningZone() {
+      // given — two tenants left on zone-a alone after zone-b failed over
+      final var configuration =
+          withMirroredTenant(buildTopology(SINGLE_ZONE_CONFIG, SINGLE_ZONE_MEMBERS));
+
+      // when — zone-b comes back with one broker
+      final var phases =
+          new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_0)).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(partitionGroupPhase(phases.get()).groupOperations())
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+          .allSatisfy(
+              (groupId, operations) ->
+                  assertThat(operations)
+                      .describedAs("tenant '%s' replicates every partition into zone-b", groupId)
+                      .filteredOn(PartitionJoinOperation.class::isInstance)
+                      .hasSize(PARTITION_IDS.size())
+                      .allSatisfy(
+                          join ->
+                              assertThat(((PartitionJoinOperation) join).memberId())
+                                  .isEqualTo(ZONE_B_0)));
+    }
+
+    /**
+     * The returning brokers must be members before any tenant's partition is placed on them, and
+     * the layout must be persisted before a partition placed by the new distributor is applied — so
+     * both come first, in one global phase.
+     */
+    @Test
+    void shouldJoinTheReturningBrokersAndPersistTheLayoutBeforeAnyTenantIsReplanned() {
+      // given
+      final var configuration =
+          withMirroredTenant(buildTopology(SINGLE_ZONE_CONFIG, SINGLE_ZONE_MEMBERS));
+
+      // when
+      final var phases =
+          new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_0)).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get()).hasSize(2);
+      assertThat(((GlobalPhase) phases.get().getFirst()).operations())
+          .containsExactly(
+              new MemberJoinOperation(ZONE_B_0),
+              new UpdatePartitionDistributorConfigOperation(ZONE_A_0, RESTORED_CONFIG));
+    }
+
+    @Test
+    void shouldRejectAnInvalidRequestBeforePlanningAnyTenant() {
+      // given — a zone that is already part of the layout
+      final var configuration =
+          withMirroredTenant(buildTopology(RESTORED_CONFIG, Set.of(ZONE_A_0, ZONE_B_0)));
+
+      // when
+      final var phases =
+          new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_1)).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+          .satisfies(
+              e ->
+                  assertThat(e)
+                      .hasMessageContaining(
+                          "Cannot add back zone 'zone-b' because it is already present"));
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -7,20 +7,26 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
@@ -28,6 +34,7 @@ import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class UpdatePartitionDistributionTransformerTest {
@@ -221,5 +228,120 @@ class UpdatePartitionDistributionTransformerTest {
         .isLeft()
         .left()
         .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+  }
+
+  @Nested
+  class Phases {
+
+    private static final ZoneAwareConfig HIGHER_REPLICATION_FACTOR =
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 2, 1000), new ZoneSpec(ZONE_B, 1, 500)));
+
+    /**
+     * A single-tenant cluster must plan exactly the change it planned before {@code phases()}
+     * existed, so this compares the two directly rather than re-deriving an expected plan: the
+     * phases the multi-group path builds against the phases {@code toPhases} derives from the
+     * legacy flat operation list. Any divergence in operation content, ordering, or phase
+     * boundaries fails it.
+     */
+    @Test
+    void shouldPlanTheSameReplicationFactorChangeAsTheLegacyPath() {
+      shouldPlanTheSameChangeAsTheLegacyPath(HIGHER_REPLICATION_FACTOR);
+    }
+
+    /** The layout change an operator makes to move leadership, which changes no placement. */
+    @Test
+    void shouldPlanTheSamePriorityChangeAsTheLegacyPath() {
+      shouldPlanTheSameChangeAsTheLegacyPath(
+          new ZoneAwareConfig(
+              List.of(new ZoneSpec(ZONE_A, 1, 500), new ZoneSpec(ZONE_B, 1, 1000))));
+    }
+
+    private void shouldPlanTheSameChangeAsTheLegacyPath(final ZoneAwareConfig newConfig) {
+      // given
+      final var topology = buildTopology(INITIAL_CONFIG, MEMBERS);
+      final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(topology));
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(CurrentClusterConfiguration.toPhases(transformer.operations(topology).get()));
+    }
+
+    /**
+     * The replication factor of a zone-aware cluster is derived from its zone layout, so this is
+     * both the placement check and the replication-factor one: a tenant left out of the plan keeps
+     * the replication factor of the layout being replaced.
+     */
+    @Test
+    void shouldApplyTheDerivedReplicationFactorToEveryTenant() {
+      // given — two tenants at replication factor 2, and a layout that raises it to 3
+      final var configuration = withMirroredTenant(buildTopology(INITIAL_CONFIG, MEMBERS));
+
+      // when
+      final var phases =
+          new UpdatePartitionDistributionTransformer(HIGHER_REPLICATION_FACTOR)
+              .phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(partitionGroupPhase(phases.get()).groupOperations())
+          .describedAs("every tenant's partitions are replanned, not only the default tenant's")
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+          .allSatisfy(
+              (groupId, operations) ->
+                  assertThat(operations)
+                      .describedAs(
+                          "tenant '%s' gains the third replica of every partition", groupId)
+                      .filteredOn(PartitionJoinOperation.class::isInstance)
+                      .hasSize(PARTITION_IDS.size()));
+    }
+
+    /**
+     * The layout is global state, so it is persisted once for the whole cluster and before any
+     * partition moves — a partition placed by the new distributor must not be applied while the old
+     * layout is still the persisted one.
+     */
+    @Test
+    void shouldPersistTheLayoutOnceBeforeAnyTenantIsReplanned() {
+      // given
+      final var configuration = withMirroredTenant(buildTopology(INITIAL_CONFIG, MEMBERS));
+
+      // when
+      final var phases =
+          new UpdatePartitionDistributionTransformer(HIGHER_REPLICATION_FACTOR)
+              .phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get()).hasSize(2);
+      assertThat(((GlobalPhase) phases.get().getFirst()).operations())
+          .containsExactly(
+              new UpdatePartitionDistributorConfigOperation(
+                  COORDINATOR, HIGHER_REPLICATION_FACTOR));
+    }
+
+    @Test
+    void shouldRejectAnInvalidRequestBeforePlanningAnyTenant() {
+      // given — a request body the endpoint does not support
+      final var configuration = withMirroredTenant(buildTopology(INITIAL_CONFIG, MEMBERS));
+
+      // when
+      final var phases =
+          new UpdatePartitionDistributionTransformer(new RoundRobinConfig()).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+          .satisfies(
+              e ->
+                  assertThat(e)
+                      .hasMessageContaining(
+                          "Only ZONE_AWARE partition distribution config is supported."));
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +17,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
@@ -25,6 +29,7 @@ import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class UpdateZonePrioritiesTransformerTest {
@@ -128,5 +133,55 @@ final class UpdateZonePrioritiesTransformerTest {
         .isInstanceOf(InvalidRequest.class)
         .hasMessageContaining(
             "Updating zone priorities requires a persisted zone-aware partition distribution config, but was not set");
+  }
+
+  @Nested
+  class Phases {
+
+    /**
+     * A single-tenant cluster must plan exactly the change it planned before {@code phases()}
+     * existed, so this compares the two directly rather than re-deriving an expected plan.
+     */
+    @Test
+    void shouldPlanTheSameChangeAsTheLegacyPath() {
+      // given
+      final var topology = zoneAwareCluster(new ZoneSpec(ZONE_A, 1, 3), new ZoneSpec(ZONE_B, 1, 1));
+      final var transformer = new UpdateZonePrioritiesTransformer(List.of(ZONE_B, ZONE_A));
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(topology));
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(CurrentClusterConfiguration.toPhases(transformer.operations(topology).get()));
+    }
+
+    /**
+     * Leadership follows the Raft priorities of each partition, so moving it to another zone means
+     * reconfiguring the priorities of every tenant's partitions — a tenant left out keeps its
+     * leaders where they were.
+     */
+    @Test
+    void shouldReconfigurePrioritiesForEveryTenant() {
+      // given — two tenants on a cluster where zone-a leads
+      final var configuration =
+          withMirroredTenant(
+              zoneAwareCluster(new ZoneSpec(ZONE_A, 1, 3), new ZoneSpec(ZONE_B, 1, 1)));
+
+      // when — zone-b takes over leadership
+      final var phases =
+          new UpdateZonePrioritiesTransformer(List.of(ZONE_B, ZONE_A)).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(partitionGroupPhase(phases.get()).groupOperations())
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+          .allSatisfy(
+              (groupId, operations) ->
+                  assertThat(operations)
+                      .describedAs("tenant '%s' moves its leaders to zone-b", groupId)
+                      .anyMatch(PartitionReconfigurePriorityOperation.class::isInstance));
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -231,7 +231,8 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodeJoinPartitionRequest() {
     // given
-    final var joinPartitionRequest = new JoinPartitionRequest(MemberId.from("2"), 3, 5, false);
+    final var joinPartitionRequest =
+        new JoinPartitionRequest(MemberId.from("2"), 3, 5, Optional.empty(), false);
 
     // when
     final var encodedRequest = protoBufSerializer.encodeJoinPartitionRequest(joinPartitionRequest);
@@ -244,7 +245,8 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodeLeavePartitionRequest() {
     // given
-    final var leavePartitionRequest = new LeavePartitionRequest(MemberId.from("6"), 2, false);
+    final var leavePartitionRequest =
+        new LeavePartitionRequest(MemberId.from("6"), 2, Optional.empty(), false);
 
     // when
     final var encodedRequest =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -243,10 +243,39 @@ final class ProtoBufSerializerTest {
   }
 
   @Test
+  void shouldEncodeAndDecodeJoinPartitionRequestWithPhysicalTenant() {
+    // given
+    final var joinPartitionRequest =
+        new JoinPartitionRequest(MemberId.from("2"), 3, 5, Optional.of("tenant-a"), false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeJoinPartitionRequest(joinPartitionRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeJoinPartitionRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(joinPartitionRequest);
+  }
+
+  @Test
   void shouldEncodeAndDecodeLeavePartitionRequest() {
     // given
     final var leavePartitionRequest =
         new LeavePartitionRequest(MemberId.from("6"), 2, Optional.empty(), false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeLeavePartitionRequest(leavePartitionRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeLeavePartitionRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(leavePartitionRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeLeavePartitionRequestWithPhysicalTenant() {
+    // given
+    final var leavePartitionRequest =
+        new LeavePartitionRequest(MemberId.from("6"), 2, Optional.of("tenant-a"), false);
 
     // when
     final var encodedRequest =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PhysicalTenantFixtures.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PhysicalTenantFixtures.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import java.util.List;
+import java.util.Map;
+
+public final class PhysicalTenantFixtures {
+
+  public static final String TENANT_A = "tenant-a";
+
+  private PhysicalTenantFixtures() {}
+
+  /**
+   * The given single-group topology as a multi-group configuration whose two partition groups are
+   * mirror images: the default tenant and {@link #TENANT_A} run the same partitions over the same
+   * brokers.
+   *
+   * <p>Mirroring rather than varying the two is what makes a plan easy to read: whatever a request
+   * does to the default tenant it must do to the other one as well, so a plan that only ever saw
+   * the default group is distinguishable by the group it is missing, not by a placement difference
+   * that has to be derived.
+   */
+  public static CurrentClusterConfiguration withMirroredTenant(
+      final ClusterConfiguration topology) {
+    final var single = CurrentClusterConfiguration.fromLegacy(topology);
+    return new CurrentClusterConfiguration(
+        single.version(),
+        single.globalConfiguration(),
+        Map.of(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+            TENANT_A,
+            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
+        single.phasedChangeState());
+  }
+
+  /**
+   * The phase of a plan that carries the per-tenant work, which is where a plan that only ever saw
+   * the default partition group differs from one that saw every tenant's.
+   */
+  public static PartitionGroupParallelPhase partitionGroupPhase(final List<Phase> phases) {
+    return phases.stream()
+        .filter(PartitionGroupParallelPhase.class::isInstance)
+        .map(PartitionGroupParallelPhase.class::cast)
+        .findFirst()
+        .orElseThrow(
+            () -> new AssertionError("expected the plan to contain partition work: " + phases));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionJoinLeaveIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionJoinLeaveIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a partition join and a partition leave through {@code
+ * /actuator/cluster/brokers/{brokerId}/partitions/{partitionId}} act on the physical tenant the
+ * request names (issue #60078), and on no other.
+ *
+ * <p>Partition ids restart at 1 in every physical tenant, so both tenants here run a partition
+ * numbered 1. Before the endpoints took a {@code physicalTenant} parameter they resolved that
+ * number against the default tenant whatever the operator meant, which made repairing a non-default
+ * tenant's replication impossible and silently changed the default tenant instead.
+ *
+ * <p>The replicas each tenant starts with are read from the cluster rather than assumed: which
+ * broker a single-replica partition lands on is the distributor's business, and the test only needs
+ * one broker that holds tenant A's partition and one that does not.
+ */
+@ZeebeIntegration
+final class PhysicalTenantPartitionJoinLeaveIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int PARTITION_ID = 1;
+  private static final int BROKERS_COUNT = 2;
+  private static final int PARTITIONS_COUNT = 1;
+  private static final int REPLICATION_FACTOR = 1;
+  private static final int JOIN_PRIORITY = 1;
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(BROKERS_COUNT)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withBrokerConfig(
+              broker ->
+                  TENANTS.configure(
+                      broker
+                          .withUnauthenticatedAccess()
+                          // TestClusterBuilder sizes the actor threads as
+                          // (partitions * replicationFactor) / brokers, which is 0 here, and a
+                          // scheduler with no threads cannot start a broker at all. Size them for
+                          // both tenants' partitions on one broker, which is what the join
+                          // produces.
+                          .withUnifiedConfig(
+                              camunda -> {
+                                camunda.getSystem().setCpuThreadCount(2);
+                                camunda.getSystem().setIoThreadCount(2);
+                              })))
+          .build();
+
+  @Test
+  void shouldJoinAndLeaveOnlyTheNamedPhysicalTenantsPartition() {
+    // given — each tenant's partition 1 has a single replica, and the default tenant's replicas are
+    // recorded so any change to them is visible
+    final var actuator = ClusterActuator.of(cluster.availableGateway());
+    awaitReplicas(actuator, TENANT_A, REPLICATION_FACTOR);
+    final var tenantAHolder = replicasOf(actuator, TENANT_A).iterator().next();
+    final var defaultReplicas = replicasOf(actuator, PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+    final var joiningBroker =
+        cluster.brokers().keySet().stream()
+            .map(MemberId::id)
+            .filter(id -> !id.equals(tenantAHolder))
+            .findFirst()
+            .orElseThrow();
+
+    // when — that other broker joins partition 1 of tenant A
+    awaitAccepted(
+        "the cluster accepts the join",
+        () ->
+            actuator.joinPartition(
+                Integer.parseInt(joiningBroker), PARTITION_ID, JOIN_PRIORITY, TENANT_A));
+
+    // then — tenant A's partition 1 gains the replica...
+    await("tenant A's partition is replicated by the joining broker")
+        .atMost(Duration.ofSeconds(120))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(replicasOf(actuator, TENANT_A))
+                    .containsExactlyInAnyOrder(tenantAHolder, joiningBroker));
+    // ...and the default tenant's identically numbered partition is untouched
+    assertThat(replicasOf(actuator, PhysicalTenantsITHelper.DEFAULT_TENANT_ID))
+        .isEqualTo(defaultReplicas);
+
+    // when — the same broker leaves partition 1 of tenant A again
+    awaitAccepted(
+        "the cluster accepts the leave",
+        () -> actuator.leavePartition(Integer.parseInt(joiningBroker), PARTITION_ID, TENANT_A));
+
+    // then — tenant A is back to its single replica, and the default tenant still never moved
+    await("tenant A's partition is no longer replicated by that broker")
+        .atMost(Duration.ofSeconds(120))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThat(replicasOf(actuator, TENANT_A)).containsExactly(tenantAHolder));
+    assertThat(replicasOf(actuator, PhysicalTenantsITHelper.DEFAULT_TENANT_ID))
+        .isEqualTo(defaultReplicas);
+  }
+
+  /** The ids of the brokers replicating {@link #PARTITION_ID} of the given physical tenant. */
+  private Set<String> replicasOf(final ClusterActuator actuator, final String physicalTenantId) {
+    return actuator.getTopology(physicalTenantId).getBrokers().stream()
+        .filter(
+            broker ->
+                broker.getPartitions().stream()
+                    .anyMatch(partition -> Objects.equals(partition.getId(), PARTITION_ID)))
+        .map(broker -> broker.getId().toString())
+        .collect(Collectors.toSet());
+  }
+
+  private void awaitReplicas(
+      final ClusterActuator actuator, final String physicalTenantId, final int expected) {
+    await(
+            "physical tenant '%s' replicates its partition %d times"
+                .formatted(physicalTenantId, expected))
+        .atMost(Duration.ofSeconds(120))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(replicasOf(actuator, physicalTenantId)).hasSize(expected));
+  }
+
+  /**
+   * Retries {@code request} until the cluster accepts it. The request is not an assertion — it
+   * either returns or throws a {@link feign.FeignException} — so it cannot be handed to {@code
+   * untilAsserted}, which only retries on {@link AssertionError}. A retry is needed because the
+   * cluster can still be applying its own initial configuration change when the test starts, and
+   * rejects a second change while one is in progress.
+   */
+  private void awaitAccepted(final String alias, final Runnable request) {
+    await(alias)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              request.run();
+              return true;
+            });
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -146,6 +146,23 @@ public interface ClusterActuator {
       @Param boolean dryRun);
 
   /**
+   * Request that the broker joins the given physical tenant's partition with the given priority.
+   * Partition ids restart at 1 in every physical tenant, so the partition is only identified by the
+   * two together.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     the physical tenant is unknown
+   */
+  @RequestLine("POST /brokers/{brokerId}/partitions/{partitionId}?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Body("%7B\"priority\": {priority}%7D")
+  PlannedOperationsResponse joinPartition(
+      @Param final int brokerId,
+      @Param final int partitionId,
+      @Param final int priority,
+      @Param final String physicalTenant);
+
+  /**
    * Request that the broker leaves the partition.
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
@@ -163,6 +180,19 @@ public interface ClusterActuator {
   @RequestLine("DELETE /brokers/{brokerId}/partitions/{partitionId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   PlannedOperationsResponse leavePartition(@Param final int brokerId, @Param final int partitionId);
+
+  /**
+   * Request that the broker leaves the given physical tenant's partition. Partition ids restart at
+   * 1 in every physical tenant, so the partition is only identified by the two together.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     the physical tenant is unknown
+   */
+  @RequestLine(
+      "DELETE /brokers/{brokerId}/partitions/{partitionId}?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse leavePartition(
+      @Param final int brokerId, @Param final int partitionId, @Param final String physicalTenant);
 
   /**
    * Queries the current cluster topology


### PR DESCRIPTION
`POST` and `DELETE /actuator/cluster/brokers/{brokerId}/partitions/{partitionId}` accept a `physicalTenant` query parameter and resolve the partition within that tenant's partition group. Unlike the other issues in this epic this was a correctness gap rather than a missing capability: partition ids restart at 1 in every physical tenant, so both endpoints resolved a bare `partitionId` against the default group and quietly acted on the wrong tenant instead of refusing.

An absent parameter keeps meaning the default physical tenant, not every tenant — a partition belongs to exactly one tenant, so the "apply to all tenants" reading the whole-cluster requests use has nothing to address here. That is the same choice `PATCH /routing-state` already makes, so its schema parameter is renamed for the meaning it carries rather than its one call site, and shared.

Both endpoints were reachable but absent from `cluster-api.yaml` entirely, so they are described there now, including the `priority` body the join takes. The controller binds that body to the schema's generated type instead of its own record, leaving one definition of the request rather than two that can drift.

Neither request could see the other partition groups before: they were served by an inline lambda returning a flat operation list, which the coordinator's default `phases()` projected onto the default group. Each now has a transformer of its own, planning into the group the request names and answering an unknown tenant with a 404, consistent with `GET /actuator/cluster`.

Stacked on #60424, which is itself stacked on #60420 and #60348; review those first, and the base moves down the stack as they merge.

closes #60078