### PR TITLE
ci: run "go mod tidy" on Golang load test projects

### DIFF
--- a/.github/renovate/team-reliability-testing.json5
+++ b/.github/renovate/team-reliability-testing.json5
@@ -91,6 +91,13 @@
       ],
       enabled: false,
     },
+
+    {
+      // Run "go mod tidy" on Golang updates
+      matchFileNames: ["load-tests/**"],
+      matchManagers: ["gomod"],
+      postUpdateOptions: ["gomodTidy"],
+    },
   ],
 
   ignorePaths: [


### PR DESCRIPTION

## Description

This prevents to have partially broken updates, that requires to also update other parts of the `go.sum` file.

- https://docs.renovatebot.com/configuration-options/#gomodtidy
- https://docs.renovatebot.com/golang/#module-tidying

Should help https://github.com/camunda/camunda/pull/59798 (cf. [my comment](https://github.com/camunda/camunda/pull/59798#event-29614670672))


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
