### PR TITLE
docs: remove stale experimental notice from Document API javadoc

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2287,12 +2287,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
       long userTaskKey);
 
   /**
-   * <strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Command to create a document.
+   * Command to create a document.
    *
    * <pre>
    *   camundaClient
@@ -2308,12 +2303,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   CreateDocumentCommandStep1 newCreateDocumentCommand();
 
   /**
-   * <strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Command to create a batch of documents. Unlike {@link #newCreateDocumentCommand()}, this
+   * Command to create a batch of documents. Unlike {@link #newCreateDocumentCommand()}, this
    * command allows you to create multiple documents in a single request. This can be more efficient
    * than creating each document individually, however, there are multiple limitations to consider.
    * <br>
@@ -2356,12 +2346,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   CreateDocumentBatchCommandStep1 newCreateDocumentBatchCommand();
 
   /**
-   * <strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Command to get a document.
+   * Command to get a document.
    *
    * <pre>
    *   camundaClient
@@ -2376,12 +2361,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   DocumentContentGetRequest newDocumentContentGetRequest(String documentId);
 
   /**
-   * <strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Command to get a document.
+   * Command to get a document.
    *
    * <pre>
    *   camundaClient
@@ -2396,12 +2376,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
       DocumentReferenceResponse documentReferenceResponse);
 
   /**
-   * <strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Command to update a document.
+   * Command to update a document.
    *
    * <pre>
    *   camundaClient
@@ -2417,12 +2392,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   CreateDocumentLinkCommandStep1 newCreateDocumentLinkCommand(String documentId);
 
   /**
-   * <strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Command to update a document.
+   * Command to update a document.
    *
    * <pre>
    *   camundaClient
@@ -2438,12 +2408,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
       DocumentReferenceResponse documentReferenceResponse);
 
   /**
-   * <strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Command to update a document.
+   * Command to update a document.
    *
    * <pre>
    *   camundaClient
@@ -2458,12 +2423,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   DeleteDocumentCommandStep1 newDeleteDocumentCommand(String documentId);
 
   /**
-   * <strong>Experimental: This method is under development. The respective API on compatible
-   * clusters cannot be considered production-ready. Thus, this method doesn't work out of the box
-   * with all clusters. Until this warning is removed, anything described below may not yet have
-   * taken effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Command to update a document.
+   * Command to update a document.
    *
    * <pre>
    *   camundaClient

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2376,7 +2376,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
       DocumentReferenceResponse documentReferenceResponse);
 
   /**
-   * Command to update a document.
+   * Command to create a document link.
    *
    * <pre>
    *   camundaClient
@@ -2392,7 +2392,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   CreateDocumentLinkCommandStep1 newCreateDocumentLinkCommand(String documentId);
 
   /**
-   * Command to update a document.
+   * Command to create a document link.
    *
    * <pre>
    *   camundaClient
@@ -2408,7 +2408,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
       DocumentReferenceResponse documentReferenceResponse);
 
   /**
-   * Command to update a document.
+   * Command to delete a document.
    *
    * <pre>
    *   camundaClient
@@ -2423,7 +2423,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   DeleteDocumentCommandStep1 newDeleteDocumentCommand(String documentId);
 
   /**
-   * Command to update a document.
+   * Command to delete a document.
    *
    * <pre>
    *   camundaClient


### PR DESCRIPTION
## Summary
- The `@ExperimentalApi` annotation was previously removed from the Document API command methods on `CamundaClient` (create document, create document batch, get document, create document link, delete document), but the javadoc still contained a stale "Experimental: This method is under development..." paragraph.
- Removed the stale paragraph from all 8 affected method javadocs. No functional/API changes.

## Backport
- `stable/8.9` already have no `@ExperimentalApi` annotation on these methods, so the label is added for those.

## Test plan
- [x] `./mvnw license:format spotless:apply -pl clients/java` — no additional changes
- [x] `./mvnw install -pl clients/java -Dquickly` — compiles successfully
- [x] Javadoc-only change, no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)