### PR TITLE
docs: fix broken cross-plugin ADR links in Identity architecture doc

### DIFF
--- a/identity/docs/architecture.md
+++ b/identity/docs/architecture.md
@@ -1097,9 +1097,9 @@ The architectural decisions for Identity are documented as individual ADR files:
 Cross-cutting decisions on the CSL migration (affecting Identity along with other modules) are
 documented at the repo-root level rather than here:
 
-- [ADR: Endpoint Required-Permission Mapping](../../docs/adr/security/001-endpoint-required-permission-mapping.md)
-- [ADR: Tenant Access Provider Ownership and Seam](../../docs/adr/security/002-tenant-access-provider-ownership-and-seam.md)
-- [ADR: Physical-Tenant Routing of Authorization Reads](../../docs/adr/orchestration-cluster/0005-physical-tenant-routing-of-authorization-reads.md) -- the background for the per-physical-tenant `AuthorizationCheckPort` scoping described in [5.2.2](#522-security---level-2).
+- [ADR: Endpoint Required-Permission Mapping](https://github.com/camunda/camunda/blob/main/docs/adr/security/001-endpoint-required-permission-mapping.md)
+- [ADR: Tenant Access Provider Ownership and Seam](https://github.com/camunda/camunda/blob/main/docs/adr/security/002-tenant-access-provider-ownership-and-seam.md)
+- [ADR: Physical-Tenant Routing of Authorization Reads](https://github.com/camunda/camunda/blob/main/docs/adr/orchestration-cluster/0005-physical-tenant-routing-of-authorization-reads.md) -- the background for the per-physical-tenant `AuthorizationCheckPort` scoping described in [5.2.2](#522-security---level-2).
 
 No dedicated ADR records the decision to adopt CSL itself; that predates these two and is not
 tracked in `identity/docs/adr/` or `docs/adr/`.


### PR DESCRIPTION
## Problem

The docs site production build (the **Docs PR Preview** workflow) fails MDX compilation:

```
Error: MDX compilation failed for file ".../identity/docs/architecture.md"
Cause: Markdown link with URL `../../docs/adr/security/001-endpoint-required-permission-mapping.md` ... couldn't be resolved.
```

[`identity/docs/architecture.md`](identity/docs/architecture.md) links to three repo-root ADRs using filesystem-relative paths (`../../docs/adr/...`). The docs site compiles `identity/docs` as its **own** Docusaurus plugin content root (`routeBasePath: /identity` in [`monorepo-docs-site/docusaurus.config.js`](monorepo-docs-site/docusaurus.config.js)), so links that escape that root cannot be resolved. The production build sets `onBrokenMarkdownLinks: throw`, so it hard-fails.

The links were introduced in `b6a19179915` (Aug 13) but slipped through: the docs-preview build is gated by a paths filter that does **not** include `identity/docs/**`, so that PR never ran the build. An unrelated `docs/monorepo-docs` change tripped over them first.

## Fix

Point the three links at full GitHub URLs on `main`, matching the existing convention for cross-root references in the compiled docs (e.g. [`docs/monorepo-docs/frontend/session-heartbeat.md`](docs/monorepo-docs/frontend/session-heartbeat.md)). They render correctly both on GitHub and in the docs site, and always track the current ADR.

Verified with a local production docs build (`npm run build` in `monorepo-docs-site`) — the build now succeeds with zero broken links.

## Scope

- The full docs build was scanned with broken-link reporting enabled: these three were the **only** broken links across all four compiled content roots (`docs/monorepo-docs`, `docs/architecture`, `docs/adr`, `identity/docs`).
- The underlying CI gap (paths filter not covering all compiled docs sources) is addressed in a **separate PR** so the author who breaks such a link sees it on their own PR.

Relates to #60298