### PR TITLE
ci: stop apt-get timeouts under sudo from crashing CI jobs

### DIFF
--- a/.github/actions/apt-fast-mirror-failover/action.yml
+++ b/.github/actions/apt-fast-mirror-failover/action.yml
@@ -1,0 +1,23 @@
+---
+name: Configure apt fast mirror failover
+description: |
+  Drops an apt.conf.d snippet so apt abandons a hung mirror quickly instead
+  of riding out its ~120s default per-mirror timeout. GitHub's Ubuntu
+  runner image lists http://azure.archive.ubuntu.com as the priority-1
+  mirror, which intermittently hangs instead of erroring; apt then wastes
+  up to two minutes per attempt before failing over to the working
+  archive.ubuntu.com/security.ubuntu.com mirrors. See INC-6639 / #58992.
+
+inputs: {}
+
+runs:
+  using: composite
+  steps:
+    - name: Write apt fast-failover config
+      shell: bash
+      run: |
+        sudo tee /etc/apt/apt.conf.d/99-fast-mirror-failover.conf > /dev/null <<'EOF'
+        Acquire::http::Timeout "10";
+        Acquire::https::Timeout "10";
+        Acquire::Retries "2";
+        EOF

--- a/.github/actions/validate-pom-metadata/action.yml
+++ b/.github/actions/validate-pom-metadata/action.yml
@@ -11,6 +11,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: ./.github/actions/apt-fast-mirror-failover
+
     # `timeout` runs inside the sudo'd root process tree so it can self-terminate a hung
     # apt-get without nick-fields/retry having to kill across the privilege boundary --
     # doing that externally throws `kill EPERM` and crashes instead of retrying, see

--- a/.github/actions/validate-pom-metadata/action.yml
+++ b/.github/actions/validate-pom-metadata/action.yml
@@ -11,6 +11,10 @@ inputs:
 runs:
   using: composite
   steps:
+    # `timeout` runs inside the sudo'd root process tree so it can self-terminate a hung
+    # apt-get without nick-fields/retry having to kill across the privilege boundary --
+    # doing that externally throws `kill EPERM` and crashes instead of retrying, see
+    # https://github.com/nick-fields/retry/issues/124.
     - name: Install xmllint
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
@@ -18,7 +22,7 @@ runs:
         retry_wait_seconds: 10
         timeout_minutes: 2
         shell: bash
-        command: sudo apt-get update && sudo apt-get install -y --no-install-recommends libxml2-utils
+        command: sudo timeout 115 bash -c "apt-get update && apt-get install -y --no-install-recommends libxml2-utils"
 
     - name: Validate flattened POM metadata
       shell: bash

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -290,7 +290,7 @@ jobs:
           retry_wait_seconds: 10
           timeout_minutes: 2
           shell: bash
-          command: sudo timeout 115 bash -c "apt-get -qq update && apt-get install -y strace"
+          command: sudo timeout 115 bash -c "apt-get update && apt-get install -y strace"
       - name: Allow ptrace for strace tests
         run: sudo sysctl -w kernel.yama.ptrace_scope=0
       - uses: ./.github/actions/setup-build

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -279,6 +279,7 @@ jobs:
           persist-credentials: false
       - name: Print metadata
         uses: ./.github/actions/print-metadata
+      - uses: ./.github/actions/apt-fast-mirror-failover
       # `timeout` runs inside the sudo'd root process tree so it can self-terminate a hung
       # apt-get without nick-fields/retry having to kill across the privilege boundary --
       # doing that externally throws `kill EPERM` and crashes instead of retrying, see

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -279,10 +279,20 @@ jobs:
           persist-credentials: false
       - name: Print metadata
         uses: ./.github/actions/print-metadata
-      - name: Install and allow strace tests
-        run: |
-          sudo apt-get -qq update && sudo apt-get install -y strace
-          sudo sysctl -w kernel.yama.ptrace_scope=0
+      # `timeout` runs inside the sudo'd root process tree so it can self-terminate a hung
+      # apt-get without nick-fields/retry having to kill across the privilege boundary --
+      # doing that externally throws `kill EPERM` and crashes instead of retrying, see
+      # https://github.com/nick-fields/retry/issues/124.
+      - name: Install strace
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 10
+          timeout_minutes: 2
+          shell: bash
+          command: sudo timeout 115 bash -c "apt-get -qq update && apt-get install -y strace"
+      - name: Allow ptrace for strace tests
+        run: sudo sysctl -w kernel.yama.ptrace_scope=0
       - uses: ./.github/actions/setup-build
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2543,6 +2543,7 @@ jobs:
         timeout-minutes: 1
         with:
           persist-credentials: false
+      - uses: ./.github/actions/apt-fast-mirror-failover
       # `timeout` runs inside the sudo'd root process tree so it can self-terminate a hung
       # apt-get without nick-fields/retry having to kill across the privilege boundary --
       # doing that externally throws `kill EPERM` and crashes instead of retrying, see

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2543,6 +2543,10 @@ jobs:
         timeout-minutes: 1
         with:
           persist-credentials: false
