### PR TITLE
Expose the lease opt-in on the Java client streaming worker (3/3)

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
@@ -107,7 +107,13 @@ public interface ActivateJobsCommandStep1
      * Activate the jobs with a lease. When enabled, each activated job is assigned a distinct lease
      * token, returned as {@link io.camunda.client.api.response.ActivatedJob#getLeaseToken()
      * ActivatedJob#getLeaseToken()}. The lease token fences the complete, fail, and throw-error
-     * commands against a superseded activation of the same job.
+     * commands against a superseded activation of the same job: a command carrying a stale or
+     * missing token is rejected. An update-job command honors a supplied lease token the same way,
+     * but an update without one always applies, so operator and bulk updates of leased jobs remain
+     * possible.
+     *
+     * <p>Once a job has been activated with a lease, it is served only to leasing workers of that
+     * job type; a homogeneous fleet per job type is recommended.
      *
      * <p>If not set, jobs are activated without a lease.
      *

--- a/clients/java/src/main/java/io/camunda/client/api/command/StreamJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/StreamJobsCommandStep1.java
@@ -102,5 +102,25 @@ public interface StreamJobsCommandStep1 {
      *     it to the broker.
      */
     StreamJobsCommandStep3 fetchVariables(String... fetchVariables);
+
+    /**
+     * Stream the jobs with a lease. When enabled, each activated job is assigned a distinct lease
+     * token, returned as {@link io.camunda.client.api.response.ActivatedJob#getLeaseToken()
+     * ActivatedJob#getLeaseToken()}. The lease token fences the complete, fail, and throw-error
+     * commands against a superseded activation of the same job: a command carrying a stale or
+     * missing token is rejected. An update-job command honors a supplied lease token the same way,
+     * but an update without one always applies, so operator and bulk updates of leased jobs remain
+     * possible.
+     *
+     * <p>Once a job has been activated with a lease, it is served only to leasing streams of that
+     * job type; a homogeneous fleet of leasing streams per job type is recommended.
+     *
+     * <p>If not set, jobs are streamed without a lease.
+     *
+     * @param withLease whether to stream the jobs with a lease
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    StreamJobsCommandStep3 withLease(boolean withLease);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
@@ -185,11 +185,17 @@ public interface JobWorkerBuilderStep1 {
     JobWorkerBuilderStep3 fetchVariables(String... fetchVariables);
 
     /**
-     * Activate the jobs polled by this worker with a lease. When enabled, each activated job is
-     * assigned a distinct lease token, fencing the complete, fail, and throw-error commands against
-     * a superseded activation of the same job.
+     * Activate the jobs handled by this worker with a lease, whether it polls or streams. When
+     * enabled, each activated job is assigned a distinct lease token, fencing the complete, fail,
+     * and throw-error commands against a superseded activation of the same job: a command carrying
+     * a stale or missing token is rejected. An update-job command honors a supplied lease token the
+     * same way, but an update without one always applies, so operator and bulk updates of leased
+     * jobs remain possible.
      *
-     * <p>Only applies to the polling path. If not set, jobs are activated without a lease.
+     * <p>Once a job has been activated with a lease, it is served only to leasing workers of that
+     * job type; a homogeneous fleet per job type is recommended.
+     *
+     * <p>If not set, jobs are activated without a lease.
      *
      * @param withLease whether to activate the jobs with a lease
      * @return the builder for this worker

--- a/clients/java/src/main/java/io/camunda/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/StreamJobsCommandImpl.java
@@ -154,6 +154,12 @@ public final class StreamJobsCommandImpl
   }
 
   @Override
+  public StreamJobsCommandStep3 withLease(final boolean withLease) {
+    builder.setWithLease(withLease);
+    return this;
+  }
+
+  @Override
   public StreamJobsCommandStep3 tenantId(final String tenantId) {
     customTenantIds.add(tenantId);
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
@@ -202,6 +202,11 @@ final class JobStreamerImpl implements JobStreamer {
     if (fetchVariables != null) {
       command = command.fetchVariables(fetchVariables);
     }
+    // only set when true: an explicit false is still sent over the wire, which would break
+    // rolling upgrades against a gateway that doesn't yet know this field
+    if (withLease) {
+      command.withLease(true);
+    }
 
     return command;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
@@ -55,6 +55,7 @@ final class JobStreamerImpl implements JobStreamer {
   private final TenantFilter tenantFilter;
   private final Duration streamTimeout;
   private final Duration streamInactivityTimeout;
+  private final boolean withLease;
   private final BackoffSupplier backoffSupplier;
   private final ScheduledExecutorService executor;
   private final LongSupplier nanoClock;
@@ -97,7 +98,8 @@ final class JobStreamerImpl implements JobStreamer {
       final BackoffSupplier backoffSupplier,
       final ScheduledExecutorService executor,
       final LongSupplier nanoClock,
-      final JobWorkerMetrics metrics) {
+      final JobWorkerMetrics metrics,
+      final boolean withLease) {
     this.jobClient = jobClient;
     this.jobType = jobType;
     this.workerName = workerName;
@@ -107,6 +109,7 @@ final class JobStreamerImpl implements JobStreamer {
     this.tenantFilter = tenantFilter;
     this.streamTimeout = streamTimeout;
     this.streamInactivityTimeout = streamInactivityTimeout;
+    this.withLease = withLease;
     this.backoffSupplier = backoffSupplier;
     this.executor = executor;
     this.nanoClock = nanoClock;

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -270,7 +270,7 @@ public final class JobWorkerBuilderImpl
               scheduledExecutor,
               System::nanoTime,
               metrics,
-              false);
+              withLease);
       jobExecutor = new BlockingExecutor(jobHandlingExecutor, maxJobsActive, timeout);
     } else {
       jobStreamer = JobStreamer.noop();

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -269,7 +269,8 @@ public final class JobWorkerBuilderImpl
               backoffSupplier,
               scheduledExecutor,
               System::nanoTime,
-              metrics);
+              metrics,
+              false);
       jobExecutor = new BlockingExecutor(jobHandlingExecutor, maxJobsActive, timeout);
     } else {
       jobStreamer = JobStreamer.noop();

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
@@ -167,6 +167,28 @@ final class JobStreamImplTest {
   }
 
   @Test
+  void shouldSetWithLease() {
+    // given
+    jobStreamer = createStreamer(Duration.ofHours(8), null, true);
+    final StreamActivatedJobsRequest expectedRequest =
+        StreamActivatedJobsRequest.newBuilder()
+            .setType("type")
+            .setWorker("worker")
+            .setTimeout(Duration.ofSeconds(10).toMillis())
+            .addFetchVariable("foo")
+            .addFetchVariable("bar")
+            .addTenantIds("test-tenant")
+            .setWithLease(true)
+            .build();
+
+    // when
+    jobStreamer.openStreamer(ignored -> {});
+
+    // then
+    assertThat(service.lastRequest()).isEqualTo(expectedRequest);
+  }
+
+  @Test
   void shouldForwardJobsToConsumer() {
     // given
     final List<ActivatedJob> jobs = new ArrayList<>();
@@ -447,6 +469,13 @@ final class JobStreamImplTest {
 
   private JobStreamerImpl createStreamer(
       final Duration streamingTimeout, final Duration streamInactivityTimeout) {
+    return createStreamer(streamingTimeout, streamInactivityTimeout, false);
+  }
+
+  private JobStreamerImpl createStreamer(
+      final Duration streamingTimeout,
+      final Duration streamInactivityTimeout,
+      final boolean withLease) {
     return new JobStreamerImpl(
         client,
         "type",
@@ -461,7 +490,7 @@ final class JobStreamImplTest {
         scheduler,
         virtualNanos::get,
         metrics,
-        false);
+        withLease);
   }
 
   private void advanceTime(final long amount, final TimeUnit unit) {

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
@@ -460,7 +460,8 @@ final class JobStreamImplTest {
         ignored -> 10_000L,
         scheduler,
         virtualNanos::get,
-        metrics);
+        metrics,
+        false);
   }
 
   private void advanceTime(final long amount, final TimeUnit unit) {

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -420,6 +420,57 @@ class JobWorkerBuilderImplTest {
         () -> assertThat(tenantIdCaptor.getValue()).containsExactlyInAnyOrder("1", "2", "3", "4"));
   }
 
+  @Test
+  void shouldForwardWithLeaseOnStream() {
+    // given
+    final StreamJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
+    Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
+        .thenReturn(lastStep);
+    Mockito.when(lastStep.tenantIds(anyList())).thenReturn(lastStep);
+    Mockito.when(lastStep.tenantFilter(any(TenantFilter.class))).thenReturn(lastStep);
+    Mockito.when(lastStep.withLease(anyBoolean())).thenReturn(lastStep);
+    Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
+
+    // when
+    jobWorkerBuilder
+        .jobType("type")
+        .handler((c, j) -> {})
+        .timeout(1)
+        .name("test")
+        .maxJobsActive(30)
+        .streamEnabled(true)
+        .withLease(true)
+        .open();
+
+    // then
+    await(() -> verify(lastStep).withLease(true));
+  }
+
+  @Test
+  void shouldNotForwardWithLeaseOnStreamByDefault() {
+    // given - a streaming worker that never opts into withLease
+    final StreamJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
+    Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
+        .thenReturn(lastStep);
+    Mockito.when(lastStep.tenantIds(anyList())).thenReturn(lastStep);
+    Mockito.when(lastStep.tenantFilter(any(TenantFilter.class))).thenReturn(lastStep);
+    Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
+
+    // when
+    jobWorkerBuilder
+        .jobType("type")
+        .handler((c, j) -> {})
+        .timeout(1)
+        .name("test")
+        .maxJobsActive(30)
+        .streamEnabled(true)
+        .open();
+
+    // then - withLease must never be called at all, mirroring the poll-path contract: the field
+    // stays absent on the wire rather than an explicit false that older gateways would reject
+    await(() -> verify(lastStep, never()).withLease(anyBoolean()));
+  }
+
   private void await(final ThrowingRunnable throwingRunnable) {
     Awaitility.await()
         .ignoreExceptions()

--- a/clients/java/src/test/java/io/camunda/client/job/StreamJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/StreamJobsTest.java
@@ -138,6 +138,23 @@ public final class StreamJobsTest extends ClientTest {
   }
 
   @Test
+  public void shouldSurfaceLeaseTokenOnStreamedJob() {
+    // given - a leased job pushed over the stream, as a gateway would send when the stream was
+    // opened with withLease(true)
+    final List<io.camunda.client.api.response.ActivatedJob> receivedJobs = new ArrayList<>();
+    final ActivatedJob activatedJob =
+        ActivatedJob.newBuilder().setKey(12).setType("foo").setLeaseToken("lease-token-1").build();
+    gatewayService.onStreamJobsRequest(activatedJob);
+
+    // when
+    client.newStreamJobsCommand().jobType("foo").consumer(receivedJobs::add).send().join();
+
+    // then
+    assertThat(receivedJobs).hasSize(1);
+    assertThat(receivedJobs.get(0).getLeaseToken()).isEqualTo("lease-token-1");
+  }
+
+  @Test
   public void shouldSetTimeoutFromDuration() {
     // given
     final Duration timeout = Duration.ofMinutes(2);

--- a/clients/java/src/test/java/io/camunda/client/job/StreamJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/StreamJobsTest.java
@@ -335,6 +335,32 @@ public final class StreamJobsTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetWithLease() {
+    // when
+    client
+        .newStreamJobsCommand()
+        .jobType("foo")
+        .consumer(ignored -> {})
+        .withLease(true)
+        .send()
+        .join();
+
+    // then
+    final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getWithLease()).isTrue();
+  }
+
+  @Test
+  public void shouldNotSetWithLeaseByDefault() {
+    // when
+    client.newStreamJobsCommand().jobType("foo").consumer(ignored -> {}).send().join();
+
+    // then
+    final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getWithLease()).isFalse();
+  }
+
+  @Test
   public void shouldSetAssignedTenantFilter() {
     // given
     client

--- a/clients/java/src/test/java/io/camunda/client/job/StreamJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/StreamJobsTest.java
@@ -116,6 +116,7 @@ public final class StreamJobsTest extends ClientTest {
     assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob1.getVariables());
     assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
+    assertThat(job.getLeaseToken()).isNull();
 
     job = receivedJobs.get(1);
     assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());
@@ -135,6 +136,7 @@ public final class StreamJobsTest extends ClientTest {
     assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob2.getVariables());
     assertThat(job.getTenantId()).isEqualTo(activatedJob2.getTenantId());
+    assertThat(job.getLeaseToken()).isNull();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/StreamJobsWithLeaseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/StreamJobsWithLeaseIT.java
@@ -15,7 +15,9 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.Strings;
@@ -65,6 +67,7 @@ final class StreamJobsWithLeaseIT {
             .withLease(true)
             .open()) {
       // when
+      awaitStreamRegistered(jobType);
       client.newCreateInstanceCommand().bpmnProcessId(jobType).latestVersion().send().join();
       Awaitility.await("until the streamed job is received")
           .atMost(Duration.ofSeconds(10))
@@ -102,6 +105,8 @@ final class StreamJobsWithLeaseIT {
             .streamEnabled(true)
             .withLease(true)
             .open()) {
+      // when
+      awaitStreamRegistered(jobType);
       client.newCreateInstanceCommand().bpmnProcessId(jobType).latestVersion().send().join();
       Awaitility.await("until the streamed job is received")
           .atMost(Duration.ofSeconds(10))
@@ -121,5 +126,15 @@ final class StreamJobsWithLeaseIT {
       assertThatThrownBy(() -> client.newCompleteCommand(job.getKey()).send().join())
           .hasMessageContaining(expectedMessage);
     }
+  }
+
+  private void awaitStreamRegistered(final String jobType) {
+    final var actuator = JobStreamActuator.of(zeebe);
+    Awaitility.await("until stream with type '%s' is registered".formatted(jobType))
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(actuator)
+                    .remoteStreams()
+                    .haveJobType(1, jobType));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/StreamJobsWithLeaseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/StreamJobsWithLeaseIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobWorker;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies end-to-end (real gRPC + real broker) that a streaming worker opted into {@code
+ * withLease} receives a lease token on each activated job, and that the token fences job completion
+ * the same way it does on the poll path (see {@link CompleteJobTest}).
+ */
+@ZeebeIntegration
+final class StreamJobsWithLeaseIT {
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker")
+  private static TestStandaloneBroker zeebe;
+
+  @AutoClose private final CamundaClient client = zeebe.newClientBuilder().build();
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    zeebe = new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+  }
+
+  @Test
+  void shouldCarryLeaseTokenOnStreamedJobAndAllowCompletionWithIt() {
+    // given
+    final var jobType = Strings.newRandomValidBpmnId();
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(jobType)
+            .startEvent()
+            .serviceTask("task", b -> b.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    final var receivedJobs = new CopyOnWriteArrayList<ActivatedJob>();
+    try (final JobWorker ignored =
+        client
+            .newWorker()
+            .jobType(jobType)
+            .handler((c, j) -> receivedJobs.add(j))
+            .streamEnabled(true)
+            .withLease(true)
+            .open()) {
+      // when
+      client.newCreateInstanceCommand().bpmnProcessId(jobType).latestVersion().send().join();
+      Awaitility.await("until the streamed job is received")
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(() -> assertThat(receivedJobs).hasSize(1));
+      final ActivatedJob job = receivedJobs.get(0);
+
+      // then
+      assertThat(job.getLeaseToken())
+          .describedAs("Expected the streamed job to carry a lease token")
+          .isNotEmpty();
+
+      // completing with the lease token carried on the job must succeed
+      client.newCompleteCommand(job).send().join();
+    }
+  }
+
+  @Test
+  void shouldRejectCompletingStreamedLeasedJobWithoutMatchingLeaseToken() {
+    // given
+    final var jobType = Strings.newRandomValidBpmnId();
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(jobType)
+            .startEvent()
+            .serviceTask("task", b -> b.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    final var receivedJobs = new CopyOnWriteArrayList<ActivatedJob>();
+    try (final JobWorker ignored =
+        client
+            .newWorker()
+            .jobType(jobType)
+            .handler((c, j) -> receivedJobs.add(j))
+            .streamEnabled(true)
+            .withLease(true)
+            .open()) {
+      client.newCreateInstanceCommand().bpmnProcessId(jobType).latestVersion().send().join();
+      Awaitility.await("until the streamed job is received")
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(() -> assertThat(receivedJobs).hasSize(1));
+      final ActivatedJob job = receivedJobs.get(0);
+      assertThat(job.getLeaseToken())
+          .describedAs("Expected the streamed job to carry a lease token")
+          .isNotEmpty();
+
+      // when / then - completing by job key alone carries no lease token, so a leased job must
+      // reject it the same way the poll path does
+      final var expectedMessage =
+          String.format(
+              "Expected to process job with key '%d', but a matching lease token must be provided "
+                  + "because the job is currently leased",
+              job.getKey());
+      assertThatThrownBy(() -> client.newCompleteCommand(job.getKey()).send().join())
+          .hasMessageContaining(expectedMessage);
+    }
+  }
+}


### PR DESCRIPTION
## Description

**A lease-configured streaming worker no longer silently drops its lease.** The streaming command and the worker builder now expose `withLease`, and a worker built with `.withLease(true).streamEnabled(true)` registers a leasing stream instead of a non-leasing one. This is PR 3 of the 3-PR stack for #56457 (PR1 #59894, PR2 #60182, both merged).

### The gap this closes

Before this PR, `JobWorkerBuilderImpl.open()` passed the lease flag to the poller but hardcoded `false` when constructing the streamer, and `JobStreamerImpl.buildCommand()` never read its own `withLease` field. A worker that opted into leasing while also streaming got unleased jobs pushed to it, with no error or warning.

### What changed

- `StreamJobsCommandStep3.withLease(boolean)` - new opt-in on the raw streaming command, mirroring `ActivateJobsCommandStep3.withLease`.
- `JobWorkerBuilderImpl` now forwards its `withLease` field into `JobStreamerImpl` instead of a literal `false`.
- `JobStreamerImpl.buildCommand()` now calls `.withLease(true)` when configured, guarded so an explicit `false` is never sent - keeps compatibility with a gateway that doesn't know the field yet during a rolling upgrade.
- Javadoc: documented the exclusivity guarantee and the update-job fencing asymmetry on both the streaming and polling command surfaces, so they read the same way regardless of which path activated the job.

### Validation

- Unit tests: `JobWorkerBuilderImplTest`, `JobStreamImplTest`, `StreamJobsTest` cover the opt-in threading, the command-level propagation, the lease token surfacing on a streamed job, and the default-off guards.
- Integration test: `StreamJobsWithLeaseIT` - against a real broker, a leasing stream delivers a job carrying a lease token; completing it with the token succeeds, completing it without one is rejected. This is the only level that can catch a gateway or client mapping gap end to end.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56457
