### PR TITLE
feat: scope partition join, leave and priority changes to a physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.Error;
 import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
+import io.camunda.zeebe.management.cluster.PartitionJoinRequest;
 import io.camunda.zeebe.management.cluster.RequestHandlingActivePartitions;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
 import io.camunda.zeebe.management.cluster.RoutingState;
@@ -410,9 +411,11 @@ public class ClusterEndpoint {
       @PathVariable final String resourceId,
       @PathVariable("subResource") final Resource subResource,
       @PathVariable final String subResourceId,
-      @RequestBody final PartitionAddRequest request,
+      @RequestBody final PartitionJoinRequest request,
       @RequestParam(defaultValue = "false") final boolean dryRun) {
-    final int priority = request.priority();
+    // The generated body type makes priority nullable even though the schema requires it;
+    // an omitted priority has always meant the lowest one, so keep answering that way.
+    final int priority = Optional.ofNullable(request.getPriority()).orElse(0);
     return switch (resource) {
       case brokers ->
           switch (subResource) {
@@ -677,8 +680,6 @@ public class ClusterEndpoint {
   private static Optional<String> nonBlank(final @Nullable String value) {
     return Optional.ofNullable(value).filter(v -> !v.isBlank());
   }
-
-  public record PartitionAddRequest(int priority) {}
 
   private static final class UnknownRequestParameterException extends RuntimeException {
     private UnknownRequestParameterException(final String message) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -403,6 +403,12 @@ public class ClusterEndpoint {
         });
   }
 
+  /**
+   * Adds a broker to a partition's replication group, or changes the priority it replicates that
+   * partition with. Partition ids restart at 1 in every physical tenant, so without a {@code
+   * physicalTenant} query parameter the partition is resolved in the default physical tenant; with
+   * it, in that tenant's partition group.
+   */
   @PostMapping(
       path = "/{resource}/{resourceId}/{subResource}/{subResourceId}",
       consumes = "application/json")
@@ -412,10 +418,12 @@ public class ClusterEndpoint {
       @PathVariable("subResource") final Resource subResource,
       @PathVariable final String subResourceId,
       @RequestBody final PartitionJoinRequest request,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
     // The generated body type makes priority nullable even though the schema requires it;
     // an omitted priority has always meant the lowest one, so keep answering that way.
     final int priority = Optional.ofNullable(request.getPriority()).orElse(0);
+    final Optional<String> tenant = nonBlank(physicalTenant);
     return switch (resource) {
       case brokers ->
           switch (subResource) {
@@ -428,7 +436,11 @@ public class ClusterEndpoint {
                             requestSender
                                 .joinPartition(
                                     new JoinPartitionRequest(
-                                        member, Integer.parseInt(subResourceId), priority, dryRun))
+                                        member,
+                                        Integer.parseInt(subResourceId),
+                                        priority,
+                                        tenant,
+                                        dryRun))
                                 .join()));
             case brokers, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
           };
@@ -443,7 +455,11 @@ public class ClusterEndpoint {
                             requestSender
                                 .joinPartition(
                                     new JoinPartitionRequest(
-                                        member, Integer.parseInt(resourceId), priority, dryRun))
+                                        member,
+                                        Integer.parseInt(resourceId),
+                                        priority,
+                                        tenant,
+                                        dryRun))
                                 .join()));
             case partitions, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
           };
@@ -451,6 +467,11 @@ public class ClusterEndpoint {
     };
   }
 
+  /**
+   * Removes a broker from a partition's replication group. Partition ids restart at 1 in every
+   * physical tenant, so without a {@code physicalTenant} query parameter the partition is resolved
+   * in the default physical tenant; with it, in that tenant's partition group.
+   */
   @DeleteMapping(
       path = "/{resource}/{resourceId}/{subResource}/{subResourceId}",
       consumes = "application/json")
@@ -459,7 +480,9 @@ public class ClusterEndpoint {
       @PathVariable final String resourceId,
       @PathVariable("subResource") final Resource subResource,
       @PathVariable final String subResourceId,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(required = false) final @Nullable String physicalTenant) {
+    final Optional<String> tenant = nonBlank(physicalTenant);
     return switch (resource) {
       case brokers ->
           switch (subResource) {
@@ -471,7 +494,7 @@ public class ClusterEndpoint {
                             requestSender
                                 .leavePartition(
                                     new LeavePartitionRequest(
-                                        member, Integer.parseInt(subResourceId), dryRun))
+                                        member, Integer.parseInt(subResourceId), tenant, dryRun))
                                 .join()));
             case brokers, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
           };
@@ -485,7 +508,7 @@ public class ClusterEndpoint {
                             requestSender
                                 .leavePartition(
                                     new LeavePartitionRequest(
-                                        member, Integer.parseInt(resourceId), dryRun))
+                                        member, Integer.parseInt(resourceId), tenant, dryRun))
                                 .join()));
             case partitions, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
           };

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -63,10 +63,14 @@ paths:
       description: Adds the broker to the replication group of the given partition, replicating it
         with the requested priority. If the broker already replicates the partition, only its
         priority is changed. The broker must be running to complete the operation.
