### PR TITLE
test: verify a new snapshot is present before attempting a backup

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -29,10 +29,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
 import org.agrona.collections.MutableBoolean;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
@@ -289,10 +289,17 @@ public interface BackupCompatibilityAcceptance {
 
   private long takeBackup(final BrokerContainer broker, final long backupId, final int retryCount) {
     final var partitionsActuator = PartitionsActuator.of(broker);
+    final var previousSnapshotId = partitionsActuator.query().get(1).snapshotId();
     partitionsActuator.takeSnapshot();
-    Awaitility.await("Snapshot is taken")
-        .atMost(Duration.ofSeconds(60))
-        .until(() -> partitionsActuator.query().get(1).snapshotId(), Objects::nonNull);
+    try {
+      Awaitility.await("Snapshot is taken")
+          .atMost(Duration.ofSeconds(20))
+          .until(
+              () -> partitionsActuator.query().get(1).snapshotId(),
+              id -> id != null && !id.equals(previousSnapshotId));
+    } catch (final ConditionTimeoutException e) {
+      // Ignore for retry
+    }
 
     // Initiate additional processing to progress logstream so that backup doesn't fail
     createProcessInstanceWithJob(broker);
@@ -324,10 +331,7 @@ public interface BackupCompatibilityAcceptance {
   }
 
   private boolean shouldRetryBackupDueToSnapshot(final BackupInfo status, final int retryCount) {
-    return status.getState() == StateCode.FAILED
-        && status.getFailureReason() != null
-        && status.getFailureReason().contains("No valid snapshots found for backup")
-        && retryCount < MAX_BACKUP_RETRIES;
+    return status.getState() == StateCode.FAILED && retryCount < MAX_BACKUP_RETRIES;
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Await for snapshot completion before a backup is taken. Another attemp to stabilize minor flakes in S3/Azure/GCSBackupCompatibilityIT.shouldRestoreBackupWhenSnapshotContainsCheckpointFromPreviousVersion

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
