### PR TITLE
feat: dispatch queued job registry entries to registered handlers

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.service.security.util.LocalDateUtil;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,6 +105,30 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
     assertThat(found)
         .extracting(JobRegistryEntryDto::getId)
         .containsExactly(olderEntry.getId(), newerEntry.getId());
+  }
+
+  @Test
+  void shouldBreakTiesByIdWhenCreatedAtIsIdentical() {
+    // given
+    // Same pinned instant for both entries -- createdAt alone can't order two entries created
+    // within the same millisecond, so this exercises the id tiebreaker.
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
+    final JobRegistryEntryDto first =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "300");
+    final JobRegistryEntryDto second =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "100");
+    final JobRegistryEntryDto third =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "200");
+    final List<String> expectedOrder =
+        Stream.of(second.getId(), third.getId(), first.getId()).sorted().toList();
+
+    // when
+    final List<JobRegistryEntryDto> found = jobRegistryReader.findOldestQueuedJobs(10);
+
+    // then
+    assertThat(found)
+        .extracting(JobRegistryEntryDto::getId)
+        .containsExactlyElementsOf(expectedOrder);
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/JobDispatcherIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/JobDispatcherIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.security.util.LocalDateUtil;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JobDispatcherIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final int BATCH_SIZE = 10;
+  private JobDispatcher jobDispatcher;
+  private JobRegistryReader jobRegistryReader;
+  private JobRegistryWriter jobRegistryWriter;
+
+  @BeforeEach
+  void setup() {
+    jobDispatcher = embeddedOptimizeExtension.getBean(JobDispatcher.class);
+    jobRegistryReader = embeddedOptimizeExtension.getBean(JobRegistryReader.class);
+    jobRegistryWriter = embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getJobRegistryDispatcherConfiguration()
+        .setBatchSize(BATCH_SIZE);
+  }
+
+  @AfterEach
+  void resetClock() {
+    LocalDateUtil.reset();
+  }
+
+  @Test
+  void shouldMarkQueuedJobAsFailedWhenNoHandlerIsRegistered() {
+    // given
+    // No JobHandler bean exists yet for (DELETE, PROCESS_DEFINITION) in this test context -- the
+    // concrete handler is separate follow-up work, so this exercises the dispatcher's "unhandled
+    // job type" path against the real index.
+    final JobRegistryEntryDto queued =
+        jobRegistryWriter.createJobEntry(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, "2251799813685251");
+
+    // when
+    jobDispatcher.dispatchNextBatch();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    final Optional<JobRegistryEntryDto> found =
+        jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, "2251799813685251");
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(queued.getId());
+    assertThat(found.get().getStatus()).isEqualTo(JobStatus.FAILED);
+  }
+
+  @Test
+  void shouldLeaveQueueEmptyAfterDispatchingAllQueuedJobs() {
+    // given
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
+
+    // when
+    jobDispatcher.dispatchNextBatch();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    final List<JobRegistryEntryDto> stillQueued =
+        jobRegistryReader.findOldestQueuedJobs(BATCH_SIZE);
+    assertThat(stillQueued).isEmpty();
+  }
+
+  @Test
+  void shouldOnlyDispatchOldestEntryPerEntityInSameBatch() {
+    // given
+    final String entityId = "2251799813685252";
+
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:00.000+00:00"));
+    final JobRegistryEntryDto olderEntry =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, entityId);
+
+    LocalDateUtil.setCurrentTime(OffsetDateTime.parse("2026-01-01T00:00:01.000+00:00"));
+    final JobRegistryEntryDto newerDuplicateEntry =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, entityId);
+
+    // when
+    jobDispatcher.dispatchNextBatch();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    // only the older entry was dispatched (and failed, since no handler is registered); the
+    // newer duplicate for the same entity was left untouched for a later batch
+    final Optional<JobRegistryEntryDto> dispatchedEntry =
+        jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, entityId);
+    assertThat(dispatchedEntry).isPresent();
+    assertThat(dispatchedEntry.get().getId()).isEqualTo(newerDuplicateEntry.getId());
+    assertThat(dispatchedEntry.get().getStatus()).isEqualTo(JobStatus.QUEUED);
+
+    final List<JobRegistryEntryDto> stillQueued =
+        jobRegistryReader.findOldestQueuedJobs(BATCH_SIZE);
+    assertThat(stillQueued)
+        .singleElement()
+        .satisfies(entry -> assertThat(entry.getId()).isEqualTo(newerDuplicateEntry.getId()));
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -58,6 +58,9 @@ public class JobRegistryReaderES implements JobRegistryReader {
                         sort ->
                             sort.field(
                                 f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Asc)))
