### PR TITLE
[Backport stable/8.8] fix: prevent Operate Vitest OOM from colliding placeholder IDs

### DIFF
--- a/operate/client/src/modules/utils/generateUniqueID.ts
+++ b/operate/client/src/modules/utils/generateUniqueID.ts
@@ -7,7 +7,12 @@
  */
 
 const generateUniqueID = () => {
-  return (Date.now() + Math.floor(Math.random() * 100)).toString();
+  return (
+    crypto.randomUUID?.() ??
+    Array.from(crypto.getRandomValues(new Uint32Array(4)), (value) =>
+      value.toString(16).padStart(8, '0'),
+    ).join('')
+  );
 };
 
 export {generateUniqueID};


### PR DESCRIPTION
## Summary

Backport of #59751 to `stable/8.8`. Cherry-pick of `b5d9e2c8e94a65169a8265fde2c6e1160880be68`, no conflicts.

#59751 replaced `generateUniqueID()`'s collision-prone `Date.now() + Math.floor(Math.random() * 100)` (100-value space per millisecond, batch-generated synchronously via `Array.from({length: newScopeCount}).map(() => generateUniqueID())` in `modifications.ts`) with Web Crypto-backed IDs, to prevent ID collisions that can produce cyclic modification placeholders and OOM the Vitest worker.

It merged to `main` on 2026-08-10 with a `backport stable/8.8` label already applied, but no backport PR was ever generated — this closes that gap.

## Why this matters now

`stable/8.8`'s `fe-unit-tests` job has hit the same vitest heap-OOM signature three times:
- INC-6992 (shard 4/6, 2026-08-05) — before #59751 existed
- INC-6993 (shard 3/6, 2026-08-05) — before #59751 existed
- INC-7216 (shard 2/6, 2026-08-17) — **12 days after #59751 merged to main**, on `stable/8.8` which never received it

All three incidents are on `stable/8.8`. None have recurred on `main` since the fix landed there. Confirmed via direct diff that `stable/8.8` was still running the unpatched generator at the commit that produced INC-7216:

```
git diff origin/stable/8.8 origin/main -- operate/client/src/modules/utils/generateUniqueID.ts
```

Issue: #59641

## Test plan

- [x] Cherry-pick applies cleanly, single file, no conflicts
- [x] Confirmed `stable/8.8` lacked this fix prior to this PR (diff above)
- [x] Confirmed no equivalent OOM incidents on `main` since 2026-08-10