### PR TITLE
feat: apply a forced broker or zone removal to every physical tenant

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersRequestTransformer.java
@@ -11,11 +11,18 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Names the brokers to force-remove rather than the ones to keep, and answers the request by
+ * retaining every other broker. See {@link ForceScaleDownRequestTransformer} for what the removal
+ * itself does.
+ */
 public final class ForceRemoveBrokersRequestTransformer implements ConfigurationChangeRequest {
 
   private final Set<MemberId> membersToRemove;
@@ -27,6 +34,21 @@ public final class ForceRemoveBrokersRequestTransformer implements Configuration
     this.coordinator = coordinator;
   }
 
+  /** Force-removes the named brokers from every physical tenant's partition group. */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    final var membersToRetain =
+        new HashSet<>(configuration.globalConfiguration().members().keySet());
+    membersToRetain.removeAll(membersToRemove);
+
+    return new ForceScaleDownRequestTransformer(membersToRetain, coordinator).phases(configuration);
+  }
+
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveZoneTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveZoneTransformer.java
@@ -7,17 +7,26 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Force-evicts a failed zone's brokers from the member set (no data movement, since the zone is
@@ -31,10 +40,89 @@ public final class ForceRemoveZoneTransformer implements ConfigurationChangeRequ
     this.zoneId = zoneId;
   }
 
