### PR TITLE
fix: classify suspension gate behavior for AgentInstance and AgentHistory processors

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -62,6 +62,6 @@ public final class AgentHistoryCommitProcessor
 
   @Override
   public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryRecord> record) {
-    return SuspensionBehavior.BUFFER;
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -162,6 +162,6 @@ public final class AgentHistoryCreateProcessor
 
   @Override
   public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryRecord> record) {
-    return SuspensionBehavior.BUFFER;
+    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
@@ -56,6 +56,6 @@ public final class AgentHistoryDiscardProcessor
 
   @Override
   public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryRecord> record) {
-    return SuspensionBehavior.BUFFER;
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -77,6 +77,6 @@ public final class AgentInstanceCompleteProcessor
 
   @Override
   public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
-    return SuspensionBehavior.BUFFER;
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -251,6 +251,6 @@ public final class AgentInstanceCreateProcessor
 
   @Override
   public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
-    return SuspensionBehavior.BUFFER;
+    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -425,6 +425,6 @@ public final class AgentInstanceUpdateProcessor
 
   @Override
   public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
-    return SuspensionBehavior.BUFFER;
+    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionCheck.java
@@ -11,7 +11,10 @@ import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState.State;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -89,9 +92,8 @@ public final class SuspensionCheck {
 
   /**
    * Resolves the process instance a command targets. Most values carry their own {@code
-   * processInstanceKey}; external {@code JOB}, {@code INCIDENT}, {@code USER_TASK}, {@code
-   * AD_HOC_SUB_PROCESS_INSTRUCTION} and {@code VARIABLE_DOCUMENT} commands only carry the entity
-   * key, so the persisted entity is consulted. Returns {@code -1} when it can't be resolved.
+   * processInstanceKey}. However, a few other external commands only carry the entity key, so the
+   * persisted entity is consulted. Returns {@code -1} when it can't be resolved.
    */
   private long resolveProcessInstanceKey(final TypedRecord<?> command) {
     if (command.getValue() instanceof final ProcessInstanceRelated processInstanceRelated) {
@@ -128,8 +130,38 @@ public final class SuspensionCheck {
         final var scope = processingState.getElementInstanceState().getInstance(scopeKey);
         yield scope != null ? scope.getValue().getProcessInstanceKey() : -1;
       }
+      case AGENT_INSTANCE -> resolveAgentInstanceProcessInstanceKey(command);
+      case AGENT_HISTORY -> resolveAgentHistoryProcessInstanceKey(command);
       default -> -1;
     };
+  }
+
+  /**
+   * CREATE carries {@code elementInstanceKey} on the value; the target element instance's process
+   * instance key is looked up. Every other AgentInstance command (currently only UPDATE) targets an
+   * existing agent instance identified by the command's own key.
+   */
+  private long resolveAgentInstanceProcessInstanceKey(final TypedRecord<?> command) {
+    if (command.getIntent() == AgentInstanceIntent.CREATE) {
+      final var value = (AgentInstanceRecordValue) command.getValue();
+      final var elementInstance =
+          processingState.getElementInstanceState().getInstance(value.getElementInstanceKey());
+      return elementInstance != null ? elementInstance.getValue().getProcessInstanceKey() : -1;
+    }
+
+    final var agentInstance = processingState.getAgentInstanceState().getRecord(command.getKey());
+    return agentInstance != null ? agentInstance.getProcessInstanceKey() : -1;
+  }
+
+  /**
+   * CREATE carries {@code agentInstanceKey} on the value; the target agent instance's process
+   * instance key is looked up.
+   */
+  private long resolveAgentHistoryProcessInstanceKey(final TypedRecord<?> command) {
+    final var value = (AgentHistoryRecordValue) command.getValue();
+    final var agentInstance =
+        processingState.getAgentInstanceState().getRecord(value.getAgentInstanceKey());
+    return agentInstance != null ? agentInstance.getProcessInstanceKey() : -1;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
@@ -146,15 +146,26 @@ public class AgentHistorySuspensionGateTest {
 
     final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
     final long jobKey = activateJobForProcessInstance(processInstanceKey);
-    createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey);
+    final long historyItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey).getKey();
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
     // when
-    final var result = ENGINE.agentHistories().withJobKey(jobKey).discard();
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .agentHistory(
+                AgentHistoryIntent.DISCARD,
+                new AgentHistoryRecord()
+                    .setJobKey(jobKey)
+                    .setProcessInstanceKey(processInstanceKey)));
 
     // then — DISCARD succeeds while the process instance is suspended (PROCESS classification)
-    assertThat(result.getIntent()).isEqualTo(AgentHistoryIntent.DISCARDED);
+    assertThat(
+            RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+                .withRecordKey(historyItemKey)
+                .getFirst())
+        .isNotNull();
   }
 
   @Test
