### PR TITLE
ci: trigger stable/8.7 Zeebe CI

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -406,6 +406,20 @@ jobs:
     with:
       base_group_name: deploy-docker-snapshot
 
+  debug:
+    name: Debug
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - run: |-
+          cat <<EOF | jq . --sort-keys
+          ${{ toJSON(github) }}
+          EOF
+
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
     timeout-minutes: 15

--- a/zeebe/README.md
+++ b/zeebe/README.md
@@ -24,3 +24,5 @@ This is a small overview of the contents of the different modules:
 - `exporters/elasticsearch-exporter` contains the official Elasticsearch exporter for Zeebe
 - `journal` contains the append-only log used by the consensus algorithm
 - `snapshots` abstracts how state snapshots (i.e. `zb-db`) are handled
+
+test

--- a/zeebe/README.md
+++ b/zeebe/README.md
@@ -26,3 +26,4 @@ This is a small overview of the contents of the different modules:
 - `snapshots` abstracts how state snapshots (i.e. `zb-db`) are handled
 
 test
+test2


### PR DESCRIPTION
## Description

Empty PR to triggers [the (Zeebe) CI](https://github.com/camunda/camunda/actions/workflows/ci.yml?query=branch%3Astable%2F8.7) for stable/8.7

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://app.incident.io/camunda/incidents/7187
