### PR TITLE
feat: allow asserting individual process incidents

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -25,6 +25,8 @@ import io.camunda.process.test.api.assertions.DecisionSelector;
 import io.camunda.process.test.api.assertions.DecisionSelectors;
 import io.camunda.process.test.api.assertions.ElementSelector;
 import io.camunda.process.test.api.assertions.ElementSelectors;
+import io.camunda.process.test.api.assertions.IncidentAssert;
+import io.camunda.process.test.api.assertions.IncidentSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.UserTaskAssert;
@@ -34,6 +36,7 @@ import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.api.similarity.SemanticSimilarityConfig;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.assertions.DecisionInstanceAssertj;
+import io.camunda.process.test.impl.assertions.IncidentAssertj;
 import io.camunda.process.test.impl.assertions.ProcessInstanceAssertj;
 import io.camunda.process.test.impl.assertions.UserTaskAssertj;
 import io.camunda.process.test.impl.assertions.ValueAssertj;
@@ -319,6 +322,17 @@ public class CamundaAssert {
         elementSelector,
         judgeConfig,
         semanticSimilarityConfig);
+  }
+
+  /**
+   * To verify an incident.
+   *
+   * @param incidentSelector the selector of the incident to verify
+   * @return the assertion object
+   * @see io.camunda.process.test.api.assertions.IncidentSelectors
+   */
+  public static IncidentAssert assertThatIncident(final IncidentSelector incidentSelector) {
+    return new IncidentAssertj(getDataSource(), getAwaitBehavior(), incidentSelector);
   }
 
   /**

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/IncidentAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/IncidentAssert.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.assertions;
+
+import io.camunda.client.api.search.enums.IncidentErrorType;
+
+/** The assertion object to verify an incident. */
+public interface IncidentAssert extends WithAssertionConfiguration<IncidentAssert> {
+
+  /**
+   * Verifies that the incident is active. Incidents in state {@code ACTIVE}, {@code PENDING}, or
+   * {@code MIGRATED} are considered active.
+   *
+   * <p>The assertion waits until the incident is active.
+   *
+   * @return the assertion object
+   */
+  IncidentAssert isActive();
+
+  /**
+   * Verifies that the incident is resolved.
+   *
+   * <p>The assertion waits until the incident is resolved.
+   *
+   * @return the assertion object
+   */
+  IncidentAssert isResolved();
+
+  /**
+   * Verifies that the incident has the expected error type.
+   *
+   * <p>The assertion waits until the incident has the expected error type.
+   *
+   * @param errorType the expected error type
+   * @return the assertion object
+   */
+  IncidentAssert hasErrorType(IncidentErrorType errorType);
+
+  /**
+   * Verifies that the incident has the expected error message.
+   *
+   * <p>The assertion waits until the incident has the expected error message.
+   *
+   * @param errorMessage the expected error message
+   * @return the assertion object
+   */
+  IncidentAssert hasErrorMessage(String errorMessage);
+
+  /**
+   * Verifies that the incident belongs to the expected BPMN element.
+   *
+   * <p>The assertion waits until the incident has the expected element ID.
+   *
+   * @param elementId the expected BPMN element ID
+   * @return the assertion object
+   */
+  IncidentAssert hasElementId(String elementId);
+
+  /**
+   * Verifies that the incident belongs to the expected process instance.
+   *
+   * <p>The assertion waits until the incident has the expected process instance key.
+   *
+   * @param processInstanceKey the expected process instance key
+   * @return the assertion object
+   */
+  IncidentAssert hasProcessInstanceKey(long processInstanceKey);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/IncidentSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/IncidentSelectors.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.response.Incident;
 
@@ -49,6 +51,29 @@ public class IncidentSelectors {
    */
   public static IncidentSelector byProcessInstanceKey(final long processInstanceKey) {
     return new IncidentProcessInstanceKeySelector(processInstanceKey);
+  }
+
+  /**
+   * Select the incident by its error type.
+   *
+   * @param errorType the incident error type
+   * @return the selector
+   */
+  public static IncidentSelector byErrorType(final IncidentErrorType errorType) {
+    return new IncidentErrorTypeSelector(errorType);
+  }
+
+  /**
+   * Select the incident by its exact state.
+   *
+   * <p>For example, {@code byState(IncidentState.ACTIVE)} matches only {@code ACTIVE}, not {@code
+   * PENDING} or {@code MIGRATED}.
+   *
+   * @param state the exact incident state
+   * @return the selector
+   */
+  public static IncidentSelector byState(final IncidentState state) {
+    return new IncidentStateSelector(state);
   }
 
   private static final class IncidentElementIdSelector implements IncidentSelector {
@@ -120,6 +145,54 @@ public class IncidentSelectors {
     @Override
     public void applyFilter(final IncidentFilter filter) {
       filter.processInstanceKey(processInstanceKey);
+    }
+  }
+
+  private static final class IncidentErrorTypeSelector implements IncidentSelector {
+
+    private final IncidentErrorType errorType;
+
+    private IncidentErrorTypeSelector(final IncidentErrorType errorType) {
+      this.errorType = errorType;
+    }
+
+    @Override
+    public boolean test(final Incident incident) {
+      return errorType.equals(incident.getErrorType());
+    }
+
+    @Override
+    public String describe() {
+      return "errorType: " + errorType.name();
+    }
+
+    @Override
+    public void applyFilter(final IncidentFilter filter) {
+      filter.errorType(errorType);
+    }
+  }
+
+  private static final class IncidentStateSelector implements IncidentSelector {
+
+    private final IncidentState state;
+
+    private IncidentStateSelector(final IncidentState state) {
+      this.state = state;
+    }
+
+    @Override
+    public boolean test(final Incident incident) {
+      return state.equals(incident.getState());
+    }
+
+    @Override
+    public String describe() {
+      return "state: " + state.name();
+    }
+
+    @Override
+    public void applyFilter(final IncidentFilter filter) {
+      filter.state(state);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/IncidentAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/IncidentAssertj.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
+import io.camunda.process.test.api.assertions.IncidentAssert;
+import io.camunda.process.test.api.assertions.IncidentSelector;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+
+public class IncidentAssertj extends AbstractAssert<IncidentAssertj, IncidentSelector>
+    implements IncidentAssert {
+
+  private final CamundaDataSource dataSource;
+  private CamundaAssertAwaitBehavior awaitBehavior;
+
+  public IncidentAssertj(
+      final CamundaDataSource dataSource,
+      final CamundaAssertAwaitBehavior awaitBehavior,
+      final IncidentSelector incidentSelector) {
+    super(incidentSelector, IncidentAssert.class);
+    this.dataSource = dataSource;
+    this.awaitBehavior = awaitBehavior;
+  }
+
+  @Override
+  public IncidentAssert withAssertionTimeout(final Duration assertionTimeout) {
+    awaitBehavior = awaitBehavior.withAssertionTimeout(assertionTimeout);
+    return this;
+  }
+
+  @Override
+  public IncidentAssert isActive() {
+    awaitIncident(
+        incident ->
+            assertThat(IncidentStateSupport.isActive(incident.getState()))
+                .withFailMessage(
+                    "Expected incident [%s] to be active, but was %s",
+                    actual.describe(), formatState(incident.getState()))
+                .isTrue());
+    return this;
+  }
+
+  @Override
+  public IncidentAssert isResolved() {
+    awaitIncident(
+        incident ->
+            assertThat(incident.getState())
+                .withFailMessage(
+                    "Expected incident [%s] to be resolved, but was %s",
+                    actual.describe(), formatState(incident.getState()))
+                .isEqualTo(IncidentState.RESOLVED));
+    return this;
+  }
+
+  @Override
+  public IncidentAssert hasErrorType(final IncidentErrorType errorType) {
+    awaitIncident(
+        incident ->
+            assertThat(incident.getErrorType())
+                .withFailMessage(
+                    "Expected incident [%s] to have error type %s, but was %s",
+                    actual.describe(), errorType, incident.getErrorType())
+                .isEqualTo(errorType));
+    return this;
+  }
+
+  @Override
+  public IncidentAssert hasErrorMessage(final String errorMessage) {
+    awaitIncident(
+        incident ->
+            assertThat(incident.getErrorMessage())
+                .withFailMessage(
+                    "Expected incident [%s] to have error message '%s', but was '%s'",
+                    actual.describe(), errorMessage, incident.getErrorMessage())
+                .isEqualTo(errorMessage));
+    return this;
+  }
+
+  @Override
+  public IncidentAssert hasElementId(final String elementId) {
+    awaitIncident(
+        incident ->
+            assertThat(incident.getElementId())
+                .withFailMessage(
+                    "Expected incident [%s] to have element ID '%s', but was '%s'",
+                    actual.describe(), elementId, incident.getElementId())
+                .isEqualTo(elementId));
+    return this;
+  }
+
+  @Override
+  public IncidentAssert hasProcessInstanceKey(final long processInstanceKey) {
+    awaitIncident(
+        incident ->
+            assertThat(incident.getProcessInstanceKey())
+                .withFailMessage(
+                    "Expected incident [%s] to have process instance key %d, but was %d",
+                    actual.describe(), processInstanceKey, incident.getProcessInstanceKey())
+                .isEqualTo(processInstanceKey));
+    return this;
+  }
+
+  private void awaitIncident(final Consumer<Incident> assertion) {
+    awaitBehavior.untilAsserted(
+        () -> dataSource.findIncidents(actual::applyFilter),
+        incidents -> {
+          final Optional<Incident> incident = incidents.stream().filter(actual::test).findFirst();
+
+          assertThat(incident)
+              .withFailMessage("No incident [%s] found", actual.describe())
+              .isPresent();
+
+          assertion.accept(incident.get());
+        });
+  }
+
+  private static String formatState(final IncidentState state) {
+    return state == null ? "unknown" : state.name().toLowerCase();
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/IncidentStateSupport.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/IncidentStateSupport.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import io.camunda.client.api.search.enums.IncidentState;
+import java.util.EnumSet;
+import java.util.Set;
+
+final class IncidentStateSupport {
+
+  private static final Set<IncidentState> ACTIVE_STATES =
+      EnumSet.of(IncidentState.ACTIVE, IncidentState.PENDING, IncidentState.MIGRATED);
+
+  private IncidentStateSupport() {}
+
+  static boolean isActive(final IncidentState state) {
+    return ACTIVE_STATES.contains(state);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -51,7 +51,7 @@ public class ProcessInstanceAssertj
 
   private final ElementAssertj elementAssertj;
   private final VariableAssertj variableAssertj;
-  private final IncidentAssertj incidentAssertj;
+  private final ProcessInstanceIncidentAssertj incidentAssertj;
   private final MessageSubscriptionAssertj messageSubscriptionAssertj;
   private final String failureMessagePrefix;
   private final Function<String, ElementSelector> elementSelector;
@@ -99,7 +99,9 @@ public class ProcessInstanceAssertj
             judgeConfig,
             semanticSimilarityConfig,
             failureMessagePrefix);
-    incidentAssertj = new IncidentAssertj(dataSource, this::getAwaitBehavior, failureMessagePrefix);
+    incidentAssertj =
+        new ProcessInstanceIncidentAssertj(
+            dataSource, this::getAwaitBehavior, failureMessagePrefix);
     messageSubscriptionAssertj =
         new MessageSubscriptionAssertj(dataSource, this::getAwaitBehavior, failureMessagePrefix);
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceIncidentAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceIncidentAssertj.java
@@ -18,32 +18,28 @@ package io.camunda.process.test.impl.assertions;
 import static org.apache.commons.lang3.StringUtils.abbreviate;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
-public class IncidentAssertj extends AbstractAssert<ElementAssertj, String> {
+public class ProcessInstanceIncidentAssertj
+    extends AbstractAssert<ProcessInstanceIncidentAssertj, String> {
 
   private static final int MAX_ERROR_MESSAGE_LENGTH = 500;
-
-  private static final List<IncidentState> ACTIVE_INCIDENT_STATES =
-      Arrays.asList(IncidentState.ACTIVE, IncidentState.PENDING, IncidentState.MIGRATED);
 
   private final CamundaDataSource dataSource;
   private final Supplier<CamundaAssertAwaitBehavior> awaitBehavior;
 
-  protected IncidentAssertj(
+  protected ProcessInstanceIncidentAssertj(
       final CamundaDataSource dataSource,
       final Supplier<CamundaAssertAwaitBehavior> awaitBehavior,
       final String failureMessagePrefix) {
-    super(failureMessagePrefix, IncidentAssertj.class);
+    super(failureMessagePrefix, ProcessInstanceIncidentAssertj.class);
     this.dataSource = dataSource;
     this.awaitBehavior = awaitBehavior;
   }
@@ -77,7 +73,7 @@ public class IncidentAssertj extends AbstractAssert<ElementAssertj, String> {
 
   private List<Incident> activeIncidents(final List<Incident> incidents) {
     return incidents.stream()
-        .filter(i -> ACTIVE_INCIDENT_STATES.contains(i.getState()))
+        .filter(i -> IncidentStateSupport.isActive(i.getState()))
         .collect(Collectors.toList());
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/AssertionFacade.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/AssertionFacade.java
@@ -17,6 +17,8 @@ package io.camunda.process.test.impl.testCases;
 
 import io.camunda.process.test.api.assertions.DecisionInstanceAssert;
 import io.camunda.process.test.api.assertions.DecisionSelector;
+import io.camunda.process.test.api.assertions.IncidentAssert;
+import io.camunda.process.test.api.assertions.IncidentSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.UserTaskAssert;
@@ -49,4 +51,12 @@ public interface AssertionFacade {
    * @return the assertion object
    */
   DecisionInstanceAssert assertThatDecision(final DecisionSelector decisionSelector);
+
+  /**
+   * Returns the assertion object for the given incident selector.
+   *
+   * @param incidentSelector the selector to identify the incident
+   * @return the assertion object
+   */
+  IncidentAssert assertThatIncident(final IncidentSelector incidentSelector);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/CamundaTestCaseRunner.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/CamundaTestCaseRunner.java
@@ -20,6 +20,8 @@ import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.assertions.DecisionInstanceAssert;
 import io.camunda.process.test.api.assertions.DecisionSelector;
+import io.camunda.process.test.api.assertions.IncidentAssert;
+import io.camunda.process.test.api.assertions.IncidentSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.UserTaskAssert;
@@ -105,6 +107,11 @@ public class CamundaTestCaseRunner implements TestCaseRunner {
     @Override
     public DecisionInstanceAssert assertThatDecision(final DecisionSelector selector) {
       return CamundaAssert.assertThatDecision(selector);
+    }
+
+    @Override
+    public IncidentAssert assertThatIncident(final IncidentSelector selector) {
+      return CamundaAssert.assertThatIncident(selector);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/TestCaseInstructionHandlerRegistry.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/TestCaseInstructionHandlerRegistry.java
@@ -21,6 +21,7 @@ import io.camunda.process.test.api.testCases.TestCaseInstruction;
 import io.camunda.process.test.impl.testCases.instructions.AssertDecisionInstructionHandler;
 import io.camunda.process.test.impl.testCases.instructions.AssertElementInstanceInstructionHandler;
 import io.camunda.process.test.impl.testCases.instructions.AssertElementInstancesInstructionHandler;
+import io.camunda.process.test.impl.testCases.instructions.AssertIncidentInstructionHandler;
 import io.camunda.process.test.impl.testCases.instructions.AssertProcessInstanceInstructionHandler;
 import io.camunda.process.test.impl.testCases.instructions.AssertProcessInstanceMessageSubscriptionInstructionHandler;
 import io.camunda.process.test.impl.testCases.instructions.AssertUserTaskInstructionHandler;
@@ -64,6 +65,7 @@ public class TestCaseInstructionHandlerRegistry {
     register(new AssertDecisionInstructionHandler());
     register(new AssertElementInstanceInstructionHandler());
     register(new AssertElementInstancesInstructionHandler());
+    register(new AssertIncidentInstructionHandler());
     register(new AssertProcessInstanceInstructionHandler());
     register(new AssertProcessInstanceMessageSubscriptionInstructionHandler());
     register(new AssertUserTaskInstructionHandler());

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/instructions/AssertIncidentInstructionHandler.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/instructions/AssertIncidentInstructionHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testCases.instructions;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.assertions.IncidentAssert;
+import io.camunda.process.test.api.assertions.IncidentSelector;
+import io.camunda.process.test.api.testCases.instructions.AssertIncidentInstruction;
+import io.camunda.process.test.api.testCases.instructions.assertIncident.IncidentState;
+import io.camunda.process.test.impl.testCases.AssertionFacade;
+import io.camunda.process.test.impl.testCases.TestCaseInstructionHandler;
+
+public class AssertIncidentInstructionHandler
+    implements TestCaseInstructionHandler<AssertIncidentInstruction> {
+
+  @Override
+  public void execute(
+      final AssertIncidentInstruction instruction,
+      final CamundaProcessTestContext context,
+      final CamundaClient camundaClient,
+      final AssertionFacade assertionFacade) {
+
+    final IncidentSelector incidentSelector =
+        InstructionSelectorFactory.buildIncidentSelector(instruction.getIncidentSelector());
+    final IncidentAssert incidentAssert = assertionFacade.assertThatIncident(incidentSelector);
+
+    instruction.getState().ifPresent(expectedState -> assertState(incidentAssert, expectedState));
+    instruction
+        .getErrorType()
+        .map(errorType -> IncidentErrorType.valueOf(errorType.name()))
+        .ifPresent(incidentAssert::hasErrorType);
+    instruction.getErrorMessage().ifPresent(incidentAssert::hasErrorMessage);
+    instruction.getElementId().ifPresent(incidentAssert::hasElementId);
+  }
+
+  @Override
+  public Class<AssertIncidentInstruction> getInstructionType() {
+    return AssertIncidentInstruction.class;
+  }
+
+  private static void assertState(
+      final IncidentAssert incidentAssert, final IncidentState expectedState) {
+    switch (expectedState) {
+      case IS_ACTIVE:
+        incidentAssert.isActive();
+        break;
+      case IS_RESOLVED:
+        incidentAssert.isResolved();
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported incident state: " + expectedState);
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/AssertionConfigurationTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/AssertionConfigurationTest.java
@@ -24,13 +24,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.process.test.api.assertions.DecisionSelectors;
+import io.camunda.process.test.api.assertions.IncidentSelectors;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
 import io.camunda.process.test.api.assertions.UserTaskSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.utils.DecisionInstanceBuilder;
 import io.camunda.process.test.utils.ElementInstanceBuilder;
+import io.camunda.process.test.utils.IncidentBuilder;
 import io.camunda.process.test.utils.MessageSubscriptionBuilder;
 import io.camunda.process.test.utils.ProcessInstanceBuilder;
 import io.camunda.process.test.utils.UserTaskBuilder;
@@ -364,6 +367,39 @@ public class AssertionConfigurationTest {
       final InOrder inOrder = inOrder(globalAwaitBehavior, overrideAwaitBehavior);
       inOrder.verify(overrideAwaitBehavior, times(1)).untilAsserted(any());
       inOrder.verify(globalAwaitBehavior, times(1)).untilAsserted(any());
+    }
+  }
+
+  @Nested
+  class IncidentAssertionTests {
+
+    private static final String ELEMENT_ID = "payment";
+
+    @BeforeEach
+    void configureDataSource() {
+      // given
+      lenient()
+          .when(camundaDataSource.findIncidents(any()))
+          .thenReturn(
+              Collections.singletonList(
+                  IncidentBuilder.newActiveIncident(
+                          IncidentErrorType.JOB_NO_RETRIES, "Payment failed")
+                      .setElementId(ELEMENT_ID)
+                      .build()));
+    }
+
+    @Test
+    void shouldOverrideTimeoutForIncidentAssertions() {
+      // when
+      CamundaAssert.assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+          .withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE)
+          .isActive()
+          .hasErrorType(IncidentErrorType.JOB_NO_RETRIES);
+
+      // then
+      verify(globalAwaitBehavior).withAssertionTimeout(ASSERTION_TIMEOUT_OVERRIDE);
+      verify(overrideAwaitBehavior, times(2)).untilAsserted(any());
+      verifyNoMoreInteractions(globalAwaitBehavior);
     }
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.api;
 
 import static io.camunda.process.test.api.CamundaAssert.assertThatDecision;
+import static io.camunda.process.test.api.CamundaAssert.assertThatIncident;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.api.CamundaAssert.assertThatUserTask;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byId;
@@ -33,6 +34,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.api.response.EvaluateDecisionResponse;
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.response.DecisionRequirements;
 import io.camunda.client.api.search.response.ProcessDefinition;
@@ -40,6 +42,7 @@ import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.process.test.api.assertions.DecisionSelectors;
 import io.camunda.process.test.api.assertions.ElementSelectors;
+import io.camunda.process.test.api.assertions.IncidentSelector;
 import io.camunda.process.test.api.assertions.IncidentSelectors;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
 import io.camunda.process.test.api.assertions.UserTaskSelectors;
@@ -1323,6 +1326,55 @@ public class CamundaProcessTestExtensionIT {
 
   @Nested
   class IncidentTests {
+
+    @Test
+    void shouldAssertSpecificIncident() {
+      // given
+      final String processId = "incident-assertion-process";
+      final String gatewayId = "priority-gateway";
+      final String errorMessage =
+          "Expected at least one condition to evaluate to true, or to have a default flow";
+
+      deployProcessModel(
+          Bpmn.createExecutableProcess(processId)
+              .startEvent()
+              .exclusiveGateway(gatewayId)
+              .conditionExpression("priority > 10")
+              .endEvent("high-priority-end")
+              .moveToLastExclusiveGateway()
+              .conditionExpression("priority < 5")
+              .endEvent("low-priority-end")
+              .done());
+
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .variable("priority", 7)
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      final IncidentSelector incidentSelector =
+          IncidentSelectors.byElementId(gatewayId)
+              .and(IncidentSelectors.byProcessInstanceKey(processInstanceKey));
+
+      assertThatIncident(incidentSelector)
+          .isActive()
+          .hasErrorType(IncidentErrorType.CONDITION_ERROR)
+          .hasErrorMessage(errorMessage)
+          .hasElementId(gatewayId)
+          .hasProcessInstanceKey(processInstanceKey);
+
+      // when
+      client.newSetVariablesCommand(processInstanceKey).variable("priority", 15).send().join();
+      processTestContext.resolveIncident(incidentSelector);
+
+      // then
+      assertThatIncident(incidentSelector).isResolved();
+      assertThatProcessInstance(ProcessInstanceSelectors.byKey(processInstanceKey)).isCompleted();
+    }
 
     @Test
     void shouldResolveIncident() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/IncidentAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/IncidentAssertTest.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static io.camunda.process.test.api.CamundaAssert.assertThatIncident;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.process.test.api.assertions.IncidentSelectors;
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.utils.CamundaAssertExpectFailure;
+import io.camunda.process.test.utils.CamundaAssertExtension;
+import io.camunda.process.test.utils.IncidentBuilder;
+import java.util.Arrays;
+import java.util.Collections;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({CamundaAssertExtension.class, MockitoExtension.class})
+public class IncidentAssertTest {
+
+  private static final String ELEMENT_ID = "payment";
+  private static final long PROCESS_INSTANCE_KEY = 123L;
+
+  @Mock private CamundaDataSource camundaDataSource;
+
+  @BeforeEach
+  void configureAssertions() {
+    CamundaAssert.initialize(camundaDataSource);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentState.class,
+      names = {"ACTIVE", "PENDING", "MIGRATED"})
+  void shouldAssertIncidentIsActive(final IncidentState state) {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, state)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isActive();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentState.class,
+      names = {"RESOLVED", "UNKNOWN", "UNKNOWN_ENUM_VALUE"})
+  @CamundaAssertExpectFailure
+  void shouldFailIfIncidentIsNotActive(final IncidentState state) {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, state)));
+
+    // when / then
+    Assertions.assertThatThrownBy(
+            () -> assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isActive())
+        .hasMessage(
+            "Expected incident [elementId: %s] to be active, but was %s",
+            ELEMENT_ID, state.name().toLowerCase());
+  }
+
+  @Test
+  @CamundaAssertExpectFailure
+  void shouldFailIfNoMatchingIncidentExists() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident("shipping", IncidentState.ACTIVE)));
+
+    // when / then
+    Assertions.assertThatThrownBy(
+            () -> assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isActive())
+        .hasMessage("No incident [elementId: %s] found", ELEMENT_ID);
+  }
+
+  @Test
+  void shouldEventuallyFindMatchingIncident() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.emptyList())
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.ACTIVE)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isActive();
+  }
+
+  @Test
+  void shouldIgnoreNonMatchingIncidents() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Arrays.asList(
+                newIncident("shipping", IncidentState.RESOLVED),
+                newIncident(ELEMENT_ID, IncidentState.ACTIVE)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isActive();
+  }
+
+  @Test
+  void shouldAssertIncidentIsResolved() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.RESOLVED)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isResolved();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentState.class,
+      names = {"ACTIVE", "PENDING", "MIGRATED", "UNKNOWN", "UNKNOWN_ENUM_VALUE"})
+  @CamundaAssertExpectFailure
+  void shouldFailIfIncidentIsNotResolved(final IncidentState state) {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, state)));
+
+    // when / then
+    Assertions.assertThatThrownBy(
+            () -> assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isResolved())
+        .hasMessage(
+            "Expected incident [elementId: %s] to be resolved, but was %s",
+            ELEMENT_ID, state.name().toLowerCase());
+  }
+
+  @Test
+  void shouldEventuallyAssertIncidentIsResolved() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.ACTIVE)))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.RESOLVED)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isResolved();
+  }
+
+  @Test
+  void shouldRefreshIncidentForEachChainedAssertion() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.ACTIVE)))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.RESOLVED)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).isActive().isResolved();
+  }
+
+  @Test
+  void shouldChainIncidentAssertions() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.ACTIVE)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+        .isActive()
+        .hasErrorType(IncidentErrorType.JOB_NO_RETRIES)
+        .hasErrorMessage("Payment failed")
+        .hasElementId(ELEMENT_ID)
+        .hasProcessInstanceKey(PROCESS_INSTANCE_KEY);
+  }
+
+  @Test
+  void shouldAssertIncidentHasErrorType() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(ELEMENT_ID, IncidentState.ACTIVE, IncidentErrorType.JOB_NO_RETRIES)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+        .hasErrorType(IncidentErrorType.JOB_NO_RETRIES);
+  }
+
+  @Test
+  @CamundaAssertExpectFailure
+  void shouldFailIfIncidentHasDifferentErrorType() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(ELEMENT_ID, IncidentState.ACTIVE, IncidentErrorType.CONDITION_ERROR)));
+
+    // when / then
+    Assertions.assertThatThrownBy(
+            () ->
+                assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+                    .hasErrorType(IncidentErrorType.JOB_NO_RETRIES))
+        .hasMessage(
+            "Expected incident [elementId: %s] to have error type %s, but was %s",
+            ELEMENT_ID, IncidentErrorType.JOB_NO_RETRIES, IncidentErrorType.CONDITION_ERROR);
+  }
+
+  @Test
+  void shouldEventuallyAssertIncidentHasErrorType() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(ELEMENT_ID, IncidentState.ACTIVE, IncidentErrorType.CONDITION_ERROR)))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(ELEMENT_ID, IncidentState.ACTIVE, IncidentErrorType.JOB_NO_RETRIES)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+        .hasErrorType(IncidentErrorType.JOB_NO_RETRIES);
+  }
+
+  @Test
+  void shouldAssertIncidentHasErrorMessage() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(
+                    ELEMENT_ID,
+                    IncidentState.ACTIVE,
+                    IncidentErrorType.JOB_NO_RETRIES,
+                    "Payment failed")));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).hasErrorMessage("Payment failed");
+  }
+
+  @Test
+  @CamundaAssertExpectFailure
+  void shouldFailIfIncidentHasDifferentErrorMessage() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(
+                    ELEMENT_ID,
+                    IncidentState.ACTIVE,
+                    IncidentErrorType.JOB_NO_RETRIES,
+                    "Card declined")));
+
+    // when / then
+    Assertions.assertThatThrownBy(
+            () ->
+                assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+                    .hasErrorMessage("Payment failed"))
+        .hasMessage(
+            "Expected incident [elementId: %s] to have error message '%s', but was '%s'",
+            ELEMENT_ID, "Payment failed", "Card declined");
+  }
+
+  @Test
+  @CamundaAssertExpectFailure
+  void shouldFailSafelyIfIncidentHasNullErrorMessage() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(
+                    ELEMENT_ID, IncidentState.ACTIVE, IncidentErrorType.JOB_NO_RETRIES, null)));
+
+    // when / then
+    Assertions.assertThatThrownBy(
+            () ->
+                assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+                    .hasErrorMessage("Payment failed"))
+        .hasMessage(
+            "Expected incident [elementId: %s] to have error message '%s', but was '%s'",
+            ELEMENT_ID, "Payment failed", null);
+  }
+
+  @Test
+  void shouldEventuallyAssertIncidentHasErrorMessage() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(
+                    ELEMENT_ID,
+                    IncidentState.ACTIVE,
+                    IncidentErrorType.JOB_NO_RETRIES,
+                    "Card declined")))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(
+                    ELEMENT_ID,
+                    IncidentState.ACTIVE,
+                    IncidentErrorType.JOB_NO_RETRIES,
+                    "Payment failed")));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID)).hasErrorMessage("Payment failed");
+  }
+
+  @Test
+  void shouldAssertIncidentHasElementId() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.ACTIVE)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byProcessInstanceKey(PROCESS_INSTANCE_KEY))
+        .hasElementId(ELEMENT_ID);
+  }
+
+  @Test
+  @CamundaAssertExpectFailure
+  void shouldFailIfIncidentHasDifferentElementId() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident("shipping", IncidentState.ACTIVE)));
+
+    // when / then
+    Assertions.assertThatThrownBy(
+            () ->
+                assertThatIncident(IncidentSelectors.byProcessInstanceKey(PROCESS_INSTANCE_KEY))
+                    .hasElementId(ELEMENT_ID))
+        .hasMessage(
+            "Expected incident [processInstanceKey: %d] to have element ID '%s', but was '%s'",
+            PROCESS_INSTANCE_KEY, ELEMENT_ID, "shipping");
+  }
+
+  @Test
+  void shouldEventuallyAssertIncidentHasElementId() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident("shipping", IncidentState.ACTIVE)))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.ACTIVE)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byProcessInstanceKey(PROCESS_INSTANCE_KEY))
+        .hasElementId(ELEMENT_ID);
+  }
+
+  @Test
+  void shouldAssertIncidentHasProcessInstanceKey() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.ACTIVE)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+        .hasProcessInstanceKey(PROCESS_INSTANCE_KEY);
+  }
+
+  @Test
+  @CamundaAssertExpectFailure
+  void shouldFailIfIncidentHasDifferentProcessInstanceKey() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(
+                    ELEMENT_ID,
+                    IncidentState.ACTIVE,
+                    IncidentErrorType.JOB_NO_RETRIES,
+                    "Payment failed",
+                    456L)));
+
+    // when / then
+    Assertions.assertThatThrownBy(
+            () ->
+                assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+                    .hasProcessInstanceKey(PROCESS_INSTANCE_KEY))
+        .hasMessage(
+            "Expected incident [elementId: %s] to have process instance key %d, but was %d",
+            ELEMENT_ID, PROCESS_INSTANCE_KEY, 456L);
+  }
+
+  @Test
+  void shouldEventuallyAssertIncidentHasProcessInstanceKey() {
+    // given
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Collections.singletonList(
+                newIncident(
+                    ELEMENT_ID,
+                    IncidentState.ACTIVE,
+                    IncidentErrorType.JOB_NO_RETRIES,
+                    "Payment failed",
+                    456L)))
+        .thenReturn(Collections.singletonList(newIncident(ELEMENT_ID, IncidentState.ACTIVE)));
+
+    // when / then
+    assertThatIncident(IncidentSelectors.byElementId(ELEMENT_ID))
+        .hasProcessInstanceKey(PROCESS_INSTANCE_KEY);
+  }
+
+  private static Incident newIncident(final String elementId, final IncidentState state) {
+    return newIncident(elementId, state, IncidentErrorType.JOB_NO_RETRIES);
+  }
+
+  private static Incident newIncident(
+      final String elementId,
+      final IncidentState state,
+      final IncidentErrorType incidentErrorType) {
+    return newIncident(elementId, state, incidentErrorType, "Payment failed");
+  }
+
+  private static Incident newIncident(
+      final String elementId,
+      final IncidentState state,
+      final IncidentErrorType incidentErrorType,
+      final String errorMessage) {
+    return newIncident(elementId, state, incidentErrorType, errorMessage, PROCESS_INSTANCE_KEY);
+  }
+
+  private static Incident newIncident(
+      final String elementId,
+      final IncidentState state,
+      final IncidentErrorType incidentErrorType,
+      final String errorMessage,
+      final long processInstanceKey) {
+    return IncidentBuilder.newActiveIncident(incidentErrorType, errorMessage)
+        .setElementId(elementId)
+        .setProcessInstanceKey(processInstanceKey)
+        .setState(state)
+        .build();
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/IncidentSelectorsTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/IncidentSelectorsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.filter.IncidentFilter;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.process.test.api.assertions.IncidentSelector;
+import io.camunda.process.test.api.assertions.IncidentSelectors;
+import io.camunda.process.test.utils.IncidentBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class IncidentSelectorsTest {
+
+  @Mock private IncidentFilter incidentFilter;
+
+  @Test
+  void shouldSelectIncidentByErrorType() {
+    // given
+    final IncidentSelector selector =
+        IncidentSelectors.byErrorType(IncidentErrorType.JOB_NO_RETRIES);
+
+    // when
+    selector.applyFilter(incidentFilter);
+
+    // then
+    verify(incidentFilter).errorType(IncidentErrorType.JOB_NO_RETRIES);
+    assertThat(selector.test(newIncident(IncidentErrorType.JOB_NO_RETRIES, IncidentState.ACTIVE)))
+        .isTrue();
+    assertThat(selector.test(newIncident(IncidentErrorType.CONDITION_ERROR, IncidentState.ACTIVE)))
+        .isFalse();
+    assertThat(selector.describe()).isEqualTo("errorType: JOB_NO_RETRIES");
+  }
+
+  @Test
+  void shouldSelectIncidentByExactState() {
+    // given
+    final IncidentSelector selector = IncidentSelectors.byState(IncidentState.ACTIVE);
+
+    // when
+    selector.applyFilter(incidentFilter);
+
+    // then
+    verify(incidentFilter).state(IncidentState.ACTIVE);
+    assertThat(selector.test(newIncident(IncidentErrorType.JOB_NO_RETRIES, IncidentState.ACTIVE)))
+        .isTrue();
+    assertThat(selector.test(newIncident(IncidentErrorType.JOB_NO_RETRIES, IncidentState.PENDING)))
+        .isFalse();
+    assertThat(selector.describe()).isEqualTo("state: ACTIVE");
+  }
+
+  @Test
+  void shouldComposeIncidentSelectors() {
+    // given
+    final IncidentSelector selector =
+        IncidentSelectors.byErrorType(IncidentErrorType.JOB_NO_RETRIES)
+            .and(IncidentSelectors.byState(IncidentState.ACTIVE));
+
+    // when
+    selector.applyFilter(incidentFilter);
+
+    // then
+    verify(incidentFilter).errorType(IncidentErrorType.JOB_NO_RETRIES);
+    verify(incidentFilter).state(IncidentState.ACTIVE);
+    assertThat(selector.test(newIncident(IncidentErrorType.JOB_NO_RETRIES, IncidentState.ACTIVE)))
+        .isTrue();
+    assertThat(selector.test(newIncident(IncidentErrorType.JOB_NO_RETRIES, IncidentState.RESOLVED)))
+        .isFalse();
+    assertThat(selector.describe()).isEqualTo("errorType: JOB_NO_RETRIES, state: ACTIVE");
+  }
+
+  private static Incident newIncident(
+      final IncidentErrorType errorType, final IncidentState state) {
+    return IncidentBuilder.newActiveIncident(errorType, "Payment failed").setState(state).build();
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceIncidentAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceIncidentAssertTest.java
@@ -45,7 +45,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({CamundaAssertExtension.class, MockitoExtension.class})
-public class IncidentAssertTest {
+public class ProcessInstanceIncidentAssertTest {
 
   private static final long PROCESS_INSTANCE_KEY = 1L;
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testCases/AssertIncidentInstructionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testCases/AssertIncidentInstructionTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testCases;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.filter.IncidentFilter;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.assertions.IncidentAssert;
+import io.camunda.process.test.api.assertions.IncidentSelector;
+import io.camunda.process.test.api.testCases.ImmutableIncidentSelector;
+import io.camunda.process.test.api.testCases.instructions.AssertIncidentInstruction;
+import io.camunda.process.test.api.testCases.instructions.ImmutableAssertIncidentInstruction;
+import io.camunda.process.test.api.testCases.instructions.assertIncident.IncidentErrorType;
+import io.camunda.process.test.api.testCases.instructions.assertIncident.IncidentState;
+import io.camunda.process.test.impl.testCases.instructions.AssertIncidentInstructionHandler;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AssertIncidentInstructionTest {
+
+  @Mock private CamundaProcessTestContext processTestContext;
+  @Mock private CamundaClient camundaClient;
+  @Mock private AssertionFacade assertionFacade;
+  @Mock private IncidentAssert incidentAssert;
+  @Mock private IncidentFilter incidentFilter;
+  @Captor private ArgumentCaptor<IncidentSelector> incidentSelectorCaptor;
+
+  private final AssertIncidentInstructionHandler instructionHandler =
+      new AssertIncidentInstructionHandler();
+
+  @Test
+  void shouldSelectIncidentByAllSelectorProperties() {
+    // given
+    final AssertIncidentInstruction instruction =
+        ImmutableAssertIncidentInstruction.builder()
+            .incidentSelector(
+                ImmutableIncidentSelector.builder()
+                    .elementId("payment-task")
+                    .processDefinitionId("payment-process")
+                    .build())
+            .build();
+
+    // when
+    execute(instruction);
+
+    // then
+    verify(assertionFacade).assertThatIncident(incidentSelectorCaptor.capture());
+    incidentSelectorCaptor.getValue().applyFilter(incidentFilter);
+    verify(incidentFilter).elementId("payment-task");
+    verify(incidentFilter).processDefinitionId("payment-process");
+    verifyNoInteractions(incidentAssert);
+    verifyNoMoreInteractions(processTestContext, camundaClient, assertionFacade);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("stateAssertions")
+  void shouldAssertState(
+      final IncidentState state, final Consumer<IncidentAssert> expectedAssertion) {
+    // given
+    final AssertIncidentInstruction instruction =
+        ImmutableAssertIncidentInstruction.builder()
+            .incidentSelector(ImmutableIncidentSelector.builder().elementId("payment-task").build())
+            .state(state)
+            .build();
+
+    // when
+    execute(instruction);
+
+    // then
+    verify(assertionFacade).assertThatIncident(any());
+    expectedAssertion.accept(verify(incidentAssert));
+    verifyNoMoreInteractions(processTestContext, camundaClient, assertionFacade, incidentAssert);
+  }
+
+  @ParameterizedTest
+  @EnumSource(IncidentErrorType.class)
+  void shouldAssertEveryErrorType(final IncidentErrorType errorType) {
+    // given
+    final AssertIncidentInstruction instruction =
+        ImmutableAssertIncidentInstruction.builder()
+            .incidentSelector(ImmutableIncidentSelector.builder().elementId("payment-task").build())
+            .errorType(errorType)
+            .build();
+
+    // when
+    execute(instruction);
+
+    // then
+    verify(assertionFacade).assertThatIncident(any());
+    verify(incidentAssert)
+        .hasErrorType(
+            io.camunda.client.api.search.enums.IncidentErrorType.valueOf(errorType.name()));
+    verifyNoMoreInteractions(processTestContext, camundaClient, assertionFacade, incidentAssert);
+  }
+
+  @Test
+  void shouldKeepJsonAndClientErrorTypesInSync() {
+    // given
+    final Set<String> jsonErrorTypes =
+        Arrays.stream(IncidentErrorType.values()).map(Enum::name).collect(Collectors.toSet());
+    final Set<String> clientErrorTypes =
+        Arrays.stream(io.camunda.client.api.search.enums.IncidentErrorType.values())
+            .map(Enum::name)
+            .collect(Collectors.toSet());
+
+    // when / then
+    assertThat(jsonErrorTypes).isEqualTo(clientErrorTypes);
+  }
+
+  @Test
+  void shouldAssertErrorMessage() {
+    // given
+    final AssertIncidentInstruction instruction =
+        ImmutableAssertIncidentInstruction.builder()
+            .incidentSelector(ImmutableIncidentSelector.builder().elementId("payment-task").build())
+            .errorMessage("Payment worker failed")
+            .build();
+
+    // when
+    execute(instruction);
+
+    // then
+    verify(assertionFacade).assertThatIncident(any());
+    verify(incidentAssert).hasErrorMessage("Payment worker failed");
+    verifyNoMoreInteractions(processTestContext, camundaClient, assertionFacade, incidentAssert);
+  }
+
+  @Test
+  void shouldAssertElementId() {
+    // given
+    final AssertIncidentInstruction instruction =
+        ImmutableAssertIncidentInstruction.builder()
+            .incidentSelector(
+                ImmutableIncidentSelector.builder().processDefinitionId("payment-process").build())
+            .elementId("payment-task")
+            .build();
+
+    // when
+    execute(instruction);
+
+    // then
+    verify(assertionFacade).assertThatIncident(any());
+    verify(incidentAssert).hasElementId("payment-task");
+    verifyNoMoreInteractions(processTestContext, camundaClient, assertionFacade, incidentAssert);
+  }
+
+  static Stream<Arguments> stateAssertions() {
+    return Stream.of(
+        Arguments.of(IncidentState.IS_ACTIVE, (Consumer<IncidentAssert>) IncidentAssert::isActive),
+        Arguments.of(
+            IncidentState.IS_RESOLVED, (Consumer<IncidentAssert>) IncidentAssert::isResolved));
+  }
+
+  private void execute(final AssertIncidentInstruction instruction) {
+    when(assertionFacade.assertThatIncident(any())).thenReturn(incidentAssert);
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testCases/TestCaseRunnerTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testCases/TestCaseRunnerTest.java
@@ -25,12 +25,15 @@ import static org.mockito.Mockito.when;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.assertions.IncidentAssert;
+import io.camunda.process.test.api.testCases.ImmutableIncidentSelector;
 import io.camunda.process.test.api.testCases.ImmutableProcessDefinitionSelector;
 import io.camunda.process.test.api.testCases.ImmutableProcessInstanceSelector;
 import io.camunda.process.test.api.testCases.ImmutableTestCase;
 import io.camunda.process.test.api.testCases.TestCase;
 import io.camunda.process.test.api.testCases.TestCaseInstruction;
 import io.camunda.process.test.api.testCases.TestCaseRunner;
+import io.camunda.process.test.api.testCases.instructions.ImmutableAssertIncidentInstruction;
 import io.camunda.process.test.api.testCases.instructions.ImmutableAssertProcessInstanceInstruction;
 import io.camunda.process.test.api.testCases.instructions.ImmutableCreateProcessInstanceInstruction;
 import io.camunda.process.test.api.testCases.instructions.assertProcessInstance.ProcessInstanceState;
@@ -49,6 +52,7 @@ public class TestCaseRunnerTest {
   private CamundaClient camundaClient;
 
   @Mock private AssertionFacade assertionFacade;
+  @Mock private IncidentAssert incidentAssert;
 
   @Test
   void shouldExecuteInstruction() {
@@ -70,6 +74,25 @@ public class TestCaseRunnerTest {
 
     // then
     verify(camundaClient).newCreateInstanceCommand();
+  }
+
+  @Test
+  void shouldExecuteAssertIncidentInstruction() {
+    // given
+    final TestCaseRunner runner = new CamundaTestCaseRunner(processTestContext, assertionFacade);
+    when(processTestContext.createClient()).thenReturn(camundaClient);
+    when(assertionFacade.assertThatIncident(any())).thenReturn(incidentAssert);
+
+    final TestCase testCase =
+        createTestCase(
+            ImmutableAssertIncidentInstruction.builder()
+                .incidentSelector(
+                    ImmutableIncidentSelector.builder().elementId("payment-task").build())
+                .build());
+
+    // when / then
+    assertThatCode(() -> runner.run(testCase)).doesNotThrowAnyException();
+    verify(assertionFacade).assertThatIncident(any());
   }
 
   @Test

--- a/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/TestCaseInstruction.java
+++ b/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/TestCaseInstruction.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import io.camunda.process.test.api.testCases.instructions.AssertDecisionInstruction;
 import io.camunda.process.test.api.testCases.instructions.AssertElementInstanceInstruction;
 import io.camunda.process.test.api.testCases.instructions.AssertElementInstancesInstruction;
+import io.camunda.process.test.api.testCases.instructions.AssertIncidentInstruction;
 import io.camunda.process.test.api.testCases.instructions.AssertProcessInstanceInstruction;
 import io.camunda.process.test.api.testCases.instructions.AssertProcessInstanceMessageSubscriptionInstruction;
 import io.camunda.process.test.api.testCases.instructions.AssertUserTaskInstruction;
@@ -63,6 +64,9 @@ import io.camunda.process.test.api.testCases.instructions.UpdateVariablesInstruc
   @JsonSubTypes.Type(
       value = AssertElementInstancesInstruction.class,
       name = TestCaseInstructionType.ASSERT_ELEMENT_INSTANCES),
+  @JsonSubTypes.Type(
+      value = AssertIncidentInstruction.class,
+      name = TestCaseInstructionType.ASSERT_INCIDENT),
   @JsonSubTypes.Type(
       value = AssertProcessInstanceInstruction.class,
       name = TestCaseInstructionType.ASSERT_PROCESS_INSTANCE),

--- a/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/TestCaseInstructionType.java
+++ b/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/TestCaseInstructionType.java
@@ -21,6 +21,7 @@ public class TestCaseInstructionType {
   public static final String ASSERT_DECISION = "ASSERT_DECISION";
   public static final String ASSERT_ELEMENT_INSTANCE = "ASSERT_ELEMENT_INSTANCE";
   public static final String ASSERT_ELEMENT_INSTANCES = "ASSERT_ELEMENT_INSTANCES";
+  public static final String ASSERT_INCIDENT = "ASSERT_INCIDENT";
   public static final String ASSERT_PROCESS_INSTANCE = "ASSERT_PROCESS_INSTANCE";
   public static final String ASSERT_PROCESS_INSTANCE_MESSAGE_SUBSCRIPTION =
       "ASSERT_PROCESS_INSTANCE_MESSAGE_SUBSCRIPTION";

--- a/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/instructions/AssertIncidentInstruction.java
+++ b/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/instructions/AssertIncidentInstruction.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.testCases.instructions;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.process.test.api.testCases.IncidentSelector;
+import io.camunda.process.test.api.testCases.TestCaseInstruction;
+import io.camunda.process.test.api.testCases.TestCaseInstructionType;
+import io.camunda.process.test.api.testCases.instructions.assertIncident.IncidentErrorType;
+import io.camunda.process.test.api.testCases.instructions.assertIncident.IncidentState;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/** An instruction to assert an incident. */
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableAssertIncidentInstruction.Builder.class)
+public interface AssertIncidentInstruction extends TestCaseInstruction {
+
+  @Value.Default
+  @Override
+  default String getType() {
+    return TestCaseInstructionType.ASSERT_INCIDENT;
+  }
+
+  /**
+   * The selector to identify the incident.
+   *
+   * @return the incident selector
+   */
+  IncidentSelector getIncidentSelector();
+
+  /**
+   * The expected state of the incident. Optional.
+   *
+   * @return the expected state or empty if not asserted
+   */
+  Optional<IncidentState> getState();
+
+  /**
+   * The expected error type of the incident. Optional.
+   *
+   * @return the expected error type or empty if not asserted
+   */
+  Optional<IncidentErrorType> getErrorType();
+
+  /**
+   * The expected error message of the incident. Optional.
+   *
+   * @return the expected error message or empty if not asserted
+   */
+  Optional<String> getErrorMessage();
+
+  /**
+   * The expected BPMN element ID of the incident. Optional.
+   *
+   * @return the expected element ID or empty if not asserted
+   */
+  Optional<String> getElementId();
+}

--- a/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/instructions/assertIncident/IncidentErrorType.java
+++ b/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/instructions/assertIncident/IncidentErrorType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.testCases.instructions.assertIncident;
+
+/** The possible error types of an incident to assert. */
+public enum IncidentErrorType {
+  UNSPECIFIED,
+  UNKNOWN,
+  IO_MAPPING_ERROR,
+  JOB_NO_RETRIES,
+  EXECUTION_LISTENER_NO_RETRIES,
+  TASK_LISTENER_NO_RETRIES,
+  AD_HOC_SUB_PROCESS_NO_RETRIES,
+  CONDITION_ERROR,
+  EXTRACT_VALUE_ERROR,
+  CALLED_ELEMENT_ERROR,
+  UNHANDLED_ERROR_EVENT,
+  MESSAGE_SIZE_EXCEEDED,
+  CALLED_DECISION_ERROR,
+  DECISION_EVALUATION_ERROR,
+  FORM_NOT_FOUND,
+  RESOURCE_NOT_FOUND,
+  SECRET_RESOLUTION_ERROR,
+  UNKNOWN_ENUM_VALUE
+}

--- a/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/instructions/assertIncident/IncidentState.java
+++ b/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/instructions/assertIncident/IncidentState.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.testCases.instructions.assertIncident;
+
+/** The possible states of an incident to assert. */
+public enum IncidentState {
+  IS_ACTIVE,
+  IS_RESOLVED
+}

--- a/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
+++ b/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
@@ -57,6 +57,9 @@
           "$ref": "#/definitions/AssertElementInstancesInstruction"
         },
         {
+          "$ref": "#/definitions/AssertIncidentInstruction"
+        },
+        {
           "$ref": "#/definitions/AssertProcessInstanceInstruction"
         },
         {
@@ -530,6 +533,66 @@
         "processInstanceSelector",
         "elementSelectors",
         "state"
+      ],
+      "additionalProperties": false
+    },
+    "AssertIncidentInstruction": {
+      "description": "An instruction to assert an incident.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of the instruction.",
+          "type": "string",
+          "const": "ASSERT_INCIDENT"
+        },
+        "incidentSelector": {
+          "description": "The selector to identify the incident.",
+          "$ref": "#/definitions/IncidentSelector"
+        },
+        "state": {
+          "description": "The expected state of the incident. Optional.",
+          "type": "string",
+          "enum": [
+            "IS_ACTIVE",
+            "IS_RESOLVED"
+          ]
+        },
+        "errorType": {
+          "description": "The expected error type of the incident. Optional.",
+          "type": "string",
+          "enum": [
+            "UNSPECIFIED",
+            "UNKNOWN",
+            "IO_MAPPING_ERROR",
+            "JOB_NO_RETRIES",
+            "EXECUTION_LISTENER_NO_RETRIES",
+            "TASK_LISTENER_NO_RETRIES",
+            "AD_HOC_SUB_PROCESS_NO_RETRIES",
+            "CONDITION_ERROR",
+            "EXTRACT_VALUE_ERROR",
+            "CALLED_ELEMENT_ERROR",
+            "UNHANDLED_ERROR_EVENT",
+            "MESSAGE_SIZE_EXCEEDED",
+            "CALLED_DECISION_ERROR",
+            "DECISION_EVALUATION_ERROR",
+            "FORM_NOT_FOUND",
+            "RESOURCE_NOT_FOUND",
+            "SECRET_RESOLUTION_ERROR",
+            "UNKNOWN_ENUM_VALUE"
+          ]
+        },
+        "errorMessage": {
+          "description": "The expected error message of the incident. Optional.",
+          "type": "string"
+        },
+        "elementId": {
+          "description": "The expected BPMN element ID of the incident. Optional.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "incidentSelector"
       ],
       "additionalProperties": false
     },

--- a/testing/camunda-process-test-json-test-cases/src/test/java/io/camunda/process/test/testCases/PojoCompatibilityTest.java
+++ b/testing/camunda-process-test-json-test-cases/src/test/java/io/camunda/process/test/testCases/PojoCompatibilityTest.java
@@ -44,6 +44,7 @@ import io.camunda.process.test.api.testCases.instructions.ImmutableActivateEleme
 import io.camunda.process.test.api.testCases.instructions.ImmutableAssertDecisionInstruction;
 import io.camunda.process.test.api.testCases.instructions.ImmutableAssertElementInstanceInstruction;
 import io.camunda.process.test.api.testCases.instructions.ImmutableAssertElementInstancesInstruction;
+import io.camunda.process.test.api.testCases.instructions.ImmutableAssertIncidentInstruction;
 import io.camunda.process.test.api.testCases.instructions.ImmutableAssertProcessInstanceInstruction;
 import io.camunda.process.test.api.testCases.instructions.ImmutableAssertProcessInstanceMessageSubscriptionInstruction;
 import io.camunda.process.test.api.testCases.instructions.ImmutableAssertUserTaskInstruction;
@@ -73,6 +74,8 @@ import io.camunda.process.test.api.testCases.instructions.ImmutableThrowBpmnErro
 import io.camunda.process.test.api.testCases.instructions.ImmutableUpdateVariablesInstruction;
 import io.camunda.process.test.api.testCases.instructions.assertElementInstance.ElementInstanceState;
 import io.camunda.process.test.api.testCases.instructions.assertElementInstances.ElementInstancesState;
+import io.camunda.process.test.api.testCases.instructions.assertIncident.IncidentErrorType;
+import io.camunda.process.test.api.testCases.instructions.assertIncident.IncidentState;
 import io.camunda.process.test.api.testCases.instructions.assertProcessInstance.ProcessInstanceState;
 import io.camunda.process.test.api.testCases.instructions.assertProcessInstanceMessageSubscription.MessageSubscriptionState;
 import io.camunda.process.test.api.testCases.instructions.assertUserTask.UserTaskState;
@@ -367,6 +370,28 @@ public class PojoCompatibilityTest {
                     .addElementSelectors(
                         ImmutableElementSelector.builder().elementId("task2").build())
                     .state(ElementInstancesState.IS_COMPLETED_IN_ORDER)
+                    .build())),
+        // ===== ASSERT_INCIDENT =====
+        Arguments.of(
+            "assert incident: minimal",
+            singleTestCase(
+                ImmutableAssertIncidentInstruction.builder()
+                    .incidentSelector(
+                        ImmutableIncidentSelector.builder().elementId("task1").build())
+                    .build())),
+        Arguments.of(
+            "assert incident: full",
+            singleTestCase(
+                ImmutableAssertIncidentInstruction.builder()
+                    .incidentSelector(
+                        ImmutableIncidentSelector.builder()
+                            .processDefinitionId("my-process")
+                            .elementId("task1")
+                            .build())
+                    .state(IncidentState.IS_ACTIVE)
+                    .errorType(IncidentErrorType.JOB_NO_RETRIES)
+                    .errorMessage("No retries left")
+                    .elementId("task1")
                     .build())),
         // ===== COMPLETE_USER_TASK =====
         Arguments.of(

--- a/testing/camunda-process-test-json-test-cases/src/test/java/io/camunda/process/test/testCases/SchemaValidationTest.java
+++ b/testing/camunda-process-test-json-test-cases/src/test/java/io/camunda/process/test/testCases/SchemaValidationTest.java
@@ -84,6 +84,60 @@ public class SchemaValidationTest {
   }
 
   @Test
+  void shouldValidateAssertIncidentInstruction() {
+    // given
+    final String json =
+        "{\"testCases\":[{\"name\":\"assert incident\",\"instructions\":[{"
+            + "\"type\":\"ASSERT_INCIDENT\","
+            + "\"incidentSelector\":{\"elementId\":\"payment-task\"},"
+            + "\"state\":\"IS_ACTIVE\","
+            + "\"errorType\":\"JOB_NO_RETRIES\","
+            + "\"errorMessage\":\"Payment worker failed\","
+            + "\"elementId\":\"payment-task\""
+            + "}]}]}";
+
+    // when
+    final List<Error> errors = jsonSchema.validate(json, InputFormat.JSON);
+
+    // then
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  void shouldRejectAssertIncidentWithoutSelector() {
+    // given
+    final String json =
+        "{\"testCases\":[{\"name\":\"assert incident\",\"instructions\":[{"
+            + "\"type\":\"ASSERT_INCIDENT\","
+            + "\"state\":\"IS_ACTIVE\""
+            + "}]}]}";
+
+    // when
+    final List<Error> errors = jsonSchema.validate(json, InputFormat.JSON);
+
+    // then
+    assertThat(errors).isNotEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"\"state\":\"INVALID\"", "\"errorType\":\"INVALID\""})
+  void shouldRejectAssertIncidentWithInvalidEnum(final String invalidProperty) {
+    // given
+    final String json =
+        "{\"testCases\":[{\"name\":\"assert incident\",\"instructions\":[{"
+            + "\"type\":\"ASSERT_INCIDENT\","
+            + "\"incidentSelector\":{\"elementId\":\"payment-task\"},"
+            + invalidProperty
+            + "}]}]}";
+
+    // when
+    final List<Error> errors = jsonSchema.validate(json, InputFormat.JSON);
+
+    // then
+    assertThat(errors).isNotEmpty();
+  }
+
+  @Test
   void shouldRejectConditionalBehaviorWithEmptyActions() throws IOException {
     // given
     final String json =


### PR DESCRIPTION
## Description

Camunda Process Test currently supports checking whether a process instance has
active incidents, but it cannot select and assert one specific incident.

This change introduces selector-based incident assertions for both Java and JSON
test cases.

```mermaid
flowchart LR
    J[Java test] --> A[Incident assertion API]
    X[JSON ASSERT_INCIDENT] --> H[Instruction handler]
    H --> A
    A --> S[IncidentSelector]
    S --> D[CamundaDataSource]
    D --> W[Await selected incident]
    W --> C[Verify state and details]
```

The selector answers **which incident to find**, while the fluent assertion
answers **what should be true about it**.

```java
assertThatIncident(IncidentSelectors.byElementId("payment"))
    .isActive()
    .hasErrorType(IncidentErrorType.CONDITION_ERROR)
    .hasErrorMessage("Payment amount is invalid");
```

The implementation:

- adds selectors for element ID, process instance key, process definition ID,
  error type, and exact state
- supports active/resolved state and incident detail assertions
- treats `ACTIVE`, `PENDING`, and `MIGRATED` as active, consistent with the
  existing process-instance assertion
- allows custom assertion timeouts while waiting for exported incident data
- adds the equivalent `ASSERT_INCIDENT` JSON instruction
- keeps existing process-instance incident assertions unchanged

## Verification

- Camunda Process Test Java: 1,122 tests passed
- JSON test cases: 162 tests passed
- Java and JSON module verification passed
- formatting, license, Checkstyle, and API compatibility checks passed
- integration coverage verifies creating, asserting, resolving, and completing
  a real incident scenario

## Related issues

Closes #55482
