### PR TITLE
fix: allow variable modification while a process instance is suspended

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -231,8 +231,9 @@ public class ProcessInstanceSuspendResumeIT {
 
   /**
    * Variable updates during suspension may satisfy a conditional catch event. The variable write
-   * itself must apply immediately, but token activation is buffered and only runs after resume (see
-   * #58089).
+   * itself must apply immediately, and the token only moves past the catch event after resume. That
+   * the trigger is buffered rather than dropped is asserted on the record stream in
+   * VariableDocumentUpdateWhileSuspendedTest; secondary storage cannot show it reliably.
    */
   @Test
   void shouldBufferConditionalActivationTriggeredByVariableUpdateUntilResume() {
@@ -287,7 +288,7 @@ public class ProcessInstanceSuspendResumeIT {
         .send()
         .join();
 
-    // then - variable is updated, but the catch event does not activate the next element yet
+    // then - variable is updated while the instance stays suspended
     await()
         .atMost(Duration.ofSeconds(30))
         .ignoreExceptions()
@@ -302,23 +303,6 @@ public class ProcessInstanceSuspendResumeIT {
                             .items())
                     .anySatisfy(v -> assertThat(v.getValue()).isEqualTo("42")));
 
-    // give the engine a short window where a non-buffered trigger would have advanced the token
-    await()
-        .pollDelay(Duration.ofSeconds(2))
-        .atMost(Duration.ofSeconds(3))
-        .untilAsserted(
-            () ->
-                assertThat(
-                        camundaClient
-                            .newElementInstanceSearchRequest()
-                            .filter(
-                                f ->
-                                    f.processInstanceKey(processInstanceKey)
-                                        .elementId(afterConditionTaskId))
-                            .send()
-                            .join()
-                            .items())
-                    .isEmpty());
     assertThat(
             camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join().getState())
         .isEqualTo(ProcessInstanceState.SUSPENDED);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -14,6 +14,7 @@ import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 
@@ -29,6 +30,7 @@ import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
@@ -160,6 +162,188 @@ public class ProcessInstanceSuspendResumeIT {
                     .isNotEmpty());
 
     // leaves an instance active at taskB; cancel it so it doesn't linger on the shared broker
+    camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstanceToBeTerminated(camundaClient, processInstanceKey);
+  }
+
+  /**
+   * Variable modification is a recovery tool while a process instance is suspended (see #58089).
+   * The set-variables command must be accepted immediately and the new values must be visible in
+   * secondary storage, without resuming the instance.
+   */
+  @Test
+  void shouldUpdateVariablesWhileSuspended() {
+    // given
+    final var process = deployProcess();
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, process.processId(), Map.of("recoverable", "before"))
+            .getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // when - set-variables is accepted on a suspended instance
+    assertThatCode(
+            () ->
+                camundaClient
+                    .newSetVariablesCommand(processInstanceKey)
+                    .variables(Map.of("recoverable", "after", "added", 1))
+                    .send()
+                    .join())
+        .doesNotThrowAnyException();
+
+    // then - values are exported and the instance stays suspended
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var variables =
+                  camundaClient
+                      .newVariableSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(variables)
+                  .anySatisfy(
+                      v -> {
+                        assertThat(v.getName()).isEqualTo("recoverable");
+                        assertThat(v.getValue()).isEqualTo("\"after\"");
+                      });
+              assertThat(variables)
+                  .anySatisfy(
+                      v -> {
+                        assertThat(v.getName()).isEqualTo("added");
+                        assertThat(v.getValue()).isEqualTo("1");
+                      });
+            });
+
+    final ProcessInstance stillSuspended =
+        camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
+    assertThat(stillSuspended.getState()).isEqualTo(ProcessInstanceState.SUSPENDED);
+
+    camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstanceToBeTerminated(camundaClient, processInstanceKey);
+  }
+
+  /**
+   * Variable updates during suspension may satisfy a conditional catch event. The variable write
+   * itself must apply immediately, but token activation is buffered and only runs after resume (see
+   * #58089).
+   */
+  @Test
+  void shouldBufferConditionalActivationTriggeredByVariableUpdateUntilResume() {
+    // given - waiting on a conditional intermediate catch event that is not yet satisfied
+    final var processId = Strings.newRandomValidBpmnId();
+    final var catchEventId = "conditional-catch";
+    final var afterConditionTaskId = "afterCondition";
+    final var jobType = Strings.newRandomValidBpmnId();
+    final var model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .intermediateCatchEvent(catchEventId)
+            .condition(c -> c.condition("=x > 10").zeebeVariableEvents("create, update"))
+            .serviceTask(afterConditionTaskId, t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(model, processId + ".bpmn")
+        .send()
+        .join();
+    waitForProcessesToBeDeployed(camundaClient, f -> f.processDefinitionId(processId), 1);
+
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, processId, Map.of("x", 1)).getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId(catchEventId)
+                                        .state(ElementInstanceState.ACTIVE))
+                            .send()
+                            .join()
+                            .items())
+                    .isNotEmpty());
+
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // when - variable update satisfies the condition while suspended
+    camundaClient
+        .newSetVariablesCommand(processInstanceKey)
+        .variables(Map.of("x", 42))
+        .send()
+        .join();
+
+    // then - variable is updated, but the catch event does not activate the next element yet
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newVariableSearchRequest()
+                            .filter(f -> f.processInstanceKey(processInstanceKey).name("x"))
+                            .send()
+                            .join()
+                            .items())
+                    .anySatisfy(v -> assertThat(v.getValue()).isEqualTo("42")));
+
+    // give the engine a short window where a non-buffered trigger would have advanced the token
+    await()
+        .pollDelay(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(3))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId(afterConditionTaskId))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+    assertThat(
+            camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join().getState())
+        .isEqualTo(ProcessInstanceState.SUSPENDED);
+
+    // when - resume drains the buffered conditional trigger
+    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+
+    // then - token moves past the catch event
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId(afterConditionTaskId)
+                                        .state(ElementInstanceState.ACTIVE))
+                            .send()
+                            .join()
+                            .items())
+                    .isNotEmpty());
+
     camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
     waitForProcessInstanceToBeTerminated(camundaClient, processInstanceKey);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -9,7 +9,6 @@ package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForProcessInstance;
