### PR TITLE
fix: fix multitenancy for v1 mode on process definition filter

### DIFF
--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/FieldsModal.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/FieldsModal.tsx
@@ -101,23 +101,15 @@ const FieldsModal: React.FC<Props> = ({
         return undefined;
       }
 
-      if (clientMode === 'v1') {
-        return DEFAULT_TENANT_ID;
-      }
-
       if (formTenant !== undefined && formTenant !== '') {
         return formTenant;
-      }
-
-      if (formTenant === '') {
-        return undefined;
       }
 
       if (currentUser?.tenants.length === 1) {
         return currentUser.tenants[0]?.tenantId;
       }
 
-      return undefined;
+      return clientMode === 'v1' ? DEFAULT_TENANT_ID : undefined;
     },
     [clientMode, currentUser, isMultiTenancyEnabled],
   );

--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/index.v1.test.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/index.v1.test.tsx
@@ -186,7 +186,7 @@ describe('<CustomFiltersModal />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should load default-tenant processes for a user with one accessible tenant', async () => {
+  it('should load processes from the only accessible tenant', async () => {
     vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
       ...clientConfig.getClientConfig(),
       clientMode: 'v1',
@@ -200,7 +200,7 @@ describe('<CustomFiltersModal />', () => {
         }),
       ),
       http.get('/v1/internal/processes', ({request}) => {
-        if (new URL(request.url).searchParams.get('tenantId') !== '<default>') {
+        if (new URL(request.url).searchParams.get('tenantId') !== 'staging') {
           return HttpResponse.json(null, {status: 400});
         }
 
@@ -260,7 +260,7 @@ describe('<CustomFiltersModal />', () => {
     );
   });
 
-  it('should load default-tenant processes when another tenant is selected', async () => {
+  it('should load processes from the selected tenant', async () => {
     vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
       ...clientConfig.getClientConfig(),
       clientMode: 'v1',
@@ -274,7 +274,7 @@ describe('<CustomFiltersModal />', () => {
         HttpResponse.json(userMocks.currentUserWithTenants),
       ),
       http.get('/v1/internal/processes', ({request}) => {
-        if (new URL(request.url).searchParams.get('tenantId') !== '<default>') {
+        if (new URL(request.url).searchParams.get('tenantId') !== 'tenantB') {
           return HttpResponse.json(null, {status: 400});
         }
 
@@ -296,6 +296,66 @@ describe('<CustomFiltersModal />', () => {
     await waitFor(() =>
       expect(screen.getByRole('combobox', {name: /process/i})).toBeEnabled(),
     );
+  });
+
+  it('should reload processes when the selected tenant changes', async () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      clientMode: 'v1',
+      isMultiTenancyEnabled: true,
+    });
+    nodeMockServer.use(
+      http.get('/v2/authentication/me', () =>
+        HttpResponse.json(userMocks.currentUserWithTenants),
+      ),
+      http.get(
+        '/v1/internal/processes',
+        ({request}) => {
+          if (
+            new URL(request.url).searchParams.get('tenantId') !== '<default>'
+          ) {
+            return HttpResponse.json(null, {status: 400});
+          }
+
+          return HttpResponse.json([
+            createMockProcess('process-default-tenant'),
+          ]);
+        },
+        {once: true},
+      ),
+      http.get('/v1/internal/processes', ({request}) => {
+        if (new URL(request.url).searchParams.get('tenantId') !== 'tenantB') {
+          return HttpResponse.json(null, {status: 400});
+        }
+
+        return HttpResponse.json([createMockProcess('process-tenantB')]);
+      }),
+    );
+
+    const {user} = render(
+      <CustomFiltersModal
+        isOpen
+        onClose={() => {}}
+        onSuccess={() => {}}
+        onDelete={() => {}}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    expect(
+      await screen.findByRole('option', {
+        name: /process process-default-tenant/i,
+      }),
+    ).toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByRole('combobox', {name: /tenant/i}),
+      'tenantB',
+    );
+
+    expect(
+      await screen.findByRole('option', {name: /process process-tenantB/i}),
+    ).toBeInTheDocument();
   });
 
   it('should load processes without a tenant when multi-tenancy is disabled', async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Small leftover from a mistake I made at https://github.com/camunda/camunda/pull/60365

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #60339