+  /**
+   * Evicts the zone's brokers from every physical tenant's partition group, by handing the brokers
+   * that survive it to {@link
+   * ForceScaleDownRequestTransformer#phases(CurrentClusterConfiguration)}. Evicting them from the
+   * default group alone left the other tenants' partitions on the failed zone's brokers, and the
+   * member removal that follows then refused the whole plan — so the first half of the zone
+   * failover procedure could not run on a cluster with more than one tenant.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    return zoneRemoval(
+            configuration.globalConfiguration().partitionDistributorConfig(),
+            configuration.globalConfiguration().members().keySet())
+        .flatMap(
+            removal ->
+                new ForceScaleDownRequestTransformer(
+                        removal.membersToRetain(), removal.coordinator())
+                    .phases(configuration)
+                    .map(phases -> withLayoutUpdateLast(phases, removal.updateLayout())));
+  }
+
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
-    final var partitionDistributorConfig = currentConfiguration.partitionDistributorConfig();
+    return zoneRemoval(
+            currentConfiguration.partitionDistributorConfig(),
+            currentConfiguration.members().keySet())
+        .flatMap(
+            removal ->
+                new ForceScaleDownRequestTransformer(
+                        removal.membersToRetain(), removal.coordinator())
+                    .operations(currentConfiguration)
+                    .map(
+                        ops -> {
+                          final var allOps =
+                              new ArrayList<ClusterConfigurationChangeOperation>(ops.size() + 1);
+                          allOps.addAll(ops);
+                          allOps.add(removal.updateLayout());
+                          return allOps;
+                        }));
+  }
+
+  @Override
+  public boolean isForced() {
+    return true;
+  }
+
+  /**
+   * Appends the operation that drops the zone from the persisted layout to the plan's trailing
+   * global phase — the one that removes the zone's brokers — instead of giving it a phase of its
+   * own. Both the layout and the member set are cluster-wide state, and a plan that persisted the
+   * shrunk layout in a phase of its own would leave the cluster briefly describing a zone layout
+   * its members do not match.
+   */
+  private static List<Phase> withLayoutUpdateLast(
+      final List<Phase> phases, final GlobalChangeOperation updateLayout) {
+    if (!phases.isEmpty() && phases.getLast() instanceof final GlobalPhase trailing) {
+      final var merged = new ArrayList<>(trailing.operations());
+      merged.add(updateLayout);
+      return Stream.concat(
+              phases.stream().limit(phases.size() - 1L), Stream.of(new GlobalPhase(merged)))
+          .toList();
+    }
+    return Stream.concat(phases.stream(), Stream.of(new GlobalPhase(List.of(updateLayout))))
+        .toList();
+  }
+
+  /**
+   * Validates the request and answers with what removing the zone amounts to: the brokers that
+   * survive it, the broker that coordinates the change, and the operation that persists the layout
+   * without the zone.
+   *
+   * <p>Takes the persisted layout and the member set rather than a configuration because that is
+   * all the answer depends on — both are global state, with no per-tenant dimension.
+   */
+  private Either<Exception, ZoneRemoval> zoneRemoval(
+      final Optional<PartitionDistributorConfig> partitionDistributorConfig,
+      final Set<MemberId> members) {
     final ZoneAwareConfig zoneAwareConfig;
     if (partitionDistributorConfig.isPresent()
         && partitionDistributorConfig.get() instanceof final ZoneAwareConfig cfg) {
@@ -56,9 +144,7 @@ public final class ForceRemoveZoneTransformer implements ConfigurationChangeRequ
     }
 
     final var zoneMembers =
-        currentConfiguration.members().keySet().stream()
-            .filter(member -> member.isInZone(zoneId))
-            .collect(Collectors.toSet());
+        members.stream().filter(member -> member.isInZone(zoneId)).collect(Collectors.toSet());
     if (zoneMembers.isEmpty()) {
       return Either.left(
           new InvalidRequest(
@@ -74,7 +160,7 @@ public final class ForceRemoveZoneTransformer implements ConfigurationChangeRequ
                   + "' because it is the last remaining zone in the partition distribution config."));
     }
 
-    final var retain = new HashSet<>(currentConfiguration.members().keySet());
+    final var retain = new HashSet<>(members);
     retain.removeAll(zoneMembers);
     if (retain.isEmpty()) {
       return Either.left(
@@ -85,25 +171,20 @@ public final class ForceRemoveZoneTransformer implements ConfigurationChangeRequ
     }
 
     final var coordinator =
-        ClusterConfigurationCoordinatorSupplier.of(() -> currentConfiguration)
+        ClusterConfigurationCoordinatorSupplier.ofMembers(members)
             .getNextCoordinatorExcluding(zoneMembers);
 
-    final var configWithoutZone = new ZoneAwareConfig(remainingZones);
-
-    return new ForceScaleDownRequestTransformer(retain, coordinator)
-        .operations(currentConfiguration)
-        .map(
-            ops -> {
-              final var allOps = new ArrayList<ClusterConfigurationChangeOperation>(ops.size() + 1);
-              allOps.addAll(ops);
-              allOps.add(
-                  new UpdatePartitionDistributorConfigOperation(coordinator, configWithoutZone));
-              return allOps;
-            });
+    return Either.right(
+        new ZoneRemoval(
+            retain,
+            coordinator,
+            new UpdatePartitionDistributorConfigOperation(
+                coordinator, new ZoneAwareConfig(remainingZones))));
   }
 
-  @Override
-  public boolean isForced() {
-    return true;
-  }
+  /** What removing the zone amounts to, once the request is known to be valid. */
+  private record ZoneRemoval(
+      Set<MemberId> membersToRetain,
+      MemberId coordinator,
+      UpdatePartitionDistributorConfigOperation updateLayout) {}
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformer.java
@@ -14,14 +14,22 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -29,6 +37,12 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+/**
+ * Removes brokers that are already gone: every partition they replicated is force-reconfigured onto
+ * whichever of the retained brokers still hold it, and the departed brokers are then dropped from
+ * the member set. There is no data movement — a forced removal exists precisely because the
+ * departing brokers cannot be asked to hand their partitions over.
+ */
 public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequest {
 
   private final Set<MemberId> membersToRetain;
@@ -41,17 +55,18 @@ public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequ
     this.coordinator = coordinator;
   }
 
+  /**
+   * Plans the same change as {@link #phases(CurrentClusterConfiguration)}, but for the default
+   * partition group alone. Nothing in production plans through here anymore; it is what the tests
+   * around this transformer and the two that delegate to it assert on.
+   */
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    for (final var member : membersToRetain) {
-      if (!clusterConfiguration.hasMember(member)) {
-        return Either.left(
-            new InvalidRequest(
-                String.format(
-                    "Expected to force configure while retaining broker '%s', but broker '%s' is not in the current cluster. Current members are '%s'",
-                    member, member, clusterConfiguration.members().keySet())));
-      }
+    final var unknownRetainedMember =
+        unknownRetainedMember(clusterConfiguration.members().keySet());
+    if (unknownRetainedMember.isPresent()) {
+      return Either.left(unknownRetainedMember.get());
     }
 
     final SortedMap<Integer, SortedSet<MemberId>> partitionsWithNewMembers =
@@ -80,6 +95,77 @@ public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequ
     return generateOperations(partitionsWithNewMembers, memberToRemove);
   }
 
+  /**
+   * Plans the forced reconfiguration for every physical tenant's partitions rather than the default
+   * tenant's only. Planning the default group alone left the other tenants' partitions on the
+   * departed brokers, and the member removal that follows — which checks every partition group —
+   * then refused the whole plan, so a cluster with more than one tenant could not force-remove a
+   * broker at all.
+   *
+   * <p>One phase reconfigures every tenant in parallel, and a second removes the brokers, in that
+   * order: a broker may only leave the member set once nothing replicates on it any more.
+   *
+   * <p>Partition ids restart at 1 in every physical tenant, so the partitions of different tenants
+   * are resolved against their own group and never merged: two tenants each having a partition 1 is
+   * two partitions, planned independently of one another.
+   */
+  @Override
+  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
+    final var members = configuration.globalConfiguration().members().keySet();
+    final var unknownRetainedMember = unknownRetainedMember(members);
+    if (unknownRetainedMember.isPresent()) {
+      return Either.left(unknownRetainedMember.get());
+    }
+
+    final SortedMap<String, SortedMap<Integer, SortedSet<MemberId>>> replicasByTenant =
+        new TreeMap<>();
+    configuration
+        .partitionGroups()
+        .forEach(
+            (physicalTenantId, group) ->
+                replicasByTenant.put(physicalTenantId, survivingReplicas(group)));
+
+    final var orphanedByTenant = new TreeMap<String, List<Integer>>();
+    replicasByTenant.forEach(
+        (physicalTenantId, replicas) -> {
+          final var orphaned = orphanedPartitions(replicas);
+          if (!orphaned.isEmpty()) {
+            orphanedByTenant.put(physicalTenantId, orphaned);
+          }
+        });
+    if (!orphanedByTenant.isEmpty()) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "Expected to force configure and retain members '%s', but this will result in partitions '%s' having no replicas",
+                  membersToRetain, orphanedByTenant)));
+    }
+
+    final Map<String, List<PartitionGroupOperation>> reconfigureByTenant = new TreeMap<>();
+    replicasByTenant.forEach(
+        (physicalTenantId, replicas) -> {
+          if (!replicas.isEmpty()) {
+            reconfigureByTenant.put(physicalTenantId, reconfigurePartitionsOf(replicas));
+          }
+        });
+
+    final List<GlobalChangeOperation> removeMembers =
+        members.stream()
+            .filter(member -> !membersToRetain.contains(member))
+            .sorted(MemberId.ID_COMPARATOR)
+            .map(member -> (GlobalChangeOperation) new MemberRemoveOperation(coordinator, member))
+            .toList();
+
+    final List<Phase> phases = new ArrayList<>();
+    if (!reconfigureByTenant.isEmpty()) {
+      phases.add(new PartitionGroupParallelPhase(reconfigureByTenant));
+    }
+    if (!removeMembers.isEmpty()) {
+      phases.add(new GlobalPhase(removeMembers));
+    }
+    return Either.right(phases);
+  }
+
   @Override
   public boolean isForced() {
     return true;
@@ -89,9 +175,8 @@ public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequ
       final SortedMap<Integer, SortedSet<MemberId>> partitionsWithNewMembers,
       final SortedSet<MemberId> memberToRemove) {
 
-    final var partitionForceConfigureOperations = reconfigurePartitions(partitionsWithNewMembers);
     final List<ClusterConfigurationChangeOperation> operations =
-        new ArrayList<>(partitionForceConfigureOperations);
+        new ArrayList<>(reconfigurePartitionsOf(partitionsWithNewMembers));
 
     final var memberRemoveOperations = forceRemoveMembers(memberToRemove);
     operations.addAll(memberRemoveOperations);
@@ -99,24 +184,49 @@ public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequ
     return Either.right(operations);
   }
 