-import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
@@ -105,8 +104,6 @@ public class ProcessInstanceSuspendResumeIT {
     // they don't linger on the shared broker for the rest of the suite
     camundaClient.newCancelInstanceCommand(suspendedKey).send().join();
     camundaClient.newCancelInstanceCommand(notSuspendedKey).send().join();
-    waitForProcessInstanceToBeTerminated(camundaClient, suspendedKey);
-    waitForProcessInstanceToBeTerminated(camundaClient, notSuspendedKey);
   }
 
   @Test
@@ -163,14 +160,8 @@ public class ProcessInstanceSuspendResumeIT {
 
     // leaves an instance active at taskB; cancel it so it doesn't linger on the shared broker
     camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
-    waitForProcessInstanceToBeTerminated(camundaClient, processInstanceKey);
   }
 
-  /**
-   * Variable modification is a recovery tool while a process instance is suspended (see #58089).
-   * The set-variables command must be accepted immediately and the new values must be visible in
-   * secondary storage, without resuming the instance.
-   */
   @Test
   void shouldUpdateVariablesWhileSuspended() {
     // given
@@ -226,15 +217,8 @@ public class ProcessInstanceSuspendResumeIT {
     assertThat(stillSuspended.getState()).isEqualTo(ProcessInstanceState.SUSPENDED);
 
     camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
-    waitForProcessInstanceToBeTerminated(camundaClient, processInstanceKey);
   }
 
-  /**
-   * Variable updates during suspension may satisfy a conditional catch event. The variable write
-   * itself must apply immediately, and the token only moves past the catch event after resume. That
-   * the trigger is buffered rather than dropped is asserted on the record stream in
-   * VariableDocumentUpdateWhileSuspendedTest; secondary storage cannot show it reliably.
-   */
   @Test
   void shouldBufferConditionalActivationTriggeredByVariableUpdateUntilResume() {
     // given - waiting on a conditional intermediate catch event that is not yet satisfied
@@ -327,9 +311,7 @@ public class ProcessInstanceSuspendResumeIT {
                             .join()
                             .items())
                     .isNotEmpty());
-
     camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
-    waitForProcessInstanceToBeTerminated(camundaClient, processInstanceKey);
   }
 
   private static void activateAndCompleteJobs(final String jobType, final int count) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheck.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState.State;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -88,9 +89,9 @@ public final class SuspensionCheck {
 
   /**
    * Resolves the process instance a command targets. Most values carry their own {@code
-   * processInstanceKey}; external {@code JOB}, {@code INCIDENT}, {@code USER_TASK} and {@code
-   * AD_HOC_SUB_PROCESS_INSTRUCTION} commands only carry the entity key, so the persisted entity is
-   * consulted. Returns {@code -1} when it can't be resolved.
+   * processInstanceKey}; external {@code JOB}, {@code INCIDENT}, {@code USER_TASK}, {@code
+   * AD_HOC_SUB_PROCESS_INSTRUCTION} and {@code VARIABLE_DOCUMENT} commands only carry the entity
+   * key, so the persisted entity is consulted. Returns {@code -1} when it can't be resolved.
    */
   private long resolveProcessInstanceKey(final TypedRecord<?> command) {
     if (command.getValue() instanceof final ProcessInstanceRelated processInstanceRelated) {
@@ -121,6 +122,11 @@ public final class SuspensionCheck {
                 .getElementInstanceState()
                 .getInstance(adHocValue.getAdHocSubProcessInstanceKey());
         yield elementInstance != null ? elementInstance.getValue().getProcessInstanceKey() : -1;
+      }
+      case VARIABLE_DOCUMENT -> {
+        final var scopeKey = ((VariableDocumentRecordValue) command.getValue()).getScopeKey();
+        final var scope = processingState.getElementInstanceState().getInstance(scopeKey);
+        yield scope != null ? scope.getValue().getProcessInstanceKey() : -1;
       }
       default -> -1;
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -20,6 +20,8 @@ import io.camunda.zeebe.engine.processing.common.ValidationException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
@@ -48,7 +50,8 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.agrona.DirectBuffer;
 
 public final class VariableDocumentUpdateProcessor
-    implements TypedRecordProcessor<VariableDocumentRecord> {
+    implements TypedRecordProcessor<VariableDocumentRecord>,
+        SuspensionAware<VariableDocumentRecord> {
 
   private static final String ERROR_MESSAGE_SCOPE_NOT_FOUND =
       "Expected to update variables for element with key '%d', but no such element was found";
@@ -264,6 +267,18 @@ public final class VariableDocumentUpdateProcessor
     writers
         .response()
         .writeAcceptedResponseOnCommand(key, VariableDocumentIntent.UPDATED, value, record);
+  }
+
+  /**
+   * Allow variable updates while suspended for recovery. Reject only Camunda user-task scopes: that
+   * path can start an {@code UPDATING} task listener, which cannot complete while suspended.
+   */
+  @Override
+  public SuspensionBehavior suspensionBehavior(final TypedRecord<VariableDocumentRecord> record) {
+    final var scope = elementInstanceState.getInstance(record.getValue().getScopeKey());
+    return scope != null && isCamundaUserTask(scope)
+        ? SuspensionBehavior.REJECT
+        : SuspensionBehavior.PROCESS;
   }
 
   public static void mergeVariables(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheckTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -176,6 +177,30 @@ final class SuspensionCheckTest {
 
     // then - the real process instance key is resolved via job state and returned to the caller
     assertThat(result.outcome()).isEqualTo(SuspensionBehavior.REJECT);
+    assertThat(result.processInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
+  }
+
+  @Test
+  void shouldResolveProcessInstanceKeyFromScopeForVariableDocumentCommand() {
+    // given - VARIABLE_DOCUMENT only carries a scope key; resolve via the element instance
+    final long scopeKey = 99L;
+    final var elementInstanceState = mock(ElementInstanceState.class);
+    final var scope = mock(ElementInstance.class);
+    when(processingState.getElementInstanceState()).thenReturn(elementInstanceState);
+    when(elementInstanceState.getInstance(scopeKey)).thenReturn(scope);
+    when(scope.getValue())
+        .thenReturn(new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
+    markerIs(State.SUSPENDED);
+    final var command = mock(TypedRecord.class);
+    when(command.getValue()).thenReturn(new VariableDocumentRecord().setScopeKey(scopeKey));
+    when(command.getValueType()).thenReturn(ValueType.VARIABLE_DOCUMENT);
+
+    // when
+    final var result =
+        suspensionCheck.resolve(command, overridingProcessor(SuspensionBehavior.PROCESS));
+
+    // then
+    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.PROCESS);
     assertThat(result.processInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateWhileSuspendedTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateWhileSuspendedTest.java
@@ -14,14 +14,18 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -153,5 +157,66 @@ public final class VariableDocumentUpdateWhileSuspendedTest {
             tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  /**
+   * A user task scope drives the update lifecycle and can create an {@code updating} task listener
+   * job. That job cannot be completed while suspended, so the task would stay in {@code UPDATING}
+   * and the request would never complete. The command is rejected instead.
+   */
+  @Test
+  public void shouldRejectVariableUpdateScopedAtUserTaskWhileSuspended() {
+    // given - suspended on a Camunda user task with an updating task listener
+    final String processId = Strings.newRandomValidBpmnId();
+    final String listenerType = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask(
+                    "task",
+                    t -> t.zeebeUserTask().zeebeTaskListener(l -> l.updating().type(listenerType)))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final Record<UserTaskRecordValue> userTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var rejection =
+        ENGINE
+            .variables()
+            .ofScope(userTask.getValue().getElementInstanceKey())
+            .withDocument(Map.of("x", 1))
+            .expectRejection()
+            .update();
+
+    // then - the task is untouched and no listener job was created
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason()).contains(String.valueOf(processInstanceKey));
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= rejection.getPosition())
+                .userTaskRecords()
+                .withIntent(UserTaskIntent.UPDATING)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .describedAs("user task must not enter the update lifecycle while suspended")
+        .isFalse();
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= rejection.getPosition())
+                .jobRecords()
+                .withIntent(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .describedAs("no updating task listener job must be created while suspended")
+        .isFalse();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateWhileSuspendedTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateWhileSuspendedTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Variable modification must remain available while a process instance is suspended (see #58089).
+ * Follow-up token movement from conditional events is buffered until resume.
+ */
+public final class VariableDocumentUpdateWhileSuspendedTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldUpdateVariablesWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final String jobType = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(Map.of("recoverable", "before"))
+            .create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var updated =
+        ENGINE
+            .variables()
+            .ofScope(processInstanceKey)
+            .withDocument(Map.of("recoverable", "after", "added", 1))
+            .update();
+
+    // then
+    assertThat(updated.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(updated.getIntent()).isEqualTo(VariableDocumentIntent.UPDATED);
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("recoverable")
+                .withValue("\"after\"")
+                .exists())
+        .isTrue();
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("added")
+                .withValue("1")
+                .exists())
+        .isTrue();
+    assertThat(ENGINE.getProcessingState().getSuspensionState().isSuspended(processInstanceKey))
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBufferConditionalTriggerFromVariableUpdateUntilResume() {
+    // given - suspended on an unsatisfied conditional intermediate catch event
+    final String processId = Strings.newRandomValidBpmnId();
+    final String catchEventId = "conditional-catch";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent(catchEventId)
+                .condition(c -> c.condition("=x > 10").zeebeVariableEvents("create, update"))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVariables(Map.of("x", 1)).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(catchEventId)
+        .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - variable update satisfies the condition while suspended
+    final var updated =
+        ENGINE.variables().ofScope(processInstanceKey).withDocument(Map.of("x", 42)).update();
+
+    // then - conditional TRIGGER is buffered rather than processed immediately
+    final Record<?> buffered =
+        RecordingExporter.records()
+            .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+            .withIntent(ProcessInstanceBufferedCommandIntent.BUFFERED)
+            .filter(
+                r -> {
+                  final var value = (ProcessInstanceBufferedCommandRecordValue) r.getValue();
+                  return value.getProcessInstanceKey() == processInstanceKey
+                      && value.getValueType() == ValueType.CONDITIONAL_SUBSCRIPTION
+                      && value.getIntent() == ConditionalSubscriptionIntent.TRIGGER;
+                })
+            .getFirst();
+    assertThat(buffered.getPosition()).isGreaterThan(updated.getPosition());
+    assertThat(ENGINE.getProcessingState().getSuspensionState().isSuspended(processInstanceKey))
+        .describedAs("variable update must not clear suspension")
+        .isTrue();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - drain activates the catch event and completes the process
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+}


### PR DESCRIPTION
## Summary

- Allow `VARIABLE_DOCUMENT` updates while a process instance is suspended by opting the processor into `SuspensionBehavior.PROCESS`.
- Teach `SuspensionCheck` to resolve the process instance key for variable document commands from the scope element instance.
- Add engine and acceptance coverage for local/propagate updates and for conditional catch-event side effects staying buffered until resume.

Variable modification is a recovery path after suspension due to a fault. Token-advancing follow-ups remain gated by their own processors.

Closes #58089

## Test plan

- [x] `VariableDocumentUpdateWhileSuspendedTest` (engine unit)
- [x] `SuspensionCheckTest` coverage for `VARIABLE_DOCUMENT` key resolution
- [x] `ProcessInstanceSuspendResumeIT` acceptance cases for update during suspension and conditional-event buffering
- [x] CI green on this PR