+        Partition ids restart at 1 in every physical tenant, so the partition is resolved within
+        the physical tenant named by physicalTenant, or within the default physical tenant when
+        the parameter is absent.
       parameters:
         - $ref: '#/components/parameters/BrokerId'
         - $ref: '#/components/parameters/PartitionId'
         - $ref: '#/components/parameters/DryRunParameter'
+        - $ref: '#/components/parameters/DefaultingPhysicalTenantParameter'
       requestBody:
         required: true
         content:
@@ -78,6 +82,8 @@ paths:
           $ref: '#/components/responses/JoinPartitionResponse'
         '400':
           $ref: 'components.yaml#/responses/InvalidRequest'
+        '404':
+          $ref: 'components.yaml#/responses/NotFound'
         '409':
           $ref: 'components.yaml#/responses/ConcurrentChangeError'
         '500':
@@ -91,15 +97,21 @@ paths:
       description: Removes the broker from the replication group of the given partition. The
         partition must keep at least one replica, so the last remaining replica cannot be removed.
         The broker must be running to complete the operation.
+        Partition ids restart at 1 in every physical tenant, so the partition is resolved within
+        the physical tenant named by physicalTenant, or within the default physical tenant when
+        the parameter is absent.
       parameters:
         - $ref: '#/components/parameters/BrokerId'
         - $ref: '#/components/parameters/PartitionId'
         - $ref: '#/components/parameters/DryRunParameter'
+        - $ref: '#/components/parameters/DefaultingPhysicalTenantParameter'
       responses:
         '202':
           $ref: '#/components/responses/LeavePartitionResponse'
         '400':
           $ref: 'components.yaml#/responses/InvalidRequest'
+        '404':
+          $ref: 'components.yaml#/responses/NotFound'
         '409':
           $ref: 'components.yaml#/responses/ConcurrentChangeError'
         '500':
@@ -279,7 +291,7 @@ paths:
               $ref: "components.yaml#/schemas/RoutingState"
       parameters:
         - $ref: '#/components/parameters/DryRunParameter'
-        - $ref: '#/components/parameters/RoutingStatePhysicalTenantParameter'
+        - $ref: '#/components/parameters/DefaultingPhysicalTenantParameter'
       responses:
         '202':
           description: Accepted
@@ -480,7 +492,7 @@ components:
       required: false
       schema:
         $ref: 'components.yaml#/schemas/PhysicalTenantId'
-    RoutingStatePhysicalTenantParameter:
+    DefaultingPhysicalTenantParameter:
       name: physicalTenant
       description: Id of the physical tenant to target. If not specified, the default physical tenant is targeted,
         not every physical tenant - unlike the other operations taking this parameter.

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -57,6 +57,58 @@ paths:
           $ref: 'components.yaml#/responses/GatewayError'
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
+  /brokers/{brokerId}/partitions/{partitionId}:
+    post:
+      summary: Add a broker to a partition's replication group, or change its priority
+      description: Adds the broker to the replication group of the given partition, replicating it
+        with the requested priority. If the broker already replicates the partition, only its
+        priority is changed. The broker must be running to complete the operation.
+      parameters:
+        - $ref: '#/components/parameters/BrokerId'
+        - $ref: '#/components/parameters/PartitionId'
+        - $ref: '#/components/parameters/DryRunParameter'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "components.yaml#/schemas/PartitionJoinRequest"
+      responses:
+        '202':
+          $ref: '#/components/responses/JoinPartitionResponse'
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+    delete:
+      summary: Remove a broker from a partition's replication group
+      description: Removes the broker from the replication group of the given partition. The
+        partition must keep at least one replica, so the last remaining replica cannot be removed.
+        The broker must be running to complete the operation.
+      parameters:
+        - $ref: '#/components/parameters/BrokerId'
+        - $ref: '#/components/parameters/PartitionId'
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          $ref: '#/components/responses/LeavePartitionResponse'
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
   /brokers:
     post:
       summary: Reconfigure the cluster with the given brokers.
@@ -397,6 +449,13 @@ components:
       description: Name of the zone
       schema:
         type: string
+    PartitionId:
+      name: partitionId
+      required: true
+      in: path
+      description: Id of the partition
+      schema:
+        $ref: 'components.yaml#/schemas/PartitionId'
     ChangeId:
       name: changeId
       required: true
@@ -472,6 +531,20 @@ components:
 
     ClusterConfigPurgeResponse:
       description: Request to purge cluster data is accepted.
+      content:
+        application/json:
+          schema:
+            $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+
+    JoinPartitionResponse:
+      description: Request for the broker to join the partition is accepted.
+      content:
+        application/json:
+          schema:
+            $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+
+    LeavePartitionResponse:
+      description: Request for the broker to leave the partition is accepted.
       content:
         application/json:
           schema:

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -303,6 +303,19 @@ schemas:
         items:
           $ref: "components.yaml#/schemas/BrokerId"
 
