### PR TITLE
test: retry Docker Hub tag lookup in exporter migration ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
@@ -543,8 +543,11 @@ public class ExporterMigrationTestHelper {
   /**
    * Docker Hub is an external dependency, and this runs while JUnit provides the arguments for the
    * migration ITs. An argument-provider failure is a container-level failure, which Failsafe's
-   * {@code rerunFailingTestsCount} cannot recover — so a single reset connection or rate-limited
-   * response fails the build outright. The retry therefore has to live here.
+   * {@code rerunFailingTestsCount} cannot recover — so a single reset connection would fail the
+   * build outright. The retry therefore has to live here.
+   *
+   * <p>Only transport failures are retried. An HTTP error response means Docker Hub answered, so it
+   * fails immediately rather than repeating a request that is already known to be rejected.
    */
   public static List<String> fetchAllPatchesFromPreviousMinor() {
     return Awaitility.await("fetch camunda/camunda image tags for " + PREVIOUS_MINOR_VERSION)
@@ -576,14 +579,15 @@ public class ExporterMigrationTestHelper {
                 .build();
         final HttpResponse<String> response =
             client.send(request, HttpResponse.BodyHandlers.ofString());
-        final JsonNode root = mapper.readTree(response.body());
 
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
-          throw new IOException(
+          throw new IllegalStateException(
               String.format(
                   "Failed to fetch Docker Hub tags from %s: HTTP %d, body: %s",
                   url, response.statusCode(), response.body()));
         }
+
+        final JsonNode root = mapper.readTree(response.body());
 
         for (final JsonNode tag : root.get("results")) {
           allTags.add(tag.get("name").asString());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
@@ -50,6 +51,8 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 public class ExporterMigrationTestHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExporterMigrationTestHelper.class);
 
   private static final String CONTAINER_DATA_PATH = "/usr/local/camunda/data";
   private static final String HTTP_PREFIX = "http://";
@@ -67,6 +70,10 @@ public class ExporterMigrationTestHelper {
       String.format(
           "https://hub.docker.com/v2/repositories/camunda/camunda/tags?page_size=%d&name=%s",
           100, PREVIOUS_MINOR_VERSION);
+  private static final Duration TAG_FETCH_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration TAG_FETCH_REQUEST_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration TAG_FETCH_MAX_DURATION = Duration.ofMinutes(2);
+  private static final Duration TAG_FETCH_RETRY_INTERVAL = Duration.ofSeconds(2);
 
   private static final String PROCESS_ID = "migration-test";
   private static final String JOB_TYPE = "test-job";
@@ -527,45 +534,72 @@ public class ExporterMigrationTestHelper {
     return Integer.compare(patch1, patch2);
   }
 
-  public static List<String> fetchLatestPatchFromPreviousMinor()
-      throws IOException, InterruptedException {
+  public static List<String> fetchLatestPatchFromPreviousMinor() {
     final List<String> allVersions = fetchAllPatchesFromPreviousMinor();
     final int len = allVersions.size();
     return List.of(allVersions.get(len - 2)); // skip SNAPSHOT from the end of the list
   }
 
-  public static List<String> fetchAllPatchesFromPreviousMinor()
+  /**
+   * Docker Hub is an external dependency, and this runs while JUnit provides the arguments for the
+   * migration ITs. An argument-provider failure is a container-level failure, which Failsafe's
+   * {@code rerunFailingTestsCount} cannot recover — so a single reset connection or rate-limited
+   * response fails the build outright. The retry therefore has to live here.
+   */
+  public static List<String> fetchAllPatchesFromPreviousMinor() {
+    return Awaitility.await("fetch camunda/camunda image tags for " + PREVIOUS_MINOR_VERSION)
+        .atMost(TAG_FETCH_MAX_DURATION)
+        .pollDelay(Duration.ZERO)
+        .pollInterval(TAG_FETCH_RETRY_INTERVAL)
+        .pollInSameThread()
+        .ignoreExceptionsInstanceOf(IOException.class)
+        .until(
+            ExporterMigrationTestHelper::fetchAllPatchesFromPreviousMinorOnce,
+            versions -> !versions.isEmpty());
+  }
+
+  private static List<String> fetchAllPatchesFromPreviousMinorOnce()
       throws IOException, InterruptedException {
-    final HttpClient client = HttpClient.newHttpClient();
     final ObjectMapper mapper = new ObjectMapper();
 
     final List<String> allTags = new ArrayList<>();
     String url = API_URL;
 
-    while (true) {
-      final HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
-      final HttpResponse<String> response =
-          client.send(request, HttpResponse.BodyHandlers.ofString());
-      final JsonNode root = mapper.readTree(response.body());
+    try (final HttpClient client =
+        HttpClient.newBuilder().connectTimeout(TAG_FETCH_CONNECT_TIMEOUT).build()) {
+      while (true) {
+        final HttpRequest request =
+            HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(TAG_FETCH_REQUEST_TIMEOUT)
+                .GET()
+                .build();
+        final HttpResponse<String> response =
+            client.send(request, HttpResponse.BodyHandlers.ofString());
+        final JsonNode root = mapper.readTree(response.body());
 
-      if (response.statusCode() < 200 || response.statusCode() >= 300) {
-        throw new IOException(
-            String.format(
-                "Failed to fetch Docker Hub tags from %s: HTTP %d, body: %s",
-                url, response.statusCode(), response.body()));
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+          throw new IOException(
+              String.format(
+                  "Failed to fetch Docker Hub tags from %s: HTTP %d, body: %s",
+                  url, response.statusCode(), response.body()));
+        }
+
+        for (final JsonNode tag : root.get("results")) {
+          allTags.add(tag.get("name").asString());
+        }
+
+        // pagination
+        final JsonNode next = root.get("next");
+        if (next == null || next.isNull()) { // NOTE: edge case
+          break;
+        }
+
+        url = next.asString();
       }
-
-      for (final JsonNode tag : root.get("results")) {
-        allTags.add(tag.get("name").asString());
-      }
-
-      // pagination
-      final JsonNode next = root.get("next");
-      if (next == null || next.isNull()) { // NOTE: edge case
-        break;
-      }
-
-      url = next.asString();
+    } catch (final IOException e) {
+      LOG.warn("Failed to fetch Docker Hub tags from {}, retrying", url, e);
+      throw e;
     }
 
     final List<String> allVersions = new ArrayList<>();


### PR DESCRIPTION
## Description

The Root Acceptance Tests ITs job failed on a stable/8.9 push when hub.docker.com reset the connection while listing camunda/camunda image tags:

```
  java.io.IOException: Connection reset
    at ExporterMigrationTestHelper.fetchAllPatchesFromPreviousMinor
    at ExporterMigrationTestHelper.fetchLatestPatchFromPreviousMinor
  Caused by: java.net.SocketException: Connection reset
```

The lookup was a single HTTP call with no retry and no timeout, so one hiccup at an external service failed the build. It also could not be absorbed by CI's -Dfailsafe.rerunFailingTestsCount=7: the call runs while JUnit provides the @MethodSource arguments, and an argument-provider failure is a container-level failure that Failsafe cannot rerun. Failsafe reported it as an error rather than a flake even though a later invocation of the same class passed.

The fetch is now wrapped in an Awaitility retry that ignores only IOException, polling every 2s for up to 2min, with an explicit 10s connect and 30s request timeout. Retrying transport failures is the fix that matches the failure mode; a non-2xx response and an empty result set still fail immediately, since those are real errors rather than network blips. Each failed attempt is logged, because Awaitility's timeout message does not carry the underlying cause.

The HTTP client moved into a try-with-resources so repeated attempts do not leak selector threads.

## Related issues

related to https://app.slack.com/client/T0PM0P1SA/C0BP6KVVA95