@@ -168,15 +179,26 @@ public class AgentHistorySuspensionGateTest {
 
     final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
     final long jobKey = activateJobForProcessInstance(processInstanceKey);
-    createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey);
+    final long historyItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey).getKey();
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
     // when
-    final var result = ENGINE.agentHistories().withJobKey(jobKey).commit();
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .agentHistory(
+                AgentHistoryIntent.COMMIT,
+                new AgentHistoryRecord()
+                    .setJobKey(jobKey)
+                    .setProcessInstanceKey(processInstanceKey)));
 
     // then — COMMIT succeeds while the process instance is suspended (PROCESS classification)
-    assertThat(result.getIntent()).isEqualTo(AgentHistoryIntent.COMMITTED);
+    assertThat(
+            RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+                .withRecordKey(historyItemKey)
+                .getFirst())
+        .isNotNull();
   }
 
   // --- helpers ---
@@ -217,9 +239,9 @@ public class AgentHistorySuspensionGateTest {
         .getKey();
   }
 
-  private static void createHistoryItem(
+  private static Record<?> createHistoryItem(
       final long agentInstanceKey, final long jobKey, final long elementInstanceKey) {
-    ENGINE
+    return ENGINE
         .agentHistories()
         .withAgentInstanceKey(agentInstanceKey)
         .withJobKey(jobKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
@@ -14,8 +14,10 @@ import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -38,19 +40,19 @@ import org.junit.Test;
  * <p>CREATE is classified {@code isInternalCommand() ? BUFFER : REJECT}:
  *
  * <ul>
+ *   <li>External commands (carrying request metadata) are REJECT'd to prevent an authorization
+ *       bypass: a buffered command is drained as an internal command on resume, skipping the CSL
+ *       check.
  *   <li>Internal commands are BUFFER'd so they can be replayed when the instance resumes.
- *   <li>External commands would be REJECT'd to prevent an authorization bypass: a buffered command
- *       is drained as an internal command, skipping the CSL check.
  * </ul>
  *
  * <p>COMMIT and DISCARD are classified {@code PROCESS} so that teardown bookkeeping cannot be
  * orphaned when a suspended instance is cancelled.
  *
- * <p>For CREATE, {@code processInstanceKey} must be present on the command record for the gate to
- * fire. Production clients only carry other keys, so the gate returns PROCESS early for real
- * external commands; the test below supplies it explicitly via {@link RecordToWrite}. {@link
- * RecordToWrite#command()} produces internal commands (no request metadata), so the BUFFER path is
- * exercised rather than REJECT.
+ * <p>{@link io.camunda.zeebe.engine.processing.streamprocessor.SuspensionCheck} resolves the
+ * process instance key for CREATE by looking up the agent instance identified by {@code
+ * agentInstanceKey} — populated by real clients, so the gate fires for genuine external/internal
+ * commands without any test scaffolding.
  */
 public class AgentHistorySuspensionGateTest {
 
@@ -61,11 +63,11 @@ public class AgentHistorySuspensionGateTest {
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldBufferInternalCreateCommandWhileSuspended() {
+  public void shouldRejectExternalCreateCommandWhileSuspended() {
     // given
-    final String processId = Strings.newRandomValidBpmnId();
-    final String taskId = Strings.newRandomValidBpmnId();
-    final var serviceTaskActivated = deployAndCreateProcessInstance(processId, taskId);
+    final var serviceTaskActivated =
+        deployAndCreateProcessInstance(
+            Strings.newRandomValidBpmnId(), Strings.newRandomValidBpmnId());
     final long elementInstanceKey = serviceTaskActivated.getKey();
     final long processInstanceKey = serviceTaskActivated.getValue().getProcessInstanceKey();
 
@@ -74,14 +76,45 @@ public class AgentHistorySuspensionGateTest {
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
-    // when — supply processInstanceKey explicitly so the suspension gate can resolve the target PI.
-    // RecordToWrite.command() produces an internal command, so the gate classifies it as BUFFER.
+    // when — create(username) carries request metadata, so isInternalCommand() is false and the
+    // gate classifies it as REJECT
+    final var rejection =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(jobKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withRole(AgentHistoryRole.USER)
+            .expectRejection()
+            .create("some-user");
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldBufferInternalCreateCommandWhileSuspended() {
+    // given
+    final var serviceTaskActivated =
+        deployAndCreateProcessInstance(
+            Strings.newRandomValidBpmnId(), Strings.newRandomValidBpmnId());
+    final long elementInstanceKey = serviceTaskActivated.getKey();
+    final long processInstanceKey = serviceTaskActivated.getValue().getProcessInstanceKey();
+
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final long jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when — RecordToWrite.command() produces an internal command, so the gate classifies it as
+    // BUFFER
     final var commandRecord =
         new AgentHistoryRecord()
             .setAgentInstanceKey(agentInstanceKey)
             .setJobKey(jobKey)
             .setElementInstanceKey(elementInstanceKey)
-            .setProcessInstanceKey(processInstanceKey)
             .setRole(AgentHistoryRole.USER);
     ENGINE.writeRecords(
         RecordToWrite.command().agentHistory(AgentHistoryIntent.CREATE, commandRecord));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies the suspension gate classifications of AgentHistory processors.
+ *
+ * <p>CREATE is classified {@code isInternalCommand() ? BUFFER : REJECT}:
+ *
+ * <ul>
+ *   <li>Internal commands are BUFFER'd so they can be replayed when the instance resumes.
+ *   <li>External commands would be REJECT'd to prevent an authorization bypass: a buffered command
+ *       is drained as an internal command, skipping the CSL check.
+ * </ul>
+ *
+ * <p>COMMIT and DISCARD are classified {@code PROCESS} so that teardown bookkeeping cannot be
+ * orphaned when a suspended instance is cancelled.
+ *
+ * <p>For CREATE, {@code processInstanceKey} must be present on the command record for the gate to
+ * fire. Production clients only carry other keys, so the gate returns PROCESS early for real
+ * external commands; the test below supplies it explicitly via {@link RecordToWrite}. {@link
+ * RecordToWrite#command()} produces internal commands (no request metadata), so the BUFFER path is
+ * exercised rather than REJECT.
+ */
+public class AgentHistorySuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBufferInternalCreateCommandWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final String taskId = Strings.newRandomValidBpmnId();
+    final var serviceTaskActivated = deployAndCreateProcessInstance(processId, taskId);
+    final long elementInstanceKey = serviceTaskActivated.getKey();
+    final long processInstanceKey = serviceTaskActivated.getValue().getProcessInstanceKey();
+
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final long jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when — supply processInstanceKey explicitly so the suspension gate can resolve the target PI.
+    // RecordToWrite.command() produces an internal command, so the gate classifies it as BUFFER.
+    final var commandRecord =
+        new AgentHistoryRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setJobKey(jobKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setRole(AgentHistoryRole.USER);
+    ENGINE.writeRecords(
+        RecordToWrite.command().agentHistory(AgentHistoryIntent.CREATE, commandRecord));
+
+    // then — the gate queues the internal command; it will be drained when the instance resumes
+    final Record<RecordValue> buffered =
+        RecordingExporter.records()
+            .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+            .withIntent(ProcessInstanceBufferedCommandIntent.BUFFERED)
+            .filter(
+                r -> {
+                  final var v = (ProcessInstanceBufferedCommandRecordValue) r.getValue();
+                  return v.getProcessInstanceKey() == processInstanceKey
+                      && v.getValueType() == ValueType.AGENT_HISTORY;
+                })
+            .getFirst();
+    assertThat(((ProcessInstanceBufferedCommandRecordValue) buffered.getValue()).getIntent())
+        .isEqualTo(AgentHistoryIntent.CREATE);
+  }
+
+  @Test
+  public void shouldProcessDiscardCommandWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final String taskId = Strings.newRandomValidBpmnId();
+    final var serviceTaskActivated = deployAndCreateProcessInstance(processId, taskId);
+    final long elementInstanceKey = serviceTaskActivated.getKey();
+    final long processInstanceKey = serviceTaskActivated.getValue().getProcessInstanceKey();
+
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final long jobKey = activateJobForProcessInstance(processInstanceKey);
+    createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey);
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var result = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    // then — DISCARD succeeds while the process instance is suspended (PROCESS classification)
+    assertThat(result.getIntent()).isEqualTo(AgentHistoryIntent.DISCARDED);
+  }
+
+  @Test
+  public void shouldProcessCommitCommandWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final String taskId = Strings.newRandomValidBpmnId();
+    final var serviceTaskActivated = deployAndCreateProcessInstance(processId, taskId);
+    final long elementInstanceKey = serviceTaskActivated.getKey();
+    final long processInstanceKey = serviceTaskActivated.getValue().getProcessInstanceKey();
+
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final long jobKey = activateJobForProcessInstance(processInstanceKey);
+    createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey);
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var result = ENGINE.agentHistories().withJobKey(jobKey).commit();
+
+    // then — COMMIT succeeds while the process instance is suspended (PROCESS classification)
+    assertThat(result.getIntent()).isEqualTo(AgentHistoryIntent.COMMITTED);
+  }
+
+  // --- helpers ---
+
+  private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance(
+      final String processId, final String taskId) {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(taskId, t -> t.zeebeJobType(JOB_TYPE).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .withElementId(taskId)
+        .getFirst();
+  }
+
+  private static Record<?> createAgentInstance(final long elementInstanceKey) {
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withDefinition("gpt-4o", "openai", "sys")
+        .create();
+  }
+
+  private static long activateJobForProcessInstance(final long processInstanceKey) {
+    ENGINE.jobs().withType(JOB_TYPE).activate();
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .getFirst()
+        .getKey();
+  }
+
+  private static void createHistoryItem(
+      final long agentInstanceKey, final long jobKey, final long elementInstanceKey) {
+    ENGINE
+        .agentHistories()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withJobKey(jobKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withRole(AgentHistoryRole.USER)
+        .create();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
@@ -234,11 +234,10 @@ public class AgentInstanceSuspensionGateTest {
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
     // when
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+    ENGINE.agentInstances().withProcessInstanceKey(processInstanceKey).complete();
 
-    // then — cancelling a suspended instance with an active agent instance emits
-    // AGENT_INSTANCE:COMPLETED. COMPLETE is classified PROCESS so that the processor is not
-    // gated by the suspension marker.
+    // then — COMPLETE is classified PROCESS so the suspended process instance completes its agent
+    // instance.
     final var completed =
         RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
             .withRecordKey(agentInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
@@ -13,8 +13,10 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
@@ -35,21 +37,21 @@ import org.junit.Test;
  * <p>CREATE and UPDATE are classified {@code isInternalCommand() ? BUFFER : REJECT}:
  *
  * <ul>
+ *   <li>External commands (from REST/gRPC clients, carrying request metadata) are REJECT'd to
+ *       prevent an authorization bypass: a buffered command is drained as an internal command on
+ *       resume, skipping the CSL check.
  *   <li>Internal commands (engine-generated follow-ups) are BUFFER'd so they can be replayed when
  *       the instance resumes.
- *   <li>External commands (from REST/gRPC clients) would be REJECT'd to prevent an authorization
- *       bypass: a buffered command is drained as an internal command, skipping the CSL check.
  * </ul>
  *
  * <p>COMPLETE is classified {@code PROCESS} so that teardown bookkeeping is not orphaned when a
  * suspended instance is cancelled.
  *
- * <p>The suspension gate resolves the process instance key from the command record. For CREATE and
- * UPDATE, {@code processInstanceKey} must be present on the record for the gate to fire. Production
- * clients only carry {@code elementInstanceKey} on these commands, so the gate returns PROCESS
- * early for real external commands; the tests below supply {@code processInstanceKey} explicitly
- * via {@link RecordToWrite} to exercise the gate. {@link RecordToWrite#command()} produces internal
- * commands (no request metadata), so the BUFFER path is exercised rather than REJECT.
+ * <p>{@link io.camunda.zeebe.engine.processing.streamprocessor.SuspensionCheck} resolves the
+ * process instance key for CREATE by looking up the target element instance ({@code
+ * elementInstanceKey}), and for UPDATE by looking up the agent instance identified by the command
+ * key — both are populated by real clients, so the gate fires for genuine external/internal
+ * commands without any test scaffolding.
  */
 public class AgentInstanceSuspensionGateTest {
 
@@ -58,36 +60,86 @@ public class AgentInstanceSuspensionGateTest {
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldBufferInternalCreateCommandWhileSuspended() {
+  public void shouldRejectExternalCreateCommandWhileSuspended() {
     // given
-    final String processId = Strings.newRandomValidBpmnId();
-    final String taskId = Strings.newRandomValidBpmnId();
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(processId)
-                .startEvent()
-                .serviceTask(taskId, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
-    final var serviceTaskActivated =
+    final long elementInstanceKey = activateServiceTask();
+    final long processInstanceKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .getFirst();
-    final long elementInstanceKey = serviceTaskActivated.getKey();
+            .withRecordKey(elementInstanceKey)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
-    // when — supply processInstanceKey explicitly so the suspension gate can resolve the target PI.
-    // RecordToWrite.command() produces an internal command (no request metadata), so the gate
-    // classifies it as BUFFER (not REJECT, which is the path for external commands).
-    final var commandRecord =
-        new AgentInstanceRecord()
-            .setElementInstanceKey(elementInstanceKey)
-            .setProcessInstanceKey(processInstanceKey);
+    // when — create(username) carries request metadata, so isInternalCommand() is false and the
+    // gate classifies it as REJECT
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .expectRejection()
+            .create("some-user");
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldRejectExternalUpdateCommandWhileSuspended() {
+    // given
+    final long elementInstanceKey = activateServiceTask();
+    final long processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withRecordKey(elementInstanceKey)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    final long agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "sys")
+            .withLimits(100L, 5, 5)
+            .create()
+            .getKey();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when — update(username) carries request metadata, so the gate classifies it as REJECT
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withMetricsDelta(10L, 5L, 1, 1)
+            .expectRejection()
+            .update("some-user");
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldBufferInternalCreateCommandWhileSuspended() {
+    // given
+    final long elementInstanceKey = activateServiceTask();
+    final long processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withRecordKey(elementInstanceKey)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when — RecordToWrite.command() produces an internal command (no request metadata), so the
+    // gate classifies it as BUFFER
+    final var commandRecord = new AgentInstanceRecord().setElementInstanceKey(elementInstanceKey);
     ENGINE.writeRecords(
         RecordToWrite.command().agentInstance(AgentInstanceIntent.CREATE, commandRecord));
 
@@ -110,24 +162,13 @@ public class AgentInstanceSuspensionGateTest {
   @Test
   public void shouldBufferInternalUpdateCommandWhileSuspended() {
     // given
-    final String processId = Strings.newRandomValidBpmnId();
-    final String taskId = Strings.newRandomValidBpmnId();
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(processId)
-                .startEvent()
-                .serviceTask(taskId, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
-    final var serviceTaskActivated =
+    final long elementInstanceKey = activateServiceTask();
+    final long processInstanceKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .getFirst();
-    final long elementInstanceKey = serviceTaskActivated.getKey();
+            .withRecordKey(elementInstanceKey)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
 
     final long agentInstanceKey =
         ENGINE
@@ -140,13 +181,9 @@ public class AgentInstanceSuspensionGateTest {
 
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
 
-    // when — supply processInstanceKey explicitly so the suspension gate can resolve the target PI.
-    // RecordToWrite.command() produces an internal command, so the gate classifies it as BUFFER.
-    final var commandRecord =
-        new AgentInstanceRecord()
-            .setAgentInstanceKey(agentInstanceKey)
-            .setProcessInstanceKey(processInstanceKey)
-            .setChangedAttributes(List.of("metrics"));
+    // when — RecordToWrite.command() produces an internal command, so the gate classifies it as
+    // BUFFER
+    final var commandRecord = new AgentInstanceRecord().setChangedAttributes(List.of("metrics"));
     commandRecord
         .getMetrics()
         .setInputTokens(10L)
@@ -177,24 +214,13 @@ public class AgentInstanceSuspensionGateTest {
   @Test
   public void shouldProcessCompleteCommandWhileSuspendedOnCancel() {
     // given
-    final String processId = Strings.newRandomValidBpmnId();
-    final String taskId = Strings.newRandomValidBpmnId();
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(processId)
-                .startEvent()
-                .serviceTask(taskId, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
-    final var serviceTaskActivated =
+    final long elementInstanceKey = activateServiceTask();
+    final long processInstanceKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .getFirst();
-    final long elementInstanceKey = serviceTaskActivated.getKey();
+            .withRecordKey(elementInstanceKey)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
 
     final long agentInstanceKey =
         ENGINE
@@ -218,5 +244,25 @@ public class AgentInstanceSuspensionGateTest {
             .withRecordKey(agentInstanceKey)
             .getFirst();
     assertThat(completed).isNotNull();
+  }
+
+  private static long activateServiceTask() {
+    final String processId = Strings.newRandomValidBpmnId();
+    final String taskId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(taskId, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .getFirst()
+        .getKey();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies the suspension gate classifications of AgentInstance processors.
+ *
+ * <p>CREATE and UPDATE are classified {@code isInternalCommand() ? BUFFER : REJECT}:
+ *
+ * <ul>
+ *   <li>Internal commands (engine-generated follow-ups) are BUFFER'd so they can be replayed when
+ *       the instance resumes.
+ *   <li>External commands (from REST/gRPC clients) would be REJECT'd to prevent an authorization
+ *       bypass: a buffered command is drained as an internal command, skipping the CSL check.
+ * </ul>
+ *
+ * <p>COMPLETE is classified {@code PROCESS} so that teardown bookkeeping is not orphaned when a
+ * suspended instance is cancelled.
+ *
+ * <p>The suspension gate resolves the process instance key from the command record. For CREATE and
+ * UPDATE, {@code processInstanceKey} must be present on the record for the gate to fire. Production
+ * clients only carry {@code elementInstanceKey} on these commands, so the gate returns PROCESS
+ * early for real external commands; the tests below supply {@code processInstanceKey} explicitly
+ * via {@link RecordToWrite} to exercise the gate. {@link RecordToWrite#command()} produces internal
+ * commands (no request metadata), so the BUFFER path is exercised rather than REJECT.
+ */
+public class AgentInstanceSuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBufferInternalCreateCommandWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final String taskId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(taskId, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final var serviceTaskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+    final long elementInstanceKey = serviceTaskActivated.getKey();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when — supply processInstanceKey explicitly so the suspension gate can resolve the target PI.
+    // RecordToWrite.command() produces an internal command (no request metadata), so the gate
+    // classifies it as BUFFER (not REJECT, which is the path for external commands).
+    final var commandRecord =
+        new AgentInstanceRecord()
+            .setElementInstanceKey(elementInstanceKey)
+            .setProcessInstanceKey(processInstanceKey);
+    ENGINE.writeRecords(
+        RecordToWrite.command().agentInstance(AgentInstanceIntent.CREATE, commandRecord));
+
+    // then — the gate queues the internal command; it will be drained when the instance resumes
+    final Record<RecordValue> buffered =
+        RecordingExporter.records()
+            .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+            .withIntent(ProcessInstanceBufferedCommandIntent.BUFFERED)
+            .filter(
+                r -> {
+                  final var v = (ProcessInstanceBufferedCommandRecordValue) r.getValue();
+                  return v.getProcessInstanceKey() == processInstanceKey
+                      && v.getValueType() == ValueType.AGENT_INSTANCE;
+                })
+            .getFirst();
+    assertThat(((ProcessInstanceBufferedCommandRecordValue) buffered.getValue()).getIntent())
+        .isEqualTo(AgentInstanceIntent.CREATE);
+  }
+
+  @Test
+  public void shouldBufferInternalUpdateCommandWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final String taskId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(taskId, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final var serviceTaskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+    final long elementInstanceKey = serviceTaskActivated.getKey();
+
+    final long agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "sys")
+            .withLimits(100L, 5, 5)
+            .create()
+            .getKey();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when — supply processInstanceKey explicitly so the suspension gate can resolve the target PI.
+    // RecordToWrite.command() produces an internal command, so the gate classifies it as BUFFER.
+    final var commandRecord =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setChangedAttributes(List.of("metrics"));
+    commandRecord
+        .getMetrics()
+        .setInputTokens(10L)
+        .setOutputTokens(5L)
+        .setModelCalls(1)
+        .setToolCalls(1);
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .key(agentInstanceKey)
+            .agentInstance(AgentInstanceIntent.UPDATE, commandRecord));
+
+    // then — the gate queues the internal command; it will be drained when the instance resumes
+    final Record<RecordValue> buffered =
+        RecordingExporter.records()
+            .withValueType(ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND)
+            .withIntent(ProcessInstanceBufferedCommandIntent.BUFFERED)
+            .filter(
+                r -> {
+                  final var v = (ProcessInstanceBufferedCommandRecordValue) r.getValue();
+                  return v.getProcessInstanceKey() == processInstanceKey
+                      && v.getValueType() == ValueType.AGENT_INSTANCE;
+                })
+            .getFirst();
+    assertThat(((ProcessInstanceBufferedCommandRecordValue) buffered.getValue()).getIntent())
+        .isEqualTo(AgentInstanceIntent.UPDATE);
+  }
+
+  @Test
+  public void shouldProcessCompleteCommandWhileSuspendedOnCancel() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final String taskId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(taskId, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final var serviceTaskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+    final long elementInstanceKey = serviceTaskActivated.getKey();
+
+    final long agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "sys")
+            .withLimits(100L, 5, 5)
+            .create()
+            .getKey();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then — cancelling a suspended instance with an active agent instance emits
+    // AGENT_INSTANCE:COMPLETED. COMPLETE is classified PROCESS so that the processor is not
+    // gated by the suspension marker.
+    final var completed =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+            .withRecordKey(agentInstanceKey)
+            .getFirst();
+    assertThat(completed).isNotNull();
+  }
+}


### PR DESCRIPTION
## Description

`AgentInstanceCreateProcessor`, `AgentInstanceUpdateProcessor`, `AgentHistoryCreateProcessor`,
`AgentInstanceCompleteProcessor`, `AgentHistoryCommitProcessor`, and
`AgentHistoryDiscardProcessor` previously returned `BUFFER` unconditionally from
`suspensionBehavior()`.

**External create/update commands (`AgentInstance CREATE/UPDATE`, `AgentHistory CREATE`)** are
now classified `isInternalCommand() ? BUFFER : REJECT`. Buffering an external command is unsafe:
a buffered command is drained as an internal command on resume, at which point
`CslAuthorizationCheck` skips the auth check — so an external caller could get a suspended
create/update queued and later executed without authorization. Internal follow-ups continue to
be buffered so they replay on resume.

`SuspensionCheck.resolveProcessInstanceKey()` had no case for `AGENT_INSTANCE`/`AGENT_HISTORY`,
so before this PR the classification never actually applied — the gate always resolved to `-1`
and short-circuited to `PROCESS`. This PR also adds the missing lookups (element instance for
CREATE, agent instance for UPDATE/History-CREATE), so REJECT and BUFFER now take effect for real.

**Teardown commands (`AgentInstance COMPLETE`, `AgentHistory COMMIT/DISCARD`)** are classified
`PROCESS`. These are internal-only bookkeeping follow-ups (`@ExcludeAuthorizationCheck`) that
don't advance the process instance, so running them regardless of suspension state is safe, and
no process-instance-key resolution is needed for them: `AgentHistory COMMIT` can't be emitted
while suspended anyway (`JobCompleteProcessor` itself is gated with `REJECT`), and `DISCARD`/
`COMPLETE` only fire from process-instance-termination paths where the suspension marker is
already cleared by the time they're processed.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58926