-  private List<ClusterConfigurationChangeOperation> reconfigurePartitions(
-      final SortedMap<Integer, SortedSet<MemberId>> partitionsWithNewMembers) {
-    return partitionsWithNewMembers.entrySet().stream()
-        .map(
-            partition ->
-                new PartitionForceReconfigureOperation(
-                    partition.getValue().stream().findFirst().orElseThrow(),
-                    partition.getKey(),
-                    partition.getValue()))
-        .map(ClusterConfigurationChangeOperation.class::cast)
-        .toList();
-  }
-
   private List<ClusterConfigurationChangeOperation> forceRemoveMembers(
       final SortedSet<MemberId> membersToRemove) {
     return membersToRemove.stream()
         .map(member -> new MemberRemoveOperation(coordinator, member))
         .map(ClusterConfigurationChangeOperation.class::cast)
+        .toList();
+  }
+
+  /**
+   * The first retained broker that the cluster does not know, if there is one. Retaining a broker
+   * that is not a member is a typo in the request rather than an instruction, and answering it by
+   * removing every other broker would be catastrophic.
+   */
+  private Optional<Exception> unknownRetainedMember(final Set<MemberId> members) {
+    return membersToRetain.stream()
+        .filter(member -> !members.contains(member))
+        .findFirst()
+        .map(
+            member ->
+                new InvalidRequest(
+                    String.format(
+                        "Expected to force configure while retaining broker '%s', but broker '%s' is not in the current cluster. Current members are '%s'",
+                        member, member, members)));
+  }
+
+  private SortedMap<Integer, SortedSet<MemberId>> survivingReplicas(
+      final PartitionGroupConfiguration group) {
+    return survivingReplicas(
+        group.members().entrySet().stream()
+            .collect(
+                Collectors.toMap(Entry::getKey, entry -> entry.getValue().partitions().keySet())));
+  }
+
+  private List<PartitionGroupOperation> reconfigurePartitionsOf(
+      final SortedMap<Integer, SortedSet<MemberId>> survivingReplicas) {
+    return survivingReplicas.entrySet().stream()
+        .map(
+            partition ->
+                (PartitionGroupOperation)
+                    new PartitionForceReconfigureOperation(
+                        partition.getValue().stream().findFirst().orElseThrow(),
+                        partition.getKey(),
+                        partition.getValue()))
         .toList();
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformer.java
@@ -15,16 +15,19 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.Co
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequest {
 
@@ -51,27 +54,16 @@ public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequ
       }
     }
 
