### PR TITLE
ci: run Optimize E2E against the branch's Camunda SNAPSHOT image

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -527,7 +527,7 @@ jobs:
         run: |
           while : ; do
             count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
-            if [[ $count -eq 17 ]]; then
+            if [[ $count -eq 60 ]]; then
               echo "Process definitions imported ($count). Waiting for process instance import to stabilize..."
               prev="-1"
               stable=0
@@ -545,7 +545,7 @@ jobs:
               echo "Import stabilized at $cur process instances"
               break
             fi
-            echo "Index has $count entities. Waiting for 17..."
+            echo "Index has $count entities. Waiting for 60..."
             sleep 10
           done
 

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -503,6 +503,8 @@ jobs:
           compose_file: optimize/client/docker-compose.yml
           project_name: e2e
           additional_flags: "--profile self-managed"
+        env:
+          CAMUNDA_VERSION: ${{ steps.pom_info.outputs.x_camunda_docker_version }}
 
       - uses: ./.github/actions/build-zeebe
         id: build-camunda

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
+    inputs:
+      branches:
+        description: 'JSON array of branches to run against, e.g. ["main"] or ["my-feature-branch"]'
+        required: false
+        default: '["main", "stable/8.8", "stable/8.9"]'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, stable/8.8, stable/8.9]
+        branch: ${{ fromJSON(inputs.branches || '["main", "stable/8.8", "stable/8.9"]') }}
     permissions:
       contents: read
       id-token: write # for authenticating with GCP

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Wait for import to complete
         run: |
-          expected=${{ matrix.branch == 'stable/8.8' && '49' || '17' }}
+          expected=${{ matrix.branch == 'stable/8.8' && '49' || '60' }}
           while : ; do
             count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
             if [[ $count -eq $expected ]]; then

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -85,6 +85,8 @@ jobs:
           compose_file: optimize/client/docker-compose.yml
           project_name: e2e
           additional_flags: "--profile self-managed"
+        env:
+          CAMUNDA_VERSION: ${{ steps.pom_info.outputs.x_camunda_docker_version }}
 
       - name: Build backend
         run: ./mvnw -T1C clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     cpu_count: 4
     mem_limit: 2g
     healthcheck:
-      test: ['CMD-SHELL', 'curl -f http://localhost:9200/_cat/health | grep -q green']
+      test: ['CMD-SHELL', "curl -f http://localhost:9200/_cat/health | grep -qE 'green|yellow'"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -47,7 +47,7 @@
 
     <zeebe.version>${project.version}</zeebe.version>
     <!-- This is used in the start-backend.js script to determine the backing Camunda version -->
-    <camunda.docker.version>8.9.0</camunda.docker.version>
+    <camunda.docker.version>SNAPSHOT</camunda.docker.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.9</zeebe.docker.version>
 


### PR DESCRIPTION
Closes INC-7198. Test fixes for the failures this exposes are stacked on top in #60514.

## Why

The Optimize E2E stack (`optimize/client/docker-compose.yml`) runs `camunda/camunda` and `camunda/identity` from `${CAMUNDA_VERSION:-8.9.0}`. Two separate defects, and fixing only one changes nothing.

**1. CI never set `CAMUNDA_VERSION`.** It fell through to the literal baked into the compose file. Locally, `yarn start-backend` passes `camunda.docker.version` from `optimize/pom.xml` — so the pom was the source of truth everywhere except CI, the one place it exists for. Bumping it would have had no effect on either E2E job.

**2. The pom pinned a released tag.** The demo data these tests assert on is generated *inside* the Camunda image by the `dev-data` profile, not from the checked-out branch. The data-generator fix in "test: add consolidated auth tests and refactor data generators" therefore never reached the nightly — it kept running the generator as it shipped in 8.9.0. That is why INC-7198 recurred after the fix was merged: merging it changed nothing the job could see. No released tag can carry it; it exists only in 8.10 development.

## What changed

- `CAMUNDA_VERSION` on the compose step in `ci-optimize.yml` and `optimize-e2e-tests-sm-nightly.yml`, from the `pom_info` step both jobs already ran and neither used.
- `camunda.docker.version`: `8.9.0` → `SNAPSHOT`, matching Operate and the orchestration-cluster compose files.
- Expected process-definition count `17` → `60`, the count the newer generator produces.
- Elasticsearch healthcheck accepts `yellow`. It required `green`, which this single-node cluster only reaches while empty — Camunda and Optimize create indices with one replica, so it goes yellow at the first index and stays there. Startup was a race against that, which the 8.9.0 image won often enough to look stable and SNAPSHOT lost every time. Same gate as `docker-compose.smoketest.yml` and the OpenSearch compose action.
- The nightly takes a `branches` dispatch input, so it can be run against a feature branch instead of only `main` and the two stable branches. Without it, nothing in this PR was verifiable before merge.

## Verification

Nightly dispatched against this branch: [run 32231562423](https://github.com/camunda/camunda/actions/runs/32231562423). Compared against last night's scheduled run on `main` with the old pin, [run 32208554690](https://github.com/camunda/camunda/actions/runs/32208554690):

| | `main` @ 8.9.0 | this branch @ SNAPSHOT |
|---|---|---|
| Start services | pass | pass |
| Wait for import (60 definitions) | pass | **pass** |
| Failing tests | **9** | **4** |

Both SNAPSHOT images pulled and reported healthy, and the import settled on exactly 60 definitions — the two things that could not be checked without a run.

Five tests that fail on `main` today pass here: `add an incident filter`, `group by process`, `incident reports`, `multi definition selection`, `variable submenus are positioned correctly`. That is the shape you would expect if the suite had drifted ahead of the image it runs against.

The 4 that still fail all fail on `main` today as well, so none is a regression from this PR:

- `external datasources` — never got the fix that `stable/8.9` has (#57260).
- `add, edit and delete sources` — searches `big` and asserts on the first result, which is now `Big form process`.
- `aggregators` — reads the value before the new aggregation renders and compares `--` with `--`. Also fails on `stable/8.8` and `stable/8.9`, so it predates all of this.
- `drag a report in a Dashboard` — drag is a no-op (`expected 40 to be above 40`); no dependency on the Camunda image.

All four are fixed in #60514, stacked on this branch, so this PR stays scoped to the image pin.

## Backports

`stable/8.9` and `stable/8.8` need `8.9-SNAPSHOT` / `8.8-SNAPSHOT` rather than a straight cherry-pick — the nightly resolves the property from the pom of the branch it checks out. Both tags are published and current.
