### PR TITLE
fix: put spring-session-core on the Optimize runtime classpath

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -485,11 +485,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- CSL's session filter is Spring Session-backed (MapSessionRepository by default); chain
-           integration tests mint sessions through it directly instead of a raw servlet HttpSession -->
+      <!-- Runtime requirement of CSL's WebSessionConfiguration, which OptimizeCamundaSecurityConfig
+           imports whenever optimize.security.csl.enabled is set; chain integration tests also mint
+           sessions through the Spring Session-backed filter instead of a raw servlet HttpSession -->
       <groupId>org.springframework.session</groupId>
       <artifactId>spring-session-core</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <!-- this is necessary. Dependency:analyze error suppressed -->
@@ -850,6 +850,13 @@
             <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-jackson2</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-actuator</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+          <ignoredNonTestScopedDependencies>
+            <!-- No production class references it: CSL's WebSessionConfiguration is what needs it
+                 at runtime, and only the chain integration tests reference it from Optimize's own
+                 sources. It must stay non-test scoped so the distribution can start with
+                 optimize.security.csl.enabled=true. -->
+            <ignoredNonTestScopedDependency>org.springframework.session:spring-session-core</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
         </configuration>
         <executions>
           <execution>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -842,6 +842,33 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ban-test-scoped-spring-session</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <searchTransitive>false</searchTransitive>
+                  <excludes>
+                    <exclude>org.springframework.session:spring-session-core:*:*:test</exclude>
+                  </excludes>
+                  <message>spring-session-core must stay non-test scoped: CSL's WebSessionConfiguration
+                    needs it at runtime, and no test can catch its absence because the test classpath
+                    always has it. Test scope silently packages it out of the distribution, which then
+                    fails to start with optimize.security.csl.enabled=true (see #60518).</message>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <ignoredUnusedDeclaredDependencies>


### PR DESCRIPTION
## Description

Optimize crash-loops on startup with `optimize.security.csl.enabled=true`, before it opens its
port:

```
Failed to introspect Class [io.camunda.security.spring.session.WebSessionConfiguration]
Caused by: java.lang.NoClassDefFoundError: org/springframework/session/SessionRepository
```

`spring-session-core` was declared for the CSL chain integration tests with `<scope>test</scope>`.
By Maven's nearest-wins rule that direct declaration overrides the compile scope the CSL Spring
Boot starter provides transitively, so the artifact reached the tests but was packaged out of the
distribution — even though `OptimizeCamundaSecurityConfig` imports CSL's `WebSessionConfiguration`
whenever the flag is set.

Dropping the scope restores the starter's compile scope. Verified with
`./mvnw dependency:tree -pl optimize/backend -Dincludes=org.springframework.session:spring-session-core`:

- before: `org.springframework.session:spring-session-core:jar:4.1.0:test`
- after: `org.springframework.session:spring-session-core:jar:4.1.0:compile`

The bug stayed latent until the bump to camunda-security-library `0.1.0-alpha67` (#60396), from
which the class is introspected during condition evaluation. Optimize images built before that
bump start normally, which is why CSL adoption testing only hit this now.

No Optimize production class references the artifact — only `CslChainIntegrationTest` does — so
`dependency:analyze` reports it as `Non-test scoped test only dependencies found` and fails the
Java checks. It is excluded via `ignoredNonTestScopedDependencies` in the same pom, with the
reasoning inline, rather than letting the scope regress to test.

### Why there is no test

No test can catch this. Every test runs with `spring-session-core` on the classpath, which is
precisely why `CslChainIntegrationTest` and `CslWebSessionWiringTest` pass on `main` today while the
packaged distribution cannot start. A context-start test with `optimize.security.csl.enabled=true`
would give false confidence. Only the declared scope separates a working distribution from a broken
one, and `dependency:analyze` cannot help either — it complains about the correct scope, so it stays
silent on a regression back to test.

The second commit therefore bans the test-scoped coordinate via `maven-enforcer`, so re-adding the
scope fails the build with an explanation. Verified both ways:

- as declared: `enforcer:enforce@ban-test-scoped-spring-session` passes
- with `<scope>test</scope>` restored: `BUILD FAILURE … org.springframework.session:spring-session-core:jar:4.1.0 <--- banned via the exclude/include list`

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60518
