### PR TITLE
fix: resolve secret references whose name contains a dash

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
@@ -60,8 +60,8 @@ class SecretAuthorizationIT {
 
   /**
    * The broker reads a real file-based store. {@code tls.crt} is deliberately among the secrets:
-   * the file store accepts that name but it cannot form a {@code camunda.secrets.<name>} reference,
-   * so the listing has to leave it out.
+   * the file store accepts a dot in a name but the reference charset the endpoints accept does not
+   * (see {@code SecretServices.REFERENCE_NAME_PATTERN}), so the listing has to leave it out.
    */
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
@@ -57,11 +57,14 @@ class SecretAuthorizationIT {
 
   private static final String TOKEN_VALUE = "token-file-value";
   private static final String OTHER_VALUE = "a-file-value";
+  private static final String DASHED_VALUE = "db-password-file-value";
 
   /**
-   * The broker reads a real file-based store. {@code tls.crt} is deliberately among the secrets:
-   * the file store accepts a dot in a name but the reference charset the endpoints accept does not
-   * (see {@code SecretServices.REFERENCE_NAME_PATTERN}), so the listing has to leave it out.
+   * The broker reads a real file-based store. {@code db-password} and {@code tls.crt} are
+   * deliberately among the secrets: they are the two sides of the reference charset the endpoints
+   * accept (see {@code SecretServices.REFERENCE_NAME_PATTERN}). The file store takes both names,
+   * but only the dashed one can form a reference, so it is granted, listed and resolved like any
+   * other name while the listing has to leave {@code tls.crt} out.
    */
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
@@ -74,6 +77,8 @@ class SecretAuthorizationIT {
                 Files.writeString(directory.resolve("a"), OTHER_VALUE, StandardCharsets.UTF_8);
                 Files.writeString(directory.resolve("b"), "b-file-value", StandardCharsets.UTF_8);
                 Files.writeString(
+                    directory.resolve("db-password"), DASHED_VALUE, StandardCharsets.UTF_8);
+                Files.writeString(
                     directory.resolve("tls.crt"), "certificate", StandardCharsets.UTF_8);
               });
 
@@ -83,6 +88,7 @@ class SecretAuthorizationIT {
   // Held by the store (one file per secret, the file name being the bare secret name).
   private static final String GRANTED_REFERENCE = "camunda.secrets.token";
   private static final String OTHER_REFERENCE = "camunda.secrets.a";
+  private static final String DASHED_REFERENCE = "camunda.secrets.db-password";
   // No file of that name exists, so a wildcard-authorized lookup misses.
   private static final String UNKNOWN_REFERENCE = "camunda.secrets.doesnotexist";
 
@@ -108,8 +114,10 @@ class SecretAuthorizationIT {
       new TestUser(
           REVEAL_USER,
           "password",
-          // Granted REVEAL on GRANTED_REFERENCE only — not on OTHER_REFERENCE.
-          List.of(new Permissions(SECRET, REVEAL, List.of(GRANTED_REFERENCE))));
+          // Granted REVEAL on GRANTED_REFERENCE and DASHED_REFERENCE only — not on
+          // OTHER_REFERENCE. The dashed reference is granted as its own resource id, so a grant on
+          // it has to survive the dash all the way through the authorization stack.
+          List.of(new Permissions(SECRET, REVEAL, List.of(GRANTED_REFERENCE, DASHED_REFERENCE))));
 
   @UserDefinition
   private static final TestUser WILDCARD_USER_DEF =
@@ -154,6 +162,26 @@ class SecretAuthorizationIT {
     final var body = read(response.body());
     assertThat(references(body.get("resolved"))).containsExactly(GRANTED_REFERENCE);
     assertThat(body.get("resolved").get(0).get("value").asText()).isEqualTo(TOKEN_VALUE);
+    assertThat(body.get("errors")).isEmpty();
+  }
+
+  @Test
+  @DisabledIfSystemProperty(
+      named = PHYSICAL_TENANT_PROPERTY,
+      matches = ".+",
+      disabledReason = PHYSICAL_TENANT_DISABLED_REASON)
+  void shouldResolveHyphenatedReferenceWhenAuthorizedOnIt(
+      @Authenticated(REVEAL_USER) final CamundaClient client) throws Exception {
+    // when a user with SECRET:REVEAL on a dashed reference resolves it — the scenario of
+    // https://github.com/camunda/camunda/issues/60364, through the real authorization stack
+    final var response = resolve(client, REVEAL_USER, List.of(DASHED_REFERENCE));
+
+    // then the dash survives the grant, the reference charset and the store lookup alike: the name
+    // is matched as one resource id and the value on disk comes back
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(references(body.get("resolved"))).containsExactly(DASHED_REFERENCE);
+    assertThat(body.get("resolved").get(0).get("value").asText()).isEqualTo(DASHED_VALUE);
     assertThat(body.get("errors")).isEmpty();
   }
 
@@ -273,13 +301,16 @@ class SecretAuthorizationIT {
     // when a user granted SECRET:READ:* lists references
     final var response = list(client, WILDCARD_READ_USER);
 
-    // then every secret the store holds is returned as a reference, names only. The store's
-    // tls.crt is left out: it cannot form a valid reference, so it would only offer the caller
-    // something resolve() and any BPMN expression reject.
+    // then every secret the store holds is returned as a reference, names only. The dashed name is
+    // among them verbatim, unescaped — it is a reference resolve() accepts, and escaping it is the
+    // author's job only once it goes into a FEEL expression. The store's tls.crt is left out: it
+    // cannot form a valid reference, so it would only offer the caller something resolve() and any
+    // BPMN expression reject.
     assertThat(response.statusCode()).isEqualTo(200);
     final var body = read(response.body());
     assertThat(referenceNames(body.get("references")))
-        .containsExactlyInAnyOrder(GRANTED_REFERENCE, OTHER_REFERENCE, "camunda.secrets.b");
+        .containsExactlyInAnyOrder(
+            GRANTED_REFERENCE, OTHER_REFERENCE, DASHED_REFERENCE, "camunda.secrets.b");
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -69,17 +69,36 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    */
   public static final int MAX_REFERENCE_LENGTH = 256;
 
+  /**
+   * The {@code <name>} segment of a reference: a single, non-empty token of alphanumerics, {@code
+   * _} and {@code -}. The charset is what keeps the FEEL expression an author writes, the
+   * authorization resource id a permission is granted on, and the store lookup key one identifier —
+   * the same string on all three surfaces, never one of them escaped or rewritten.
+   *
+   * <p>Writing that string in FEEL is a separate matter: a dash is in the charset, but FEEL reads a
+   * bare dash as the minus operator, so a dashed name is only ever authored backtick-escaped
+   * ({@code =camunda.secrets.`db-password`}). It is in regardless, because the backing stores
+   * routinely hold dashed names and leaving it out made {@code db-password} storable and listable
+   * but never resolvable. A dot is out because unquoted it separates path segments — {@code
+   * camunda.secrets.tls.crt} is four FEEL segments rather than a reference — and the raw-text
+   * scanners that share this charset cannot tell such a name from a trailing path access.
+   *
+   * <p>Not an injection boundary, and must not be narrowed as if it were: every authorization
+   * lookup matches the resource id exactly (a terms query on ES/OS, a parameterized {@code IN} on
+   * RDBMS, {@code Set.contains} here) rather than by pattern, and the charset has always admitted
+   * {@code _}, which is a SQL {@code LIKE} single-character wildcard.
+   *
+   * <p>Kept identical to the name segment of {@code SecretReference.REFERENCE_PATTERN} in {@code
+   * zeebe/engine}, which this module cannot depend on, so that both subsystems agree on what is a
+   * valid reference name. Public for the same reason {@link #MAX_REFERENCE_LENGTH} is: {@code
+   * SecretReferenceCharsetSyncTest}, in the one module with both artifacts on its classpath, is
+   * what holds the two definitions together.
+   */
+  public static final Pattern REFERENCE_NAME_PATTERN = Pattern.compile("[\\p{Alnum}_-]+");
+
   private static final Logger LOG = LoggerFactory.getLogger(SecretServices.class);
 
   private static final String REFERENCE_PREFIX = "camunda.secrets.";
-
-  // The <name> segment of a reference: a single, non-empty token of alphanumeric characters and
-  // underscores. Deliberately narrow — the reference is used as an authorization resource id and a
-  // store lookup key, so pattern/glob characters ('*', '%'), whitespace and dots must never reach
-  // either. Kept identical to the engine detector's single-segment camunda.secrets.<name> pattern
-  // (see SecretReferenceLiteralValidator) so both subsystems agree on what counts as a valid
-  // reference name for the same syntax.
-  private static final Pattern REFERENCE_NAME_PATTERN = Pattern.compile("[\\p{Alnum}_]+");
 
   private final AuthorizationChecker authorizationChecker;
   private final AuthorizationsConfiguration authorizationsConfig;
@@ -349,6 +368,11 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    * Enumerates the references of every configured store, sorted and without duplicates. A store's
    * {@code list()} deliberately bypasses what it has cached: that is the values read so far, which
    * is not the tenant's set of secrets.
+   *
+   * <p>A listed reference is usable verbatim with {@link #resolve}, but not always in a FEEL
+   * expression: a name FEEL does not accept as a bare identifier — a dashed one above all — has to
+   * be backtick-escaped there, {@code =camunda.secrets.`db-password`}. The endpoint's description
+   * in {@code secrets.yaml} says so, since the caller cannot see this method.
    */
   private List<String> listFromStores() {
     final var references = new TreeSet<String>();
@@ -358,10 +382,10 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
           if (isResolvableName(name)) {
             references.add(REFERENCE_PREFIX + name);
           } else {
-            // A store may allow names this API cannot: a reference is a single
-            // camunda.secrets.<name> segment, so a name carrying a dot or a dash could neither be
-            // resolved by resolve() nor written in a BPMN expression or granted a permission.
-            // Listing it would only offer the caller a reference every other surface rejects.
+            // A store may allow names this API cannot: a name carrying a dot is outside the
+            // reference charset resolve() accepts and cannot be granted a permission on either,
+            // so listing it would only offer the caller a reference every other surface here
+            // rejects. See REFERENCE_NAME_PATTERN for why the charset stops where it does.
             LOG.debug(
                 "Omitting secret '{}' of store '{}' from the listing: its name cannot form a valid"
                     + " secret reference",

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -569,11 +569,15 @@ public class SecretServicesTest {
     // given a batch that is entirely malformed
     authorizationsConfig.setEnabled(true);
 
-    // when references carry pattern/glob or whitespace characters in the name segment
+    // when references carry pattern/glob, whitespace or dot characters in the name segment
     final var resolution =
         services
             .resolve(
-                List.of("camunda.secrets.*", "camunda.secrets.a%b", "camunda.secrets.a b"),
+                List.of(
+                    "camunda.secrets.*",
+                    "camunda.secrets.a%b",
+                    "camunda.secrets.a b",
+                    "camunda.secrets.a.b"),
                 authentication)
             .join();
 
@@ -585,6 +589,66 @@ public class SecretServicesTest {
         .containsOnly(SecretErrorCode.INVALID_REFERENCE);
     assertThat(store.resolveCalls()).isEmpty();
     verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
+  }
+
+  @Test
+  void shouldResolveReferenceWithHyphenInName() {
+    // given a dashed secret name, which the file, GCP and AWS stores all accept
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    store.holds("db-password", "s3cr3t");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.db-password"), authentication).join();
+
+    // then the dash reaches the store untouched and the value comes back
+    assertThat(resolution.errors()).isEmpty();
+    assertThat(resolution.resolved())
+        .extracting(ResolvedSecret::reference, ResolvedSecret::value)
+        .containsExactly(tuple("camunda.secrets.db-password", "s3cr3t"));
+    assertThat(store.resolveCalls()).containsExactly(Set.of("db-password"));
+  }
+
+  @Test
+  void shouldAcceptLeadingAndTrailingHyphenInName() {
+    // given names a backing store may legitimately hold: the pattern is not anchored, since
+    // anchoring would only move the store-versus-reference mismatch rather than close it
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+    store.holds("-lead", "one");
+    store.holds("trail-", "two");
+
+    // when
+    final var resolution =
+        services
+            .resolve(List.of("camunda.secrets.-lead", "camunda.secrets.trail-"), authentication)
+            .join();
+
+    // then both resolve
+    assertThat(resolution.errors()).isEmpty();
+    assertThat(resolution.resolved())
+        .extracting(ResolvedSecret::reference)
+        .containsExactlyInAnyOrder("camunda.secrets.-lead", "camunda.secrets.trail-");
+  }
+
+  @Test
+  void shouldAuthorizeHyphenatedReferenceByItsFullReferenceString() {
+    // given a grant on the prefix before the dash, not on the whole reference
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.db");
+    store.holds("db-password", "s3cr3t");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.db-password"), authentication).join();
+
+    // then the dash is part of the resource id, so the grant does not carry over to it
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors())
+        .extracting(SecretServices.SecretResolutionError::code)
+        .containsExactly(SecretErrorCode.ACCESS_DENIED);
+    assertThat(store.resolveCalls()).isEmpty();
   }
 
   @Test
@@ -716,7 +780,8 @@ public class SecretServicesTest {
     authorizationsConfig.setEnabled(true);
     grantReadWildcard();
     store.holds("tls.crt", "certificate");
-    store.holds("db-password", "password");
+    store.holds("a b", "spaced");
+    store.holds("a*b", "globbed");
     store.holds("ok_name", "value");
 
     // when
@@ -725,7 +790,23 @@ public class SecretServicesTest {
     // then only the names that form a valid reference are offered: the others could neither be
     // resolved nor written in a BPMN expression, so listing them would only mislead the caller
     assertThat(references).contains("camunda.secrets.ok_name");
-    assertThat(references).doesNotContain("camunda.secrets.tls.crt", "camunda.secrets.db-password");
+    assertThat(references)
+        .doesNotContain("camunda.secrets.tls.crt", "camunda.secrets.a b", "camunda.secrets.a*b");
+  }
+
+  @Test
+  void shouldListStoreNamesContainingAHyphen() {
+    // given a dashed name, which every backing store holds as a matter of course
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+    store.holds("db-password", "password");
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then it is offered, since resolve() takes it and it can be written in a BPMN expression as
+    // camunda.secrets.`db-password`
+    assertThat(references).contains("camunda.secrets.db-password");
   }
 
   @Test

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -40,6 +40,11 @@ import scala.jdk.javaapi.CollectionConverters;
  *       qualified name and is deliberately not treated as a reference.
  * </ul>
  *
+ * <p>A name carrying a character FEEL does not allow in a bare identifier — a dash above all — has
+ * to be backtick-escaped by the author: {@code =camunda.secrets.`db-password`}. Written bare,
+ * {@code =camunda.secrets.db-password} is a subtraction to FEEL, so it reports a reference named
+ * {@code db} and then fails at evaluation.
+ *
  * <p>Known gaps (an undetected or less-specific reference is simply not resolved, so nothing
  * leaks): a {@code camunda} bound by an iterator/parameter/context key still reports the reference;
  * a reference inside a FEEL list literal (e.g. {@code =[camunda.secrets.token]}) is reported at the
@@ -71,9 +76,23 @@ public record SecretReference(String storeId, String name) {
    * io.camunda.zeebe.engine.processing.deployment.model.validation.SecretReferenceLiteralValidator}
    * and {@link
    * io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableSecretReferenceScanner}).
+   *
+   * <p>The name segment is ASCII alphanumerics, {@code _} and {@code -}. The dash is in because the
+   * backing stores routinely hold dashed names — a Kubernetes secret data key is {@code
+   * [-._a-zA-Z0-9]+}, a GCP secret id {@code [a-zA-Z0-9_-]+}. It is not anchored: a leading or
+   * trailing dash is a legal store name too, and rejecting one here would move the
+   * store-versus-reference mismatch rather than close it.
+   *
+   * <p>Narrower than what {@link #parse} accepts, which applies no charset check at all and takes
+   * whatever feel-scala reports as an identifier — unicode letters, {@code $}, and anything at all
+   * once backtick-escaped, {@code =camunda.secrets.`tls.crt`} included. Those names are detected
+   * and resolved here while the {@code /v2/secrets} endpoints reject them. A dot cannot join this
+   * charset without this raw-text pattern swallowing a trailing path access ({@code
+   * camunda.secrets.token.length}), and a non-ASCII name first needs a decision on how it is
+   * normalized before it becomes an authorization resource id.
    */
   public static final Pattern REFERENCE_PATTERN =
-      Pattern.compile(Pattern.quote(PREFIX) + "[\\p{Alnum}_]+");
+      Pattern.compile(Pattern.quote(PREFIX) + "[\\p{Alnum}_-]+");
 
   /** Segments a {@code camunda.secrets.<name>} reference has: root, namespace and name. */
   private static final int REFERENCE_SEGMENT_COUNT = 3;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceScannerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableSecretReferenceScannerTest.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import java.util.List;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Pure unit tests for {@link ClusterVariableSecretReferenceScanner}, covering the same transferable
@@ -128,13 +130,41 @@ final class ClusterVariableSecretReferenceScannerTest {
   }
 
   @Test
-  void shouldStopNameAtFirstNonAlphanumericCharacter() {
-    // given a name containing a hyphen, which is not \p{Alnum}
+  void shouldCaptureHyphenatedNameInFull() {
+    // given a name containing a hyphen, as the backing stores routinely hold
     final var references = scan("\"camunda.secrets.my-name\"");
 
-    // then only the alphanumeric run up to the hyphen is captured, documenting the charset
-    // boundary of the shared reference pattern (SecretReference.REFERENCE_PATTERN)
-    assertThat(references).extracting(DetectedReference::name).containsExactly("my");
+    // then the whole name is captured. Truncating at the hyphen used to resolve the unrelated
+    // secret 'my' whenever one existed, which is the failure this charset closes
+    assertThat(references).extracting(DetectedReference::name).containsExactly("my-name");
+  }
+
+  @ParameterizedTest(name = "camunda.secrets.{0} captures {1}")
+  @CsvSource({"my.name, my", "my name, my", "my*name, my"})
+  void shouldStopNameAtFirstCharacterOutsideTheNameCharset(
+      final String written, final String captured) {
+    // given a name carrying a character the reference charset excludes: a dot would make the
+    // reference a fourth FEEL segment, and whitespace and glob characters are no FEEL identifier
+    final var references = scan("\"camunda.secrets." + written + "\"");
+
+    // then the name ends where the charset does, documenting the boundary of the shared reference
+    // pattern (SecretReference.REFERENCE_PATTERN)
+    assertThat(references).extracting(DetectedReference::name).containsExactly(captured);
+  }
+
+  @ParameterizedTest(name = "camunda.secrets.{0} captures {1}")
+  @CsvSource({"token-, token-", "token-v2, token-v2", "token-camunda.secrets.other, token-camunda"})
+  void shouldReadAHyphenAsPartOfTheNameRatherThanEndingIt(
+      final String written, final String captured) {
+    // given a reference followed by a hyphen: trailing, suffixed, and with a second reference
+    // joined on. The pattern is not anchored, so the hyphen never ends a name
+    final var references = scan("\"camunda.secrets." + written + "\"");
+
+    // then the whole run is one name. A composed value that meant 'camunda.secrets.token' plus
+    // literal text after the hyphen therefore stops resolving: the store answers NOT_FOUND and the
+    // incident names the captured string. That is the deliberate trade — the narrower charset
+    // instead resolved the unrelated secret 'token' silently, which is what #60364 is about
+    assertThat(references).extracting(DetectedReference::name).containsExactly(captured);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
@@ -358,6 +358,15 @@ class SecretReferenceTest {
         arguments("=camunda.secrets.tokén", refs("tokén")),
         // backtick-escaped names allow special characters
         arguments("=camunda.secrets.`my-secret`", refs("my-secret")),
+        // backticks escape a dot too, so this is a three-segment name 'tls.crt' rather than the
+        // four-segment path the unquoted camunda.secrets.tls.crt is. The detector reports it and
+        // the engine resolves it from the store, while SecretServices' charset rejects the same
+        // name on /v2/secrets/resolve — the #60364 mismatch, one charset over
+        arguments("=camunda.secrets.`tls.crt`", refs("tls.crt")),
+        // written bare, a dash is FEEL's minus operator, so the source parses as
+        // camunda.secrets.my - secret and only 'my' is reported. Backticks are the way to write a
+        // dashed name, and the evaluation of the subtraction fails afterwards
+        arguments("=camunda.secrets.my-secret", refs("my")),
         // a reference used inside a comment is not part of the expression
         arguments("=camunda.secrets.token // camunda.secrets.other", refs("token")),
         // a literal reference is ignored

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
@@ -55,6 +55,20 @@ class FlowNodeSecretReferenceTest {
   }
 
   @Test
+  void shouldStoreBacktickedHyphenatedSecretReference() {
+    // given - a dashed store name, which FEEL only accepts backtick-escaped
+    final var task =
+        transform(t -> t.zeebeInputExpression("camunda.secrets.`db-password`", "auth.password"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - the dash survives into the reference the job record carries to the store
+    assertThat(secretReferences)
+        .containsExactly(entry("/auth/password", Set.of(new SecretReference("db-password"))));
+  }
+
+  @Test
   void shouldStoreMultipleReferencesForSingleInputMapping() {
     // given
     final var task =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
@@ -254,6 +254,31 @@ final class SecretReferenceLiteralValidatorTest {
     verify(collector).addError(eq(0), contains("camunda.secrets.token"));
   }
 
+  @ParameterizedTest(
+      name = "[{0}] rejects static value that is a hyphenated secret reference, naming it in full")
+  @MethodSource("validators")
+  void shouldRejectStaticValueThatIsAHyphenatedSecretReference(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
+    // when - a static value, so what is rejected is the literal use, not the hyphen: a hyphenated
+    // name is perfectly valid when written as an expression (see the test below)
+    final var collector = validate("camunda.secrets.db-password", validate);
+
+    // then - the whole name is named back to the author, not the 'camunda.secrets.db' prefix the
+    // narrower charset used to report
+    verify(collector).addError(eq(0), contains("camunda.secrets.db-password"));
+  }
+
+  @ParameterizedTest(name = "[{0}] allows backtick-escaped hyphenated reference as an expression")
+  @MethodSource("validators")
+  void shouldAllowBacktickedHyphenatedSecretReferenceUsedAsAnExpression(
+      final String name, final BiConsumer<String, ValidationResultCollector> validate) {
+    // when - the only way to write a dashed name in FEEL, since a bare dash is the minus operator
+    final var collector = validate("=camunda.secrets.`db-password`", validate);
+
+    // then - backticks are not string quotes, so the reference is an expression and passes
+    verifyNoInteractions(collector);
+  }
+
   private ValidationResultCollector validate(
       final String source, final BiConsumer<String, ValidationResultCollector> validate) {
     final var collector = mock(ValidationResultCollector.class);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -581,6 +581,25 @@ final class JobSecretInjectorTest {
     }
 
     @Test
+    void shouldNotCorruptDashedPlaceholderThatIsPrefixOfAnother() {
+      // given - the same collision with dashed names, which is the shape that actually occurs:
+      // 'db-password' next to 'db-password-old' is an ordinary naming convention, 'token' next to
+      // 'token2' is not
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("h", "camunda.secrets.db-password camunda.secrets.db-password-old"),
+                  ref("db-password", "/h"),
+                  ref("db-password-old", "/h")));
+
+      // when
+      inject(batch, Map.of("db-password", "A", "db-password-old", "BB"));
+
+      // then - neither value is mangled
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("h", "A BB"));
+    }
+
+    @Test
     void shouldInjectAtDeeplyNestedPathAndPreserveSiblings() {
       // given - siblings of every type around the addressed leaf
       final var variables =

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -75,9 +75,14 @@ paths:
         returns secret values, only the reference names.
 
         The references are read from the secret stores configured for the caller's physical tenant.
-        Secret names that cannot form a valid `camunda.secrets.<name>` reference (for example names
-        containing a dot or a dash) are omitted, since they could neither be resolved nor be used in
-        a BPMN expression.
+        A store may hold names outside the reference name charset (for example one containing a
+        dot); those are omitted, since `/secrets/resolve` would reject them and no permission can
+        be granted on them.
+
+        A returned reference is usable verbatim with `/secrets/resolve`. In a FEEL expression,
+        however, a name that is not a bare identifier has to be backtick-escaped, since FEEL reads
+        a bare dash as the minus operator: a listed `camunda.secrets.db-password` is written
+        `` =camunda.secrets.`db-password` `` in a BPMN input mapping.
 
         This endpoint is an alpha feature and may be subject to change in future releases.
       requestBody:
@@ -120,7 +125,10 @@ components:
           items:
             type: string
             maxLength: 256
-            description: A secret reference of the form `camunda.secrets.<name>`.
+            description: |
+              A secret reference of the form `camunda.secrets.<name>`, where `<name>` is a
+              non-empty token of letters, digits, `_` and `-`. A reference outside that form is
+              reported in `errors` with `INVALID_REFERENCE` rather than failing the request.
     SecretResolveResult:
       type: object
       required:

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretReferenceCharsetSyncTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretReferenceCharsetSyncTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.service.SecretServices;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Holds the two definitions of the secret reference name charset together.
+ *
+ * <p>{@link SecretReference#REFERENCE_PATTERN} (the engine's raw-text scanners) and {@link
+ * SecretServices#REFERENCE_NAME_PATTERN} (the {@code /v2/secrets} endpoints) describe the same
+ * thing in two modules, because {@code service} cannot depend on {@code zeebe/engine}. They have to
+ * agree: a name one accepts and the other rejects is storable and listable but not resolvable,
+ * which is exactly the failure of <a href="https://github.com/camunda/camunda/issues/60364">
+ * #60364</a>. Nothing but this test fails when only one of them is edited.
+ *
+ * <p>This module is the only one with both artifacts on its classpath, which is why a unit test
+ * lives here.
+ */
+final class SecretReferenceCharsetSyncTest {
+
+  @ParameterizedTest(name = "\"{0}\"")
+  @ValueSource(
+      strings = {
+        // inside the charset
+        "token",
+        "db-password",
+        "MY_SECRET_2",
+        "_underscore",
+        "-lead",
+        "trail-",
+        "9",
+        // outside it — a dot is a further FEEL segment, the rest are no FEEL identifier at all
+        "tls.crt",
+        "a b",
+        "a*b",
+        "a%b",
+        "a/b",
+        // outside it, and detected by the FEEL AST walk regardless: both patterns are ASCII-only
+        // while SecretReference.parse applies no charset check at all
+        "tokén",
+        "api$key",
+      })
+  void shouldAcceptTheSameNamesInBothModules(final String name) {
+    // when the same name is offered to the engine's raw-text pattern and to the endpoints'
+    final var engineAccepts =
+        SecretReference.REFERENCE_PATTERN.matcher(SecretReference.PREFIX + name).matches();
+    final var serviceAccepts = SecretServices.REFERENCE_NAME_PATTERN.matcher(name).matches();
+
+    // then they agree
+    assertThat(serviceAccepts)
+        .as(
+            "the endpoints and the engine detector disagree on '%s': widening or narrowing one "
+                + "charset requires the same edit to the other",
+            name)
+        .isEqualTo(engineAccepts);
+  }
+
+  @ParameterizedTest(name = "\"{0}\"")
+  @ValueSource(strings = {"", " ", "."})
+  void shouldRejectANameThatIsNotOneInBothModules(final String name) {
+    // given a name that is empty or is a single out-of-charset character, which neither module may
+    // read as a reference name — the empty case above all, since a bare 'camunda.secrets.' prefix
+    // must not scan as a reference to an unnamed secret
+    // then
+    assertThat(SecretReference.REFERENCE_PATTERN.matcher(SecretReference.PREFIX + name).matches())
+        .isFalse();
+    assertThat(SecretServices.REFERENCE_NAME_PATTERN.matcher(name).matches()).isFalse();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretReferenceCharsetSyncTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretReferenceCharsetSyncTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.service.SecretServices;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -24,6 +25,11 @@ import org.junit.jupiter.params.provider.ValueSource;
  * which is exactly the failure of <a href="https://github.com/camunda/camunda/issues/60364">
  * #60364</a>. Nothing but this test fails when only one of them is edited.
  *
+ * <p>The two sets below are golden rather than a mutual comparison: each name is asserted against
+ * the verdict it must get, not merely against what the other pattern says about it. Asserting only
+ * that the two agree would pass a wrong edit applied to both — dropping the dash from each pattern
+ * reintroduces #60364 while leaving them perfectly in sync.
+ *
  * <p>This module is the only one with both artifacts on its classpath, which is why a unit test
  * lives here.
  */
@@ -32,49 +38,90 @@ final class SecretReferenceCharsetSyncTest {
   @ParameterizedTest(name = "\"{0}\"")
   @ValueSource(
       strings = {
-        // inside the charset
         "token",
         "db-password",
         "MY_SECRET_2",
         "_underscore",
+        // a dash anywhere in the name, including runs of them and a name that is nothing else: all
+        // legal store keys, and neither pattern is anchored to keep one out
+        "a--b",
         "-lead",
         "trail-",
+        "-",
+        "--",
         "9",
-        // outside it — a dot is a further FEEL segment, the rest are no FEEL identifier at all
+      })
+  void shouldAcceptTheSameNamesInBothModules(final String name) {
+    assertAccepted(name);
+  }
+
+  @Test
+  void shouldAcceptANameFillingTheWholeReferenceLength() {
+    // given the longest name a reference of MAX_REFERENCE_LENGTH can carry. Derived from the
+    // constants rather than written out, so the case follows a change to either.
+    final var name =
+        "a".repeat(SecretServices.MAX_REFERENCE_LENGTH - SecretReference.PREFIX.length());
+
+    // then both charsets take it: they say what a name is made of and nothing about how long it may
+    // be, so neither may bound the length by accident. The 256 cap is MAX_REFERENCE_LENGTH's own,
+    // pinned at and one past the boundary by SecretServicesTest.
+    assertAccepted(name);
+  }
+
+  @ParameterizedTest(name = "\"{0}\"")
+  @ValueSource(
+      strings = {
+        // a dot is a further FEEL segment, the rest are no FEEL identifier at all
         "tls.crt",
         "a b",
         "a*b",
         "a%b",
         "a/b",
-        // outside it, and detected by the FEEL AST walk regardless: both patterns are ASCII-only
+        // out of charset, and detected by the FEEL AST walk regardless: both patterns are
+        // ASCII-only
         // while SecretReference.parse applies no charset check at all
         "tokén",
         "api$key",
+        // no name at all. The empty case above all: a bare 'camunda.secrets.' prefix must not scan
+        // as a reference to an unnamed secret.
+        "",
+        " ",
+        ".",
       })
-  void shouldAcceptTheSameNamesInBothModules(final String name) {
+  void shouldRejectTheSameNamesInBothModules(final String name) {
     // when the same name is offered to the engine's raw-text pattern and to the endpoints'
-    final var engineAccepts =
-        SecretReference.REFERENCE_PATTERN.matcher(SecretReference.PREFIX + name).matches();
-    final var serviceAccepts = SecretServices.REFERENCE_NAME_PATTERN.matcher(name).matches();
-
-    // then they agree
-    assertThat(serviceAccepts)
-        .as(
-            "the endpoints and the engine detector disagree on '%s': widening or narrowing one "
-                + "charset requires the same edit to the other",
-            name)
-        .isEqualTo(engineAccepts);
+    // then neither reads it as a reference name
+    assertThat(engineAccepts(name))
+        .as("the engine detector accepts '%s', which the endpoints reject", name)
+        .isFalse();
+    assertThat(serviceAccepts(name))
+        .as("the endpoints accept '%s', which the engine detector rejects", name)
+        .isFalse();
   }
 
-  @ParameterizedTest(name = "\"{0}\"")
-  @ValueSource(strings = {"", " ", "."})
-  void shouldRejectANameThatIsNotOneInBothModules(final String name) {
-    // given a name that is empty or is a single out-of-charset character, which neither module may
-    // read as a reference name — the empty case above all, since a bare 'camunda.secrets.' prefix
-    // must not scan as a reference to an unnamed secret
-    // then
-    assertThat(SecretReference.REFERENCE_PATTERN.matcher(SecretReference.PREFIX + name).matches())
-        .isFalse();
-    assertThat(SecretServices.REFERENCE_NAME_PATTERN.matcher(name).matches()).isFalse();
+  private static void assertAccepted(final String name) {
+    // when the same name is offered to the engine's raw-text pattern and to the endpoints'
+    // then both read it as a reference name
+    assertThat(engineAccepts(name))
+        .as(
+            "the engine detector rejects '%s': narrowing this charset requires the same edit to "
+                + "SecretServices.REFERENCE_NAME_PATTERN, and leaves the name unresolvable",
+            name)
+        .isTrue();
+    assertThat(serviceAccepts(name))
+        .as(
+            "the endpoints reject '%s': narrowing this charset requires the same edit to "
+                + "SecretReference.REFERENCE_PATTERN, and makes the name storable but not "
+                + "resolvable",
+            name)
+        .isTrue();
+  }
+
+  private static boolean engineAccepts(final String name) {
+    return SecretReference.REFERENCE_PATTERN.matcher(SecretReference.PREFIX + name).matches();
+  }
+
+  private static boolean serviceAccepts(final String name) {
+    return SecretServices.REFERENCE_NAME_PATTERN.matcher(name).matches();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretReferencePropertyDeploymentRejectionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretReferencePropertyDeploymentRejectionIT.java
@@ -48,7 +48,7 @@ final class SecretReferencePropertyDeploymentRejectionIT {
   private final String processId = Strings.newRandomValidBpmnId();
   private final String jobType = Strings.newRandomValidBpmnId();
   private final String propertyName = "authToken";
-  // a FEEL reference is a path, so the name has to be a single alphanumeric segment
+  // a FEEL reference is a path, so the name is kept to a bare identifier that needs no escaping
   private final String secretName = "s" + UUID.randomUUID().toString().replace("-", "");
   private final String secretReference = "camunda.secrets." + secretName;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionJobActivationIT.java
@@ -20,6 +20,7 @@ import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awai
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitNoStreamRegistered;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitResolutionRequested;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.awaitStreamRegistered;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.backtickedSecretReference;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstance;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.createProcessInstances;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.deployProcessWithInput;
@@ -34,6 +35,7 @@ import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.reac
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionFailureStates;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.resolutionWasRequestedFor;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.secretReference;
+import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.uniqueHyphenatedSecretName;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.uniqueSecretName;
 import static io.camunda.zeebe.it.engine.secret.SecretResolutionTestHarness.writeSecret;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -160,6 +162,30 @@ final class SecretResolutionJobActivationIT {
     assertThat(resolutionWasRequestedFor(secretName, job.getKey())).isTrue();
     assertThat(incidentsOf(processInstanceKey)).isEmpty();
     assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldResolveBacktickedHyphenatedSecretReference() {
+    // given - a dashed store name, the shape a Kubernetes secret data key or a GCP secret id
+    // routinely has, referenced the only way FEEL allows: backtick-escaped. The AST detector
+    // applies no charset check, so this authoring form already worked; the test pins it end to end
+    // because nothing else did
+    final String hyphenatedName = uniqueHyphenatedSecretName();
+    final String hyphenatedValue = "value-of-" + hyphenatedName;
+    writeSecret(broker, hyphenatedName, hyphenatedValue);
+    deployProcessWithInput(client, processId, jobType, backtickedSecretReference(hyphenatedName));
+    final long processInstanceKey = createProcessInstance(client, processId);
+    awaitJobKeyOf(processInstanceKey);
+
+    // when
+    final ActivatedJob job = onlyJob(poll().join());
+
+    // then - the dash survives the detector, the job record, the store lookup and the injector
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, hyphenatedValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(resolutionWasRequestedFor(hyphenatedName, job.getKey())).isTrue();
+    assertThat(incidentsOf(processInstanceKey)).isEmpty();
+    assertNoRecordCarriesValue(hyphenatedValue);
   }
 
   @Test
@@ -457,6 +483,28 @@ final class SecretResolutionJobActivationIT {
     awaitActivationExported(jobType, job.getKey());
     assertThat(resolutionWasRequestedFor(secretName, job.getKey())).isTrue();
     assertNoRecordCarriesValue(secretValue);
+  }
+
+  @Test
+  void shouldActivateWithADashedSecretReachedThroughAClusterVariable() {
+    // given - a dashed store name reached through a cluster variable. This is the one path that
+    // finds a reference by scanning raw text (ClusterVariableSecretReferenceScanner) rather than by
+    // walking a parsed FEEL AST, so it is the path the reference charset actually gates
+    final String dashedName = uniqueHyphenatedSecretName();
+    final String dashedValue = "value-of-" + dashedName;
+    writeSecret(broker, dashedName, dashedValue);
+    createSecretReferenceClusterVariable(dashedName);
+    deployProcessReadingTheClusterVariable();
+    final long processInstanceKey = createProcessInstance(client, processId);
+
+    // then - the whole dashed name is captured and resolved. The narrower charset stopped the name
+    // at the dash, which requested an unrelated secret when one of that shorter name existed
+    final ActivatedJob job = onlyJob(poll().join());
+    assertThat(job.getVariablesAsMap()).containsEntry(INPUT_TARGET, dashedValue);
+    awaitActivationExported(jobType, job.getKey());
+    assertThat(resolutionWasRequestedFor(dashedName, job.getKey())).isTrue();
+    assertThat(incidentsOf(processInstanceKey)).isEmpty();
+    assertNoRecordCarriesValue(dashedValue);
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionTestHarness.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/secret/SecretResolutionTestHarness.java
@@ -119,15 +119,32 @@ public final class SecretResolutionTestHarness {
   /**
    * A name no other test uses. The secret cache is per broker and shared with the gateway's secret
    * endpoints, so a name reused across tests runs against a warm cache and never exercises the
-   * cache-miss path. A reference is a FEEL path, so the name has to be a single alphanumeric
-   * segment.
+   * cache-miss path. A reference is a FEEL path, so the name is kept to a bare identifier that
+   * needs no escaping; see {@link #uniqueHyphenatedSecretName()} for the escaped variant.
    */
   public static String uniqueSecretName() {
     return "s" + UUID.randomUUID().toString().replace("-", "");
   }
 
+  /**
+   * The same, with a dash in it — the shape the backing stores routinely hold ({@code db-password},
+   * {@code tls-key}). Only usable through {@link #backtickedSecretReference(String)}, since FEEL
+   * reads a bare dash as the minus operator.
+   */
+  public static String uniqueHyphenatedSecretName() {
+    return uniqueSecretName() + "-dashed";
+  }
+
   public static String secretReference(final String secretName) {
     return "camunda.secrets." + secretName;
+  }
+
+  /**
+   * A reference whose name is backtick-escaped, which is how a name FEEL does not accept as a bare
+   * identifier — a dashed one above all — is written in an expression.
+   */
+  public static String backtickedSecretReference(final String secretName) {
+    return secretReference("`" + secretName + "`");
   }
 
   /** Writes one secret of the broker's file-based store, creating or replacing its file. */


### PR DESCRIPTION
## Description

A secret named `db-password` could be stored and listed but never resolved: two
independent regexes limited the `<name>` segment of `camunda.secrets.<name>` to
`[\p{Alnum}_]+`, so the reference was rejected one layer above the store holding it.
The backing stores accept dashes as a matter of course — a Kubernetes secret data key
is `[-._a-zA-Z0-9]+`, a GCP secret id `[a-zA-Z0-9_-]+`.

Both patterns now accept `-`. The alternative, rejecting dashed names at creation
time, was dropped: it breaks every store that already holds one.

Notable details:

- The pattern is deliberately not anchored. A leading or trailing dash is a legal
  store name, so anchoring would move the store-versus-reference mismatch rather than
  close it, and would make a genuine `token-` resolve silently as `token`.
- The cluster-variable scanner previously truncated `camunda.secrets.db-password` to
  `db` and silently resolved an unrelated secret. It now captures the full name.
- In FEEL a dashed name must be backtick-escaped, `` =camunda.secrets.`db-password` ``,
  since a bare dash is the minus operator. Documented in the `/v2/secrets/list`
  description; a deploy-time validator for the unquoted form is a follow-up.
- `SecretReferenceCharsetSyncTest` pins the two patterns together — `service` cannot
  depend on `zeebe/engine`, so the invariant needs a test in the one module with both
  on its classpath.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #60364
