### PR TITLE
Add RDBMS reader for agent definitions

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms;
 import io.camunda.db.rdbms.read.RdbmsTenantReaders;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
+import io.camunda.db.rdbms.read.service.AgentDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.AgentHistoryDbReader;
 import io.camunda.db.rdbms.read.service.AgentInstanceDbReader;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
@@ -228,6 +229,10 @@ public class RdbmsService {
 
   public HistoryDeletionDbReader getHistoryDeletionDbReader() {
     return tenantReaders.historyDeletionReader();
+  }
+
+  public AgentDefinitionDbReader getAgentDefinitionDbReader() {
+    return tenantReaders.agentDefinitionReader();
   }
 
   public AgentInstanceDbReader getAgentInstanceDbReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
@@ -112,7 +112,7 @@ public record RdbmsTenantReaders(
   public static RdbmsTenantReaders create(
       final RdbmsMapperBundle mappers, final RdbmsReaderConfig readerConfig) {
     return new RdbmsTenantReaders(
-        new AgentDefinitionDbReader(),
+        new AgentDefinitionDbReader(mappers.agentDefinitionMapper(), readerConfig),
         new AgentInstanceDbReader(mappers.agentInstanceMapper(), readerConfig),
         new AgentHistoryDbReader(mappers.agentHistoryMapper(), readerConfig),
         new AuditLogDbReader(mappers.auditLogMapper(), readerConfig),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AgentDefinitionDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AgentDefinitionDbQuery.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.filter.AgentDefinitionFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record AgentDefinitionDbQuery(
+    AgentDefinitionFilter filter,
+    List<String> authorizedResourceIds,
+    List<String> authorizedTenantIds,
+    DbQuerySorting<AgentDefinitionEntity> sort,
+    DbQueryPage page) {
+
+  public static AgentDefinitionDbQuery of(
+      final Function<AgentDefinitionDbQuery.Builder, ObjectBuilder<AgentDefinitionDbQuery>> fn) {
+    return fn.apply(new AgentDefinitionDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<AgentDefinitionDbQuery> {
+
+    private static final AgentDefinitionFilter EMPTY_FILTER =
+        FilterBuilders.agentDefinition().build();
+
+    private AgentDefinitionFilter filter;
+    private List<String> authorizedResourceIds;
+    private List<String> authorizedTenantIds;
+    private DbQuerySorting<AgentDefinitionEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final AgentDefinitionFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder authorizedResourceIds(final List<String> value) {
+      authorizedResourceIds = value;
+      return this;
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<AgentDefinitionEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<AgentDefinitionFilter.Builder, ObjectBuilder<AgentDefinitionFilter>> fn) {
+      return filter(FilterBuilders.agentDefinition(fn));
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<AgentDefinitionEntity>,
+                ObjectBuilder<DbQuerySorting<AgentDefinitionEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public AgentDefinitionDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(Collections.emptyList()));
+      authorizedResourceIds = Objects.requireNonNullElse(authorizedResourceIds, List.of());
+      authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
+      return new AgentDefinitionDbQuery(
+          filter, authorizedResourceIds, authorizedTenantIds, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentDefinitionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentDefinitionEntityMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
+import io.camunda.search.entities.AgentDefinitionEntity;
+
+public class AgentDefinitionEntityMapper {
+
+  public static AgentDefinitionEntity toEntity(final AgentDefinitionDbModel dbModel) {
+    if (dbModel == null) {
+      return null;
+    }
+    return new AgentDefinitionEntity(
+        dbModel.agentDefinitionKey(),
+        dbModel.agentType(),
+        nullToEmpty(dbModel.name()),
+        nullToEmpty(dbModel.elementId()),
+        nullToEmpty(dbModel.processDefinitionId()),
+        dbModel.processDefinitionKey(),
+        dbModel.processDefinitionVersion(),
+        dbModel.processDefinitionVersionTag(),
+        nullToEmpty(dbModel.tenantId()));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReader.java
@@ -8,16 +8,25 @@
 package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.db.rdbms.read.domain.AgentDefinitionDbQuery;
+import io.camunda.db.rdbms.read.mapper.AgentDefinitionEntityMapper;
 import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
 import io.camunda.db.rdbms.sql.columns.AgentDefinitionSearchColumn;
 import io.camunda.search.clients.reader.AgentDefinitionReader;
 import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AgentDefinitionDbReader extends AbstractEntityReader<AgentDefinitionEntity>
     implements AgentDefinitionReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AgentDefinitionDbReader.class);
 
   private final AgentDefinitionMapper agentDefinitionMapper;
 
@@ -28,10 +37,51 @@ public class AgentDefinitionDbReader extends AbstractEntityReader<AgentDefinitio
   }
 
   @Override
+  public @Nullable AgentDefinitionEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return search(
+            AgentDefinitionQuery.of(
+                b -> b.filter(f -> f.agentDefinitionKeys(key)).page(p -> p.from(0).size(1))))
+        .items()
+        .stream()
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
   public SearchQueryResult<AgentDefinitionEntity> search(
       final AgentDefinitionQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException(
-        "AgentDefinitionReader#search() not supported for RDBMS, see"
-            + " https://github.com/camunda/camunda/issues/59079");
+    final var dbSort = convertSort(query.sort(), AgentDefinitionSearchColumn.AGENT_DEFINITION_KEY);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return buildSearchQueryResult(0, List.of(), dbSort);
+    }
+    final var authorizedResourceIds =
+        resourceAccessChecks
+            .getAuthorizedResourceIdsByType()
+            .getOrDefault(AuthorizationResourceType.PROCESS_DEFINITION.name(), List.of());
+    final var dbPage = convertPaging(dbSort, query.page());
+    final var dbQuery =
+        AgentDefinitionDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedResourceIds(authorizedResourceIds)
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(dbPage));
+
+    LOG.trace("[RDBMS DB] Search for agent definitions with filter {}", dbQuery);
+    return executePagedQuery(
+        () -> agentDefinitionMapper.count(dbQuery),
+        () ->
+            agentDefinitionMapper.search(dbQuery).stream()
+                .map(AgentDefinitionEntityMapper::toEntity)
+                .toList(),
+        dbPage,
+        dbSort);
+  }
+
+  public SearchQueryResult<AgentDefinitionEntity> search(final AgentDefinitionQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReader.java
@@ -7,13 +7,25 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
+import io.camunda.db.rdbms.sql.columns.AgentDefinitionSearchColumn;
 import io.camunda.search.clients.reader.AgentDefinitionReader;
 import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 
-public class AgentDefinitionDbReader implements AgentDefinitionReader {
+public class AgentDefinitionDbReader extends AbstractEntityReader<AgentDefinitionEntity>
+    implements AgentDefinitionReader {
+
+  private final AgentDefinitionMapper agentDefinitionMapper;
+
+  public AgentDefinitionDbReader(
+      final AgentDefinitionMapper agentDefinitionMapper, final RdbmsReaderConfig readerConfig) {
+    super(AgentDefinitionSearchColumn.values(), readerConfig);
+    this.agentDefinitionMapper = agentDefinitionMapper;
+  }
 
   @Override
   public SearchQueryResult<AgentDefinitionEntity> search(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentDefinitionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentDefinitionMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.read.domain.AgentDefinitionDbQuery;
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
+import java.util.List;
+
+public interface AgentDefinitionMapper {
+
+  void insert(AgentDefinitionDbModel agentDefinition);
+
+  Long count(AgentDefinitionDbQuery query);
+
+  List<AgentDefinitionDbModel> search(AgentDefinitionDbQuery query);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentDefinitionSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentDefinitionSearchColumn.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.AgentDefinitionEntity;
+
+public enum AgentDefinitionSearchColumn implements SearchColumn<AgentDefinitionEntity> {
+  AGENT_DEFINITION_KEY("agentDefinitionKey"),
+  AGENT_TYPE("agentType"),
+  NAME("name"),
+  ELEMENT_ID("elementId"),
+  PROCESS_DEFINITION_ID("processDefinitionId"),
+  PROCESS_DEFINITION_KEY("processDefinitionKey"),
+  PROCESS_DEFINITION_VERSION("processDefinitionVersion"),
+  PROCESS_DEFINITION_VERSION_TAG("processDefinitionVersionTag"),
+  TENANT_ID("tenantId");
+
+  private final String property;
+
+  AgentDefinitionSearchColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<AgentDefinitionEntity> getEntityClass() {
+    return AgentDefinitionEntity.class;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsMapperBundle.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsMapperBundle.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
 import io.camunda.db.rdbms.sql.AgentHistoryMapper;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
@@ -51,6 +52,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 public record RdbmsMapperBundle(
     SqlSessionFactory sqlSessionFactory,
     VendorDatabaseProperties vendorDatabaseProperties,
+    AgentDefinitionMapper agentDefinitionMapper,
     AgentHistoryMapper agentHistoryMapper,
     AgentInstanceMapper agentInstanceMapper,
     AuditLogMapper auditLogMapper,
@@ -96,6 +98,7 @@ public record RdbmsMapperBundle(
     return new RdbmsMapperBundle(
         sqlSessionFactory,
         vendorDatabaseProperties,
+        sqlSession.getMapper(AgentDefinitionMapper.class),
         sqlSession.getMapper(AgentHistoryMapper.class),
         sqlSession.getMapper(AgentInstanceMapper.class),
         sqlSession.getMapper(AuditLogMapper.class),

--- a/db/rdbms/src/main/resources/mapper/AgentDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentDefinitionMapper.xml
@@ -10,6 +10,22 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.camunda.db.rdbms.sql.AgentDefinitionMapper">
 
+  <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel">
+    <constructor>
+      <idArg column="AGENT_DEFINITION_KEY" javaType="java.lang.Long" name="agentDefinitionKey"/>
+      <arg column="AGENT_TYPE"
+        javaType="io.camunda.search.entities.AgentDefinitionEntity$AgentType" name="agentType"/>
+      <arg column="NAME" javaType="java.lang.String" name="name"/>
+      <arg column="ELEMENT_ID" javaType="java.lang.String" name="elementId"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String" name="processDefinitionId"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long" name="processDefinitionKey"/>
+      <arg column="PROCESS_DEFINITION_VERSION" javaType="_int" name="processDefinitionVersion"/>
+      <arg column="PROCESS_DEFINITION_VERSION_TAG" javaType="java.lang.String"
+        name="processDefinitionVersionTag"/>
+      <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
+    </constructor>
+  </resultMap>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel">
     INSERT INTO ${prefix}AGENT_DEFINITION (
       AGENT_DEFINITION_KEY,
@@ -34,5 +50,101 @@
       #{tenantId}
     )
   </insert>
+
+  <select id="search"
+    parameterType="io.camunda.db.rdbms.read.domain.AgentDefinitionDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.AgentDefinitionMapper.searchResultMap">
+    SELECT * FROM (
+      SELECT
+        AGENT_DEFINITION_KEY,
+        AGENT_TYPE,
+        NAME,
+        ELEMENT_ID,
+        PROCESS_DEFINITION_ID,
+        PROCESS_DEFINITION_KEY,
+        PROCESS_DEFINITION_VERSION,
+        PROCESS_DEFINITION_VERSION_TAG,
+        TENANT_ID
+      FROM ${prefix}AGENT_DEFINITION
+      <include refid="io.camunda.db.rdbms.sql.AgentDefinitionMapper.searchAndAuthFilter"/>
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <select id="count"
+    parameterType="io.camunda.db.rdbms.read.domain.AgentDefinitionDbQuery"
+    resultType="java.lang.Long">
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}AGENT_DEFINITION
+      <include refid="io.camunda.db.rdbms.sql.AgentDefinitionMapper.searchAndAuthFilter"/>
+      ${count.limit}
+    ) t
+  </select>
+
+  <sql id="searchAndAuthFilter">
+    <where>
+      <include refid="io.camunda.db.rdbms.sql.AgentDefinitionMapper.searchFilter"/>
+    </where>
+  </sql>
+
+  <sql id="searchFilter">
+    <if test="filter.agentDefinitionKeyOperations != null and !filter.agentDefinitionKeyOperations.isEmpty()">
+      <foreach collection="filter.agentDefinitionKeyOperations" item="operation">
+        AND AGENT_DEFINITION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.agentTypeOperations != null and !filter.agentTypeOperations.isEmpty()">
+      <foreach collection="filter.agentTypeOperations" item="operation">
+        AND AGENT_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+      <foreach collection="filter.nameOperations" item="operation">
+        AND NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.elementIdOperations != null and !filter.elementIdOperations.isEmpty()">
+      <foreach collection="filter.elementIdOperations" item="operation">
+        AND ELEMENT_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionIdOperations" item="operation">
+        AND PROCESS_DEFINITION_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionKeyOperations" item="operation">
+        AND PROCESS_DEFINITION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionVersionOperations != null and !filter.processDefinitionVersionOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionVersionOperations" item="operation">
+        AND PROCESS_DEFINITION_VERSION
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionVersionTagOperations != null and !filter.processDefinitionVersionTagOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionVersionTagOperations" item="operation">
+        AND PROCESS_DEFINITION_VERSION_TAG
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+      <foreach collection="filter.tenantIdOperations" item="operation">
+        AND TENANT_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+  </sql>
 
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/AgentDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentDefinitionMapper.xml
@@ -86,6 +86,18 @@
 
   <sql id="searchAndAuthFilter">
     <where>
+      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+        AND PROCESS_DEFINITION_ID IN
+        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator="," close=")">
+          #{resourceId}
+        </foreach>
+      </if>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
       <include refid="io.camunda.db.rdbms.sql.AgentDefinitionMapper.searchFilter"/>
     </where>
   </sql>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReaderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel.AgentDefinitionDbModelBuilder;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentDefinitionDbReaderTest {
+
+  private final AgentDefinitionMapper agentDefinitionMapper = mock(AgentDefinitionMapper.class);
+  private final AgentDefinitionDbReader agentDefinitionDbReader =
+      new AgentDefinitionDbReader(agentDefinitionMapper, AbstractEntityReaderTest.TEST_CONFIG);
+
+  // ===== Entity mapping =====
+
+  @Test
+  void shouldReturnMappedEntitiesFromSearch() {
+    // given
+    when(agentDefinitionMapper.count(any())).thenReturn(2L);
+    when(agentDefinitionMapper.search(any()))
+        .thenReturn(
+            List.of(
+                new AgentDefinitionDbModelBuilder()
+                    .agentDefinitionKey(1L)
+                    .agentType(AgentType.AI_AGENT_TASK)
+                    .name("agent-1")
+                    .elementId("element-1")
+                    .processDefinitionId("myProcess")
+                    .processDefinitionKey(10L)
+                    .processDefinitionVersion(1)
+                    .processDefinitionVersionTag("v1")
+                    .tenantId("<default>")
+                    .build(),
+                new AgentDefinitionDbModelBuilder()
+                    .agentDefinitionKey(2L)
+                    .agentType(AgentType.AI_AGENT_TASK)
+                    .name("agent-2")
+                    .elementId("element-2")
+                    .processDefinitionId("myProcess")
+                    .processDefinitionKey(10L)
+                    .processDefinitionVersion(1)
+                    .processDefinitionVersionTag("v1")
+                    .tenantId("<default>")
+                    .build()));
+
+    // when
+    final var result =
+        agentDefinitionDbReader.search(
+            AgentDefinitionQuery.of(b -> b), ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(result.total()).isEqualTo(2L);
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items())
+        .extracting(AgentDefinitionEntity::agentDefinitionKey)
+        .containsExactly(1L, 2L);
+  }
+
+  // ===== getByKey =====
+
+  @Test
+  void shouldReturnEntityForGetByKey() {
+    // given
+    when(agentDefinitionMapper.count(any())).thenReturn(1L);
+    when(agentDefinitionMapper.search(any()))
+        .thenReturn(
+            List.of(
+                new AgentDefinitionDbModelBuilder()
+                    .agentDefinitionKey(42L)
+                    .agentType(AgentType.AI_AGENT_TASK)
+                    .name("agent-42")
+                    .elementId("element-42")
+                    .processDefinitionId("myProcess")
+                    .processDefinitionKey(10L)
+                    .processDefinitionVersion(1)
+                    .processDefinitionVersionTag("v1")
+                    .tenantId("<default>")
+                    .build()));
+
+    // when
+    final var entity = agentDefinitionDbReader.getByKey(42L, ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.agentDefinitionKey()).isEqualTo(42L);
+    verify(agentDefinitionMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().agentDefinitionKeyOperations().stream()
+                        .anyMatch(op -> op.value().equals(42L))));
+  }
+
+  @Test
+  void shouldReturnNullForGetByKeyWhenNotFound() {
+    // given
+    when(agentDefinitionMapper.count(any())).thenReturn(0L);
+    when(agentDefinitionMapper.search(any())).thenReturn(List.of());
+
+    // when
+    final var entity = agentDefinitionDbReader.getByKey(99L, ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(entity).isNull();
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReaderTest.java
@@ -11,17 +11,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.db.rdbms.read.domain.AgentDefinitionDbQuery;
 import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
 import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel.AgentDefinitionDbModelBuilder;
 import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.search.filter.AgentDefinitionFilter;
 import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class AgentDefinitionDbReaderTest {
 
@@ -120,5 +124,67 @@ class AgentDefinitionDbReaderTest {
 
     // then
     assertThat(entity).isNull();
+  }
+
+  // ===== Filter pass-through =====
+
+  @Test
+  void shouldPassFullFilterToQueryIntact() {
+    // given
+    when(agentDefinitionMapper.count(any())).thenReturn(1L);
+    when(agentDefinitionMapper.search(any()))
+        .thenReturn(
+            List.of(
+                new AgentDefinitionDbModelBuilder()
+                    .agentDefinitionKey(1L)
+                    .agentType(AgentType.AI_AGENT_TASK)
+                    .name("agent-1")
+                    .elementId("element-1")
+                    .processDefinitionId("myProcess")
+                    .processDefinitionKey(10L)
+                    .processDefinitionVersion(1)
+                    .processDefinitionVersionTag("v1")
+                    .tenantId("<default>")
+                    .build()));
+
+    final var filter =
+        AgentDefinitionFilter.of(
+            f ->
+                f.agentDefinitionKeys(1L)
+                    .agentTypes("AI_AGENT_TASK")
+                    .names("agent-name")
+                    .elementIds("element-id")
+                    .processDefinitionIds("process-definition-id")
+                    .processDefinitionKeys(2L)
+                    .processDefinitionVersions(3)
+                    .processDefinitionVersionTags("version-tag")
+                    .tenantIds("tenant-id"));
+
+    // when
+    agentDefinitionDbReader.search(
+        AgentDefinitionQuery.of(b -> b.filter(filter)), ResourceAccessChecks.disabled());
+
+    // then
+    final var queryCaptor = ArgumentCaptor.forClass(AgentDefinitionDbQuery.class);
+    verify(agentDefinitionMapper).search(queryCaptor.capture());
+    assertThat(queryCaptor.getValue().filter()).isEqualTo(filter);
+  }
+
+  // ===== Page-size edge case =====
+
+  @Test
+  void shouldReturnEmptyItemsButCorrectTotalWhenPageSizeIsZero() {
+    // given
+    when(agentDefinitionMapper.count(any())).thenReturn(42L);
+
+    // when
+    final var result =
+        agentDefinitionDbReader.search(
+            AgentDefinitionQuery.of(b -> b.page(p -> p.size(0))), ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(result.total()).isEqualTo(42L);
+    assertThat(result.items()).isEmpty();
+    verify(agentDefinitionMapper, times(0)).search(any());
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentDefinitionDbReaderTest.java
@@ -22,7 +22,10 @@ import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
 import io.camunda.search.filter.AgentDefinitionFilter;
 import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.security.core.authz.AuthorizationCheck;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.security.core.authz.TenantCheck;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -186,5 +189,109 @@ class AgentDefinitionDbReaderTest {
     assertThat(result.total()).isEqualTo(42L);
     assertThat(result.items()).isEmpty();
     verify(agentDefinitionMapper, times(0)).search(any());
+  }
+
+  // ===== Authorization early-exit =====
+
+  @Test
+  void shouldReturnEmptyResultWhenNoAuthorizedProcessDefinitionIds() {
+    // given
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                RequiredAuthorization.of(a -> a.processDefinition().readProcessDefinition())),
+            TenantCheck.disabled());
+
+    // when
+    final var result =
+        agentDefinitionDbReader.search(AgentDefinitionQuery.of(b -> b), resourceAccessChecks);
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.total()).isZero();
+    verify(agentDefinitionMapper, times(0)).search(any());
+    verify(agentDefinitionMapper, times(0)).count(any());
+  }
+
+  @Test
+  void shouldReturnEmptyResultWhenNoAuthorizedTenantIds() {
+    // given
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    // when
+    final var result =
+        agentDefinitionDbReader.search(AgentDefinitionQuery.of(b -> b), resourceAccessChecks);
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.total()).isZero();
+    verify(agentDefinitionMapper, times(0)).search(any());
+    verify(agentDefinitionMapper, times(0)).count(any());
+  }
+
+  // ===== Authorized ids reach the query =====
+
+  @Test
+  void shouldPassAuthorizedProcessDefinitionIdsToQuery() {
+    // given
+    final var authorizedIds = List.of("process-a", "process-b");
+    when(agentDefinitionMapper.count(any())).thenReturn(1L);
+    when(agentDefinitionMapper.search(any()))
+        .thenReturn(
+            List.of(
+                new AgentDefinitionDbModelBuilder()
+                    .agentDefinitionKey(1L)
+                    .agentType(AgentType.AI_AGENT_TASK)
+                    .name("agent-1")
+                    .elementId("element-1")
+                    .processDefinitionId("myProcess")
+                    .processDefinitionKey(10L)
+                    .processDefinitionVersion(1)
+                    .processDefinitionVersionTag("v1")
+                    .tenantId("<default>")
+                    .build()));
+
+    // when
+    agentDefinitionDbReader.search(
+        AgentDefinitionQuery.of(b -> b),
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                RequiredAuthorization.of(
+                    a -> a.processDefinition().readProcessDefinition().resourceIds(authorizedIds))),
+            TenantCheck.disabled()));
+
+    // then
+    verify(agentDefinitionMapper)
+        .search(argThat(q -> q.authorizedResourceIds().equals(authorizedIds)));
+  }
+
+  @Test
+  void shouldPassAuthorizedTenantIdsToQuery() {
+    // given
+    final var tenantIds = List.of("tenant-1", "tenant-2");
+    when(agentDefinitionMapper.count(any())).thenReturn(1L);
+    when(agentDefinitionMapper.search(any()))
+        .thenReturn(
+            List.of(
+                new AgentDefinitionDbModelBuilder()
+                    .agentDefinitionKey(1L)
+                    .agentType(AgentType.AI_AGENT_TASK)
+                    .name("agent-1")
+                    .elementId("element-1")
+                    .processDefinitionId("myProcess")
+                    .processDefinitionKey(10L)
+                    .processDefinitionVersion(1)
+                    .processDefinitionVersionTag("v1")
+                    .tenantId("<default>")
+                    .build()));
+
+    // when
+    agentDefinitionDbReader.search(
+        AgentDefinitionQuery.of(b -> b),
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(tenantIds)));
+
+    // then
+    verify(agentDefinitionMapper).search(argThat(q -> q.authorizedTenantIds().equals(tenantIds)));
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.sql.columns;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
@@ -200,7 +201,12 @@ public class SearchColumnTest {
               AgentInstanceStatus.class,
               List.of(
                   Tuple.of(AgentInstanceStatus.IDLE, AgentInstanceStatus.IDLE),
-                  Tuple.of(AgentInstanceStatus.IDLE, "IDLE"))));
+                  Tuple.of(AgentInstanceStatus.IDLE, "IDLE"))),
+          Map.entry(
+              AgentType.class,
+              List.of(
+                  Tuple.of(AgentType.AI_AGENT_TASK, AgentType.AI_AGENT_TASK),
+                  Tuple.of(AgentType.AI_AGENT_TASK, "AI_AGENT_TASK"))));
 
   private static List<Object[]> provideSearchColumns() {
     return SearchColumnUtils.findAll().stream()

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
 import io.camunda.db.rdbms.sql.AgentHistoryMapper;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
@@ -88,6 +89,7 @@ class RdbmsWriterFactoryTest {
     return new RdbmsMapperBundle(
         mock(SqlSessionFactory.class),
         mock(VendorDatabaseProperties.class),
+        mock(AgentDefinitionMapper.class),
         mock(AgentHistoryMapper.class),
         mock(AgentInstanceMapper.class),
         mock(AuditLogMapper.class),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionFilterIT.java
@@ -17,6 +17,7 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.AgentDefinitionEntity;
 import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
 import io.camunda.search.filter.AgentDefinitionFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -40,6 +41,78 @@ public class AgentDefinitionFilterIT {
             testApplication,
             new AgentDefinitionFilter.Builder()
                 .agentDefinitionKeys(model.agentDefinitionKey())
+                .build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByAgentDefinitionKeyIn(
+      final CamundaRdbmsTestApplication testApplication) {
+    final var model1 = createAndSaveRandomAgentDefinition(testApplication, b -> b);
+    final var model2 = createAndSaveRandomAgentDefinition(testApplication, b -> b);
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder()
+                .agentDefinitionKeyOperations(
+                    Operation.in(model1.agentDefinitionKey(), model2.agentDefinitionKey()))
+                .build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items())
+        .extracting(AgentDefinitionEntity::agentDefinitionKey)
+        .containsExactlyInAnyOrder(model1.agentDefinitionKey(), model2.agentDefinitionKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByNameLike(final CamundaRdbmsTestApplication testApplication) {
+    final String tenantId = "tenant-name-like-" + nextStringId();
+    final var model1 =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.tenantId(tenantId).name("expectedLike1"));
+    final var model2 =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.tenantId(tenantId).name("expectedLike2"));
+    createAndSaveRandomAgentDefinition(
+        testApplication, b -> b.tenantId(tenantId).name("different" + nextStringId()));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder()
+                .tenantIds(tenantId)
+                .nameOperations(Operation.like("expectedLike*"))
+                .build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items())
+        .extracting(AgentDefinitionEntity::agentDefinitionKey)
+        .containsExactlyInAnyOrder(model1.agentDefinitionKey(), model2.agentDefinitionKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByProcessDefinitionVersionRange(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String tenantId = "tenant-version-range-" + nextStringId();
+    createAndSaveRandomAgentDefinition(
+        testApplication, b -> b.tenantId(tenantId).processDefinitionVersion(1));
+    final var model =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.tenantId(tenantId).processDefinitionVersion(5));
+    createAndSaveRandomAgentDefinition(
+        testApplication, b -> b.tenantId(tenantId).processDefinitionVersion(9));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder()
+                .tenantIds(tenantId)
+                .processDefinitionVersionOperations(Operation.gt(2), Operation.lt(8))
                 .build());
 
     assertThat(result.total()).isEqualTo(1);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionFilterIT.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agentdefinition;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentDefinitionFixtures.createAndSaveRandomAgentDefinition;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.search.filter.AgentDefinitionFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.AgentDefinitionSort;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentDefinitionFilterIT {
+
+  @TestTemplate
+  public void shouldFilterByAgentDefinitionKey(final CamundaRdbmsTestApplication testApplication) {
+    final var model = createAndSaveRandomAgentDefinition(testApplication, b -> b);
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder()
+                .agentDefinitionKeys(model.agentDefinitionKey())
+                .build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByAgentType(final CamundaRdbmsTestApplication testApplication) {
+    final String tenantId = "tenant-agent-type-" + nextStringId();
+    final var model =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.tenantId(tenantId).agentType(AgentType.AI_AGENT_TASK));
+    createAndSaveRandomAgentDefinition(
+        testApplication, b -> b.tenantId(tenantId).agentType(AgentType.EXTERNAL_AGENT));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder()
+                .tenantIds(tenantId)
+                .agentTypes(AgentType.AI_AGENT_TASK.name())
+                .build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+    assertThat(result.items().getFirst().agentType()).isEqualTo(AgentType.AI_AGENT_TASK);
+  }
+
+  @TestTemplate
+  public void shouldFilterByName(final CamundaRdbmsTestApplication testApplication) {
+    final String name = "agent-name-" + nextStringId();
+    final var model = createAndSaveRandomAgentDefinition(testApplication, b -> b.name(name));
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        search(testApplication, new AgentDefinitionFilter.Builder().names(name).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+    assertThat(result.items().getFirst().name()).isEqualTo(name);
+  }
+
+  @TestTemplate
+  public void shouldFilterByElementId(final CamundaRdbmsTestApplication testApplication) {
+    final String elementId = "Task_specificElement-" + nextStringId();
+    final var model =
+        createAndSaveRandomAgentDefinition(testApplication, b -> b.elementId(elementId));
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        search(testApplication, new AgentDefinitionFilter.Builder().elementIds(elementId).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+    assertThat(result.items().getFirst().elementId()).isEqualTo(elementId);
+  }
+
+  @TestTemplate
+  public void shouldFilterByProcessDefinitionId(final CamundaRdbmsTestApplication testApplication) {
+    final String processDefinitionId = "myProcess-" + nextStringId();
+    final var model =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.processDefinitionId(processDefinitionId));
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder().processDefinitionIds(processDefinitionId).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+    assertThat(result.items().getFirst().processDefinitionId()).isEqualTo(processDefinitionId);
+  }
+
+  @TestTemplate
+  public void shouldFilterByProcessDefinitionKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final long processDefinitionKey = nextKey();
+    final var model =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.processDefinitionKey(processDefinitionKey));
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder()
+                .processDefinitionKeys(processDefinitionKey)
+                .build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+    assertThat(result.items().getFirst().processDefinitionKey()).isEqualTo(processDefinitionKey);
+  }
+
+  @TestTemplate
+  public void shouldFilterByProcessDefinitionVersion(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String tenantId = "tenant-version-" + nextStringId();
+    final var model =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.tenantId(tenantId).processDefinitionVersion(7));
+    createAndSaveRandomAgentDefinition(
+        testApplication, b -> b.tenantId(tenantId).processDefinitionVersion(8));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder()
+                .tenantIds(tenantId)
+                .processDefinitionVersions(7)
+                .build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+    assertThat(result.items().getFirst().processDefinitionVersion()).isEqualTo(7);
+  }
+
+  @TestTemplate
+  public void shouldFilterByProcessDefinitionVersionTag(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String versionTag = "version-tag-" + nextStringId();
+    final var model =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.processDefinitionVersionTag(versionTag));
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder().processDefinitionVersionTags(versionTag).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+    assertThat(result.items().getFirst().processDefinitionVersionTag()).isEqualTo(versionTag);
+  }
+
+  @TestTemplate
+  public void shouldFilterByTenantId(final CamundaRdbmsTestApplication testApplication) {
+    final String tenantId = "tenant-" + nextStringId();
+    createAndSaveRandomAgentDefinition(testApplication, b -> b.tenantId(tenantId));
+    createAndSaveRandomAgentDefinition(testApplication, b -> b.tenantId(tenantId));
+    createAndSaveRandomAgentDefinition(testApplication, b -> b.tenantId("<other>"));
+
+    final var result =
+        search(testApplication, new AgentDefinitionFilter.Builder().tenantIds(tenantId).build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items()).allMatch(e -> tenantId.equals(e.tenantId()));
+  }
+
+  private SearchQueryResult<AgentDefinitionEntity> search(
+      final CamundaRdbmsTestApplication testApplication, final AgentDefinitionFilter filter) {
+    return testApplication
+        .getRdbmsService()
+        .getAgentDefinitionDbReader()
+        .search(
+            new AgentDefinitionQuery(
+                filter, AgentDefinitionSort.of(b -> b), SearchQueryPage.of(b -> b)),
+            ResourceAccessChecks.disabled());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agentdefinition;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentDefinitionFixtures.createAndSaveRandomAgentDefinition;
+import static io.camunda.it.rdbms.db.fixtures.AgentDefinitionFixtures.createAndSaveRandomAgentDefinitions;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.filter.AgentDefinitionFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.sort.AgentDefinitionSort;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentDefinitionIT {
+
+  @TestTemplate
+  public void shouldCreateAndGetAgentDefinitionByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final AgentDefinitionDbModel model =
+        createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var entity =
+        testApplication
+            .getRdbmsService()
+            .getAgentDefinitionDbReader()
+            .getByKey(model.agentDefinitionKey(), ResourceAccessChecks.disabled());
+
+    assertThat(entity).isNotNull();
+    assertFieldsMatch(model, entity);
+  }
+
+  @TestTemplate
+  public void shouldReadBackNullVersionTagAsNull(
+      final CamundaRdbmsTestApplication testApplication) {
+    final AgentDefinitionDbModel model =
+        createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.processDefinitionVersionTag(null));
+
+    final var entity =
+        testApplication
+            .getRdbmsService()
+            .getAgentDefinitionDbReader()
+            .getByKey(model.agentDefinitionKey(), ResourceAccessChecks.disabled());
+
+    assertThat(entity).isNotNull();
+    assertThat(entity.processDefinitionVersionTag()).isNull();
+  }
+
+  @TestTemplate
+  public void shouldReturnNullForUnknownKey(final CamundaRdbmsTestApplication testApplication) {
+    final var entity =
+        testApplication
+            .getRdbmsService()
+            .getAgentDefinitionDbReader()
+            .getByKey(nextKey(), ResourceAccessChecks.disabled());
+
+    assertThat(entity).isNull();
+  }
+
+  @TestTemplate
+  public void shouldFindAllAgentDefinitionsPaged(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String tenantId = "tenant-paged-" + nextStringId();
+    createAndSaveRandomAgentDefinitions(testApplication, 20, b -> b.tenantId(tenantId));
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentDefinitionDbReader()
+            .search(
+                new AgentDefinitionQuery(
+                    new AgentDefinitionFilter.Builder().tenantIds(tenantId).build(),
+                    AgentDefinitionSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))),
+                ResourceAccessChecks.disabled());
+
+    assertThat(result).isNotNull();
+    assertThat(result.total()).isEqualTo(20);
+    assertThat(result.items()).hasSize(5);
+  }
+
+  private void assertFieldsMatch(
+      final AgentDefinitionDbModel dbModel, final AgentDefinitionEntity entity) {
+    assertThat(entity.agentDefinitionKey()).isEqualTo(dbModel.agentDefinitionKey());
+    assertThat(entity.agentType()).isEqualTo(dbModel.agentType());
+    assertThat(entity.name()).isEqualTo(dbModel.name());
+    assertThat(entity.elementId()).isEqualTo(dbModel.elementId());
+    assertThat(entity.processDefinitionId()).isEqualTo(dbModel.processDefinitionId());
+    assertThat(entity.processDefinitionKey()).isEqualTo(dbModel.processDefinitionKey());
+    assertThat(entity.processDefinitionVersion()).isEqualTo(dbModel.processDefinitionVersion());
+    assertThat(entity.processDefinitionVersionTag())
+        .isEqualTo(dbModel.processDefinitionVersionTag());
+    assertThat(entity.tenantId()).isEqualTo(dbModel.tenantId());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionIT.java
@@ -11,6 +11,8 @@ import static io.camunda.it.rdbms.db.fixtures.AgentDefinitionFixtures.createAndS
 import static io.camunda.it.rdbms.db.fixtures.AgentDefinitionFixtures.createAndSaveRandomAgentDefinitions;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.resourceAccessChecksFromResourceIds;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.resourceAccessChecksFromTenantIds;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
@@ -21,6 +23,7 @@ import io.camunda.search.filter.AgentDefinitionFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.search.sort.AgentDefinitionSort;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -94,6 +97,51 @@ public class AgentDefinitionIT {
     assertThat(result).isNotNull();
     assertThat(result.total()).isEqualTo(20);
     assertThat(result.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldFindAgentDefinitionByAuthorizedResourceId(
+      final CamundaRdbmsTestApplication testApplication) {
+    final AgentDefinitionDbModel model =
+        createAndSaveRandomAgentDefinition(testApplication, b -> b);
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentDefinitionDbReader()
+            .search(
+                AgentDefinitionQuery.of(b -> b),
+                resourceAccessChecksFromResourceIds(
+                    AuthorizationResourceType.PROCESS_DEFINITION, model.processDefinitionId()));
+
+    assertThat(result).isNotNull();
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
+  }
+
+  @TestTemplate
+  public void shouldFindAgentDefinitionByAuthorizedTenantId(
+      final CamundaRdbmsTestApplication testApplication) {
+    final AgentDefinitionDbModel model =
+        createAndSaveRandomAgentDefinition(testApplication, b -> b);
+    createAndSaveRandomAgentDefinition(testApplication, b -> b);
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentDefinitionDbReader()
+            .search(
+                AgentDefinitionQuery.of(b -> b),
+                resourceAccessChecksFromTenantIds(model.tenantId()));
+
+    assertThat(result).isNotNull();
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().agentDefinitionKey())
+        .isEqualTo(model.agentDefinitionKey());
   }
 
   private void assertFieldsMatch(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentdefinition/AgentDefinitionSortIT.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agentdefinition;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentDefinitionFixtures.createAndSaveRandomAgentDefinition;
+import static io.camunda.it.rdbms.db.fixtures.AgentDefinitionFixtures.createAndSaveRandomAgentDefinitions;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentDefinitionEntity;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import io.camunda.search.filter.AgentDefinitionFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.search.sort.AgentDefinitionSort;
+import io.camunda.search.sort.AgentDefinitionSort.Builder;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentDefinitionSortIT {
+
+  @TestTemplate
+  public void shouldSortByAgentDefinitionKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.agentDefinitionKey().asc(),
+        Comparator.comparingLong(AgentDefinitionEntity::agentDefinitionKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByAgentDefinitionKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.agentDefinitionKey().desc(),
+        Comparator.comparingLong(AgentDefinitionEntity::agentDefinitionKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByAgentTypeAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByAgentType(
+        testApplication, b -> b.agentType().asc(), Comparator.comparing(e -> e.agentType().name()));
+  }
+
+  @TestTemplate
+  public void shouldSortByAgentTypeDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByAgentType(
+        testApplication,
+        b -> b.agentType().desc(),
+        Comparator.comparing((AgentDefinitionEntity e) -> e.agentType().name()).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication, b -> b.name().asc(), Comparator.comparing(AgentDefinitionEntity::name));
+  }
+
+  @TestTemplate
+  public void shouldSortByNameDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.name().desc(),
+        Comparator.comparing(AgentDefinitionEntity::name).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByElementIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.elementId().asc(),
+        Comparator.comparing(AgentDefinitionEntity::elementId));
+  }
+
+  @TestTemplate
+  public void shouldSortByElementIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.elementId().desc(),
+        Comparator.comparing(AgentDefinitionEntity::elementId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionIdAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.processDefinitionId().asc(),
+        Comparator.comparing(AgentDefinitionEntity::processDefinitionId));
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionIdDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.processDefinitionId().desc(),
+        Comparator.comparing(AgentDefinitionEntity::processDefinitionId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionKeyAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.processDefinitionKey().asc(),
+        Comparator.comparingLong(AgentDefinitionEntity::processDefinitionKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.processDefinitionKey().desc(),
+        Comparator.comparingLong(AgentDefinitionEntity::processDefinitionKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionVersionAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByProcessDefinitionVersion(
+        testApplication,
+        b -> b.processDefinitionVersion().asc(),
+        Comparator.comparingInt(AgentDefinitionEntity::processDefinitionVersion));
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionVersionDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByProcessDefinitionVersion(
+        testApplication,
+        b -> b.processDefinitionVersion().desc(),
+        Comparator.comparingInt(AgentDefinitionEntity::processDefinitionVersion).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionVersionTagAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.processDefinitionVersionTag().asc(),
+        Comparator.comparing(AgentDefinitionEntity::processDefinitionVersionTag));
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionVersionTagDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSortingByTenantIdMarker(
+        testApplication,
+        b -> b.processDefinitionVersionTag().desc(),
+        Comparator.comparing(AgentDefinitionEntity::processDefinitionVersionTag).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByProcessDefinitionIdMarker(
+        testApplication,
+        b -> b.tenantId().asc(),
+        Comparator.comparing(AgentDefinitionEntity::tenantId));
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingByProcessDefinitionIdMarker(
+        testApplication,
+        b -> b.tenantId().desc(),
+        Comparator.comparing(AgentDefinitionEntity::tenantId).reversed());
+  }
+
+  /**
+   * Seeds 5 definitions sharing one tenantId (used purely to isolate this test's rows from other
+   * tests' data) while the field under test keeps the distinct value the fixture already assigns
+   * per created row.
+   */
+  private void testSortingByTenantIdMarker(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<AgentDefinitionSort>> sortBuilder,
+      final Comparator<AgentDefinitionEntity> comparator) {
+    final String tenantId = "tenant-sort-" + nextStringId();
+    createAndSaveRandomAgentDefinitions(testApplication, 5, b -> b.tenantId(tenantId));
+
+    final var items =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder().tenantIds(tenantId).build(),
+            sortBuilder);
+
+    assertThat(items).hasSize(5);
+    assertThat(items).isSortedAccordingTo(comparator);
+  }
+
+  /**
+   * Mirror of {@link #testSortingByTenantIdMarker} for the tenantId sort itself: isolates via a
+   * fixed processDefinitionId while tenantId keeps its distinct per-row default value.
+   */
+  private void testSortingByProcessDefinitionIdMarker(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<AgentDefinitionSort>> sortBuilder,
+      final Comparator<AgentDefinitionEntity> comparator) {
+    final String processDefinitionId = "process-sort-" + nextStringId();
+    createAndSaveRandomAgentDefinitions(
+        testApplication, 5, b -> b.processDefinitionId(processDefinitionId));
+
+    final var items =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder().processDefinitionIds(processDefinitionId).build(),
+            sortBuilder);
+
+    assertThat(items).hasSize(5);
+    assertThat(items).isSortedAccordingTo(comparator);
+  }
+
+  /**
+   * agentType only has 3 valid values, so the fixture's random default cannot be relied on for
+   * distinctness across a batch. Seed exactly one definition per {@link AgentType} instead.
+   */
+  private void testSortingByAgentType(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<AgentDefinitionSort>> sortBuilder,
+      final Comparator<AgentDefinitionEntity> comparator) {
+    final String tenantId = "tenant-sort-" + nextStringId();
+    for (final AgentType type : AgentType.values()) {
+      createAndSaveRandomAgentDefinition(
+          testApplication, b -> b.tenantId(tenantId).agentType(type));
+    }
+
+    final var items =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder().tenantIds(tenantId).build(),
+            sortBuilder);
+
+    assertThat(items).hasSize(AgentType.values().length);
+    assertThat(items).isSortedAccordingTo(comparator);
+  }
+
+  /**
+   * processDefinitionVersion is always 1 in the fixture default, so it must be assigned distinct
+   * values explicitly per row for the sort order to be unambiguous.
+   */
+  private void testSortingByProcessDefinitionVersion(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<AgentDefinitionSort>> sortBuilder,
+      final Comparator<AgentDefinitionEntity> comparator) {
+    final String tenantId = "tenant-sort-" + nextStringId();
+    for (int i = 0; i < 5; i++) {
+      final int version = i + 1;
+      createAndSaveRandomAgentDefinition(
+          testApplication, b -> b.tenantId(tenantId).processDefinitionVersion(version));
+    }
+
+    final var items =
+        search(
+            testApplication,
+            new AgentDefinitionFilter.Builder().tenantIds(tenantId).build(),
+            sortBuilder);
+
+    assertThat(items).hasSize(5);
+    assertThat(items).isSortedAccordingTo(comparator);
+  }
+
+  private List<AgentDefinitionEntity> search(
+      final CamundaRdbmsTestApplication testApplication,
+      final AgentDefinitionFilter filter,
+      final Function<Builder, ObjectBuilder<AgentDefinitionSort>> sortBuilder) {
+    return testApplication
+        .getRdbmsService()
+        .getAgentDefinitionDbReader()
+        .search(
+            new AgentDefinitionQuery(
+                filter,
+                AgentDefinitionSort.of(sortBuilder),
+                SearchQueryPage.of(b -> b.from(0).size(20))),
+            ResourceAccessChecks.disabled())
+        .items();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentDefinitionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentDefinitionFixtures.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
+import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel.AgentDefinitionDbModelBuilder;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentDefinitionEntity.AgentType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public final class AgentDefinitionFixtures extends CommonFixtures {
+
+  private AgentDefinitionFixtures() {}
+
+  public static AgentDefinitionDbModel createRandomAgentDefinition(
+      final Function<AgentDefinitionDbModelBuilder, AgentDefinitionDbModelBuilder>
+          builderFunction) {
+    final var key = nextKey();
+    final var builder =
+        new AgentDefinitionDbModelBuilder()
+            .agentDefinitionKey(key)
+            .agentType(randomEnum(AgentType.class))
+            .name("agent-" + nextStringId())
+            .elementId("element-" + key)
+            .processDefinitionId("process-" + nextStringKey())
+            .processDefinitionKey(nextKey())
+            .processDefinitionVersion(1)
+            .processDefinitionVersionTag("v-" + nextStringId())
+            .tenantId("tenant-" + key);
+    return builderFunction.apply(builder).build();
+  }
+
+  public static List<AgentDefinitionDbModel> createAndSaveRandomAgentDefinitions(
+      final CamundaRdbmsTestApplication testApplication,
+      final int count,
+      final Function<AgentDefinitionDbModelBuilder, AgentDefinitionDbModelBuilder>
+          builderFunction) {
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    final List<AgentDefinitionDbModel> models = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      final AgentDefinitionDbModel model = createRandomAgentDefinition(builderFunction);
+      models.add(model);
+      rdbmsWriters.getAgentDefinitionWriter().create(model);
+    }
+    rdbmsWriters.flush();
+    return models;
+  }
+
+  public static AgentDefinitionDbModel createAndSaveRandomAgentDefinition(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<AgentDefinitionDbModelBuilder, AgentDefinitionDbModelBuilder>
+          builderFunction) {
+    return createAndSaveRandomAgentDefinitions(testApplication, 1, builderFunction).getFirst();
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
@@ -57,10 +57,8 @@ class RdbmsDbModelCoverageArchTest {
           // UsageMetricIT
           "UsageMetricTUTenantStatisticsDbModel", // TU tenant statistics variant; covered by
           // UsageMetricIT
-          "ClusterVariableMetadataDbModel", // metadata sub-entity of ClusterVariable; covered by
-          // ClusterVariableIT
-          "AgentDefinitionDbModel"); // no read/search API yet (issue #59072 is write-only);
-  // add AgentDefinitionIT once #59079 implements AgentDefinitionDbReader#search()
+          "ClusterVariableMetadataDbModel"); // metadata sub-entity of ClusterVariable; covered by
+  // ClusterVariableIT
 
   // IT class simple names scanned from test-jars once at class-load time.
   static final Set<String> IT_SIMPLE_NAMES =

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
@@ -55,8 +55,6 @@ class RdbmsDbModelSortITCoverageArchTest {
           "TenantMemberDbModel", // member sub-entity; no TenantMemberSortIT
           "RoleMemberDbModel", // member sub-entity; no RoleMemberSortIT
           "ClusterVariableMetadataDbModel", // metadata sub-entity; covered by ClusterVariableIT
-          "AgentDefinitionDbModel", // no read/search API yet (issue #59072 is write-only); add
-          // AgentDefinitionSortIT once #59079 implements AgentDefinitionDbReader#search()
           "ProcessDefinitionVariableNameLookupDbModel", // variable-name cache; has an IT but no
           // sort fields
           "BatchOperationErrorDbModel", // error sub-entity of BatchOperation; no sort fields


### PR DESCRIPTION
## Description

Agent definitions can now be searched and fetched by key on RDBMS deployments, matching what's already possible on Elasticsearch/OpenSearch deployments:
- Filter on any of the nine fields, using `IN`, `LIKE`, and range operators, not just equality.
- Sort by any of the nine fields.
- Search results are scoped to the caller's authorized process-definition IDs and tenant IDs.
- A definition with no version tag reads back as `null`, not an empty string.

Before this, RDBMS deployments returned a 500 on the agent-definition REST endpoints (#60042), because the read path was a stub.

Out of scope, tracked elsewhere:
- End-to-end/acceptance coverage for agent definitions, on any backend. Tracked by #59096, and additionally blocked on Java client support for agent definitions, which doesn't exist yet.
- Authorization enforcement on the get-by-key path. `AgentDefinitionServices.getByKey` already resolves this via the shared post-fetch mechanism, scoped to `READ_PROCESS_DEFINITION` on the agent definition's owning process-definition id — the identical pattern `AgentInstanceServices.getByKey` uses, proven end-to-end by `AgentInstanceAuthorizationIT`. No equivalent `AgentDefinitionAuthorizationIT` exists yet to prove it for agent definitions specifically; that's part of #59096's scope, not this PR's.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59079