### PR TITLE
fix: restore correct wretry.action digest reverted by Renovate

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -93,7 +93,7 @@ runs:
       # https://github.com/Wandalen/wretry.action/issues/182. Blanked out because
       # docker/setup-buildx-action's action.yml has no `${{ }}` expressions of its own; re-check this
       # if that's still true when its pin next bumps.
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0_js_action
+      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       with:
         action: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         # wretry cannot inspect the wrapped action's error -- `retry_condition` only sees contexts
@@ -202,7 +202,7 @@ runs:
       # Pinned to `_js_action` for the same reason as the buildx step above. build-push-action's only
       # `${{ }}` expression is its `github-token` default, set explicitly below instead since the
       # context that would resolve it is blanked out; re-check on future version bumps.
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0_js_action
+      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       env:
         DOCKER_BUILD_SUMMARY: false
         DOCKER_BUILD_RECORD_UPLOAD: false

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -195,14 +195,14 @@
       enabled: false,
     },
     {
-      description: "Wandalen/wretry.action is deliberately pinned to the v3.8.0_js_action tag, not the v3.8.0 composite it wraps (see PR #60406). That tag isn't semver-shaped, so Renovate's digest lookup resolves it to v3.8.0's commit instead and silently swaps the SHA while leaving the comment untouched. Bump by hand.",
+      description: "Wandalen/wretry.action releases a `vX.Y.Z` composite tag and a paired `vX.Y.Z_js_action` tag together (the composite's own dependency); we pin the latter (see PR #60406). Renovate's versioning strips the `_js_action` suffix and can't tell the two tags apart, so digest updates resolve to the composite's commit instead. Scope this dependency to only consider `_js_action`-suffixed tags.",
       matchFileNames: [
         ".github/actions/build-platform-docker/action.yml",
       ],
       matchPackageNames: [
         "Wandalen/wretry.action",
       ],
-      enabled: false,
+      extractVersion: "^(?<version>v\\d+\\.\\d+\\.\\d+)_js_action$",
     },
     {
       description: "Identify updates related to builds, tooling, etc. that should be routed to Engineering Operations team.",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -195,6 +195,16 @@
       enabled: false,
     },
     {
+      description: "Wandalen/wretry.action is deliberately pinned to the v3.8.0_js_action tag, not the v3.8.0 composite it wraps (see PR #60406). That tag isn't semver-shaped, so Renovate's digest lookup resolves it to v3.8.0's commit instead and silently swaps the SHA while leaving the comment untouched. Bump by hand.",
+      matchFileNames: [
+        ".github/actions/build-platform-docker/action.yml",
+      ],
+      matchPackageNames: [
+        "Wandalen/wretry.action",
+      ],
+      enabled: false,
+    },
+    {
       description: "Identify updates related to builds, tooling, etc. that should be routed to Engineering Operations team.",
       matchManagers: [
         "custom.regex",


### PR DESCRIPTION
## Summary

Renovate PR #60480 ("Update Wandalen/wretry.action digest to e68c23e") silently reintroduced the `Argument list too long` failure from INC-7226 that #60406 fixed.

**What happened**: `build-platform-docker/action.yml` pins two `Wandalen/wretry.action` steps to the `v3.8.0_js_action` tag rather than the documented `v3.8.0` composite tag, specifically so `github_context`/`env_context`/`job_context`/`matrix_context` can be overridden to blank values (`v3.8.0`'s composite hardcodes these to `toJSON(github)`/etc. with no override, which is what caused INC-7226 — a large PR body merged into `main` blew past the runner's `ARG_MAX`). Renovate's versioning strips the `_js_action` suffix for comparison, can't tell `v3.8.0_js_action` apart from the plain `v3.8.0` tag, and a digest refresh swapped the pinned SHA to `v3.8.0`'s commit while leaving the `# v3.8.0_js_action` comment untouched — so the override inputs are still in the file but silently ignored (the composite doesn't forward unrecognized inputs to its internal call).

**This PR**:
1. Restores the correct SHA (`71a909e`, the actual `v3.8.0_js_action` commit) on both wretry.action steps.
2. Fixes the Renovate config properly instead of disabling updates for this dependency: `Wandalen/wretry.action` tags a `vX.Y.Z` composite and a paired `vX.Y.Z_js_action` tag together for every release since `v1.0.34`. Added an `extractVersion` rule scoped to this file that only considers `_js_action`-suffixed tags as candidates, so future paired releases are still picked up normally, but the plain composite tag can never again be resolved as a "match" for this pin.

## Test plan

- [x] `npx --yes --package "renovate@latest" -- renovate-config-validator --no-global .github/renovate.json* .github/renovate/*` — passes locally (same invocation CI uses)
- [ ] `Lint / Renovate Config Validator` and `Lint / Action Pinning` CI checks pass on this PR
- [ ] Exercise a job using `build-platform-docker` (e.g. Docker ITs) and confirm the wretry-wrapped steps succeed
- [ ] Next real Renovate digest run for this dependency proposes (or doesn't) an update correctly scoped to `_js_action` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)