### PR TITLE
ci: trigger docs preview on all compiled docs content roots

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -480,7 +480,16 @@ runs:
       ref: ${{ github.event.merge_group.head_ref || github.ref }}
       filters: |
         docs-change:
+          # Keep in sync with the content roots compiled by the docs site in
+          # monorepo-docs-site/docusaurus.config.js. Each of these folders is a
+          # Docusaurus plugin/preset content root; a broken link in any of them
+          # fails the production build. Omitting one here means changes to it
+          # never trigger the docs-preview build, so a broken link stays latent
+          # until an unrelated docs change trips over it.
           - 'docs/monorepo-docs/**'
+          - 'docs/architecture/**'
+          - 'docs/adr/**'
+          - 'identity/docs/**'
           - 'monorepo-docs-site/!(node_modules)/**'
           - 'monorepo-docs-site/*'
           - '.github/workflows/docs-build-deploy.yml'


### PR DESCRIPTION
## Problem

The **Docs PR Preview** build (and the docs deploy) is gated by the `docs-change` paths filter in [`.github/actions/paths-filter/action.yml`](.github/actions/paths-filter/action.yml). It only listed:

```
docs/monorepo-docs/**
monorepo-docs-site/**
```

But the docs site compiles **four** content roots (each a Docusaurus plugin/preset in [`monorepo-docs-site/docusaurus.config.js`](monorepo-docs-site/docusaurus.config.js)):

| Content root | Route |
|---|---|
| `docs/monorepo-docs` | `/` |
| `docs/architecture` | `/architecture` |
| `docs/adr` | `/adr` |
| `identity/docs` | `/identity` |

Three of those roots were **absent** from the filter. So a change to `docs/architecture`, `docs/adr`, or `identity/docs` never triggered the production docs build. A broken markdown link introduced in one of them stayed **latent** until an unrelated `docs/monorepo-docs` change tripped over it — surfacing the failure on the wrong PR, far from its author.

That is exactly what happened: broken ADR links landed in `identity/docs/architecture.md` on Aug 13 without their PR ever running the docs build; an unrelated `docs/monorepo-docs/ci.md` change hit the failure days later.

## Fix

Add the three missing content roots to the `docs-change` filter, so any change to a folder the docs site compiles triggers the docs-preview build — catching broken links on the PR that introduces them. A comment ties the list back to the Docusaurus config so the two stay in sync.

## Validation

- Parsed the resulting `action.yml` and confirmed the `docs-change` filter contains all eight globs.
- `actionlint` reports no new issues on the consuming workflows (the two pre-existing `queue: max` concurrency warnings are unrelated).

## Related

- Companion PR fixes the actual broken links in `identity/docs/architecture.md`.

Relates to #60298