### PR TITLE
fix: name the mismatched secret reference in the job-push incident

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -36,10 +36,9 @@ public final class BpmnIncidentBehavior implements StreamProcessorLifecycleAware
    * the path names the mismatch via {@link #SECRET_REFERENCE_UNRESOLVED_MESSAGE}.
    */
   public static final String SECRET_INJECTION_FAILED_MESSAGE =
-      "The job with key '%s' can not be activated, because its secret reference no longer "
-          + "matches the job's variables. Correct the mismatched variable and resolve the "
-          + "incident, or use process instance modification to reactivate the element and "
-          + "create a fresh job.";
+      "The job with key '%s' can not be activated, because injecting its secret values "
+          + "failed. Resolve the incident, or use process instance modification to "
+          + "reactivate the element and create a fresh job.";
 
   /**
    * Message the job-push path raises when it knows which secret reference failed to inject: it

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -28,16 +28,31 @@ import io.camunda.zeebe.util.collection.Tuple;
 public final class BpmnIncidentBehavior implements StreamProcessorLifecycleAware {
 
   /**
-   * Message of the incident both activation paths raise when a job's secret value injection fails.
-   * Shared because the cause is the same on either path: the value the placeholder was baked in for
-   * changed before the job was handed out. It carries no failure detail, since the exception may
-   * quote the variables document and with it secret data that must stay out of persisted records.
+   * Cause-neutral fallback the job-push path raises when a job's secret value injection fails for a
+   * reason it cannot attribute to a specific reference (e.g. malformed variables msgpack). It
+   * carries no failure detail, since the exception may quote the variables document and with it
+   * secret data that must stay out of persisted records. When the failure is a {@link
+   * io.camunda.zeebe.engine.processing.job.JobSecretLookup.SecretPointerMismatchException} instead,
+   * the path names the mismatch via {@link #SECRET_REFERENCE_UNRESOLVED_MESSAGE}.
    */
   public static final String SECRET_INJECTION_FAILED_MESSAGE =
       "The job with key '%s' can not be activated, because its secret reference no longer "
           + "matches the job's variables. Correct the mismatched variable and resolve the "
           + "incident, or use process instance modification to reactivate the element and "
           + "create a fresh job.";
+
+  /**
+   * Message the job-push path raises when it knows which secret reference failed to inject: it
+   * names the reference's placeholder and JSON pointer path (never the secret's value). The batch
+   * path uses an identically worded message of its own ({@code
+   * JobBatchActivateProcessor#SECRET_REFERENCE_UNRESOLVED_MESSAGE}); the two are candidates to
+   * merge once both paths name the mismatch (#60405). Format args: job key, placeholder, path.
+   */
+  public static final String SECRET_REFERENCE_UNRESOLVED_MESSAGE =
+      "The job with key '%s' can not be activated, because the secret reference '%s' "
+          + "could not be resolved at '%s'. Fix the variable's value or the input "
+          + "mapping that sets it, then resolve the incident, or use process instance "
+          + "modification to reactivate the element and create a fresh job.";
 
   private final IncidentRecord incidentRecord = new IncidentRecord();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
 import java.util.HashSet;
@@ -336,7 +337,8 @@ public class BpmnJobActivationBehavior {
    * falls back to the cause-neutral message. Only the placeholder and path are read from the
    * exception, never its own message, which may quote the variables document.
    */
-  private static String secretInjectionIncidentMessage(final long jobKey, final Exception failure) {
+  @VisibleForTesting
+  static String secretInjectionIncidentMessage(final long jobKey, final Exception failure) {
     if (failure instanceof final SecretPointerMismatchException mismatch) {
       return BpmnIncidentBehavior.SECRET_REFERENCE_UNRESOLVED_MESSAGE.formatted(
           jobKey, mismatch.placeholder(), mismatch.path());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup;
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup.Secret;
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup.SecretCheckResult;
+import io.camunda.zeebe.engine.processing.job.JobSecretLookup.SecretPointerMismatchException;
 import io.camunda.zeebe.engine.processing.job.JobVariablesCollector;
 import io.camunda.zeebe.engine.processing.job.LeaseTokens;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
@@ -296,7 +297,10 @@ public class BpmnJobActivationBehavior {
    * belongs. Raising that incident also takes the job out of the activation until an operator
    * resolves it, so a failing injection cannot be retried on every activation (see {@code
    * IncidentCreatedV2Applier}). The failure details are only logged, since the exception may quote
-   * the variables document.
+   * the variables document. When the failure is a {@link SecretPointerMismatchException}, the
+   * incident names the mismatched placeholder and JSON pointer (never the secret's value), the same
+   * detail the batch path gives; any other failure falls back to the cause-neutral {@link
+   * BpmnIncidentBehavior#SECRET_INJECTION_FAILED_MESSAGE}.
    */
   private boolean injectSecretValues(
       final long jobKey, final JobRecord pushableJobRecord, final SecretCheckResult secrets) {
@@ -321,9 +325,23 @@ public class BpmnJobActivationBehavior {
           jobKey,
           pushableJobRecord,
           ErrorType.SECRET_RESOLUTION_ERROR,
-          BpmnIncidentBehavior.SECRET_INJECTION_FAILED_MESSAGE.formatted(jobKey));
+          secretInjectionIncidentMessage(jobKey, e));
       return false;
     }
+  }
+
+  /**
+   * Builds the message for a failed secret injection incident: when the failure identifies the
+   * mismatched reference, it names that reference's placeholder and JSON pointer; otherwise it
+   * falls back to the cause-neutral message. Only the placeholder and path are read from the
+   * exception, never its own message, which may quote the variables document.
+   */
+  private static String secretInjectionIncidentMessage(final long jobKey, final Exception failure) {
+    if (failure instanceof final SecretPointerMismatchException mismatch) {
+      return BpmnIncidentBehavior.SECRET_REFERENCE_UNRESOLVED_MESSAGE.formatted(
+          jobKey, mismatch.placeholder(), mismatch.path());
+    }
+    return BpmnIncidentBehavior.SECRET_INJECTION_FAILED_MESSAGE.formatted(jobKey);
   }
 
   public void notifyJobAvailableAsSideEffect(final JobRecord jobRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -50,10 +50,11 @@ import java.util.Map;
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
 
   // named distinctly from BpmnIncidentBehavior#SECRET_INJECTION_FAILED_MESSAGE: same error type,
-  // different cause-neutral fallback text, because that one is shared with the job-push path and
-  // this one is reached only when this path's own FailedInjectionJob carries no path/placeholder.
-  // Once the job-push path also names the mismatch (#60404), the two fallbacks - and this path's
-  // named-mismatch message alongside the job-push one - become candidates to merge (#60405)
+  // different cause-neutral fallback text, and reached only when this path's own FailedInjectionJob
+  // carries no path/placeholder. Now that the job-push path also names the mismatch (#60404), the
+  // two cause-neutral fallbacks - and this path's named-mismatch message alongside the job-push
+  // one (BpmnIncidentBehavior#SECRET_REFERENCE_UNRESOLVED_MESSAGE) - are candidates to merge
+  // (#60405)
   private static final String SECRET_INJECTION_UNKNOWN_CAUSE_MESSAGE =
       "The job with key '%s' can not be activated, because injecting its secret values "
           + "failed. Resolve the incident, or use process instance modification to "
@@ -345,12 +346,14 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
    * is known, the message names its placeholder and JSON pointer path - never the secret's value,
    * and never anything from the exception's own (log-only) message; an unrelated failure (e.g.
    * invalid msgpack) has neither, so the message stays cause-neutral instead of naming a mismatch
-   * that was never established. Unlike the job-push path's {@link
-   * BpmnIncidentBehavior#SECRET_INJECTION_FAILED_MESSAGE}, this path has a {@link
-   * FailedInjectionJob} to draw on, so its cause-neutral fallback is its own, separate message
-   * rather than that shared one. The job is also excluded from activation until this incident is
-   * resolved (see IncidentCreatedV2Applier's SECRET_RESOLUTION_ERROR handling), so it does not loop
-   * through repeated failing injections.
+   * that was never established. The job-push path names the same detail from the {@link
+   * io.camunda.zeebe.engine.processing.job.JobSecretLookup.SecretPointerMismatchException}
+   * directly; this path draws it from the {@link FailedInjectionJob} instead, and keeps its own
+   * cause-neutral fallback ({@link #SECRET_INJECTION_UNKNOWN_CAUSE_MESSAGE}) rather than the
+   * job-push one - the two named messages and the two fallbacks are candidates to merge (#60405).
+   * The job is also excluded from activation until this incident is resolved (see
+   * IncidentCreatedV2Applier's SECRET_RESOLUTION_ERROR handling), so it does not loop through
+   * repeated failing injections.
    */
   private void raiseIncidentJobSecretInjectionFailed(final FailedInjectionJob failed) {
     final String message =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretLookup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretLookup.java
@@ -296,15 +296,16 @@ public final class JobSecretLookup {
   public record CachedSecret(Secret secret, String value) {}
 
   /**
-   * Thrown by {@link #injectedVariablesOf} when a secret reference's JSON pointer exists but
-   * doesn't address a text leaf of an object, or addresses one whose content doesn't contain the
-   * expected placeholder, and no sibling reference at the same path resolved it either.
-   * Package-private: only {@link JobSecretInjector} inspects {@link #path()} and {@link
-   * #placeholder()} to name the mismatch in a {@code SECRET_RESOLUTION_ERROR} incident; the
-   * job-push path catches it as a plain failure and falls back to a generic incident message, since
-   * this exception's own message is log-only and never persisted.
+   * Thrown by {@link JobSecretLookup#injectedVariablesOf} when a secret reference's JSON pointer
+   * exists but doesn't address a text leaf of an object, or addresses one whose content doesn't
+   * contain the expected placeholder, and no sibling reference at the same path resolved it either.
+   * Both activation paths inspect {@link #path()} and {@link #placeholder()} to name the mismatch
+   * in a {@code SECRET_RESOLUTION_ERROR} incident: the batch path via {@link JobSecretInjector},
+   * the job-push path in {@code BpmnJobActivationBehavior}, which is why this is public. Only the
+   * placeholder and JSON pointer are ever read out; this exception's own message is log-only and
+   * never persisted, since it may quote the variables document.
    */
-  static final class SecretPointerMismatchException extends RuntimeException {
+  public static final class SecretPointerMismatchException extends RuntimeException {
     private final String path;
     private final String placeholder;
 
@@ -324,11 +325,11 @@ public final class JobSecretLookup {
       this.placeholder = placeholder;
     }
 
-    String path() {
+    public String path() {
       return path;
     }
 
-    String placeholder() {
+    public String placeholder() {
       return placeholder;
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehaviorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+final class BpmnJobActivationBehaviorTest {
+
+  private static final long JOB_KEY = 42L;
+
+  @Test
+  void shouldFallBackToCauseNeutralMessageWhenFailureIsNotAMismatch() {
+    // given - an injection failure the path cannot attribute to a specific reference, e.g. the
+    // job's variables are not valid msgpack, which surfaces as an IOException rather than a
+    // SecretPointerMismatchException
+    final var failure = new IOException("variables document quoting a secret value");
+
+    // when
+    final var message = BpmnJobActivationBehavior.secretInjectionIncidentMessage(JOB_KEY, failure);
+
+    // then - the incident carries the cause-neutral fallback, naming neither a reference nor the
+    // exception's own message, which may quote the variables document and with it secret data
+    assertThat(message)
+        .isEqualTo(BpmnIncidentBehavior.SECRET_INJECTION_FAILED_MESSAGE.formatted(JOB_KEY))
+        .doesNotContain(failure.getMessage());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretPushInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretPushInjectionTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -254,6 +255,86 @@ public final class JobSecretPushInjectionTest {
     assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.SECRET_RESOLUTION_ERROR);
     assertThat(jobStream.getActivatedJobs()).isEmpty();
     assertThat(jobState(jobKey)).isEqualTo(State.WAITING_FOR_SECRET_RESOLUTION);
+  }
+
+  @Test
+  public void shouldNameTheMismatchedReferenceWhenInjectionFailsOnPush() {
+    // given - the default tenant, required for a tenant-scoped cluster variable and for the job
+    // that belongs to it to be looked up later
+    engine.tenant().newTenant().withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER).create();
+
+    // and - a SECRET_REFERENCE cluster variable that currently points at "tokenA"
+    engine
+        .clusterVariables()
+        .withName("creds")
+        .setTenantScope()
+        .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .withValue(Map.of("token", "camunda.secrets.tokenA"))
+        .create();
+
+    // and - a service task whose start execution listener opens a window between the input
+    // mapping baking the *then-current* placeholder ("tokenA") into the job's variables and the
+    // job's creation, which resolves the reference from whatever the cluster variable holds by then
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("mismatch-process")
+            .startEvent()
+            .serviceTask(
+                "mismatch-task",
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeStartExecutionListener("mismatch-start-el")
+                        .zeebeInputExpression("camunda.vars.tenant.creds.token", "authToken"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        engine.processInstance().ofBpmnProcessId("mismatch-process").create();
+    final long listenerJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("mismatch-start-el")
+            .getFirst()
+            .getKey();
+
+    // and - inside that window the reference is repointed at "tokenB", whose value is cached
+    // before the job becomes activatable, so the push path actually attempts (and fails) the
+    // replacement instead of parking the job on an uncached reference
+    engine
+        .clusterVariables()
+        .withName("creds")
+        .setTenantScope()
+        .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .withValue(Map.of("token", "camunda.secrets.tokenB"))
+        .update();
+    CACHED_SECRETS.put("tokenB", "resolved-B");
+
+    // when - completing the listener lets the job be created with a "tokenB" reference while its
+    // variables still literally hold "camunda.secrets.tokenA", and the push path injects it
+    engine.job().withKey(listenerJobKey).complete();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+
+    // then - the incident names the mismatched placeholder and its JSON pointer, the same detail
+    // the batch path gives, instead of the cause-neutral fallback message
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).withJobKey(jobKey).getFirst();
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.SECRET_RESOLUTION_ERROR);
+    assertThat(incident.getValue().getErrorMessage())
+        .contains("camunda.secrets.tokenB")
+        .contains("/authToken")
+        .contains("could not be resolved at")
+        .contains("Fix the variable's value or the input mapping that sets it");
+
+    // and - the job is not pushed, and no exported record leaks the resolved value
+    assertThat(jobStream.getActivatedJobs()).isEmpty();
+    assertThat(RecordingExporter.getRecords())
+        .noneMatch(record -> record.getValue().toString().contains("resolved-B"));
   }
 
   @Test


### PR DESCRIPTION
## Description

When secret injection fails on the **job-push** activation path, the incident previously always used the cause-neutral `SECRET_INJECTION_FAILED_MESSAGE`, which does not say *which* secret reference or *which* path is at fault. The **batch** (long-poll) path, given the same `SecretPointerMismatchException`, already names the reference's placeholder and JSON pointer.

That means the detail a customer saw depended purely on which activation path happened to serve the job — an implementation detail invisible to them. This was left over from #60180, which added the leaf-precision tolerance and the named message to the batch path only.

This PR makes the job-push path inspect the mismatch the same way, so both activation paths give the same actionable incident detail.

## Changes

- **`refactor:`** made `SecretPointerMismatchException` and its `path()`/`placeholder()` accessors `public` so both packages can read the mismatch (batch path lives in `...job`, push path in `...bpmn.behavior`).
- **`fix:`** the job-push path now builds a message naming the placeholder + JSON pointer (new `SECRET_REFERENCE_UNRESOLVED_MESSAGE`) on a mismatch, falling back to the existing cause-neutral message otherwise. Only the placeholder and pointer are read from the exception — never a secret value or the exception's own message — so nothing sensitive reaches a persisted record.
- Added `shouldNameTheMismatchedReferenceWhenInjectionFailsOnPush` to `JobSecretPushInjectionTest`.

The named message text is duplicated with the batch path for now; unifying the two named messages **and** the two cause-neutral fallbacks is tracked separately in #60405.

Closes #60404

## Backport

Not required.