### PR TITLE
fix: upgrade httpclient5 to 5.6.4 to resolve CVE-2026-64607

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -412,6 +412,7 @@ public class OpensearchConnector {
       final HttpAsyncClientBuilder httpAsyncClientBuilder,
       final OpensearchProperties osConfig,
       final HttpRequestInterceptor... requestInterceptors) {
+    httpAsyncClientBuilder.disableContentCompression();
     setupAuthentication(httpAsyncClientBuilder, osConfig);
 
     LOGGER.trace("Attempt to load interceptor plugins");

--- a/optimize/qa/schema-integrity-tests/pom.xml
+++ b/optimize/qa/schema-integrity-tests/pom.xml
@@ -108,6 +108,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
       <scope>runtime</scope>

--- a/optimize/qa/schema-integrity-tests/src/test/java/io/camunda/optimize/test/upgrade/client/OpenSearchSchemaTestClient.java
+++ b/optimize/qa/schema-integrity-tests/src/test/java/io/camunda/optimize/test/upgrade/client/OpenSearchSchemaTestClient.java
@@ -43,6 +43,11 @@ public class OpenSearchSchemaTestClient extends AbstractDatabaseSchemaTestClient
     openSearchClient =
         new OpenSearchClient(
             ApacheHttpClient5TransportBuilder.builder(new HttpHost("http", "localhost", port))
+                .setHttpClientConfigCallback(
+                    httpClientBuilder -> {
+                      httpClientBuilder.disableContentCompression();
+                      return httpClientBuilder;
+                    })
                 .build());
   }
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -434,6 +434,7 @@ public class OpenSearchClientBuilder {
       final HttpAsyncClientBuilder httpAsyncClientBuilder,
       final ConfigurationService configurationService,
       final HttpRequestInterceptor... requestInterceptors) {
+    httpAsyncClientBuilder.disableContentCompression();
     setupAuthentication(httpAsyncClientBuilder, configurationService);
 
     for (final HttpRequestInterceptor interceptor : requestInterceptors) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,7 +61,7 @@
     <version.hamcrest>3.0</version.hamcrest>
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
-    <version.httpclient5>5.5.2</version.httpclient5>
+    <version.httpclient5>5.6.4</version.httpclient5>
     <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.8.16</version.identity>

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -165,6 +165,7 @@ public final class OpensearchConnector {
       final HttpAsyncClientBuilder httpAsyncClientBuilder,
       final ConnectConfiguration osConfig,
       final HttpRequestInterceptor... interceptors) {
+    httpAsyncClientBuilder.disableContentCompression();
     setupAuthentication(httpAsyncClientBuilder, osConfig);
 
     for (final HttpRequestInterceptor interceptor : interceptors) {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -400,6 +400,7 @@ public class OpenSearchConnector {
       final HttpAsyncClientBuilder httpAsyncClientBuilder,
       final OpenSearchProperties osConfig,
       final org.apache.hc.core5.http.HttpRequestInterceptor... httpRequestInterceptors) {
+    httpAsyncClientBuilder.disableContentCompression();
     setupAuthentication(httpAsyncClientBuilder, osConfig);
 
     LOGGER.trace("Attempt to load interceptor plugins");

--- a/tasklist/qa/backup-restore-tests/pom.xml
+++ b/tasklist/qa/backup-restore-tests/pom.xml
@@ -182,6 +182,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
       <scope>test</scope>

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -152,6 +152,12 @@ public class BackupRestoreTest {
     final ApacheHttpClient5TransportBuilder builder =
         ApacheHttpClient5TransportBuilder.builder(host);
 
+    builder.setHttpClientConfigCallback(
+        httpClientBuilder -> {
+          httpClientBuilder.disableContentCompression();
+          return httpClientBuilder;
+        });
+
     final JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(CommonUtils.OBJECT_MAPPER);
     builder.setMapper(jsonpMapper);
 

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryWireMockTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryWireMockTest.java
@@ -45,7 +45,11 @@ class OpensearchBackupRepositoryWireMockTest {
     transport =
         ApacheHttpClient5TransportBuilder.builder(host)
             .setMapper(new JacksonJsonpMapper())
-            .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder)
+            .setHttpClientConfigCallback(
+                httpClientBuilder -> {
+                  httpClientBuilder.disableContentCompression();
+                  return httpClientBuilder;
+                })
             .build();
 
     final var syncClient = new OpenSearchClient(transport);


### PR DESCRIPTION
## Description

Fixes [CVE-2026-64607](https://github.com/advisories/GHSA-hjcp-jmpx-g3qm) on `stable/8.8` (CVSS 5.3, connection leak → pool exhaustion DoS). `httpclient5` 5.5.2 is vulnerable; the fix is in 5.6.3, and this targets **5.6.4** to match what `main` and `stable/8.9` already run.

Two commits, which must land together:

1. **`version.httpclient5` 5.5.2 → 5.6.4** in `parent/pom.xml`.
2. **Disable httpclient5 content compression on OpenSearch clients.** Required by (1): httpclient5 5.6 added `ContentCompressionAsyncExec`, which adds `Accept-Encoding: gzip` to every request. The OpenSearch client expects uncompressed responses by default and then fails with `ZipException: Not in GZIP format`. Without this, the bump alone turns ~all OpenSearch CI jobs red.

This mirrors #47633, already merged on `main`. It is **not** a mechanical backport — `stable/8.8` has diverged enough that the automated backport produced an unusable result (see below), so the fix was ported deliberately, file by file, against this branch's actual layout.

### Scope limits (both matching #47633's final merged state)

- **Generic `HttpClientFactory` deliberately untouched.** #47633's first commit disabled compression there and its last commit (`fix: undo generic client compression disable`) reverted that before merge. Excluded here for the same reason.
- **Zeebe `opensearch-exporter`'s `RestClientFactory` untouched** — on this branch it still builds on httpclient4 (`org.apache.http.impl.nio.client`), which has no such interceptor. On `main` that module had already migrated to httpclient5, which is why #47633 patched it there.
- `BackupRestoreTest` builds its transport via `ApacheHttpClient5TransportBuilder` directly rather than through a patched connector, so it gets the callback at the call site plus an explicit `httpclient5` test dependency.

### Note on the automated backport

Backport automation was attempted (#60467 / #60468) and produced **unusable drafts**: committed conflict markers, a `version.httpcore5` **downgrade** 5.4.3 → 5.4.2 that would reintroduce CVE-2026-54399, and whole duplicate files added at `main`-only paths. Those drafts should be closed in favour of these PRs.

### Verification

Reviewers should confirm CI, since the environment that prepared this could not run Maven locally (401 against Camunda's private Artifactory for pinned Spring/Spring Boot SNAPSHOT BOMs on this branch).

## Related issues

relates CVE-2026-64607, #47633, #47245