### PR TITLE
fix: stop JWKS refresh from blocking concurrent authentication requests

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
@@ -51,8 +51,9 @@ public class JWSKeySelectorFactory {
   private static final int JWK_SOURCE_HTTP_CONNECT_TIMEOUT_MS = 2000;
   private static final int JWK_SOURCE_HTTP_READ_TIMEOUT_MS = 2000;
 
-  // Nimbus's own default is 15,000ms; this still gives one full retry's worth of slack (roughly
-  // 2x the connect+read timeout above) while failing much faster when the IdP is genuinely down.
+  // How long a caller blocks waiting for another thread's in-flight synchronous refresh before
+  // giving up. Nimbus's own default is 15,000ms; this still leaves comfortable headroom over the
+  // connect+read timeouts above while failing much faster when the IdP is genuinely down.
   private static final long JWK_SOURCE_CACHE_REFRESH_TIMEOUT_MS = 5000;
 
   private final Set<JWSAlgorithm> jwsAlgorithms;

--- a/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
@@ -143,10 +143,13 @@ public class JWSKeySelectorFactory {
             JWK_SOURCE_HTTP_CONNECT_TIMEOUT_MS,
             JWK_SOURCE_HTTP_READ_TIMEOUT_MS,
             JWKSourceBuilder.DEFAULT_HTTP_SIZE_LIMIT);
-    // refreshAheadCache(true): refresh happens ahead of expiry, off the request path, so
-    // concurrent lookups are served the still-valid cached keys instead of blocking on a
-    // synchronous refetch. outageTolerant is deliberately left at Nimbus's default (false): a
-    // cache that is genuinely expired with no successful refresh still fails closed.
+    // refreshAheadCache(true) matches Nimbus's own default (true); the previous
+    // refreshAheadCache(false) here was an explicit override copied from Spring's
+    // NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder#jwkSource, and that override — not a Nimbus
+    // default — is what made refresh run synchronously on the request path. Restoring the
+    // default means concurrent lookups are served the still-valid cached keys instead of
+    // blocking on a synchronous refetch. outageTolerant is deliberately left at Nimbus's default
+    // (false): a cache that is genuinely expired with no successful refresh still fails closed.
     return JWKSourceBuilder.create(jwkSetUri, retriever)
         .refreshAheadCache(true)
         .rateLimited(false)

--- a/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
@@ -13,6 +13,7 @@ import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
 import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -44,6 +45,15 @@ public class JWSKeySelectorFactory {
           JWSAlgorithm.ES256,
           JWSAlgorithm.ES384,
           JWSAlgorithm.ES512);
+
+  // Nimbus's own default is 500ms for both, tuned for fast, responsive IdPs; this tolerates a
+  // realistically slower external IdP while still failing fast on genuine unavailability.
+  private static final int JWK_SOURCE_HTTP_CONNECT_TIMEOUT_MS = 2000;
+  private static final int JWK_SOURCE_HTTP_READ_TIMEOUT_MS = 2000;
+
+  // Nimbus's own default is 15,000ms; this still gives one full retry's worth of slack (roughly
+  // 2x the connect+read timeout above) while failing much faster when the IdP is genuinely down.
+  private static final long JWK_SOURCE_CACHE_REFRESH_TIMEOUT_MS = 5000;
 
   private final Set<JWSAlgorithm> jwsAlgorithms;
 
@@ -127,10 +137,19 @@ public class JWSKeySelectorFactory {
    * @return a {@link JWKSource} for use in verifying JWT signatures
    */
   protected JWKSource<SecurityContext> createJWKSource(final URL jwkSetUri) {
-    return JWKSourceBuilder.create(jwkSetUri)
-        .refreshAheadCache(false)
+    final var retriever =
+        new DefaultResourceRetriever(
+            JWK_SOURCE_HTTP_CONNECT_TIMEOUT_MS,
+            JWK_SOURCE_HTTP_READ_TIMEOUT_MS,
+            JWKSourceBuilder.DEFAULT_HTTP_SIZE_LIMIT);
+    // refreshAheadCache(true): refresh happens ahead of expiry, off the request path, so
+    // concurrent lookups are served the still-valid cached keys instead of blocking on a
+    // synchronous refetch. outageTolerant is deliberately left at Nimbus's default (false): a
+    // cache that is genuinely expired with no successful refresh still fails closed.
+    return JWKSourceBuilder.create(jwkSetUri, retriever)
+        .refreshAheadCache(true)
         .rateLimited(false)
-        .cache(true)
+        .cache(JWKSourceBuilder.DEFAULT_CACHE_TIME_TO_LIVE, JWK_SOURCE_CACHE_REFRESH_TIMEOUT_MS)
         .build();
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
@@ -148,8 +148,13 @@ public class JWSKeySelectorFactory {
     // NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder#jwkSource, and that override — not a Nimbus
     // default — is what made refresh run synchronously on the request path. Restoring the
     // default means concurrent lookups are served the still-valid cached keys instead of
-    // blocking on a synchronous refetch. outageTolerant is deliberately left at Nimbus's default
-    // (false): a cache that is genuinely expired with no successful refresh still fails closed.
+    // blocking on a synchronous refetch. This is non-scheduled (refreshAheadScheduled stays
+    // false): the ahead-of-expiry refresh only fires when a request lands inside the last 30s
+    // before expiry, so the guarantee holds under continuous traffic — the reported incident —
+    // but a sparse-traffic instance can still hit a synchronous refresh at full expiry, now
+    // bounded by the timeouts below instead of Nimbus's tighter defaults. outageTolerant is
+    // deliberately left at Nimbus's default (false): a cache that is genuinely expired with no
+    // successful refresh still fails closed.
     return JWKSourceBuilder.create(jwkSetUri, retriever)
         .refreshAheadCache(true)
         .rateLimited(false)

--- a/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
@@ -20,10 +20,19 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.CachingJWKSetSource;
+import com.nimbusds.jose.jwk.source.JWKSetBasedJWKSource;
+import com.nimbusds.jose.jwk.source.JWKSetSource;
+import com.nimbusds.jose.jwk.source.JWKSetSourceWrapper;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RefreshAheadCachingJWKSetSource;
+import com.nimbusds.jose.jwk.source.URLBasedJWKSetSource;
 import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
 import com.nimbusds.jose.util.JSONObjectUtils;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import java.net.URI;
 import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
@@ -275,6 +284,36 @@ final class JWSKeySelectorFactoryTest {
 
     // then
     assertThat(m2mKeys).isNotEmpty();
+  }
+
+  @Test
+  void shouldConfigureJwkSourceWithRefreshAheadCachingAndIncreasedTimeouts() throws Exception {
+    // given
+    final var jwkSetUri = URI.create(baseUrl() + "/refresh-ahead/.well-known/jwks.json").toURL();
+
+    // when
+    final JWKSource<SecurityContext> jwkSource = factory.createJWKSource(jwkSetUri);
+
+    // then the outer source refreshes ahead of expiry instead of Nimbus's default blocking cache
+    assertThat(jwkSource).isInstanceOf(JWKSetBasedJWKSource.class);
+    final JWKSetSource<SecurityContext> outer =
+        ((JWKSetBasedJWKSource<SecurityContext>) jwkSource).getJWKSetSource();
+    assertThat(outer).isInstanceOf(RefreshAheadCachingJWKSetSource.class);
+
+    // and the blocking cache-refresh wait is reduced from Nimbus's 15s default
+    final CachingJWKSetSource<SecurityContext> cachingSource =
+        (CachingJWKSetSource<SecurityContext>) outer;
+    assertThat(cachingSource.getCacheRefreshTimeout()).isEqualTo(5000L);
+
+    // and the underlying HTTP retriever uses a real, bounded timeout — today there is none at all
+    final JWKSetSource<SecurityContext> inner =
+        ((JWKSetSourceWrapper<SecurityContext>) outer).getSource();
+    assertThat(inner).isInstanceOf(URLBasedJWKSetSource.class);
+    final var retriever = ((URLBasedJWKSetSource<SecurityContext>) inner).getResourceRetriever();
+    assertThat(retriever).isInstanceOf(DefaultResourceRetriever.class);
+    final DefaultResourceRetriever defaultRetriever = (DefaultResourceRetriever) retriever;
+    assertThat(defaultRetriever.getConnectTimeout()).isEqualTo(2000);
+    assertThat(defaultRetriever.getReadTimeout()).isEqualTo(2000);
   }
 
   private static String baseUrl() {

--- a/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
@@ -305,7 +305,7 @@ final class JWSKeySelectorFactoryTest {
         (CachingJWKSetSource<SecurityContext>) outer;
     assertThat(cachingSource.getCacheRefreshTimeout()).isEqualTo(5000L);
 
-    // and the underlying HTTP retriever uses a real, bounded timeout — today there is none at all
+    // and the underlying HTTP retriever's timeouts are raised from Nimbus's 500ms default
     final JWKSetSource<SecurityContext> inner =
         ((JWKSetSourceWrapper<SecurityContext>) outer).getSource();
     assertThat(inner).isInstanceOf(URLBasedJWKSetSource.class);

--- a/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
@@ -294,7 +294,9 @@ final class JWSKeySelectorFactoryTest {
     // when
     final JWKSource<SecurityContext> jwkSource = factory.createJWKSource(jwkSetUri);
 
-    // then the outer source refreshes ahead of expiry instead of Nimbus's default blocking cache
+    // then the outer source refreshes ahead of expiry, matching Nimbus's own default (the
+    // removed .refreshAheadCache(false) override, copied from Spring's
+    // NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder, was what had disabled it)
     assertThat(jwkSource).isInstanceOf(JWKSetBasedJWKSource.class);
     final JWKSetSource<SecurityContext> outer =
         ((JWKSetBasedJWKSource<SecurityContext>) jwkSource).getJWKSetSource();


### PR DESCRIPTION
## Summary
- `JWSKeySelectorFactory#createJWKSource` built its JWKS source with `refreshAheadCache(false)` and `rateLimited(false)` — explicit overrides copied from Spring's internal `NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder#jwkSource`, **not** Nimbus's own defaults (Nimbus's `JWKSourceBuilder` defaults both `refreshAhead` and `rateLimited` to `true`). Those overrides are what made every request that arrived while the cache was expired block on the same synchronous refetch of the IdP's key set; a brief IdP slowdown caused a synchronized burst of authentication failures.
- Removes the `refreshAheadCache(false)` override, restoring Nimbus's own default so refresh happens ahead of expiry, off the request path, and concurrent lookups are served the still-valid cached keys instead of blocking.
- Also raises the HTTP connect/read timeouts to 2s (Nimbus's own real default here is 500ms, tuned for fast, responsive IdPs) and reduces the blocking cache-refresh wait to 5s (Nimbus's own default is 15s) — the wait callers face on the paths refresh-ahead doesn't cover (first cold fetch, unrecognized `kid`).
- `outageTolerant` is deliberately left at Nimbus's default (disabled): a cache that is genuinely expired with no successful refresh still fails closed.

This PR covers the access-token verification path only (`JWSKeySelectorFactory`, used by the resource-server chain for API calls), and only the cache-expiry trigger described in #60337, under continuous traffic (a request landing within the 30s refresh-ahead window). Two gaps remain, tracked separately rather than folded in here:
- `rateLimited(false)` remains as before (not part of this fix) — Nimbus's own default here is `true` (30s minimum interval between fetches). This is what would actually collapse #60337's *other* reproduction trigger (a burst of unrecognized-`kid` requests, each forcing an immediate synchronous refetch regardless of `refreshAheadCache`) into one fetch; that trigger is untouched by this PR. Tracked as a follow-up: #60462
- The id_token verification path (browser OIDC login, `WebSecurityConfig#idTokenDecoderFactory`) still uses the old unbounded-timeout/no-refresh-ahead construction — a separate `JwtDecoderFactory<ClientRegistration>` that can't reuse this fix's changes without its own dedicated work. Tracked as a follow-up: #60464

Related to #60337 — left open, since the unrecognized-`kid` trigger (addressed by #60462) is part of #60337's own reproduction steps and isn't fixed by this PR.

## Test plan
- [x] New test in `JWSKeySelectorFactoryTest` asserting the built `JWKSource` is wired with `refreshAheadCache(true)` (Nimbus's `RefreshAheadCachingJWKSetSource` wrapper, matching Nimbus's own default), the reduced 5s cache-refresh timeout, and the increased 2s HTTP timeouts
- [x] Existing `JWSKeySelectorFactoryTest` suite passes unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