+  PartitionJoinRequest:
+    description: Request body for adding a broker to a partition's replication group. The broker
+      and the partition are given in the path.
+    type: object
+    required:
+      - priority
+    properties:
+      priority:
+        type: integer
+        format: int32
+        description: Preferred-leader ranking of the broker within the partition; higher value wins
+        example: 1
+
   ClusterZoneMigrationRequest:
     description: >
       Request to migrate one zone from a bare or partially zoned cluster. The complete zone order,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -39,11 +39,48 @@ public sealed interface ClusterConfigurationManagementRequest {
   record RemoveMembersRequest(Set<MemberId> members, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record JoinPartitionRequest(MemberId memberId, int partitionId, int priority, boolean dryRun)
-      implements ClusterConfigurationManagementRequest {}
+  /**
+   * Adds a member to one partition's replication group, or changes the priority it already
+   * replicates that partition with.
+   *
+   * @param partitionId the partition within {@code physicalTenantId}'s partition group. Partition
+   *     ids restart at 1 in every physical tenant, so this identifies a partition only together
+   *     with the tenant.
+   * @param physicalTenantId the physical tenant whose partition to join, or empty for the default
+   *     physical tenant. A single partition belongs to exactly one tenant, so an absent id cannot
+   *     mean "every tenant" here, unlike the requests that address a whole cluster.
+   */
+  record JoinPartitionRequest(
+      MemberId memberId,
+      int partitionId,
+      int priority,
+      Optional<String> physicalTenantId,
+      boolean dryRun)
+      implements ClusterConfigurationManagementRequest {
 
-  record LeavePartitionRequest(MemberId memberId, int partitionId, boolean dryRun)
-      implements ClusterConfigurationManagementRequest {}
+    public JoinPartitionRequest {
+      physicalTenantId.ifPresent(assertNonEmpty("physicalTenantId"));
+    }
+  }
+
+  /**
+   * Removes a member from one partition's replication group.
+   *
+   * @param partitionId the partition within {@code physicalTenantId}'s partition group. Partition
+   *     ids restart at 1 in every physical tenant, so this identifies a partition only together
+   *     with the tenant.
+   * @param physicalTenantId the physical tenant whose partition to leave, or empty for the default
+   *     physical tenant. A single partition belongs to exactly one tenant, so an absent id cannot
+   *     mean "every tenant" here, unlike the requests that address a whole cluster.
+   */
+  record LeavePartitionRequest(
+      MemberId memberId, int partitionId, Optional<String> physicalTenantId, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {
+
+    public LeavePartitionRequest {
+      physicalTenantId.ifPresent(assertNonEmpty("physicalTenantId"));
+    }
+  }
 
   record ReassignPartitionsRequest(Set<MemberId> members, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -88,7 +88,8 @@ public final class ClusterConfigurationManagementRequestsHandler
         new JoinPartitionRequestTransformer(
             joinPartitionRequest.memberId(),
             joinPartitionRequest.partitionId(),
-            joinPartitionRequest.priority()));
+            joinPartitionRequest.priority(),
+            joinPartitionRequest.physicalTenantId()));
   }
 
   @Override
@@ -97,7 +98,9 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         leavePartitionRequest.dryRun(),
         new LeavePartitionRequestTransformer(
-            leavePartitionRequest.memberId(), leavePartitionRequest.partitionId()));
+            leavePartitionRequest.memberId(),
+            leavePartitionRequest.partitionId(),
+            leavePartitionRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -36,14 +36,10 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeResult;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.util.Either;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -89,13 +85,10 @@ public final class ClusterConfigurationManagementRequestsHandler
       final JoinPartitionRequest joinPartitionRequest) {
     return handleRequest(
         joinPartitionRequest.dryRun(),
-        ignore ->
-            Either.right(
-                List.of(
-                    new PartitionJoinOperation(
-                        joinPartitionRequest.memberId(),
-                        joinPartitionRequest.partitionId(),
-                        joinPartitionRequest.priority()))));
+        new JoinPartitionRequestTransformer(
+            joinPartitionRequest.memberId(),
+            joinPartitionRequest.partitionId(),
+            joinPartitionRequest.priority()));
   }
 
   @Override
