### PR TITLE
feat: land on Details tab when selecting a call activity

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
@@ -12,6 +12,7 @@ import {
   Navigate,
   RouterProvider,
   useLocation,
+  useNavigate,
 } from 'react-router';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
@@ -23,9 +24,15 @@ import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
 import {mockSearchIncidentsByElementInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByElementInstance';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {open} from 'modules/mocks/diagrams';
+import {modificationsStore} from 'modules/stores/modifications';
 import {LocationLog} from 'modules/utils/LocationLog';
 
 const PROCESS_INSTANCE_ID = '123';
+const CALL_ACTIVITY_ID = 'confirmDelivery';
+const SERVICE_TASK_ID = 'checkPayment';
 
 const RedirectToVariables: React.FC = () => {
   const location = useLocation();
@@ -34,13 +41,28 @@ const RedirectToVariables: React.FC = () => {
   );
 };
 
-function getWrapper(initialPath?: string) {
+const SelectElement: React.FC<{elementId: string}> = ({elementId}) => {
+  const navigate = useNavigate();
+  return (
+    <button onClick={() => navigate({search: `?elementId=${elementId}`})}>
+      Select {elementId}
+    </button>
+  );
+};
+
+function getWrapper(initialPath?: string, processDefinitionKey?: string) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
     const router = createMemoryRouter(
       [
         {
           path: Paths.processInstance(undefined, true),
-          element: children,
+          element: (
+            <ProcessDefinitionKeyContext.Provider value={processDefinitionKey}>
+              <SelectElement elementId={CALL_ACTIVITY_ID} />
+              <SelectElement elementId={SERVICE_TASK_ID} />
+              {children}
+            </ProcessDefinitionKeyContext.Provider>
+          ),
           children: [
             {index: true, element: <RedirectToVariables />},
             {
@@ -662,6 +684,85 @@ describe('<BottomPanelTabs />', () => {
       Paths.processInstanceVariables({
         processInstanceId: PROCESS_INSTANCE_ID,
       }),
+    );
+  });
+
+  it('should switch to the details tab when a call activity is selected', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(open('instanceMigration.bpmn'));
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(searchResult([]));
+
+    const path = Paths.processInstanceVariables({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    const {user} = render(<BottomPanelTabs />, {
+      wrapper: getWrapper(path, '123'),
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: `Select ${CALL_ACTIVITY_ID}`}),
+    );
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceDetails({processInstanceId: PROCESS_INSTANCE_ID}),
+    );
+  });
+
+  it('should not switch tabs when a non-call-activity element is selected', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(open('instanceMigration.bpmn'));
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(searchResult([]));
+
+    const path = Paths.processInstanceVariables({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    const {user} = render(<BottomPanelTabs />, {
+      wrapper: getWrapper(path, '123'),
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: `Select ${SERVICE_TASK_ID}`}),
+    );
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceVariables({processInstanceId: PROCESS_INSTANCE_ID}),
+    );
+  });
+
+  it('should not switch to the details tab for a call activity in modification mode', async () => {
+    modificationsStore.enableModificationMode();
+    mockFetchProcessDefinitionXml().withSuccess(open('instanceMigration.bpmn'));
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(searchResult([]));
+
+    const path = Paths.processInstanceVariables({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    const {user} = render(<BottomPanelTabs />, {
+      wrapper: getWrapper(path, '123'),
+    });
+
+    await user.click(
+      screen.getByRole('button', {name: `Select ${CALL_ACTIVITY_ID}`}),
+    );
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceVariables({processInstanceId: PROCESS_INSTANCE_ID}),
     );
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -6,7 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Navigate, Outlet, useLocation} from 'react-router';
+import {useLayoutEffect, useRef} from 'react';
+import {Navigate, Outlet, useLocation, useNavigate} from 'react-router';
 import {Paths} from 'modules/Routes';
 import {Container, TabContent} from './styled';
 import {TabListNav} from './TabListNav';
@@ -16,6 +17,8 @@ import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstan
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/useProcessInstanceIncidentsCount';
 import {useElementInstanceIncidentsCount} from 'modules/queries/incidents/useElementInstanceIncidentsCount';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
+import {modificationsStore} from 'modules/stores/modifications';
 
 function useSelectionAwareIncidentsCount(
   processInstanceKey: string,
@@ -50,12 +53,58 @@ function useSelectionAwareIncidentsCount(
 }
 
 const BottomPanelTabs: React.FC = () => {
-  const {hasSelection} = useProcessInstanceElementSelection();
+  const {hasSelection, selectedElementId} =
+    useProcessInstanceElementSelection();
   const {data: processInstance} = useProcessInstance();
+  const {data: businessObjects} = useBusinessObjects();
   const {processInstanceId} = useProcessInstancePageParams();
   const {currentPage} = useCurrentPage();
   const location = useLocation();
+  const navigate = useNavigate();
   const hasIncident = processInstance?.hasIncident === true;
+
+  const prevHasSelectionRef = useRef(hasSelection);
+  useLayoutEffect(() => {
+    // Switches to the Details tab when users select a call activity, so the
+    // "Called Process Instance" link is immediately visible - independent of
+    // the general any-element selection behavior.
+    //
+    // Business objects load asynchronously, so a selection can arrive before
+    // we can classify its element type. Bail out without touching
+    // prevHasSelectionRef in that case, so the transition is still detected
+    // once business objects resolve, instead of being marked as "seen"
+    // before we ever got to check the element type.
+    if (businessObjects === undefined) {
+      return;
+    }
+
+    const prevHasSelection = prevHasSelectionRef.current;
+    prevHasSelectionRef.current = hasSelection;
+    if (
+      !hasSelection ||
+      prevHasSelection ||
+      modificationsStore.isModificationModeEnabled ||
+      businessObjects[selectedElementId ?? '']?.$type !== 'bpmn:CallActivity'
+    ) {
+      return;
+    }
+
+    navigate(
+      {
+        pathname: Paths.processInstanceDetails({processInstanceId}),
+        search: location.search,
+      },
+      {replace: true},
+    );
+  }, [
+    hasSelection,
+    selectedElementId,
+    businessObjects,
+    processInstanceId,
+    location.search,
+    navigate,
+  ]);
+
   const incidentsCount = useSelectionAwareIncidentsCount(
     processInstanceId ?? '',
     hasIncident,


### PR DESCRIPTION
## Description

Selecting a call activity now switches the bottom panel to the Details tab, so the "Called Process Instance" link is immediately visible instead of requiring a manual tab switch. Scoped only to call activities and independent of #56968/#60401 — doesn't depend on that PR or its backport.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60507
