### PR TITLE
Revert #59982

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -428,27 +428,19 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - run: ./mvnw -B -D skipTests -D skipChecks -pl load-tests/load-tester -am install
-      # registry.camunda.cloud intermittently stops answering the manifest PUT at the end of the
-      # push. jib's own retries all fall inside a ~5 minute window, so they re-hit the same bad
-      # spell and the job fails. Each attempt here is capped well above the ~15s a healthy push
-      # takes, so a hung one is abandoned quickly and the registry is sampled again a minute later.
-      - name: Build Starter Image
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+          minimus: true
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
         with:
-          max_attempts: 3
-          retry_wait_seconds: 60
-          timeout_minutes: 2
-          shell: bash
-          command: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ env.IMAGE_TAG }}"
-      - name: Build Worker Image
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - uses: ./.github/actions/build-platform-docker
+        id: build-zeebe-docker
         with:
-          max_attempts: 3
-          retry_wait_seconds: 60
-          timeout_minutes: 2
-          shell: bash
-          command: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ env.IMAGE_TAG }}"
+          repository: camunda/zeebe
+          version: ${{ needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -433,10 +433,6 @@ jobs:
       # push. jib's own retries all fall inside a ~5 minute window, so they re-hit the same bad
       # spell and the job fails. Each attempt here is capped well above the ~15s a healthy push
       # takes, so a hung one is abandoned quickly and the registry is sampled again a minute later.
-      #
-      # This is mitigation, not a fix — it makes a hanging registry survivable, it does not stop it
-      # hanging. Drop both wrappers once these images are published to GAR instead
-      # (camunda/team-infrastructure#992), which removes the dependency on this registry altogether.
       - name: Build Starter Image
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:


### PR DESCRIPTION
## Description

Revert #59982: the code change in #59982 completely changes what is being built and doesn't work correctly due to the missing environment variables that were added.

* reverts commit https://github.com/camunda/camunda/commit/e32d1242faeee86e328b6c2707905e2727147cec.
* reverts commit https://github.com/camunda/camunda/commit/c975e6d360e0b0d2b2668e91c6c3cfaba0d34af7.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://app.incident.io/camunda/incidents/7187