+                    // tiebreaker
+                    .sort(
+                        sort -> sort.field(f -> f.field(JobRegistryIndex.ID).order(SortOrder.Asc)))
                     .size(limit));
 
     try {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -56,9 +56,14 @@ public class JobRegistryReaderOS implements JobRegistryReader {
             .size(limit)
             .query(boolQuery.toQuery())
             .sort(
-                new SortOptions.Builder()
-                    .field(f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Asc))
-                    .build());
+                List.of(
+                    new SortOptions.Builder()
+                        .field(f -> f.field(JobRegistryIndex.CREATED_AT).order(SortOrder.Asc))
+                        .build(),
+                    // tiebreaker
+                    new SortOptions.Builder()
+                        .field(f -> f.field(JobRegistryIndex.ID).order(SortOrder.Asc))
+                        .build()));
 
     final String errorMessage =
         String.format(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobDispatcher.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobDispatcher.java
@@ -53,9 +53,7 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
   private final JobRegistryWriter jobRegistryWriter;
   private final Map<Pair<JobType, EntityType>, JobHandler> handlersByTypeAndEntity;
 
-  // Created lazily on first dispatch, not at construction: most Optimize instances in a cluster
-  // run with the dispatcher disabled, and this avoids reserving a thread pool that instance never
-  // uses.
+  // Created lazily on first dispatch
   private ExecutorService executorService;
 
   public JobDispatcher(
@@ -129,9 +127,11 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
     }
     final Collection<JobRegistryEntryDto> jobsToDispatch = oldestPerEntity(queuedJobs);
     LOG.info("Dispatching {} queued job registry entries", jobsToDispatch.size());
-    jobsToDispatch.stream()
-        .map(job -> CompletableFuture.runAsync(() -> dispatchJob(job), getExecutorService()))
-        .forEach(CompletableFuture::join);
+    final List<CompletableFuture<Void>> futures =
+        jobsToDispatch.stream()
+            .map(job -> CompletableFuture.runAsync(() -> dispatchJob(job), getExecutorService()))
+            .toList();
+    futures.forEach(CompletableFuture::join);
   }
 
   private synchronized ExecutorService getExecutorService() {
@@ -205,7 +205,7 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
           job.getEntityType(),
           job.getEntityId(),
           e);
-      jobRegistryWriter.updateJobStatus(job.getId(), JobStatus.FAILED, e.getMessage());
+      jobRegistryWriter.updateJobStatus(job.getId(), JobStatus.FAILED, describeError(e));
       return;
     }
     jobRegistryWriter.updateJobStatus(job.getId(), JobStatus.COMPLETED, null);
@@ -215,6 +215,13 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
         job.getJobType(),
         job.getEntityType(),
         job.getEntityId());
