### PR TITLE
fix: detect RDBMS_SCHEMA_VERSION table regardless of identifier casing

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Inc
 import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
@@ -265,6 +267,11 @@ public class RdbmsSchemaVersionStore {
    * is not a simple "table not found" condition so that unexpected errors (e.g. permission
    * failures, broken connections) abort startup instead of being silently treated as a missing
    * table.
+   *
+   * <p>Unquoted identifiers fold differently per vendor: H2 stores them upper case, while
+   * PostgreSQL stores them lower case. {@link java.sql.DatabaseMetaData#getTables} matches the
+   * stored identifier exactly, so every plausible casing is tried in turn rather than assuming one
+   * vendor's convention.
    */
   @VisibleForTesting
   protected boolean tableExists(final Connection connection, final String tableName)
@@ -272,16 +279,15 @@ public class RdbmsSchemaVersionStore {
     final var meta = connection.getMetaData();
     final var catalog = connection.getCatalog();
     final var schema = connection.getSchema();
-    // Try uppercase first (most databases store identifiers in upper case), then as-is.
-    try (final var rs =
-        meta.getTables(catalog, schema, tableName.toUpperCase(), new String[] {"TABLE"})) {
-      if (rs.next()) {
-        return true;
+    for (final var candidate :
+        new LinkedHashSet<>(List.of(tableName.toUpperCase(), tableName.toLowerCase(), tableName))) {
+      try (final var rs = meta.getTables(catalog, schema, candidate, new String[] {"TABLE"})) {
+        if (rs.next()) {
+          return true;
+        }
       }
     }
-    try (final var rs = meta.getTables(catalog, schema, tableName, new String[] {"TABLE"})) {
-      return rs.next();
-    }
+    return false;
   }
 
   /**

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.db.rdbms.RdbmsSchemaVersionStore;
+import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.zeebe.util.VersionUtil;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies {@link RdbmsSchemaVersionStore#tableExists} finds {@code RDBMS_SCHEMA_VERSION} on every
+ * real database vendor, not just H2 -- unquoted identifiers fold differently per vendor (e.g.
+ * PostgreSQL/MySQL/MariaDB lower case vs. H2/Oracle/MSSQL upper case), which the check previously
+ * missed.
+ */
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+final class RdbmsSchemaVersionStoreIT {
+
+  @TestTemplate
+  void shouldFindExistingSchemaVersionRegardlessOfVendorIdentifierCasing(
+      final CamundaRdbmsTestApplication testApplication) {
+    final DataSource dataSource = testApplication.bean(DataSource.class);
+    final var versionStore = new RdbmsSchemaVersionStore(dataSource, "", VersionUtil.getVersion());
+
+    // The test application's own startup migration already recorded the running version, so a
+    // second, independently constructed store checking against that same version is the
+    // happy-path case: the version matches, so this must pass without error.
+    assertThatCode(versionStore::checkCompatibility).doesNotThrowAnyException();
+  }
+
+  @TestTemplate
+  void shouldDetectIncompatibleUpgradePathRegardlessOfVendorIdentifierCasing(
+      final CamundaRdbmsTestApplication testApplication) throws Exception {
+    final DataSource dataSource = testApplication.bean(DataSource.class);
+    final var versionStore = new RdbmsSchemaVersionStore(dataSource, "", VersionUtil.getVersion());
+
+    // Rewind the version the test application's own startup migration already recorded, far
+    // enough behind the running version to be an illegal, minor-version-skipping upgrade path.
+    // Plain DML resolves the unquoted table name via the vendor's own identifier folding, the
+    // same way the production upsert in RdbmsSchemaVersionStore#recordCurrentVersion does, so this
+    // does not itself depend on the tableExists behavior under test.
+    try (final var connection = dataSource.getConnection()) {
+      final var autoCommit = connection.getAutoCommit();
+      connection.setAutoCommit(false);
+      try (final var statement = connection.createStatement()) {
+        statement.executeUpdate("UPDATE RDBMS_SCHEMA_VERSION SET VERSION = '8.0.0' WHERE ID = 1");
+      }
+      connection.commit();
+      connection.setAutoCommit(autoCommit);
+    }
+
+    try {
+      assertThatThrownBy(versionStore::checkCompatibility)
+          .isInstanceOf(RdbmsSchemaVersionIncompatibleException.class);
+    } finally {
+      // Restore the version a real boot would have recorded, so any later test reusing this
+      // vendor's shared, cached test application observes a consistent, correctly-migrated state.
+      versionStore.recordCurrentVersion();
+    }
+  }
+}


### PR DESCRIPTION
Fixes a problem where the Rdbms schema version is not correctly read and verified:
-  The `RDBMS_SCHEMA_VERSION` table is created via an unquoted Liquibase identifier, and unquoted identifiers fold differently per vendor: H2 stores them upper case, but PostgreSQL stores them lower case. `DatabaseMetaData.getTables` matches the stored identifier exactly, so on PostgreSQL the lookup never found the table, `tableExists` returned false, and `resolveCurrentSchemaVersion` concluded the schema was fresh even though it was fully migrated and the application was otherwise working normally

Fix:
- by trying every plausible casing - upper, lower, and as-passed — instead of
assuming one vendor's convention.
