### PR TITLE
ci: route RDBMS ITs failure alerts to data-layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1311,6 +1311,10 @@ jobs:
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token for the GCS distball download
+    env:
+      # Route base-branch failure alerts to the code owner of /db/ and the RDBMS ITs
+      # (.codeowners), instead of the workflow-level default @camunda/engineering-operations.
+      TEST_OWNER: '@camunda/data-layer'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Description

The `General / Integration / RDBMS ITs` job in `ci.yml` set no job-level `TEST_OWNER`, so base-branch failure alerts fell back to the workflow-level default `@camunda/engineering-operations` — a team that does not own the failing code.

Per `.codeowners`, both the production RDBMS schema code under `/db/` and the RDBMS integration tests under `qa/acceptance-tests/.../it/rdbms/db/*` belong to `@camunda/data-layer`.

This surfaced while bumping `main` to `8.11.0-SNAPSHOT` (#60380): the RDBMS ITs went red on a data-layer test-isolation issue, but the base-branch alert would have paged engineering-operations rather than the owning team.

## Change

Set `TEST_OWNER: '@camunda/data-layer'` on the `rdbms-integration-tests` job so future base-branch failures route to the code owner. Alert routing only — no test behavior changes.

## Notes

- Related context: #60298 (stable/8.10 branch creation).