### PR TITLE
fix: prevent duplicate phase advancement of a phased change plan

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -8,26 +8,24 @@
 package io.camunda.zeebe.dynamic.config;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.ScopeReconciler.Operation;
+import io.camunda.zeebe.dynamic.config.ScopeReconciler.Operations;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliers;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliers;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
-import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics.OperationObserver;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
-import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.time.Duration;
@@ -36,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import org.jspecify.annotations.Nullable;
@@ -64,6 +63,21 @@ import org.slf4j.LoggerFactory;
  * applicable to the member. Only a member can make changes to its own state in the configuration.
  * See {@link GlobalConfigurationChangeAppliers} and {@link
  * PartitionGroupConfigurationChangeAppliers} to see how a change is applied locally.
+ *
+ * <h4>Driving changes forward: scopes and plans</h4>
+ *
+ * <p>Applying the local member's pending operations and advancing a phased change plan are both
+ * driven from one place: {@link #reconcile(CurrentClusterConfiguration)}, invoked after every
+ * successful local configuration update (see {@link #updateLocalCurrentConfiguration}). It fans out
+ * to two kinds of per-key workers, each independently retrying with its own backoff so that one
+ * key's failures cannot delay another's:
+ *
+ * <ul>
+ *   <li>A {@link ScopeReconciler} per {@link Scope} (the global configuration, or one named
+ *       partition group) applies the local member's next pending operation in that scope.
+ *   <li>A {@link PlanAdvancer} per pending plan id advances that plan to its next phase, or
+ *       completes it, once its current phase has fully drained.
+ * </ul>
  */
 public final class ClusterConfigurationManagerImpl implements ClusterConfigurationManager {
 
@@ -74,7 +88,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private final ActorFuture<Void> startFuture;
   private InconsistentConfigurationListener onInconsistentConfigurationDetected;
   private final MemberId localMemberId;
-  private final ExponentialBackoffRetryDelay backoffRetry;
   private boolean initialized = false;
   private final TopologyManagerMetrics topologyMetrics;
   private final boolean useNewConfig;
@@ -85,15 +98,11 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private @Nullable GlobalConfigurationChangeAppliers globalChangeAppliers;
   private final Map<String, PartitionGroupConfigurationChangeAppliers>
       partitionGroupChangeAppliers = new HashMap<>();
-  private boolean onGoingGlobalOperation = false;
-  private boolean shouldRetryGlobal = false;
-  private final Map<String, Boolean> onGoingGroupOperation = new HashMap<>();
-  private final Map<String, Boolean> shouldRetryGroup = new HashMap<>();
-  private final Map<String, ExponentialBackoffRetryDelay> groupBackoffRetry = new HashMap<>();
   private final Duration minRetryDelay;
   private final Duration maxRetryDelay;
+  private final Map<Scope, ScopeReconciler> scopeReconcilers = new HashMap<>();
   // Keyed by plan id, since multiple plans can be advancing (and independently retrying) at once.
-  private final Map<Long, ScheduledTimer> advancePhaseRetryTimers = new HashMap<>();
+  private final Map<Long, PlanAdvancer> planAdvancers = new HashMap<>();
   private final int completedChangeHistoryLimit;
 
   /** Constructs a manager operating on the multi-partition-group model. */
@@ -151,7 +160,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     this.maxRetryDelay = maxRetryDelay;
     this.completedChangeHistoryLimit = completedChangeHistoryLimit;
     PhasedChangeState.setHistoryLimit(completedChangeHistoryLimit);
-    backoffRetry = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
     useNewConfig = true;
     coordinatorSupplier =
         ClusterConfigurationCoordinatorSupplier.from(
@@ -194,7 +202,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
 
   /**
    * Applies {@code updater} to the multi-group configuration, persists and gossips the result, then
-   * triggers local operation application. Only valid when {@link #useNewConfig} is true.
+   * triggers reconciliation (see {@link #reconcile}). Only valid when {@link #useNewConfig} is
+   * true.
    */
   @Override
   public ActorFuture<CurrentClusterConfiguration> updateMultiConfiguration(
@@ -205,12 +214,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
           try {
             final var updated = updater.apply(persistedCurrentConfiguration.getConfiguration());
             updateLocalCurrentConfiguration(updated)
-                .ifRightOrLeft(
-                    applied -> {
-                      future.complete(applied);
-                      applyNewConfigurationChangeOperation();
-                    },
-                    future::completeExceptionally);
+                .ifRightOrLeft(future::complete, future::completeExceptionally);
           } catch (final Exception e) {
             LOG.error("Failed to update cluster configuration", e);
             future.completeExceptionally(e);
@@ -340,6 +344,20 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(() -> onInconsistentConfigurationDetected = null);
   }
 
+  /**
+   * Drops every scope's and plan's reconciliation worker. Only meant to be called once, as part of
+   * shutting down the whole manager (see {@link ClusterConfigurationManagerService#closeAsync} ) —
+   * unlike {@link #removePartitionGroupChangeAppliers}, which must leave a group's {@link
+   * ScopeReconciler} alone so it survives that group's own register/remove churn.
+   */
+  void close() {
+    executor.run(
+        () -> {
+          scopeReconcilers.clear();
+          planAdvancers.clear();
+        });
+  }
+
   void setCurrentConfigurationGossiper(
       final Consumer<CurrentClusterConfiguration> currentConfigurationGossiper) {
     this.currentConfigurationGossiper = currentConfigurationGossiper;
@@ -349,7 +367,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(
         () -> {
           globalChangeAppliers = appliers;
-          applyNewConfigurationChangeOperation();
+          scopeReconcilers.computeIfAbsent(
+              new Scope.Global(), ignored -> newGlobalScopeReconciler());
+          reconcile(persistedCurrentConfiguration.getConfiguration());
         });
   }
 
@@ -358,19 +378,31 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(
         () -> {
           partitionGroupChangeAppliers.put(groupId, appliers);
-          applyNewConfigurationChangeOperation();
+          scopeReconcilers.computeIfAbsent(
+              new Scope.Group(groupId), ignored -> newGroupScopeReconciler(groupId));
+          reconcile(persistedCurrentConfiguration.getConfiguration());
         });
   }
 
   void removePartitionGroupChangeAppliers(final String groupId) {
-    executor.run(() -> partitionGroupChangeAppliers.remove(groupId));
+    executor.run(
+        () -> {
+          partitionGroupChangeAppliers.remove(groupId);
+          // Deliberately not removing this group's ScopeReconciler here: it's only ever fetched
+          // via computeIfAbsent in registerPartitionGroupChangeAppliers above, so it survives a
+          // remove/register round-trip unmolested. PartitionManagerImpl/RecoveryPartitionManager
+          // re-register their change appliers on every recovery/processing mode transition;
+          // discarding the ScopeReconciler here would discard its in-flight retry/backoff state
+          // on every such transition, leaving a broker stuck mid-transition (see
+          // ModeChangeAcceptanceIT#shouldCycleBetweenRecoveryAndProcessing).
+        });
   }
 
   /**
    * Merges a {@link CurrentClusterConfiguration} received via gossip into the local one. If the
-   * merge changes the local configuration, it is persisted, re-gossiped, and local operation
-   * application is triggered. Leaves local state unchanged until {@link #start} has completed, to
-   * avoid a race between the configuration initializer and a concurrently received gossip update.
+   * merge changes the local configuration, it is persisted, re-gossiped, and reconciliation is
+   * triggered. Leaves local state unchanged until {@link #start} has completed, to avoid a race
+   * between the configuration initializer and a concurrently received gossip update.
    */
   void onGossipReceivedCurrent(final CurrentClusterConfiguration receivedConfiguration) {
     executor.run(
@@ -402,7 +434,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
                           onInconsistentConfigurationDetected.onInconsistentConfiguration(
                               applied, local);
                         }
-                        applyNewConfigurationChangeOperation();
                       },
                       error ->
                           LOG.warn(
@@ -429,7 +460,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
       if (currentConfigurationGossiper != null) {
         currentConfigurationGossiper.accept(configuration);
       }
-      maybeAdvancePhase(configuration);
+      reconcile(configuration);
       return Either.right(configuration);
     } catch (final Exception e) {
       return Either.left(e);
@@ -437,85 +468,70 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   }
 
   /**
-   * Drives phased-plan advancement for every currently pending plan (multiple may be pending
-   * concurrently, targeting disjoint sub-configurations). Invoked after every successful local
-   * configuration update. Only the coordinator (the member with the lowest id, per {@link
-   * ClusterConfigurationCoordinatorSupplier}) advances plans, so that a single member is
-   * responsible for the transition. When a plan's current phase's sub-configuration(s) have drained
-   * their pending changes, that plan is advanced to the next phase, or completed if it was the last
-   * phase. The action is idempotent — re-firing on an already-advanced phase is a no-op. Plans are
-   * advanced one at a time (each id re-reads the latest configuration before mutating it), so
-   * advancing one plan never clobbers a concurrent update to another.
+   * The single entry point that drives every pending plan and every scope's pending operation
+   * forward, invoked after every successful local configuration update. Only the coordinator (the
+   * member with the lowest id, per {@link ClusterConfigurationCoordinatorSupplier}) advances plans,
+   * so that a single member is responsible for the transition; every member applies its own pending
+   * operations regardless of coordinator status. Both are idempotent — re-firing while an action is
+   * already in flight for a given plan or scope is a no-op (see {@link PlanAdvancer} and {@link
+   * ScopeReconciler}).
+   *
+   * <p>This call chain is synchronous, not scheduled: staging an operation persists/gossips
+   * immediately, which re-enters this method before returning (guarded by the in-flight flags above
+   * from becoming a second concurrent attempt, not from recursing at all). Its stack depth is
+   * therefore bounded by the number of registered scopes with a simultaneously-ready operation, not
+   * by the number of phases or operations processed overall — acceptable at the scope counts
+   * (global plus one per physical tenant) this module deals with today, but worth keeping in mind
+   * if that count were ever to grow very large.
    */
-  private void maybeAdvancePhase(final CurrentClusterConfiguration config) {
-    if (config.phasedChangeState().pending().isEmpty() || !isLocalMemberCoordinator()) {
-      return;
+  private void reconcile(final CurrentClusterConfiguration config) {
+    final var pendingIds = config.phasedChangeState().pending().keySet();
+    if (isLocalMemberCoordinator()) {
+      for (final var planId : List.copyOf(pendingIds)) {
+        planAdvancers.computeIfAbsent(planId, this::newPlanAdvancer).maybeAdvance(config);
+      }
     }
-    for (final var planId : List.copyOf(config.phasedChangeState().pending().keySet())) {
-      maybeAdvancePhase(config, planId);
+    // Drop advancers for plans that are no longer pending, so this map doesn't grow one entry per
+    // plan for the process lifetime. Skipped when already empty (the common case: most updates
+    // happen while no plan is pending at all) rather than diffing against pendingIds for nothing.
+    if (!planAdvancers.isEmpty()) {
+      planAdvancers.keySet().retainAll(pendingIds);
     }
+    scopeReconcilers.values().forEach(ScopeReconciler::reconcile);
   }
 
-  private void maybeAdvancePhase(final CurrentClusterConfiguration config, final long planId) {
-    final var plan = config.phasedChangeState().pending().get(planId);
-    if (plan == null) {
-      // Already advanced/completed by a previous call in this same batch, or by another trigger.
-      return;
-    }
-    final boolean currentPhaseComplete =
-        switch (plan.currentPhase()) {
-          case final GlobalPhase ignored -> !config.globalConfiguration().hasPendingChanges();
-          case final PartitionGroupParallelPhase parallelPhase ->
-              parallelPhase.groupOperations().keySet().stream()
-                  .map(config::partitionGroup)
-                  .allMatch(group -> group != null && !group.hasPendingChanges());
-        };
-    if (!currentPhaseComplete) {
-      return;
-    }
-
-    if (plan.hasNextPhase()) {
-      updateMultiConfiguration(c -> c.activateNextPhase(planId))
-          .onComplete(
-              (ignore, error) -> {
-                if (error != null) {
-                  LOG.warn(
-                      "Failed to advance phased change plan '{}' to next phase", planId, error);
-                  scheduleAdvancePhase(planId);
-                } else {
-                  advancePhaseRetryTimers.remove(planId);
-                }
-              });
-    } else {
-      updateMultiConfiguration(
-              c ->
-                  c.completePlan(
-                      planId, PhasedChangePlanStatus.COMPLETED, completedChangeHistoryLimit))
-          .onComplete(
-              (ignore, error) -> {
-                if (error != null) {
-                  LOG.warn("Failed to complete phased change plan '{}'", planId, error);
-                  scheduleAdvancePhase(planId);
-                } else {
-                  advancePhaseRetryTimers.remove(planId);
-                }
-              });
-    }
-  }
-
-  private void scheduleAdvancePhase(final long planId) {
-    advancePhaseRetryTimers.computeIfAbsent(
+  private PlanAdvancer newPlanAdvancer(final long planId) {
+    return new PlanAdvancer(
         planId,
-        ignored ->
-            executor.schedule(
-                backoffRetry.nextDelay(),
-                () -> {
-                  // Cleared before firing (not in the success/failure branches of the retry
-                  // itself), so a repeat failure can schedule a new timer instead of finding a
-                  // stale, already-fired one still occupying this key.
-                  advancePhaseRetryTimers.remove(planId);
-                  maybeAdvancePhase(persistedCurrentConfiguration.getConfiguration(), planId);
-                }));
+        executor,
+        this::updateMultiConfiguration,
+        () -> persistedCurrentConfiguration.getConfiguration(),
+        this::isLocalMemberCoordinator,
+        minRetryDelay,
+        maxRetryDelay,
+        completedChangeHistoryLimit);
+  }
+
+  private ScopeReconciler newGlobalScopeReconciler() {
+    return new ScopeReconciler(
+        new GlobalScopeOperations(),
+        () -> persistedCurrentConfiguration.getConfiguration(),
+        this::updateLocalCurrentConfiguration,
+        executor,
+        topologyMetrics,
+        minRetryDelay,
+        maxRetryDelay);
+  }
+
+  private ScopeReconciler newGroupScopeReconciler(final String groupId) {
+    return new ScopeReconciler(
+        new GroupScopeOperations(groupId),
+        () -> persistedCurrentConfiguration.getConfiguration(),
+        this::updateLocalCurrentConfiguration,
+        executor,
+        topologyMetrics,
+        minRetryDelay,
+        maxRetryDelay);
   }
 
   private boolean isLocalMemberCoordinator() {
@@ -523,197 +539,127 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         && localMemberId.equals(coordinatorSupplier.getDefaultCoordinator());
   }
 
+  private record GlobalOperation(
+      GlobalChangeOperation operation, GlobalConfigurationChangeApplier applier)
+      implements Operation {
+
+    @Override
+    public Either<Exception, CurrentClusterConfiguration> initialize(
+        final CurrentClusterConfiguration config) {
+      return applier.init(config).map(config::updateGlobalConfiguration);
+    }
+
+    @Override
+    public ActorFuture<UnaryOperator<CurrentClusterConfiguration>> apply() {
+      return applier
+          .apply()
+          .thenApply(
+              transformer ->
+                  (UnaryOperator<CurrentClusterConfiguration>)
+                      config ->
+                          config.updateGlobalConfiguration(
+                              g -> g.advanceConfigurationChange(transformer)));
+    }
+  }
+
+  private record GroupOperation(
+      String groupId,
+      PartitionGroupOperation operation,
+      PartitionGroupConfigurationChangeApplier applier)
+      implements Operation {
+
+    @Override
+    public Either<Exception, CurrentClusterConfiguration> initialize(
+        final CurrentClusterConfiguration config) {
+      final var group = config.partitionGroup(groupId);
+      return applier
+          .init(config.globalConfiguration(), group)
+          .map(transformer -> config.updatePartitionGroupConfig(groupId, transformer));
+    }
+
+    @Override
+    public ActorFuture<UnaryOperator<CurrentClusterConfiguration>> apply() {
+      return applier
+          .apply()
+          .thenApply(
+              transformer ->
+                  (UnaryOperator<CurrentClusterConfiguration>)
+                      config ->
+                          config.updatePartitionGroupConfig(
+                              groupId, g -> g.advanceConfigurationChange(transformer)));
+    }
+  }
+
   /**
-   * Applies the next pending operation for the local member on the global configuration and on
-   * every partition group. Operations across partition groups are applied concurrently — each group
-   * has its own in-progress/retry state — while the operations within a single group (and within
-   * the global configuration) are applied sequentially.
+   * Identifies exactly one reconciliation target: the global configuration, or a single named
+   * partition group. Distinct from {@code PhasedChangePlan.Scope}, which names a <em>plan's</em>
+   * footprint (possibly several groups at once, for admission conflict checks) — this key always
+   * names exactly one target, since it addresses a single {@link ScopeReconciler}.
    */
-  private void applyNewConfigurationChangeOperation() {
-    applyGlobalConfigurationChangeOperation();
-    // can apply operations to global and groups in parallel. The ordering is constrained by the
-    // phases. So additional enforcement of ordering is not needed here.
-    for (final String groupId :
-        List.copyOf(persistedCurrentConfiguration.getConfiguration().partitionGroups().keySet())) {
-      // Can apply operations to multiple groups in parallel, but only one operation per group at a
-      // time.
-      applyPartitionGroupConfigurationChangeOperation(groupId);
+  private sealed interface Scope permits Scope.Global, Scope.Group {
+
+    record Global() implements Scope {}
+
+    record Group(String groupId) implements Scope {}
+  }
+
+  /** {@link ScopeReconciler.Operations} for the global configuration. */
+  private final class GlobalScopeOperations implements Operations {
+
+    @Override
+    public Optional<Operation> nextOperation(final CurrentClusterConfiguration config) {
+      if (globalChangeAppliers == null) {
+        return Optional.empty();
+      }
+      return config
+          .globalConfiguration()
+          .pendingChangesFor(localMemberId)
+          .map(
+              operation ->
+                  new GlobalOperation(operation, globalChangeAppliers.getApplier(operation)));
+    }
+
+    @Override
+    public long versionOf(final CurrentClusterConfiguration config) {
+      return config.globalConfiguration().version();
+    }
+
+    @Override
+    public String describe() {
+      return "global";
     }
   }
 
-  private void applyGlobalConfigurationChangeOperation() {
-    final var config = persistedCurrentConfiguration.getConfiguration();
-    final var pending = config.globalConfiguration().pendingChangesFor(localMemberId);
-    if ((onGoingGlobalOperation && !shouldRetryGlobal)
-        || globalChangeAppliers == null
-        || pending.isEmpty()) {
-      return;
+  /** {@link ScopeReconciler.Operations} for one named partition group. */
+  private final class GroupScopeOperations implements Operations {
+
+    private final String groupId;
+
+    private GroupScopeOperations(final String groupId) {
+      this.groupId = groupId;
     }
 
-    onGoingGlobalOperation = true;
-    shouldRetryGlobal = false;
-    final var operation = pending.orElseThrow();
-    final var observer = topologyMetrics.observeOperation(operation);
-    LOG.info("Applying global configuration change operation {}", operation);
-    final var applier = globalChangeAppliers.getApplier(operation);
-    final var initialized =
-        applier
-            .init(config)
-            .map(config::updateGlobalConfiguration)
-            .flatMap(this::updateLocalCurrentConfiguration);
-
-    if (initialized.isLeft()) {
-      observer.failed();
-      onGoingGlobalOperation = false;
-      LOG.error(
-          "Failed to initialize global configuration change operation {}",
-          operation,
-          initialized.getLeft());
-      return;
+    @Override
+    public Optional<Operation> nextOperation(final CurrentClusterConfiguration config) {
+      final var appliers = partitionGroupChangeAppliers.get(groupId);
+      final var group = config.partitionGroup(groupId);
+      if (appliers == null || group == null) {
+        return Optional.empty();
+      }
+      return group
+          .pendingChangesFor(localMemberId)
+          .map(operation -> new GroupOperation(groupId, operation, appliers.getApplier(operation)));
     }
 
-    final var startedConfiguration = initialized.get();
-    applier
-        .apply()
-        .onComplete(
-            (transformer, error) ->
-                onGlobalOperationApplied(
-                    startedConfiguration, operation, transformer, error, observer));
-  }
-
-  private void onGlobalOperationApplied(
-      final CurrentClusterConfiguration configurationOnWhichOperationIsApplied,
-      final GlobalChangeOperation operation,
-      final UnaryOperator<GlobalConfiguration> transformer,
-      final Throwable error,
-      final OperationObserver observer) {
-    onGoingGlobalOperation = false;
-    if (error != null) {
-      observer.failed();
-      shouldRetryGlobal = true;
-      final Duration delay = backoffRetry.nextDelay();
-      LOG.warn(
-          "Failed to apply global configuration change operation {}. Will be retried in {}.",
-          operation,
-          delay,
-          error);
-      executor.schedule(delay, this::applyNewConfigurationChangeOperation);
-      return;
+    @Override
+    public long versionOf(final CurrentClusterConfiguration config) {
+      final var group = config.partitionGroup(groupId);
+      return group == null ? -1 : group.version();
     }
 
-    observer.applied();
-    backoffRetry.reset();
-    if (persistedCurrentConfiguration.getConfiguration().globalConfiguration().version()
-        != configurationOnWhichOperationIsApplied.globalConfiguration().version()) {
-      LOG.debug(
-          "Global configuration changed while applying operation {}. Most likely the change was cancelled.",
-          operation);
-      return;
+    @Override
+    public String describe() {
+      return "partition group '%s'".formatted(groupId);
     }
-    final var advanced =
-        persistedCurrentConfiguration
-            .getConfiguration()
-            .updateGlobalConfiguration(g -> g.advanceConfigurationChange(transformer));
-    updateLocalCurrentConfiguration(advanced);
-    LOG.info("Global operation {} applied.", operation);
-    executor.run(this::applyNewConfigurationChangeOperation);
-  }
-
-  private void applyPartitionGroupConfigurationChangeOperation(final String groupId) {
-    final var config = persistedCurrentConfiguration.getConfiguration();
-    final var group = config.partitionGroup(groupId);
-    final var appliers = partitionGroupChangeAppliers.get(groupId);
-    if (group == null || appliers == null) {
-      return;
-    }
-    final var pending = group.pendingChangesFor(localMemberId);
-    if ((onGoingGroupOperation.getOrDefault(groupId, false)
-            && !shouldRetryGroup.getOrDefault(groupId, false))
-        || pending.isEmpty()) {
-      return;
-    }
-
-    onGoingGroupOperation.put(groupId, true);
-    shouldRetryGroup.put(groupId, false);
-    final var operation = pending.orElseThrow();
-    final var observer = topologyMetrics.observeOperation(operation);
-    LOG.info("Applying partition group '{}' configuration change operation {}", groupId, operation);
-    final var applier = appliers.getApplier(operation);
-    final var initialized =
-        applier
-            .init(config.globalConfiguration(), group)
-            .map(transformer -> config.updatePartitionGroupConfig(groupId, transformer))
-            .flatMap(this::updateLocalCurrentConfiguration);
-
-    if (initialized.isLeft()) {
-      observer.failed();
-      onGoingGroupOperation.put(groupId, false);
-      LOG.error(
-          "Failed to initialize partition group '{}' configuration change operation {}",
-          groupId,
-          operation,
-          initialized.getLeft());
-      return;
-    }
-
-    final var startedConfiguration = initialized.get();
-    applier
-        .apply()
-        .onComplete(
-            (transformer, error) ->
-                onPartitionGroupOperationApplied(
-                    groupId, startedConfiguration, operation, transformer, error, observer));
-  }
-
-  private void onPartitionGroupOperationApplied(
-      final String groupId,
-      final CurrentClusterConfiguration configurationOnWhichOperationIsApplied,
-      final PartitionGroupOperation operation,
-      final UnaryOperator<PartitionGroupConfiguration> transformer,
-      final Throwable error,
-      final OperationObserver observer) {
-    onGoingGroupOperation.put(groupId, false);
-    if (error != null) {
-      observer.failed();
-      shouldRetryGroup.put(groupId, true);
-      final Duration delay =
-          groupBackoffRetry
-              .computeIfAbsent(
-                  groupId,
-                  ignored -> new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay))
-              .nextDelay();
-      LOG.warn(
-          "Failed to apply partition group '{}' configuration change operation {}. Will be retried in {}.",
-          groupId,
-          operation,
-          delay,
-          error);
-      executor.schedule(delay, this::applyNewConfigurationChangeOperation);
-      return;
-    }
-
-    observer.applied();
-    final var groupBackoff = groupBackoffRetry.get(groupId);
-    if (groupBackoff != null) {
-      groupBackoff.reset();
-    }
-    final var currentGroup =
-        persistedCurrentConfiguration.getConfiguration().partitionGroup(groupId);
-    if (currentGroup == null
-        || currentGroup.version()
-            != configurationOnWhichOperationIsApplied.partitionGroup(groupId).version()) {
-      LOG.warn(
-          "Partition group '{}' changed while applying operation {}. Most likely the change was cancelled.",
-          groupId,
-          operation);
-      return;
-    }
-    final var advanced =
-        persistedCurrentConfiguration
-            .getConfiguration()
-            .updatePartitionGroupConfig(groupId, g -> g.advanceConfigurationChange(transformer));
-    updateLocalCurrentConfiguration(advanced);
-    LOG.info("Partition group '{}' operation {} applied.", groupId, operation);
-    executor.run(this::applyNewConfigurationChangeOperation);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -322,6 +322,7 @@ public final class ClusterConfigurationManagerService
       configurationRequestServer.close();
     }
     clusterConfigurationGossiper.close();
+    clusterConfigurationManager.close();
     return managerActor.closeAsync().andThen(gossipActor::closeAsync, Runnable::run);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PlanAdvancer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PlanAdvancer.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.ScheduledTimer;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drives a single pending {@code PhasedChangePlan}'s advancement through its phases, one instance
+ * per plan id. Owns its own {@link ExponentialBackoffRetryDelay} so a repeated failure advancing
+ * this plan cannot push another concurrently-pending plan's retry delay toward the max the way a
+ * single shared backoff instance would.
+ *
+ * <p>Fixes the "two independent triggers both observe the same completed phase and both enqueue an
+ * advance" race: {@link #advancing} is set the moment an advance/complete action is enqueued and
+ * cleared only once it resolves, so a second trigger arriving while the first is still in flight is
+ * a no-op here. As a second, independent safety net (e.g. across a coordinator handoff, where two
+ * different {@code PlanAdvancer} instances on two different members could each decide to act),
+ * {@code CurrentClusterConfiguration#tryActivateNextPhase(long, int)} and {@code
+ * CurrentClusterConfiguration#tryCompletePlan(long, int, PhasedChangePlanStatus, int)} re-validate
+ * the plan is still at the expected phase before mutating it, turning a stale/duplicate action into
+ * a no-op rather than a double-advance or an exception.
+ */
+@NullMarked
+final class PlanAdvancer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PlanAdvancer.class);
+
+  private final long planId;
+  private final ConcurrencyControl executor;
+  private final Function<
+          UnaryOperator<CurrentClusterConfiguration>, ActorFuture<CurrentClusterConfiguration>>
+      submitUpdate;
+  private final Supplier<CurrentClusterConfiguration> currentConfiguration;
+  private final BooleanSupplier isLocalMemberCoordinator;
+  private final int completedChangeHistoryLimit;
+  private final ExponentialBackoffRetryDelay backoff;
+
+  private boolean advancing;
+  private @Nullable ScheduledTimer retryTimer;
+
+  PlanAdvancer(
+      final long planId,
+      final ConcurrencyControl executor,
+      final Function<
+              UnaryOperator<CurrentClusterConfiguration>, ActorFuture<CurrentClusterConfiguration>>
+          submitUpdate,
+      final Supplier<CurrentClusterConfiguration> currentConfiguration,
+      final BooleanSupplier isLocalMemberCoordinator,
+      final Duration minRetryDelay,
+      final Duration maxRetryDelay,
+      final int completedChangeHistoryLimit) {
+    this.planId = planId;
+    this.executor = executor;
+    this.submitUpdate = submitUpdate;
+    this.currentConfiguration = currentConfiguration;
+    this.isLocalMemberCoordinator = isLocalMemberCoordinator;
+    this.completedChangeHistoryLimit = completedChangeHistoryLimit;
+    backoff = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
+  }
+
+  /**
+   * Advances the plan to its next phase, or completes it, if {@code config} shows its current phase
+   * as fully drained. A no-op if an action for this plan is already in flight, the plan is no
+   * longer pending, its current phase has not (yet) drained, or the local member is no longer the
+   * coordinator.
+   *
+   * <p>The coordinator check is re-evaluated on every call, not just the first: this instance can
+   * outlive the local member's coordinator status (e.g. a membership change hands coordination to
+   * another member while this plan's advance is in flight, or while a retry is scheduled), and both
+   * the success-continuation and the retry callback below call back into this method directly,
+   * bypassing whatever coordinator check gated the original external trigger.
+   */
+  void maybeAdvance(final CurrentClusterConfiguration config) {
+    if (advancing || !isLocalMemberCoordinator.getAsBoolean()) {
+      return;
+    }
+    final var plan = config.phasedChangeState().pending().get(planId);
+    if (plan == null || !config.isCurrentPhaseComplete(planId)) {
+      return;
+    }
+
+    advancing = true;
+    final int expectedPhaseIndex = plan.currentPhaseIndex();
+    final var future =
+        plan.hasNextPhase()
+            ? submitUpdate.apply(c -> c.tryActivateNextPhase(planId, expectedPhaseIndex))
+            : submitUpdate.apply(
+                c ->
+                    c.tryCompletePlan(
+                        planId,
+                        expectedPhaseIndex,
+                        PhasedChangePlanStatus.COMPLETED,
+                        completedChangeHistoryLimit));
+    future.onComplete(
+        (ignore, error) -> {
+          advancing = false;
+          if (error != null) {
+            LOG.warn("Failed to advance phased change plan '{}' to next phase", planId, error);
+            scheduleRetry();
+            return;
+          }
+          backoff.reset();
+          if (retryTimer != null) {
+            retryTimer.cancel();
+            retryTimer = null;
+          }
+          // The phase just activated (or the plan just completed) may itself already be fully
+          // drained by the time this callback runs: applying it can complete synchronously as a
+          // side effect of persisting the update above (see ScopeReconciler), and that completion
+          // arrived while this instance was still marked advancing, so it was ignored (see the
+          // dedup guard above). Re-checking here against the latest config is what picks it back
+          // up, instead of leaving the plan stuck until some unrelated later trigger happens to
+          // reconcile it.
+          maybeAdvance(currentConfiguration.get());
+        });
+  }
+
+  private void scheduleRetry() {
+    if (retryTimer != null) {
+      return;
+    }
+    retryTimer =
+        executor.schedule(
+            backoff.nextDelay(),
+            () -> {
+              // Cleared before firing (not in maybeAdvance's completion callback), so a repeat
+              // failure can schedule a fresh timer instead of finding a stale, already-fired one
+              // still occupying this field.
+              retryTimer = null;
+              maybeAdvance(currentConfiguration.get());
+            });
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ScopeReconciler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ScopeReconciler.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics.OperationObserver;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drives ongoing/retry/backoff for the local member's next pending operation within a single
+ * reconciliation scope (the global configuration, or one named partition group). One instance per
+ * scope, each with its own {@link ExponentialBackoffRetryDelay}, so a repeated failure applying one
+ * scope's operation cannot push another scope's retry delay toward the max the way a single shared
+ * backoff instance would (see {@link ClusterConfigurationManagerImpl}, which used to keep three
+ * parallel {@code Map}s for this per group, plus two more scalar fields for the global case).
+ *
+ * <p>{@link Operations} supplies the scope-specific pieces (finding the local member's pending
+ * operation, and staging/applying it) so this class only implements the orchestration that is
+ * otherwise identical between the global and per-group cases.
+ *
+ * <p>Staging an operation ({@code initialize().flatMap(updateLocally)}) persists/gossips the staged
+ * config synchronously, which re-enters {@link ClusterConfigurationManagerImpl#reconcile} — and
+ * therefore every registered {@code ScopeReconciler}'s {@link #reconcile()}, including this one —
+ * before that call returns. The {@code ongoing} flag (set before staging, not after) turns that
+ * re-entrant call into a no-op rather than a recursive one, so this doesn't deepen with the number
+ * of operations processed; it's bounded only by the number of scopes that simultaneously have a
+ * ready operation, which is fine at the scope counts (global plus one per physical tenant) this
+ * module deals with today.
+ */
+@NullMarked
+final class ScopeReconciler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ScopeReconciler.class);
+
+  private final Operations operations;
+  private final Supplier<CurrentClusterConfiguration> currentConfiguration;
+  private final Function<
+          CurrentClusterConfiguration, Either<Exception, CurrentClusterConfiguration>>
+      updateLocally;
+  private final ConcurrencyControl executor;
+  private final TopologyManagerMetrics topologyMetrics;
+  private final ExponentialBackoffRetryDelay backoff;
+
+  private boolean ongoing;
+
+  ScopeReconciler(
+      final Operations operations,
+      final Supplier<CurrentClusterConfiguration> currentConfiguration,
+      final Function<CurrentClusterConfiguration, Either<Exception, CurrentClusterConfiguration>>
+          updateLocally,
+      final ConcurrencyControl executor,
+      final TopologyManagerMetrics topologyMetrics,
+      final Duration minRetryDelay,
+      final Duration maxRetryDelay) {
+    this.operations = operations;
+    this.currentConfiguration = currentConfiguration;
+    this.updateLocally = updateLocally;
+    this.executor = executor;
+    this.topologyMetrics = topologyMetrics;
+    backoff = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
+  }
+
+  /**
+   * Applies the local member's next pending operation in this scope, if any and if none is already
+   * in flight. A no-op if an operation is already ongoing.
+   */
+  void reconcile() {
+    if (ongoing) {
+      return;
+    }
+    final var config = currentConfiguration.get();
+    final var next = operations.nextOperation(config);
+    if (next.isEmpty()) {
+      return;
+    }
+
+    // Set before staging the operation (not in the branches below): staging calls back into
+    // updateLocally, which re-invokes reconcile() on every scope, including this one — this flag
+    // is what makes that re-entrant call a no-op instead of a second concurrent attempt.
+    ongoing = true;
+    final var op = next.get();
+    final var observer = topologyMetrics.observeOperation(op.operation());
+    LOG.info(
+        "Applying {} configuration change operation {}", operations.describe(), op.operation());
+    final var initialized = op.initialize(config).flatMap(updateLocally);
+    if (initialized.isLeft()) {
+      observer.failed();
+      ongoing = false;
+      LOG.error(
+          "Failed to initialize {} configuration change operation {}",
+          operations.describe(),
+          op.operation(),
+          initialized.getLeft());
+      return;
+    }
+
+    final var startedConfiguration = initialized.get();
+    final var startedVersion = operations.versionOf(startedConfiguration);
+    op.apply()
+        .onComplete(
+            (transformer, error) ->
+                onApplied(op.operation(), transformer, error, startedVersion, observer));
+  }
+
+  private void onApplied(
+      final ClusterConfigurationChangeOperation operation,
+      // Declared non-null to match ActorFuture#onComplete's callback type (V, @Nullable
+      // Throwable): only dereferenced below once error == null is confirmed, which is the only
+      // branch where the future actually completed with a value.
+      final UnaryOperator<CurrentClusterConfiguration> transformer,
+      final @Nullable Throwable error,
+      final long startedVersion,
+      final OperationObserver observer) {
+    ongoing = false;
+    if (error != null) {
+      observer.failed();
+      final Duration delay = backoff.nextDelay();
+      LOG.warn(
+          "Failed to apply {} configuration change operation {}. Will be retried in {}.",
+          operations.describe(),
+          operation,
+          delay,
+          error);
+      executor.schedule(delay, this::reconcile);
+      return;
+    }
+
+    observer.applied();
+    final var config = currentConfiguration.get();
+    if (operations.versionOf(config) != startedVersion) {
+      // The remote operation itself succeeded (observer.applied() above already reflects that);
+      // only the local advance is moot because the scope changed underneath it (most likely the
+      // change was cancelled). Reset the backoff here too, or a scope that failed a few times
+      // before this cancellation would face an inflated delay on its next, unrelated failure.
+      backoff.reset();
+      LOG.debug(
+          "{} changed while applying operation {}. Most likely the change was cancelled.",
+          operations.describe(),
+          operation);
+      return;
+    }
+    final var advanced = transformer.apply(config);
+    // Persisting/gossiping the advanced config re-triggers reconciliation across every scope and
+    // plan (see ClusterConfigurationManagerImpl#reconcile), which is what picks up a newly-drained
+    // phase's next operation — no separate "run the whole loop again" call is needed here.
+    final var persisted = updateLocally.apply(advanced);
+    if (persisted.isLeft()) {
+      // The remote operation already succeeded; only the local persist/gossip of that fact
+      // failed. Retrying from reconcile() re-derives and re-applies the same still-pending
+      // operation from scratch — the same path a crash between the remote apply and the local
+      // persist would already force this module to tolerate, so no separate "retry just the
+      // persist" mechanism is needed here.
+      final Duration delay = backoff.nextDelay();
+      LOG.warn(
+          "Failed to persist {} configuration change operation {} after applying it. Will be"
+              + " retried in {}.",
+          operations.describe(),
+          operation,
+          delay,
+          persisted.getLeft());
+      executor.schedule(delay, this::reconcile);
+      return;
+    }
+    backoff.reset();
+    LOG.info("{} operation {} applied.", operations.describe(), operation);
+  }
+
+  /** Scope-specific strategy for finding and staging the local member's next pending operation. */
+  interface Operations {
+
+    Optional<Operation> nextOperation(CurrentClusterConfiguration config);
+
+    /** The sub-configuration's own version, used to detect a concurrent cancel/change. */
+    long versionOf(CurrentClusterConfiguration config);
+
+    /**
+     * Human-readable scope name for logs, e.g. {@code "global"} or {@code "partition group 'x'"}.
+     */
+    String describe();
+  }
+
+  /** A single in-flight application of one pending operation, found by {@link Operations}. */
+  interface Operation {
+
+    ClusterConfigurationChangeOperation operation();
+
+    /** Validates and stages the operation into the affected sub-configuration. */
+    Either<Exception, CurrentClusterConfiguration> initialize(CurrentClusterConfiguration config);
+
+    /**
+     * Performs the operation, completing with a transform that advances the affected
+     * sub-configuration once it succeeds.
+     */
+    ActorFuture<UnaryOperator<CurrentClusterConfiguration>> apply();
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -444,6 +444,11 @@ public record CurrentClusterConfiguration(
    *
    * @throws IllegalStateException if no plan {@code planId} is pending, or it is already on its
    *     last phase
+   * @apiNote Unconditional and unguarded — it throws if the precondition doesn't hold, rather than
+   *     re-validating it, so it is only safe against a config snapshot no concurrent trigger can
+   *     act on (e.g. a single-threaded dry-run simulation). A caller driving a live plan against a
+   *     config that another trigger could concurrently advance must use {@link
+   *     #tryActivateNextPhase(long, int)} instead.
    */
   public CurrentClusterConfiguration activateNextPhase(final long planId) {
     final var plan = phasedChangeState.pending().get(planId);
@@ -461,10 +466,37 @@ public record CurrentClusterConfiguration(
   }
 
   /**
+   * Like {@link #activateNextPhase(long)}, but re-validates {@code expectedPhaseIndex} against the
+   * plan's actual current phase index first, no-op'ing (returning {@code this}) instead of mutating
+   * if it no longer matches — i.e. the plan is no longer pending, or some other trigger already
+   * advanced it past the phase this call was decided against. Intended for callers that computed
+   * "phase complete, advance it" from a config snapshot that may since have gone stale (e.g. two
+   * independent triggers both observing the same completed phase): re-validating at execution time,
+   * rather than throwing, turns a stale/duplicate advance into a harmless no-op instead of an
+   * exception that would otherwise be retried forever against a precondition that can never become
+   * true again. The {@code try} prefix marks it as the safe-by-default choice for any caller
+   * driving a live plan, as opposed to {@link #activateNextPhase(long)}.
+   */
+  public CurrentClusterConfiguration tryActivateNextPhase(
+      final long planId, final int expectedPhaseIndex) {
+    final var plan = phasedChangeState.pending().get(planId);
+    if (plan == null || plan.currentPhaseIndex() != expectedPhaseIndex) {
+      return this;
+    }
+    return activateNextPhase(planId);
+  }
+
+  /**
    * Completes the pending plan {@code planId} with the given terminal status, moving it into {@code
    * history}. Sub-configuration changes activated by the plan are left untouched.
    *
    * @throws IllegalStateException if plan {@code planId} is not pending
+   * @apiNote Unconditional and unguarded — it throws if the plan isn't pending, rather than
+   *     re-validating, so it is only safe against a config snapshot no concurrent trigger can act
+   *     on (e.g. a single-threaded dry-run simulation, or a caller that already confirmed the plan
+   *     is pending under the same single-writer authority that owns it). A caller driving a live
+   *     plan against a config that another trigger could concurrently complete must use {@link
+   *     #tryCompletePlan(long, int, PhasedChangePlanStatus, int)} instead.
    */
   public CurrentClusterConfiguration completePlan(
       final long planId, final PhasedChangePlanStatus status) {
@@ -475,6 +507,49 @@ public record CurrentClusterConfiguration(
   public CurrentClusterConfiguration completePlan(
       final long planId, final PhasedChangePlanStatus status, final int historyLimit) {
     return withPhasedChangeState(phasedChangeState.completePlan(planId, status, historyLimit));
+  }
+
+  /**
+   * Like {@link #completePlan(long, PhasedChangePlanStatus, int)}, but re-validates {@code
+   * expectedPhaseIndex} first, no-op'ing (returning {@code this}) instead of throwing if the plan
+   * is no longer pending or has moved past that phase. See {@link #tryActivateNextPhase(long, int)}
+   * for why re-validation, not an exception, is the correct response to a stale/duplicate
+   * completion trigger. The {@code try} prefix marks it as the safe-by-default choice for any
+   * caller driving a live plan, as opposed to the unguarded {@link #completePlan(long,
+   * PhasedChangePlanStatus, int)}.
+   */
+  public CurrentClusterConfiguration tryCompletePlan(
+      final long planId,
+      final int expectedPhaseIndex,
+      final PhasedChangePlanStatus status,
+      final int historyLimit) {
+    final var plan = phasedChangeState.pending().get(planId);
+    if (plan == null || plan.currentPhaseIndex() != expectedPhaseIndex) {
+      return this;
+    }
+    return completePlan(planId, status, historyLimit);
+  }
+
+  /**
+   * Returns {@code true} if plan {@code planId}'s current phase has fully drained: every
+   * sub-configuration it targets (the global configuration for a {@link GlobalPhase}, or each named
+   * partition group for a {@link PartitionGroupParallelPhase}) has no pending changes left.
+   *
+   * @throws IllegalStateException if no plan {@code planId} is pending
+   */
+  public boolean isCurrentPhaseComplete(final long planId) {
+    final var plan = phasedChangeState.pending().get(planId);
+    if (plan == null) {
+      throw new IllegalStateException(
+          "Cannot check phase completion: no plan '%d' is pending".formatted(planId));
+    }
+    return switch (plan.currentPhase()) {
+      case final GlobalPhase ignored -> !globalConfiguration.hasPendingChanges();
+      case final PartitionGroupParallelPhase parallelPhase ->
+          parallelPhase.groupOperations().keySet().stream()
+              .map(this::partitionGroup)
+              .allMatch(group -> group != null && !group.hasPendingChanges());
+    };
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
@@ -180,6 +180,67 @@ final class ClusterConfigurationManagerImplTest {
   }
 
   @Test
+  void shouldApplyEveryOperationInASingleGroupPhaseSequentially() {
+    // given — member 1 replicates partitions 1 and 2; a phase joins the local member (0) to both,
+    // the ordinary scale-up shape (toPhases folds a run of same-kind ops into one phase, so a
+    // multi-partition scale-up is one phase with several operations, not several phases)
+    final var manager = newManager(MEMBER_0);
+    final var group =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(
+                        1, PartitionState.active(1, partitionConfig),
+                        2, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(
+                    MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                    MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    // when — one phase carries two join operations for the local member, one per partition
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(
+                                    new PartitionJoinOperation(MEMBER_0, 1, 1),
+                                    new PartitionJoinOperation(MEMBER_0, 2, 1)))))))
+        .join();
+
+    // then — both operations drained in order and the plan completed; a reconciliation loop that
+    // stopped after the first operation would leave partition 2 (and the plan) stuck pending
+    final var config = configuration(manager);
+    final var defaultGroup = config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasPendingChanges()).isFalse();
+    assertThat(defaultGroup.getMember(MEMBER_0).partitions()).containsOnlyKeys(1, 2);
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    final var lastChange = config.phasedChangeState().lastChange();
+    assertThat(lastChange).isPresent();
+    assertThat(lastChange.get().status()).isEqualTo(PhasedChangePlanStatus.COMPLETED);
+  }
+
+  @Test
   void shouldApplyOneParallelPhaseToEveryPartitionGroupItTargets() {
     // given — two partition groups (physical tenants), each with the local member replicating its
     // own partition 1. A cluster purge plans one parallel phase spanning every group, so a phase
@@ -379,6 +440,78 @@ final class ClusterConfigurationManagerImplTest {
     final var defaultGroup = config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
     assertThat(defaultGroup.hasMember(MEMBER_0)).isTrue();
     assertThat(defaultGroup.hasPendingChanges()).isFalse();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    final var lastChange = config.phasedChangeState().lastChange();
+    assertThat(lastChange).isPresent();
+    assertThat(lastChange.get().status()).isEqualTo(PhasedChangePlanStatus.COMPLETED);
+  }
+
+  @Test
+  void shouldAdvanceThroughTwoPhasesTargetingDisjointPartitionGroups() {
+    // given — member 0 is the coordinator; two physical tenants ("a" and "b") each hold one
+    // partition replicated only by member 1
+    final var manager = newManager(MEMBER_0);
+    manager.registerPartitionGroupChangeAppliers(
+        "a",
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+    manager.registerPartitionGroupChangeAppliers(
+        "b",
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+
+    final var groupWithMember1 =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(
+                    MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                    MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of("a", groupWithMember1, "b", groupWithMember1),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    // when — a two-phase plan adds member 0 as a replica of group "a"'s partition 1, then group
+    // "b"'s partition 1: each phase targets exactly one, disjoint group — the shape a
+    // stray-double-advance would corrupt silently, by activating phase 1 without phase 0 having
+    // actually drained, or by skipping straight past phase 1 without ever activating it
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of("a", List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))),
+                        new PartitionGroupParallelPhase(
+                            Map.of("b", List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))))))
+        .join();
+
+    // then — both phases were applied in order and the plan completed; neither group was skipped
+    final var config = configuration(manager);
+    assertThat(config.partitionGroup("a").hasMember(MEMBER_0)).isTrue();
+    assertThat(config.partitionGroup("b").hasMember(MEMBER_0)).isTrue();
     assertThat(config.phasedChangeState().pending()).isEmpty();
     final var lastChange = config.phasedChangeState().lastChange();
     assertThat(lastChange).isPresent();
@@ -750,6 +883,81 @@ final class ClusterConfigurationManagerImplTest {
         .isTrue();
     assertThat(defaultGroup.hasPendingChanges()).isFalse();
     assertThat(config.phasedChangeState().pending()).isEmpty();
+  }
+
+  @Test
+  void shouldRetryPendingOperationInPartitionGroupMultipleTimesBeforeSucceeding() {
+    // given — same setup as shouldRetryPendingOperationInPartitionGroupIfFailed, but the
+    // operation fails three times in a row before eventually succeeding — the previously
+    // untested case where the retry itself also fails, more than once
+    final var manager = newManager(MEMBER_0);
+    final var group =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(Map.of()),
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(
+                    MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                    MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new FailingExecutor(3),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+
+    // when
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))))))
+        .join();
+
+    // then — three consecutive failures did not stop the retries; the fourth attempt completed
+    Awaitility.await("Pending operation should be retried until it succeeds")
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () -> {
+              final var config = configuration(manager);
+              assertThat(
+                      config
+                          .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                          .hasPendingChanges())
+                  .isFalse();
+              assertThat(config.phasedChangeState().pending()).isEmpty();
+            });
+    final var defaultGroup =
+        configuration(manager).partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasMember(MEMBER_0))
+        .describedAs("Member 0 is added to the default group despite three failed attempts")
+        .isTrue();
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PlanAdvancerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PlanAdvancerTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link PlanAdvancer} directly, with its collaborators faked, rather than through the
+ * whole {@link ClusterConfigurationManagerImpl}. This is what makes the in-flight dedup guard (the
+ * actual fix for "a phase can start before the previous one finishes") independently verifiable:
+ * the test controls exactly when the submitted update resolves, so it can assert that a second
+ * trigger arriving while the first is still in flight is rejected, deterministically.
+ *
+ * <p>Several tests below assert on the fake {@code submitUpdate} collaborator's invocation count
+ * rather than on the resulting {@link CurrentClusterConfiguration}'s state. That's deliberate, not
+ * a shortcut: the dedup guard's whole purpose is to prevent a call from happening at all, and
+ * {@link CurrentClusterConfiguration#tryActivateNextPhase(long, int)}/{@link
+ * CurrentClusterConfiguration#tryCompletePlan} already make a redundant call a no-op on the
+ * resulting state — so a broken dedup guard that let a second call through would still converge to
+ * the same final state, and a state-only assertion could not tell the two apart. The call count is
+ * the only observable that actually distinguishes "the guard fired" from "the guard didn't fire but
+ * the model-layer re-validation caught it anyway".
+ */
+final class PlanAdvancerTest {
+
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+
+  private static CurrentClusterConfiguration drainCurrentPhase(
+      final CurrentClusterConfiguration config) {
+    return config.updateGlobalConfiguration(
+        g -> g.advanceConfigurationChange(UnaryOperator.identity()));
+  }
+
+  @Test
+  void shouldSubmitExactlyOneAdvanceForTwoConcurrentTriggers() {
+    // given — a two-phase plan whose current phase (phase 0) has fully drained; two independent
+    // triggers (e.g. the coordinator's own local-apply callback and a peer's gossip echo) are
+    // about to both observe "phase complete" for the same plan
+    final var initialized =
+        CurrentClusterConfiguration.init()
+            .initPlan(
+                List.of(
+                    new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0))),
+                    new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_0)))));
+    final var planId = initialized.phasedChangeState().onlyPending().id();
+    final var drained = drainCurrentPhase(initialized);
+
+    final var submissions = new AtomicInteger();
+    final var pendingFuture =
+        new AtomicReference<CompletableActorFuture<CurrentClusterConfiguration>>();
+    final var currentConfig = new AtomicReference<>(drained);
+    final var advancer =
+        new PlanAdvancer(
+            planId,
+            executor,
+            updater -> {
+              submissions.incrementAndGet();
+              final var future = new CompletableActorFuture<CurrentClusterConfiguration>();
+              pendingFuture.set(future);
+              return future;
+            },
+            currentConfig::get,
+            () -> true,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1),
+            10);
+
+    // when — both triggers fire before the first submitted action resolves
+    advancer.maybeAdvance(drained);
+    advancer.maybeAdvance(drained);
+
+    // then — only the first trigger actually submitted an update; the second was a no-op
+    assertThat(submissions).hasValue(1);
+
+    // when — the in-flight action resolves: the plan moved to phase 1, and phase 1 happens to
+    // already be fully drained by the time this callback runs (the exact scenario that used to
+    // strand the plan — see PlanAdvancer's completion callback)
+    final var advancedToPhase1 = drained.tryActivateNextPhase(planId, 0);
+    final var phase1Drained = drainCurrentPhase(advancedToPhase1);
+    currentConfig.set(phase1Drained);
+    pendingFuture.get().complete(advancedToPhase1);
+
+    // then — resolving cleared the dedup guard, and the callback's own re-check against the
+    // latest config picked up the already-drained phase 1 and completed the plan, without
+    // needing a further external trigger
+    assertThat(submissions).hasValue(2);
+  }
+
+  @Test
+  void shouldNoOpWhenCurrentPhaseHasNotDrained() {
+    // given — a plan whose current phase still has a pending operation
+    final var initialized =
+        CurrentClusterConfiguration.init()
+            .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
+    final var planId = initialized.phasedChangeState().onlyPending().id();
+
+    final var submissions = new AtomicInteger();
+    final var advancer =
+        new PlanAdvancer(
+            planId,
+            executor,
+            updater -> {
+              submissions.incrementAndGet();
+              return new CompletableActorFuture<>();
+            },
+            () -> initialized,
+            () -> true,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1),
+            10);
+
+    // when
+    advancer.maybeAdvance(initialized);
+
+    // then — nothing submitted; the phase has not drained yet
+    assertThat(submissions).hasValue(0);
+  }
+
+  @Test
+  void shouldNoOpWhenPlanIsNoLongerPending() {
+    // given — a plan id that was never issued (nothing pending for it)
+    final var config = CurrentClusterConfiguration.init();
+    final var submissions = new AtomicInteger();
+    final var advancer =
+        new PlanAdvancer(
+            1L,
+            executor,
+            updater -> {
+              submissions.incrementAndGet();
+              return new CompletableActorFuture<>();
+            },
+            () -> config,
+            () -> true,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1),
+            10);
+
+    // when
+    advancer.maybeAdvance(config);
+
+    // then
+    assertThat(submissions).hasValue(0);
+  }
+
+  @Test
+  void shouldNoOpWhenLocalMemberIsNotCoordinator() {
+    // given — a plan whose current phase has fully drained, but the local member is not (or is no
+    // longer) the coordinator
+    final var initialized =
+        CurrentClusterConfiguration.init()
+            .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
+    final var planId = initialized.phasedChangeState().onlyPending().id();
+    final var drained = drainCurrentPhase(initialized);
+
+    final var submissions = new AtomicInteger();
+    final var advancer =
+        new PlanAdvancer(
+            planId,
+            executor,
+            updater -> {
+              submissions.incrementAndGet();
+              return new CompletableActorFuture<>();
+            },
+            () -> drained,
+            () -> false,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1),
+            10);
+
+    // when
+    advancer.maybeAdvance(drained);
+
+    // then — nothing submitted, even though the phase is complete
+    assertThat(submissions).hasValue(0);
+  }
+
+  @Test
+  void shouldNotSelfContinueAfterLosingCoordinatorStatusMidFlight() {
+    // given — a two-phase plan whose phase 0 has drained; the local member starts out as
+    // coordinator, but stops being one before the in-flight advance resolves (e.g. a membership
+    // change hands coordination to another member)
+    final var initialized =
+        CurrentClusterConfiguration.init()
+            .initPlan(
+                List.of(
+                    new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0))),
+                    new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_0)))));
+    final var planId = initialized.phasedChangeState().onlyPending().id();
+    final var drained = drainCurrentPhase(initialized);
+
+    final var submissions = new AtomicInteger();
+    final var pendingFuture =
+        new AtomicReference<CompletableActorFuture<CurrentClusterConfiguration>>();
+    final var currentConfig = new AtomicReference<>(drained);
+    final var isCoordinator = new AtomicReference<>(Boolean.TRUE);
+    final var advancer =
+        new PlanAdvancer(
+            planId,
+            executor,
+            updater -> {
+              submissions.incrementAndGet();
+              final var future = new CompletableActorFuture<CurrentClusterConfiguration>();
+              pendingFuture.set(future);
+              return future;
+            },
+            currentConfig::get,
+            isCoordinator::get,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1),
+            10);
+
+    // when — the advance is submitted while still coordinator, but resolves (with phase 1 already
+    // drained too) only after coordinator status is lost
+    advancer.maybeAdvance(drained);
+    assertThat(submissions).hasValue(1);
+
+    final var advancedToPhase1 = drained.tryActivateNextPhase(planId, 0);
+    final var phase1Drained = drainCurrentPhase(advancedToPhase1);
+    currentConfig.set(phase1Drained);
+    isCoordinator.set(false);
+    pendingFuture.get().complete(advancedToPhase1);
+
+    // then — the self-continuation re-checks coordinator status and does not submit the
+    // otherwise-ready completion
+    assertThat(submissions).hasValue(1);
+  }
+
+  @Test
+  void shouldRetryOnFailureUntilSuccess() {
+    // given — a single-phase plan whose only phase has drained, so maybeAdvance will submit a
+    // completePlan; the first two submissions fail (e.g. a transient persist error) before the
+    // third succeeds. currentConfig is updated on every successful submission — as the real
+    // manager's updateMultiConfiguration would — so the self-continuation after success sees the
+    // plan genuinely resolved instead of recursing forever against a config that never changes.
+    final var initialized =
+        CurrentClusterConfiguration.init()
+            .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
+    final var planId = initialized.phasedChangeState().onlyPending().id();
+    final var drained = drainCurrentPhase(initialized);
+    final var currentConfig = new AtomicReference<>(drained);
+
+    final var attempts = new AtomicInteger();
+    final var advancer =
+        new PlanAdvancer(
+            planId,
+            executor,
+            updater -> {
+              if (attempts.incrementAndGet() <= 2) {
+                return TestActorFuture.failedFuture(new RuntimeException("transient failure"));
+              }
+              final var updated = updater.apply(currentConfig.get());
+              currentConfig.set(updated);
+              return TestActorFuture.completedFuture(updated);
+            },
+            currentConfig::get,
+            () -> true,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1),
+            10);
+
+    // when — with the default (synchronous) TestConcurrencyControl, each scheduled retry runs
+    // inline, so one top-level call drives the whole failure/retry sequence to completion
+    advancer.maybeAdvance(currentConfig.get());
+
+    // then — two failed submissions, then a third that succeeded; the failure did not stop
+    // retries, and did not leave the advancer permanently marked as in-flight
+    assertThat(attempts).hasValue(3);
+    assertThat(currentConfig.get().phasedChangeState().pending()).isEmpty();
+  }
+
+  @Test
+  void shouldPickUpAdvanceWhenExternalTriggerArrivesBeforeScheduledRetryFires() {
+    // given — an async-scheduling executor, so the retry scheduled after a failure is queued
+    // rather than run inline, leaving a real window for another trigger (e.g. a peer's gossip
+    // echo of the same completed phase) to race it
+    final var asyncExecutor = new TestConcurrencyControl(true);
+    final var initialized =
+        CurrentClusterConfiguration.init()
+            .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
+    final var planId = initialized.phasedChangeState().onlyPending().id();
+    final var drained = drainCurrentPhase(initialized);
+    final var currentConfig = new AtomicReference<>(drained);
+
+    final var attempts = new AtomicInteger();
+    final var advancer =
+        new PlanAdvancer(
+            planId,
+            asyncExecutor,
+            updater -> {
+              if (attempts.incrementAndGet() == 1) {
+                return TestActorFuture.failedFuture(new RuntimeException("transient failure"));
+              }
+              final var updated = updater.apply(currentConfig.get());
+              currentConfig.set(updated);
+              return TestActorFuture.completedFuture(updated);
+            },
+            currentConfig::get,
+            () -> true,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1),
+            10);
+
+    // when — the first advance attempt fails; its retry is scheduled but not yet run
+    advancer.maybeAdvance(currentConfig.get());
+    assertThat(attempts).hasValue(1);
+    assertThat(asyncExecutor.scheduledTasks()).isEqualTo(1);
+
+    // and — an external trigger calls maybeAdvance() directly, before the scheduled retry fires
+    advancer.maybeAdvance(currentConfig.get());
+
+    // then — the external trigger's own call already retried and succeeded, and — unlike
+    // ScopeReconciler, which has no retryTimer to cancel — the success path here explicitly
+    // cancels the now-stale scheduled retry rather than leaving it to fire as a no-op later
+    assertThat(attempts).hasValue(2);
+    assertThat(currentConfig.get().phasedChangeState().pending()).isEmpty();
+    assertThat(asyncExecutor.scheduledTasks()).isZero();
+    assertThat(asyncExecutor.runAll()).isZero();
+    assertThat(attempts).hasValue(2);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ScopeReconcilerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ScopeReconcilerTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.util.Either;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link ScopeReconciler} directly, with a fake {@link ScopeReconciler.Operations} and a
+ * controllable {@code updateLocally} collaborator, rather than through the whole {@link
+ * ClusterConfigurationManagerImpl}. This is what makes the "persist after a successful apply can
+ * fail too" path independently verifiable — every manager-level test gives the persist step a real,
+ * always-succeeding {@code PersistedCurrentClusterConfiguration}, so that failure branch is
+ * otherwise never exercised.
+ */
+final class ScopeReconcilerTest {
+
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final TopologyManagerMetrics topologyMetrics =
+      new TopologyManagerMetrics(new SimpleMeterRegistry());
+
+  @Test
+  void shouldRetryWhenPersistingASuccessfullyAppliedOperationFails() {
+    // given — a fake scope with one always-available pending operation, and an updateLocally
+    // collaborator whose second call (the persist of the *advanced* config, right after the
+    // operation's remote apply succeeded) fails once before succeeding
+    final var appliedCount = new AtomicInteger();
+    final var persistAttempts = new AtomicInteger();
+    final var config = CurrentClusterConfiguration.init();
+
+    final ScopeReconciler.Operations operations =
+        new ScopeReconciler.Operations() {
+          @Override
+          public Optional<ScopeReconciler.Operation> nextOperation(
+              final CurrentClusterConfiguration currentConfiguration) {
+            return Optional.of(
+                new ScopeReconciler.Operation() {
+                  @Override
+                  public ClusterConfigurationChangeOperation operation() {
+                    return new MemberJoinOperation(MEMBER_0);
+                  }
+
+                  @Override
+                  public Either<Exception, CurrentClusterConfiguration> initialize(
+                      final CurrentClusterConfiguration currentConfiguration) {
+                    return Either.right(currentConfiguration);
+                  }
+
+                  @Override
+                  public ActorFuture<UnaryOperator<CurrentClusterConfiguration>> apply() {
+                    appliedCount.incrementAndGet();
+                    return CompletableActorFuture.completed(UnaryOperator.identity());
+                  }
+                });
+          }
+
+          @Override
+          public long versionOf(final CurrentClusterConfiguration currentConfiguration) {
+            return 0;
+          }
+
+          @Override
+          public String describe() {
+            return "fake";
+          }
+        };
+
+    final var updateLocally =
+        (Function<CurrentClusterConfiguration, Either<Exception, CurrentClusterConfiguration>>)
+            c -> {
+              // The 2nd call is the persist of the advanced config right after a successful
+              // apply (the 1st call is staging/"init", the 3rd is the retried pass's own init,
+              // the 4th is the retried pass's own post-apply persist).
+              if (persistAttempts.incrementAndGet() == 2) {
+                return Either.left(new IOException("disk full"));
+              }
+              return Either.right(c);
+            };
+
+    final var reconciler =
+        new ScopeReconciler(
+            operations,
+            () -> config,
+            updateLocally,
+            executor,
+            topologyMetrics,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+
+    // when
+    reconciler.reconcile();
+
+    // then — the remote operation was re-applied once the persist failure forced a full retry
+    // (retrying just the persist, without redoing the apply, would require tracking more state
+    // than this module currently does — see ScopeReconciler#onApplied), and that retry's own
+    // persist succeeded, so the failure was not silently swallowed
+    assertThat(appliedCount).hasValue(2);
+    assertThat(persistAttempts).hasValue(4);
+  }
+
+  @Test
+  void shouldRetryApplyFailureMultipleTimesBeforeSucceeding() {
+    // given — a fake operation whose apply() fails twice (e.g. the applier's own "not ready yet"
+    // retryable check) before succeeding on the third attempt
+    final var applyAttempts = new AtomicInteger();
+    final var config = CurrentClusterConfiguration.init();
+    final var operations = alwaysAvailableOperation(applyAttempts, 2);
+
+    final var reconciler =
+        new ScopeReconciler(
+            operations,
+            () -> config,
+            c -> Either.right(c),
+            executor,
+            topologyMetrics,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+
+    // when — with the default (synchronous) TestConcurrencyControl, each scheduled retry runs
+    // inline, so one top-level reconcile() call drives the whole failure/retry sequence
+    reconciler.reconcile();
+
+    // then — two failed attempts, then a third that succeeded; the failure was not swallowed and
+    // retries did not stop after the first one
+    assertThat(applyAttempts).hasValue(3);
+  }
+
+  @Test
+  void shouldPickUpOperationWhenExternalTriggerArrivesBeforeScheduledRetryFires() {
+    // given — an async-scheduling executor, so a retry scheduled after a failure is queued
+    // rather than run inline, leaving a real window for another trigger to race it (e.g. the
+    // coordinator's own local-apply callback landing while a peer's gossip echo is also pending)
+    final var asyncExecutor = new TestConcurrencyControl(true);
+    final var applyAttempts = new AtomicInteger();
+    final var config = CurrentClusterConfiguration.init();
+    final var operations = alwaysAvailableOperation(applyAttempts, 1);
+
+    final var reconciler =
+        new ScopeReconciler(
+            operations,
+            () -> config,
+            c -> Either.right(c),
+            asyncExecutor,
+            topologyMetrics,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+
+    // when — the first attempt fails; its retry is scheduled but not yet run
+    reconciler.reconcile();
+    assertThat(applyAttempts).hasValue(1);
+    assertThat(asyncExecutor.scheduledTasks()).isEqualTo(1);
+
+    // and — an external trigger calls reconcile() directly, before the scheduled retry fires
+    reconciler.reconcile();
+
+    // then — the external trigger's own call already retried and succeeded
+    assertThat(applyAttempts).hasValue(2);
+
+    // and — when the stale scheduled retry eventually fires too, it finds nothing left pending
+    // (nextOperation() returns empty) and is a harmless no-op, not a second application of the
+    // same operation
+    final var tasksRun = asyncExecutor.runAll();
+    assertThat(tasksRun).isEqualTo(1);
+    assertThat(applyAttempts).hasValue(2);
+  }
+
+  @Test
+  void shouldNotStartASecondAttemptWhileOneIsInFlight() {
+    // given — apply() returns a future that does not resolve on its own, simulating an in-flight
+    // asynchronous remote operation (e.g. waiting on a partition role change)
+    final var applyAttempts = new AtomicInteger();
+    final var pendingFuture =
+        new AtomicReference<CompletableActorFuture<UnaryOperator<CurrentClusterConfiguration>>>();
+    final var config = CurrentClusterConfiguration.init();
+
+    final ScopeReconciler.Operations operations =
+        new ScopeReconciler.Operations() {
+          @Override
+          public Optional<ScopeReconciler.Operation> nextOperation(
+              final CurrentClusterConfiguration currentConfiguration) {
+            return Optional.of(
+                new ScopeReconciler.Operation() {
+                  @Override
+                  public ClusterConfigurationChangeOperation operation() {
+                    return new MemberJoinOperation(MEMBER_0);
+                  }
+
+                  @Override
+                  public Either<Exception, CurrentClusterConfiguration> initialize(
+                      final CurrentClusterConfiguration currentConfiguration) {
+                    return Either.right(currentConfiguration);
+                  }
+
+                  @Override
+                  public ActorFuture<UnaryOperator<CurrentClusterConfiguration>> apply() {
+                    applyAttempts.incrementAndGet();
+                    final var future =
+                        new CompletableActorFuture<UnaryOperator<CurrentClusterConfiguration>>();
+                    pendingFuture.set(future);
+                    return future;
+                  }
+                });
+          }
+
+          @Override
+          public long versionOf(final CurrentClusterConfiguration currentConfiguration) {
+            return 0;
+          }
+
+          @Override
+          public String describe() {
+            return "fake";
+          }
+        };
+
+    final var reconciler =
+        new ScopeReconciler(
+            operations,
+            () -> config,
+            c -> Either.right(c),
+            executor,
+            topologyMetrics,
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+
+    // when — the first reconcile() call starts an attempt that never resolves on its own, and a
+    // second trigger (e.g. a concurrent gossip receipt) arrives while it's still in flight
+    reconciler.reconcile();
+    reconciler.reconcile();
+
+    // then — only the first attempt actually called apply(); the second call was a no-op
+    assertThat(applyAttempts).hasValue(1);
+
+    // and — once the in-flight attempt resolves, the guard clears
+    pendingFuture.get().complete(UnaryOperator.identity());
+    reconciler.reconcile();
+    assertThat(applyAttempts).hasValue(2);
+  }
+
+  /**
+   * An {@link ScopeReconciler.Operations} whose single operation fails {@code
+   * failuresBeforeSuccess} times before succeeding, and which stops offering an operation at all
+   * once it has succeeded — i.e. it models a scope that genuinely has nothing left pending once
+   * resolved, the same as a real {@code PartitionGroupConfiguration} once its change plan drains.
+   */
+  private static ScopeReconciler.Operations alwaysAvailableOperation(
+      final AtomicInteger applyAttempts, final int failuresBeforeSuccess) {
+    final var succeeded = new AtomicBoolean(false);
+    return new ScopeReconciler.Operations() {
+      @Override
+      public Optional<ScopeReconciler.Operation> nextOperation(
+          final CurrentClusterConfiguration currentConfiguration) {
+        if (succeeded.get()) {
+          return Optional.empty();
+        }
+        return Optional.of(
+            new ScopeReconciler.Operation() {
+              @Override
+              public ClusterConfigurationChangeOperation operation() {
+                return new MemberJoinOperation(MEMBER_0);
+              }
+
+              @Override
+              public Either<Exception, CurrentClusterConfiguration> initialize(
+                  final CurrentClusterConfiguration currentConfiguration) {
+                return Either.right(currentConfiguration);
+              }
+
+              @Override
+              public ActorFuture<UnaryOperator<CurrentClusterConfiguration>> apply() {
+                final int attempt = applyAttempts.incrementAndGet();
+                if (attempt <= failuresBeforeSuccess) {
+                  return CompletableActorFuture.completedExceptionally(
+                      new IllegalStateException("not ready yet"));
+                }
+                succeeded.set(true);
+                return CompletableActorFuture.completed(UnaryOperator.identity());
+              }
+            });
+      }
+
+      @Override
+      public long versionOf(final CurrentClusterConfiguration currentConfiguration) {
+        return 0;
+      }
+
+      @Override
+      public String describe() {
+        return "fake";
+      }
+    };
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -892,6 +892,53 @@ class CurrentClusterConfigurationTest {
     }
 
     @Test
+    void shouldActivateNextPhaseWhenExpectedPhaseIndexMatchesCurrent() {
+      // given — plan: phase 0 global, phase 1 targets group "a"
+      final var config =
+          config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty())
+              .initPlan(List.of(globalPhase(), parallelPhase("a")));
+      final var planId = config.phasedChangeState().onlyPending().id();
+
+      // when — expectedPhaseIndex (0) matches the plan's actual current phase index
+      final var updated = config.tryActivateNextPhase(planId, 0);
+
+      // then — advances exactly as the unguarded overload would
+      assertThat(updated.phasedChangeState().onlyPending().currentPhaseIndex()).isEqualTo(1);
+      assertThat(updated.partitionGroup("a").hasPendingChanges()).isTrue();
+    }
+
+    @Test
+    void shouldNoOpActivateNextPhaseWhenExpectedPhaseIndexIsStale() {
+      // given — a plan already advanced to phase 1 by an earlier trigger
+      final var config =
+          config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty())
+              .initPlan(List.of(globalPhase(), parallelPhase("a")));
+      final var planId = config.phasedChangeState().onlyPending().id();
+      final var advanced = config.activateNextPhase(planId);
+
+      // when — a second, stale trigger still expects phase 0 (the phase it observed as complete
+      // before the first trigger's advance ran)
+      final var result = advanced.tryActivateNextPhase(planId, 0);
+
+      // then — no-op: the stale re-validation is rejected instead of throwing or double-advancing
+      assertThat(result).isEqualTo(advanced);
+    }
+
+    @Test
+    void shouldNoOpActivateNextPhaseWithExpectedPhaseIndexWhenPlanNoLongerPending() {
+      // given — a plan that has already completed
+      final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
+      final var planId = config.phasedChangeState().onlyPending().id();
+      final var completed = config.completePlan(planId, PhasedChangePlanStatus.COMPLETED);
+
+      // when — a stale trigger tries to advance the now-resolved plan
+      final var result = completed.tryActivateNextPhase(planId, 0);
+
+      // then — no-op, not an exception
+      assertThat(result).isEqualTo(completed);
+    }
+
+    @Test
     void shouldThrowWhenActivatingNextPhaseOnLastPhase() {
       // given — a single-phase plan
       final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
@@ -927,6 +974,50 @@ class CurrentClusterConfigurationTest {
       assertThat(completed.phasedChangeState().lastChange()).isPresent();
       assertThat(completed.phasedChangeState().lastChange().orElseThrow().status())
           .isEqualTo(status);
+    }
+
+    @Test
+    void shouldCompletePlanWhenExpectedPhaseIndexMatchesCurrent() {
+      // given
+      final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
+      final var planId = config.phasedChangeState().onlyPending().id();
+
+      // when
+      final var completed = config.tryCompletePlan(planId, 0, PhasedChangePlanStatus.COMPLETED, 10);
+
+      // then — completes exactly as the unguarded overload would
+      assertThat(completed.phasedChangeState().pending()).isEmpty();
+      assertThat(completed.phasedChangeState().lastChange()).isPresent();
+    }
+
+    @Test
+    void shouldNoOpCompletePlanWhenExpectedPhaseIndexIsStale() {
+      // given — a two-phase plan already advanced to phase 1 by an earlier trigger
+      final var config =
+          config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty())
+              .initPlan(List.of(globalPhase(), parallelPhase("a")));
+      final var planId = config.phasedChangeState().onlyPending().id();
+      final var advanced = config.activateNextPhase(planId);
+
+      // when — a stale trigger tries to complete the plan as if it were still on phase 0
+      final var result = advanced.tryCompletePlan(planId, 0, PhasedChangePlanStatus.COMPLETED, 10);
+
+      // then — no-op: the plan is still pending at phase 1, untouched
+      assertThat(result).isEqualTo(advanced);
+    }
+
+    @Test
+    void shouldNoOpCompletePlanWithExpectedPhaseIndexWhenPlanNoLongerPending() {
+      // given — a plan that has already completed
+      final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
+      final var planId = config.phasedChangeState().onlyPending().id();
+      final var completed = config.completePlan(planId, PhasedChangePlanStatus.COMPLETED);
+
+      // when — a stale duplicate completion trigger for the same, already-resolved plan
+      final var result = completed.tryCompletePlan(planId, 0, PhasedChangePlanStatus.CANCELLED, 10);
+
+      // then — no-op, not an exception; the plan's original terminal status is untouched
+      assertThat(result).isEqualTo(completed);
     }
 
     @Test
@@ -979,6 +1070,80 @@ class CurrentClusterConfigurationTest {
       assertThat(updated.partitionGroup("a").hasPendingChanges()).isTrue();
       assertThat(updated.partitionGroup("b").hasPendingChanges()).isFalse();
       assertThat(updated.globalConfiguration().hasPendingChanges()).isFalse();
+    }
+  }
+
+  @Nested
+  class IsCurrentPhaseComplete {
+
+    @Test
+    void shouldThrowWhenNoPlanIsPending() {
+      // given
+      final var config = CurrentClusterConfiguration.init();
+
+      // when / then
+      assertThatThrownBy(() -> config.isCurrentPhaseComplete(1L))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldBeIncompleteForGlobalPhaseWithPendingChanges() {
+      // given — a plan whose current phase is global, freshly activated
+      final var config =
+          CurrentClusterConfiguration.init()
+              .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
+      final var planId = config.phasedChangeState().onlyPending().id();
+
+      // then — the global configuration still has the phase's operation pending
+      assertThat(config.isCurrentPhaseComplete(planId)).isFalse();
+    }
+
+    @Test
+    void shouldBeCompleteForGlobalPhaseOnceDrained() {
+      // given — the global phase's own operation has been applied and advanced
+      final var config =
+          CurrentClusterConfiguration.init()
+              .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
+      final var planId = config.phasedChangeState().onlyPending().id();
+      final var drained =
+          config.updateGlobalConfiguration(
+              g -> g.advanceConfigurationChange(UnaryOperator.identity()));
+
+      // then
+      assertThat(drained.isCurrentPhaseComplete(planId)).isTrue();
+    }
+
+    @Test
+    void shouldBeIncompleteForParallelPhaseUntilEveryNamedGroupDrains() {
+      // given — a parallel phase targeting groups "a" and "b"; only "a" has drained
+      final var phase =
+          new PartitionGroupParallelPhase(
+              Map.of(
+                  "a", List.of(new DeleteHistoryOperation(MEMBER_0)),
+                  "b", List.of(new DeleteHistoryOperation(MEMBER_0))));
+      final var config =
+          config(
+                  global(1, Map.of()),
+                  Map.of("a", group(1, Map.of()), "b", group(1, Map.of())),
+                  PhasedChangeState.empty())
+              .initPlan(List.of(phase));
+      final var planId = config.phasedChangeState().onlyPending().id();
+
+      // when — group "a" drains its side of the phase, "b" is still pending
+      final var partiallyDrained =
+          config.updatePartitionGroupConfig(
+              "a", g -> g.advanceConfigurationChange(UnaryOperator.identity()));
+
+      // then
+      assertThat(partiallyDrained.isCurrentPhaseComplete(planId)).isFalse();
+
+      // when — group "b" drains too
+      final var fullyDrained =
+          partiallyDrained.updatePartitionGroupConfig(
+              "b", g -> g.advanceConfigurationChange(UnaryOperator.identity()));
+
+      // then
+      assertThat(fullyDrained.isCurrentPhaseComplete(planId)).isTrue();
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes a bug in `ClusterConfigurationManagerImpl`: two independent triggers (the coordinator's own local-apply callback and a peer's gossip echoing the same completion) could each observe a phase as complete and each enqueue an advance, letting the second one blindly re-advance an already-advanced plan — silently skipping a phase when the two targeted disjoint groups, or throwing if they overlapped.
- Replaces the class's four ad hoc bookkeeping maps (`onGoingGroupOperation`, `shouldRetryGroup`, `groupBackoffRetry`, `advancePhaseRetryTimers`) plus two scalar fields (`onGoingGlobalOperation`, `shouldRetryGlobal`), all sharing one class-level backoff, with two families of self-contained, independently unit-testable workers — `ScopeReconciler` (one per global/group scope) and `PlanAdvancer` (one per pending plan) — each with its own backoff and an in-flight dedup guard, collapsed into a single idempotent `reconcile()` entry point.
- Adds `CurrentClusterConfiguration#isCurrentPhaseComplete` (moving the phase-completion switch out of the manager and onto the model) and `tryActivateNextPhase`/`tryCompletePlan` (re-validate the plan is still at the expected phase before mutating it, no-op'ing instead of throwing on a stale/duplicate trigger).

closes #60149 

🤖 Generated with [Claude Code](https://claude.com/claude-code)