-    final List<Integer> partitions =
-        clusterConfiguration.members().values().stream()
-            .map(MemberState::partitions)
-            .flatMap(p -> p.keySet().stream())
-            .distinct()
-            .toList();
-
     final SortedMap<Integer, SortedSet<MemberId>> partitionsWithNewMembers =
-        calculateNewConfiguration(clusterConfiguration, membersToRetain, partitions);
+        survivingReplicas(
+            clusterConfiguration.members().entrySet().stream()
+                .collect(
+                    Collectors.toMap(
+                        Entry::getKey, entry -> entry.getValue().partitions().keySet())));
 
-    final var partitionsWithNoReplicas =
-        partitions.stream()
-            .filter(
-                p ->
-                    !partitionsWithNewMembers.containsKey(p)
-                        || partitionsWithNewMembers.get(p).isEmpty())
-            .toList();
+    final var partitionsWithNoReplicas = orphanedPartitions(partitionsWithNewMembers);
 
-    final var hasReplicasForAllPartitions = partitionsWithNoReplicas.isEmpty();
-
-    if (!hasReplicasForAllPartitions) {
+    if (!partitionsWithNoReplicas.isEmpty()) {
       return Either.left(
           new InvalidRequest(
               String.format(
@@ -128,26 +120,37 @@ public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequ
         .toList();
   }
 
-  private SortedMap<Integer, SortedSet<MemberId>> calculateNewConfiguration(
-      final ClusterConfiguration currentTopology,
-      final Set<MemberId> membersToRetain,
-      final List<Integer> partitions) {
+  /**
+   * The partitions of one physical tenant paired with the replicas that survive the removal: every
+   * partition any broker of that tenant holds, mapped to the retained brokers among them.
+   *
+   * <p>A partition whose every replica is being removed maps to an empty set rather than dropping
+   * out of the map — that is the case {@link #orphanedPartitions(SortedMap)} has to find.
+   *
+   * @param partitionsByMember which partitions each broker holds, for one physical tenant
+   */
+  private SortedMap<Integer, SortedSet<MemberId>> survivingReplicas(
+      final Map<MemberId, ? extends Collection<Integer>> partitionsByMember) {
+    final SortedMap<Integer, SortedSet<MemberId>> survivingReplicas = new TreeMap<>();
+    partitionsByMember.forEach(
+        (member, partitions) ->
+            partitions.forEach(
+                partitionId -> {
+                  final var replicas =
+                      survivingReplicas.computeIfAbsent(partitionId, ignored -> new TreeSet<>());
+                  if (membersToRetain.contains(member)) {
+                    replicas.add(member);
+                  }
+                }));
+    return survivingReplicas;
+  }
 
-    final SortedMap<Integer, SortedSet<MemberId>> partitionToMembersMap = new TreeMap<>();
-    for (final var partitionId : partitions) {
-      partitionToMembersMap.put(partitionId, new TreeSet<>());
-      for (final var member : membersToRetain) {
-        if (currentTopology.getMember(member).hasPartition(partitionId)) {
-          partitionToMembersMap.computeIfPresent(
-              partitionId,
-              (ignore, members) -> {
-                members.add(member);
-                return members;
-              });
-        }
-      }
-    }
-
-    return partitionToMembersMap;
+  /** The partitions that the removal would leave without a single replica. */
+  private static List<Integer> orphanedPartitions(
+      final SortedMap<Integer, SortedSet<MemberId>> survivingReplicas) {
+    return survivingReplicas.entrySet().stream()
+        .filter(partition -> partition.getValue().isEmpty())
+        .map(Entry::getKey)
+        .toList();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantForcedRemovalTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantForcedRemovalTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.BARE_0;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.BARE_1;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.BARE_2;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_A;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_A_0;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_B;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.ZONE_B_0;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ForceRemoveBrokersRequestTransformer;
+import io.camunda.zeebe.dynamic.config.api.ForceRemoveZoneTransformer;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A forced removal is what an operator reaches for once brokers or a whole zone are already gone,
+ * so it has to reconfigure every physical tenant's partitions and not only the default tenant's.
+ * Force-reconfiguring the default tenant alone left the departing brokers replicating the other
+ * tenants' partitions, and the member removal that follows — which checks every partition group —
+ * then refused the whole plan during validation, leaving the configuration untouched. A cluster
+ * with more than one tenant could not use its recovery paths at all.
+ *
+ * <p>Driven through the coordinator rather than the transformers, because the refusal came from the
+ * appliers rather than from the plan: the coordinator runs the whole plan through the real ones —
+ * the member leave among them — and hands back the configuration the request would leave behind.
+ */
+final class PhysicalTenantForcedRemovalTest {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int PARTITION_ID = 1;
+  private static final ZoneAwareConfig DUAL_ZONE =
+      new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 500)));
+
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @TempDir private Path tmp;
+
+  private ClusterConfigurationManagerImpl manager;
+  private ConfigurationChangeCoordinatorImpl coordinator;
+
+  /**
+   * The two tenants are placed differently on purpose: broker 2 holds nothing of the default tenant
+   * and only tenant A's partition, which is the case a plan that stops at the default group has
+   * nothing to say about.
+   */
+  @Test
+  void shouldForceRemoveABrokerFromEveryPhysicalTenant() {
+    // given — three brokers running two tenants; broker 2 holds only tenant A's partition
+    wire(
+        BARE_0,
+        twoTenants(
+            cluster(Set.of(BARE_0, BARE_1, BARE_2), Set.of(BARE_0, BARE_1)),
+            cluster(Set.of(BARE_0, BARE_1, BARE_2), Set.of(BARE_1, BARE_2))));
+
+    // when — broker 2 is gone
+    final var configuration =
+        forceRemove(new ForceRemoveBrokersRequestTransformer(Set.of(BARE_2), BARE_0));
+
+    // then — tenant A keeps its partition on the broker that survives, the default tenant is
+    // untouched, and broker 2 has left
+    assertThat(replicasOf(configuration, DEFAULT_GROUP))
+        .describedAs("replicas of the default tenant's partition")
+        .containsExactlyInAnyOrder(BARE_0, BARE_1);
+    assertThat(replicasOf(configuration, TENANT_A))
+        .describedAs("replicas of tenant '%s' partition", TENANT_A)
+        .containsExactly(BARE_1);
+    assertThat(configuration.globalConfiguration().members())
+        .describedAs("brokers left in the cluster")
+        .containsOnlyKeys(BARE_0, BARE_1);
+  }
+
+  @Test
+  void shouldForceRemoveAZoneFromEveryPhysicalTenant() {
+    // given — two zones of one broker each, both tenants replicated across both
+    final var members = Set.of(ZONE_A_0, ZONE_B_0);
+    wire(
+        ZONE_A_0,
+        twoTenants(
+            cluster(members, members).setPartitionDistributorConfig(DUAL_ZONE),
+            cluster(members, members)));
+
+    // when — zone-b fails over
+    final var configuration = forceRemove(new ForceRemoveZoneTransformer(ZONE_B));
+
+    // then — every tenant is left on the surviving zone, which is also the only one the persisted
+    // layout still names
+    assertThat(replicasOf(configuration, DEFAULT_GROUP))
+        .describedAs("replicas of the default tenant's partition")
+        .containsExactly(ZONE_A_0);
+    assertThat(replicasOf(configuration, TENANT_A))
+        .describedAs("replicas of tenant '%s' partition", TENANT_A)
+        .containsExactly(ZONE_A_0);
+    assertThat(configuration.globalConfiguration().members())
+        .describedAs("brokers left in the cluster")
+        .containsOnlyKeys(ZONE_A_0);
+    assertThat(configuration.globalConfiguration().partitionDistributorConfig())
+        .contains(new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000))));
+  }
+
+  /**
+   * Runs the request and answers with the configuration it produces.
+   *
+   * <p>A dry run rather than a real apply: applying would drive each operation on the broker that
+   * is named by it, and the brokers a forced removal is aimed at are by definition not running. The
+   * dry run still puts the whole plan through the real appliers — the member leave that used to
+   * refuse it among them — so a plan that misses a tenant fails here exactly as it does in a real
+   * cluster.
+   */
+  private CurrentClusterConfiguration forceRemove(final ConfigurationChangeRequest request) {
+    return coordinator.simulateOperations(request).join().finalMultiConfiguration();
+  }
+
+  /** The brokers replicating the given physical tenant's only partition. */
+  private Set<MemberId> replicasOf(
+      final CurrentClusterConfiguration configuration, final String physicalTenantId) {
+    return configuration.partitionGroup(physicalTenantId).members().entrySet().stream()
+        .filter(member -> member.getValue().partitions().containsKey(PARTITION_ID))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+  }
+
+  /** A cluster of {@code members} in which {@code replicas} replicate partition 1. */
+  private ClusterConfiguration cluster(final Set<MemberId> members, final Set<MemberId> replicas) {
+    var topology = ClusterConfiguration.init();
+    for (final var member : members) {
+      topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
+    }
+    var priority = replicas.size();
+    for (final var replica : replicas) {
+      final var state = PartitionState.active(priority--, partitionConfig);
+      topology = topology.updateMember(replica, member -> member.addPartition(PARTITION_ID, state));
+    }
+    return topology;
+  }
+
+  /**
+   * The two topologies as one configuration running two physical tenants. Both have to describe the
+   * same brokers — the member set is cluster-wide, and only the partition assignment differs per
+   * tenant.
+   */
+  private CurrentClusterConfiguration twoTenants(
+      final ClusterConfiguration defaultTenant, final ClusterConfiguration otherTenant) {
+    final var base = CurrentClusterConfiguration.fromLegacy(defaultTenant);
+    return new CurrentClusterConfiguration(
+        base.version(),
+        base.globalConfiguration(),
+        Map.of(
+            DEFAULT_GROUP,
+            base.partitionGroup(DEFAULT_GROUP),
+            TENANT_A,
+            CurrentClusterConfiguration.fromLegacy(otherTenant).partitionGroup(DEFAULT_GROUP)),
+        base.phasedChangeState());
+  }
+
+  private void wire(final MemberId localMemberId, final CurrentClusterConfiguration seed) {
+    manager =
+        new ClusterConfigurationManagerImpl(
+            executor,
+            localMemberId,
+            PersistedCurrentClusterConfiguration.ofFile(
+                tmp.resolve("config.meta"), new ProtoBufSerializer()),
+            new TopologyManagerMetrics(new SimpleMeterRegistry()),
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+    manager.setCurrentConfigurationGossiper(ignored -> {});
+    manager.registerGlobalChangeAppliers(
+        new GlobalConfigurationChangeAppliersImpl(
+            new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
+    seed.partitionGroups()
+        .keySet()
+        .forEach(
+            groupId ->
+                manager.registerPartitionGroupChangeAppliers(
+                    groupId,
+                    new PartitionGroupConfigurationChangeAppliersImpl(
+                        new NoopPartitionChangeExecutor(),
+                        new NoopPartitionScalingChangeExecutor(),
+                        new NoopModeChangeExecutor(),
+                        new NoopRestoreChangeExecutor())));
+    coordinator = new ConfigurationChangeCoordinatorImpl(manager, localMemberId, executor);
+    manager.updateMultiConfiguration(ignored -> seed).join();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersTransformerTest.java
@@ -7,14 +7,19 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.Map;
@@ -57,6 +62,38 @@ final class ForceRemoveBrokersTransformerTest {
     // then
     applyRequestAndVerifyResultingTopology(
         2, Set.of(id0, id2), patchRequest, currentTopology, expectedDistribution);
+  }
+
+  /**
+   * The request names the brokers that are gone, so the brokers to keep are everything else — and
+   * every physical tenant's partitions have to be handed to them, not only the default tenant's.
+   */
+  @Test
+  void shouldForceRemoveBrokersFromEveryPhysicalTenant() {
+    // given
+    final var configuration =
+        withMirroredTenant(
+            ClusterConfiguration.init()
+                .addMember(id0, MemberState.initializeAsActive(Map.of()))
+                .addMember(id1, MemberState.initializeAsActive(Map.of()))
+                .updateMember(
+                    id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+                .updateMember(
+                    id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig))));
+
+    // when — broker 1 is gone
+    final var phases =
+        new ForceRemoveBrokersRequestTransformer(Set.of(id1), id0).phases(configuration);
+
+    // then
+    assertThat(phases).isRight();
+    Assertions.assertThat(partitionGroupPhase(phases.get()).groupOperations())
+        .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+        .allSatisfy(
+            (physicalTenantId, operations) ->
+                Assertions.assertThat(operations)
+                    .describedAs("partitions of physical tenant '%s'", physicalTenantId)
+                    .containsExactly(new PartitionForceReconfigureOperation(id0, 1, Set.of(id0))));
   }
 
   private void applyRequestAndVerifyResultingTopology(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveZoneTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveZoneTransformerTest.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
@@ -20,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRob
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
@@ -27,6 +32,7 @@ import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class ForceRemoveZoneTransformerTest {
@@ -146,5 +152,93 @@ final class ForceRemoveZoneTransformerTest {
     assertThat(result.getLeft())
         .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
         .hasMessageContaining("last remaining zone");
+  }
+
+  @Nested
+  class Phases {
+
+    private static final ZoneAwareConfig SURVIVING_CONFIG =
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000)));
+
+    @Test
+    void shouldPlanTheSameChangeAsTheLegacyPath() {
+      // given — a cluster with a single physical tenant, which is what the legacy path can express
+      final var topology = buildTopology(DUAL_ZONE_CONFIG, DUAL_ZONE_MEMBERS);
+      final var transformer = new ForceRemoveZoneTransformer(ZONE_B);
+
+      // when
+      final var phases = transformer.phases(CurrentClusterConfiguration.fromLegacy(topology));
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(CurrentClusterConfiguration.toPhases(transformer.operations(topology).get()));
+    }
+
+    /**
+     * A zone fails over for the whole cluster, so every tenant's partitions have to be handed to
+     * the brokers outside it. A tenant left out keeps replicas in the failed zone — and the member
+     * removal that follows refuses the whole failover over it.
+     */
+    @Test
+    void shouldEvictTheFailedZoneFromEveryPhysicalTenant() {
+      // given
+      final var configuration =
+          withMirroredTenant(buildTopology(DUAL_ZONE_CONFIG, DUAL_ZONE_MEMBERS));
+
+      // when — zone-b fails over
+      final var phases = new ForceRemoveZoneTransformer(ZONE_B).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(partitionGroupPhase(phases.get()).groupOperations())
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+          .allSatisfy(
+              (physicalTenantId, operations) ->
+                  assertThat(operations)
+                      .describedAs("partitions of physical tenant '%s'", physicalTenantId)
+                      .containsExactly(
+                          new PartitionForceReconfigureOperation(ZONE_A_0, 1, Set.of(ZONE_A_0)),
+                          new PartitionForceReconfigureOperation(ZONE_A_0, 2, Set.of(ZONE_A_0))));
+    }
+
+    /**
+     * The shrunk layout is persisted in the same phase that removes the zone's brokers, so the
+     * cluster never describes a zone layout its members do not match.
+     */
+    @Test
+    void shouldDropTheZoneFromTheLayoutAsTheBrokersAreRemoved() {
+      // given
+      final var configuration =
+          withMirroredTenant(buildTopology(DUAL_ZONE_CONFIG, DUAL_ZONE_MEMBERS));
+
+      // when
+      final var phases = new ForceRemoveZoneTransformer(ZONE_B).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get()).hasSize(2);
+      assertThat(((GlobalPhase) phases.get().getLast()).operations())
+          .containsExactly(
+              new MemberRemoveOperation(ZONE_A_0, ZONE_B_0),
+              new UpdatePartitionDistributorConfigOperation(ZONE_A_0, SURVIVING_CONFIG));
+    }
+
+    @Test
+    void shouldRejectAnInvalidRequestBeforePlanningAnyTenant() {
+      // given
+      final var configuration =
+          withMirroredTenant(buildTopology(DUAL_ZONE_CONFIG, DUAL_ZONE_MEMBERS));
+
+      // when
+      final var phases = new ForceRemoveZoneTransformer(ZONE_C).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+          .satisfies(error -> assertThat(error).hasMessageContaining("unknown zone"));
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformerTest.java
@@ -7,19 +7,25 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ForceScaleDownRequestTransformerTest {
@@ -90,5 +96,135 @@ class ForceScaleDownRequestTransformerTest {
     // then
     EitherAssert.assertThat(result).isLeft();
     assertThat(result.getLeft()).isInstanceOf(InvalidRequest.class);
+  }
+
+  @Nested
+  class Phases {
+
+    @Test
+    void shouldPlanTheSameChangeAsTheLegacyPath() {
+      // given — a cluster with a single physical tenant, which is what the legacy path can express
+      final var transformer = new ForceScaleDownRequestTransformer(Set.of(id0, id2), id0);
+
+      // when
+      final var phases =
+          transformer.phases(CurrentClusterConfiguration.fromLegacy(currentTopology));
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get())
+          .isEqualTo(
+              CurrentClusterConfiguration.toPhases(transformer.operations(currentTopology).get()));
+    }
+
+    /**
+     * The brokers are gone for every tenant at once, so every tenant's partitions have to be handed
+     * to the brokers that survive. A tenant left out keeps replicas on brokers that no longer exist
+     * — and the member removal that follows refuses the whole plan over it.
+     */
+    @Test
+    void shouldForceReconfigureEveryPhysicalTenantsPartitions() {
+      // given
+      final var configuration = withMirroredTenant(currentTopology);
+
+      // when — brokers 1 and 3 are gone
+      final var phases =
+          new ForceScaleDownRequestTransformer(Set.of(id0, id2), id0).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(partitionGroupPhase(phases.get()).groupOperations())
+          .containsOnlyKeys(CurrentClusterConfiguration.DEFAULT_GROUP, TENANT_A)
+          .allSatisfy(
+              (physicalTenantId, operations) ->
+                  assertThat(operations)
+                      .describedAs("partitions of physical tenant '%s'", physicalTenantId)
+                      .containsExactly(
+                          new PartitionForceReconfigureOperation(id0, 1, Set.of(id0)),
+                          new PartitionForceReconfigureOperation(id2, 2, Set.of(id2))));
+    }
+
+    /**
+     * A broker may only leave the member set once nothing replicates on it any more, so the removal
+     * is a phase of its own after the one that reconfigures every tenant.
+     */
+    @Test
+    void shouldRemoveTheBrokersOnlyAfterEveryTenantIsReconfigured() {
+      // given
+      final var configuration = withMirroredTenant(currentTopology);
+
+      // when
+      final var phases =
+          new ForceScaleDownRequestTransformer(Set.of(id0, id2), id0).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases).isRight();
+      assertThat(phases.get()).hasSize(2);
+      assertThat(((GlobalPhase) phases.get().getLast()).operations())
+          .containsExactly(
+              new MemberRemoveOperation(id0, id1), new MemberRemoveOperation(id0, id3));
+    }
+
+    /**
+     * Rejecting is what the default tenant's path already does, and the recoverable answer of the
+     * two: the operator can retain one more broker and ask again, where a removal that proceeded
+     * cannot be undone. The tenants that would lose a partition are named, because the request that
+     * triggers this does not mention them — it names brokers.
+     */
+    @Test
+    void shouldRejectWhenAnyPhysicalTenantsPartitionWouldLoseEveryReplica() {
+      // given — the default tenant's partition 1 survives on broker 0, tenant A's does not survive
+      // at all
+      final var configuration = twoTenants(partitionOne(id0, id1), partitionOne(id1));
+
+      // when — broker 1 is gone
+      final var phases =
+          new ForceScaleDownRequestTransformer(Set.of(id0, id2, id3), id0).phases(configuration);
+
+      // then
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(InvalidRequest.class)
+          .satisfies(
+              error ->
+                  assertThat(error)
+                      .hasMessageContaining("having no replicas")
+                      .hasMessageContaining("{%s=[1]}".formatted(TENANT_A)));
+    }
+
+    /** A cluster of the four members, where only the given brokers replicate partition 1. */
+    private ClusterConfiguration partitionOne(final MemberId... replicas) {
+      var topology = ClusterConfiguration.init();
+      for (final var member : Set.of(id0, id1, id2, id3)) {
+        topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
+      }
+      var priority = 1;
+      for (final var replica : replicas) {
+        final var partition = PartitionState.active(priority++, partitionConfig);
+        topology = topology.updateMember(replica, member -> member.addPartition(1, partition));
+      }
+      return topology;
+    }
+
+    /**
+     * Two physical tenants whose partitions are placed differently, unlike the mirrored pair the
+     * other tests use: only a tenant that can lose a partition the other one keeps shows that each
+     * tenant is judged on its own replicas.
+     */
+    private CurrentClusterConfiguration twoTenants(
+        final ClusterConfiguration defaultTenant, final ClusterConfiguration otherTenant) {
+      final var defaultGroup = CurrentClusterConfiguration.DEFAULT_GROUP;
+      final var base = CurrentClusterConfiguration.fromLegacy(defaultTenant);
+      return new CurrentClusterConfiguration(
+          base.version(),
+          base.globalConfiguration(),
+          Map.of(
+              defaultGroup,
+              base.partitionGroup(defaultGroup),
+              TENANT_A,
+              CurrentClusterConfiguration.fromLegacy(otherTenant).partitionGroup(defaultGroup)),
+          base.phasedChangeState());
+    }
   }
 }


### PR DESCRIPTION
The forced removal paths — `POST /actuator/cluster/brokers?force=true`, `PATCH /actuator/cluster?force=true` with `brokers.remove`, and `DELETE /actuator/cluster/zones/{zoneId}` — force-reconfigured the default physical tenant's partitions only, so on a cluster with more than one tenant the member removal that follows found the departing broker still replicating another tenant's partitions and refused the whole plan during validation. The configuration was left untouched, and since these are the recovery paths there was no graceful alternative: a graceful removal needs the departing brokers alive to move their partitions off.

`ForceScaleDownRequestTransformer` now plans the reconfiguration for every tenant's partition group in one phase and removes the brokers in the phase after it, and the two requests that delegate to it — force-removing named brokers, and removing a failed zone — inherit that. A zone removal still persists the shrunk layout, in the same phase that removes the brokers, so the cluster never describes a zone layout its members do not match. This is not a variant of the graceful path and does not reuse its planner: there is no distributor run and no data movement, only each partition handed to whichever of the retained brokers still hold it.

The first acceptance criterion asked for a decision, and the decision is to reject: a forced removal that would leave any tenant's partition without a single replica refuses the whole request and names the tenants and partitions it would lose. That is what the default tenant's path already does, so no tenant on a multi-tenant cluster gets a weaker guarantee than a single-tenant cluster has today, and it is the recoverable answer of the two — an operator can retain one more broker and ask again, where a removal that proceeded cannot be undone. Accepting the loss deliberately should be an explicit opt-in on the request rather than the default, which is new API surface and belongs in its own issue. The trade being made is that one unlucky tenant now blocks a removal the other tenants would have been fine with, which is why the error names the tenants: the request names brokers, so otherwise an operator cannot tell which tenant is in the way.

The two cases the issue names are driven through the coordinator rather than the transformers, because the refusal came from the appliers rather than from the plan — without the fix both fail with exactly the error an operator saw. Each transformer test additionally pins that a single-tenant cluster plans exactly what it planned before, by comparing against the legacy path rather than a re-derived expectation.

Stacked on #60429, which is itself stacked on #60424, #60420 and #60348; review those first, and the base moves down the stack as they merge.

closes #60343