### PR TITLE
Partially shadow scope variables with input mappings

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -94,9 +94,6 @@ public final class BpmnVariableMappingBehavior {
 
     final var resultBuilder =
         new InputMappingResultBuilder(
-            // the value a nested target partially shadows: resolved from the element's own scope
-            // key, walking up the chain exactly as an unmapped name does, so a partially mapped
-            // name falls through to the same value a never-mapped read of it would have seen
             name -> variablesState.getVariable(scopeKey, BufferUtil.wrapString(name)));
     // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
     // for input mappings, so a modeled reference survives evaluation instead of nulling

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -17,8 +17,9 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
-import io.camunda.zeebe.engine.processing.variable.MappingResultBuilder;
+import io.camunda.zeebe.engine.processing.variable.InputMappingResultBuilder;
 import io.camunda.zeebe.engine.processing.variable.MsgPackPath;
+import io.camunda.zeebe.engine.processing.variable.OutputMappingResultBuilder;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -92,7 +93,7 @@ public final class BpmnVariableMappingBehavior {
     }
 
     final var resultBuilder =
-        MappingResultBuilder.forInputMappings(
+        new InputMappingResultBuilder(
             // the value a nested target partially shadows: resolved from the element's own scope
             // key, walking up the chain exactly as an unmapped name does, so a partially mapped
             // name falls through to the same value a never-mapped read of it would have seen
@@ -166,7 +167,7 @@ public final class BpmnVariableMappingBehavior {
       // it and keep the existing sibling properties: look up the top-level variable in the element
       // scope, then navigate into it along the remaining path segments (null when absent).
       final var resultBuilder =
-          MappingResultBuilder.forOutputMappings(
+          new OutputMappingResultBuilder(
               path ->
                   Optional.ofNullable(
                           variablesState.getVariable(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -89,7 +89,7 @@ public final class BpmnVariableMappingBehavior {
       return Either.right(null);
     }
 
-    final var resultBuilder = new MappingResultBuilder();
+    final var resultBuilder = MappingResultBuilder.forInputMappings(name -> null);
     // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
     // for input mappings, so a modeled reference survives evaluation instead of nulling
     final var processor =
@@ -159,7 +159,7 @@ public final class BpmnVariableMappingBehavior {
       // it and keep the existing sibling properties: look up the top-level variable in the element
       // scope, then navigate into it along the remaining path segments (null when absent).
       final var resultBuilder =
-          new MappingResultBuilder(
+          MappingResultBuilder.forOutputMappings(
               path ->
                   Optional.ofNullable(
                           variablesState.getVariable(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -71,8 +71,10 @@ public final class BpmnVariableMappingBehavior {
    * Apply the input mappings for a BPMN element. Generally called on activating of the element.
    *
    * <p>The mappings are evaluated one by one in modeling order. Each mapping's source expression
-   * sees the results of the earlier mappings (they take priority over same-named scope variables)
-   * and falls back to the element's variable scope otherwise. Evaluation stops at the first failing
+   * sees the results of the earlier mappings and falls back to the element's variable scope
+   * otherwise. An earlier result at a nested target shadows a same-named scope variable only
+   * partially: the keys it defined win, and the rest fall through to the scope value. An earlier
+   * result assigned to a whole name shadows it totally. Evaluation stops at the first failing
    * mapping and no variables are applied in that case.
    *
    * @param context The current bpmn element context
@@ -89,7 +91,12 @@ public final class BpmnVariableMappingBehavior {
       return Either.right(null);
     }
 
-    final var resultBuilder = MappingResultBuilder.forInputMappings(name -> null);
+    final var resultBuilder =
+        MappingResultBuilder.forInputMappings(
+            // the value a nested target partially shadows: resolved from the element's own scope
+            // key, walking up the chain exactly as an unmapped name does, so a partially mapped
+            // name falls through to the same value a never-mapped read of it would have seen
+            name -> variablesState.getVariable(scopeKey, BufferUtil.wrapString(name)));
     // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
     // for input mappings, so a modeled reference survives evaluation instead of nulling
     final var processor =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMapping.java
@@ -14,7 +14,8 @@ import org.jspecify.annotations.NullMarked;
 /**
  * A single transformed input mapping: the parsed source expression and the target path it is stored
  * under, split into its {@code '.'}-separated segments (e.g. target {@code a.b.c} becomes {@code
- * [a, b, c]}). Input mappings are evaluated one by one in modeling order at runtime.
+ * [a, b, c]}). Input mappings are evaluated one by one in modeling order at runtime, and a nested
+ * target shadows a same-named variable from a higher scope only for the keys it defines.
  */
 @NullMarked
 public record InputMapping(Expression source, List<String> targetPath) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMapping.java
@@ -16,7 +16,7 @@ import org.jspecify.annotations.NullMarked;
  * stored under, split into its {@code '.'}-separated segments (e.g. target {@code a.b.c} becomes
  * {@code [a, b, c]}). Output mappings are evaluated one by one in modeling order at runtime; a
  * nested target merges with the existing scope value at every path level (see {@code
- * MappingResultBuilder}).
+ * OutputMappingResultBuilder}).
  */
 @NullMarked
 public record OutputMapping(Expression source, List<String> targetPath) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -39,11 +39,13 @@ import java.util.stream.Collectors;
  * {@link OutputMapping} and {@code BpmnVariableMappingBehavior}).
  *
  * <p>Input and output mappings differ in how a nested target relates to the existing scope variable
- * at runtime, and both differences are handled by {@code MappingResultBuilder}. An output mapping's
- * result is merged into that variable if it is a JSON object, at every nesting level, so the merged
- * value is what gets written. An input mapping's result is not merged — it is written as-is — but a
- * later source reading the target's root name sees the mapped keys layered over the value the scope
- * chain resolves, so a mapping shadows only the keys it defines.
+ * at runtime, and each difference is handled by its own {@code MappingResultBuilder}
+ * implementation. An output mapping's result is merged into that variable if it is a JSON object,
+ * at every nesting level, so the merged value is what gets written ({@code
+ * OutputMappingResultBuilder}). An input mapping's result is not merged — it is written as-is — but
+ * a later source reading the target's root name sees the mapped keys layered over the value the
+ * scope chain resolves, so a mapping shadows only the keys it defines ({@code
+ * InputMappingResultBuilder}).
  */
 public final class VariableMappingTransformer {
 
@@ -92,7 +94,7 @@ public final class VariableMappingTransformer {
    * Transforms the output mappings, keeping each mapping as its own source expression plus target
    * path so they can be evaluated one by one in modeling order at runtime. A nested target merges
    * with the existing scope value at every path level at runtime (see {@code
-   * MappingResultBuilder}).
+   * OutputMappingResultBuilder}).
    */
   public List<OutputMapping> transformOutputMappings(
       final Collection<? extends ZeebeMapping> outputMappings,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -43,9 +43,9 @@ import java.util.stream.Collectors;
  * implementation. An output mapping's result is merged into that variable if it is a JSON object,
  * at every nesting level, so the merged value is what gets written ({@code
  * OutputMappingResultBuilder}). An input mapping's result is not merged — it is written as-is — but
- * a later source reading the target's root name sees the mapped keys layered over the value the
- * scope chain resolves, so a mapping shadows only the keys it defines ({@code
- * InputMappingResultBuilder}).
+ * when a later mapping in the same list reads that root name in its own source, it sees the mapped
+ * keys layered over the value the scope chain resolves, so a mapping shadows only the keys it
+ * defines ({@code InputMappingResultBuilder}).
  */
 public final class VariableMappingTransformer {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -38,10 +38,12 @@ import java.util.stream.Collectors;
  * runtime, with each mapping's result visible to subsequent mappings (see {@link InputMapping},
  * {@link OutputMapping} and {@code BpmnVariableMappingBehavior}).
  *
- * <p>Output mappings differ from input mappings in how a nested target is merged at runtime: the
- * result must be merged with the existing scope variable if that variable is a JSON object, at
- * every nesting level. This merging is done by {@code MappingResultBuilder} while accumulating
- * results.
+ * <p>Input and output mappings differ in how a nested target relates to the existing scope variable
+ * at runtime, and both differences are handled by {@code MappingResultBuilder}. An output mapping's
+ * result is merged into that variable if it is a JSON object, at every nesting level, so the merged
+ * value is what gets written. An input mapping's result is not merged — it is written as-is — but a
+ * later source reading the target's root name sees the mapped keys layered over the value the scope
+ * chain resolves, so a mapping shadows only the keys it defines.
  */
 public final class VariableMappingTransformer {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/InputMappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/InputMappingResultBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.agrona.DirectBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link MappingResultBuilder} for input mappings: a mapping to a nested target descends into (or
+ * creates) intermediate objects and never merges into the accumulated document; a mapping whose
+ * target collides structurally with an earlier one (a value where an object is needed, or vice
+ * versa) replaces the earlier entry — last-wins. A <em>read</em> of a name a nested target built is
+ * layered over the value that name resolves to in the element's scope chain, so keys no mapping
+ * defined fall through instead of disappearing. A level an earlier mapping assigned whole shadows
+ * that value totally and stops the fall-through for its whole subtree.
+ */
+@NullMarked
+public final class InputMappingResultBuilder implements MappingResultBuilder {
+
+  private final Map<String, Object> entries = new LinkedHashMap<>();
+
+  /**
+   * Resolves a top-level variable name to the value the element's scope chain gives it — the value
+   * a nested target partially shadows.
+   */
+  private final Function<String, @Nullable DirectBuffer> scopeValueResolver;
+
+  /**
+   * @param scopeValueResolver resolves a top-level variable name to the value the scope chain gives
+   *     it, or {@code null} when there is none
+   */
+  public InputMappingResultBuilder(
+      final Function<String, @Nullable DirectBuffer> scopeValueResolver) {
+    this.scopeValueResolver = scopeValueResolver;
+  }
+
+  /**
+   * Puts a copy of the given MsgPack value at the nested target path. The value buffer is copied
+   * because evaluation result buffers are transient and may be reused by the next evaluation.
+   */
+  @Override
+  public void put(final List<String> targetPath, final DirectBuffer value) {
+    Map<String, Object> current = entries;
+    for (int i = 0; i < targetPath.size() - 1; i++) {
+      current = getOrCreate(current, targetPath.get(i)).children();
+    }
+    current.put(targetPath.getLast(), BufferUtil.cloneBuffer(value));
+  }
+
+  /**
+   * Returns the accumulated value of the given top-level variable, or {@code null} if no mapping
+   * has produced it yet. A nested structure is serialized on lookup, layered over the value its
+   * name resolves to in the scope chain, unless an earlier mapping assigned that name whole.
+   */
+  @Override
+  public @Nullable DirectBuffer getVariable(final String name) {
+    final var entry = entries.get(name);
+    if (entry == null) {
+      return null;
+    } else if (entry instanceof final DirectBuffer value) {
+      return value;
+    } else {
+      final var level = (MappingLevels.Level) entry;
+      final var shadowed = level.replacedExistingValue() ? null : scopeValueResolver.apply(name);
+      return MappingLevels.serialize(level.children(), shadowed);
+    }
+  }
+
+  /** Returns all accumulated results as a single MsgPack document (a map). */
+  @Override
+  public DirectBuffer toDocument() {
+    return MappingLevels.serialize(entries, null);
+  }
+
+  /**
+   * Returns the level at the given key, creating a fresh (never seeded) one if the current entry is
+   * absent or a plain value. A plain value means an earlier mapping already assigned this whole
+   * path, so the fresh level is marked as having replaced it and never falls through to it on read.
+   */
+  private MappingLevels.Level getOrCreate(final Map<String, Object> parent, final String key) {
+    final var entry = parent.get(key);
+    if (entry instanceof final MappingLevels.Level level) {
+      return level;
+    }
+    final var fresh = MappingLevels.Level.fresh(entry != null);
+    parent.put(key, fresh);
+    return fresh;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/InputMappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/InputMappingResultBuilder.java
@@ -28,6 +28,16 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public final class InputMappingResultBuilder implements MappingResultBuilder {
 
+  /**
+   * Values are either a MsgPack {@link DirectBuffer} — a value assigned to that whole name — or a
+   * {@link MappingLevels.Level} built by one or more dotted targets. Never a poisoned level: only
+   * output mappings can produce one.
+   *
+   * <p>Insertion-ordered deliberately. This order becomes the order the VARIABLE records are
+   * written in when the document is merged into the scope, and the key order inside the MsgPack
+   * bytes of a stored nested value. Both must come out identical on every replica, so it cannot be
+   * left to {@link java.util.HashMap}'s iteration order.
+   */
   private final Map<String, Object> entries = new LinkedHashMap<>();
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingLevels.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingLevels.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackCodes;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The msgpack representation shared by {@link InputMappingResultBuilder} and {@link
+ * OutputMappingResultBuilder}: an accumulated level, the poison sentinel, and the (optionally
+ * layered) serializer. Package-private and mode-agnostic — neither builder's notion of what a level
+ * means belongs here, only the structure both of them accumulate.
+ */
+@NullMarked
+final class MappingLevels {
+
+  /**
+   * Marks a nested level whose existing scope value was not a context: the level evaluates to null,
+   * matching FEEL's {@code context merge(<non-context>, {...})}. Serialized as NIL. Only {@link
+   * OutputMappingResultBuilder} ever produces one.
+   */
+  static final Object POISON = new Object();
+
+  static final DirectBuffer NIL = new UnsafeBuffer(new byte[] {MsgPackCodes.NIL});
+
+  private MappingLevels() {}
+
+  static boolean isNil(final DirectBuffer value) {
+    return value.capacity() == 1 && value.getByte(0) == MsgPackCodes.NIL;
+  }
+
+  /** Reads the top level of a msgpack map into a builder map; values stay opaque cloned slices. */
+  static Map<String, Object> deserializeTopLevel(final DirectBuffer map) {
+    final var result = new LinkedHashMap<String, Object>();
+    final var reader = new MsgPackReader();
+    reader.wrap(map, 0, map.capacity());
+    final int entryCount = reader.readMapHeader();
+    for (int i = 0; i < entryCount; i++) {
+      final var key = BufferUtil.bufferAsString(reader.readToken().getValueBuffer());
+      final int valueOffset = reader.getOffset();
+      reader.skipValue();
+      final var slice = new UnsafeBuffer(map, valueOffset, reader.getOffset() - valueOffset);
+      result.put(key, BufferUtil.cloneBuffer(slice));
+    }
+    return result;
+  }
+
+  /**
+   * Serializes a (possibly deeply nested) level, layering it over the given shadowed value. Pass
+   * {@code null} to serialize the level as-is.
+   */
+  static DirectBuffer serialize(
+      final Map<String, Object> children, final @Nullable DirectBuffer shadowed) {
+    final var writer = new MsgPackWriter();
+    final var buffer = new ExpandableArrayBuffer();
+    writer.wrap(buffer, 0);
+    writeLayered(writer, children, shadowed);
+    return new UnsafeBuffer(buffer, 0, writer.getOffset());
+  }
+
+  /**
+   * Writes a level to msgpack using an iterative depth-first traversal instead of recursion. A
+   * {@code zeebe:input} target path can have an unbounded number of '.'-separated segments
+   * (ZeebeExpressionValidator's path pattern doesn't cap it), and this runs on every element
+   * activation — plain recursion here previously let a deeply-nested target throw an uncaught
+   * StackOverflowError before NestingDepthValidator ever got a chance to reject the document
+   * gracefully.
+   *
+   * <p>At each level the accumulated entries are written over the top level of the value that level
+   * shadows, so a key no mapping defined resolves to the shadowed value's key. A level that an
+   * earlier mapping assigned whole shadows totally and stops the fall-through for its whole
+   * subtree.
+   */
+  private static void writeLayered(
+      final MsgPackWriter writer,
+      final Map<String, Object> rootChildren,
+      final @Nullable DirectBuffer rootShadowed) {
+    final Deque<LevelFrame> pending = new ArrayDeque<>();
+    pending.push(openLevel(writer, rootChildren, rootShadowed));
+
+    while (!pending.isEmpty()) {
+      final var frame = pending.peek();
+      if (!frame.entries().hasNext()) {
+        pending.pop();
+        continue;
+      }
+      final var entry = frame.entries().next();
+      writer.writeString(BufferUtil.wrapString(entry.getKey()));
+      final var value = entry.getValue();
+      if (value instanceof final Level level) {
+        pending.push(
+            openLevel(writer, level.children(), shadowedChildOf(frame, entry.getKey(), level)));
+      } else if (value == POISON) {
+        writer.writeNil();
+      } else {
+        writer.writeRaw((DirectBuffer) value);
+      }
+    }
+  }
+
+  /**
+   * Writes the map header for one level and returns the frame to iterate it: the level's own
+   * entries written over the top level of the value it shadows.
+   */
+  private static LevelFrame openLevel(
+      final MsgPackWriter writer,
+      final Map<String, Object> children,
+      final @Nullable DirectBuffer shadowed) {
+    final Map<String, Object> shadowedChildren =
+        shadowed != null && !isNil(shadowed) && MsgPackCodes.isMap(shadowed.getByte(0))
+            ? deserializeTopLevel(shadowed)
+            : Map.of();
+    final Map<String, Object> merged;
+    if (shadowedChildren.isEmpty()) {
+      merged = children;
+    } else {
+      // a fresh map: the accumulated level must not gain the shadowed value's keys
+      merged = new LinkedHashMap<>(shadowedChildren);
+      merged.putAll(children);
+    }
+    writer.writeMapHeader(merged.size());
+    return new LevelFrame(merged.entrySet().iterator(), shadowedChildren);
+  }
+
+  private static @Nullable DirectBuffer shadowedChildOf(
+      final LevelFrame frame, final String key, final Level level) {
+    if (level.replacedExistingValue()) {
+      return null;
+    }
+    return frame.shadowedChildren().get(key) instanceof final DirectBuffer shadowed
+        ? shadowed
+        : null;
+  }
+
+  /** One level of the iterative traversal: the entries to write, and what they shadow. */
+  private record LevelFrame(
+      Iterator<Map.Entry<String, Object>> entries, Map<String, Object> shadowedChildren) {}
+
+  /**
+   * A nested level built by one or more dotted target paths.
+   *
+   * @param children the level's entries: a nested {@link Level}, {@link #POISON}, or a MsgPack
+   *     {@link DirectBuffer}
+   * @param replacedExistingValue whether this level replaced a plain value rather than being
+   *     created from nothing — a neutral structural fact both builders compute. {@link
+   *     InputMappingResultBuilder} is the only one that acts on it: such a level never falls
+   *     through to the value it replaced on a read, because that earlier assignment already
+   *     replaced that value outright, and re-creating the level is a fresh start (structural
+   *     last-wins) rather than a merge into what it dropped.
+   */
+  record Level(Map<String, Object> children, boolean replacedExistingValue) {
+    static Level fresh(final boolean replacedExistingValue) {
+      return new Level(new LinkedHashMap<>(), replacedExistingValue);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingLevels.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingLevels.java
@@ -24,21 +24,12 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * The msgpack representation shared by {@link InputMappingResultBuilder} and {@link
- * OutputMappingResultBuilder}: an accumulated level, the poison sentinel, and the (optionally
- * layered) serializer. Package-private and mode-agnostic — neither builder's notion of what a level
- * means belongs here, only the structure both of them accumulate.
+ * OutputMappingResultBuilder}: an accumulated level and the (optionally layered) serializer.
+ * Package-private and mode-agnostic — neither builder's notion of what a level means belongs here,
+ * only the structure both of them accumulate.
  */
 @NullMarked
 final class MappingLevels {
-
-  /**
-   * Marks a nested level whose existing scope value was not a context: the level evaluates to null,
-   * matching FEEL's {@code context merge(<non-context>, {...})}. Serialized as NIL. Only {@link
-   * OutputMappingResultBuilder} ever produces one.
-   */
-  static final Object POISON = new Object();
-
-  static final DirectBuffer NIL = new UnsafeBuffer(new byte[] {MsgPackCodes.NIL});
 
   private MappingLevels() {}
 
@@ -107,8 +98,6 @@ final class MappingLevels {
       if (value instanceof final Level level) {
         pending.push(
             openLevel(writer, level.children(), shadowedChildOf(frame, entry.getKey(), level)));
-      } else if (value == POISON) {
-        writer.writeNil();
       } else {
         writer.writeRaw((DirectBuffer) value);
       }
@@ -156,8 +145,7 @@ final class MappingLevels {
   /**
    * A nested level built by one or more dotted target paths.
    *
-   * @param children the level's entries: a nested {@link Level}, {@link #POISON}, or a MsgPack
-   *     {@link DirectBuffer}
+   * @param children the level's entries: a nested {@link Level} or a MsgPack {@link DirectBuffer}
    * @param replacedExistingValue whether this level replaced a plain value rather than being
    *     created from nothing — a neutral structural fact both builders compute. {@link
    *     InputMappingResultBuilder} is the only one that acts on it: such a level never falls

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
@@ -121,9 +121,10 @@ public final class MappingResultBuilder {
 
   /**
    * Returns the accumulated value of the given top-level variable, or {@code null} if no mapping
-   * has produced it yet. Nested structures are serialized to a MsgPack document on lookup. A
-   * poisoned top-level entry returns a NIL buffer (not Java {@code null}, which would let the
-   * caller fall back to the scope lookup instead of seeing the poisoned null).
+   * has produced it yet. A nested structure is serialized on lookup, layered over the value its
+   * name resolves to in the scope chain (input mappings only) unless an earlier mapping assigned
+   * that name whole. A poisoned top-level entry returns a NIL buffer (not Java {@code null}, which
+   * would let the caller fall back to the scope lookup instead of seeing the poisoned null).
    */
   public @Nullable DirectBuffer getVariable(final String name) {
     final var entry = entries.get(name);
@@ -134,13 +135,15 @@ public final class MappingResultBuilder {
     } else if (entry instanceof final DirectBuffer value) {
       return value;
     } else {
-      return serialize(((NestedLevel) entry).children());
+      final var level = (NestedLevel) entry;
+      final var shadowed = level.totallyShadowed() ? null : shadowedValueResolver.apply(name);
+      return serializeLayered(level.children(), shadowed);
     }
   }
 
   /** Returns all accumulated results as a single MsgPack document (a map). */
   public DirectBuffer toDocument() {
-    return serialize(entries);
+    return serializeLayered(entries, null);
   }
 
   /**
@@ -197,38 +200,47 @@ public final class MappingResultBuilder {
     return result;
   }
 
-  private DirectBuffer serialize(final Map<String, Object> map) {
+  /**
+   * Serializes a (possibly deeply nested) level, layering it over the given shadowed value. Pass
+   * {@code null} to serialize the level as-is.
+   */
+  private DirectBuffer serializeLayered(
+      final Map<String, Object> children, final @Nullable DirectBuffer shadowed) {
     final var buffer = new ExpandableArrayBuffer();
     writer.wrap(buffer, 0);
-    writeMap(map);
+    writeLayered(children, shadowed);
     return new UnsafeBuffer(buffer, 0, writer.getOffset());
   }
 
   /**
-   * Writes a (possibly deeply nested) result map to msgpack using an iterative depth-first
-   * traversal instead of recursion. A {@code zeebe:input} target path can have an unbounded number
-   * of '.'-separated segments (ZeebeExpressionValidator's path pattern doesn't cap it), and this
-   * runs on every element activation — plain recursion here previously let a deeply-nested target
-   * throw an uncaught StackOverflowError before NestingDepthValidator ever got a chance to reject
-   * the document gracefully.
+   * Writes a level to msgpack using an iterative depth-first traversal instead of recursion. A
+   * {@code zeebe:input} target path can have an unbounded number of '.'-separated segments
+   * (ZeebeExpressionValidator's path pattern doesn't cap it), and this runs on every element
+   * activation — plain recursion here previously let a deeply-nested target throw an uncaught
+   * StackOverflowError before NestingDepthValidator ever got a chance to reject the document
+   * gracefully.
+   *
+   * <p>At each level the accumulated entries are written over the top level of the value that level
+   * shadows, so a key no mapping defined resolves to the shadowed value's key. A level that an
+   * earlier mapping assigned whole shadows totally and stops the fall-through for its whole
+   * subtree.
    */
-  private void writeMap(final Map<String, Object> root) {
-    final Deque<Iterator<Map.Entry<String, Object>>> pending = new ArrayDeque<>();
-    writer.writeMapHeader(root.size());
-    pending.push(root.entrySet().iterator());
+  private void writeLayered(
+      final Map<String, Object> rootChildren, final @Nullable DirectBuffer rootShadowed) {
+    final Deque<LevelFrame> pending = new ArrayDeque<>();
+    pending.push(openLevel(rootChildren, rootShadowed));
 
     while (!pending.isEmpty()) {
-      final var iterator = pending.peek();
-      if (!iterator.hasNext()) {
+      final var frame = pending.peek();
+      if (!frame.entries().hasNext()) {
         pending.pop();
         continue;
       }
-      final var entry = iterator.next();
+      final var entry = frame.entries().next();
       writer.writeString(BufferUtil.wrapString(entry.getKey()));
       final var value = entry.getValue();
       if (value instanceof final NestedLevel level) {
-        writer.writeMapHeader(level.children().size());
-        pending.push(level.children().entrySet().iterator());
+        pending.push(openLevel(level.children(), shadowedChildOf(frame, entry.getKey(), level)));
       } else if (value == POISON) {
         writer.writeNil();
       } else {
@@ -236,6 +248,42 @@ public final class MappingResultBuilder {
       }
     }
   }
+
+  /**
+   * Writes the map header for one level and returns the frame to iterate it: the level's own
+   * entries written over the top level of the value it shadows.
+   */
+  private LevelFrame openLevel(
+      final Map<String, Object> children, final @Nullable DirectBuffer shadowed) {
+    final Map<String, Object> shadowedChildren =
+        shadowed != null && !isNil(shadowed) && MsgPackCodes.isMap(shadowed.getByte(0))
+            ? deserializeTopLevel(shadowed)
+            : Map.of();
+    final Map<String, Object> merged;
+    if (shadowedChildren.isEmpty()) {
+      merged = children;
+    } else {
+      // a fresh map: the accumulated level must not gain the shadowed value's keys
+      merged = new LinkedHashMap<>(shadowedChildren);
+      merged.putAll(children);
+    }
+    writer.writeMapHeader(merged.size());
+    return new LevelFrame(merged.entrySet().iterator(), shadowedChildren);
+  }
+
+  private static @Nullable DirectBuffer shadowedChildOf(
+      final LevelFrame frame, final String key, final NestedLevel level) {
+    if (level.totallyShadowed()) {
+      return null;
+    }
+    return frame.shadowedChildren().get(key) instanceof final DirectBuffer shadowed
+        ? shadowed
+        : null;
+  }
+
+  /** One level of the iterative traversal: the entries to write, and what they shadow. */
+  private record LevelFrame(
+      Iterator<Map.Entry<String, Object>> entries, Map<String, Object> shadowedChildren) {}
 
   /**
    * A nested level built by one or more dotted target paths.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
@@ -32,13 +32,18 @@ import org.jspecify.annotations.Nullable;
  * document to be merged into the element's local scope.
  *
  * <p>For input mappings ({@link #forInputMappings}), a mapping to a nested target descends into (or
- * creates) intermediate objects; a mapping whose target collides structurally with an earlier one
- * (a value where an object is needed, or vice versa) replaces the earlier entry — last-wins.
+ * creates) intermediate objects and never merges into the accumulated document; a mapping whose
+ * target collides structurally with an earlier one (a value where an object is needed, or vice
+ * versa) replaces the earlier entry — last-wins. A <em>read</em> of a name a nested target built is
+ * layered over the value that name resolves to in the element's scope chain, so keys no mapping
+ * defined fall through instead of disappearing. A level an earlier mapping assigned whole shadows
+ * that value totally and stops the fall-through for its whole subtree.
  *
  * <p>For output mappings ({@link #forOutputMappings}), a nested target instead merges with the
- * existing scope variable at every path level: a level that is absent or holds a plain value is
- * seeded from the current scope value at that path. A non-context scope value poisons the level to
- * null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
+ * existing scope variable at every path level while accumulating: a level that is absent or holds a
+ * plain value is seeded from the current scope value at that path. A non-context scope value
+ * poisons the level to null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
+ * Reads are not layered — the merge is already in the document.
  */
 @NullMarked
 public final class MappingResultBuilder {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
@@ -7,302 +7,34 @@
  */
 package io.camunda.zeebe.engine.processing.variable;
 
-import io.camunda.zeebe.msgpack.spec.MsgPackCodes;
-import io.camunda.zeebe.msgpack.spec.MsgPackReader;
-import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
-import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import org.agrona.DirectBuffer;
-import org.agrona.ExpandableArrayBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Accumulates the results of variable mappings that are evaluated one by one in modeling order.
- * Each mapping's result is stored under its (possibly nested) target path, and can be looked up by
- * its top-level variable name so that subsequent mappings can reference the values produced by
- * earlier mappings. {@link #toDocument()} returns the accumulated results as a single MsgPack
- * document to be merged into the element's local scope.
+ * Accumulates the results of variable mappings evaluated one by one in modeling order. Each
+ * mapping's result is stored under its (possibly nested) target path and can be looked up by its
+ * top-level variable name, so later mappings can reference what earlier ones produced.
  *
- * <p>For input mappings ({@link #forInputMappings}), a mapping to a nested target descends into (or
- * creates) intermediate objects and never merges into the accumulated document; a mapping whose
- * target collides structurally with an earlier one (a value where an object is needed, or vice
- * versa) replaces the earlier entry — last-wins. A <em>read</em> of a name a nested target built is
- * layered over the value that name resolves to in the element's scope chain, so keys no mapping
- * defined fall through instead of disappearing. A level an earlier mapping assigned whole shadows
- * that value totally and stops the fall-through for its whole subtree.
- *
- * <p>For output mappings ({@link #forOutputMappings}), a nested target instead merges with the
- * existing scope variable at every path level while accumulating: a level that is absent or holds a
- * plain value is seeded from the current scope value at that path. A non-context scope value
- * poisons the level to null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
- * Reads are not layered — the merge is already in the document.
+ * <p>The two implementations differ in how a nested target relates to the value already in scope,
+ * and they share no such logic: {@link InputMappingResultBuilder} writes only what was mapped and
+ * layers the scope value in on read; {@link OutputMappingResultBuilder} merges the scope value in
+ * while accumulating and reads back plainly.
  */
 @NullMarked
-public final class MappingResultBuilder {
+public sealed interface MappingResultBuilder
+    permits InputMappingResultBuilder, OutputMappingResultBuilder {
 
-  /**
-   * Marks a nested level whose existing scope value was not a context: the level evaluates to null,
-   * matching FEEL's {@code context merge(<non-context>, {...})}. Serialized as NIL.
-   */
-  private static final Object POISON = new Object();
-
-  private static final DirectBuffer NIL = new UnsafeBuffer(new byte[] {MsgPackCodes.NIL});
-
-  /**
-   * Values are either a nested {@link NestedLevel}, {@link #POISON}, or a MsgPack {@link
-   * DirectBuffer}.
-   */
-  private final Map<String, Object> entries = new LinkedHashMap<>();
-
-  private final MsgPackWriter writer = new MsgPackWriter();
-
-  /**
-   * Output mappings only: resolves a target-path prefix to the scope value to seed a level from.
-   */
-  private final Function<List<String>, @Nullable DirectBuffer> seedValueResolver;
-
-  /**
-   * Input mappings only: resolves a top-level variable name to the value the element's scope chain
-   * gives it — the value a nested target partially shadows.
-   */
-  private final Function<String, @Nullable DirectBuffer> shadowedValueResolver;
-
-  private MappingResultBuilder(
-      final Function<List<String>, @Nullable DirectBuffer> seedValueResolver,
-      final Function<String, @Nullable DirectBuffer> shadowedValueResolver) {
-    this.seedValueResolver = seedValueResolver;
-    this.shadowedValueResolver = shadowedValueResolver;
-  }
-
-  /**
-   * Builder for input mappings: a nested target never merges with the existing scope value while
-   * accumulating.
-   *
-   * @param shadowedValueResolver resolves a top-level variable name to the value the scope chain
-   *     gives it, or {@code null} when there is none
-   */
-  public static MappingResultBuilder forInputMappings(
-      final Function<String, @Nullable DirectBuffer> shadowedValueResolver) {
-    return new MappingResultBuilder(path -> null, shadowedValueResolver);
-  }
-
-  /**
-   * Builder for output mappings: when a nested target path needs a map at a level that is absent
-   * (or currently holds a plain value), the level is seeded from the existing scope value at that
-   * path. A non-context scope value poisons the level to null, matching FEEL's {@code context
-   * merge(<non-context>, {...})} behavior.
-   *
-   * @param seedValueResolver resolves a target-path prefix to the current scope value at that path,
-   *     or {@code null} when there is none; invoked only when a level must be (re)created
-   */
-  public static MappingResultBuilder forOutputMappings(
-      final Function<List<String>, @Nullable DirectBuffer> seedValueResolver) {
-    return new MappingResultBuilder(seedValueResolver, name -> null);
-  }
-
-  /**
-   * Puts a copy of the given MsgPack value at the nested target path. The value buffer is copied
-   * because evaluation result buffers are transient and may be reused by the next evaluation.
-   */
-  public void put(final List<String> targetPath, final DirectBuffer value) {
-    Map<String, Object> current = entries;
-    for (int i = 0; i < targetPath.size() - 1; i++) {
-      final var next = getOrSeedNested(current, targetPath.subList(0, i + 1));
-      if (next == null) {
-        return; // level is poisoned: the mapped value is discarded, the level stays null
-      }
-      current = next.children();
-    }
-    current.put(targetPath.getLast(), BufferUtil.cloneBuffer(value));
-  }
+  /** Puts a copy of the given MsgPack value at the nested target path. */
+  void put(List<String> targetPath, DirectBuffer value);
 
   /**
    * Returns the accumulated value of the given top-level variable, or {@code null} if no mapping
-   * has produced it yet. A nested structure is serialized on lookup, layered over the value its
-   * name resolves to in the scope chain (input mappings only) unless an earlier mapping assigned
-   * that name whole. A poisoned top-level entry returns a NIL buffer (not Java {@code null}, which
-   * would let the caller fall back to the scope lookup instead of seeing the poisoned null).
+   * has produced it yet — {@code null} tells the caller to fall back to the scope lookup.
    */
-  public @Nullable DirectBuffer getVariable(final String name) {
-    final var entry = entries.get(name);
-    if (entry == null) {
-      return null;
-    } else if (entry == POISON) {
-      return NIL;
-    } else if (entry instanceof final DirectBuffer value) {
-      return value;
-    } else {
-      final var level = (NestedLevel) entry;
-      final var shadowed = level.totallyShadowed() ? null : shadowedValueResolver.apply(name);
-      return serializeLayered(level.children(), shadowed);
-    }
-  }
+  @Nullable DirectBuffer getVariable(String name);
 
   /** Returns all accumulated results as a single MsgPack document (a map). */
-  public DirectBuffer toDocument() {
-    return serializeLayered(entries, null);
-  }
-
-  /**
-   * Returns the level at the given path prefix, creating it if the current entry is absent or a
-   * plain value. A newly created level is seeded with the top-level entries of the existing scope
-   * value at that path (children stay opaque buffers); a non-context scope value poisons the level
-   * instead. Returns {@code null} when the level is (or becomes) poisoned.
-   */
-  private @Nullable NestedLevel getOrSeedNested(
-      final Map<String, Object> parent, final List<String> pathPrefix) {
-    final var key = pathPrefix.getLast();
-    final var entry = parent.get(key);
-    if (entry == POISON) {
-      return null;
-    }
-    if (entry instanceof final NestedLevel level) {
-      return level;
-    }
-    // Absent, or a plain value from an earlier mapping. A plain value means that mapping already
-    // replaced whatever this path resolved to, so the re-created level must not fall through to it.
-    final var totallyShadowed = entry != null;
-    final var scopeValue = seedValueResolver.apply(pathPrefix);
-    if (scopeValue == null || isNil(scopeValue)) {
-      final var fresh = NestedLevel.fresh(totallyShadowed);
-      parent.put(key, fresh);
-      return fresh;
-    }
-    if (!MsgPackCodes.isMap(scopeValue.getByte(0))) {
-      parent.put(key, POISON);
-      return null;
-    }
-    final var seeded = new NestedLevel(deserializeTopLevel(scopeValue), totallyShadowed);
-    parent.put(key, seeded);
-    return seeded;
-  }
-
-  private static boolean isNil(final DirectBuffer value) {
-    return value.capacity() == 1 && value.getByte(0) == MsgPackCodes.NIL;
-  }
-
-  /** Reads the top level of a msgpack map into a builder map; values stay opaque cloned slices. */
-  private static Map<String, Object> deserializeTopLevel(final DirectBuffer map) {
-    final var result = new LinkedHashMap<String, Object>();
-    final var reader = new MsgPackReader();
-    reader.wrap(map, 0, map.capacity());
-    final int entryCount = reader.readMapHeader();
-    for (int i = 0; i < entryCount; i++) {
-      final var key = BufferUtil.bufferAsString(reader.readToken().getValueBuffer());
-      final int valueOffset = reader.getOffset();
-      reader.skipValue();
-      final var slice = new UnsafeBuffer(map, valueOffset, reader.getOffset() - valueOffset);
-      result.put(key, BufferUtil.cloneBuffer(slice));
-    }
-    return result;
-  }
-
-  /**
-   * Serializes a (possibly deeply nested) level, layering it over the given shadowed value. Pass
-   * {@code null} to serialize the level as-is.
-   */
-  private DirectBuffer serializeLayered(
-      final Map<String, Object> children, final @Nullable DirectBuffer shadowed) {
-    final var buffer = new ExpandableArrayBuffer();
-    writer.wrap(buffer, 0);
-    writeLayered(children, shadowed);
-    return new UnsafeBuffer(buffer, 0, writer.getOffset());
-  }
-
-  /**
-   * Writes a level to msgpack using an iterative depth-first traversal instead of recursion. A
-   * {@code zeebe:input} target path can have an unbounded number of '.'-separated segments
-   * (ZeebeExpressionValidator's path pattern doesn't cap it), and this runs on every element
-   * activation — plain recursion here previously let a deeply-nested target throw an uncaught
-   * StackOverflowError before NestingDepthValidator ever got a chance to reject the document
-   * gracefully.
-   *
-   * <p>At each level the accumulated entries are written over the top level of the value that level
-   * shadows, so a key no mapping defined resolves to the shadowed value's key. A level that an
-   * earlier mapping assigned whole shadows totally and stops the fall-through for its whole
-   * subtree.
-   */
-  private void writeLayered(
-      final Map<String, Object> rootChildren, final @Nullable DirectBuffer rootShadowed) {
-    final Deque<LevelFrame> pending = new ArrayDeque<>();
-    pending.push(openLevel(rootChildren, rootShadowed));
-
-    while (!pending.isEmpty()) {
-      final var frame = pending.peek();
-      if (!frame.entries().hasNext()) {
-        pending.pop();
-        continue;
-      }
-      final var entry = frame.entries().next();
-      writer.writeString(BufferUtil.wrapString(entry.getKey()));
-      final var value = entry.getValue();
-      if (value instanceof final NestedLevel level) {
-        pending.push(openLevel(level.children(), shadowedChildOf(frame, entry.getKey(), level)));
-      } else if (value == POISON) {
-        writer.writeNil();
-      } else {
-        writer.writeRaw((DirectBuffer) value);
-      }
-    }
-  }
-
-  /**
-   * Writes the map header for one level and returns the frame to iterate it: the level's own
-   * entries written over the top level of the value it shadows.
-   */
-  private LevelFrame openLevel(
-      final Map<String, Object> children, final @Nullable DirectBuffer shadowed) {
-    final Map<String, Object> shadowedChildren =
-        shadowed != null && !isNil(shadowed) && MsgPackCodes.isMap(shadowed.getByte(0))
-            ? deserializeTopLevel(shadowed)
-            : Map.of();
-    final Map<String, Object> merged;
-    if (shadowedChildren.isEmpty()) {
-      merged = children;
-    } else {
-      // a fresh map: the accumulated level must not gain the shadowed value's keys
-      merged = new LinkedHashMap<>(shadowedChildren);
-      merged.putAll(children);
-    }
-    writer.writeMapHeader(merged.size());
-    return new LevelFrame(merged.entrySet().iterator(), shadowedChildren);
-  }
-
-  private static @Nullable DirectBuffer shadowedChildOf(
-      final LevelFrame frame, final String key, final NestedLevel level) {
-    if (level.totallyShadowed()) {
-      return null;
-    }
-    return frame.shadowedChildren().get(key) instanceof final DirectBuffer shadowed
-        ? shadowed
-        : null;
-  }
-
-  /** One level of the iterative traversal: the entries to write, and what they shadow. */
-  private record LevelFrame(
-      Iterator<Map.Entry<String, Object>> entries, Map<String, Object> shadowedChildren) {}
-
-  /**
-   * A nested level built by one or more dotted target paths.
-   *
-   * @param children the level's entries: a nested {@link NestedLevel}, {@link #POISON}, or a
-   *     MsgPack {@link DirectBuffer}
-   * @param totallyShadowed whether an earlier mapping assigned this whole path a value before this
-   *     level was created. Such a level never falls through to the value it shadows on a read: the
-   *     earlier assignment already replaced that value outright, and re-creating the level is a
-   *     fresh start (structural last-wins) rather than a merge into what it dropped.
-   */
-  private record NestedLevel(Map<String, Object> children, boolean totallyShadowed) {
-    static NestedLevel fresh(final boolean totallyShadowed) {
-      return new NestedLevel(new LinkedHashMap<>(), totallyShadowed);
-    }
-  }
+  DirectBuffer toDocument();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilder.java
@@ -31,14 +31,14 @@ import org.jspecify.annotations.Nullable;
  * earlier mappings. {@link #toDocument()} returns the accumulated results as a single MsgPack
  * document to be merged into the element's local scope.
  *
- * <p>For input mappings (no-arg constructor), a mapping to a nested target descends into (or
+ * <p>For input mappings ({@link #forInputMappings}), a mapping to a nested target descends into (or
  * creates) intermediate objects; a mapping whose target collides structurally with an earlier one
  * (a value where an object is needed, or vice versa) replaces the earlier entry — last-wins.
  *
- * <p>For output mappings (constructor with a {@code scopeValueResolver}), a nested target instead
- * merges with the existing scope variable at every path level: a level that is absent or holds a
- * plain value is seeded from the current scope value at that path. A non-context scope value
- * poisons the level to null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
+ * <p>For output mappings ({@link #forOutputMappings}), a nested target instead merges with the
+ * existing scope variable at every path level: a level that is absent or holds a plain value is
+ * seeded from the current scope value at that path. A non-context scope value poisons the level to
+ * null, matching FEEL's {@code context merge(<non-context>, {...})} behavior.
  */
 @NullMarked
 public final class MappingResultBuilder {
@@ -52,32 +52,55 @@ public final class MappingResultBuilder {
   private static final DirectBuffer NIL = new UnsafeBuffer(new byte[] {MsgPackCodes.NIL});
 
   /**
-   * Values are either a nested {@code Map<String, Object>}, {@link #POISON}, or a MsgPack {@link
+   * Values are either a nested {@link NestedLevel}, {@link #POISON}, or a MsgPack {@link
    * DirectBuffer}.
    */
   private final Map<String, Object> entries = new LinkedHashMap<>();
 
   private final MsgPackWriter writer = new MsgPackWriter();
 
-  private final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver;
+  /**
+   * Output mappings only: resolves a target-path prefix to the scope value to seed a level from.
+   */
+  private final Function<List<String>, @Nullable DirectBuffer> seedValueResolver;
 
-  /** Builder for input mappings: nested targets never merge with existing scope values. */
-  public MappingResultBuilder() {
-    this(path -> null);
+  /**
+   * Input mappings only: resolves a top-level variable name to the value the element's scope chain
+   * gives it — the value a nested target partially shadows.
+   */
+  private final Function<String, @Nullable DirectBuffer> shadowedValueResolver;
+
+  private MappingResultBuilder(
+      final Function<List<String>, @Nullable DirectBuffer> seedValueResolver,
+      final Function<String, @Nullable DirectBuffer> shadowedValueResolver) {
+    this.seedValueResolver = seedValueResolver;
+    this.shadowedValueResolver = shadowedValueResolver;
+  }
+
+  /**
+   * Builder for input mappings: a nested target never merges with the existing scope value while
+   * accumulating.
+   *
+   * @param shadowedValueResolver resolves a top-level variable name to the value the scope chain
+   *     gives it, or {@code null} when there is none
+   */
+  public static MappingResultBuilder forInputMappings(
+      final Function<String, @Nullable DirectBuffer> shadowedValueResolver) {
+    return new MappingResultBuilder(path -> null, shadowedValueResolver);
   }
 
   /**
    * Builder for output mappings: when a nested target path needs a map at a level that is absent
    * (or currently holds a plain value), the level is seeded from the existing scope value at that
    * path. A non-context scope value poisons the level to null, matching FEEL's {@code context
-   * merge} behavior.
+   * merge(<non-context>, {...})} behavior.
    *
-   * @param scopeValueResolver resolves a target-path prefix to the current scope value at that
-   *     path, or {@code null} when there is none; invoked only when a level must be (re)created
+   * @param seedValueResolver resolves a target-path prefix to the current scope value at that path,
+   *     or {@code null} when there is none; invoked only when a level must be (re)created
    */
-  public MappingResultBuilder(
-      final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver) {
-    this.scopeValueResolver = scopeValueResolver;
+  public static MappingResultBuilder forOutputMappings(
+      final Function<List<String>, @Nullable DirectBuffer> seedValueResolver) {
+    return new MappingResultBuilder(seedValueResolver, name -> null);
   }
 
   /**
@@ -91,7 +114,7 @@ public final class MappingResultBuilder {
       if (next == null) {
         return; // level is poisoned: the mapped value is discarded, the level stays null
       }
-      current = next;
+      current = next.children();
     }
     current.put(targetPath.getLast(), BufferUtil.cloneBuffer(value));
   }
@@ -111,7 +134,7 @@ public final class MappingResultBuilder {
     } else if (entry instanceof final DirectBuffer value) {
       return value;
     } else {
-      return serialize(asNestedMap(entry));
+      return serialize(((NestedLevel) entry).children());
     }
   }
 
@@ -121,26 +144,27 @@ public final class MappingResultBuilder {
   }
 
   /**
-   * Returns the map at the given path prefix, creating it if the current entry is absent or a plain
-   * value. A newly created map is seeded with the top-level entries of the existing scope value at
-   * that path (children stay opaque buffers); a non-context scope value poisons the level instead.
-   * Returns {@code null} when the level is (or becomes) poisoned.
+   * Returns the level at the given path prefix, creating it if the current entry is absent or a
+   * plain value. A newly created level is seeded with the top-level entries of the existing scope
+   * value at that path (children stay opaque buffers); a non-context scope value poisons the level
+   * instead. Returns {@code null} when the level is (or becomes) poisoned.
    */
-  private @Nullable Map<String, Object> getOrSeedNested(
+  private @Nullable NestedLevel getOrSeedNested(
       final Map<String, Object> parent, final List<String> pathPrefix) {
     final var key = pathPrefix.getLast();
     final var entry = parent.get(key);
     if (entry == POISON) {
       return null;
     }
-    if (entry instanceof Map<?, ?>) {
-      return asNestedMap(entry);
+    if (entry instanceof final NestedLevel level) {
+      return level;
     }
-    // absent, or a plain value from an earlier mapping: re-seed the (re)created level from the
-    // scope value at this path, dropping the earlier plain value
-    final var scopeValue = scopeValueResolver.apply(pathPrefix);
+    // Absent, or a plain value from an earlier mapping. A plain value means that mapping already
+    // replaced whatever this path resolved to, so the re-created level must not fall through to it.
+    final var totallyShadowed = entry != null;
+    final var scopeValue = seedValueResolver.apply(pathPrefix);
     if (scopeValue == null || isNil(scopeValue)) {
-      final var fresh = new LinkedHashMap<String, Object>();
+      final var fresh = NestedLevel.fresh(totallyShadowed);
       parent.put(key, fresh);
       return fresh;
     }
@@ -148,7 +172,7 @@ public final class MappingResultBuilder {
       parent.put(key, POISON);
       return null;
     }
-    final var seeded = deserializeTopLevel(scopeValue);
+    final var seeded = new NestedLevel(deserializeTopLevel(scopeValue), totallyShadowed);
     parent.put(key, seeded);
     return seeded;
   }
@@ -171,11 +195,6 @@ public final class MappingResultBuilder {
       result.put(key, BufferUtil.cloneBuffer(slice));
     }
     return result;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Map<String, Object> asNestedMap(final Object entry) {
-    return (Map<String, Object>) entry;
   }
 
   private DirectBuffer serialize(final Map<String, Object> map) {
@@ -207,15 +226,30 @@ public final class MappingResultBuilder {
       final var entry = iterator.next();
       writer.writeString(BufferUtil.wrapString(entry.getKey()));
       final var value = entry.getValue();
-      if (value instanceof Map<?, ?>) {
-        final var nested = asNestedMap(value);
-        writer.writeMapHeader(nested.size());
-        pending.push(nested.entrySet().iterator());
+      if (value instanceof final NestedLevel level) {
+        writer.writeMapHeader(level.children().size());
+        pending.push(level.children().entrySet().iterator());
       } else if (value == POISON) {
         writer.writeNil();
       } else {
         writer.writeRaw((DirectBuffer) value);
       }
+    }
+  }
+
+  /**
+   * A nested level built by one or more dotted target paths.
+   *
+   * @param children the level's entries: a nested {@link NestedLevel}, {@link #POISON}, or a
+   *     MsgPack {@link DirectBuffer}
+   * @param totallyShadowed whether an earlier mapping assigned this whole path a value before this
+   *     level was created. Such a level never falls through to the value it shadows on a read: the
+   *     earlier assignment already replaced that value outright, and re-creating the level is a
+   *     fresh start (structural last-wins) rather than a merge into what it dropped.
+   */
+  private record NestedLevel(Map<String, Object> children, boolean totallyShadowed) {
+    static NestedLevel fresh(final boolean totallyShadowed) {
+      return new NestedLevel(new LinkedHashMap<>(), totallyShadowed);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilder.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackCodes;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.agrona.DirectBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link MappingResultBuilder} for output mappings: a nested target merges with the existing scope
+ * variable at every path level while accumulating — a level that is absent or holds a plain value
+ * is seeded from the current scope value at that path. A non-context scope value poisons the level
+ * to null, matching FEEL's {@code context merge(<non-context>, {...})} behavior. Reads are not
+ * layered — the merge is already in the document.
+ */
+@NullMarked
+public final class OutputMappingResultBuilder implements MappingResultBuilder {
+
+  private final Map<String, Object> entries = new LinkedHashMap<>();
+
+  /** Resolves a target-path prefix to the scope value to seed a level from. */
+  private final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver;
+
+  /**
+   * @param scopeValueResolver resolves a target-path prefix to the current scope value at that
+   *     path, or {@code null} when there is none; invoked only when a level must be (re)created
+   */
+  public OutputMappingResultBuilder(
+      final Function<List<String>, @Nullable DirectBuffer> scopeValueResolver) {
+    this.scopeValueResolver = scopeValueResolver;
+  }
+
+  /**
+   * Puts a copy of the given MsgPack value at the nested target path. The value buffer is copied
+   * because evaluation result buffers are transient and may be reused by the next evaluation.
+   */
+  @Override
+  public void put(final List<String> targetPath, final DirectBuffer value) {
+    Map<String, Object> current = entries;
+    for (int i = 0; i < targetPath.size() - 1; i++) {
+      final var next = getOrSeedNested(current, targetPath.subList(0, i + 1));
+      if (next == null) {
+        return; // level is poisoned: the mapped value is discarded, the level stays null
+      }
+      current = next.children();
+    }
+    current.put(targetPath.getLast(), BufferUtil.cloneBuffer(value));
+  }
+
+  /**
+   * Returns the accumulated value of the given top-level variable, or {@code null} if no mapping
+   * has produced it yet. A nested structure is serialized on lookup. A poisoned top-level entry
+   * returns a NIL buffer (not Java {@code null}, which would let the caller fall back to the scope
+   * lookup instead of seeing the poisoned null).
+   */
+  @Override
+  public @Nullable DirectBuffer getVariable(final String name) {
+    final var entry = entries.get(name);
+    if (entry == null) {
+      return null;
+    } else if (entry == MappingLevels.POISON) {
+      return MappingLevels.NIL;
+    } else if (entry instanceof final DirectBuffer value) {
+      return value;
+    } else {
+      final var level = (MappingLevels.Level) entry;
+      return MappingLevels.serialize(level.children(), null);
+    }
+  }
+
+  /** Returns all accumulated results as a single MsgPack document (a map). */
+  @Override
+  public DirectBuffer toDocument() {
+    return MappingLevels.serialize(entries, null);
+  }
+
+  /**
+   * Returns the level at the given path prefix, creating it if the current entry is absent or a
+   * plain value. A newly created level is seeded with the top-level entries of the existing scope
+   * value at that path (children stay opaque buffers); a non-context scope value poisons the level
+   * instead. Returns {@code null} when the level is (or becomes) poisoned.
+   */
+  private MappingLevels.@Nullable Level getOrSeedNested(
+      final Map<String, Object> parent, final List<String> pathPrefix) {
+    final var key = pathPrefix.getLast();
+    final var entry = parent.get(key);
+    if (entry == MappingLevels.POISON) {
+      return null;
+    }
+    if (entry instanceof final MappingLevels.Level level) {
+      return level;
+    }
+    // Absent, or a plain value from an earlier mapping. A plain value means that mapping already
+    // replaced whatever this path resolved to, so the re-created level must not fall through to it.
+    final var replacedExistingValue = entry != null;
+    final var scopeValue = scopeValueResolver.apply(pathPrefix);
+    if (scopeValue == null || MappingLevels.isNil(scopeValue)) {
+      final var fresh = MappingLevels.Level.fresh(replacedExistingValue);
+      parent.put(key, fresh);
+      return fresh;
+    }
+    if (!MsgPackCodes.isMap(scopeValue.getByte(0))) {
+      parent.put(key, MappingLevels.POISON);
+      return null;
+    }
+    final var seeded =
+        new MappingLevels.Level(
+            MappingLevels.deserializeTopLevel(scopeValue), replacedExistingValue);
+    parent.put(key, seeded);
+    return seeded;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilder.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -26,6 +27,15 @@ import org.jspecify.annotations.Nullable;
  */
 @NullMarked
 public final class OutputMappingResultBuilder implements MappingResultBuilder {
+
+  /**
+   * A level whose scope value was not a context: it evaluates to null, matching FEEL's {@code
+   * context merge(<non-context>, {...})}. Held as a pre-serialized msgpack nil so the shared
+   * serializer needs no knowledge of it — it is written like any other value buffer. Compared by
+   * identity, which is what distinguishes a poisoned level from a mapping that assigned null (a
+   * distinct, cloned buffer).
+   */
+  private static final DirectBuffer POISONED = new UnsafeBuffer(new byte[] {MsgPackCodes.NIL});
 
   private final Map<String, Object> entries = new LinkedHashMap<>();
 
@@ -69,8 +79,6 @@ public final class OutputMappingResultBuilder implements MappingResultBuilder {
     final var entry = entries.get(name);
     if (entry == null) {
       return null;
-    } else if (entry == MappingLevels.POISON) {
-      return MappingLevels.NIL;
     } else if (entry instanceof final DirectBuffer value) {
       return value;
     } else {
@@ -95,7 +103,7 @@ public final class OutputMappingResultBuilder implements MappingResultBuilder {
       final Map<String, Object> parent, final List<String> pathPrefix) {
     final var key = pathPrefix.getLast();
     final var entry = parent.get(key);
-    if (entry == MappingLevels.POISON) {
+    if (entry == POISONED) {
       return null;
     }
     if (entry instanceof final MappingLevels.Level level) {
@@ -111,7 +119,7 @@ public final class OutputMappingResultBuilder implements MappingResultBuilder {
       return fresh;
     }
     if (!MsgPackCodes.isMap(scopeValue.getByte(0))) {
-      parent.put(key, MappingLevels.POISON);
+      parent.put(key, POISONED);
       return null;
     }
     final var seeded =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResultBuilderTest.java
@@ -13,14 +13,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
-final class MappingResultBuilderTest {
+final class InputMappingResultBuilderTest {
 
-  private final MappingResultBuilder builder = MappingResultBuilder.forInputMappings(name -> null);
+  private final InputMappingResultBuilder builder = new InputMappingResultBuilder(name -> null);
 
   @Test
   void shouldBuildEmptyDocument() {
@@ -138,113 +137,10 @@ final class MappingResultBuilderTest {
   }
 
   @Test
-  void shouldSeedNestedTargetFromScopeValue() {
-    // given: scope has a = {'c': 2}
-    final var builder =
-        MappingResultBuilder.forOutputMappings(
-            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
-
-    // when
-    builder.put(List.of("a", "b"), asMsgPack("1"));
-
-    // then: existing sibling 'c' survives the merge
-    assertEquality(builder.toDocument(), "{'a': {'b': 1, 'c': 2}}");
-  }
-
-  @Test
-  void shouldSeedEveryPathLevelFromScopeValue() {
-    // given: scope has a = {'b': {'d': 2}, 'e': 3}
-    final var scope =
-        Map.of(
-            List.of("a"), asMsgPack("{'b': {'d': 2}, 'e': 3}"),
-            List.of("a", "b"), asMsgPack("{'d': 2}"));
-    final var builder = MappingResultBuilder.forOutputMappings(scope::get);
-
-    // when
-    builder.put(List.of("a", "b", "c"), asMsgPack("1"));
-
-    // then: siblings survive at both levels
-    assertEquality(builder.toDocument(), "{'a': {'b': {'c': 1, 'd': 2}, 'e': 3}}");
-  }
-
-  @Test
-  void shouldPoisonLevelWhenScopeValueIsNotAMap() {
-    // given: scope has a = 5
-    final var builder =
-        MappingResultBuilder.forOutputMappings(
-            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
-
-    // when
-    builder.put(List.of("a", "b"), asMsgPack("1"));
-
-    // then: the level is null, like FEEL's context merge(5, {...})
-    assertEquality(builder.toDocument(), "{'a': null}");
-    assertEquality(builder.getVariable("a"), "null");
-  }
-
-  @Test
-  void shouldDiscardFurtherPutsUnderPoisonedLevel() {
-    final var builder =
-        MappingResultBuilder.forOutputMappings(
-            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
-
-    // when
-    builder.put(List.of("a", "b"), asMsgPack("1"));
-    builder.put(List.of("a", "c"), asMsgPack("2"));
-
-    // then
-    assertEquality(builder.toDocument(), "{'a': null}");
-  }
-
-  @Test
-  void shouldReplacePoisonedLevelWithPlainTargetPut() {
-    final var builder =
-        MappingResultBuilder.forOutputMappings(
-            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
-
-    // when: a nested put poisons 'a', then a plain put replaces it
-    builder.put(List.of("a", "b"), asMsgPack("1"));
-    builder.put(List.of("a"), asMsgPack("7"));
-
-    // then
-    assertEquality(builder.toDocument(), "{'a': 7}");
-  }
-
-  @Test
-  void shouldReseedFromScopeWhenNestedPutFollowsPlainPut() {
-    // given: scope a = {'c': 2}; a plain put stored a value buffer for 'a'
-    final var builder =
-        MappingResultBuilder.forOutputMappings(
-            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
-    builder.put(List.of("a"), asMsgPack("{'z': 9}"));
-
-    // when: the shape flips back to a map — the plain mapping's value is discarded and the fresh
-    // level is seeded from the SCOPE value, not the previously mapped value
-    builder.put(List.of("a", "b"), asMsgPack("1"));
-
-    // then
-    assertEquality(builder.toDocument(), "{'a': {'b': 1, 'c': 2}}");
-  }
-
-  @Test
-  void shouldSeedFreshMapWhenScopeValueIsNil() {
-    // given: scope has a = null — FEEL's `if (a != null)` takes the else branch
-    final var builder =
-        MappingResultBuilder.forOutputMappings(
-            path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
-
-    // when
-    builder.put(List.of("a", "b"), asMsgPack("1"));
-
-    // then
-    assertEquality(builder.toDocument(), "{'a': {'b': 1}}");
-  }
-
-  @Test
   void shouldLayerNestedLevelOverShadowedValue() {
     // given: the scope chain resolves x to {'a': 1, 'b': 2}
     final var builder =
-        MappingResultBuilder.forInputMappings(
+        new InputMappingResultBuilder(
             name -> name.equals("x") ? asMsgPack("{'a': 1, 'b': 2}") : null);
 
     // when: only x.a is mapped
@@ -260,7 +156,7 @@ final class MappingResultBuilderTest {
   void shouldLayerEveryLevelOfANestedLevelOverShadowedValue() {
     // given: a shadowed value nested as deeply as the target path
     final var builder =
-        MappingResultBuilder.forInputMappings(
+        new InputMappingResultBuilder(
             name -> name.equals("x") ? asMsgPack("{'a': {'b': 1, 'c': 2}, 'd': 4}") : null);
 
     // when
@@ -275,7 +171,7 @@ final class MappingResultBuilderTest {
   void shouldNotLayerAValueAssignedToTheWholeName() {
     // given
     final var builder =
-        MappingResultBuilder.forInputMappings(
+        new InputMappingResultBuilder(
             name -> name.equals("x") ? asMsgPack("{'a': 1, 'b': 2}") : null);
 
     // when: x is assigned as a whole, not at a path inside it
@@ -289,7 +185,7 @@ final class MappingResultBuilderTest {
   void shouldNotLayerALevelRecreatedAfterTheWholeNameWasAssigned() {
     // given: x was assigned whole, so the value it shadowed is already gone
     final var builder =
-        MappingResultBuilder.forInputMappings(
+        new InputMappingResultBuilder(
             name -> name.equals("x") ? asMsgPack("{'a': 1, 'b': 2}") : null);
     builder.put(List.of("x"), asMsgPack("1"));
 
@@ -304,7 +200,7 @@ final class MappingResultBuilderTest {
   void shouldNotLayerANestedLevelRecreatedAfterThatLevelWasAssigned() {
     // given: the case above one level down — this is why the flag is per level, not per name
     final var builder =
-        MappingResultBuilder.forInputMappings(
+        new InputMappingResultBuilder(
             name -> name.equals("x") ? asMsgPack("{'a': {'b': 1}, 'd': 4}") : null);
     builder.put(List.of("x", "a"), asMsgPack("1"));
 
@@ -319,7 +215,7 @@ final class MappingResultBuilderTest {
   void shouldNotLayerWhenTheShadowedValueIsNotAMap() {
     // given
     final var builder =
-        MappingResultBuilder.forInputMappings(name -> name.equals("x") ? asMsgPack("5") : null);
+        new InputMappingResultBuilder(name -> name.equals("x") ? asMsgPack("5") : null);
 
     // when
     builder.put(List.of("x", "a"), asMsgPack("1"));
@@ -332,7 +228,7 @@ final class MappingResultBuilderTest {
   @Test
   void shouldNotLayerWhenNothingShadowsTheName() {
     // given
-    final var builder = MappingResultBuilder.forInputMappings(name -> null);
+    final var builder = new InputMappingResultBuilder(name -> null);
 
     // when
     builder.put(List.of("x", "a"), asMsgPack("1"));
@@ -345,7 +241,7 @@ final class MappingResultBuilderTest {
   void shouldNotLetALayeredReadLeakIntoTheDocument() {
     // given
     final var builder =
-        MappingResultBuilder.forInputMappings(
+        new InputMappingResultBuilder(
             name -> name.equals("x") ? asMsgPack("{'a': 1, 'b': 2}") : null);
     builder.put(List.of("x", "a"), asMsgPack("3"));
 
@@ -362,8 +258,7 @@ final class MappingResultBuilderTest {
     // given — a 50 000-segment target path whose shadowed value is a map at the top level, so the
     // layering traversal descends the whole structure
     final var builder =
-        MappingResultBuilder.forInputMappings(
-            name -> name.equals("a") ? asMsgPack("{'a': 1}") : null);
+        new InputMappingResultBuilder(name -> name.equals("a") ? asMsgPack("{'a': 1}") : null);
     final var targetPath =
         IntStream.range(0, 50_000).mapToObj(i -> "a").collect(Collectors.toList());
     builder.put(targetPath, asMsgPack("1"));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 final class MappingResultBuilderTest {
 
-  private final MappingResultBuilder builder = new MappingResultBuilder();
+  private final MappingResultBuilder builder = MappingResultBuilder.forInputMappings(name -> null);
 
   @Test
   void shouldBuildEmptyDocument() {
@@ -141,7 +141,8 @@ final class MappingResultBuilderTest {
   void shouldSeedNestedTargetFromScopeValue() {
     // given: scope has a = {'c': 2}
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -157,7 +158,7 @@ final class MappingResultBuilderTest {
         Map.of(
             List.of("a"), asMsgPack("{'b': {'d': 2}, 'e': 3}"),
             List.of("a", "b"), asMsgPack("{'d': 2}"));
-    final var builder = new MappingResultBuilder(scope::get);
+    final var builder = MappingResultBuilder.forOutputMappings(scope::get);
 
     // when
     builder.put(List.of("a", "b", "c"), asMsgPack("1"));
@@ -170,7 +171,8 @@ final class MappingResultBuilderTest {
   void shouldPoisonLevelWhenScopeValueIsNotAMap() {
     // given: scope has a = 5
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -183,7 +185,8 @@ final class MappingResultBuilderTest {
   @Test
   void shouldDiscardFurtherPutsUnderPoisonedLevel() {
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -196,7 +199,8 @@ final class MappingResultBuilderTest {
   @Test
   void shouldReplacePoisonedLevelWithPlainTargetPut() {
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
 
     // when: a nested put poisons 'a', then a plain put replaces it
     builder.put(List.of("a", "b"), asMsgPack("1"));
@@ -210,7 +214,8 @@ final class MappingResultBuilderTest {
   void shouldReseedFromScopeWhenNestedPutFollowsPlainPut() {
     // given: scope a = {'c': 2}; a plain put stored a value buffer for 'a'
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
     builder.put(List.of("a"), asMsgPack("{'z': 9}"));
 
     // when: the shape flips back to a map — the plain mapping's value is discarded and the fresh
@@ -225,7 +230,8 @@ final class MappingResultBuilderTest {
   void shouldSeedFreshMapWhenScopeValueIsNil() {
     // given: scope has a = null — FEEL's `if (a != null)` takes the else branch
     final var builder =
-        new MappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
+        MappingResultBuilder.forOutputMappings(
+            path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
 
     // when
     builder.put(List.of("a", "b"), asMsgPack("1"));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResultBuilderTest.java
@@ -239,4 +239,136 @@ final class MappingResultBuilderTest {
     // then
     assertEquality(builder.toDocument(), "{'a': {'b': 1}}");
   }
+
+  @Test
+  void shouldLayerNestedLevelOverShadowedValue() {
+    // given: the scope chain resolves x to {'a': 1, 'b': 2}
+    final var builder =
+        MappingResultBuilder.forInputMappings(
+            name -> name.equals("x") ? asMsgPack("{'a': 1, 'b': 2}") : null);
+
+    // when: only x.a is mapped
+    builder.put(List.of("x", "a"), asMsgPack("3"));
+
+    // then: the read layers the mapped key over the shadowed value ...
+    assertEquality(builder.getVariable("x"), "{'a': 3, 'b': 2}");
+    // ... but the document keeps only what was mapped
+    assertEquality(builder.toDocument(), "{'x': {'a': 3}}");
+  }
+
+  @Test
+  void shouldLayerEveryLevelOfANestedLevelOverShadowedValue() {
+    // given: a shadowed value nested as deeply as the target path
+    final var builder =
+        MappingResultBuilder.forInputMappings(
+            name -> name.equals("x") ? asMsgPack("{'a': {'b': 1, 'c': 2}, 'd': 4}") : null);
+
+    // when
+    builder.put(List.of("x", "a", "b"), asMsgPack("9"));
+
+    // then: unmapped keys survive at every level, which a top-level-only merge would not do
+    assertEquality(builder.getVariable("x"), "{'a': {'b': 9, 'c': 2}, 'd': 4}");
+    assertEquality(builder.toDocument(), "{'x': {'a': {'b': 9}}}");
+  }
+
+  @Test
+  void shouldNotLayerAValueAssignedToTheWholeName() {
+    // given
+    final var builder =
+        MappingResultBuilder.forInputMappings(
+            name -> name.equals("x") ? asMsgPack("{'a': 1, 'b': 2}") : null);
+
+    // when: x is assigned as a whole, not at a path inside it
+    builder.put(List.of("x"), asMsgPack("{'a': 3}"));
+
+    // then: shadowing is total
+    assertEquality(builder.getVariable("x"), "{'a': 3}");
+  }
+
+  @Test
+  void shouldNotLayerALevelRecreatedAfterTheWholeNameWasAssigned() {
+    // given: x was assigned whole, so the value it shadowed is already gone
+    final var builder =
+        MappingResultBuilder.forInputMappings(
+            name -> name.equals("x") ? asMsgPack("{'a': 1, 'b': 2}") : null);
+    builder.put(List.of("x"), asMsgPack("1"));
+
+    // when: a dotted target re-creates x as a fresh object
+    builder.put(List.of("x", "a"), asMsgPack("2"));
+
+    // then: the total shadow persists — b does not come back
+    assertEquality(builder.getVariable("x"), "{'a': 2}");
+  }
+
+  @Test
+  void shouldNotLayerANestedLevelRecreatedAfterThatLevelWasAssigned() {
+    // given: the case above one level down — this is why the flag is per level, not per name
+    final var builder =
+        MappingResultBuilder.forInputMappings(
+            name -> name.equals("x") ? asMsgPack("{'a': {'b': 1}, 'd': 4}") : null);
+    builder.put(List.of("x", "a"), asMsgPack("1"));
+
+    // when
+    builder.put(List.of("x", "a", "c"), asMsgPack("2"));
+
+    // then: a stays totally shadowed, but x's untouched sibling d still falls through
+    assertEquality(builder.getVariable("x"), "{'a': {'c': 2}, 'd': 4}");
+  }
+
+  @Test
+  void shouldNotLayerWhenTheShadowedValueIsNotAMap() {
+    // given
+    final var builder =
+        MappingResultBuilder.forInputMappings(name -> name.equals("x") ? asMsgPack("5") : null);
+
+    // when
+    builder.put(List.of("x", "a"), asMsgPack("1"));
+
+    // then: nothing to fall through to — and no POISON either, that is output-mapping-only
+    assertEquality(builder.getVariable("x"), "{'a': 1}");
+    assertEquality(builder.toDocument(), "{'x': {'a': 1}}");
+  }
+
+  @Test
+  void shouldNotLayerWhenNothingShadowsTheName() {
+    // given
+    final var builder = MappingResultBuilder.forInputMappings(name -> null);
+
+    // when
+    builder.put(List.of("x", "a"), asMsgPack("1"));
+
+    // then
+    assertEquality(builder.getVariable("x"), "{'a': 1}");
+  }
+
+  @Test
+  void shouldNotLetALayeredReadLeakIntoTheDocument() {
+    // given
+    final var builder =
+        MappingResultBuilder.forInputMappings(
+            name -> name.equals("x") ? asMsgPack("{'a': 1, 'b': 2}") : null);
+    builder.put(List.of("x", "a"), asMsgPack("3"));
+
+    // when: the layered read happens between two puts that build x
+    assertEquality(builder.getVariable("x"), "{'a': 3, 'b': 2}");
+    builder.put(List.of("x", "c"), asMsgPack("9"));
+
+    // then: the read did not add b to the accumulator
+    assertEquality(builder.toDocument(), "{'x': {'a': 3, 'c': 9}}");
+  }
+
+  @Test
+  void shouldNotThrowStackOverflowWhenLayeringADeeplyNestedLevel() {
+    // given — a 50 000-segment target path whose shadowed value is a map at the top level, so the
+    // layering traversal descends the whole structure
+    final var builder =
+        MappingResultBuilder.forInputMappings(
+            name -> name.equals("a") ? asMsgPack("{'a': 1}") : null);
+    final var targetPath =
+        IntStream.range(0, 50_000).mapToObj(i -> "a").collect(Collectors.toList());
+    builder.put(targetPath, asMsgPack("1"));
+
+    // when / then — must not throw
+    assertThatCode(() -> builder.getVariable("a")).doesNotThrowAnyException();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResultBuilderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
+import static io.camunda.zeebe.test.util.MsgPackUtil.assertEquality;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class OutputMappingResultBuilderTest {
+
+  @Test
+  void shouldSeedNestedTargetFromScopeValue() {
+    // given: scope has a = {'c': 2}
+    final var builder =
+        new OutputMappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then: existing sibling 'c' survives the merge
+    assertEquality(builder.toDocument(), "{'a': {'b': 1, 'c': 2}}");
+  }
+
+  @Test
+  void shouldSeedEveryPathLevelFromScopeValue() {
+    // given: scope has a = {'b': {'d': 2}, 'e': 3}
+    final var scope =
+        Map.of(
+            List.of("a"), asMsgPack("{'b': {'d': 2}, 'e': 3}"),
+            List.of("a", "b"), asMsgPack("{'d': 2}"));
+    final var builder = new OutputMappingResultBuilder(scope::get);
+
+    // when
+    builder.put(List.of("a", "b", "c"), asMsgPack("1"));
+
+    // then: siblings survive at both levels
+    assertEquality(builder.toDocument(), "{'a': {'b': {'c': 1, 'd': 2}, 'e': 3}}");
+  }
+
+  @Test
+  void shouldPoisonLevelWhenScopeValueIsNotAMap() {
+    // given: scope has a = 5
+    final var builder =
+        new OutputMappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then: the level is null, like FEEL's context merge(5, {...})
+    assertEquality(builder.toDocument(), "{'a': null}");
+    assertEquality(builder.getVariable("a"), "null");
+  }
+
+  @Test
+  void shouldDiscardFurtherPutsUnderPoisonedLevel() {
+    final var builder =
+        new OutputMappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+    builder.put(List.of("a", "c"), asMsgPack("2"));
+
+    // then
+    assertEquality(builder.toDocument(), "{'a': null}");
+  }
+
+  @Test
+  void shouldReplacePoisonedLevelWithPlainTargetPut() {
+    final var builder =
+        new OutputMappingResultBuilder(path -> path.equals(List.of("a")) ? asMsgPack("5") : null);
+
+    // when: a nested put poisons 'a', then a plain put replaces it
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+    builder.put(List.of("a"), asMsgPack("7"));
+
+    // then
+    assertEquality(builder.toDocument(), "{'a': 7}");
+  }
+
+  @Test
+  void shouldReseedFromScopeWhenNestedPutFollowsPlainPut() {
+    // given: scope a = {'c': 2}; a plain put stored a value buffer for 'a'
+    final var builder =
+        new OutputMappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("{'c': 2}") : null);
+    builder.put(List.of("a"), asMsgPack("{'z': 9}"));
+
+    // when: the shape flips back to a map — the plain mapping's value is discarded and the fresh
+    // level is seeded from the SCOPE value, not the previously mapped value
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then
+    assertEquality(builder.toDocument(), "{'a': {'b': 1, 'c': 2}}");
+  }
+
+  @Test
+  void shouldSeedFreshMapWhenScopeValueIsNil() {
+    // given: scope has a = null — FEEL's `if (a != null)` takes the else branch
+    final var builder =
+        new OutputMappingResultBuilder(
+            path -> path.equals(List.of("a")) ? asMsgPack("null") : null);
+
+    // when
+    builder.put(List.of("a", "b"), asMsgPack("1"));
+
+    // then
+    assertEquality(builder.toDocument(), "{'a': {'b': 1}}");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/InputMappingPartialShadowingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/InputMappingPartialShadowingTest.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static io.camunda.zeebe.engine.processing.variable.mapping.VariableValue.variable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
+import io.camunda.zeebe.model.bpmn.builder.ZeebeVariablesMappingBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/**
+ * Input mappings shadow a same-named variable from a higher scope only <em>partially</em>: a later
+ * source that reads the name sees the keys the earlier mappings defined layered over the value the
+ * scope chain resolves to, instead of replacing it outright.
+ *
+ * <p>The layering is a read-time concern only. The local variable that is written stays exactly
+ * what the mappings targeted — a mapping to {@code x.a} still creates a local {@code x} holding
+ * nothing but {@code a}. Every scenario below therefore asserts <em>both</em> the mapped root and
+ * the variable that read it; asserting only the reader would also pass for an implementation that
+ * seeds the accumulated document from the scope value, which is not the agreed behaviour.
+ *
+ * <p>Fall-through adds exactly one layer, however deep the scope chain goes: rule 2's walk up the
+ * chain stops at the first scope holding the name and takes that whole value, so only the value the
+ * chain resolves to is layered under the mapping — not every same-named variable on the way to the
+ * root.
+ *
+ * <p>Partial shadowing is only meaningful where both sides are objects. A mapping that assigns a
+ * whole name — a scalar, a null, or an object — shadows the ancestor totally, because there is
+ * nothing left to fall through to.
+ *
+ * <p>Regression tests for <a href="https://github.com/camunda/camunda/issues/59646">#59646</a>.
+ */
+public final class InputMappingPartialShadowingTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String MAPPED_ELEMENT_ID = "mapped";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final TestName testName = new TestName();
+
+  // ---------------------------------------------------------------------------------------------
+  // Total shadowing: a mapping that assigns a whole name leaves nothing to fall through to
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void shouldTotallyShadowAncestorWhenTheWholeNameIsMappedToNull() {
+    // given: x is mapped as a whole, so there is no partial anything to fall through to. This is
+    // the guard against an implementation that layers scalars and nulls over the ancestor too:
+    // there is no "absent" state, an assigned target is authoritative.
+    final long processInstanceKey =
+        activate(
+            "{'x': 5}", b -> b.zeebeInputExpression("null", "x").zeebeInputExpression("x", "y"));
+
+    // then
+    assertMappedElementVariables(processInstanceKey, variable("x", "null"), variable("y", "null"));
+  }
+
+  @Test
+  public void shouldTotallyShadowAncestorWhenTheWholeNameIsMappedToAnObject() {
+    // given: the mapped value is an object, but it was assigned to x as a whole rather than to a
+    // path inside it, so the ancestor's b is not reachable under x anymore
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': 1, 'b': 2}}",
+            b -> b.zeebeInputExpression("{a: 3}", "x").zeebeInputExpression("x", "y"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':3}"), variable("y", "{'a':3}"));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Scenario 7.2 — narrowing an object onto its own name (issue #59646)
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void shouldKeepSiblingFieldsWhenNarrowingAnObjectOntoItsOwnName() {
+    // given: the "keep only the fields this task needs, under the same name" idiom. The second
+    // mapping's source must still resolve x against the ancestor for the key the first mapping did
+    // not define.
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': 1, 'b': 2}}",
+            b -> b.zeebeInputExpression("x.a", "x.a").zeebeInputExpression("x.b", "x.b"));
+
+    // then
+    assertMappedElementVariables(processInstanceKey, variable("x", "{'a':1,'b':2}"));
+  }
+
+  @Test
+  public void shouldKeepSiblingFieldsWhenNarrowingAnObjectOntoItsOwnNameInReverseOrder() {
+    // given: the same shape with the two mappings swapped — partial shadowing makes the result
+    // order-independent, where total shadowing lets declaration order pick which field survives
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': 1, 'b': 2}}",
+            b -> b.zeebeInputExpression("x.b", "x.b").zeebeInputExpression("x.a", "x.a"));
+
+    // then
+    assertMappedElementVariables(processInstanceKey, variable("x", "{'a':1,'b':2}"));
+  }
+
+  @Test
+  public void shouldKeepSiblingFieldsWhenNarrowingANestedObjectOntoItsOwnName() {
+    // given: the same shape one level deeper. This is the case that separates a recursive merge
+    // from a top-level-only one: a top-level-only merge sees x.a defined locally, takes the local
+    // {b: 1} whole, and resolves x.a.c to null.
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': {'b': 1, 'c': 2}}}",
+            b -> b.zeebeInputExpression("x.a.b", "x.a.b").zeebeInputExpression("x.a.c", "x.a.c"));
+
+    // then
+    assertMappedElementVariables(processInstanceKey, variable("x", "{'a':{'b':1,'c':2}}"));
+  }
+
+  @Test
+  public void shouldCopyEveryFieldWhenNarrowingAnObjectOntoADifferentName() {
+    // given: the control for the three above — renaming the target root means no shadowing is
+    // involved at all, and this has always worked
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': 1, 'b': 2}}",
+            b -> b.zeebeInputExpression("x.a", "y.a").zeebeInputExpression("x.b", "y.b"));
+
+    // then
+    assertMappedElementVariables(processInstanceKey, variable("y", "{'a':1,'b':2}"));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Scenarios 7.3 and 7.4 — reading back a partially mapped object
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void shouldFallThroughToTheAncestorWhenReadingAnObjectAFieldWasAddedTo() {
+    // given: a.b adds a field the ancestor's a does not have. The local a holds only b — nothing
+    // seeds it from the ancestor — but reading a layers that b over the ancestor's a.
+    final long processInstanceKey =
+        activate(
+            "{'a': {'z': 99}}",
+            b -> b.zeebeInputExpression("1", "a.b").zeebeInputExpression("a", "c"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("a", "{'b':1}"), variable("c", "{'b':1,'z':99}"));
+  }
+
+  @Test
+  public void shouldFallThroughToTheAncestorWhenReadingAnObjectAFieldWasOverriddenIn() {
+    // given: x.a overrides a field the ancestor's x already has. The mapped key wins on the read,
+    // the unmapped one falls through.
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': 1, 'b': 2}}",
+            b -> b.zeebeInputExpression("3", "x.a").zeebeInputExpression("x", "y"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':3}"), variable("y", "{'a':3,'b':2}"));
+  }
+
+  @Test
+  public void shouldFallThroughToTheAncestorWhenReadingAFieldThatOnlyTheAncestorHas() {
+    // given: the read digs straight into a key the mappings never defined
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': 1, 'b': 2}}",
+            b -> b.zeebeInputExpression("3", "x.a").zeebeInputExpression("x.b", "y"));
+
+    // then
+    assertMappedElementVariables(processInstanceKey, variable("x", "{'a':3}"), variable("y", "2"));
+  }
+
+  @Test
+  public void shouldNotLetAFallThroughReadLeakIntoTheMappedVariable() {
+    // given: a read of x sits between two mappings that build it. The layered value the read sees
+    // must not become part of what is written — x keeps only the keys the mappings targeted, so the
+    // ancestor's b is in y but not in x.
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': 1, 'b': 2}}",
+            b ->
+                b.zeebeInputExpression("3", "x.a")
+                    .zeebeInputExpression("x", "y")
+                    .zeebeInputExpression("9", "x.c"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':3,'c':9}"), variable("y", "{'a':3,'b':2}"));
+  }
+
+  @Test
+  public void shouldTotallyShadowAtTheLevelAMappingAssignedWhole() {
+    // given: x.a assigns the whole of a, so a's own nesting in the ancestor is gone — but x's
+    // sibling key d, which no mapping touched, still falls through. Fall-through stops at the
+    // level a mapping actually assigned.
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': {'b': 1}, 'd': 4}}",
+            b -> b.zeebeInputExpression("5", "x.a").zeebeInputExpression("x", "y"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':5}"), variable("y", "{'a':5,'d':4}"));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Nothing to fall through to
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void shouldNotFallThroughWhenTheAncestorValueIsNotAnObject() {
+    // given: the ancestor's x is a scalar, so there are no keys to layer under the mapping
+    final long processInstanceKey =
+        activate(
+            "{'x': 5}", b -> b.zeebeInputExpression("1", "x.a").zeebeInputExpression("x", "y"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':1}"), variable("y", "{'a':1}"));
+  }
+
+  @Test
+  public void shouldNotFallThroughWhenNoAncestorScopeHasTheName() {
+    // given: nothing anywhere up the chain is called x
+    final long processInstanceKey =
+        activate("{}", b -> b.zeebeInputExpression("1", "x.a").zeebeInputExpression("x", "y"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':1}"), variable("y", "{'a':1}"));
+  }
+
+  @Test
+  public void shouldNotFallThroughAgainAfterAMappingAssignedTheWholeName() {
+    // given: mapping 1 shadows x totally; mapping 2 re-creates it as an object, which rule 6 says
+    // is a FRESH object rather than a merge into the dropped scalar. The total shadow persists, so
+    // the read sees only what mapping 2 put there.
+    //
+    // Derived: the artifact does not spell this shape out. It follows from rule 6.3's "fresh
+    // object" plus rule 7.1's "an assigned target is authoritative" — a target that was once
+    // assigned whole never becomes partially shadowed again.
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': 1, 'b': 2}}",
+            b ->
+                b.zeebeInputExpression("1", "x")
+                    .zeebeInputExpression("2", "x.a")
+                    .zeebeInputExpression("x", "y"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':2}"), variable("y", "{'a':2}"));
+  }
+
+  @Test
+  public void shouldNotFallThroughAgainAfterAMappingAssignedAWholeNestedLevel() {
+    // given: the shape above, one level down. x.a is assigned whole and then re-created as a fresh
+    // object by x.a.c, so a stays totally shadowed and the ancestor's a.b is gone — while x's
+    // sibling d, which no mapping ever assigned, still falls through.
+    //
+    // Derived: the same reasoning as the test above, and the reason the total shadow has to be
+    // tracked per path level rather than per root variable.
+    final long processInstanceKey =
+        activate(
+            "{'x': {'a': {'b': 1}, 'd': 4}}",
+            b ->
+                b.zeebeInputExpression("1", "x.a")
+                    .zeebeInputExpression("2", "x.a.c")
+                    .zeebeInputExpression("x", "y"));
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':{'c':2}}"), variable("y", "{'a':{'c':2},'d':4}"));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Scenario 7.5 — the fall-through stops at the nearest ancestor scope
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void shouldFallThroughToTheNearestAncestorScopeOnly() {
+    // given: an x on the process instance and a narrower x on the enclosing sub-process. Rule 2's
+    // walk up the chain stops at the sub-process and takes its x whole, so partial shadowing layers
+    // the mapping over that value only — the process instance's c never reaches y.
+    final String processId = processId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .subProcess(
+                    "enclosing",
+                    enclosing -> {
+                      enclosing.zeebeInputExpression("{a: 1, b: 2}", "x");
+                      enclosing
+                          .embeddedSubProcess()
+                          .startEvent()
+                          .subProcess(
+                              MAPPED_ELEMENT_ID,
+                              mapped -> {
+                                mapped.embeddedSubProcess().startEvent().endEvent();
+                                mapped
+                                    .zeebeInputExpression("3", "x.a")
+                                    .zeebeInputExpression("x", "y");
+                              })
+                          .endEvent();
+                    })
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables("{'x': {'a': 1, 'b': 2, 'c': 3}}")
+            .create();
+
+    // then
+    assertMappedElementVariables(
+        processInstanceKey, variable("x", "{'a':3}"), variable("y", "{'a':3,'b':2}"));
+  }
+
+  @Test
+  public void shouldFallThroughToTheMultiInstanceInputElementVariable() {
+    // given: the input element variable is written to the inner activity's OWN scope while the
+    // child is activating, before its input mappings run, so it is the value a nested target
+    // partially shadows — the one shape where the fall-through resolves in the element's own scope
+    // rather than an ancestor's
+    final String processId = processId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    MAPPED_ELEMENT_ID,
+                    t ->
+                        t.zeebeJobType("test")
+                            .zeebeInputExpression("3", "item.a")
+                            .zeebeInputExpression("item", "y")
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables("{'items': [{'a': 1, 'b': 2}]}")
+            .create();
+
+    // then: the multi-instance body shares the inner activity's element id, so filter by type
+    final long innerInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(MAPPED_ELEMENT_ID)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst()
+            .getKey();
+
+    // four variable records at the inner scope: item and loopCounter from the loop setup, then
+    // item updated and y created by the input mapping merge. ELEMENT_ACTIVATED above is exported
+    // after the merge, so all four are already present and limit(4) does not block.
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withScopeKey(innerInstanceKey)
+                .limit(4))
+        .extracting(Record::getValue)
+        .extracting(v -> variable(v.getName(), v.getValue()))
+        .contains(variable("y", "{'a':3,'b':2}"), variable("item", "{'a':3}"));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Deploys a process whose single sub-process carries the given input mappings, starts an instance
+   * with the given variables, and returns its key.
+   */
+  private long activate(
+      final String initialVariables,
+      final Consumer<ZeebeVariablesMappingBuilder<SubProcessBuilder>> mappings) {
+    final String processId = processId();
+    ENGINE.deployment().withXmlResource(processWithMappings(processId, mappings)).deploy();
+    return ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVariables(initialVariables)
+        .create();
+  }
+
+  private static BpmnModelInstance processWithMappings(
+      final String processId,
+      final Consumer<ZeebeVariablesMappingBuilder<SubProcessBuilder>> mappings) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .subProcess(
+            MAPPED_ELEMENT_ID,
+            b -> {
+              b.embeddedSubProcess().startEvent().endEvent();
+              mappings.accept(b);
+            })
+        .endEvent()
+        .done();
+  }
+
+  /** Asserts the local variables of the mapped element instance, and only those. */
+  private void assertMappedElementVariables(
+      final long processInstanceKey, final VariableValue... expected) {
+    final long mappedElementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(MAPPED_ELEMENT_ID)
+            .getFirst()
+            .getKey();
+
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withScopeKey(mappedElementInstanceKey)
+                .limit(expected.length))
+        .extracting(Record::getValue)
+        .extracting(v -> variable(v.getName(), v.getValue()))
+        .containsExactlyInAnyOrder(expected);
+  }
+
+  /** A process id per test method, so deployments and instances never collide. */
+  private String processId() {
+    return "process-" + testName.getMethodName();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/InputMappingPartialShadowingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/InputMappingPartialShadowingTest.java
@@ -69,26 +69,22 @@ public final class InputMappingPartialShadowingTest {
     // given: x is mapped as a whole, so there is no partial anything to fall through to. This is
     // the guard against an implementation that layers scalars and nulls over the ancestor too:
     // there is no "absent" state, an assigned target is authoritative.
-    final long processInstanceKey =
-        activate(
-            "{'x': 5}", b -> b.zeebeInputExpression("null", "x").zeebeInputExpression("x", "y"));
-
-    // then
-    assertMappedElementVariables(processInstanceKey, variable("x", "null"), variable("y", "null"));
+    assertInputMapping(
+        "{'x': 5}",
+        b -> b.zeebeInputExpression("null", "x").zeebeInputExpression("x", "y"),
+        variable("x", "null"),
+        variable("y", "null"));
   }
 
   @Test
   public void shouldTotallyShadowAncestorWhenTheWholeNameIsMappedToAnObject() {
     // given: the mapped value is an object, but it was assigned to x as a whole rather than to a
     // path inside it, so the ancestor's b is not reachable under x anymore
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': 1, 'b': 2}}",
-            b -> b.zeebeInputExpression("{a: 3}", "x").zeebeInputExpression("x", "y"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("x", "{'a':3}"), variable("y", "{'a':3}"));
+    assertInputMapping(
+        "{'x': {'a': 1, 'b': 2}}",
+        b -> b.zeebeInputExpression("{a: 3}", "x").zeebeInputExpression("x", "y"),
+        variable("x", "{'a':3}"),
+        variable("y", "{'a':3}"));
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -100,26 +96,20 @@ public final class InputMappingPartialShadowingTest {
     // given: the "keep only the fields this task needs, under the same name" idiom. The second
     // mapping's source must still resolve x against the ancestor for the key the first mapping did
     // not define.
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': 1, 'b': 2}}",
-            b -> b.zeebeInputExpression("x.a", "x.a").zeebeInputExpression("x.b", "x.b"));
-
-    // then
-    assertMappedElementVariables(processInstanceKey, variable("x", "{'a':1,'b':2}"));
+    assertInputMapping(
+        "{'x': {'a': 1, 'b': 2}}",
+        b -> b.zeebeInputExpression("x.a", "x.a").zeebeInputExpression("x.b", "x.b"),
+        variable("x", "{'a':1,'b':2}"));
   }
 
   @Test
   public void shouldKeepSiblingFieldsWhenNarrowingAnObjectOntoItsOwnNameInReverseOrder() {
     // given: the same shape with the two mappings swapped — partial shadowing makes the result
     // order-independent, where total shadowing lets declaration order pick which field survives
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': 1, 'b': 2}}",
-            b -> b.zeebeInputExpression("x.b", "x.b").zeebeInputExpression("x.a", "x.a"));
-
-    // then
-    assertMappedElementVariables(processInstanceKey, variable("x", "{'a':1,'b':2}"));
+    assertInputMapping(
+        "{'x': {'a': 1, 'b': 2}}",
+        b -> b.zeebeInputExpression("x.b", "x.b").zeebeInputExpression("x.a", "x.a"),
+        variable("x", "{'a':1,'b':2}"));
   }
 
   @Test
@@ -127,26 +117,20 @@ public final class InputMappingPartialShadowingTest {
     // given: the same shape one level deeper. This is the case that separates a recursive merge
     // from a top-level-only one: a top-level-only merge sees x.a defined locally, takes the local
     // {b: 1} whole, and resolves x.a.c to null.
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': {'b': 1, 'c': 2}}}",
-            b -> b.zeebeInputExpression("x.a.b", "x.a.b").zeebeInputExpression("x.a.c", "x.a.c"));
-
-    // then
-    assertMappedElementVariables(processInstanceKey, variable("x", "{'a':{'b':1,'c':2}}"));
+    assertInputMapping(
+        "{'x': {'a': {'b': 1, 'c': 2}}}",
+        b -> b.zeebeInputExpression("x.a.b", "x.a.b").zeebeInputExpression("x.a.c", "x.a.c"),
+        variable("x", "{'a':{'b':1,'c':2}}"));
   }
 
   @Test
   public void shouldCopyEveryFieldWhenNarrowingAnObjectOntoADifferentName() {
     // given: the control for the three above — renaming the target root means no shadowing is
     // involved at all, and this has always worked
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': 1, 'b': 2}}",
-            b -> b.zeebeInputExpression("x.a", "y.a").zeebeInputExpression("x.b", "y.b"));
-
-    // then
-    assertMappedElementVariables(processInstanceKey, variable("y", "{'a':1,'b':2}"));
+    assertInputMapping(
+        "{'x': {'a': 1, 'b': 2}}",
+        b -> b.zeebeInputExpression("x.a", "y.a").zeebeInputExpression("x.b", "y.b"),
+        variable("y", "{'a':1,'b':2}"));
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -157,40 +141,32 @@ public final class InputMappingPartialShadowingTest {
   public void shouldFallThroughToTheAncestorWhenReadingAnObjectAFieldWasAddedTo() {
     // given: a.b adds a field the ancestor's a does not have. The local a holds only b — nothing
     // seeds it from the ancestor — but reading a layers that b over the ancestor's a.
-    final long processInstanceKey =
-        activate(
-            "{'a': {'z': 99}}",
-            b -> b.zeebeInputExpression("1", "a.b").zeebeInputExpression("a", "c"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("a", "{'b':1}"), variable("c", "{'b':1,'z':99}"));
+    assertInputMapping(
+        "{'a': {'z': 99}}",
+        b -> b.zeebeInputExpression("1", "a.b").zeebeInputExpression("a", "c"),
+        variable("a", "{'b':1}"),
+        variable("c", "{'b':1,'z':99}"));
   }
 
   @Test
   public void shouldFallThroughToTheAncestorWhenReadingAnObjectAFieldWasOverriddenIn() {
     // given: x.a overrides a field the ancestor's x already has. The mapped key wins on the read,
     // the unmapped one falls through.
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': 1, 'b': 2}}",
-            b -> b.zeebeInputExpression("3", "x.a").zeebeInputExpression("x", "y"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("x", "{'a':3}"), variable("y", "{'a':3,'b':2}"));
+    assertInputMapping(
+        "{'x': {'a': 1, 'b': 2}}",
+        b -> b.zeebeInputExpression("3", "x.a").zeebeInputExpression("x", "y"),
+        variable("x", "{'a':3}"),
+        variable("y", "{'a':3,'b':2}"));
   }
 
   @Test
   public void shouldFallThroughToTheAncestorWhenReadingAFieldThatOnlyTheAncestorHas() {
     // given: the read digs straight into a key the mappings never defined
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': 1, 'b': 2}}",
-            b -> b.zeebeInputExpression("3", "x.a").zeebeInputExpression("x.b", "y"));
-
-    // then
-    assertMappedElementVariables(processInstanceKey, variable("x", "{'a':3}"), variable("y", "2"));
+    assertInputMapping(
+        "{'x': {'a': 1, 'b': 2}}",
+        b -> b.zeebeInputExpression("3", "x.a").zeebeInputExpression("x.b", "y"),
+        variable("x", "{'a':3}"),
+        variable("y", "2"));
   }
 
   @Test
@@ -198,17 +174,14 @@ public final class InputMappingPartialShadowingTest {
     // given: a read of x sits between two mappings that build it. The layered value the read sees
     // must not become part of what is written — x keeps only the keys the mappings targeted, so the
     // ancestor's b is in y but not in x.
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': 1, 'b': 2}}",
-            b ->
-                b.zeebeInputExpression("3", "x.a")
-                    .zeebeInputExpression("x", "y")
-                    .zeebeInputExpression("9", "x.c"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("x", "{'a':3,'c':9}"), variable("y", "{'a':3,'b':2}"));
+    assertInputMapping(
+        "{'x': {'a': 1, 'b': 2}}",
+        b ->
+            b.zeebeInputExpression("3", "x.a")
+                .zeebeInputExpression("x", "y")
+                .zeebeInputExpression("9", "x.c"),
+        variable("x", "{'a':3,'c':9}"),
+        variable("y", "{'a':3,'b':2}"));
   }
 
   @Test
@@ -216,14 +189,11 @@ public final class InputMappingPartialShadowingTest {
     // given: x.a assigns the whole of a, so a's own nesting in the ancestor is gone — but x's
     // sibling key d, which no mapping touched, still falls through. Fall-through stops at the
     // level a mapping actually assigned.
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': {'b': 1}, 'd': 4}}",
-            b -> b.zeebeInputExpression("5", "x.a").zeebeInputExpression("x", "y"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("x", "{'a':5}"), variable("y", "{'a':5,'d':4}"));
+    assertInputMapping(
+        "{'x': {'a': {'b': 1}, 'd': 4}}",
+        b -> b.zeebeInputExpression("5", "x.a").zeebeInputExpression("x", "y"),
+        variable("x", "{'a':5}"),
+        variable("y", "{'a':5,'d':4}"));
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -233,24 +203,21 @@ public final class InputMappingPartialShadowingTest {
   @Test
   public void shouldNotFallThroughWhenTheAncestorValueIsNotAnObject() {
     // given: the ancestor's x is a scalar, so there are no keys to layer under the mapping
-    final long processInstanceKey =
-        activate(
-            "{'x': 5}", b -> b.zeebeInputExpression("1", "x.a").zeebeInputExpression("x", "y"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("x", "{'a':1}"), variable("y", "{'a':1}"));
+    assertInputMapping(
+        "{'x': 5}",
+        b -> b.zeebeInputExpression("1", "x.a").zeebeInputExpression("x", "y"),
+        variable("x", "{'a':1}"),
+        variable("y", "{'a':1}"));
   }
 
   @Test
   public void shouldNotFallThroughWhenNoAncestorScopeHasTheName() {
     // given: nothing anywhere up the chain is called x
-    final long processInstanceKey =
-        activate("{}", b -> b.zeebeInputExpression("1", "x.a").zeebeInputExpression("x", "y"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("x", "{'a':1}"), variable("y", "{'a':1}"));
+    assertInputMapping(
+        "{}",
+        b -> b.zeebeInputExpression("1", "x.a").zeebeInputExpression("x", "y"),
+        variable("x", "{'a':1}"),
+        variable("y", "{'a':1}"));
   }
 
   @Test
@@ -262,17 +229,14 @@ public final class InputMappingPartialShadowingTest {
     // Derived: the artifact does not spell this shape out. It follows from rule 6.3's "fresh
     // object" plus rule 7.1's "an assigned target is authoritative" — a target that was once
     // assigned whole never becomes partially shadowed again.
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': 1, 'b': 2}}",
-            b ->
-                b.zeebeInputExpression("1", "x")
-                    .zeebeInputExpression("2", "x.a")
-                    .zeebeInputExpression("x", "y"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("x", "{'a':2}"), variable("y", "{'a':2}"));
+    assertInputMapping(
+        "{'x': {'a': 1, 'b': 2}}",
+        b ->
+            b.zeebeInputExpression("1", "x")
+                .zeebeInputExpression("2", "x.a")
+                .zeebeInputExpression("x", "y"),
+        variable("x", "{'a':2}"),
+        variable("y", "{'a':2}"));
   }
 
   @Test
@@ -283,17 +247,14 @@ public final class InputMappingPartialShadowingTest {
     //
     // Derived: the same reasoning as the test above, and the reason the total shadow has to be
     // tracked per path level rather than per root variable.
-    final long processInstanceKey =
-        activate(
-            "{'x': {'a': {'b': 1}, 'd': 4}}",
-            b ->
-                b.zeebeInputExpression("1", "x.a")
-                    .zeebeInputExpression("2", "x.a.c")
-                    .zeebeInputExpression("x", "y"));
-
-    // then
-    assertMappedElementVariables(
-        processInstanceKey, variable("x", "{'a':{'c':2}}"), variable("y", "{'a':{'c':2},'d':4}"));
+    assertInputMapping(
+        "{'x': {'a': {'b': 1}, 'd': 4}}",
+        b ->
+            b.zeebeInputExpression("1", "x.a")
+                .zeebeInputExpression("2", "x.a.c")
+                .zeebeInputExpression("x", "y"),
+        variable("x", "{'a':{'c':2}}"),
+        variable("y", "{'a':{'c':2},'d':4}"));
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -402,6 +363,18 @@ public final class InputMappingPartialShadowingTest {
   }
 
   // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Deploys a process whose single sub-process carries the given input mappings, runs an instance
+   * with the given scope variables, and asserts the local variables the element ends up with — and
+   * only those.
+   */
+  private void assertInputMapping(
+      final String scopeVariables,
+      final Consumer<ZeebeVariablesMappingBuilder<SubProcessBuilder>> mappings,
+      final VariableValue... expected) {
+    assertMappedElementVariables(activate(scopeVariables, mappings), expected);
+  }
 
   /**
    * Deploys a process whose single sub-process carries the given input mappings, starts an instance

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -200,7 +200,7 @@ final class VariableInputMappingTransformerTest {
     // when: evaluate the mappings one by one in modeling order, same as
     // BpmnVariableMappingBehavior.applyInputMappings does at runtime — accumulated results shadow
     // the base variables, which fall back for anything not mapped yet
-    final var resultBuilder = new MappingResultBuilder();
+    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -233,7 +233,7 @@ final class VariableInputMappingTransformerTest {
                     .isTrue());
 
     // when
-    final var resultBuilder = new MappingResultBuilder();
+    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -275,7 +275,7 @@ final class VariableInputMappingTransformerTest {
       final Map<String, DirectBuffer> variables,
       final ExpressionLanguage language) {
     final var inputMappings = transformer.transformInputMappings(mappings, language);
-    final var resultBuilder = new MappingResultBuilder();
+    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -57,12 +57,19 @@ final class VariableInputMappingTransformerTest {
         "{'a':{'b':1, 'c':2}}"
       },
       {List.of(mapping("x", "a.b.c")), Map.of("x", asMsgPack("1")), "{'a':{'b':{'c':1}}}"},
-      // a mapping reads the PARTIAL object an earlier a.* mapping built so far, not the outer
-      // scope's "a"
+      // a nested target shadows the outer scope's "a" only for the key it defines; the mapping that
+      // reads "a" gets that key layered over the outer scope's value, not instead of it
       {
         List.of(mapping("x", "a.b"), mapping("a", "c")),
         Map.of("x", asMsgPack("1"), "a", asMsgPack("{'z':99}")),
-        "{'a':{'b':1}, 'c':{'b':1}}"
+        "{'a':{'b':1}, 'c':{'b':1, 'z':99}}"
+      },
+      // narrowing an object onto its own name is an identity copy for the fields it names, not a
+      // last-one-wins race between them — issue #59646
+      {
+        List.of(mapping("x.a", "x.a"), mapping("x.b", "x.b")),
+        Map.of("x", asMsgPack("{'a':1, 'b':2}")),
+        "{'x':{'a':1, 'b':2}}"
       },
       // nested source
       {List.of(mapping("x.y", "a")), Map.of("x", asMsgPack("{'y':1}")), "{'a':1}"},

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
-import io.camunda.zeebe.engine.processing.variable.MappingResultBuilder;
+import io.camunda.zeebe.engine.processing.variable.InputMappingResultBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.Either;
@@ -207,7 +207,7 @@ final class VariableInputMappingTransformerTest {
     // when: evaluate the mappings one by one in modeling order, same as
     // BpmnVariableMappingBehavior.applyInputMappings does at runtime — accumulated results shadow
     // the base variables, which fall back for anything not mapped yet
-    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
+    final var resultBuilder = new InputMappingResultBuilder(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -240,7 +240,7 @@ final class VariableInputMappingTransformerTest {
                     .isTrue());
 
     // when
-    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
+    final var resultBuilder = new InputMappingResultBuilder(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
@@ -282,7 +282,7 @@ final class VariableInputMappingTransformerTest {
       final Map<String, DirectBuffer> variables,
       final ExpressionLanguage language) {
     final var inputMappings = transformer.transformInputMappings(mappings, language);
-    final var resultBuilder = MappingResultBuilder.forInputMappings(variables::get);
+    final var resultBuilder = new InputMappingResultBuilder(variables::get);
     for (final var mapping : inputMappings.mappings()) {
       final EvaluationContext context =
           name -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
-import io.camunda.zeebe.engine.processing.variable.MappingResultBuilder;
 import io.camunda.zeebe.engine.processing.variable.MsgPackPath;
+import io.camunda.zeebe.engine.processing.variable.OutputMappingResultBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.Either;
@@ -203,7 +203,7 @@ public final class VariableOutputMappingTransformerTest {
     // BpmnVariableMappingBehavior.applyOutputMappings does at runtime — accumulated results
     // shadow the scope variables, and nested targets merge with the scope value at every level
     final var resultBuilder =
-        MappingResultBuilder.forOutputMappings(
+        new OutputMappingResultBuilder(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -236,7 +236,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when: evaluate one by one, stopping at the first failure (mirrors runtime fail-fast)
     final var resultBuilder =
-        MappingResultBuilder.forOutputMappings(
+        new OutputMappingResultBuilder(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -277,7 +277,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when
     final var resultBuilder =
-        MappingResultBuilder.forOutputMappings(
+        new OutputMappingResultBuilder(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -310,7 +310,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when
     final var resultBuilder =
-        MappingResultBuilder.forOutputMappings(
+        new OutputMappingResultBuilder(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -203,7 +203,7 @@ public final class VariableOutputMappingTransformerTest {
     // BpmnVariableMappingBehavior.applyOutputMappings does at runtime — accumulated results
     // shadow the scope variables, and nested targets merge with the scope value at every level
     final var resultBuilder =
-        new MappingResultBuilder(
+        MappingResultBuilder.forOutputMappings(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -236,7 +236,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when: evaluate one by one, stopping at the first failure (mirrors runtime fail-fast)
     final var resultBuilder =
-        new MappingResultBuilder(
+        MappingResultBuilder.forOutputMappings(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -277,7 +277,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when
     final var resultBuilder =
-        new MappingResultBuilder(
+        MappingResultBuilder.forOutputMappings(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
@@ -310,7 +310,7 @@ public final class VariableOutputMappingTransformerTest {
 
     // when
     final var resultBuilder =
-        new MappingResultBuilder(
+        MappingResultBuilder.forOutputMappings(
             path ->
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

An input mapping to a nested target used to shadow its whole root variable. So if you map two fields of the same variable onto their own names — `foo.bar ← =foo.bar`, `foo.baz ← =foo.baz` — the first mapping creates a local `foo`, the second one resolves `foo` against that half-built object instead of the outer scope, finds no `baz` there, and maps `null`. Whichever field you declared last is the one that survives. No incident, no warning.

Input mappings now shadow a scope variable only for the keys they actually define. A source that reads a name an earlier nested target built sees the mapped keys layered over whatever that name resolves to in the scope chain, so anything unmapped falls through as before.

The important bit is that this is a *read-time* layering only. What gets written as a local variable is still exactly what you mapped — map `x.a` and your local `x` holds nothing but `a`. It's only the read that layers. Doing it the other way around (seeding the accumulated document from the scope value, the way output mappings merge) would have written keys nobody mapped, which is a different behaviour and not the one we want. Every fall-through test asserts both the mapped root and the variable that read it, because that pair is what tells the two implementations apart.

Two things follow from that and are worth knowing:

1. Fall-through adds exactly one layer. Rule 2's walk up the scope chain stops at the first scope holding the name and takes that whole value, so the mapping layers over the value the chain resolves to — not over every same-named variable between here and the process instance.
2. A target that was assigned *whole* stays totally shadowed, even if a later nested mapping re-creates it as an object. `x ← 1` then `x.a ← 2` gives a fresh `x`, not a merge into the value the first mapping dropped. That's tracked per path level rather than per variable, so it holds at `x.a` just as it does at `x`.

While I was in there I split `MappingResultBuilder` in two. It was serving both input and output mappings from one class and annotating its own fields "input mappings only" / "output mappings only", which is a class telling you it's really two. It's now a sealed interface with one implementation per direction, and no abstract hooks — the split removes work rather than moving it, since the input builder can never poison a level and the output builder never layers on read. What's genuinely shared is the msgpack representation, which lives in a package-private helper with no notion of direction.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59646