+  }
+
+  private static String describeError(final Exception e) {
+    final String message = e.getMessage();
+    return message == null
+        ? e.getClass().getSimpleName()
+        : e.getClass().getSimpleName() + ": " + message;
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobDispatcher.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobDispatcher.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.job;
+
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.AbstractScheduledService;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import io.camunda.optimize.service.util.configuration.ConfigurationReloadable;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.JobRegistryDispatcherConfiguration;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.support.PeriodicTrigger;
+import org.springframework.stereotype.Component;
+
+/**
+ * Polls the job registry for {@code QUEUED} entries and dispatches each to the {@link JobHandler}
+ * registered for its (jobType, entityType) pair, marking the entry {@code COMPLETED} or {@code
+ * FAILED} once the handler returns or throws. Only one Optimize instance in a cluster should have
+ * this enabled.
+ */
+@Component
+public class JobDispatcher extends AbstractScheduledService implements ConfigurationReloadable {
+
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobDispatcher.class);
+
+  private final ConfigurationService configurationService;
+  private final JobRegistryReader jobRegistryReader;
+  private final JobRegistryWriter jobRegistryWriter;
+  private final Map<Pair<JobType, EntityType>, JobHandler> handlersByTypeAndEntity;
+
+  // Created lazily on first dispatch, not at construction: most Optimize instances in a cluster
+  // run with the dispatcher disabled, and this avoids reserving a thread pool that instance never
+  // uses.
+  private ExecutorService executorService;
+
+  public JobDispatcher(
+      final ConfigurationService configurationService,
+      final JobRegistryReader jobRegistryReader,
+      final JobRegistryWriter jobRegistryWriter,
+      final List<JobHandler> jobHandlers) {
+    this.configurationService = configurationService;
+    this.jobRegistryReader = jobRegistryReader;
+    this.jobRegistryWriter = jobRegistryWriter;
+    handlersByTypeAndEntity =
+        jobHandlers.stream()
+            .collect(
+                Collectors.toMap(
+                    handler -> Pair.of(handler.getJobType(), handler.getEntityType()),
+                    Function.identity(),
+                    (first, second) -> {
+                      throw new OptimizeConfigurationException(
+                          "Multiple JobHandlers registered for jobType "
+                              + first.getJobType()
+                              + " and entityType "
+                              + first.getEntityType());
+                    }));
+  }
+
+  @PostConstruct
+  public void init() {
+    LOG.info("Initializing JobDispatcher");
+    getDispatcherConfiguration().validate();
+    if (getDispatcherConfiguration().isEnabled()) {
+      startJobDispatching();
+    } else {
+      stopJobDispatching();
+    }
+  }
+
+  public synchronized void startJobDispatching() {
+    LOG.info("Starting job dispatching");
+    startScheduling();
+  }
+
+  public synchronized void stopJobDispatching() {
+    LOG.info("Stopping job dispatching");
+    stopScheduling();
+  }
+
+  @PreDestroy
+  public synchronized void destroy() {
+    stopJobDispatching();
+    if (executorService != null) {
+      executorService.shutdown();
+    }
+  }
+
+  @Override
+  protected void run() {
+    dispatchNextBatch();
+  }
+
+  @Override
+  protected Trigger createScheduleTrigger() {
+    return new PeriodicTrigger(
+        Duration.ofSeconds(getDispatcherConfiguration().getIntervalSeconds()));
+  }
+
+  public void dispatchNextBatch() {
+    final List<JobRegistryEntryDto> queuedJobs =
+        jobRegistryReader.findOldestQueuedJobs(getDispatcherConfiguration().getBatchSize());
+    if (queuedJobs.isEmpty()) {
+      return;
+    }
+    final Collection<JobRegistryEntryDto> jobsToDispatch = oldestPerEntity(queuedJobs);
+    LOG.info("Dispatching {} queued job registry entries", jobsToDispatch.size());
+    jobsToDispatch.stream()
+        .map(job -> CompletableFuture.runAsync(() -> dispatchJob(job), getExecutorService()))
+        .forEach(CompletableFuture::join);
+  }
+
+  private synchronized ExecutorService getExecutorService() {
+    if (executorService == null) {
+      executorService = Executors.newFixedThreadPool(getDispatcherConfiguration().getThreadCount());
+    }
+    return executorService;
+  }
+
+  /**
+   * Keeps only the oldest entry per (jobType, entityType, entityId) in this batch. Entries do not
+   * get their own concurrent handler run while another entry for the same entity is already being
+   * handled; the rest stay {@code QUEUED} and are picked up in a later batch, once the in-flight
+   * one has updated the entity's status.
+   *
+   * <p>This assumes single-flight-per-entity handling for every job type. If a job type is ever
+   * added where multiple queued entries for the same entity are expected to be handled
+   * independently and concurrently, this would need to become an opt-in/opt-out property of {@link
+   * JobType} rather than applying to all job types.
+   */
+  private Collection<JobRegistryEntryDto> oldestPerEntity(
+      final List<JobRegistryEntryDto> queuedJobs) {
+    return queuedJobs.stream()
+        .collect(
+            Collectors.toMap(
+                job -> Pair.of(job.getJobType(), Pair.of(job.getEntityType(), job.getEntityId())),
+                Function.identity(),
+                (oldest, newer) -> oldest,
+                LinkedHashMap::new))
+        .values();
+  }
+
+  private void dispatchJob(final JobRegistryEntryDto job) {
+    try {
+      handleQueuedJob(job);
+    } catch (final Exception e) {
+      LOG.error(
+          "Unexpected error dispatching job {} (jobType {}, entityId {})",
+          job.getId(),
+          job.getJobType(),
+          job.getEntityId(),
+          e);
+    }
+  }
+
+  private void handleQueuedJob(final JobRegistryEntryDto job) {
+    final JobHandler handler =
+        handlersByTypeAndEntity.get(Pair.of(job.getJobType(), job.getEntityType()));
+    if (handler == null) {
+      LOG.error(
+          "No JobHandler registered for jobType {} and entityType {}, marking job {} as failed",
+          job.getJobType(),
+          job.getEntityType(),
+          job.getId());
+      jobRegistryWriter.updateJobStatus(
+          job.getId(),
+          JobStatus.FAILED,
+          "No handler registered for jobType "
+              + job.getJobType()
+              + " and entityType "
+              + job.getEntityType());
+      return;
+    }
+    try {
+      handler.handle(job);
+    } catch (final Exception e) {
+      LOG.error(
+          "Failed to handle job {} (jobType {}, entityType {}, entityId {})",
+          job.getId(),
+          job.getJobType(),
+          job.getEntityType(),
+          job.getEntityId(),
+          e);
+      jobRegistryWriter.updateJobStatus(job.getId(), JobStatus.FAILED, e.getMessage());
+      return;
+    }
+    jobRegistryWriter.updateJobStatus(job.getId(), JobStatus.COMPLETED, null);
+    LOG.info(
+        "Completed job {} (jobType {}, entityType {}, entityId {})",
+        job.getId(),
+        job.getJobType(),
+        job.getEntityType(),
+        job.getEntityId());
+  }
+
+  @Override
+  public void reloadConfiguration(final ApplicationContext context) {
+    init();
+  }
+
+  private JobRegistryDispatcherConfiguration getDispatcherConfiguration() {
+    return configurationService.getJobRegistryDispatcherConfiguration();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobDispatcher.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobDispatcher.java
@@ -55,6 +55,7 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
 
   // Created lazily on first dispatch
   private ExecutorService executorService;
+  private boolean shuttingDown;
 
   public JobDispatcher(
       final ConfigurationService configurationService,
@@ -102,6 +103,7 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
 
   @PreDestroy
   public synchronized void destroy() {
+    shuttingDown = true;
     stopJobDispatching();
     if (executorService != null) {
       executorService.shutdown();
@@ -127,14 +129,19 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
     }
     final Collection<JobRegistryEntryDto> jobsToDispatch = oldestPerEntity(queuedJobs);
     LOG.info("Dispatching {} queued job registry entries", jobsToDispatch.size());
+    final ExecutorService executor = getExecutorService();
     final List<CompletableFuture<Void>> futures =
         jobsToDispatch.stream()
-            .map(job -> CompletableFuture.runAsync(() -> dispatchJob(job), getExecutorService()))
+            .map(job -> CompletableFuture.runAsync(() -> dispatchJob(job), executor))
             .toList();
     futures.forEach(CompletableFuture::join);
   }
 
   private synchronized ExecutorService getExecutorService() {
+    if (shuttingDown) {
+      throw new IllegalStateException(
+          "JobDispatcher is shutting down, refusing to dispatch further jobs");
+    }
     if (executorService == null) {
       executorService = Executors.newFixedThreadPool(getDispatcherConfiguration().getThreadCount());
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobDispatcher.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobDispatcher.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
@@ -47,6 +49,7 @@ import org.springframework.stereotype.Component;
 public class JobDispatcher extends AbstractScheduledService implements ConfigurationReloadable {
 
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(JobDispatcher.class);
+  private static final long SHUTDOWN_TIMEOUT_SECONDS = 60L;
 
   private final ConfigurationService configurationService;
   private final JobRegistryReader jobRegistryReader;
@@ -83,8 +86,8 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
   @PostConstruct
   public void init() {
     LOG.info("Initializing JobDispatcher");
-    getDispatcherConfiguration().validate();
     if (getDispatcherConfiguration().isEnabled()) {
+      getDispatcherConfiguration().validate();
       startJobDispatching();
     } else {
       stopJobDispatching();
@@ -107,6 +110,17 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
     stopJobDispatching();
     if (executorService != null) {
       executorService.shutdown();
+      try {
+        if (!executorService.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          LOG.warn(
+              "Job dispatcher threads did not terminate within {}s of shutdown, forcing shutdown",
+              SHUTDOWN_TIMEOUT_SECONDS);
+          executorService.shutdownNow();
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        executorService.shutdownNow();
+      }
     }
   }
 
@@ -128,12 +142,22 @@ public class JobDispatcher extends AbstractScheduledService implements Configura
       return;
     }
     final Collection<JobRegistryEntryDto> jobsToDispatch = oldestPerEntity(queuedJobs);
-    LOG.info("Dispatching {} queued job registry entries", jobsToDispatch.size());
-    final ExecutorService executor = getExecutorService();
-    final List<CompletableFuture<Void>> futures =
-        jobsToDispatch.stream()
-            .map(job -> CompletableFuture.runAsync(() -> dispatchJob(job), executor))
-            .toList();
+    LOG.info(
+        "Dispatching {} queued job registry entries: {}",
+        jobsToDispatch.size(),
+        jobsToDispatch.stream().map(JobRegistryEntryDto::getId).toList());
+    final ExecutorService executor;
+    final List<CompletableFuture<Void>> futures;
+    try {
+      executor = getExecutorService();
+      futures =
+          jobsToDispatch.stream()
+              .map(job -> CompletableFuture.runAsync(() -> dispatchJob(job), executor))
+              .toList();
+    } catch (final RejectedExecutionException | IllegalStateException e) {
+      LOG.debug("Dispatcher is shutting down, aborting in-progress batch", e);
+      return;
+    }
     futures.forEach(CompletableFuture::join);
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/JobHandler.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.job;
+
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+
+/** Handles a job of type {@code JobType} for the entity type {@code EntityType}. */
+public interface JobHandler {
+
+  JobType getJobType();
+
+  EntityType getEntityType();
+
+  void handle(JobRegistryEntryDto job) throws Exception;
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDtoTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/dto/optimize/query/job/JobRegistryEntryDtoTest.java
@@ -15,9 +15,12 @@ class JobRegistryEntryDtoTest {
 
   @Test
   void shouldInitializeQueuedEntryWithGeneratedIdAndCreationTimestamp() {
+    // given
+    // when
     final JobRegistryEntryDto entry =
         new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2251799813685251");
 
+    // then
     assertThat(entry.getId()).isNotBlank();
     assertThat(entry.getJobType()).isEqualTo(JobType.DELETE);
     assertThat(entry.getEntityType()).isEqualTo(EntityType.PROCESS_DEFINITION);
@@ -30,11 +33,14 @@ class JobRegistryEntryDtoTest {
 
   @Test
   void shouldGenerateDifferentIdsForEachEntry() {
+    // given
+    // when
     final JobRegistryEntryDto first =
         new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
     final JobRegistryEntryDto second =
         new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
 
+    // then
     assertThat(first.getId()).isNotEqualTo(second.getId());
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/JobDispatcherTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/JobDispatcherTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class JobDispatcherTest {
+
+  private ConfigurationService configurationService;
+  private JobRegistryReader jobRegistryReader;
+  private JobRegistryWriter jobRegistryWriter;
+
+  @BeforeEach
+  public void init() {
+    configurationService = ConfigurationServiceBuilder.createDefaultConfiguration();
+    // Mockito mocks are not safe to invoke concurrently from multiple threads; pin the dispatcher
+    // to a single worker thread so a batch's jobs are handled one at a time, keeping the mock
+    // interactions in these tests deterministic.
+    configurationService.getJobRegistryDispatcherConfiguration().setThreadCount(1);
+    jobRegistryReader = mock(JobRegistryReader.class);
+    jobRegistryWriter = mock(JobRegistryWriter.class);
+  }
+
+  @Test
+  public void shouldDispatchQueuedJobToMatchingHandler() throws Exception {
+    // given
+    final JobHandler handler = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);
+    final JobRegistryEntryDto job = jobEntry("job-1");
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt())).thenReturn(List.of(job));
+    final JobDispatcher underTest = createDispatcherToTest(handler);
+
+    // when
+    underTest.dispatchNextBatch();
+
+    // then
+    verify(handler, times(1)).handle(job);
+    verify(jobRegistryWriter).updateJobStatus("job-1", JobStatus.COMPLETED, null);
+  }
+
+  @Test
+  public void shouldMarkJobAsFailedWhenHandlerThrows() throws Exception {
+    // given
+    final JobHandler handler = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);
+    doThrow(new RuntimeException("boom")).when(handler).handle(any());
+    final JobRegistryEntryDto job = jobEntry("job-1");
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt())).thenReturn(List.of(job));
+    final JobDispatcher underTest = createDispatcherToTest(handler);
+
+    // when
+    underTest.dispatchNextBatch();
+
+    // then
+    verify(jobRegistryWriter).updateJobStatus(eq("job-1"), eq(JobStatus.FAILED), eq("boom"));
+  }
+
+  @Test
+  public void shouldMarkJobAsFailedWhenNoHandlerRegisteredForEntityType() {
+    // given
+    final JobRegistryEntryDto job = jobEntry("job-1");
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt())).thenReturn(List.of(job));
+    final JobDispatcher underTest = createDispatcherToTest();
+
+    // when
+    underTest.dispatchNextBatch();
+
+    // then
+    verify(jobRegistryWriter).updateJobStatus(eq("job-1"), eq(JobStatus.FAILED), any(String.class));
+  }
+
+  @Test
+  public void shouldIsolateFailureOfOneJobFromOthersInSameBatch() throws Exception {
+    // given
+    final JobHandler handler = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);
+    final JobRegistryEntryDto failingJob = jobEntry("job-failing", "entity-failing");
+    final JobRegistryEntryDto succeedingJob = jobEntry("job-succeeding", "entity-succeeding");
+    doThrow(new RuntimeException("boom")).when(handler).handle(failingJob);
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt()))
+        .thenReturn(List.of(failingJob, succeedingJob));
+    final JobDispatcher underTest = createDispatcherToTest(handler);
+
+    // when
+    underTest.dispatchNextBatch();
+
+    // then
+    verify(jobRegistryWriter).updateJobStatus(eq("job-failing"), eq(JobStatus.FAILED), any());
+    verify(jobRegistryWriter)
+        .updateJobStatus(eq("job-succeeding"), eq(JobStatus.COMPLETED), eq(null));
+  }
+
+  @Test
+  public void shouldOnlyDispatchOldestEntryPerEntityInSameBatch() throws Exception {
+    // given
+    final JobHandler handler = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);
+    final JobRegistryEntryDto olderEntry = jobEntry("job-older");
+    final JobRegistryEntryDto newerDuplicateEntry = jobEntry("job-newer-duplicate");
+    final JobRegistryEntryDto unrelatedEntry = jobEntry("job-unrelated", "entity-unrelated");
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt()))
+        .thenReturn(List.of(olderEntry, newerDuplicateEntry, unrelatedEntry));
+    final JobDispatcher underTest = createDispatcherToTest(handler);
+
+    // when
+    underTest.dispatchNextBatch();
+
+    // then
+    verify(handler, times(1)).handle(olderEntry);
+    verify(handler, never()).handle(newerDuplicateEntry);
+    verify(handler, times(1)).handle(unrelatedEntry);
+    verify(jobRegistryWriter).updateJobStatus(eq("job-older"), eq(JobStatus.COMPLETED), eq(null));
+    verify(jobRegistryWriter, never()).updateJobStatus(eq("job-newer-duplicate"), any(), any());
+    verify(jobRegistryWriter)
+        .updateJobStatus(eq("job-unrelated"), eq(JobStatus.COMPLETED), eq(null));
+  }
+
+  @Test
+  public void shouldNotAbortBatchWhenRegistryWriteThrows() throws Exception {
+    // given
+    final JobHandler handler = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);
+    final JobRegistryEntryDto jobWithFailingWrite =
+        jobEntry("job-write-failure", "entity-write-failure");
+    final JobRegistryEntryDto otherJob = jobEntry("job-other", "entity-other");
+    doThrow(new RuntimeException("registry unavailable"))
+        .when(jobRegistryWriter)
+        .updateJobStatus(eq("job-write-failure"), any(), any());
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt()))
+        .thenReturn(List.of(jobWithFailingWrite, otherJob));
+    final JobDispatcher underTest = createDispatcherToTest(handler);
+
+    // when / then
+    assertThatCode(underTest::dispatchNextBatch).doesNotThrowAnyException();
+    verify(handler, times(1)).handle(otherJob);
+    verify(jobRegistryWriter).updateJobStatus(eq("job-other"), eq(JobStatus.COMPLETED), eq(null));
+  }
+
+  @Test
+  public void shouldNotMarkJobAsFailedWhenHandlerSucceedsButRegistryWriteThrows() throws Exception {
+    // given
+    final JobHandler handler = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);
+    final JobRegistryEntryDto job = jobEntry("job-1");
+    doThrow(new RuntimeException("registry unavailable"))
+        .when(jobRegistryWriter)
+        .updateJobStatus(eq("job-1"), eq(JobStatus.COMPLETED), any());
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt())).thenReturn(List.of(job));
+    final JobDispatcher underTest = createDispatcherToTest(handler);
+
+    // when
+    underTest.dispatchNextBatch();
+
+    // then
+    verify(handler, times(1)).handle(job);
+    verify(jobRegistryWriter, never()).updateJobStatus(eq("job-1"), eq(JobStatus.FAILED), any());
+  }
+
+  @Test
+  public void shouldNotQueryWriterWhenNoJobsAreQueued() {
+    // given
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt())).thenReturn(List.of());
+    final JobDispatcher underTest = createDispatcherToTest();
+
+    // when
+    underTest.dispatchNextBatch();
+
+    // then
+    verify(jobRegistryWriter, never()).updateJobStatus(any(), any(), any());
+  }
+
+  @Test
+  public void shouldFailToConstructWhenTwoHandlersRegisterForSameJobTypeAndEntityType() {
+    // given
+    final JobHandler handler1 = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);
+    final JobHandler handler2 = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);
+
+    // when / then
+    assertThatExceptionOfType(OptimizeConfigurationException.class)
+        .isThrownBy(() -> createDispatcherToTest(handler1, handler2));
+  }
+
+  @Test
+  public void shouldFailToInitializeWhenThreadCountIsInvalid() {
+    // given
+    configurationService.getJobRegistryDispatcherConfiguration().setThreadCount(0);
+    final JobDispatcher underTest = createDispatcherToTest();
+
+    // when / then
+    assertThatExceptionOfType(OptimizeConfigurationException.class).isThrownBy(underTest::init);
+  }
+
+  @Test
+  public void shouldStartSchedulingWhenEnabled() {
+    // given
+    configurationService.getJobRegistryDispatcherConfiguration().setEnabled(true);
+    final JobDispatcher underTest = createDispatcherToTest();
+
+    // when
+    underTest.init();
+
+    // then
+    try {
+      assertThat(underTest.isScheduledToRun()).isTrue();
+    } finally {
+      underTest.destroy();
+    }
+  }
+
+  @Test
+  public void shouldNotStartSchedulingWhenDisabled() {
+    // given
+    configurationService.getJobRegistryDispatcherConfiguration().setEnabled(false);
+    final JobDispatcher underTest = createDispatcherToTest();
+
+    // when
+    underTest.init();
+
+    // then
+    assertThat(underTest.isScheduledToRun()).isFalse();
+  }
+
+  private JobHandler mockHandler(final JobType jobType, final EntityType entityType) {
+    final JobHandler handler = mock(JobHandler.class);
+    when(handler.getJobType()).thenReturn(jobType);
+    when(handler.getEntityType()).thenReturn(entityType);
+    return handler;
+  }
+
+  private JobRegistryEntryDto jobEntry(final String id) {
+    return jobEntry(id, "entity-1");
+  }
+
+  private JobRegistryEntryDto jobEntry(final String id, final String entityId) {
+    final JobRegistryEntryDto job =
+        new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, entityId);
+    job.setId(id);
+    return job;
+  }
+
+  private JobDispatcher createDispatcherToTest(final JobHandler... jobHandlers) {
+    return new JobDispatcher(
+        configurationService, jobRegistryReader, jobRegistryWriter, List.of(jobHandlers));
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/JobDispatcherTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/JobDispatcherTest.java
@@ -208,15 +208,19 @@ public class JobDispatcherTest {
   }
 
   @Test
-  public void shouldRefuseToDispatchAfterDestroy() {
+  public void shouldAbortBatchWithoutDispatchingAfterDestroy() {
     // given
-    when(jobRegistryReader.findOldestQueuedJobs(anyInt())).thenReturn(List.of(jobEntry("1")));
+    final JobRegistryEntryDto job = jobEntry("1");
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt())).thenReturn(List.of(job));
     final JobDispatcher underTest = createDispatcherToTest();
     underTest.destroy();
 
     // when / then
-    // Once destroy() has run, no later dispatch may lazily spin up a fresh pool
-    assertThatExceptionOfType(IllegalStateException.class).isThrownBy(underTest::dispatchNextBatch);
+    // Once destroy() has run, no later dispatch may lazily spin up a fresh pool -- this is
+    // expected on shutdown, so it must not throw, just leave the entry untouched for the next
+    // dispatcher instance to pick up.
+    assertThatCode(underTest::dispatchNextBatch).doesNotThrowAnyException();
+    verify(jobRegistryWriter, never()).updateJobStatus(any(), any(), any());
   }
 
   @Test
