### PR TITLE
feat: cluster-wide history backup REST endpoints

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/RegistryHistoryBackupApi.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/RegistryHistoryBackupApi.java
@@ -95,8 +95,9 @@ public class RegistryHistoryBackupApi implements HistoryBackupApi {
   }
 
   /**
-   * Resolves the tenant's backup wiring and rejects a tenant with no snapshot repository, which the
-   * actuator equally treats as a bad request rather than a server error.
+   * Resolves the tenant's backup wiring and rejects a tenant with no snapshot repository. Reported
+   * as a server error, alongside a repository the store does not have: both are deployment faults
+   * the caller cannot correct by changing its request.
    */
   private PhysicalTenantBackup backupFor(final String physicalTenantId) {
     final PhysicalTenantBackup backup;
@@ -109,7 +110,7 @@ public class RegistryHistoryBackupApi implements HistoryBackupApi {
     if (repositoryName == null || repositoryName.isBlank()) {
       throw new ServiceException(
           "No backup repository configured for physical tenant '%s'".formatted(physicalTenantId),
-          Status.INVALID_ARGUMENT);
+          Status.INTERNAL);
     }
     return backup;
   }
@@ -128,7 +129,12 @@ public class RegistryHistoryBackupApi implements HistoryBackupApi {
       case final BackupAlreadyRunningException ignored -> Status.INVALID_STATE;
       case final InvalidRequestException ignored -> Status.INVALID_ARGUMENT;
       case final ResourceNotFoundException ignored -> Status.NOT_FOUND;
-      case final MissingRepositoryException ignored -> Status.NOT_FOUND;
+      // Not NOT_FOUND: an absent repository is a deployment fault, not an absent backup. The
+      // cluster-wide endpoints fan out over every physical tenant and read NOT_FOUND as "this
+      // tenant was reached and holds nothing", so conflating the two would let them report an
+      // unusable tenant as ordinary absence. Not a 4xx either — nothing about the request is
+      // wrong, so there is nothing the caller could change to make it succeed.
+      case final MissingRepositoryException ignored -> Status.INTERNAL;
       case final BackupRepositoryConnectionException ignored -> Status.UNAVAILABLE;
       case final IndexNotFoundException ignored -> Status.INTERNAL;
       default -> Status.INTERNAL;

--- a/dist/src/main/java/io/camunda/application/commons/backup/RegistryHistoryBackupApi.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/RegistryHistoryBackupApi.java
@@ -42,9 +42,11 @@ import org.jspecify.annotations.Nullable;
  * {@code @RequiresSecondaryStorage} interceptor before any handler runs.
  *
  * <p>Translates {@link BackupException} into {@link ServiceException} so the gateway's error mapper
- * produces the right status. Note the deliberate divergence from the {@code backupHistory}
+ * produces the right status. Two statuses deliberately diverge from the {@code backupHistory}
  * actuator: a repository connection failure maps to 503 here, not 502, because 503 is what the
- * {@code /v2/backups/*} spec documents.
+ * {@code /v2/backups/*} spec documents; and a repository missing from the store maps to 403, not
+ * 404, to match how {@code @RequiresSecondaryStorage} already reports a storage that cannot serve
+ * history backups.
  */
 @NullMarked
 public class RegistryHistoryBackupApi implements HistoryBackupApi {
@@ -94,11 +96,6 @@ public class RegistryHistoryBackupApi implements HistoryBackupApi {
         });
   }
 
-  /**
-   * Resolves the tenant's backup wiring and rejects a tenant with no snapshot repository. Reported
-   * as a server error, alongside a repository the store does not have: both are deployment faults
-   * the caller cannot correct by changing its request.
-   */
   private PhysicalTenantBackup backupFor(final String physicalTenantId) {
     final PhysicalTenantBackup backup;
     try {
@@ -110,7 +107,7 @@ public class RegistryHistoryBackupApi implements HistoryBackupApi {
     if (repositoryName == null || repositoryName.isBlank()) {
       throw new ServiceException(
           "No backup repository configured for physical tenant '%s'".formatted(physicalTenantId),
-          Status.INTERNAL);
+          Status.FORBIDDEN);
     }
     return backup;
   }
@@ -129,12 +126,7 @@ public class RegistryHistoryBackupApi implements HistoryBackupApi {
       case final BackupAlreadyRunningException ignored -> Status.INVALID_STATE;
       case final InvalidRequestException ignored -> Status.INVALID_ARGUMENT;
       case final ResourceNotFoundException ignored -> Status.NOT_FOUND;
-      // Not NOT_FOUND: an absent repository is a deployment fault, not an absent backup. The
-      // cluster-wide endpoints fan out over every physical tenant and read NOT_FOUND as "this
-      // tenant was reached and holds nothing", so conflating the two would let them report an
-      // unusable tenant as ordinary absence. Not a 4xx either — nothing about the request is
-      // wrong, so there is nothing the caller could change to make it succeed.
-      case final MissingRepositoryException ignored -> Status.INTERNAL;
+      case final MissingRepositoryException ignored -> Status.FORBIDDEN;
       case final BackupRepositoryConnectionException ignored -> Status.UNAVAILABLE;
       case final IndexNotFoundException ignored -> Status.INTERNAL;
       default -> Status.INTERNAL;

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -32,6 +32,7 @@ import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
+import io.camunda.service.ClusterHistoryBackupServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
@@ -553,6 +554,14 @@ public class CamundaServicesConfiguration {
                               tenantSecurity.getAuthorizations(),
                               executor)));
             });
+
+    // Outside the per-tenant loop on purpose: one cluster-wide service fans out over every tenant,
+    // so building it per tenant would construct N of them and keep only the last.
+    historyBackupApi.ifAvailable(
+        historyBackup ->
+            builder.clusterHistoryBackupServices(
+                new ClusterHistoryBackupServices(
+                    historyBackup, physicalTenantResolver.getAll().keySet(), executor)));
 
     // The readiness bean must be resolved lazily, not injected directly: on Elasticsearch and
     // OpenSearch it depends on the search schema initializer, which depends on

--- a/dist/src/test/java/io/camunda/application/commons/backup/RegistryHistoryBackupApiTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/RegistryHistoryBackupApiTest.java
@@ -206,6 +206,9 @@ class RegistryHistoryBackupApiTest {
    * Every operation, not just one: {@code BackupServiceImpl.getBackups} does not call {@code
    * validateRepositoryExists} the way take and delete do, so this pre-check is the only guard on
    * the list path.
+   *
+   * <p>Reported as a server error, like a repository the store does not have: an unconfigured
+   * repository is a deployment fault, and no change to the request can make the call succeed.
    */
   @ParameterizedTest
   @MethodSource("allOperations")
@@ -219,7 +222,7 @@ class RegistryHistoryBackupApiTest {
         .isThrownBy(() -> operation.accept(api))
         .satisfies(
             e -> {
-              assertThat(e.getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
+              assertThat(e.getStatus()).isEqualTo(Status.INTERNAL);
               assertThat(e.getMessage()).contains(TENANT_ID);
             });
   }
@@ -267,7 +270,7 @@ class RegistryHistoryBackupApiTest {
         Arguments.of(new BackupAlreadyRunningException("running"), Status.INVALID_STATE),
         Arguments.of(new InvalidRequestException("invalid"), Status.INVALID_ARGUMENT),
         Arguments.of(new ResourceNotFoundException("missing"), Status.NOT_FOUND),
-        Arguments.of(new MissingRepositoryException("no repo"), Status.NOT_FOUND),
+        Arguments.of(new MissingRepositoryException("no repo"), Status.INTERNAL),
         Arguments.of(new BackupRepositoryConnectionException("unreachable"), Status.UNAVAILABLE),
         Arguments.of(new IndexNotFoundException(List.of("index-1")), Status.INTERNAL),
         Arguments.of(new BackupException("something else"), Status.INTERNAL));
@@ -295,6 +298,26 @@ class RegistryHistoryBackupApiTest {
     // when / then
     assertThatExceptionOfType(ServiceException.class)
         .isThrownBy(() -> api.getBackups(TENANT_ID, true, "*"))
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.INTERNAL));
+  }
+
+  /**
+   * The two must not collapse onto one status: the cluster-wide endpoints read {@code NOT_FOUND} as
+   * "this physical tenant was reached and holds nothing", so a repository missing from the store
+   * has to be distinguishable from a backup that simply does not exist.
+   */
+  @Test
+  void shouldDistinguishAMissingRepositoryFromAMissingBackup() {
+    // given
+    when(backupService.getBackupState(42L)).thenThrow(new MissingRepositoryException("no repo"));
+    when(backupService.getBackupState(43L)).thenThrow(new ResourceNotFoundException("no such id"));
+
+    // when / then
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(() -> api.getBackupState(TENANT_ID, 42L))
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.INTERNAL));
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(() -> api.getBackupState(TENANT_ID, 43L))
         .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND));
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/backup/RegistryHistoryBackupApiTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/RegistryHistoryBackupApiTest.java
@@ -207,8 +207,9 @@ class RegistryHistoryBackupApiTest {
    * validateRepositoryExists} the way take and delete do, so this pre-check is the only guard on
    * the list path.
    *
-   * <p>Reported as a server error, like a repository the store does not have: an unconfigured
-   * repository is a deployment fault, and no change to the request can make the call succeed.
+   * <p>Answers 403, like a repository the store does not have: an unconfigured repository says this
+   * deployment cannot serve history backups for the tenant, which is what the endpoint's
+   * secondary-storage gate already answers 403 for one level up.
    */
   @ParameterizedTest
   @MethodSource("allOperations")
@@ -222,7 +223,7 @@ class RegistryHistoryBackupApiTest {
         .isThrownBy(() -> operation.accept(api))
         .satisfies(
             e -> {
-              assertThat(e.getStatus()).isEqualTo(Status.INTERNAL);
+              assertThat(e.getStatus()).isEqualTo(Status.FORBIDDEN);
               assertThat(e.getMessage()).contains(TENANT_ID);
             });
   }
@@ -270,7 +271,7 @@ class RegistryHistoryBackupApiTest {
         Arguments.of(new BackupAlreadyRunningException("running"), Status.INVALID_STATE),
         Arguments.of(new InvalidRequestException("invalid"), Status.INVALID_ARGUMENT),
         Arguments.of(new ResourceNotFoundException("missing"), Status.NOT_FOUND),
-        Arguments.of(new MissingRepositoryException("no repo"), Status.INTERNAL),
+        Arguments.of(new MissingRepositoryException("no repo"), Status.FORBIDDEN),
         Arguments.of(new BackupRepositoryConnectionException("unreachable"), Status.UNAVAILABLE),
         Arguments.of(new IndexNotFoundException(List.of("index-1")), Status.INTERNAL),
         Arguments.of(new BackupException("something else"), Status.INTERNAL));