+      # `timeout` runs inside the sudo'd root process tree so it can self-terminate a hung
+      # apt-get without nick-fields/retry having to kill across the privilege boundary --
+      # doing that externally throws `kill EPERM` and crashes instead of retrying, see
+      # https://github.com/nick-fields/retry/issues/124.
       - name: Install bats and xmllint
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
@@ -2550,7 +2554,7 @@ jobs:
           retry_wait_seconds: 10
           timeout_seconds: 60
           shell: bash
-          command: sudo apt-get install -y --no-install-recommends bats libxml2-utils
+          command: sudo timeout 55 bash -c "apt-get install -y --no-install-recommends bats libxml2-utils"
       - name: Run ci-relevance tests
         run: bats .github/scripts/ci-relevance/check.bats
       - name: Run flattened-pom validation tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2552,9 +2552,9 @@ jobs:
         with:
           max_attempts: 3
           retry_wait_seconds: 10
-          timeout_seconds: 60
+          timeout_minutes: 2
           shell: bash
-          command: sudo timeout 55 bash -c "apt-get install -y --no-install-recommends bats libxml2-utils"
+          command: sudo timeout 115 bash -c "apt-get install -y --no-install-recommends bats libxml2-utils"
       - name: Run ci-relevance tests
         run: bats .github/scripts/ci-relevance/check.bats
       - name: Run flattened-pom validation tests


### PR DESCRIPTION
## Summary

**Problem:** `nick-fields/retry` wraps `sudo apt-get install` in three CI steps to survive Ubuntu-mirror stalls (`validate-pom-metadata`, `ci.yml` `shell-script-tests`, `ci-zeebe.yml` `strace-tests`). When `apt-get` hangs past the wrapper's own timeout, it tries to kill the child process tree from the unprivileged runner user — but the tree is rooted under `sudo`, so the kill syscall throws `EPERM` instead of retrying, turning a recoverable mirror flake into a hard CI failure. This is a known, still-open upstream bug: [nick-fields/retry#124](https://github.com/nick-fields/retry/issues/124).

**Incident:** `validate-pom-metadata` hit exactly this crash on a `merge_group` run ([run 32227558393](https://github.com/camunda/camunda/actions/runs/32227558393/job/95990477789), INC-6639, #58992). The same day, `ci.yml`'s `shell-script-tests` and `ci-zeebe.yml`'s `strace-tests` also failed against the same mirror in [run 32159134914](https://github.com/camunda/camunda/actions/runs/32159134914) — `strace-tests` had no retry wrapper at all, so it burned its full 20-minute job timeout on a silent hang before being cancelled.

**Root cause:** GitHub's Ubuntu 24.04 runner image lists `http://azure.archive.ubuntu.com` as its priority-1 apt mirror, falling back to `archive.ubuntu.com` / `security.ubuntu.com`. That Azure mirror is a known, unresolved upstream flake ([actions/runner-images#12949](https://github.com/actions/runner-images/issues/12949), acknowledged by GitHub as an Azure-mirror performance issue outside their control). Instead of erroring, it hangs, and apt's default per-mirror timeout (~120s via `Acquire::http::Timeout`) means one hung request can eat most or all of a CI step's budget before apt gives up and moves to the next (working) mirror.

**Fix (four commits):**

1. Move timeout enforcement inside the `sudo`'d process tree via `sudo timeout <n> bash -c "..."`, so a hung `apt-get` self-terminates from within the same root-owned tree that spawned it — `nick-fields/retry`'s own (crashing) kill path is never reached. `strace-tests` also gains the retry wrapper it was missing, with its unrelated `sysctl` call split into its own (non-retried) step.
2. Unify the inner/outer timeout budgets across all three call sites and drop `-qq` from `strace-tests`' apt call so mirror-stall progress is visible in logs instead of silently suppressed.
3. Add a shared `apt-fast-mirror-failover` composite action that drops an `/etc/apt/apt.conf.d/` snippet lowering `Acquire::http::Timeout` / `Acquire::https::Timeout` to 10s and `Acquire::Retries` to 2, so a dead mirror is abandoned in ~30s worst case instead of ~120s+. Wired into all three call sites ahead of their install step.
4. Apply the same hardening to `setup-build`'s optional `tzdata` install (used by Optimize's nightly/release workflows via the `time-zone` input) — this call site was missed initially because it lives in a shared setup action rather than a top-level workflow, but hits the exact same unretried `sudo apt-get` pattern and had already been reported failing sporadically.

Closes #58992

**Follow-up:** [#TBD] stacks on top of this branch to harden two more call sites (`zeebe-aws-aurora-dispatch-tests.yml`, `ci-optimize.yml`'s Google Chrome install) that depend on the `apt-fast-mirror-failover` action introduced here.

## Test plan

- [x] `actionlint` on `ci.yml`, `ci-zeebe.yml`, `validate-pom-metadata/action.yml`, `apt-fast-mirror-failover/action.yml`, `setup-build/action.yml`, and the six `setup-build` `time-zone` callers — clean at the edited lines (all reported findings are pre-existing and unrelated)
- [x] `conftest test --rego-version v0 -o github --policy .github` on all changed/affected workflow files — 0 failures, only pre-existing unrelated warnings
- [x] `./mvnw license:format spotless:apply -T1C` — BUILD SUCCESS, no formatting diffs
- [ ] Merge-queue / `main` push run of the affected jobs to confirm no regression (can't reproduce the original mirror-stall race on demand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