@@ -103,13 +96,8 @@ public final class ClusterConfigurationManagementRequestsHandler
       final LeavePartitionRequest leavePartitionRequest) {
     return handleRequest(
         leavePartitionRequest.dryRun(),
-        ignore ->
-            Either.right(
-                List.of(
-                    new PartitionLeaveOperation(
-                        leavePartitionRequest.memberId(),
-                        leavePartitionRequest.partitionId(),
-                        1))));
+        new LeavePartitionRequestTransformer(
+            leavePartitionRequest.memberId(), leavePartitionRequest.partitionId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adds a broker to one partition's replication group, or changes the priority it already replicates
+ * that partition with.
+ */
+public final class JoinPartitionRequestTransformer implements ConfigurationChangeRequest {
+
+  private final MemberId memberId;
+  private final int partitionId;
+  private final int priority;
+
+  public JoinPartitionRequestTransformer(
+      final MemberId memberId, final int partitionId, final int priority) {
+    this.memberId = memberId;
+    this.partitionId = partitionId;
+    this.priority = priority;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    throw new UnsupportedOperationException(
+        "JoinPartitionRequestTransformer builds its change plan via "
+            + "phases(CurrentClusterConfiguration); the new-model coordinator path never calls "
+            + "operations(ClusterConfiguration)");
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    final List<PartitionGroupOperation> operations =
+        List.of(new PartitionJoinOperation(memberId, partitionId, priority));
+    return Either.right(
+        List.of(
+            new PartitionGroupParallelPhase(
+                Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, operations))));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
@@ -56,21 +56,16 @@ public final class JoinPartitionRequestTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
-    if (physicalTenantId.isPresent()
-        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    if (!clusterConfiguration.hasPartitionGroup(groupId)) {
       return Either.left(
           new NotFound(
               "Expected to join partition %d of physical tenant '%s', but the physical tenant does not exist"
-                  .formatted(partitionId, physicalTenantId.get())));
+                  .formatted(partitionId, groupId)));
     }
 
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionJoinOperation(memberId, partitionId, priority));
-    return Either.right(
-        List.of(
-            new PartitionGroupParallelPhase(
-                Map.of(
-                    physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP),
-                    operations))));
+    return Either.right(List.of(new PartitionGroupParallelPhase(Map.of(groupId, operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Adds a broker to one partition's replication group, or changes the priority it already replicates
@@ -29,12 +31,17 @@ public final class JoinPartitionRequestTransformer implements ConfigurationChang
   private final MemberId memberId;
   private final int partitionId;
   private final int priority;
+  private final Optional<String> physicalTenantId;
 
   public JoinPartitionRequestTransformer(
-      final MemberId memberId, final int partitionId, final int priority) {
+      final MemberId memberId,
+      final int partitionId,
+      final int priority,
+      final Optional<String> physicalTenantId) {
     this.memberId = memberId;
     this.partitionId = partitionId;
     this.priority = priority;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
@@ -49,11 +56,21 @@ public final class JoinPartitionRequestTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to join partition %d of physical tenant '%s', but the physical tenant does not exist"
+                  .formatted(partitionId, physicalTenantId.get())));
+    }
+
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionJoinOperation(memberId, partitionId, priority));
     return Either.right(
         List.of(
             new PartitionGroupParallelPhase(
-                Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, operations))));
+                Map.of(
+                    physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP),
+                    operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
@@ -57,21 +57,16 @@ public final class LeavePartitionRequestTransformer implements ConfigurationChan
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
-    if (physicalTenantId.isPresent()
-        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    if (!clusterConfiguration.hasPartitionGroup(groupId)) {
       return Either.left(
           new NotFound(
               "Expected to leave partition %d of physical tenant '%s', but the physical tenant does not exist"
-                  .formatted(partitionId, physicalTenantId.get())));
+                  .formatted(partitionId, groupId)));
     }
 
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionLeaveOperation(memberId, partitionId, MINIMUM_ALLOWED_REPLICAS));
-    return Either.right(
-        List.of(
-            new PartitionGroupParallelPhase(
-                Map.of(
-                    physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP),
-                    operations))));
+    return Either.right(List.of(new PartitionGroupParallelPhase(Map.of(groupId, operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+
+/** Removes a broker from one partition's replication group. */
+public final class LeavePartitionRequestTransformer implements ConfigurationChangeRequest {
+
+  /**
+   * An operator-driven leave must not take a partition below one replica; only a cluster purge is
+   * allowed to empty it.
+   */
+  private static final int MINIMUM_ALLOWED_REPLICAS = 1;
+
+  private final MemberId memberId;
+  private final int partitionId;
+
+  public LeavePartitionRequestTransformer(final MemberId memberId, final int partitionId) {
+    this.memberId = memberId;
+    this.partitionId = partitionId;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    throw new UnsupportedOperationException(
+        "LeavePartitionRequestTransformer builds its change plan via "
+            + "phases(CurrentClusterConfiguration); the new-model coordinator path never calls "
+            + "operations(ClusterConfiguration)");
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    final List<PartitionGroupOperation> operations =
+        List.of(new PartitionLeaveOperation(memberId, partitionId, MINIMUM_ALLOWED_REPLICAS));
+    return Either.right(
+        List.of(
+            new PartitionGroupParallelPhase(
+                Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, operations))));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -19,8 +20,12 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-/** Removes a broker from one partition's replication group. */
+/**
+ * Removes a broker from one partition's replication group, in a single physical tenant's partition
+ * group.
+ */
 public final class LeavePartitionRequestTransformer implements ConfigurationChangeRequest {
 
   /**
@@ -31,10 +36,13 @@ public final class LeavePartitionRequestTransformer implements ConfigurationChan
 
   private final MemberId memberId;
   private final int partitionId;
+  private final Optional<String> physicalTenantId;
 
-  public LeavePartitionRequestTransformer(final MemberId memberId, final int partitionId) {
+  public LeavePartitionRequestTransformer(
+      final MemberId memberId, final int partitionId, final Optional<String> physicalTenantId) {
     this.memberId = memberId;
     this.partitionId = partitionId;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
@@ -49,11 +57,21 @@ public final class LeavePartitionRequestTransformer implements ConfigurationChan
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to leave partition %d of physical tenant '%s', but the physical tenant does not exist"
+                  .formatted(partitionId, physicalTenantId.get())));
+    }
+
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionLeaveOperation(memberId, partitionId, MINIMUM_ALLOWED_REPLICAS));
     return Either.right(
         List.of(
             new PartitionGroupParallelPhase(
-                Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, operations))));
+                Map.of(
+                    physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP),
+                    operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1017,23 +1017,25 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodeJoinPartitionRequest(final JoinPartitionRequest req) {
-    return Requests.JoinPartitionRequest.newBuilder()
-        .setMemberId(req.memberId().id())
-        .setPartitionId(req.partitionId())
-        .setPriority(req.priority())
-        .setDryRun(req.dryRun())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.JoinPartitionRequest.newBuilder()
+            .setMemberId(req.memberId().id())
+            .setPartitionId(req.partitionId())
+            .setPriority(req.priority())
+            .setDryRun(req.dryRun());
+    req.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+    return builder.build().toByteArray();
   }
 
   @Override
   public byte[] encodeLeavePartitionRequest(final LeavePartitionRequest req) {
-    return Requests.LeavePartitionRequest.newBuilder()
-        .setMemberId(req.memberId().id())
-        .setPartitionId(req.partitionId())
-        .setDryRun(req.dryRun())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.LeavePartitionRequest.newBuilder()
+            .setMemberId(req.memberId().id())
+            .setPartitionId(req.partitionId())
+            .setDryRun(req.dryRun());
+    req.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+    return builder.build().toByteArray();
   }
 
   @Override
@@ -1251,6 +1253,9 @@ public class ProtoBufSerializer
           MemberId.from(joinPartitionRequest.getMemberId()),
           joinPartitionRequest.getPartitionId(),
           joinPartitionRequest.getPriority(),
+          joinPartitionRequest.hasPhysicalTenantId()
+              ? Optional.of(joinPartitionRequest.getPhysicalTenantId())
+              : Optional.empty(),
           joinPartitionRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
@@ -1264,6 +1269,9 @@ public class ProtoBufSerializer
       return new LeavePartitionRequest(
           MemberId.from(leavePartitionRequest.getMemberId()),
           leavePartitionRequest.getPartitionId(),
+          leavePartitionRequest.hasPhysicalTenantId()
+              ? Optional.of(leavePartitionRequest.getPhysicalTenantId())
+              : Optional.empty(),
           leavePartitionRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -20,6 +20,9 @@ message JoinPartitionRequest {
   int32 partitionId = 2;
   int32 priority = 3;
   bool dryRun = 4;
+  // The physical tenant the partition belongs to; the default tenant if not set. Partition ids
+  // restart at 1 in every tenant, so partitionId identifies a partition only together with this.
+  optional string physicalTenantId = 5;
 }
 
 message PurgeRequest {
@@ -33,6 +36,9 @@ message LeavePartitionRequest {
   string memberId = 1;
   int32 partitionId = 2;
   bool dryRun = 3;
+  // The physical tenant the partition belongs to; the default tenant if not set. Partition ids
+  // restart at 1 in every tenant, so partitionId identifies a partition only together with this.
+  optional string physicalTenantId = 4;
 }
 
 message BrokerScaleRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
@@ -410,7 +410,8 @@ abstract class ClusterConfigurationManagementApiTestBase {
             .updateMember(
                 coordinatorId, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of())));
-    final var request = new JoinPartitionRequest(memberFactory.apply(1), 1, 3, false);
+    final var request =
+        new JoinPartitionRequest(memberFactory.apply(1), 1, 3, Optional.empty(), false);
 
     // when
     final var changeStatus = clientApi.joinPartition(request).join().get();
@@ -432,7 +433,8 @@ abstract class ClusterConfigurationManagementApiTestBase {
                 memberFactory.apply(1),
                 MemberState.initializeAsActive(
                     Map.of(1, PartitionState.active(1, partitionConfig)))));
-    final var request = new LeavePartitionRequest(memberFactory.apply(1), 1, false);
+    final var request =
+        new LeavePartitionRequest(memberFactory.apply(1), 1, Optional.empty(), false);
 
     // when
     final var changeStatus = clientApi.leavePartition(request).join().get();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
@@ -1286,6 +1286,164 @@ abstract class ClusterConfigurationManagementApiTestBase {
   }
 
   /**
+   * Partition ids restart at 1 in every physical tenant, so before the request named a tenant this
+   * join was planned into the default tenant's group — the operator asked for one tenant's
+   * partition 1 and got another's.
+   */
+  @Test
+  void shouldJoinAPartitionOfANonDefaultPhysicalTenant() {
+    // given — both tenants run a partition numbered 1, held by the coordinator alone
+    final var joiningMember = memberFactory.apply(1);
+    wireTwoTenantsSharingPartitionOne(Set.of(coordinatorId), joiningMember);
+
+    // when — the member joins partition 1 of tenant-b
+    final var changeStatus =
+        clientApi
+            .joinPartition(
+                new JoinPartitionRequest(joiningMember, 1, 3, Optional.of(TENANT_B), false))
+            .join()
+            .get();
+
+    // then — it replicates tenant-b's partition 1, and the default tenant's identically numbered
+    // partition is left alone
+    final var expected = changeStatus.response().expectedConfiguration();
+    assertThat(expected.partitionGroup(TENANT_B).members()).containsKey(joiningMember);
+    assertThat(expected.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).members())
+        .doesNotContainKey(joiningMember);
+  }
+
+  /**
+   * The counterpart of {@link #shouldJoinAPartitionOfANonDefaultPhysicalTenant()}: an unscoped
+   * leave used to be the only leave there was, so asking for another tenant's partition 1 removed
+   * the replica from the default tenant instead — data loss on a tenant the operator never named.
+   */
+  @Test
+  void shouldLeaveAPartitionOfANonDefaultPhysicalTenant() {
+    // given — both tenants run a partition numbered 1, replicated by both members
+    final var leavingMember = memberFactory.apply(1);
+    wireTwoTenantsSharingPartitionOne(Set.of(coordinatorId, leavingMember), memberFactory.apply(2));
+
+    // when — the member leaves partition 1 of tenant-b
+    final var changeStatus =
+        clientApi
+            .leavePartition(
+                new LeavePartitionRequest(leavingMember, 1, Optional.of(TENANT_B), false))
+            .join()
+            .get();
+
+    // then — it stops replicating tenant-b's partition 1 and keeps the default tenant's
+    final var expected = changeStatus.response().expectedConfiguration();
+    assertThat(expected.partitionGroup(TENANT_B).members()).doesNotContainKey(leavingMember);
+    assertThat(expected.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).members())
+        .containsKey(leavingMember);
+  }
+
+  @Test
+  void shouldRejectAJoinForAnUnknownPhysicalTenant() {
+    // given
+    final var joiningMember = memberFactory.apply(1);
+    wireTwoTenantsSharingPartitionOne(Set.of(coordinatorId), joiningMember);
+
+    // when
+    final var changeStatus =
+        clientApi
+            .joinPartition(
+                new JoinPartitionRequest(joiningMember, 1, 3, Optional.of("does-not-exist"), false))
+            .join();
+
+    // then
+    EitherAssert.assertThat(changeStatus)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldRejectALeaveForAnUnknownPhysicalTenant() {
+    // given
+    final var leavingMember = memberFactory.apply(1);
+    wireTwoTenantsSharingPartitionOne(Set.of(coordinatorId, leavingMember), memberFactory.apply(2));
+
+    // when
+    final var changeStatus =
+        clientApi
+            .leavePartition(
+                new LeavePartitionRequest(leavingMember, 1, Optional.of("does-not-exist"), false))
+            .join();
+
+    // then
+    EitherAssert.assertThat(changeStatus)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.NOT_FOUND);
+  }
+
+  /**
+   * Wires a cluster where the default tenant and {@link #TENANT_B} each run a partition numbered 1,
+   * both replicated by exactly {@code replicas}. The two groups are deliberately identical: a
+   * request that resolves the partition in the wrong group would still find a partition 1 there, so
+   * only which group changed can tell the two apart.
+   *
+   * <p>{@code idleMember} joins the cluster without replicating anything, so it is available to
+   * join either partition.
+   *
+   * <p>Left without a zone-aware distributor config, unlike {@link #wireTwoPhysicalTenants()}:
+   * nothing here asks for a placement to be computed, and a zone spec sized for a single broker
+   * could not describe this cluster.
+   */
+  private void wireTwoTenantsSharingPartitionOne(
+      final Set<MemberId> replicas, final MemberId idleMember) {
+    var topology = initialTopology.addMember(idleMember, MemberState.initializeAsActive(Map.of()));
+    for (final var replica : replicas) {
+      topology =
+          topology.hasMember(replica)
+              ? topology.updateMember(
+                  replica, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+              : topology.addMember(
+                  replica,
+                  MemberState.initializeAsActive(
+                      Map.of(1, PartitionState.active(1, partitionConfig))));
+    }
+    setCurrentTopology(topology);
+    manager.registerPartitionGroupChangeAppliers(
+        TENANT_B,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+    manager
+        .updateMultiConfiguration(
+            current ->
+                new CurrentClusterConfiguration(
+                    current.version(),
+                    current.globalConfiguration(),
+                    Map.of(
+                        CurrentClusterConfiguration.DEFAULT_GROUP,
+                        current.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
+                        TENANT_B,
+                        new PartitionGroupConfiguration(
+                            1,
+                            0,
+                            replicas.stream()
+                                .collect(
+                                    Collectors.toMap(
+                                        replica -> replica,
+                                        replica ->
+                                            BrokerPartitionState.initialize(
+                                                Map.of(
+                                                    1,
+                                                    PartitionState.active(1, partitionConfig))))),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty())),
+                    current.phasedChangeState()))
+        .join();
+  }
+
+  /**
    * Wires a three-member cluster where the default tenant's only partition sits on {@link
    * #coordinatorId} and {@link #TENANT_B}'s only partition on {@code lastMember}, so that member
    * holds nothing but a non-default tenant's partition.

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -231,7 +231,8 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodeJoinPartitionRequest() {
     // given
-    final var joinPartitionRequest = new JoinPartitionRequest(MemberId.from("2"), 3, 5, false);
+    final var joinPartitionRequest =
+        new JoinPartitionRequest(MemberId.from("2"), 3, 5, Optional.empty(), false);
 
     // when
     final var encodedRequest = protoBufSerializer.encodeJoinPartitionRequest(joinPartitionRequest);
@@ -244,7 +245,8 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodeLeavePartitionRequest() {
     // given
-    final var leavePartitionRequest = new LeavePartitionRequest(MemberId.from("6"), 2, false);
+    final var leavePartitionRequest =
+        new LeavePartitionRequest(MemberId.from("6"), 2, Optional.empty(), false);
 
     // when
     final var encodedRequest =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -243,10 +243,39 @@ final class ProtoBufSerializerTest {
   }
 
   @Test
+  void shouldEncodeAndDecodeJoinPartitionRequestWithPhysicalTenant() {
+    // given
+    final var joinPartitionRequest =
+        new JoinPartitionRequest(MemberId.from("2"), 3, 5, Optional.of("tenant-a"), false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeJoinPartitionRequest(joinPartitionRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeJoinPartitionRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(joinPartitionRequest);
+  }
+
+  @Test
   void shouldEncodeAndDecodeLeavePartitionRequest() {
     // given
     final var leavePartitionRequest =
         new LeavePartitionRequest(MemberId.from("6"), 2, Optional.empty(), false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeLeavePartitionRequest(leavePartitionRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeLeavePartitionRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(leavePartitionRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeLeavePartitionRequestWithPhysicalTenant() {
+    // given
+    final var leavePartitionRequest =
+        new LeavePartitionRequest(MemberId.from("6"), 2, Optional.of("tenant-a"), false);
 
     // when
     final var encodedRequest =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionJoinLeaveIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionJoinLeaveIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a partition join and a partition leave through {@code
+ * /actuator/cluster/brokers/{brokerId}/partitions/{partitionId}} act on the physical tenant the
+ * request names (issue #60078), and on no other.
+ *
+ * <p>Partition ids restart at 1 in every physical tenant, so both tenants here run a partition
+ * numbered 1. Before the endpoints took a {@code physicalTenant} parameter they resolved that
+ * number against the default tenant whatever the operator meant, which made repairing a non-default
+ * tenant's replication impossible and silently changed the default tenant instead.
+ *
+ * <p>The replicas each tenant starts with are read from the cluster rather than assumed: which
+ * broker a single-replica partition lands on is the distributor's business, and the test only needs
+ * one broker that holds tenant A's partition and one that does not.
+ */
+@ZeebeIntegration
+final class PhysicalTenantPartitionJoinLeaveIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int PARTITION_ID = 1;
+  private static final int BROKERS_COUNT = 2;
+  private static final int PARTITIONS_COUNT = 1;
+  private static final int REPLICATION_FACTOR = 1;
+  private static final int JOIN_PRIORITY = 1;
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      new TestClusterBuilder()
+          .withBrokersCount(BROKERS_COUNT)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withBrokerConfig(
+              broker ->
+                  TENANTS.configure(
+                      broker
+                          .withUnauthenticatedAccess()
+                          // TestClusterBuilder sizes the actor threads as
+                          // (partitions * replicationFactor) / brokers, which is 0 here, and a
+                          // scheduler with no threads cannot start a broker at all. Size them for
+                          // both tenants' partitions on one broker, which is what the join
+                          // produces.
+                          .withUnifiedConfig(
+                              camunda -> {
+                                camunda.getSystem().setCpuThreadCount(2);
+                                camunda.getSystem().setIoThreadCount(2);
+                              })))
+          .build();
+
+  @Test
+  void shouldJoinAndLeaveOnlyTheNamedPhysicalTenantsPartition() {
+    // given — each tenant's partition 1 has a single replica, and the default tenant's replicas are
+    // recorded so any change to them is visible
+    final var actuator = ClusterActuator.of(cluster.availableGateway());
+    awaitReplicas(actuator, TENANT_A, REPLICATION_FACTOR);
+    final var tenantAHolder = replicasOf(actuator, TENANT_A).iterator().next();
+    final var defaultReplicas = replicasOf(actuator, PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+    final var joiningBroker =
+        cluster.brokers().keySet().stream()
+            .map(MemberId::id)
+            .filter(id -> !id.equals(tenantAHolder))
+            .findFirst()
+            .orElseThrow();
+
+    // when — that other broker joins partition 1 of tenant A
+    awaitAccepted(
+        "the cluster accepts the join",
+        () ->
+            actuator.joinPartition(
+                Integer.parseInt(joiningBroker), PARTITION_ID, JOIN_PRIORITY, TENANT_A));
+
+    // then — tenant A's partition 1 gains the replica...
+    await("tenant A's partition is replicated by the joining broker")
+        .atMost(Duration.ofSeconds(120))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(replicasOf(actuator, TENANT_A))
+                    .containsExactlyInAnyOrder(tenantAHolder, joiningBroker));
+    // ...and the default tenant's identically numbered partition is untouched
+    assertThat(replicasOf(actuator, PhysicalTenantsITHelper.DEFAULT_TENANT_ID))
+        .isEqualTo(defaultReplicas);
+
+    // when — the same broker leaves partition 1 of tenant A again
+    awaitAccepted(
+        "the cluster accepts the leave",
+        () -> actuator.leavePartition(Integer.parseInt(joiningBroker), PARTITION_ID, TENANT_A));
+
+    // then — tenant A is back to its single replica, and the default tenant still never moved
+    await("tenant A's partition is no longer replicated by that broker")
+        .atMost(Duration.ofSeconds(120))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThat(replicasOf(actuator, TENANT_A)).containsExactly(tenantAHolder));
+    assertThat(replicasOf(actuator, PhysicalTenantsITHelper.DEFAULT_TENANT_ID))
+        .isEqualTo(defaultReplicas);
+  }
+
+  /** The ids of the brokers replicating {@link #PARTITION_ID} of the given physical tenant. */
+  private Set<String> replicasOf(final ClusterActuator actuator, final String physicalTenantId) {
+    return actuator.getTopology(physicalTenantId).getBrokers().stream()
+        .filter(
+            broker ->
+                broker.getPartitions().stream()
+                    .anyMatch(partition -> Objects.equals(partition.getId(), PARTITION_ID)))
+        .map(broker -> broker.getId().toString())
+        .collect(Collectors.toSet());
+  }
+
+  private void awaitReplicas(
+      final ClusterActuator actuator, final String physicalTenantId, final int expected) {
+    await(
+            "physical tenant '%s' replicates its partition %d times"
+                .formatted(physicalTenantId, expected))
+        .atMost(Duration.ofSeconds(120))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(replicasOf(actuator, physicalTenantId)).hasSize(expected));
+  }
+
+  /**
+   * Retries {@code request} until the cluster accepts it. The request is not an assertion — it
+   * either returns or throws a {@link feign.FeignException} — so it cannot be handed to {@code
+   * untilAsserted}, which only retries on {@link AssertionError}. A retry is needed because the
+   * cluster can still be applying its own initial configuration change when the test starts, and
+   * rejects a second change while one is in progress.
+   */
+  private void awaitAccepted(final String alias, final Runnable request) {
+    await(alias)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              request.run();
+              return true;
+            });
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -146,6 +146,23 @@ public interface ClusterActuator {
       @Param boolean dryRun);
 
   /**
+   * Request that the broker joins the given physical tenant's partition with the given priority.
+   * Partition ids restart at 1 in every physical tenant, so the partition is only identified by the
+   * two together.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     the physical tenant is unknown
+   */
+  @RequestLine("POST /brokers/{brokerId}/partitions/{partitionId}?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Body("%7B\"priority\": {priority}%7D")
+  PlannedOperationsResponse joinPartition(
+      @Param final int brokerId,
+      @Param final int partitionId,
+      @Param final int priority,
+      @Param final String physicalTenant);
+
+  /**
    * Request that the broker leaves the partition.
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
@@ -163,6 +180,19 @@ public interface ClusterActuator {
   @RequestLine("DELETE /brokers/{brokerId}/partitions/{partitionId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   PlannedOperationsResponse leavePartition(@Param final int brokerId, @Param final int partitionId);
+
+  /**
+   * Request that the broker leaves the given physical tenant's partition. Partition ids restart at
+   * 1 in every physical tenant, so the partition is only identified by the two together.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx), notably 404 if
+   *     the physical tenant is unknown
+   */
+  @RequestLine(
+      "DELETE /brokers/{brokerId}/partitions/{partitionId}?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse leavePartition(
+      @Param final int brokerId, @Param final int partitionId, @Param final String physicalTenant);
 
   /**
    * Queries the current cluster topology


### PR DESCRIPTION
`POST` and `DELETE /actuator/cluster/brokers/{brokerId}/partitions/{partitionId}` accept a `physicalTenant` query parameter and resolve the partition within that tenant's partition group. Unlike the other issues in this epic this was a correctness gap rather than a missing capability: partition ids restart at 1 in every physical tenant, so both endpoints resolved a bare `partitionId` against the default group and quietly acted on the wrong tenant instead of refusing.

An absent parameter keeps meaning the default physical tenant, not every tenant — a partition belongs to exactly one tenant, so the "apply to all tenants" reading the whole-cluster requests use has nothing to address here. That is the same choice `PATCH /routing-state` already makes, so its schema parameter is renamed for the meaning it carries rather than its one call site, and shared.

Both endpoints were reachable but absent from `cluster-api.yaml` entirely, so they are described there now, including the `priority` body the join takes. The controller binds that body to the schema's generated type instead of its own record, leaving one definition of the request rather than two that can drift.

Neither request could see the other partition groups before: they were served by an inline lambda returning a flat operation list, which the coordinator's default `phases()` projected onto the default group. Each now has a transformer of its own, planning into the group the request names and answering an unknown tenant with a 404, consistent with `GET /actuator/cluster`.

Replaces #60429, which GitHub permanently locked out of reopening after a merge-queue cascade closed it (the branch stack it was based on — #60424/#60420/#60348 — merged back-to-back and the base-retarget race left it without a valid base; the prior head force-push then blocked any reopen). Content is unchanged.

closes #60078