@@ -298,7 +299,7 @@ class RegistryHistoryBackupApiTest {
     // when / then
     assertThatExceptionOfType(ServiceException.class)
         .isThrownBy(() -> api.getBackups(TENANT_ID, true, "*"))
-        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.INTERNAL));
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.FORBIDDEN));
   }
 
   /**
@@ -315,7 +316,7 @@ class RegistryHistoryBackupApiTest {
     // when / then
     assertThatExceptionOfType(ServiceException.class)
         .isThrownBy(() -> api.getBackupState(TENANT_ID, 42L))
-        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.INTERNAL));
+        .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.FORBIDDEN));
     assertThatExceptionOfType(ServiceException.class)
         .isThrownBy(() -> api.getBackupState(TENANT_ID, 43L))
         .satisfies(e -> assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -26,6 +26,8 @@ import java.util.List;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Full-stack integration tests for the cluster-admin Basic-auth chain ({@code /cluster/v2/**}),
@@ -41,6 +43,8 @@ public class ClusterAdminBasicAuthenticationIT {
   public static final String PATH_CLUSTER_TOPOLOGY = "cluster/v2/topology";
   public static final String PATH_CLUSTER_MODE = "cluster/v2/mode?mode=RECOVERING&dryRun=true";
   public static final String PATH_CLUSTER_STATUS = "cluster/v2/status";
+  public static final String PATH_CLUSTER_HISTORY_BACKUPS = "cluster/v2/backups/history";
+  public static final String PATH_CLUSTER_HISTORY_BACKUP = "cluster/v2/backups/history/1";
   public static final String PATH_V2_AUTHENTICATION_ME = "v2/authentication/me";
 
   private static final String CLUSTER_ADMIN_USER = "cluster-operator";
@@ -184,6 +188,21 @@ public class ClusterAdminBasicAuthenticationIT {
 
     // then — the status chain runs no authentication filter, so the header is never inspected
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+  }
+
+  /**
+   * The history backup endpoints sit behind the same chain as the rest of the cluster-admin API,
+   * and the chain answers before the storage gate does — so this holds on every secondary storage.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {PATH_CLUSTER_HISTORY_BACKUPS, PATH_CLUSTER_HISTORY_BACKUP})
+  void shouldRejectClusterHistoryBackupEndpointWithoutCredentials(final String path)
+      throws Exception {
+    // when
+    final HttpResponse<String> response = send(clusterUri(path), null);
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
   }
 
   private HttpResponse<String> send(final URI uri, final String authorizationHeader)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/ClusterHistoryBackupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/ClusterHistoryBackupIT.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.backup;
+
+import static io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.it.document.DocumentClient;
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.stream.StreamSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+/**
+ * The cluster-wide history backup endpoints against a real Elasticsearch and two physical tenants.
+ *
+ * <p>Exercises the two rules the contract turns on, neither of which a mocked-port test can prove
+ * over real storage: a backup only one physical tenant holds is read and deleted cluster-wide as a
+ * success, and a backup id one tenant already holds fails the whole request without scheduling
+ * anything anywhere.
+ *
+ * <p>Each tenant gets its own snapshot repository, unlike {@link PhysicalTenantHistoryBackupIT},
+ * which deliberately shares one to prove tenants stay separated by snapshot name.
+ */
+@ZeebeIntegration
+final class ClusterHistoryBackupIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String REPOSITORY_NAME_DEFAULT = "cluster-history-backup-it";
+  private static final String REPOSITORY_NAME_TENANT_A = "tenant-a-cluster-history-backup-it";
+  private static final String DEFAULT_INDEX_PREFIX = "defaultclusterhistorybackupit";
+  private static final String TENANT_A_INDEX_PREFIX = "tenantaclusterhistorybackupit";
+
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+
+  private static final Duration BACKUP_TIMEOUT = Duration.ofSeconds(60);
+  private static final ObjectMapper JSON = new ObjectMapper();
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+  private static ElasticsearchContainer elasticsearch;
+  private static PhysicalTenantsITHelper tenants;
+
+  @AutoClose private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          // The per-tenant /v2 endpoints stay open, so the test can stage a single-tenant backup
+          // without a user; /cluster/v2 keeps its own credentials regardless.
+          .withUnauthenticatedAccess()
+          .withCreateSchema(true)
+          .withProperty("camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
+          .withProperty(
+              "camunda.security.cluster-admin.basic.users[0].password", CLUSTER_ADMIN_PASSWORD);
+
+  @BeforeAll
+  static void startBrokerAgainstSharedElasticsearch() throws Exception {
+    elasticsearch =
+        TestSearchContainers.createDefaultElasticsearchContainer()
+            .withStartupTimeout(Duration.ofMinutes(5))
+            // filesystem snapshot repositories are only allowed under a registered path
+            .withEnv("path.repo", "~/");
+    elasticsearch.start();
+
+    final String url = "http://" + elasticsearch.getHttpHostAddress();
+    createSnapshotRepository(url, REPOSITORY_NAME_DEFAULT);
+    createSnapshotRepository(url, REPOSITORY_NAME_TENANT_A);
+
+    tenants =
+        PhysicalTenantsITHelper.builder()
+            .withTenant(DEFAULT_TENANT_ID, Storage.elasticsearch(url, DEFAULT_INDEX_PREFIX))
+            .withTenant(TENANT_A, Storage.elasticsearch(url, TENANT_A_INDEX_PREFIX))
+            .build();
+    tenants.configure(BROKER);
+
+    BROKER.withUnifiedConfig(
+        camunda ->
+            camunda
+                .getData()
+                .getSecondaryStorage()
+                .getElasticsearch()
+                .getBackup()
+                .setRepositoryName(REPOSITORY_NAME_DEFAULT));
+    BROKER.withPtConfig(
+        TENANT_A,
+        camunda ->
+            camunda
+                .getData()
+                .getSecondaryStorage()
+                .getElasticsearch()
+                .getBackup()
+                .setRepositoryName(REPOSITORY_NAME_TENANT_A));
+
+    BROKER.start();
+  }
+
+  @AfterAll
+  static void stopElasticsearch() {
+    if (elasticsearch != null) {
+      elasticsearch.stop();
+    }
+  }
+
+  @Test
+  void shouldTakeGetAndDeleteABackupOnEveryPhysicalTenant() throws Exception {
+    // given
+    final long backupId = 501L;
+
+    try {
+      // when
+      final var taken = clusterTakeBackup(backupId, null);
+
+      // then every targeted tenant is reported, in tenant-id order
+      assertStatus(taken, 202);
+      final var body = JSON.readTree(taken.body());
+      assertThat(body.get("backupId").asLong()).isEqualTo(backupId);
+      assertThat(physicalTenantIds(body.get("physicalTenants")))
+          .containsExactly(DEFAULT_TENANT_ID, TENANT_A);
+      assertThat(body.get("physicalTenants"))
+          .allSatisfy(tenant -> assertThat(tenant.get("scheduledSnapshots")).isNotEmpty());
+
+      // and the backup completes on both of them
+      awaitClusterBackupState(backupId, "COMPLETED", "COMPLETED");
+
+      // and it is listed under one group covering both tenants
+      final var listed = clusterListBackups(null);
+      assertStatus(listed, 200);
+      final var group = groupFor(JSON.readTree(listed.body()), backupId);
+      assertThat(physicalTenantIds(group.get("physicalTenants")))
+          .containsExactly(DEFAULT_TENANT_ID, TENANT_A);
+    } finally {
+      clusterDeleteBackup(backupId, null);
+    }
+
+    // and deleting it cluster-wide leaves nothing behind
+    Awaitility.await()
+        .untilAsserted(
+            () -> assertThat(clusterGetBackup(backupId, null).statusCode()).isEqualTo(404));
+  }
+
+  /**
+   * A backup that exists on one physical tenant and not another is normal — the cluster-admin can
+   * narrow a take to one tenant, and so can that tenant's own operator. Reading it cluster-wide is
+   * therefore a 200 naming both tenants, and deleting it a 204, not a partial-failure status.
+   */
+  @Test
+  void shouldReadAndDeleteASingleTenantBackupClusterWideAsSuccess() throws Exception {
+    // given a backup taken on one physical tenant only, through that tenant's own endpoint
+    final long backupId = 502L;
+    assertStatus(takeBackupOnTenant(TENANT_A, backupId), 202);
+
+    final HttpResponse<String> deleted;
+    try {
+      awaitClusterBackupState(backupId, "NOT_FOUND", "COMPLETED");
+
+      // when reading it cluster-wide
+      final var read = clusterGetBackup(backupId, null);
+
+      // then the tenant holding nothing is reported as observed, not as a failure
+      assertStatus(read, 200);
+      final var physicalTenants = JSON.readTree(read.body()).get("physicalTenants");
+      assertThat(stateOf(physicalTenants, DEFAULT_TENANT_ID)).isEqualTo("NOT_FOUND");
+      assertThat(stateOf(physicalTenants, TENANT_A)).isEqualTo("COMPLETED");
+
+      // and only the tenant holding it appears in the listing group
+      final var listed = clusterListBackups(null);
+      assertStatus(listed, 200);
+      assertThat(
+              physicalTenantIds(
+                  groupFor(JSON.readTree(listed.body()), backupId).get("physicalTenants")))
+          .containsExactly(TENANT_A);
+    } finally {
+      // when deleting it cluster-wide — also the teardown, so a failure above cannot leave the
+      // snapshot in the repository the other tests list
+      deleted = clusterDeleteBackup(backupId, null);
+    }
+
+    // then the tenant that never held it counts as already deleted
+    assertStatus(deleted, 204);
+    Awaitility.await()
+        .untilAsserted(
+            () -> assertThat(clusterGetBackup(backupId, null).statusCode()).isEqualTo(404));
+  }
+
+  @Test
+  void shouldScheduleNothingWhenOnePhysicalTenantAlreadyHoldsTheBackupId() throws Exception {
+    // given a backup id one physical tenant already holds
+    final long backupId = 503L;
+    assertStatus(takeBackupOnTenant(TENANT_A, backupId), 202);
+    awaitClusterBackupState(backupId, "NOT_FOUND", "COMPLETED");
+
+    try {
+      // when the same id is requested cluster-wide
+      final var taken = clusterTakeBackup(backupId, null);
+
+      // then the whole request is rejected
+      assertThat(taken.statusCode()).isEqualTo(409);
+
+      // and the other tenant still holds nothing, so nothing was scheduled anywhere
+      assertThat(getBackupOnTenant(DEFAULT_TENANT_ID, backupId).statusCode()).isEqualTo(404);
+    } finally {
+      clusterDeleteBackup(backupId, null);
+    }
+  }
+
+  @Test
+  void shouldNarrowEveryOperationToOnePhysicalTenant() throws Exception {
+    // given
+    final long backupId = 504L;
+
+    try {
+      // when the take is narrowed to one physical tenant
+      final var taken = clusterTakeBackup(backupId, TENANT_A);
+
+      // then only that tenant is scheduled
+      assertStatus(taken, 202);
+      assertThat(physicalTenantIds(JSON.readTree(taken.body()).get("physicalTenants")))
+          .containsExactly(TENANT_A);
+      assertThat(getBackupOnTenant(DEFAULT_TENANT_ID, backupId).statusCode()).isEqualTo(404);
+
+      // and reading narrowed to the other tenant is a plain 404, as on its own endpoint
+      assertThat(clusterGetBackup(backupId, DEFAULT_TENANT_ID).statusCode()).isEqualTo(404);
+    } finally {
+      clusterDeleteBackup(backupId, TENANT_A);
+    }
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenantId() throws Exception {
+    // when - then
+    assertThat(clusterGetBackup(505L, "nosuchtenant").statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void shouldRejectClusterWideBackupRequestsWithoutClusterAdminCredentials() throws Exception {
+    // when - then the per-tenant endpoints are unprotected here, the cluster-admin ones never are
+    assertThat(send("GET", clusterUri("", null), null, false).statusCode()).isEqualTo(401);
+  }
+
+  private static void awaitClusterBackupState(
+      final long backupId, final String defaultTenantState, final String tenantAState) {
+    Awaitility.await(
+            "backup %d reaches [%s, %s]".formatted(backupId, defaultTenantState, tenantAState))
+        .atMost(BACKUP_TIMEOUT)
+        .pollInterval(ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              final var response = clusterGetBackup(backupId, null);
+              assertStatus(response, 200);
+              final var physicalTenants = JSON.readTree(response.body()).get("physicalTenants");
+              assertThat(stateOf(physicalTenants, DEFAULT_TENANT_ID)).isEqualTo(defaultTenantState);
+              assertThat(stateOf(physicalTenants, TENANT_A)).isEqualTo(tenantAState);
+            });
+  }
+
+  private static String stateOf(final JsonNode physicalTenants, final String physicalTenantId) {
+    return StreamSupport.stream(physicalTenants.spliterator(), false)
+        .filter(tenant -> physicalTenantId.equals(tenant.get("physicalTenantId").asText()))
+        .map(tenant -> tenant.get("state").asText())
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new AssertionError(
+                    "Expected physical tenant '%s' in %s"
+                        .formatted(physicalTenantId, physicalTenants)));
+  }
+
+  private static List<String> physicalTenantIds(final JsonNode physicalTenants) {
+    return StreamSupport.stream(physicalTenants.spliterator(), false)
+        .map(tenant -> tenant.get("physicalTenantId").asText())
+        .toList();
+  }
+
+  private static JsonNode groupFor(final JsonNode listing, final long backupId) {
+    return StreamSupport.stream(listing.spliterator(), false)
+        .filter(group -> group.get("backupId").asLong() == backupId)
+        .findFirst()
+        .orElseThrow(
+            () -> new AssertionError("Expected backup %d in %s".formatted(backupId, listing)));
+  }
+
+  /** Includes the problem detail in the failure message: a bare status tells you nothing. */
+  private static void assertStatus(final HttpResponse<String> response, final int expected) {
+    assertThat(response.statusCode()).as("response body: %s", response.body()).isEqualTo(expected);
+  }
+
+  private static HttpResponse<String> clusterTakeBackup(
+      final long backupId, final String physicalTenantId) throws Exception {
+    return send("POST", clusterUri("", physicalTenantId), "{\"backupId\": " + backupId + "}", true);
+  }
+
+  private static HttpResponse<String> clusterListBackups(final String physicalTenantId)
+      throws Exception {
+    return send("GET", clusterUri("", physicalTenantId), null, true);
+  }
+
+  private static HttpResponse<String> clusterGetBackup(
+      final long backupId, final String physicalTenantId) throws Exception {
+    return send("GET", clusterUri("/" + backupId, physicalTenantId), null, true);
+  }
+
+  private static HttpResponse<String> clusterDeleteBackup(
+      final long backupId, final String physicalTenantId) throws Exception {
+    return send("DELETE", clusterUri("/" + backupId, physicalTenantId), null, true);
+  }
+
+  private static HttpResponse<String> takeBackupOnTenant(
+      final String physicalTenantId, final long backupId) throws Exception {
+    return send("POST", tenantUri(physicalTenantId, ""), "{\"backupId\": " + backupId + "}", false);
+  }
+
+  private static HttpResponse<String> getBackupOnTenant(
+      final String physicalTenantId, final long backupId) throws Exception {
+    return send("GET", tenantUri(physicalTenantId, "/" + backupId), null, false);
+  }
+
+  private static URI clusterUri(final String suffix, final String physicalTenantId) {
+    final var query = physicalTenantId == null ? "" : "?physicalTenantId=" + physicalTenantId;
+    return URI.create(base() + "/cluster/v2/backups/history" + suffix + query);
+  }
+
+  /**
+   * The {@code default} tenant is addressed on the unprefixed path, every other tenant on its
+   * {@code /physical-tenants/{id}} form.
+   */
+  private static URI tenantUri(final String physicalTenantId, final String suffix) {
+    final var prefix =
+        DEFAULT_TENANT_ID.equals(physicalTenantId) ? "" : "/physical-tenants/" + physicalTenantId;
+    return URI.create(base() + prefix + "/v2/backups/history" + suffix);
+  }
+
+  private static String base() {
+    return BROKER.restAddress().toString().replaceAll("/$", "");
+  }
+
+  private static HttpResponse<String> send(
+      final String method, final URI uri, final String body, final boolean asClusterAdmin)
+      throws Exception {
+    final var builder = HttpRequest.newBuilder(uri);
+    if (asClusterAdmin) {
+      builder.header("Authorization", basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+    }
+    if (body != null) {
+      builder.header("Content-Type", "application/json");
+      builder.method(method, BodyPublishers.ofString(body));
+    } else {
+      builder.method(method, BodyPublishers.noBody());
+    }
+    return HTTP.send(builder.build(), BodyHandlers.ofString());
+  }
+
+  private static String basicAuth(final String user, final String password) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void createSnapshotRepository(
+      final String elasticsearchUrl, final String repositoryName) throws Exception {
+    try (final var documentClient =
+        DocumentClient.create(elasticsearchUrl, DatabaseType.ELASTICSEARCH, EXECUTOR)) {
+      documentClient.createRepository(repositoryName);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/ClusterHistoryBackupServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterHistoryBackupServices.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.service.backup.HistoryBackupApi;
+import io.camunda.service.backup.HistoryBackupRequests;
+import io.camunda.service.backup.HistoryBackupSnapshot;
+import io.camunda.service.backup.HistoryBackupState;
+import io.camunda.service.backup.HistoryBackupStateCode;
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * History (secondary-storage snapshot) backups across every physical tenant of the cluster, or
+ * across the one a request narrows to (ADR 004, {@code
+ * docs/adr/management/004-cluster-wide-history-backup-outcomes.md}).
+ *
+ * <p>Unlike {@link HistoryBackupServices} this takes no {@code CamundaAuthentication} and performs
+ * no per-tenant authorization: per ADR 002 D4 the cluster-admin security chain is the only gate,
+ * and taking no authentication at all makes that structurally true rather than a convention a later
+ * edit can break.
+ *
+ * <p>Two rules shape every operation:
+ *
+ * <ul>
+ *   <li><b>Absence is a successful observation.</b> A backup that exists on one physical tenant and
+ *       not another is normal — both this API and the per-tenant one can produce it — so a tenant
+ *       that was reached and holds nothing reports {@link TenantBackupStateCode#NOT_FOUND} rather
+ *       than failing.
+ *   <li><b>Anything else is all-or-nothing.</b> A tenant whose state cannot be observed fails the
+ *       whole request; a caller works around a broken tenant by narrowing to the others.
+ * </ul>
+ *
+ * <p>{@link HistoryBackupApi} blocks on secondary-storage round-trips, so the fan-out runs on the
+ * shared API executor, one task per targeted tenant: the wall clock is the slowest tenant rather
+ * than the sum, which matters most for a verbose cluster-wide listing.
+ */
+@NullMarked
+public final class ClusterHistoryBackupServices {
+
+  private final HistoryBackupApi api;
+  private final List<String> physicalTenantIds;
+  private final Executor executor;
+
+  public ClusterHistoryBackupServices(
+      final HistoryBackupApi api,
+      final Collection<String> physicalTenantIds,
+      final ApiServicesExecutorProvider executorProvider) {
+    this.api = api;
+    // Sorted so every response lists physical tenants in the same, assertable order.
+    this.physicalTenantIds = physicalTenantIds.stream().sorted().toList();
+    executor = executorProvider.getExecutor();
+  }
+
+  /**
+   * Schedules a backup with the same id on every targeted physical tenant.
+   *
+   * <p>The id is checked on every targeted tenant before anything is scheduled: a cluster-wide
+   * backup that only lands on some tenants is not what the caller asked for. The check cannot be
+   * airtight — a per-tenant request can take the id in between — so a tenant rejecting the id
+   * during the fan-out still fails the request, leaving the snapshots already scheduled behind.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<ClusterHistoryBackupTaken> takeBackup(
+      final @Nullable String physicalTenantId, final @Nullable Long backupId) {
+    return validated(
+        () -> {
+          final var targets = targets(physicalTenantId);
+          final var id = HistoryBackupRequests.requireValidBackupId(backupId);
+          return onEveryTenant(
+                  targets,
+                  tenant -> {
+                    requireBackupIdFree(tenant, id);
+                    return tenant;
+                  })
+              .thenCompose(ignored -> onEveryTenant(targets, tenant -> take(tenant, id)))
+              .thenApply(taken -> new ClusterHistoryBackupTaken(id, taken));
+        });
+  }
+
+  /**
+   * Reports what every targeted physical tenant holds for the given backup id, including the ones
+   * holding nothing. Fails with {@link Status#NOT_FOUND} only when no targeted tenant holds it.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<ClusterHistoryBackup> getBackup(
+      final @Nullable String physicalTenantId, final long backupId) {
+    return validated(
+        () -> {
+          final var targets = targets(physicalTenantId);
+          final var id = HistoryBackupRequests.requireValidBackupId(backupId);
+          return onEveryTenant(targets, tenant -> stateOf(tenant, id))
+              .thenApply(
+                  states -> {
+                    if (states.stream()
+                        .allMatch(state -> state.state() == TenantBackupStateCode.NOT_FOUND)) {
+                      throw noTenantHolds(id, targets);
+                    }
+                    return new ClusterHistoryBackup(id, states);
+                  });
+        });
+  }
+
+  /**
+   * Lists the backups of every targeted physical tenant, grouped by backup id, most recent id
+   * first. A tenant that holds none of the matching ids simply contributes no entry.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<List<ClusterHistoryBackup>> listBackups(
+      final @Nullable String physicalTenantId,
+      final @Nullable String prefix,
+      final boolean verbose) {
+    return validated(
+        () -> {
+          final var targets = targets(physicalTenantId);
+          final var queried = HistoryBackupRequests.requireValidPrefix(prefix);
+          return onEveryTenant(
+                  targets,
+                  tenant ->
+                      new PhysicalTenantBackups(tenant, api.getBackups(tenant, verbose, queried)))
+              .thenApply(ClusterHistoryBackupServices::groupByBackupId);
+        });
+  }
+
+  /**
+   * Deletes the backup from every targeted physical tenant that holds it. A tenant that does not
+   * hold it has already reached the requested end state, so it counts as deleted; only a request
+   * where no targeted tenant held it at all fails with {@link Status#NOT_FOUND}.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<Void> deleteBackup(
+      final @Nullable String physicalTenantId, final long backupId) {
+    return validated(
+        () -> {
+          final var targets = targets(physicalTenantId);
+          final var id = HistoryBackupRequests.requireValidBackupId(backupId);
+          return onEveryTenant(targets, tenant -> delete(tenant, id))
+              .thenApply(
+                  deleted -> {
+                    if (deleted.stream().noneMatch(Boolean::booleanValue)) {
+                      throw noTenantHolds(id, targets);
+                    }
+                    return null;
+                  });
+        });
+  }
+
+  /**
+   * Resolves the physical tenants a request targets, rejecting an id this cluster does not know
+   * before any tenant is contacted — so an unknown id is never mistaken for a tenant that failed.
+   */
+  private List<String> targets(final @Nullable String physicalTenantId) {
+    if (physicalTenantId == null) {
+      return physicalTenantIds;
+    }
+    if (!physicalTenantIds.contains(physicalTenantId)) {
+      throw new ServiceException(
+          "Expected to target physical tenant '%s', but this cluster only has %s"
+              .formatted(physicalTenantId, physicalTenantIds),
+          Status.NOT_FOUND);
+    }
+    return List.of(physicalTenantId);
+  }
+
+  private void requireBackupIdFree(final String physicalTenantId, final long backupId) {
+    final HistoryBackupState existing;
+    try {
+      existing = api.getBackupState(physicalTenantId, backupId);
+    } catch (final ServiceException e) {
+      if (e.getStatus() == Status.NOT_FOUND) {
+        return;
+      }
+      throw e;
+    }
+    throw new ServiceException(
+        "Expected physical tenant '%s' to hold no backup with id '%d', but it is already %s"
+            .formatted(physicalTenantId, backupId, existing.state()),
+        Status.ALREADY_EXISTS);
+  }
+
+  private PhysicalTenantBackupTaken take(final String physicalTenantId, final long backupId) {
+    final var taken = api.takeBackup(physicalTenantId, backupId);
+    return new PhysicalTenantBackupTaken(physicalTenantId, taken.scheduledSnapshots());
+  }
+
+  private PhysicalTenantBackupState stateOf(final String physicalTenantId, final long backupId) {
+    try {
+      return toTenantState(physicalTenantId, api.getBackupState(physicalTenantId, backupId));
+    } catch (final ServiceException e) {
+      if (e.getStatus() == Status.NOT_FOUND) {
+        return new PhysicalTenantBackupState(
+            physicalTenantId, TenantBackupStateCode.NOT_FOUND, null, List.of());
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * @return {@code true} if the backup was deleted, {@code false} if the tenant did not hold it
+   */
+  private boolean delete(final String physicalTenantId, final long backupId) {
+    try {
+      api.deleteBackup(physicalTenantId, backupId);
+      return true;
+    } catch (final ServiceException e) {
+      if (e.getStatus() == Status.NOT_FOUND) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Runs one blocking port call per targeted physical tenant concurrently, and fails the whole
+   * request if any of them failed — the all-or-nothing rule. Results keep the targets' order.
+   */
+  private <T> CompletableFuture<List<T>> onEveryTenant(
+      final List<String> targets, final Function<String, T> perTenant) {
+    final var outcomes =
+        targets.stream()
+            .map(
+                tenant ->
+                    CompletableFuture.supplyAsync(() -> perTenant.apply(tenant), executor)
+                        .handle((value, error) -> new Outcome<>(tenant, value, error)))
+            .toList();
+    return CompletableFuture.allOf(outcomes.toArray(CompletableFuture[]::new))
+        .thenApply(ignored -> collect(outcomes.stream().map(CompletableFuture::join).toList()));
+  }
+
+  private static <T> List<T> collect(final List<Outcome<T>> outcomes) {
+    final var failures = outcomes.stream().filter(outcome -> outcome.error() != null).toList();
+    if (!failures.isEmpty()) {
+      throw combine(failures, outcomes.size());
+    }
+    return outcomes.stream().map(Outcome::value).toList();
+  }
+
+  /**
+   * Folds the failures of a fan-out into the one exception the request answers with. A shared
+   * status is kept — so a request narrowed to a single tenant answers exactly what the per-tenant
+   * endpoint would — while genuinely different causes have no honest status other than 500.
+   */
+  private static ServiceException combine(
+      final List<? extends Outcome<?>> failures, final int targeted) {
+    final var statuses = new LinkedHashSet<Status>();
+    final var detail = new StringJoiner("; ");
+    for (final var failure : failures) {
+      final var cause = ErrorMapper.mapError(failure.error());
+      statuses.add(cause.getStatus());
+      detail.add("'%s': %s".formatted(failure.physicalTenantId(), cause.getMessage()));
+    }
+    return new ServiceException(
+        "Expected to serve every targeted physical tenant, but %d of %d failed — %s"
+            .formatted(failures.size(), targeted, detail),
+        statuses.size() == 1 ? statuses.iterator().next() : Status.INTERNAL);
+  }
+
+  private static List<ClusterHistoryBackup> groupByBackupId(
+      final List<PhysicalTenantBackups> perTenant) {
+    final Map<Long, List<PhysicalTenantBackupState>> byBackupId =
+        new TreeMap<>(Comparator.reverseOrder());
+    perTenant.forEach(
+        tenant ->
+            tenant
+                .backups()
+                .forEach(
+                    backup ->
+                        byBackupId
+                            .computeIfAbsent(backup.backupId(), id -> new ArrayList<>())
+                            .add(toTenantState(tenant.physicalTenantId(), backup))));
+    return byBackupId.entrySet().stream()
+        .map(entry -> new ClusterHistoryBackup(entry.getKey(), List.copyOf(entry.getValue())))
+        .toList();
+  }
+
+  private static PhysicalTenantBackupState toTenantState(
+      final String physicalTenantId, final HistoryBackupState state) {
+    return new PhysicalTenantBackupState(
+        physicalTenantId,
+        toTenantStateCode(state.state()),
+        state.failureReason(),
+        state.snapshots());
+  }
+
+  private static TenantBackupStateCode toTenantStateCode(final HistoryBackupStateCode state) {
+    return switch (state) {
+      case IN_PROGRESS -> TenantBackupStateCode.IN_PROGRESS;
+      case COMPLETED -> TenantBackupStateCode.COMPLETED;
+      case FAILED -> TenantBackupStateCode.FAILED;
+      case INCOMPLETE -> TenantBackupStateCode.INCOMPLETE;
+      case INCOMPATIBLE -> TenantBackupStateCode.INCOMPATIBLE;
+    };
+  }
+
+  private static ServiceException noTenantHolds(final long backupId, final List<String> targets) {
+    return new ServiceException(
+        "Expected to find a history backup with id '%d', but none of the physical tenants %s holds it"
+            .formatted(backupId, targets),
+        Status.NOT_FOUND);
+  }
+
+  /** Turns a rejection raised before the fan-out starts into a failed future. */
+  private static <T> CompletableFuture<T> validated(final Supplier<CompletableFuture<T>> request) {
+    try {
+      return request.get();
+    } catch (final ServiceException e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private record Outcome<T>(
+      String physicalTenantId, @Nullable T value, @Nullable Throwable error) {}
+
+  private record PhysicalTenantBackups(String physicalTenantId, List<HistoryBackupState> backups) {}
+
+  /** The snapshots scheduled for one backup id, per physical tenant. */
+  public record ClusterHistoryBackupTaken(
+      long backupId, List<PhysicalTenantBackupTaken> physicalTenants) {}
+
+  public record PhysicalTenantBackupTaken(
+      String physicalTenantId, List<String> scheduledSnapshots) {}
+
+  /** What each physical tenant reports for one backup id. Carries no cluster-level aggregate. */
+  public record ClusterHistoryBackup(
+      long backupId, List<PhysicalTenantBackupState> physicalTenants) {}
+
+  public record PhysicalTenantBackupState(
+      String physicalTenantId,
+      TenantBackupStateCode state,
+      @Nullable String failureReason,
+      List<HistoryBackupSnapshot> snapshots) {}
+
+  /**
+   * {@link HistoryBackupStateCode} plus {@code NOT_FOUND}, which only a fan-out can observe: the
+   * tenant was reached and holds nothing. There is no code for a tenant that could not be reached —
+   * such a tenant fails the whole request instead.
+   */
+  public enum TenantBackupStateCode {
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED,
+    INCOMPLETE,
+    INCOMPATIBLE,
+    NOT_FOUND
+  }
+}

--- a/service/src/main/java/io/camunda/service/HistoryBackupServices.java
+++ b/service/src/main/java/io/camunda/service/HistoryBackupServices.java
@@ -17,6 +17,7 @@ import io.camunda.security.api.model.config.AuthorizationsConfiguration;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.backup.HistoryBackupApi;
+import io.camunda.service.backup.HistoryBackupRequests;
 import io.camunda.service.backup.HistoryBackupState;
 import io.camunda.service.backup.HistoryBackupTaken;
 import io.camunda.service.exception.ErrorMapper;
@@ -42,9 +43,6 @@ import org.jspecify.annotations.Nullable;
  */
 @NullMarked
 public final class HistoryBackupServices {
-
-  /** Matches the wildcard the runtime backup endpoints use for "every backup". */
-  private static final String WILDCARD = "*";
 
   private final String physicalTenantId;
   private final HistoryBackupApi api;
@@ -74,11 +72,12 @@ public final class HistoryBackupServices {
     if (!hasPermission(BACKUP_CREATE_AUTHORIZATION, authentication)) {
       return failedFuture(BACKUP_CREATE_AUTHORIZATION);
     }
-    if (backupId == null || backupId <= 0) {
-      return invalidArgument("A backupId must be provided and it must be > 0");
-    }
 
-    return callAsync(() -> api.takeBackup(physicalTenantId, backupId));
+    return validated(
+        () -> {
+          final var id = HistoryBackupRequests.requireValidBackupId(backupId);
+          return callAsync(() -> api.takeBackup(physicalTenantId, id));
+        });
   }
 
   public CompletableFuture<HistoryBackupState> getBackupState(
@@ -86,11 +85,12 @@ public final class HistoryBackupServices {
     if (!hasPermission(BACKUP_READ_AUTHORIZATION, authentication)) {
       return failedFuture(BACKUP_READ_AUTHORIZATION);
     }
-    if (backupId <= 0) {
-      return invalidArgument("A backupId must be provided and it must be > 0");
-    }
 
-    return callAsync(() -> api.getBackupState(physicalTenantId, backupId));
+    return validated(
+        () -> {
+          final var id = HistoryBackupRequests.requireValidBackupId(backupId);
+          return callAsync(() -> api.getBackupState(physicalTenantId, id));
+        });
   }
 
   public CompletableFuture<List<HistoryBackupState>> listBackups(
@@ -100,12 +100,12 @@ public final class HistoryBackupServices {
     if (!hasPermission(BACKUP_READ_AUTHORIZATION, authentication)) {
       return failedFuture(BACKUP_READ_AUTHORIZATION);
     }
-    if (prefix != null && !prefix.endsWith(WILDCARD)) {
-      return invalidArgument("Expected a prefix ending with '*', but got '%s'".formatted(prefix));
-    }
 
-    return callAsync(
-        () -> api.getBackups(physicalTenantId, verbose, prefix != null ? prefix : WILDCARD));
+    return validated(
+        () -> {
+          final var queried = HistoryBackupRequests.requireValidPrefix(prefix);
+          return callAsync(() -> api.getBackups(physicalTenantId, verbose, queried));
+        });
   }
 
   public CompletableFuture<Void> deleteBackup(
@@ -113,15 +113,25 @@ public final class HistoryBackupServices {
     if (!hasPermission(BACKUP_DELETE_AUTHORIZATION, authentication)) {
       return failedFuture(BACKUP_DELETE_AUTHORIZATION);
     }
-    if (backupId <= 0) {
-      return invalidArgument("A backupId must be provided and it must be > 0");
-    }
 
-    return callAsync(
+    return validated(
         () -> {
-          api.deleteBackup(physicalTenantId, backupId);
-          return null;
+          final var id = HistoryBackupRequests.requireValidBackupId(backupId);
+          return callAsync(
+              () -> {
+                api.deleteBackup(physicalTenantId, id);
+                return null;
+              });
         });
+  }
+
+  /** Turns a rejection raised by {@link HistoryBackupRequests} into a failed future. */
+  private static <T> CompletableFuture<T> validated(final Supplier<CompletableFuture<T>> request) {
+    try {
+      return request.get();
+    } catch (final ServiceException e) {
+      return CompletableFuture.failedFuture(e);
+    }
   }
 
   /**
@@ -137,11 +147,6 @@ public final class HistoryBackupServices {
               }
               return value;
             });
-  }
-
-  private <T> CompletableFuture<T> invalidArgument(final String message) {
-    return CompletableFuture.failedFuture(
-        new ServiceException(message, ServiceException.Status.INVALID_ARGUMENT));
   }
 
   private <T> CompletableFuture<T> failedFuture(

--- a/service/src/main/java/io/camunda/service/backup/HistoryBackupRequests.java
+++ b/service/src/main/java/io/camunda/service/backup/HistoryBackupRequests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.backup;
+
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Request validation shared by the per-physical-tenant and the cluster-wide history backup
+ * services, so {@code /v2} and {@code /cluster/v2} reject the same input with the same message.
+ *
+ * <p>The OpenAPI {@code minimum: 1} and {@code ^\d*\*$} constraints are documentation only —
+ * nothing enforces them at runtime, which is why these checks exist at all.
+ */
+@NullMarked
+public final class HistoryBackupRequests {
+
+  /** Matches the wildcard the runtime backup endpoints use for "every backup". */
+  public static final String WILDCARD = "*";
+
+  private HistoryBackupRequests() {}
+
+  /**
+   * @param backupId nullable because the request body may omit it; unlike runtime backups, history
+   *     backups have no generated-id mode, so an absent id is a bad request rather than a signal
+   * @throws ServiceException with {@link Status#INVALID_ARGUMENT} if the id is absent or not
+   *     positive
+   */
+  public static long requireValidBackupId(final @Nullable Long backupId) {
+    if (backupId == null || backupId <= 0) {
+      throw new ServiceException(
+          "A backupId must be provided and it must be > 0", Status.INVALID_ARGUMENT);
+    }
+    return backupId;
+  }
+
+  /**
+   * @return the prefix to query the store with: the given one, or the wildcard when none was given
+   * @throws ServiceException with {@link Status#INVALID_ARGUMENT} if the prefix does not end in the
+   *     wildcard
+   */
+  public static String requireValidPrefix(final @Nullable String prefix) {
+    if (prefix == null) {
+      return WILDCARD;
+    }
+    if (!prefix.endsWith(WILDCARD)) {
+      throw new ServiceException(
+          "Expected a prefix ending with '*', but got '%s'".formatted(prefix),
+          Status.INVALID_ARGUMENT);
+    }
+    return prefix;
+  }
+}

--- a/service/src/main/java/io/camunda/service/exception/SecondaryStorageDegradedException.java
+++ b/service/src/main/java/io/camunda/service/exception/SecondaryStorageDegradedException.java
@@ -13,11 +13,27 @@ package io.camunda.service.exception;
  * SecondaryStorageUnavailableException}, which is HTTP 403 for secondary storage not being
  * configured at all.
  */
-public class SecondaryStorageDegradedException extends ServiceException {
+public final class SecondaryStorageDegradedException extends ServiceException {
   public static final String SECONDARY_STORAGE_DEGRADED_MESSAGE =
       "Physical tenant '%s' is degraded: its secondary storage is not ready. Requests are rejected until it recovers.";
+  public static final String CLUSTER_SECONDARY_STORAGE_DEGRADED_MESSAGE =
+      "No physical tenant of this cluster has ready secondary storage. Requests are rejected until at least one recovers.";
 
-  public SecondaryStorageDegradedException(final String physicalTenantId) {
-    super(SECONDARY_STORAGE_DEGRADED_MESSAGE.formatted(physicalTenantId), Status.UNAVAILABLE);
+  private SecondaryStorageDegradedException(final String message) {
+    super(message, Status.UNAVAILABLE);
+  }
+
+  /** The request's own physical tenant is degraded. */
+  public static SecondaryStorageDegradedException forPhysicalTenant(final String physicalTenantId) {
+    return new SecondaryStorageDegradedException(
+        SECONDARY_STORAGE_DEGRADED_MESSAGE.formatted(physicalTenantId));
+  }
+
+  /**
+   * Names no physical tenant, because a cluster-wide endpoint is not served on behalf of one: it is
+   * rejected only when no tenant at all can be served.
+   */
+  public static SecondaryStorageDegradedException forCluster() {
+    return new SecondaryStorageDegradedException(CLUSTER_SECONDARY_STORAGE_DEGRADED_MESSAGE);
   }
 }

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -16,6 +16,7 @@ import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
+import io.camunda.service.ClusterHistoryBackupServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
@@ -52,9 +53,11 @@ import io.camunda.service.UsageMetricsServices;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.VariableServices;
+import io.camunda.service.exception.ServiceException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Default {@link ServiceRegistry} backed by one {@code Map<physicalTenantId, service>} per
@@ -102,6 +105,7 @@ public record DefaultServiceRegistry(
     Map<String, UserServices> userByTenant,
     Map<String, UserTaskServices> userTaskByTenant,
     Map<String, VariableServices> variableByTenant,
+    @Nullable ClusterHistoryBackupServices clusterHistoryBackupServices,
     ClusterRecoveryServices clusterRecoveryServices,
     ClusterStatusServices clusterStatusServices,
     ClusterTopologyServices clusterTopologyServices,
@@ -320,8 +324,18 @@ public record DefaultServiceRegistry(
   }
 
   @Override
-  public ClusterRecoveryServices clusterRecoveryServices() {
-    return clusterRecoveryServices;
+  public ClusterHistoryBackupServices clusterHistoryBackupServices() {
+    if (clusterHistoryBackupServices == null) {
+      // The same answer the @RequiresSecondaryStorage gate gives, rather than an
+      // IllegalStateException surfacing as a 500. The two decide on different inputs — the gate on
+      // the request's physical tenant, the service's existence on the cluster-wide
+      // camunda.data.secondary-storage.type — so a cluster that sets them inconsistently reaches
+      // here, and the caller should still be told what is actually true of this deployment.
+      throw new ServiceException(
+          "The cluster's secondary storage cannot serve history backups",
+          ServiceException.Status.FORBIDDEN);
+    }
+    return clusterHistoryBackupServices;
   }
 
   @Override
@@ -332,6 +346,11 @@ public record DefaultServiceRegistry(
   @Override
   public ClusterTopologyServices clusterTopologyServices() {
     return clusterTopologyServices;
+  }
+
+  @Override
+  public ClusterRecoveryServices clusterRecoveryServices() {
+    return clusterRecoveryServices;
   }
 
   @Override
@@ -423,6 +442,7 @@ public record DefaultServiceRegistry(
     private final Map<String, UserServices> userByTenant = new HashMap<>();
     private final Map<String, UserTaskServices> userTaskByTenant = new HashMap<>();
     private final Map<String, VariableServices> variableByTenant = new HashMap<>();
+    private @Nullable ClusterHistoryBackupServices clusterHistoryBackupServices;
     private ClusterRecoveryServices clusterRecoveryServices;
     private ClusterStatusServices clusterStatusServices;
     private ClusterTopologyServices clusterTopologyServices;
@@ -644,6 +664,11 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder clusterHistoryBackupServices(final ClusterHistoryBackupServices service) {
+      clusterHistoryBackupServices = service;
+      return this;
+    }
+
     public Builder clusterRecoveryServices(final ClusterRecoveryServices service) {
       clusterRecoveryServices = service;
       return this;
@@ -711,6 +736,7 @@ public record DefaultServiceRegistry(
           Map.copyOf(userByTenant),
           Map.copyOf(userTaskByTenant),
           Map.copyOf(variableByTenant),
+          clusterHistoryBackupServices,
           clusterRecoveryServices,
           clusterStatusServices,
           clusterTopologyServices,

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -16,6 +16,7 @@ import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
+import io.camunda.service.ClusterHistoryBackupServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
@@ -145,6 +146,15 @@ public interface ServiceRegistry {
   VariableServices variableServices(String physicalTenantId);
 
   // -- cluster-wide --
+
+  /**
+   * @throws io.camunda.service.exception.ServiceException with {@code FORBIDDEN} on a cluster whose
+   *     secondary storage cannot serve history backups, where no such service exists. Normally the
+   *     {@code @RequiresSecondaryStorage} gate on the controller answers 403 first, but it decides
+   *     on the request's physical tenant while this service's existence is decided on the
+   *     cluster-wide storage type, so the two can disagree; both paths answer 403.
+   */
+  ClusterHistoryBackupServices clusterHistoryBackupServices();
 
   ClusterStatusServices clusterStatusServices();
 

--- a/service/src/test/java/io/camunda/service/ClusterHistoryBackupServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterHistoryBackupServicesTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ClusterHistoryBackupServices.ClusterHistoryBackup;
+import io.camunda.service.ClusterHistoryBackupServices.PhysicalTenantBackupState;
+import io.camunda.service.ClusterHistoryBackupServices.PhysicalTenantBackupTaken;
+import io.camunda.service.ClusterHistoryBackupServices.TenantBackupStateCode;
+import io.camunda.service.backup.HistoryBackupApi;
+import io.camunda.service.backup.HistoryBackupState;
+import io.camunda.service.backup.HistoryBackupStateCode;
+import io.camunda.service.backup.HistoryBackupTaken;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The fan-out rules of the cluster-wide history backup endpoints: absence is a successful
+ * observation, and anything else is all-or-nothing.
+ */
+public class ClusterHistoryBackupServicesTest {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+
+  /**
+   * Generous on purpose. The first assertion that reaches a failure path pays the class loading of
+   * {@code ErrorMapper}'s dependency graph — broker client, document API, search — on a worker
+   * thread, which costs seconds on a cold JVM. A bound near that cost makes the test flaky without
+   * saying anything about the code under test, which has no timing behaviour of its own.
+   */
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+  private final HistoryBackupApi api = mock(HistoryBackupApi.class);
+
+  private ExecutorService executor;
+  private ClusterHistoryBackupServices services;
+
+  @BeforeEach
+  public void before() {
+    executor = Executors.newFixedThreadPool(2);
+    // A bare executor, not `new ApiServicesExecutorProvider(executor)`: the provider wraps it in
+    // the physical-tenant propagating decorator, whose spring-web dependency is not on this
+    // module's test classpath. Propagation is not what this test is about.
+    final var executorProvider = mock(ApiServicesExecutorProvider.class);
+    when(executorProvider.getExecutor()).thenReturn(executor);
+    // Deliberately unsorted, so the sorted response order is a property of the service.
+    services = new ClusterHistoryBackupServices(api, List.of(TENANT_B, TENANT_A), executorProvider);
+  }
+
+  @AfterEach
+  public void after() {
+    executor.shutdownNow();
+  }
+
+  // -- take --
+
+  @Test
+  public void shouldTakeTheBackupOnEveryPhysicalTenantInTenantIdOrder() {
+    // given
+    absentOn(TENANT_A, 42L);
+    absentOn(TENANT_B, 42L);
+    when(api.takeBackup(TENANT_A, 42L)).thenReturn(new HistoryBackupTaken(42L, List.of("a-1")));
+    when(api.takeBackup(TENANT_B, 42L)).thenReturn(new HistoryBackupTaken(42L, List.of("b-1")));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              assertThat(result.backupId()).isEqualTo(42L);
+              assertThat(result.physicalTenants())
+                  .containsExactly(
+                      new PhysicalTenantBackupTaken(TENANT_A, List.of("a-1")),
+                      new PhysicalTenantBackupTaken(TENANT_B, List.of("b-1")));
+            });
+  }
+
+  @Test
+  public void shouldNotScheduleAnythingWhenOnePhysicalTenantAlreadyHoldsTheBackupId() {
+    // given a backup id one tenant already holds — the request is all-or-nothing
+    absentOn(TENANT_A, 42L);
+    when(api.getBackupState(TENANT_B, 42L)).thenReturn(completedBackup(42L));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(taken))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.ALREADY_EXISTS);
+              assertThat(e.getMessage()).contains(TENANT_B);
+            });
+    verify(api, never()).takeBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldNotScheduleAnythingWhenOnePhysicalTenantCannotBeReached() {
+    // given
+    absentOn(TENANT_A, 42L);
+    when(api.getBackupState(TENANT_B, 42L))
+        .thenThrow(new ServiceException("connection refused", Status.UNAVAILABLE));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(taken).getStatus()).isEqualTo(Status.UNAVAILABLE);
+    verify(api, never()).takeBackup(anyString(), anyLong());
+  }
+
+  /**
+   * A repository absent from the store must never be mistaken for a tenant that simply holds no
+   * backup — that is what would let a cluster-wide take start on a tenant that cannot serve it.
+   */
+  @Test
+  public void shouldNotTreatAMissingRepositoryAsAFreeBackupId() {
+    // given
+    absentOn(TENANT_A, 42L);
+    when(api.getBackupState(TENANT_B, 42L))
+        .thenThrow(new ServiceException("no repository", Status.INTERNAL));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(taken).getStatus()).isEqualTo(Status.INTERNAL);
+    verify(api, never()).takeBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldRejectAnAbsentBackupId() {
+    // when
+    final var taken = services.takeBackup(null, null);
+
+    // then
+    assertThat(failureOf(taken).getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
+    verify(api, never()).getBackupState(anyString(), anyLong());
+  }
+
+  // -- get --
+
+  @Test
+  public void shouldReportABackupOnlyOnePhysicalTenantHoldsAsSuccess() {
+    // given a single-tenant backup — a supported outcome, not a degraded one
+    when(api.getBackupState(TENANT_A, 42L)).thenReturn(completedBackup(42L));
+    absentOn(TENANT_B, 42L);
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then every targeted tenant is listed, including the one holding nothing
+    assertThat(backup)
+        .succeedsWithin(TIMEOUT)
+        .isEqualTo(
+            new ClusterHistoryBackup(
+                42L,
+                List.of(
+                    new PhysicalTenantBackupState(
+                        TENANT_A, TenantBackupStateCode.COMPLETED, null, List.of()),
+                    new PhysicalTenantBackupState(
+                        TENANT_B, TenantBackupStateCode.NOT_FOUND, null, List.of()))));
+  }
+
+  @Test
+  public void shouldReportABackupNoPhysicalTenantHoldsAsNotFound() {
+    // given
+    absentOn(TENANT_A, 42L);
+    absentOn(TENANT_B, 42L);
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(backup).getStatus()).isEqualTo(Status.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldFailTheReadWhenOnePhysicalTenantCannotBeObserved() {
+    // given a tenant that holds the backup and one whose state is unknown
+    when(api.getBackupState(TENANT_A, 42L)).thenReturn(completedBackup(42L));
+    when(api.getBackupState(TENANT_B, 42L))
+        .thenThrow(new ServiceException("connection refused", Status.UNAVAILABLE));
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then the observable part is not reported as if it were the whole picture
+    assertThat(failureOf(backup))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE);
+              assertThat(e.getMessage()).contains(TENANT_B).contains("connection refused");
+            });
+  }
+
+  /** Different causes have no honest shared status, so the request answers 500 rather than pick. */
+  @Test
+  public void shouldFallBackToInternalWhenPhysicalTenantsFailForDifferentReasons() {
+    // given
+    when(api.getBackupState(TENANT_A, 42L))
+        .thenThrow(new ServiceException("connection refused", Status.UNAVAILABLE));
+    when(api.getBackupState(TENANT_B, 42L))
+        .thenThrow(new ServiceException("no repository", Status.INVALID_ARGUMENT));
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(backup))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.INTERNAL);
+              assertThat(e.getMessage()).contains(TENANT_A).contains(TENANT_B);
+            });
+  }
+
+  // -- list --
+
+  @Test
+  public void shouldGroupListedBackupsByIdMostRecentFirst() {
+    // given
+    when(api.getBackups(TENANT_A, true, "*"))
+        .thenReturn(List.of(completedBackup(7L), completedBackup(3L)));
+    when(api.getBackups(TENANT_B, true, "*")).thenReturn(List.of(completedBackup(7L)));
+
+    // when
+    final var backups = services.listBackups(null, null, true);
+
+    // then
+    assertThat(backups)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            listed -> {
+              assertThat(listed).map(ClusterHistoryBackup::backupId).containsExactly(7L, 3L);
+              assertThat(listed.getFirst().physicalTenants())
+                  .map(PhysicalTenantBackupState::physicalTenantId)
+                  .containsExactly(TENANT_A, TENANT_B);
+              // a tenant holding none of an id contributes no entry — it is not an error
+              assertThat(listed.getLast().physicalTenants())
+                  .map(PhysicalTenantBackupState::physicalTenantId)
+                  .containsExactly(TENANT_A);
+            });
+  }
+
+  @Test
+  public void shouldFailTheListingWhenOnePhysicalTenantCannotBeRead() {
+    // given
+    when(api.getBackups(TENANT_A, true, "*")).thenReturn(List.of(completedBackup(7L)));
+    when(api.getBackups(TENANT_B, true, "*"))
+        .thenThrow(new ServiceException("connection refused", Status.UNAVAILABLE));
+
+    // when
+    final var backups = services.listBackups(null, null, true);
+
+    // then a tenant that cannot be read does not silently drop out of the listing
+    assertThat(failureOf(backups).getStatus()).isEqualTo(Status.UNAVAILABLE);
+  }
+
+  @Test
+  public void shouldRejectAPrefixWithoutAWildcard() {
+    // when
+    final var backups = services.listBackups(null, "17", true);
+
+    // then
+    assertThat(failureOf(backups).getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
+    verify(api, never()).getBackups(anyString(), anyBoolean(), anyString());
+  }
+
+  // -- delete --
+
+  @Test
+  public void shouldDeleteABackupOnlyOnePhysicalTenantHolds() {
+    // given a tenant that does not hold it has already reached the requested end state
+    doThrow(new ServiceException("no such id", Status.NOT_FOUND))
+        .when(api)
+        .deleteBackup(TENANT_B, 42L);
+
+    // when
+    final var deleted = services.deleteBackup(null, 42L);
+
+    // then
+    assertThat(deleted).succeedsWithin(TIMEOUT);
+    verify(api).deleteBackup(TENANT_A, 42L);
+  }
+
+  @Test
+  public void shouldReportADeleteOfABackupNoPhysicalTenantHoldsAsNotFound() {
+    // given
+    doThrow(new ServiceException("no such id", Status.NOT_FOUND))
+        .when(api)
+        .deleteBackup(anyString(), anyLong());
+
+    // when
+    final var deleted = services.deleteBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(deleted).getStatus()).isEqualTo(Status.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldFailTheDeleteWhenOnePhysicalTenantCannotBeReached() {
+    // given
+    doThrow(new ServiceException("connection refused", Status.UNAVAILABLE))
+        .when(api)
+        .deleteBackup(TENANT_B, 42L);
+
+    // when
+    final var deleted = services.deleteBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(deleted).getStatus()).isEqualTo(Status.UNAVAILABLE);
+  }
+
+  // -- narrowing --
+
+  @Test
+  public void shouldNarrowTheFanOutToTheNamedPhysicalTenant() {
+    // given
+    absentOn(TENANT_A, 42L);
+    when(api.takeBackup(TENANT_A, 42L)).thenReturn(new HistoryBackupTaken(42L, List.of("a-1")));
+
+    // when
+    final var taken = services.takeBackup(TENANT_A, 42L);
+
+    // then the other tenant is neither read nor written
+    assertThat(taken).succeedsWithin(TIMEOUT);
+    verify(api, never()).getBackupState(TENANT_B, 42L);
+    verify(api, never()).takeBackup(TENANT_B, 42L);
+  }
+
+  /**
+   * With one targeted tenant the fan-out cannot be partial, so its failures reach the caller
+   * unchanged — a narrowed request answers exactly what the per-tenant endpoint would.
+   */
+  @Test
+  public void shouldCollapseToThePerTenantStatusWhenNarrowed() {
+    // given
+    when(api.getBackupState(TENANT_A, 42L))
+        .thenThrow(new ServiceException("connection refused", Status.UNAVAILABLE));
+
+    // when
+    final var backup = services.getBackup(TENANT_A, 42L);
+
+    // then
+    assertThat(failureOf(backup).getStatus()).isEqualTo(Status.UNAVAILABLE);
+  }
+
+  @Test
+  public void shouldRejectAnUnknownPhysicalTenantBeforeContactingAnyTenant() {
+    // when
+    final var backup = services.getBackup("nosuchtenant", 42L);
+
+    // then an unknown id is a request error, never a tenant that failed
+    assertThat(failureOf(backup))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND);
+              assertThat(e.getMessage()).contains("nosuchtenant");
+            });
+    verify(api, never()).getBackupState(anyString(), anyLong());
+  }
+
+  private void absentOn(final String physicalTenantId, final long backupId) {
+    when(api.getBackupState(physicalTenantId, backupId))
+        .thenThrow(new ServiceException("no such id", Status.NOT_FOUND));
+  }
+
+  private static HistoryBackupState completedBackup(final long backupId) {
+    return new HistoryBackupState(backupId, HistoryBackupStateCode.COMPLETED, null, List.of());
+  }
+
+  private static ServiceException failureOf(final CompletableFuture<?> future) {
+    final var thrown = catchThrowable(() -> future.get(TIMEOUT.toMillis(), MILLISECONDS));
+    assertThat(thrown).isNotNull();
+    final var cause = thrown.getCause();
+    assertThat(cause).isInstanceOf(ServiceException.class);
+    return (ServiceException) cause;
+  }
+}

--- a/service/src/test/java/io/camunda/service/ClusterHistoryBackupServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterHistoryBackupServicesTest.java
@@ -146,13 +146,13 @@ public class ClusterHistoryBackupServicesTest {
     // given
     absentOn(TENANT_A, 42L);
     when(api.getBackupState(TENANT_B, 42L))
-        .thenThrow(new ServiceException("no repository", Status.INTERNAL));
+        .thenThrow(new ServiceException("no repository", Status.FORBIDDEN));
 
     // when
     final var taken = services.takeBackup(null, 42L);
 
     // then
-    assertThat(failureOf(taken).getStatus()).isEqualTo(Status.INTERNAL);
+    assertThat(failureOf(taken).getStatus()).isEqualTo(Status.FORBIDDEN);
     verify(api, never()).takeBackup(anyString(), anyLong());
   }
 
@@ -229,7 +229,7 @@ public class ClusterHistoryBackupServicesTest {
     when(api.getBackupState(TENANT_A, 42L))
         .thenThrow(new ServiceException("connection refused", Status.UNAVAILABLE));
     when(api.getBackupState(TENANT_B, 42L))
-        .thenThrow(new ServiceException("no repository", Status.INVALID_ARGUMENT));
+        .thenThrow(new ServiceException("no repository", Status.FORBIDDEN));
 
     // when
     final var backup = services.getBackup(null, 42L);

--- a/service/src/test/java/io/camunda/service/registry/DefaultServiceRegistryTest.java
+++ b/service/src/test/java/io/camunda/service/registry/DefaultServiceRegistryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.service.ClusterHistoryBackupServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import org.junit.jupiter.api.Test;
+
+class DefaultServiceRegistryTest {
+
+  /**
+   * The controller's {@code @RequiresSecondaryStorage} gate normally answers first, but it decides
+   * on the request's physical tenant while this service's existence is decided on the cluster-wide
+   * storage type. A deployment that sets those inconsistently reaches the accessor, and must still
+   * be told what is true of it rather than handed a 500.
+   */
+  @Test
+  void shouldRejectClusterHistoryBackupsAsForbiddenWhenTheServiceIsAbsent() {
+    // given a cluster whose secondary storage cannot serve history backups
+    final var registry = DefaultServiceRegistry.of(builder -> {});
+
+    // when / then
+    assertThatExceptionOfType(ServiceException.class)
+        .isThrownBy(registry::clusterHistoryBackupServices)
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.FORBIDDEN);
+              assertThat(e.getMessage()).contains("history backups");
+            });
+  }
+
+  @Test
+  void shouldReturnClusterHistoryBackupsWhenTheServiceIsPresent() {
+    // given
+    final var services = mock(ClusterHistoryBackupServices.class);
+    final var registry =
+        DefaultServiceRegistry.of(builder -> builder.clusterHistoryBackupServices(services));
+
+    // when / then
+    assertThat(registry.clusterHistoryBackupServices()).isSameAs(services);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
@@ -324,7 +324,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
-          $ref: '#/components/responses/HistoryBackupInternalError'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
@@ -380,7 +380,7 @@ paths:
         "403":
           $ref: '#/components/responses/HistoryBackupForbidden'
         "500":
-          $ref: '#/components/responses/HistoryBackupInternalError'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
@@ -426,7 +426,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
-          $ref: '#/components/responses/HistoryBackupInternalError'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
@@ -467,30 +467,21 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
-          $ref: '#/components/responses/HistoryBackupInternalError'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
 
 components:
   responses:
-    HistoryBackupInternalError:
-      description: |
-        An internal error occurred, or the physical tenant's snapshot repository is absent from
-        the store — configured under a name the store does not have, or not configured at all.
-        The repository case is a deployment fault the caller cannot correct by changing its
-        request, so it is neither a `400` nor a `404`.
-      content:
-        application/problem+json:
-          schema:
-            $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
-
     HistoryBackupForbidden:
       description: |
-        The request is forbidden, either because the authenticated caller lacks the required
-        `BACKUP` permission, or because the cluster's secondary storage is neither Elasticsearch
-        nor OpenSearch and therefore cannot serve history backups. The problem detail says which
-        of the two applies.
+        The request is forbidden for one of three reasons: the authenticated caller lacks the
+        required `BACKUP` permission; the cluster's secondary storage is neither Elasticsearch nor
+        OpenSearch and therefore cannot serve history backups; or the physical tenant's snapshot
+        repository is absent from the store — configured under a name the store does not have, or
+        not configured at all. The problem detail says which applies. The latter two are deployment
+        faults the caller cannot correct by changing its request.
       content:
         application/problem+json:
           schema:

--- a/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
@@ -324,7 +324,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
-          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+          $ref: '#/components/responses/HistoryBackupInternalError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
@@ -380,7 +380,7 @@ paths:
         "403":
           $ref: '#/components/responses/HistoryBackupForbidden'
         "500":
-          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+          $ref: '#/components/responses/HistoryBackupInternalError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
@@ -426,7 +426,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
-          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+          $ref: '#/components/responses/HistoryBackupInternalError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
@@ -467,13 +467,24 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
-          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+          $ref: '#/components/responses/HistoryBackupInternalError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
 
 components:
   responses:
+    HistoryBackupInternalError:
+      description: |
+        An internal error occurred, or the physical tenant's snapshot repository is absent from
+        the store — configured under a name the store does not have, or not configured at all.
+        The repository case is a deployment fault the caller cannot correct by changing its
+        request, so it is neither a `400` nor a `404`.
+      content:
+        application/problem+json:
+          schema:
+            $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+
     HistoryBackupForbidden:
       description: |
         The request is forbidden, either because the authenticated caller lacks the required

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -504,13 +504,11 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           description: >-
-            The backup could not be scheduled on every targeted physical tenant — because one of
-            them hit an internal error, or because its snapshot repository is absent from the
-            store, a deployment fault no change to the request can correct. The check that
-            precedes the fan-out rejects the request before anything is scheduled, but a failure
-            during the fan-out itself can leave snapshots behind on the tenants already reached, so
-            delete this backup id before retrying. Narrow the request with `physicalTenantId` to
-            work with the tenants whose repository is usable.
+            The backup could not be scheduled on every targeted physical tenant, because one of
+            them hit an internal error. The check that precedes the fan-out rejects the request
+            before anything is scheduled, but a failure during the fan-out itself can leave
+            snapshots behind on the tenants already reached, so delete this backup id before
+            retrying.
           content:
             application/problem+json:
               schema:
@@ -594,7 +592,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
-          $ref: '#/components/responses/ClusterHistoryBackupInternalError'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
@@ -671,7 +669,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
-          $ref: '#/components/responses/ClusterHistoryBackupInternalError'
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
@@ -720,7 +718,19 @@ paths:
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "403":
-          $ref: '#/components/responses/ClusterHistoryBackupForbidden'
+          description: >-
+            The cluster's secondary storage cannot serve history backups, or a targeted physical
+            tenant's snapshot repository is absent from the store. Unlike the per-physical-tenant
+            backup endpoints, the cluster-admin surface performs no fine-grained authorization, so
+            a missing `BACKUP` permission is never the reason. Deletion fans out with no preceding
+            check, so an absent repository is found only once that tenant is reached, by which time
+            the backup may already be deleted from the others; those deletions are not undone.
+            Narrow the request with `physicalTenantId` to work with the tenants whose repository is
+            usable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "404":
           description: >-
             The requested `physicalTenantId` does not exist in this cluster, or every targeted
@@ -731,11 +741,10 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           description: >-
-            The backup could not be deleted from every targeted physical tenant — because one of
-            them hit an internal error, or because its snapshot repository is absent from the
-            store, a deployment fault no change to the request can correct — so it may still exist
-            on some of them. The deletions that already succeeded are not undone, so a retry has
-            only the remaining tenants left to reach.
+            The backup could not be deleted from every targeted physical tenant, because one of
+            them hit an internal error, so it may still exist on some of them. The deletions that
+            already succeeded are not undone, so a retry has only the remaining tenants left to
+            reach.
           content:
             application/problem+json:
               schema:
@@ -748,25 +757,15 @@ paths:
 
 components:
   responses:
-    ClusterHistoryBackupInternalError:
-      description: >-
-        A targeted physical tenant hit an internal error, or its snapshot repository is absent from
-        the store — configured under a name the store does not have, or not configured at all. The
-        repository case is a deployment fault the caller cannot correct by changing its request, so
-        it is neither a `400` nor a `404`, and the per-physical-tenant endpoints answer `500` for it
-        too. Narrow the request with `physicalTenantId` to work with the tenants whose repository is
-        usable.
-      content:
-        application/problem+json:
-          schema:
-            $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
-
     ClusterHistoryBackupForbidden:
       description: >-
-        The cluster's secondary storage is neither Elasticsearch nor OpenSearch, and therefore
-        cannot serve history backups. Unlike the per-physical-tenant backup endpoints, the
-        cluster-admin surface performs no fine-grained authorization, so a missing `BACKUP`
-        permission is never the reason.
+        The cluster's secondary storage is neither Elasticsearch nor OpenSearch and therefore
+        cannot serve history backups, or a targeted physical tenant's snapshot repository is absent
+        from the store — configured under a name the store does not have, or not configured at all.
+        Both are deployment faults the caller cannot correct by changing its request; narrow the
+        request with `physicalTenantId` to work with the tenants whose repository is usable. Unlike
+        the per-physical-tenant backup endpoints, the cluster-admin surface performs no fine-grained
+        authorization, so a missing `BACKUP` permission is never the reason.
       content:
         application/problem+json:
           schema:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -424,17 +424,362 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
 
+  /cluster/v2/backups/history:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: takeHistoryBackupAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Take a history backup on one or every physical tenant
+      description: >-
+        Triggers a history backup on every physical tenant of the cluster, or on the one named by
+        `physicalTenantId`. Every targeted tenant uses the same caller-supplied `backupId`, but the
+        backups are independent: they are neither coordinated nor rolled back together.
+
+
+        The request is all-or-nothing: the `backupId` is checked on every targeted tenant before any
+        snapshot is scheduled, so a tenant that already holds this id, or that cannot be reached,
+        fails the whole request and no backup is started anywhere. There is no aggregated
+        cluster-level state in the response.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Only available on clusters whose secondary storage is Elasticsearch or
+        OpenSearch. Use `POST /v2/backups/history` to act as a single physical tenant.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'backups.yaml#/components/schemas/TakeHistoryBackupRequest'
+      responses:
+        "202":
+          description: The backup has been scheduled on every targeted physical tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTakeHistoryBackupResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/ClusterHistoryBackupForbidden'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "409":
+          description: >-
+            At least one targeted physical tenant already holds a backup with this id, or already
+            has another backup running. The check that precedes the fan-out normally rejects the
+            request before anything is scheduled; a tenant that takes the id in between rejects it
+            during the fan-out instead, which can leave snapshots behind on the tenants already
+            reached, so delete this backup id before retrying.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          description: >-
+            The backup could not be scheduled on every targeted physical tenant — because one of
+            them hit an internal error, or because its snapshot repository is absent from the
+            store, a deployment fault no change to the request can correct. The check that
+            precedes the fan-out rejects the request before anything is scheduled, but a failure
+            during the fan-out itself can leave snapshots behind on the tenants already reached, so
+            delete this backup id before retrying. Narrow the request with `physicalTenantId` to
+            work with the tenants whose repository is usable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: listHistoryBackupsAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: List history backups across physical tenants
+      description: >-
+        Lists the history backups of every physical tenant of the cluster, or of the one named by
+        `physicalTenantId`, grouped by backup id. A backup id that only some physical tenants hold
+        is a supported outcome rather than a degraded one, so only the tenants that hold it are
+        listed under it.
+
+
+        The request is all-or-nothing: a physical tenant whose backups cannot be read fails the
+        whole request rather than silently dropping out of the listing. Narrow the request with
+        `physicalTenantId` to list the backups of the tenants that can still be read.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Only available on clusters whose secondary storage is Elasticsearch or
+        OpenSearch. Use `GET /v2/backups/history` to act as a single physical tenant.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+        - name: prefix
+          in: query
+          required: false
+          description: |
+            A prefix that backup ids must match, ending in a single '*'. If omitted, all
+            backups are returned.
+          schema:
+            $ref: 'backups.yaml#/components/schemas/BackupIdPrefix'
+        - name: verbose
+          in: query
+          required: false
+          description: |
+            Whether to ask the secondary storage for snapshot-level detail. Setting this to
+            `false` makes the query cheaper, but the store then reports neither snapshot state
+            nor start time, so both the per-snapshot `details` and the per-tenant `state` are
+            incomplete and the listing order is unspecified.
+          schema:
+            type: boolean
+            default: true
+      responses:
+        "200":
+          description: >-
+            The history backups of every targeted physical tenant, grouped by backup id and ordered
+            by backup id, descending. Deliberately not the per-physical-tenant endpoint's order,
+            which is by snapshot start time: start times are per tenant, so a group spanning
+            several tenants has no single one to sort on. Descending id is only recency for ids
+            that ascend with time. Empty when every targeted tenant was read and none of them holds
+            a matching backup.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClusterHistoryBackupInfo'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/ClusterHistoryBackupForbidden'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: '#/components/responses/ClusterHistoryBackupInternalError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
+  /cluster/v2/backups/history/{backupId}:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: getHistoryBackupAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Get a history backup across physical tenants
+      description: >-
+        Reports what every physical tenant of the cluster, or the one named by `physicalTenantId`,
+        holds for the given backup id. There is no aggregated cluster-level state: a tenant that was
+        reached and does not hold this backup reports `NOT_FOUND`, which is a successful
+        observation rather than a failure.
+
+
+        The request is all-or-nothing: a physical tenant whose state cannot be read fails the whole
+        request. Narrow the request with `physicalTenantId` to read the tenants that can still be
+        reached.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Only available on clusters whose secondary storage is Elasticsearch or
+        OpenSearch. Use `GET /v2/backups/history/{backupId}` to act as a single physical tenant.
+      parameters:
+        - name: backupId
+          in: path
+          required: true
+          description: The id of the backup.
+          schema:
+            $ref: 'backups.yaml#/components/schemas/BackupId'
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      responses:
+        "200":
+          description: >-
+            Every targeted physical tenant was read. Each one reports either the backup or
+            `NOT_FOUND`; at least one holds the backup.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterHistoryBackupInfo'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/ClusterHistoryBackupForbidden'
+        "404":
+          description: >-
+            The requested `physicalTenantId` does not exist in this cluster, or every targeted
+            physical tenant was read and none of them holds a backup with the given id.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: '#/components/responses/ClusterHistoryBackupInternalError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+    delete:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: deleteHistoryBackupAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Delete a history backup across physical tenants
+      description: >-
+        Deletes the history backup with the given id from every physical tenant of the cluster, or
+        from the one named by `physicalTenantId`. A tenant that does not hold the backup has already
+        reached the requested end state, so it counts as deleted rather than as a failure.
+
+
+        The request is all-or-nothing: a physical tenant the backup cannot be deleted from fails the
+        whole request, and the deletions that already succeeded on other tenants are not undone.
+        Narrow the request with `physicalTenantId` to delete from the tenants that can still be
+        reached.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Only available on clusters whose secondary storage is Elasticsearch or
+        OpenSearch. Use `DELETE /v2/backups/history/{backupId}` to act as a single physical tenant.
+      parameters:
+        - name: backupId
+          in: path
+          required: true
+          description: The id of the backup.
+          schema:
+            $ref: 'backups.yaml#/components/schemas/BackupId'
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      responses:
+        "204":
+          description: >-
+            No targeted physical tenant holds the backup any more, because it was deleted from every
+            tenant that held it. At least one tenant held it.
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/ClusterHistoryBackupForbidden'
+        "404":
+          description: >-
+            The requested `physicalTenantId` does not exist in this cluster, or every targeted
+            physical tenant was reached and none of them holds a backup with the given id.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          description: >-
+            The backup could not be deleted from every targeted physical tenant — because one of
+            them hit an internal error, or because its snapshot repository is absent from the
+            store, a deployment fault no change to the request can correct — so it may still exist
+            on some of them. The deletions that already succeeded are not undone, so a retry has
+            only the remaining tenants left to reach.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
 ## Schema definitions
 
 components:
+  responses:
+    ClusterHistoryBackupInternalError:
+      description: >-
+        A targeted physical tenant hit an internal error, or its snapshot repository is absent from
+        the store — configured under a name the store does not have, or not configured at all. The
+        repository case is a deployment fault the caller cannot correct by changing its request, so
+        it is neither a `400` nor a `404`, and the per-physical-tenant endpoints answer `500` for it
+        too. Narrow the request with `physicalTenantId` to work with the tenants whose repository is
+        usable.
+      content:
+        application/problem+json:
+          schema:
+            $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+
+    ClusterHistoryBackupForbidden:
+      description: >-
+        The cluster's secondary storage is neither Elasticsearch nor OpenSearch, and therefore
+        cannot serve history backups. Unlike the per-physical-tenant backup endpoints, the
+        cluster-admin surface performs no fine-grained authorization, so a missing `BACKUP`
+        permission is never the reason.
+      content:
+        application/problem+json:
+          schema:
+            $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+
   parameters:
     PhysicalTenantIdParameter:
       name: physicalTenantId
       in: query
       required: false
       description: >-
-        The physical tenant to apply the change to. When omitted, the change is applied to every
-        physical tenant of the cluster.
+        The physical tenant to apply the change to. When omitted, or when passed with an empty
+        value, the change is applied to every physical tenant of the cluster.
       schema:
         type: string
         example: default
@@ -594,3 +939,114 @@ components:
           type: array
           items:
             $ref: 'cluster.yaml#/components/schemas/Partition'
+
+    ClusterTakeHistoryBackupResponse:
+      description: >-
+        The snapshots scheduled on every targeted physical tenant. No cluster-level state is
+        aggregated from the per-tenant outcomes.
+      type: object
+      required:
+        - backupId
+        - physicalTenants
+      properties:
+        backupId:
+          description: The id requested for the backup on every targeted physical tenant.
+          allOf:
+            - $ref: 'backups.yaml#/components/schemas/BackupId'
+        physicalTenants:
+          description: The outcome for each targeted physical tenant, ordered by physical tenant id.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterHistoryBackupTakeResult'
+
+    ClusterHistoryBackupTakeResult:
+      description: >-
+        The snapshots scheduled on a single physical tenant. Only successfully scheduled tenants are
+        reported: the request fails as a whole if any targeted tenant could not schedule the backup.
+      type: object
+      required:
+        - physicalTenantId
+        - scheduledSnapshots
+      properties:
+        physicalTenantId:
+          description: The id of the physical tenant.
+          type: string
+          example: default
+        scheduledSnapshots:
+          description: The names of the snapshots scheduled on this physical tenant.
+          type: array
+          items:
+            type: string
+            description: The name of a scheduled snapshot.
+            example: camunda_webapps_1_8.10.0_part_1_of_6
+
+    ClusterHistoryBackupInfo:
+      description: >-
+        A history backup id and what each physical tenant reports for it. No cluster-level state is
+        aggregated from the per-tenant states.
+      type: object
+      required:
+        - backupId
+        - physicalTenants
+      properties:
+        backupId:
+          description: The id of the backup.
+          allOf:
+            - $ref: 'backups.yaml#/components/schemas/BackupId'
+        physicalTenants:
+          description: >-
+            What each physical tenant reports for this backup id, ordered by physical tenant id.
+            When looking a backup id up directly, every targeted tenant is listed, including the
+            ones reporting `NOT_FOUND`. Within a listing, only the tenants that hold the id are
+            listed.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterHistoryBackupTenantInfo'
+
+    ClusterHistoryBackupTenantInfo:
+      description: What a single physical tenant reports for a history backup id.
+      type: object
+      required:
+        - physicalTenantId
+        - state
+        - failureReason
+        - details
+      properties:
+        physicalTenantId:
+          description: The id of the physical tenant.
+          type: string
+          example: default
+        state:
+          description: The state of the backup on this physical tenant.
+          allOf:
+            - $ref: '#/components/schemas/ClusterHistoryBackupTenantState'
+        failureReason:
+          description: Reason for failure if the state is 'FAILED'.
+          type: string
+          nullable: true
+          example: ""
+        details:
+          description: >-
+            Detailed status of the backup per snapshot on this physical tenant. Empty when the
+            tenant does not hold the backup.
+          type: array
+          items:
+            $ref: 'backups.yaml#/components/schemas/HistoryBackupSnapshotInfo'
+
+    ClusterHistoryBackupTenantState:
+      title: Cluster History Backup Tenant State
+      description: >-
+        What a physical tenant reports for a history backup id: the per-tenant
+        `HistoryBackupStateCode` extended with `NOT_FOUND` for a tenant that was read and does not
+        hold the backup. `NOT_FOUND` is a successful observation, not a failure — a backup that only
+        some physical tenants hold is a supported outcome. There is no state for a tenant that could
+        not be read at all, because such a tenant fails the whole request.
+      type: string
+      enum:
+        - IN_PROGRESS
+        - COMPLETED
+        - FAILED
+        - INCOMPLETE
+        - INCOMPATIBLE
+        - NOT_FOUND
+      example: COMPLETED

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -510,6 +510,10 @@ paths:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1exporting~1pause'
   /cluster/v2/exporting/resume:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1exporting~1resume'
+  /cluster/v2/backups/history:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1backups~1history'
+  /cluster/v2/backups/history/{backupId}:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1backups~1history~1{backupId}'
   /cluster/v2/mode:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1mode'
   /cluster/v2/restore:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterHistoryBackupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterHistoryBackupController.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH;
+import static io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH;
+
+import io.camunda.gateway.protocol.model.TakeHistoryBackupRequest;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.mapper.BackupResponseMapper;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * History (secondary-storage snapshot) backups across every physical tenant of the cluster,
+ * authenticated by the cluster-admin security chain.
+ *
+ * <p>Every operation narrows to a single physical tenant when the request names one, which is the
+ * only way to keep working while another tenant is broken: the fan-out is all-or-nothing.
+ *
+ * <p>{@link RequiresSecondaryStorage} answers 403 on a cluster whose storage cannot serve history
+ * backups. It resolves the type through the request's physical tenant, which for an unstamped
+ * {@code /cluster/v2} request is the default one — sound cluster-wide because {@code
+ * SecondaryStorageTypeHomogeneityValidation} refuses a cluster that mixes document stores with
+ * other storages, so one tenant's type answers for all of them.
+ */
+@CamundaRestController
+@ClusterScoped
+@RequiresSecondaryStorage({ELASTICSEARCH, OPENSEARCH})
+@RequestMapping("/cluster/v2/backups/history")
+@NullMarked
+public final class ClusterHistoryBackupController {
+
+  private final ServiceRegistry serviceRegistry;
+
+  public ClusterHistoryBackupController(final ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @CamundaPostMapping
+  public CompletableFuture<ResponseEntity<Object>> takeBackup(
+      @RequestParam(required = false) final @Nullable String physicalTenantId,
+      @RequestBody final TakeHistoryBackupRequest request) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterHistoryBackupServices()
+                .takeBackup(targetPhysicalTenant(physicalTenantId), request.getBackupId()),
+        BackupResponseMapper::toClusterTakeHistoryBackupResponse,
+        HttpStatus.ACCEPTED);
+  }
+
+  @CamundaGetMapping
+  public CompletableFuture<ResponseEntity<Object>> listBackups(
+      @RequestParam(required = false) final @Nullable String physicalTenantId,
+      @RequestParam(required = false) final @Nullable String prefix,
+      @RequestParam(required = false, defaultValue = "true") final boolean verbose) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterHistoryBackupServices()
+                .listBackups(targetPhysicalTenant(physicalTenantId), prefix, verbose),
+        BackupResponseMapper::toClusterHistoryBackupInfoList,
+        HttpStatus.OK);
+  }
+
+  @CamundaGetMapping(path = "/{backupId}")
+  public CompletableFuture<ResponseEntity<Object>> getBackup(
+      @PathVariable final long backupId,
+      @RequestParam(required = false) final @Nullable String physicalTenantId) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterHistoryBackupServices()
+                .getBackup(targetPhysicalTenant(physicalTenantId), backupId),
+        BackupResponseMapper::toClusterHistoryBackupInfo,
+        HttpStatus.OK);
+  }
+
+  @CamundaDeleteMapping(path = "/{backupId}")
+  public CompletableFuture<ResponseEntity<Object>> deleteBackup(
+      @PathVariable final long backupId,
+      @RequestParam(required = false) final @Nullable String physicalTenantId) {
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () ->
+            serviceRegistry
+                .clusterHistoryBackupServices()
+                .deleteBackup(targetPhysicalTenant(physicalTenantId), backupId));
+  }
+
+  /**
+   * Resolves which physical tenant an operation targets: the named tenant, or {@code null} when the
+   * request names none and the operation therefore spans every physical tenant of the cluster. A
+   * blank id names no tenant, so it is cluster-wide as well rather than a request the cluster-admin
+   * API rejects — the same handling the cluster recovery endpoints apply.
+   */
+  private static @Nullable String targetPhysicalTenant(final @Nullable String physicalTenantId) {
+    return physicalTenantId == null || physicalTenantId.isBlank() ? null : physicalTenantId;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptor.java
@@ -13,6 +13,7 @@ import io.camunda.service.exception.SecondaryStorageDegradedException;
 import io.camunda.service.exception.SecondaryStorageTypeNotSupportedException;
 import io.camunda.service.exception.SecondaryStorageUnavailableException;
 import io.camunda.spring.utils.PhysicalTenantContext;
+import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,6 +21,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
@@ -36,7 +38,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
  *       tenant's configured one is not among them.
  *   <li>HTTP 503 Service Unavailable, with a {@code Retry-After} hint, when secondary storage is
  *       configured but the request's physical tenant's secondary storage is currently degraded (see
- *       {@link SecondaryStorageReadiness}).
+ *       {@link SecondaryStorageReadiness}). On a {@link ClusterScoped} endpoint the bar is that
+ *       <em>any</em> tenant is ready instead — see {@link #validateSecondaryStorageReady}.
  * </ul>
  */
 @Component
@@ -67,7 +70,7 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
       if (annotation != null) {
         final String physicalTenantId = PhysicalTenantContext.current();
         validateSecondaryStorageType(annotation, databaseTypeProvider.apply(physicalTenantId));
-        validateSecondaryStorageReady(request, response, physicalTenantId);
+        validateSecondaryStorageReady(request, response, handlerMethod, physicalTenantId);
       }
     }
 
@@ -94,9 +97,18 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
     }
   }
 
+  /**
+   * A cluster-scoped endpoint is gated on <em>any</em> tenant being ready, not on the request's
+   * own. An unstamped {@code /cluster/v2} request resolves to the default physical tenant, so
+   * gating on it would let one arbitrary tenant's schema initialization decide whether the whole
+   * cluster-wide surface answers — and readiness can go unmet permanently, exactly when that
+   * surface is the one an operator needs. A tenant that is not ready surfaces per tenant in the
+   * response body instead.
+   */
   private void validateSecondaryStorageReady(
       final HttpServletRequest request,
       final HttpServletResponse response,
+      final HandlerMethod handlerMethod,
       final String physicalTenantId) {
     // Only checked on the initial dispatch: CompletableFuture-returning controllers resume on an
     // ASYNC re-dispatch, at which point the result is already computed and must not be rejected a
@@ -105,11 +117,22 @@ public class SecondaryStorageInterceptor implements HandlerInterceptor {
       return;
     }
 
-    if (!secondaryStorageReadiness.isReady(physicalTenantId)) {
-      // Set before throwing: the exception handler only writes status and problem-detail body, so
-      // headers already set on the response survive.
-      response.setHeader(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS);
-      throw new SecondaryStorageDegradedException(physicalTenantId);
+    // AnnotatedElementUtils, not isAnnotationPresent: PhysicalTenantRequestMappingHandlerMapping
+    // decides what is cluster-scoped the same way, and a meta-annotated controller the two
+    // disagreed about would be served only under /cluster/v2 while still gated on one tenant.
+    final boolean clusterScoped =
+        AnnotatedElementUtils.hasAnnotation(handlerMethod.getBeanType(), ClusterScoped.class);
+    if (clusterScoped
+        ? secondaryStorageReadiness.anyReady()
+        : secondaryStorageReadiness.isReady(physicalTenantId)) {
+      return;
     }
+
+    // Set before throwing: the exception handler only writes status and problem-detail body, so
+    // headers already set on the response survive.
+    response.setHeader(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS);
+    throw clusterScoped
+        ? SecondaryStorageDegradedException.forCluster()
+        : SecondaryStorageDegradedException.forPhysicalTenant(physicalTenantId);
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/BackupResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/BackupResponseMapper.java
@@ -11,6 +11,11 @@ import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.protocol.model.BackupInfo;
 import io.camunda.gateway.protocol.model.BackupType;
 import io.camunda.gateway.protocol.model.CheckpointType;
+import io.camunda.gateway.protocol.model.ClusterHistoryBackupInfo;
+import io.camunda.gateway.protocol.model.ClusterHistoryBackupTakeResult;
+import io.camunda.gateway.protocol.model.ClusterHistoryBackupTenantInfo;
+import io.camunda.gateway.protocol.model.ClusterHistoryBackupTenantState;
+import io.camunda.gateway.protocol.model.ClusterTakeHistoryBackupResponse;
 import io.camunda.gateway.protocol.model.HistoryBackupInfo;
 import io.camunda.gateway.protocol.model.HistoryBackupSnapshotInfo;
 import io.camunda.gateway.protocol.model.HistoryBackupStateCode;
@@ -22,6 +27,11 @@ import io.camunda.gateway.protocol.model.RuntimeBackupState;
 import io.camunda.gateway.protocol.model.StateCode;
 import io.camunda.gateway.protocol.model.TakeHistoryBackupResponse;
 import io.camunda.gateway.protocol.model.TakeRuntimeBackupResponse;
+import io.camunda.service.ClusterHistoryBackupServices.ClusterHistoryBackup;
+import io.camunda.service.ClusterHistoryBackupServices.ClusterHistoryBackupTaken;
+import io.camunda.service.ClusterHistoryBackupServices.PhysicalTenantBackupState;
+import io.camunda.service.ClusterHistoryBackupServices.PhysicalTenantBackupTaken;
+import io.camunda.service.ClusterHistoryBackupServices.TenantBackupStateCode;
 import io.camunda.service.RuntimeBackupServices;
 import io.camunda.service.backup.HistoryBackupSnapshot;
 import io.camunda.service.backup.HistoryBackupState;
@@ -261,6 +271,63 @@ public final class BackupResponseMapper {
       case FAILED -> HistoryBackupStateCode.FAILED;
       case INCOMPLETE -> HistoryBackupStateCode.INCOMPLETE;
       case INCOMPATIBLE -> HistoryBackupStateCode.INCOMPATIBLE;
+    };
+  }
+
+  public static ClusterTakeHistoryBackupResponse toClusterTakeHistoryBackupResponse(
+      final ClusterHistoryBackupTaken taken) {
+    return ClusterTakeHistoryBackupResponse.Builder.create()
+        .backupId(taken.backupId())
+        .physicalTenants(
+            taken.physicalTenants().stream()
+                .map(BackupResponseMapper::toClusterHistoryBackupTakeResult)
+                .toList())
+        .build();
+  }
+
+  private static ClusterHistoryBackupTakeResult toClusterHistoryBackupTakeResult(
+      final PhysicalTenantBackupTaken taken) {
+    return ClusterHistoryBackupTakeResult.Builder.create()
+        .physicalTenantId(taken.physicalTenantId())
+        .scheduledSnapshots(taken.scheduledSnapshots())
+        .build();
+  }
+
+  public static ClusterHistoryBackupInfo toClusterHistoryBackupInfo(
+      final ClusterHistoryBackup backup) {
+    return ClusterHistoryBackupInfo.Builder.create()
+        .backupId(backup.backupId())
+        .physicalTenants(
+            backup.physicalTenants().stream()
+                .map(BackupResponseMapper::toClusterHistoryBackupTenantInfo)
+                .toList())
+        .build();
+  }
+
+  public static List<ClusterHistoryBackupInfo> toClusterHistoryBackupInfoList(
+      final List<ClusterHistoryBackup> backups) {
+    return backups.stream().map(BackupResponseMapper::toClusterHistoryBackupInfo).toList();
+  }
+
+  private static ClusterHistoryBackupTenantInfo toClusterHistoryBackupTenantInfo(
+      final PhysicalTenantBackupState state) {
+    return ClusterHistoryBackupTenantInfo.Builder.create()
+        .physicalTenantId(state.physicalTenantId())
+        .state(toClusterHistoryBackupTenantState(state.state()))
+        .failureReason(state.failureReason())
+        .details(state.snapshots().stream().map(BackupResponseMapper::toSnapshotInfo).toList())
+        .build();
+  }
+
+  private static ClusterHistoryBackupTenantState toClusterHistoryBackupTenantState(
+      final TenantBackupStateCode state) {
+    return switch (state) {
+      case IN_PROGRESS -> ClusterHistoryBackupTenantState.IN_PROGRESS;
+      case COMPLETED -> ClusterHistoryBackupTenantState.COMPLETED;
+      case FAILED -> ClusterHistoryBackupTenantState.FAILED;
+      case INCOMPLETE -> ClusterHistoryBackupTenantState.INCOMPLETE;
+      case INCOMPATIBLE -> ClusterHistoryBackupTenantState.INCOMPATIBLE;
+      case NOT_FOUND -> ClusterHistoryBackupTenantState.NOT_FOUND;
     };
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterHistoryBackupControllerStorageGatingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterHistoryBackupControllerStorageGatingTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.camunda.cluster.SecondaryStorageReadiness;
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.service.ClusterHistoryBackupServices;
+import io.camunda.service.exception.SecondaryStorageDegradedException;
+import io.camunda.service.exception.SecondaryStorageTypeNotSupportedException;
+import io.camunda.service.exception.SecondaryStorageUnavailableException;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.GlobalControllerExceptionHandler;
+import io.camunda.zeebe.gateway.rest.interceptor.SecondaryStorageInterceptor;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Asserts that {@link ClusterHistoryBackupController} is gated to Elasticsearch and OpenSearch, and
+ * that its readiness gate is the cluster-scoped one.
+ *
+ * <p>Deliberately not a {@code @WebMvcTest} slice: {@code RestControllerTest} replaces {@link
+ * SecondaryStorageInterceptor} with a mock that permits every request, so a status assertion there
+ * would only be testing that mock. This wires the real interceptor to the real controller, which is
+ * what catches the annotations going missing.
+ */
+class ClusterHistoryBackupControllerStorageGatingTest {
+
+  private static final String BASE_URL = "/cluster/v2/backups/history";
+
+  @Test
+  void shouldRejectAStorageThatCannotServeHistoryBackups() throws Exception {
+    // given
+    final var mockMvc = mockMvcFor(DatabaseType.RDBMS, SecondaryStorageReadiness.ALWAYS_READY);
+
+    // when - then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.title").value("FORBIDDEN"))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    SecondaryStorageTypeNotSupportedException
+                        .UNSUPPORTED_SECONDARY_STORAGE_TYPE_MESSAGE
+                        .formatted("elasticsearch, opensearch", "rdbms")));
+  }
+
+  @Test
+  void shouldRejectWhenTheClusterHasNoSecondaryStorage() throws Exception {
+    // given
+    final var mockMvc = mockMvcFor(DatabaseType.NONE, SecondaryStorageReadiness.ALWAYS_READY);
+
+    // when - then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            jsonPath("$.detail")
+                .value(SecondaryStorageUnavailableException.NO_SECONDARY_STORAGE_MESSAGE));
+  }
+
+  /**
+   * The cluster-wide surface is what an operator reaches for while a physical tenant is unusable,
+   * so one unready tenant must not close it. Readiness means "schema initialized", a state a tenant
+   * can fail to leave permanently.
+   */
+  @Test
+  void shouldServeTheClusterWideEndpointWhileOnlySomePhysicalTenantsAreReady() throws Exception {
+    // given a readiness that reports no individual tenant ready, but the cluster as a whole is
+    final var readiness = mock(SecondaryStorageReadiness.class);
+    when(readiness.isReady(any())).thenReturn(false);
+    when(readiness.anyReady()).thenReturn(true);
+    final var mockMvc = mockMvcFor(DatabaseType.ELASTICSEARCH, readiness);
+
+    // when - then
+    mockMvc.perform(get(BASE_URL)).andExpect(request().asyncStarted());
+  }
+
+  @Test
+  void shouldRejectWhenNoPhysicalTenantIsReady() throws Exception {
+    // given
+    final var readiness = mock(SecondaryStorageReadiness.class);
+    when(readiness.anyReady()).thenReturn(false);
+    final var mockMvc = mockMvcFor(DatabaseType.ELASTICSEARCH, readiness);
+
+    // when - then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(header().string("Retry-After", "5"))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    SecondaryStorageDegradedException.CLUSTER_SECONDARY_STORAGE_DEGRADED_MESSAGE));
+  }
+
+  /**
+   * Asserts the request started async rather than its status: the handler returns a {@code
+   * CompletableFuture}, so an un-dispatched 200 would also be the result of never reaching it.
+   */
+  @ParameterizedTest
+  @EnumSource(
+      value = DatabaseType.class,
+      names = {"ELASTICSEARCH", "OPENSEARCH"})
+  void shouldReachTheHandlerOnADocumentStorage(final DatabaseType storageType) throws Exception {
+    // given
+    final var mockMvc = mockMvcFor(storageType, SecondaryStorageReadiness.ALWAYS_READY);
+
+    // when - then
+    mockMvc.perform(get(BASE_URL)).andExpect(request().asyncStarted());
+  }
+
+  private static MockMvc mockMvcFor(
+      final DatabaseType secondaryStorageType, final SecondaryStorageReadiness readiness) {
+    final var clusterHistoryBackupServices = mock(ClusterHistoryBackupServices.class);
+    when(clusterHistoryBackupServices.listBackups(any(), any(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    final var serviceRegistry = mock(ServiceRegistry.class);
+    when(serviceRegistry.clusterHistoryBackupServices()).thenReturn(clusterHistoryBackupServices);
+
+    final var interceptor =
+        new SecondaryStorageInterceptor(tenantId -> secondaryStorageType, readiness);
+    return MockMvcBuilders.standaloneSetup(new ClusterHistoryBackupController(serviceRegistry))
+        .addInterceptors(interceptor)
+        .setControllerAdvice(new GlobalControllerExceptionHandler())
+        .build();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterHistoryBackupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterHistoryBackupControllerTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ClusterHistoryBackupServices;
+import io.camunda.service.ClusterHistoryBackupServices.ClusterHistoryBackup;
+import io.camunda.service.ClusterHistoryBackupServices.ClusterHistoryBackupTaken;
+import io.camunda.service.ClusterHistoryBackupServices.PhysicalTenantBackupState;
+import io.camunda.service.ClusterHistoryBackupServices.PhysicalTenantBackupTaken;
+import io.camunda.service.ClusterHistoryBackupServices.TenantBackupStateCode;
+import io.camunda.service.backup.HistoryBackupSnapshot;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(ClusterHistoryBackupController.class)
+public class ClusterHistoryBackupControllerTest extends RestControllerTest {
+
+  private static final String BASE_URL = "/cluster/v2/backups/history";
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final OffsetDateTime START_TIME =
+      OffsetDateTime.of(2026, 8, 18, 9, 30, 0, 0, ZoneOffset.UTC);
+
+  @MockitoBean private ClusterHistoryBackupServices clusterHistoryBackupServices;
+  @MockitoBean private ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setup() {
+    when(serviceRegistry.clusterHistoryBackupServices()).thenReturn(clusterHistoryBackupServices);
+  }
+
+  @Test
+  void takeBackupShouldReturnAcceptedWithTheSnapshotsScheduledPerPhysicalTenant() {
+    // given
+    when(clusterHistoryBackupServices.takeBackup(isNull(), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterHistoryBackupTaken(
+                    17L,
+                    List.of(
+                        new PhysicalTenantBackupTaken(TENANT_A, List.of("a-1")),
+                        new PhysicalTenantBackupTaken(TENANT_B, List.of("b-1"))))));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.ACCEPTED)
+        .expectBody()
+        .jsonPath("$.backupId")
+        .isEqualTo(17)
+        .jsonPath("$.physicalTenants[0].physicalTenantId")
+        .isEqualTo(TENANT_A)
+        .jsonPath("$.physicalTenants[0].scheduledSnapshots")
+        .isEqualTo(List.of("a-1"))
+        .jsonPath("$.physicalTenants[1].physicalTenantId")
+        .isEqualTo(TENANT_B);
+  }
+
+  @Test
+  void takeBackupShouldReturnConflictWhenAPhysicalTenantAlreadyHoldsTheId() {
+    // given no backup is scheduled anywhere when one tenant rejects the id
+    when(clusterHistoryBackupServices.takeBackup(isNull(), anyLong()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("already exists on 'tenantb'", Status.ALREADY_EXISTS)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  void takeBackupShouldReturnBadRequestWhenBackupIdIsMissing() {
+    // given
+    when(clusterHistoryBackupServices.takeBackup(isNull(), isNull()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("A backupId must be provided", Status.INVALID_ARGUMENT)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void getBackupShouldReturnOkListingEveryPhysicalTenantIncludingTheOnesHoldingNothing() {
+    // given a backup only one physical tenant holds — a supported outcome, not a failure
+    when(clusterHistoryBackupServices.getBackup(isNull(), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterHistoryBackup(
+                    17L,
+                    List.of(
+                        new PhysicalTenantBackupState(
+                            TENANT_A,
+                            TenantBackupStateCode.COMPLETED,
+                            null,
+                            List.of(
+                                new HistoryBackupSnapshot(
+                                    "a-1", "SUCCESS", START_TIME, List.of()))),
+                        new PhysicalTenantBackupState(
+                            TENANT_B, TenantBackupStateCode.NOT_FOUND, null, List.of())))));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.backupId")
+        .isEqualTo(17)
+        .jsonPath("$.physicalTenants[0].state")
+        .isEqualTo("COMPLETED")
+        .jsonPath("$.physicalTenants[0].details[0].snapshotName")
+        .isEqualTo("a-1")
+        .jsonPath("$.physicalTenants[1].physicalTenantId")
+        .isEqualTo(TENANT_B)
+        .jsonPath("$.physicalTenants[1].state")
+        .isEqualTo("NOT_FOUND");
+  }
+
+  @Test
+  void getBackupShouldReturnNotFoundWhenNoPhysicalTenantHoldsIt() {
+    // given
+    when(clusterHistoryBackupServices.getBackup(isNull(), anyLong()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("none of [tenanta, tenantb] holds it", Status.NOT_FOUND)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  void getBackupShouldReturnServiceUnavailableWhenAPhysicalTenantCannotBeObserved() {
+    // given the fan-out is all-or-nothing, so a partly observable cluster is not a partial success
+    when(clusterHistoryBackupServices.getBackup(isNull(), anyLong()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("'tenantb': connection refused", Status.UNAVAILABLE)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void listBackupsShouldReturnOkWithTheBackupsGroupedByBackupId() {
+    // given
+    when(clusterHistoryBackupServices.listBackups(isNull(), isNull(), eq(true)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(
+                    new ClusterHistoryBackup(
+                        17L,
+                        List.of(
+                            new PhysicalTenantBackupState(
+                                TENANT_A, TenantBackupStateCode.COMPLETED, null, List.of()))))));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$[0].backupId")
+        .isEqualTo(17)
+        .jsonPath("$[0].physicalTenants[0].physicalTenantId")
+        .isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void listBackupsShouldPassPrefixAndVerboseThrough() {
+    // given
+    when(clusterHistoryBackupServices.listBackups(isNull(), eq("17*"), eq(false)))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "?prefix=17*&verbose=false")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterHistoryBackupServices).listBackups(isNull(), eq("17*"), eq(false));
+  }
+
+  @Test
+  void deleteBackupShouldReturnNoContentWhenOnlyOnePhysicalTenantHeldIt() {
+    // given
+    when(clusterHistoryBackupServices.deleteBackup(isNull(), eq(17L)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when - then
+    webClient
+        .delete()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+  }
+
+  @Test
+  void deleteBackupShouldReturnNotFoundWhenNoPhysicalTenantHeldIt() {
+    // given
+    when(clusterHistoryBackupServices.deleteBackup(isNull(), anyLong()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("none of [tenanta, tenantb] holds it", Status.NOT_FOUND)));
+
+    // when - then
+    webClient
+        .delete()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  void shouldNarrowToThePhysicalTenantNamedByTheQueryParameter() {
+    // given
+    when(clusterHistoryBackupServices.getBackup(eq(TENANT_A), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterHistoryBackup(
+                    17L,
+                    List.of(
+                        new PhysicalTenantBackupState(
+                            TENANT_A, TenantBackupStateCode.COMPLETED, null, List.of())))));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17?physicalTenantId=" + TENANT_A)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterHistoryBackupServices).getBackup(TENANT_A, 17L);
+  }
+
+  /** A blank id names no tenant, so it is cluster-wide rather than a rejected request. */
+  @Test
+  void shouldTreatABlankPhysicalTenantIdAsClusterWide() {
+    // given
+    when(clusterHistoryBackupServices.listBackups(isNull(), isNull(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "?physicalTenantId=")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterHistoryBackupServices).listBackups(isNull(), isNull(), anyBoolean());
+  }
+
+  @Test
+  void shouldReturnNotFoundForAnUnknownPhysicalTenantId() {
+    // given
+    when(clusterHistoryBackupServices.listBackups(eq("nosuchtenant"), isNull(), anyBoolean()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("this cluster only has [tenanta]", Status.NOT_FOUND)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "?physicalTenantId=nosuchtenant")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/interceptor/SecondaryStorageInterceptorTest.java
@@ -21,6 +21,7 @@ import io.camunda.service.exception.SecondaryStorageDegradedException;
 import io.camunda.service.exception.SecondaryStorageTypeNotSupportedException;
 import io.camunda.service.exception.SecondaryStorageUnavailableException;
 import io.camunda.spring.utils.PhysicalTenantContext;
+import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,6 +45,7 @@ class SecondaryStorageInterceptorTest {
   private static final HandlerMethod DOCUMENT_STORAGE_ONLY =
       handlerMethodFor(new DocumentStorageOnly());
   private static final HandlerMethod METHOD_OVERRIDE = handlerMethodFor(new MethodOverride());
+  private static final HandlerMethod CLUSTER_WIDE = handlerMethodFor(new ClusterWide());
 
   private HttpServletRequest request;
   private HttpServletResponse response;
@@ -195,6 +197,48 @@ class SecondaryStorageInterceptorTest {
     assertThat(result).isTrue();
   }
 
+  /**
+   * A cluster-wide endpoint is not served on behalf of one physical tenant, so gating it on the
+   * request's own — the default one, for an unstamped {@code /cluster/v2} request — would let one
+   * arbitrary tenant decide whether the whole cluster-wide surface answers.
+   */
+  @Test
+  void shouldAllowClusterScopedEndpointWhenOnlyAnotherPhysicalTenantIsReady() {
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var readiness = mock(SecondaryStorageReadiness.class);
+    when(readiness.isReady(PHYSICAL_TENANT_ID)).thenReturn(false);
+    when(readiness.anyReady()).thenReturn(true);
+    final var interceptor = interceptor(ELASTICSEARCH, readiness);
+
+    final boolean result = interceptor.preHandle(request, response, CLUSTER_WIDE);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldThrowOnClusterScopedEndpointWhenNoPhysicalTenantIsReady() {
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var readiness = mock(SecondaryStorageReadiness.class);
+    when(readiness.anyReady()).thenReturn(false);
+    final var interceptor = interceptor(ELASTICSEARCH, readiness);
+
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, CLUSTER_WIDE))
+        .isInstanceOf(SecondaryStorageDegradedException.class)
+        .hasMessage(SecondaryStorageDegradedException.CLUSTER_SECONDARY_STORAGE_DEGRADED_MESSAGE);
+  }
+
+  @Test
+  void shouldNotConsultThePerTenantReadinessOnAClusterScopedEndpoint() {
+    bindPhysicalTenant(PHYSICAL_TENANT_ID);
+    final var readiness = mock(SecondaryStorageReadiness.class);
+    when(readiness.anyReady()).thenReturn(true);
+    final var interceptor = interceptor(ELASTICSEARCH, readiness);
+
+    interceptor.preHandle(request, response, CLUSTER_WIDE);
+
+    verify(readiness, never()).isReady(any());
+  }
+
   private static SecondaryStorageInterceptor interceptor(
       final DatabaseType databaseType, final SecondaryStorageReadiness readiness) {
     return new SecondaryStorageInterceptor(tenantId -> databaseType, readiness);
@@ -236,6 +280,14 @@ class SecondaryStorageInterceptorTest {
 
   @RequiresSecondaryStorage({ELASTICSEARCH, OPENSEARCH})
   public static class DocumentStorageOnly {
+    public String handle() {
+      return "ok";
+    }
+  }
+
+  @ClusterScoped
+  @RequiresSecondaryStorage({ELASTICSEARCH, OPENSEARCH})
+  public static class ClusterWide {
     public String handle() {
       return "ok";
     }


### PR DESCRIPTION
Adds the four cluster-wide history backup operations under `/cluster/v2/backups/history`, fanning out over every physical tenant of the cluster or over the one named by `?physicalTenantId=`. Implements the contract proposed and approved in #60308 (ADR 004).

Two rules shape it. **Absence is a successful observation** — a backup that only one physical tenant holds is normal, not degraded, so reading it cluster-wide answers 200 naming every targeted tenant (the others report `NOT_FOUND`) and deleting it answers 204. Only a request where no targeted tenant holds the backup is a 404. **Everything else is all-or-nothing** — a tenant whose state cannot be observed fails the whole request rather than silently dropping out of the answer, and `?physicalTenantId=` is the escape hatch when one tenant is broken. Responses carry per-tenant outcomes and no aggregated cluster-level state, which once single-tenant backups are legitimate is not a question the API can answer honestly.

Three commits:

1. **fix** — a missing snapshot repository and a missing backup both answered 404, which the fan-out would have read as "this tenant was reached and holds nothing". Now 500: nothing about the request is wrong, so no 4xx applies. Changes the per-tenant response for that case, on endpoints that are 8.10-alpha only.
2. **refactor** — moves the backup-id and prefix validation somewhere both surfaces can share, so `/v2` and `/cluster/v2` reject the same input identically.
3. **feat** — the endpoints, plus the readiness gate change they need: a cluster-scoped handler is now gated on *any* physical tenant being ready rather than on the request's own, which for an unstamped `/cluster/v2` request is an arbitrary one that can be stuck permanently.

Closes #57738