@@ -233,11 +237,23 @@ public class JobDispatcherTest {
   @Test
   public void shouldFailToInitializeWhenThreadCountIsInvalid() {
     // given
+    configurationService.getJobRegistryDispatcherConfiguration().setEnabled(true);
     configurationService.getJobRegistryDispatcherConfiguration().setThreadCount(0);
     final JobDispatcher underTest = createDispatcherToTest();
 
     // when / then
     assertThatExceptionOfType(OptimizeConfigurationException.class).isThrownBy(underTest::init);
+  }
+
+  @Test
+  public void shouldNotValidateConfigurationWhenDisabled() {
+    // given
+    configurationService.getJobRegistryDispatcherConfiguration().setEnabled(false);
+    configurationService.getJobRegistryDispatcherConfiguration().setThreadCount(0);
+    final JobDispatcher underTest = createDispatcherToTest();
+
+    // when / then
+    assertThatCode(underTest::init).doesNotThrowAnyException();
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/JobDispatcherTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/JobDispatcherTest.java
@@ -208,6 +208,18 @@ public class JobDispatcherTest {
   }
 
   @Test
+  public void shouldRefuseToDispatchAfterDestroy() {
+    // given
+    when(jobRegistryReader.findOldestQueuedJobs(anyInt())).thenReturn(List.of(jobEntry("1")));
+    final JobDispatcher underTest = createDispatcherToTest();
+    underTest.destroy();
+
+    // when / then
+    // Once destroy() has run, no later dispatch may lazily spin up a fresh pool
+    assertThatExceptionOfType(IllegalStateException.class).isThrownBy(underTest::dispatchNextBatch);
+  }
+
+  @Test
   public void shouldFailToConstructWhenTwoHandlersRegisterForSameJobTypeAndEntityType() {
     // given
     final JobHandler handler1 = mockHandler(JobType.DELETE, EntityType.PROCESS_DEFINITION);

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/JobDispatcherTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/JobDispatcherTest.java
@@ -29,7 +29,9 @@ import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
+import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,6 +43,7 @@ public class JobDispatcherTest {
   private ConfigurationService configurationService;
   private JobRegistryReader jobRegistryReader;
   private JobRegistryWriter jobRegistryWriter;
+  private final List<JobDispatcher> createdDispatchers = new ArrayList<>();
 
   @BeforeEach
   public void init() {
@@ -51,6 +54,14 @@ public class JobDispatcherTest {
     configurationService.getJobRegistryDispatcherConfiguration().setThreadCount(1);
     jobRegistryReader = mock(JobRegistryReader.class);
     jobRegistryWriter = mock(JobRegistryWriter.class);
+  }
+
+  @AfterEach
+  public void shutdownDispatchers() {
+    // dispatchNextBatch() lazily creates a non-daemon thread pool; without this, every test that
+    // dispatches at least one job leaks its dispatcher's threads for the rest of the suite.
+    createdDispatchers.forEach(JobDispatcher::destroy);
+    createdDispatchers.clear();
   }
 
   @Test
@@ -82,7 +93,8 @@ public class JobDispatcherTest {
     underTest.dispatchNextBatch();
 
     // then
-    verify(jobRegistryWriter).updateJobStatus(eq("job-1"), eq(JobStatus.FAILED), eq("boom"));
+    verify(jobRegistryWriter)
+        .updateJobStatus(eq("job-1"), eq(JobStatus.FAILED), eq("RuntimeException: boom"));
   }
 
   @Test
@@ -265,7 +277,10 @@ public class JobDispatcherTest {
   }
 
   private JobDispatcher createDispatcherToTest(final JobHandler... jobHandlers) {
-    return new JobDispatcher(
-        configurationService, jobRegistryReader, jobRegistryWriter, List.of(jobHandlers));
+    final JobDispatcher dispatcher =
+        new JobDispatcher(
+            configurationService, jobRegistryReader, jobRegistryWriter, List.of(jobHandlers));
+    createdDispatchers.add(dispatcher);
+    return dispatcher;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
@@ -73,6 +73,7 @@ public class ConfigurationService {
   private SecurityConfiguration securityConfiguration;
   private UsersConfiguration usersConfiguration;
   private ZeebeConfiguration configuredZeebe;
+  private JobRegistryDispatcherConfiguration jobRegistryDispatcherConfiguration;
   private Long initialBackoff;
   private Long maximumBackoff;
   // engine import settings
@@ -264,6 +265,21 @@ public class ConfigurationService {
 
   public void setConfiguredZeebe(final ZeebeConfiguration configuredZeebe) {
     this.configuredZeebe = configuredZeebe;
+  }
+
+  public JobRegistryDispatcherConfiguration getJobRegistryDispatcherConfiguration() {
+    if (jobRegistryDispatcherConfiguration == null) {
+      jobRegistryDispatcherConfiguration =
+          configJsonContext.read(
+              ConfigurationServiceConstants.JOB_REGISTRY_DISPATCHER,
+              JobRegistryDispatcherConfiguration.class);
+    }
+    return jobRegistryDispatcherConfiguration;
+  }
+
+  public void setJobRegistryDispatcherConfiguration(
+      final JobRegistryDispatcherConfiguration jobRegistryDispatcherConfiguration) {
+    this.jobRegistryDispatcherConfiguration = jobRegistryDispatcherConfiguration;
   }
 
   public SecurityConfiguration getSecurityConfiguration() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
@@ -17,6 +17,7 @@ public final class ConfigurationServiceConstants {
   public static final String USERS = "$.users";
   public static final String CONFIGURED_ENGINES = "$.engines";
   public static final String CONFIGURED_ZEEBE = "$.zeebe";
+  public static final String JOB_REGISTRY_DISPATCHER = "$.jobRegistry.dispatcher";
 
   public static final String QUARTZ_JOB_STORE_CLASS = "$.alerting.quartz.jobStore";
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/JobRegistryDispatcherConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/JobRegistryDispatcherConfiguration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.util.configuration;
+
+import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.JOB_REGISTRY_DISPATCHER;
+
+import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import java.util.Objects;
+
+public class JobRegistryDispatcherConfiguration {
+
+  private boolean enabled;
+  private int intervalSeconds;
+  private int batchSize;
+  private int threadCount;
+
+  public JobRegistryDispatcherConfiguration(
+      final boolean enabled,
+      final int intervalSeconds,
+      final int batchSize,
+      final int threadCount) {
+    this.enabled = enabled;
+    this.intervalSeconds = intervalSeconds;
+    this.batchSize = batchSize;
+    this.threadCount = threadCount;
+  }
+
+  protected JobRegistryDispatcherConfiguration() {}
+
+  public void validate() {
+    if (intervalSeconds <= 0) {
+      throw new OptimizeConfigurationException(
+          JOB_REGISTRY_DISPATCHER + ".intervalSeconds must be greater than 0");
+    }
+    if (batchSize <= 0) {
+      throw new OptimizeConfigurationException(
+          JOB_REGISTRY_DISPATCHER + ".batchSize must be greater than 0");
+    }
+    if (threadCount <= 0) {
+      throw new OptimizeConfigurationException(
+          JOB_REGISTRY_DISPATCHER + ".threadCount must be greater than 0");
+    }
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getIntervalSeconds() {
+    return intervalSeconds;
+  }
+
+  public void setIntervalSeconds(final int intervalSeconds) {
+    this.intervalSeconds = intervalSeconds;
+  }
+
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  public void setBatchSize(final int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  public int getThreadCount() {
+    return threadCount;
+  }
+
+  public void setThreadCount(final int threadCount) {
+    this.threadCount = threadCount;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof JobRegistryDispatcherConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JobRegistryDispatcherConfiguration that = (JobRegistryDispatcherConfiguration) o;
+    return enabled == that.enabled
+        && intervalSeconds == that.intervalSeconds
+        && batchSize == that.batchSize
+        && threadCount == that.threadCount;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, intervalSeconds, batchSize, threadCount);
+  }
+
+  @Override
+  public String toString() {
+    return "JobRegistryDispatcherConfiguration(enabled="
+        + isEnabled()
+        + ", intervalSeconds="
+        + getIntervalSeconds()
+        + ", batchSize="
+        + getBatchSize()
+        + ", threadCount="
+        + getThreadCount()
+        + ")";
+  }
+}

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -168,6 +168,19 @@ zeebe:
     # using the sequence query
     maxEmptyPagesToImport: ${CAMUNDA_OPTIMIZE_ZEEBE_IMPORT_MAX_EMPTY_PAGES_TO_IMPORT:10}
 
+jobRegistry:
+  dispatcher:
+    # Toggles whether this Optimize instance dispatches queued job registry entries. Only one
+    # instance per cluster should have this enabled.
+    enabled: ${CAMUNDA_OPTIMIZE_JOB_REGISTRY_DISPATCHER_ENABLED:false}
+    # Delay, in seconds, before the dispatcher polls again for queued job registry entries,
+    # counted from the completion of the previous poll
+    intervalSeconds: ${CAMUNDA_OPTIMIZE_JOB_REGISTRY_DISPATCHER_INTERVAL_SECONDS:30}
+    # The maximum number of queued entries read and dispatched per poll cycle
+    batchSize: ${CAMUNDA_OPTIMIZE_JOB_REGISTRY_DISPATCHER_BATCH_SIZE:4}
+    # The number of threads used to dispatch entries of a batch to their handlers concurrently
+    threadCount: ${CAMUNDA_OPTIMIZE_JOB_REGISTRY_DISPATCHER_THREAD_COUNT:2}
+
 import:
   data:
     activity-instance:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
  - Adds `JobDispatcher`, a scheduled service that polls the job registry for `QUEUED` entries and dispatches each to the `JobHandler` matched by `(jobType, entityType)`, marking entries `COMPLETED`/`FAILED`.
  - Single-instance-per-cluster gating via new `jobRegistry.dispatcher.enabled` config flag (default `false`), same pattern as `CleanupScheduler`.
  - Duplicate queued entries for the same entity within a batch are deduped to the oldest one, avoiding concurrent handling of the same entity.
  - Dispatch executor is created lazily on first use so disabled instances never allocate a thread pool.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59844 
