### PR TITLE
feat: expose new rebalance endpoint in the v2 REST API

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -33,6 +33,7 @@ import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterHistoryBackupServices;
+import io.camunda.service.ClusterRebalanceServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterRuntimeBackupServices;
 import io.camunda.service.ClusterRuntimeBackupServices.PhysicalTenantBackupPort;
@@ -87,6 +88,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import io.camunda.zeebe.rebalance.RebalanceRequestSender;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -148,6 +150,7 @@ public class CamundaServicesConfiguration {
       final GatewayRestConfiguration gatewayRestConfiguration,
       final BrokerTopologyManager brokerTopologyManager,
       final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender,
+      final RebalanceRequestSender rebalanceRequestSender,
       final MeterRegistry meterRegistry,
       final Environment environment,
       final ManagementServices managementServices,
@@ -591,6 +594,7 @@ public class CamundaServicesConfiguration {
     builder.clusterExportingServices(
         new ClusterExportingServices(
             exportingRequestBroadcaster, physicalTenantResolver.getAll().keySet()));
+    builder.clusterRebalanceServices(new ClusterRebalanceServices(rebalanceRequestSender));
 
     builder.clusterRuntimeBackupServices(new ClusterRuntimeBackupServices(runtimeBackupPorts));
 

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import io.camunda.zeebe.rebalance.RebalanceRequestSender;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -415,6 +416,7 @@ class CamundaServicesConfigurationTest {
         new GatewayRestConfiguration(),
         mock(BrokerTopologyManager.class),
         mock(ClusterConfigurationManagementRequestSender.class),
+        mock(RebalanceRequestSender.class),
         new SimpleMeterRegistry(),
         new MockEnvironment(),
         new ManagementServices(new CamundaLicense(null)),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -48,6 +48,7 @@ public class ClusterAdminBasicAuthenticationIT {
   public static final String PATH_CLUSTER_RUNTIME_BACKUPS = "cluster/v2/backups/runtime";
   public static final String PATH_CLUSTER_RUNTIME_BACKUP = "cluster/v2/backups/runtime/1";
   public static final String PATH_CLUSTER_RUNTIME_BACKUP_STATE = "cluster/v2/backups/runtime/state";
+  public static final String PATH_CLUSTER_REBALANCE = "cluster/v2/rebalance";
   public static final String PATH_V2_AUTHENTICATION_ME = "v2/authentication/me";
 
   private static final String CLUSTER_ADMIN_USER = "cluster-operator";
@@ -125,6 +126,16 @@ public class ClusterAdminBasicAuthenticationIT {
         send(clusterUri(PATH_CLUSTER_TOPOLOGY), basicAuth(DB_USERNAME, DB_PASSWORD));
 
     // then — the cluster-admin chain has its own isolated store; a DB user is not known to it
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"GET", "POST", "DELETE"})
+  void shouldRejectRebalanceWithoutCredentials(final String method) throws Exception {
+    // when
+    final HttpResponse<String> response = send(method, clusterUri(PATH_CLUSTER_REBALANCE), null);
+
+    // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
   }
 
@@ -231,7 +242,13 @@ public class ClusterAdminBasicAuthenticationIT {
 
   private HttpResponse<String> send(final URI uri, final String authorizationHeader)
       throws Exception {
-    final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(uri);
+    return send("GET", uri, authorizationHeader);
+  }
+
+  private HttpResponse<String> send(
+      final String method, final URI uri, final String authorizationHeader) throws Exception {
+    final HttpRequest.Builder builder =
+        HttpRequest.newBuilder(uri).method(method, HttpRequest.BodyPublishers.noBody());
     if (authorizationHeader != null) {
       builder.header("Authorization", authorizationHeader);
     }

--- a/qa/archunit-tests/src/test/java/io/camunda/service/ServiceRegistryArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/service/ServiceRegistryArchTest.java
@@ -67,7 +67,8 @@ public final class ServiceRegistryArchTest {
       Set.of(
           ManagementServices.class.getName(),
           ClusterTopologyServices.class.getName(),
-          ClusterExportingServices.class.getName());
+          ClusterExportingServices.class.getName(),
+          ClusterRebalanceServices.class.getName());
 
   // -- conditions --
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-rebalance</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
     <dependency>

--- a/service/src/main/java/io/camunda/service/ClusterRebalanceServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRebalanceServices.java
@@ -142,8 +142,8 @@ public final class ClusterRebalanceServices {
       @Nullable Integer maxTransferAttempts,
       @Nullable Duration leaderWaitTimeout) {
 
-    public static ClusterRebalanceRequest withDefaultSettings() {
-      return new ClusterRebalanceRequest(false, null, null, null, null);
+    public static ClusterRebalanceRequest withDefaultSettings(final boolean dryRun) {
+      return new ClusterRebalanceRequest(dryRun, null, null, null, null);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/ClusterRebalanceServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRebalanceServices.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.rebalance.CancelRebalanceResponse;
+import io.camunda.zeebe.rebalance.RebalanceErrorResponse;
+import io.camunda.zeebe.rebalance.RebalanceOverrides;
+import io.camunda.zeebe.rebalance.RebalanceRequestSender;
+import io.camunda.zeebe.rebalance.RebalanceStatus;
+import io.camunda.zeebe.rebalance.TriggerRebalanceRequest;
+import io.camunda.zeebe.util.Either;
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Coordinated cluster-wide leadership rebalancing - connects the API at {@code
+ * /cluster/v2/rebalance} to the cluster's rebalance coordinator.
+ */
+@NullMarked
+public final class ClusterRebalanceServices {
+
+  private final RebalanceRequestSender rebalanceRequestSender;
+
+  public ClusterRebalanceServices(final RebalanceRequestSender rebalanceRequestSender) {
+    this.rebalanceRequestSender = rebalanceRequestSender;
+  }
+
+  public CompletableFuture<RebalanceStatus> triggerRebalance(
+      final ClusterRebalanceRequest request) {
+    final RebalanceOverrides overrides;
+    try {
+      overrides =
+          new RebalanceOverrides(
+              request.replicationLagThreshold(),
+              request.replicationTimeout(),
+              request.maxTransferAttempts(),
+              request.leaderWaitTimeout());
+    } catch (final IllegalArgumentException e) {
+      return CompletableFuture.failedFuture(
+          new ServiceException(e.getMessage(), Status.INVALID_ARGUMENT));
+    }
+    return rebalanceRequestSender
+        .triggerRebalance(new TriggerRebalanceRequest(overrides, request.dryRun()))
+        .handle(ClusterRebalanceServices::toStatusOrThrow);
+  }
+
+  public CompletableFuture<RebalanceStatus> getRebalanceStatus() {
+    return rebalanceRequestSender
+        .getRebalanceStatus()
+        .handle(ClusterRebalanceServices::toStatusOrThrow);
+  }
+
+  public CompletableFuture<CancelRebalanceResponse> cancelRebalance() {
+    return rebalanceRequestSender
+        .cancelRebalance()
+        .handle(ClusterRebalanceServices::toCancellationOrThrow);
+  }
+
+  private static RebalanceStatus toStatusOrThrow(
+      final @Nullable Either<RebalanceErrorResponse, RebalanceStatus> response,
+      final @Nullable Throwable error) {
+    if (error != null) {
+      throw toServiceException(error);
+    }
+    if (response == null) {
+      throw noAnswer();
+    }
+    if (response.isLeft()) {
+      throw toServiceException(response.getLeft());
+    }
+    return response.get();
+  }
+
+  private static CancelRebalanceResponse toCancellationOrThrow(
+      final @Nullable Either<RebalanceErrorResponse, CancelRebalanceResponse> response,
+      final @Nullable Throwable error) {
+    if (error != null) {
+      throw toServiceException(error);
+    }
+    if (response == null) {
+      throw noAnswer();
+    }
+    if (response.isLeft()) {
+      throw toServiceException(response.getLeft());
+    }
+    return response.get();
+  }
+
+  private static ServiceException noAnswer() {
+    return new ServiceException("The coordinator gave no answer to the request", Status.ABORTED);
+  }
+
+  private static ServiceException toServiceException(final RebalanceErrorResponse response) {
+    final var status =
+        switch (response.code()) {
+          case REBALANCE_IN_PROGRESS, CONFIGURATION_CHANGE_IN_PROGRESS -> Status.ALREADY_EXISTS;
+          case NOT_COORDINATOR -> Status.UNAVAILABLE;
+          case INTERNAL_ERROR -> Status.INTERNAL;
+        };
+    return new ServiceException(response.message(), status);
+  }
+
+  private static ServiceException toServiceException(final Throwable error) {
+    final var cause = unwrap(error);
+    if (cause instanceof final ServiceException serviceException) {
+      return serviceException;
+    }
+    final var status =
+        switch (cause) {
+          case final ConnectException ignored -> Status.UNAVAILABLE;
+          case final NoSuchMemberException ignored -> Status.UNAVAILABLE;
+          case final TimeoutException ignored -> Status.DEADLINE_EXCEEDED;
+          default -> Status.ABORTED;
+        };
+    return new ServiceException(cause.getMessage(), status);
+  }
+
+  private static Throwable unwrap(final Throwable error) {
+    if (error instanceof CompletionException && error.getCause() != null) {
+      return unwrap(error.getCause());
+    }
+    return error;
+  }
+
+  public record ClusterRebalanceRequest(
+      boolean dryRun,
+      @Nullable Long replicationLagThreshold,
+      @Nullable Duration replicationTimeout,
+      @Nullable Integer maxTransferAttempts,
+      @Nullable Duration leaderWaitTimeout) {
+
+    public static ClusterRebalanceRequest withDefaultSettings() {
+      return new ClusterRebalanceRequest(false, null, null, null, null);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -17,6 +17,7 @@ import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterHistoryBackupServices;
+import io.camunda.service.ClusterRebalanceServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterRuntimeBackupServices;
 import io.camunda.service.ClusterStatusServices;
@@ -108,6 +109,7 @@ public record DefaultServiceRegistry(
     Map<String, VariableServices> variableByTenant,
     @Nullable ClusterHistoryBackupServices clusterHistoryBackupServices,
     ClusterRuntimeBackupServices clusterRuntimeBackupServices,
+    ClusterRebalanceServices clusterRebalanceServices,
     ClusterRecoveryServices clusterRecoveryServices,
     ClusterStatusServices clusterStatusServices,
     ClusterTopologyServices clusterTopologyServices,
@@ -346,6 +348,11 @@ public record DefaultServiceRegistry(
   }
 
   @Override
+  public ClusterRebalanceServices clusterRebalanceServices() {
+    return clusterRebalanceServices;
+  }
+
+  @Override
   public ClusterStatusServices clusterStatusServices() {
     return clusterStatusServices;
   }
@@ -451,6 +458,7 @@ public record DefaultServiceRegistry(
     private final Map<String, VariableServices> variableByTenant = new HashMap<>();
     private @Nullable ClusterHistoryBackupServices clusterHistoryBackupServices;
     private ClusterRuntimeBackupServices clusterRuntimeBackupServices;
+    private ClusterRebalanceServices clusterRebalanceServices;
     private ClusterRecoveryServices clusterRecoveryServices;
     private ClusterStatusServices clusterStatusServices;
     private ClusterTopologyServices clusterTopologyServices;
@@ -682,6 +690,11 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder clusterRebalanceServices(final ClusterRebalanceServices service) {
+      clusterRebalanceServices = service;
+      return this;
+    }
+
     public Builder clusterRecoveryServices(final ClusterRecoveryServices service) {
       clusterRecoveryServices = service;
       return this;
@@ -751,6 +764,7 @@ public record DefaultServiceRegistry(
           Map.copyOf(variableByTenant),
           clusterHistoryBackupServices,
           clusterRuntimeBackupServices,
+          clusterRebalanceServices,
           clusterRecoveryServices,
           clusterStatusServices,
           clusterTopologyServices,

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -17,6 +17,7 @@ import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterHistoryBackupServices;
+import io.camunda.service.ClusterRebalanceServices;
 import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterRuntimeBackupServices;
 import io.camunda.service.ClusterStatusServices;
@@ -166,6 +167,8 @@ public interface ServiceRegistry {
   ClusterRecoveryServices clusterRecoveryServices();
 
   ClusterExportingServices clusterExportingServices();
+
+  ClusterRebalanceServices clusterRebalanceServices();
 
   ManagementServices managementServices();
 }

--- a/service/src/test/java/io/camunda/service/ClusterRebalanceServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRebalanceServicesTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import io.camunda.service.ClusterRebalanceServices.ClusterRebalanceRequest;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.rebalance.CancelRebalanceResponse;
+import io.camunda.zeebe.rebalance.ClusterLeadershipStatus;
+import io.camunda.zeebe.rebalance.PartitionLeadershipStatus;
+import io.camunda.zeebe.rebalance.PartitionRebalance;
+import io.camunda.zeebe.rebalance.PartitionRebalanceOutcome;
+import io.camunda.zeebe.rebalance.PartitionRebalanceProgress;
+import io.camunda.zeebe.rebalance.RebalanceErrorResponse;
+import io.camunda.zeebe.rebalance.RebalanceErrorResponse.RebalanceErrorCode;
+import io.camunda.zeebe.rebalance.RebalanceOutcome;
+import io.camunda.zeebe.rebalance.RebalanceOverrides;
+import io.camunda.zeebe.rebalance.RebalanceRequestSender;
+import io.camunda.zeebe.rebalance.RebalanceStatus;
+import io.camunda.zeebe.rebalance.TriggerRebalanceRequest;
+import io.camunda.zeebe.util.Either;
+import java.net.ConnectException;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.Test;
+
+final class ClusterRebalanceServicesTest {
+
+  private final RebalanceRequestSender sender = mock(RebalanceRequestSender.class);
+  private final ClusterRebalanceServices services = new ClusterRebalanceServices(sender);
+
+  @Test
+  void shouldTriggerWithConfiguredSettingsWhenNoOverrideIsGiven() {
+    // given
+    when(sender.triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), false)))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(RebalanceStatus.idle())));
+
+    // when
+    final var result =
+        services.triggerRebalance(ClusterRebalanceRequest.withDefaultSettings()).join();
+
+    // then
+    assertThat(result.leadershipStatus().state()).isEqualTo(ClusterLeadershipStatus.State.BALANCED);
+    assertThat(result.leadershipStatus().partitions()).isEmpty();
+    assertThat(result.lastCompleted()).isNull();
+  }
+
+  @Test
+  void shouldRejectANegativeReplicationLagThreshold() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                services
+                    .triggerRebalance(new ClusterRebalanceRequest(false, -1L, null, null, null))
+                    .join())
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(t -> ((ServiceException) t).getStatus())
+        .isEqualTo(Status.INVALID_ARGUMENT);
+  }
+
+  @Test
+  void shouldRejectANonPositiveMaxTransferAttempts() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                services
+                    .triggerRebalance(new ClusterRebalanceRequest(false, null, null, 0, null))
+                    .join())
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(t -> ((ServiceException) t).getStatus())
+        .isEqualTo(Status.INVALID_ARGUMENT);
+  }
+
+  @Test
+  void shouldKeepPartitionsOfDifferentTenantsWithTheSameNumericIdDistinct() {
+    // given
+    final var memberA = MemberId.from("0");
+    final var memberB = MemberId.from("1");
+    final var leadershipStatus =
+        ClusterLeadershipStatus.aggregateOf(
+            List.of(
+                new PartitionLeadershipStatus(
+                    "tenant-a", 1, memberA, memberB, PartitionLeadershipStatus.State.UNBALANCED),
+                new PartitionLeadershipStatus(
+                    "tenant-b", 1, memberB, memberB, PartitionLeadershipStatus.State.BALANCED)));
+    final var completed =
+        new RebalanceStatus.Completed(
+            1L,
+            RebalanceOutcome.COMPLETED,
+            List.of(
+                PartitionRebalance.pending("tenant-a", 1, memberA, memberB)
+                    .completed(PartitionRebalanceOutcome.TRANSFERRED),
+                PartitionRebalance.alreadyLeader("tenant-b", 1, memberB)),
+            Instant.EPOCH,
+            Instant.EPOCH.plusSeconds(1));
+    givenRebalanceStatus(new RebalanceStatus(null, completed, leadershipStatus));
+
+    // when
+    final var result = services.getRebalanceStatus().join();
+
+    // then
+    assertThat(result.leadershipStatus().partitions())
+        .extracting(p -> p.physicalTenantId() + "/" + p.partitionId(), p -> p.state())
+        .containsExactlyInAnyOrder(
+            tuple("tenant-a/1", PartitionLeadershipStatus.State.UNBALANCED),
+            tuple("tenant-b/1", PartitionLeadershipStatus.State.BALANCED));
+    assertThat(result.lastCompleted().partitions())
+        .extracting(p -> p.physicalTenantId() + "/" + p.partitionId(), p -> p.outcome())
+        .containsExactlyInAnyOrder(
+            tuple("tenant-a/1", PartitionRebalanceOutcome.TRANSFERRED),
+            tuple("tenant-b/1", PartitionRebalanceOutcome.ALREADY_LEADER));
+  }
+
+  @Test
+  void shouldMapTheRunningRebalancePlanAndProgress() {
+    // given
+    final var memberA = MemberId.from("0");
+    final var memberB = MemberId.from("1");
+    final var running =
+        new RebalanceStatus.Running(
+            1L,
+            RebalanceOverrides.none(),
+            false,
+            true,
+            List.of(
+                PartitionRebalance.pending("default", 1, memberA, memberB),
+                PartitionRebalance.alreadyLeader("default", 2, memberB)),
+            Instant.EPOCH);
+    givenRebalanceStatus(
+        new RebalanceStatus(running, null, ClusterLeadershipStatus.aggregateOf(List.of())));
+
+    // when
+    final var result = services.getRebalanceStatus().join().running();
+
+    // then
+    assertThat(result.rebalanceId()).isEqualTo(1L);
+    assertThat(result.dryRun()).isFalse();
+    assertThat(result.cancelRequested()).isTrue();
+    assertThat(result.partitions())
+        .extracting(
+            p -> p.partitionId(),
+            p -> p.currentLeader(),
+            p -> p.desiredLeader(),
+            p -> p.progress(),
+            p -> p.outcome())
+        .containsExactly(
+            tuple(1, memberA, memberB, PartitionRebalanceProgress.PENDING, null),
+            tuple(
+                2,
+                memberB,
+                memberB,
+                PartitionRebalanceProgress.COMPLETED,
+                PartitionRebalanceOutcome.ALREADY_LEADER));
+  }
+
+  @Test
+  void shouldReportAPlannedPartitionWithNoOutcome() {
+    // given
+    final var memberA = MemberId.from("0");
+    final var memberB = MemberId.from("1");
+    final var completed =
+        new RebalanceStatus.Completed(
+            1L,
+            RebalanceOutcome.COMPLETED,
+            List.of(PartitionRebalance.pending("tenant-a", 1, memberA, memberB)),
+            Instant.EPOCH,
+            Instant.EPOCH.plusSeconds(1));
+    givenRebalanceStatus(
+        new RebalanceStatus(null, completed, ClusterLeadershipStatus.aggregateOf(List.of())));
+
+    // when
+    final var result = services.getRebalanceStatus().join();
+
+    // then
+    assertThat(result.lastCompleted().rebalanceId()).isEqualTo(1L);
+    assertThat(result.lastCompleted().partitions().getFirst())
+        .extracting(
+            p -> p.currentLeader(), p -> p.desiredLeader(), p -> p.progress(), p -> p.outcome())
+        .containsExactly(memberA, memberB, PartitionRebalanceProgress.PENDING, null);
+  }
+
+  @Test
+  void shouldKeepCurrentLeaderAbsentWhenThePartitionHasNoLeader() {
+    // given
+    final var desired = MemberId.from("1");
+    final var leadershipStatus =
+        ClusterLeadershipStatus.aggregateOf(
+            List.of(
+                new PartitionLeadershipStatus(
+                    "default", 1, null, desired, PartitionLeadershipStatus.State.UNBALANCED)));
+    givenRebalanceStatus(new RebalanceStatus(null, null, leadershipStatus));
+
+    // when
+    final var result = services.getRebalanceStatus().join();
+
+    // then
+    assertThat(result.leadershipStatus().partitions().getFirst().currentLeader()).isNull();
+    assertThat(result.leadershipStatus().partitions().getFirst().desiredLeader())
+        .isEqualTo(desired);
+  }
+
+  @Test
+  void shouldMapEveryCompletedRebalanceOutcome() {
+    // given
+    for (final var outcome : RebalanceOutcome.values()) {
+      final var completed =
+          new RebalanceStatus.Completed(
+              1L, outcome, List.of(), Instant.EPOCH, Instant.EPOCH.plusSeconds(1));
+      givenRebalanceStatus(
+          new RebalanceStatus(null, completed, ClusterLeadershipStatus.aggregateOf(List.of())));
+
+      // when
+      final var result = services.getRebalanceStatus().join();
+
+      // then
+      assertThat(result.lastCompleted().outcome()).isEqualTo(outcome);
+    }
+  }
+
+  @Test
+  void shouldReportWhetherCancellationStoppedARunningRebalance() {
+    // given
+    when(sender.cancelRebalance())
+        .thenReturn(
+            CompletableFuture.completedFuture(Either.right(new CancelRebalanceResponse(true))));
+
+    // when
+    final var result = services.cancelRebalance().join();
+
+    // then
+    assertThat(result.wasRunning()).isTrue();
+  }
+
+  @Test
+  void shouldMapRebalanceInProgressToAlreadyExists() {
+    assertConflict(RebalanceErrorCode.REBALANCE_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldMapConfigurationChangeInProgressToAlreadyExists() {
+    assertConflict(RebalanceErrorCode.CONFIGURATION_CHANGE_IN_PROGRESS);
+  }
+
+  private void assertConflict(final RebalanceErrorCode code) {
+    // given
+    when(sender.getRebalanceStatus())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(new RebalanceErrorResponse(code, "conflict"))));
+
+    // when / then
+    assertThatThrownBy(() -> services.getRebalanceStatus().join())
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(t -> ((ServiceException) t).getStatus())
+        .isEqualTo(Status.ALREADY_EXISTS);
+  }
+
+  @Test
+  void shouldMapNotCoordinatorToUnavailable() {
+    // given
+    when(sender.getRebalanceStatus())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(
+                    new RebalanceErrorResponse(
+                        RebalanceErrorCode.NOT_COORDINATOR, "not the coordinator"))));
+
+    // when / then
+    assertThatThrownBy(() -> services.getRebalanceStatus().join())
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(t -> ((ServiceException) t).getStatus())
+        .isEqualTo(Status.UNAVAILABLE);
+  }
+
+  @Test
+  void shouldMapCoordinatorInternalErrorToInternal() {
+    // given
+    when(sender.getRebalanceStatus())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(
+                    new RebalanceErrorResponse(RebalanceErrorCode.INTERNAL_ERROR, "boom"))));
+
+    // when / then
+    assertThatThrownBy(() -> services.getRebalanceStatus().join())
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(t -> ((ServiceException) t).getStatus())
+        .isEqualTo(Status.INTERNAL);
+  }
+
+  @Test
+  void shouldMapAConnectExceptionToUnavailable() {
+    givenForwardingFailure(new ConnectException("connection refused"), Status.UNAVAILABLE);
+  }
+
+  @Test
+  void shouldMapANoSuchMemberExceptionToUnavailable() {
+    givenForwardingFailure(new NoSuchMemberException("gone"), Status.UNAVAILABLE);
+  }
+
+  @Test
+  void shouldMapATimeoutExceptionToDeadlineExceeded() {
+    givenForwardingFailure(new TimeoutException("too slow"), Status.DEADLINE_EXCEEDED);
+  }
+
+  @Test
+  void shouldMapAnUnknownForwardingFailureToAborted() {
+    givenForwardingFailure(new RuntimeException("mystery"), Status.ABORTED);
+  }
+
+  private void givenForwardingFailure(final Throwable cause, final Status expected) {
+    // given
+    when(sender.getRebalanceStatus()).thenReturn(CompletableFuture.failedFuture(cause));
+
+    // when / then
+    assertThatThrownBy(() -> services.getRebalanceStatus().join())
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(t -> ((ServiceException) t).getStatus())
+        .isEqualTo(expected);
+  }
+
+  @Test
+  void shouldMapAMissingCoordinatorReplyToAborted() {
+    // given
+    when(sender.cancelRebalance()).thenReturn(CompletableFuture.completedFuture(null));
+
+    // when / then
+    assertThatThrownBy(() -> services.cancelRebalance().join())
+        .cause()
+        .isInstanceOf(ServiceException.class)
+        .extracting(t -> ((ServiceException) t).getStatus())
+        .isEqualTo(Status.ABORTED);
+  }
+
+  private void givenRebalanceStatus(final RebalanceStatus status) {
+    when(sender.getRebalanceStatus())
+        .thenReturn(CompletableFuture.completedFuture(Either.right(status)));
+  }
+}

--- a/service/src/test/java/io/camunda/service/ClusterRebalanceServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRebalanceServicesTest.java
@@ -52,7 +52,7 @@ final class ClusterRebalanceServicesTest {
 
     // when
     final var result =
-        services.triggerRebalance(ClusterRebalanceRequest.withDefaultSettings()).join();
+        services.triggerRebalance(ClusterRebalanceRequest.withDefaultSettings(false)).join();
 
     // then
     assertThat(result.leadershipStatus().state()).isEqualTo(ClusterLeadershipStatus.State.BALANCED);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RebalanceCoordinatorStep.java
@@ -12,6 +12,7 @@ import io.atomix.raft.partition.impl.LeadershipTransferClient;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionLeaders;
 import io.camunda.zeebe.rebalance.ClusterRebalanceMetrics;
 import io.camunda.zeebe.rebalance.PartitionBalanceMetrics;
+import io.camunda.zeebe.rebalance.PartitionBalancePlanner;
 import io.camunda.zeebe.rebalance.ProtoBufRebalanceSerializer;
 import io.camunda.zeebe.rebalance.RebalanceCoordinator;
 import io.camunda.zeebe.rebalance.RebalanceRequestServer;
@@ -106,6 +107,7 @@ public class RebalanceCoordinatorStep implements StartupStep<BrokerStartupContex
                               .getBrokerConfiguration()
                               .getCluster()
                               .getHeartbeatInterval()),
+                      new PartitionBalancePlanner(partitionLeaders),
                       () -> brokerStartupContext.getRequestIdGenerator().nextId(),
                       Clock.systemUTC(),
                       rebalanceMetrics);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -122,13 +122,10 @@ public final class ZeebePartition extends Actor
             transitionContext.getPartitionId());
     coordinatorCheck =
         new ClusterConfigurationCoordinatorCheck(
-            () -> {
-              final var current =
-                  transitionContext
-                      .getClusterConfigurationService()
-                      .getCurrentClusterConfiguration();
-              return current == null ? null : current.toLegacyDefault();
-            });
+            () ->
+                transitionContext
+                    .getClusterConfigurationService()
+                    .getCurrentClusterConfiguration());
   }
 
   public static String componentName(final PartitionId partitionId) {

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -1318,6 +1318,16 @@ paths:
         `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
         Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
         valid here.
+      parameters:
+        - name: dryRun
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: >-
+            If true, report the plan the rebalance would carry out without pausing any partition
+            or transferring any leadership.
       requestBody:
         required: false
         content:
@@ -1946,12 +1956,6 @@ components:
         settings".
       type: object
       properties:
-        dryRun:
-          description: >-
-            If true, report the plan the rebalance would carry out without pausing any partition or
-            transferring any leadership.
-          type: boolean
-          default: false
         replicationLagThreshold:
           description: >-
             The highest replication lag (in bytes) that a desired leader may have for its transfer

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -1281,6 +1281,196 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
 
+  /cluster/v2/rebalance:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Cluster
+      operationId: triggerClusterRebalance
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Trigger a cluster-wide leadership rebalance
+      description: >-
+        Transfers leadership of every partition that is not led by its highest-priority replica
+        towards that replica, one partition at a time. Returns as soon as the rebalance has been
+        accepted (poll `GET /cluster/v2/rebalance` to monitor progress).
+
+
+        Each rebalance can specify overrides for the configured rebalance settings (e.g. maximum
+        replication lag to allow). An absent request body means "use the configured settings".
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClusterRebalanceRequest'
+      responses:
+        "202":
+          description: The rebalance was accepted, and its status is reported as it starts.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterBalanceResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "409":
+          description: >-
+            A rebalance or cluster configuration change is already in progress, so there is no
+            settled configuration to plan a rebalance against.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "502":
+          description: The coordinator was reached, but its response was absent or unusable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "503":
+          description: No coordinator is currently available or reachable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "504":
+          description: The coordinator did not answer before the request timeout.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+      x-added-in-version: "8.10"
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Cluster
+      operationId: getClusterRebalance
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Report the cluster's current leadership balance
+      description: >-
+        Reports whether the cluster is currently balanced, the current leadership state of every
+        partition, and what became of the last rebalance to finish. The last completed rebalance is
+        held in memory by the coordinating broker, so none will be reported if the coordinator has
+        moved or restarted since the last rebalance.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here.
+      responses:
+        "200":
+          description: The cluster's current leadership balance.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterBalanceResponse'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "502":
+          description: The coordinator was reached, but its response was absent or unusable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "503":
+          description: No coordinator is currently available or reachable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "504":
+          description: The coordinator did not answer before the request timeout.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+      x-added-in-version: "8.10"
+    delete:
+      x-eventually-consistent: false
+      tags:
+        - Cluster
+      operationId: cancelClusterRebalance
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Stop the running rebalance
+      description: >-
+        Asks the running rebalance to stop once the transfer in flight has finished. Partitions
+        already transferred keep their new leaders, and those the rebalance had not yet reached keep
+        their current ones.
+
+
+        Cancellation requests are idempotent and always accepted. The `wasRunning` response field
+        can be used to distinguish a cancellation that found a running rebalance from one that did
+        not.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here.
+      responses:
+        "200":
+          description: The cancellation was accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RebalanceCancellationResponse'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "502":
+          description: The coordinator was reached, but its response was absent or unusable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "503":
+          description: No coordinator is currently available or reachable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "504":
+          description: The coordinator did not answer before the request timeout.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+      x-added-in-version: "8.10"
+
 ## Schema definitions
 
 components:
@@ -1748,3 +1938,261 @@ components:
         - INCOMPATIBLE
         - NOT_FOUND
       example: COMPLETED
+
+    ClusterRebalanceRequest:
+      description: >-
+        The settings to run a given rebalance with. Every setting is optional; an absent request
+        body is equivalent to a body with every field absent, and means "use the configured
+        settings".
+      type: object
+      properties:
+        dryRun:
+          description: >-
+            If true, report the plan the rebalance would carry out without pausing any partition or
+            transferring any leadership.
+          type: boolean
+          default: false
+        replicationLagThreshold:
+          description: >-
+            The highest replication lag (in bytes) that a desired leader may have for its transfer
+            to be accepted.
+          type: integer
+          format: int64
+          minimum: 0
+          example: 8388608
+        replicationTimeout:
+          description: >-
+            How long a partition may stay frozen waiting for its desired leader to catch up (as a
+            positive ISO-8601 duration).
+          type: string
+          example: "PT10S"
+        maxTransferAttempts:
+          description: >-
+            How many times a current leader may prompt the desired leader to take over leadership
+            before giving up.
+          type: integer
+          format: int32
+          minimum: 1
+          example: 3
+        leaderWaitTimeout:
+          description: >-
+            How long the coordinator waits for a partition without a leader to acquire one before
+            reporting `NO_LEADER` and moving on (as a positive ISO-8601 duration).
+          type: string
+          example: "PT1M"
+
+    ClusterBalanceResponse:
+      description: >-
+        The cluster's current per-partition balance state, the running rebalance, and the last
+        completed rebalance.
+      type: object
+      required:
+        - state
+        - partitions
+        - runningRebalance
+        - lastCompletedRebalance
+      properties:
+        state:
+          description: The cluster's aggregate balance state as of the time of the request.
+          type: string
+          enum:
+            - BALANCED
+            - BALANCING
+            - UNBALANCED
+          example: "UNBALANCED"
+        partitions:
+          description: >-
+            The balance state of each partition as of the time of the request.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterRebalancePartition'
+        runningRebalance:
+          description: >-
+            Normally the rebalance currently running, or absent if no rebalance is running. For a
+            dry-run response, this is instead the unexecuted plan of that dry run.
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ClusterRunningRebalance'
+        lastCompletedRebalance:
+          description: The last completed non-dry-run rebalance this coordinator finished.
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ClusterCompletedRebalance'
+
+    ClusterRebalancePartition:
+      description: >-
+        One partition's leadership/balance status - its current leader, its desired leader, and
+        whether a rebalance is currently moving it.
+      type: object
+      required:
+        - partitionId
+        - physicalTenantId
+        - currentLeader
+        - desiredLeader
+        - state
+      properties:
+        partitionId:
+          description: The unique ID of this partition, within its physical tenant.
+          type: integer
+          format: int32
+          example: 1
+        physicalTenantId:
+          description: >-
+            The partition group this partition belongs to. Partition IDs are unique only within a
+            group, so this is needed to identify the partition.
+          type: string
+          example: default
+        currentLeader:
+          description: >-
+            The broker ID currently leading this partition, or absent if it has no leader.
+          type: string
+          nullable: true
+          example: "0"
+        desiredLeader:
+          description: The broker ID the current configuration wants to lead this partition.
+          type: string
+          example: "0"
+        state:
+          description: >-
+            Whether this partition is being actively transferred, unbalanced, or balanced.
+          type: string
+          enum:
+            - TRANSFERRING
+            - UNBALANCED
+            - BALANCED
+          example: "UNBALANCED"
+
+
+    ClusterRebalance:
+      description: >-
+        The fields common to a running and a completed rebalance.
+      type: object
+      required:
+        - rebalanceId
+        - partitions
+        - startedAt
+      properties:
+        rebalanceId:
+          description: The ID of this rebalance.
+          type: integer
+          format: int64
+        partitions:
+          description: Every partition in the rebalance plan and its progress within this rebalance.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterRebalanceOperationPartition'
+        startedAt:
+          description: When this rebalance was created.
+          type: string
+          format: date-time
+
+    ClusterRunningRebalance:
+      description: The rebalance currently running.
+      allOf:
+        - $ref: '#/components/schemas/ClusterRebalance'
+        - type: object
+          required:
+            - dryRun
+            - cancelRequested
+          properties:
+            dryRun:
+              description: Whether this rebalance is a dry run.
+              type: boolean
+            cancelRequested:
+              description: >-
+                Whether cancellation has been requested.
+              type: boolean
+
+    ClusterRebalanceOperationPartition:
+      description: One partition's plan, progress, and outcome within a rebalance.
+      type: object
+      required:
+        - partitionId
+        - physicalTenantId
+        - currentLeader
+        - desiredLeader
+        - progress
+        - result
+      properties:
+        partitionId:
+          description: The unique ID of this partition, within its physical tenant.
+          type: integer
+          format: int32
+          example: 1
+        physicalTenantId:
+          description: The partition group this partition belongs to.
+          type: string
+          example: default
+        currentLeader:
+          description: The leader last observed by this rebalance, or absent if there was no leader.
+          type: string
+          nullable: true
+          example: "0"
+        desiredLeader:
+          description: The leader selected when this rebalance was planned.
+          type: string
+          example: "1"
+        progress:
+          description: Where this rebalance has reached for the partition.
+          type: string
+          enum:
+            - PENDING
+            - TRANSFERRING
+            - COMPLETED
+        result:
+          description: The terminal outcome, present only when progress is COMPLETED.
+          type: string
+          nullable: true
+          enum:
+            - TRANSFERRED
+            - ALREADY_LEADER
+            - NOT_MEMBER
+            - NOT_REPLICATING
+            - UNREACHABLE
+            - NOT_COORDINATOR
+            - STALE_CONFIGURATION
+            - TRANSFER_IN_PROGRESS
+            - LAG_TOO_HIGH
+            - LEADER_INITIALIZING
+            - CONFIGURATION_CHANGE_IN_PROGRESS
+            - PAUSE_FAILED
+            - REPLICATION_TIMED_OUT
+            - TIMEOUT_NOW_EXHAUSTED
+            - LEADER_CHANGED
+            - NO_LEADER
+            - NO_RESPONSE
+            - CANCELLED
+
+    ClusterCompletedRebalance:
+      description: >-
+        The last completed rebalance.
+      allOf:
+        - $ref: '#/components/schemas/ClusterRebalance'
+        - type: object
+          required:
+            - finishedAt
+            - result
+          properties:
+            finishedAt:
+              description: When this rebalance finished.
+              type: string
+              format: date-time
+            result:
+              description: How the rebalance ended.
+              type: string
+              enum:
+                - COMPLETED
+                - CANCELLED
+                - FAILED
+              example: "COMPLETED"
+
+    RebalanceCancellationResponse:
+      description: Response to a rebalance cancellation request.
+      type: object
+      required:
+        - wasRunning
+      properties:
+        wasRunning:
+          description: Whether there was a rebalance to stop.
+          type: boolean
+          example: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -524,6 +524,8 @@ paths:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1backups~1history~1{backupId}'
   /cluster/v2/mode:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1mode'
+  /cluster/v2/rebalance:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1rebalance'
   /cluster/v2/restore:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1restore'
   /cluster/v2/status:

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -58,6 +58,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-rebalance</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
     </dependency>
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceController.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * Coordinated cluster-wide leadership rebalance, authenticated by the cluster-admin security chain.
@@ -41,12 +42,13 @@ public final class ClusterRebalanceController {
 
   @CamundaPostMapping(path = "/rebalance")
   public CompletableFuture<ResponseEntity<Object>> triggerRebalance(
+      @RequestParam(defaultValue = "false") final boolean dryRun,
       @RequestBody(required = false) final @Nullable ClusterRebalanceRequest body) {
     return RequestExecutor.executeServiceMethod(
         () ->
             serviceRegistry
                 .clusterRebalanceServices()
-                .triggerRebalance(ClusterRebalanceMapper.toServiceRequest(body)),
+                .triggerRebalance(ClusterRebalanceMapper.toServiceRequest(dryRun, body)),
         ClusterRebalanceMapper::toClusterBalanceResponse,
         HttpStatus.ACCEPTED);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceController.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.protocol.model.ClusterRebalanceRequest;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Coordinated cluster-wide leadership rebalance, authenticated by the cluster-admin security chain.
+ *
+ * <p>Requests are forwarded to the current rebalance coordinator.
+ */
+@CamundaRestController
+@ClusterScoped
+@RequestMapping("/cluster/v2")
+@NullMarked
+public final class ClusterRebalanceController {
+
+  private final ServiceRegistry serviceRegistry;
+
+  public ClusterRebalanceController(final ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @CamundaPostMapping(path = "/rebalance")
+  public CompletableFuture<ResponseEntity<Object>> triggerRebalance(
+      @RequestBody(required = false) final @Nullable ClusterRebalanceRequest body) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterRebalanceServices()
+                .triggerRebalance(ClusterRebalanceMapper.toServiceRequest(body)),
+        ClusterRebalanceMapper::toClusterBalanceResponse,
+        HttpStatus.ACCEPTED);
+  }
+
+  @CamundaGetMapping(path = "/rebalance")
+  public CompletableFuture<ResponseEntity<Object>> getRebalanceStatus() {
+    return RequestExecutor.executeServiceMethod(
+        serviceRegistry.clusterRebalanceServices()::getRebalanceStatus,
+        ClusterRebalanceMapper::toClusterBalanceResponse,
+        HttpStatus.OK);
+  }
+
+  @CamundaDeleteMapping(path = "/rebalance")
+  public CompletableFuture<ResponseEntity<Object>> cancelRebalance() {
+    return RequestExecutor.executeServiceMethod(
+        serviceRegistry.clusterRebalanceServices()::cancelRebalance,
+        ClusterRebalanceMapper::toRebalanceCancellationResponse,
+        HttpStatus.OK);
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceMapper.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.mapping.http.ResponseMapper;
+import io.camunda.gateway.protocol.model.ClusterBalanceResponse;
+import io.camunda.gateway.protocol.model.ClusterCompletedRebalance;
+import io.camunda.gateway.protocol.model.ClusterRebalanceOperationPartition;
+import io.camunda.gateway.protocol.model.ClusterRebalancePartition;
+import io.camunda.gateway.protocol.model.ClusterRebalanceRequest;
+import io.camunda.gateway.protocol.model.ClusterRunningRebalance;
+import io.camunda.gateway.protocol.model.RebalanceCancellationResponse;
+import io.camunda.service.ClusterRebalanceServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.rebalance.CancelRebalanceResponse;
+import io.camunda.zeebe.rebalance.ClusterLeadershipStatus;
+import io.camunda.zeebe.rebalance.PartitionLeadershipStatus;
+import io.camunda.zeebe.rebalance.PartitionRebalance;
+import io.camunda.zeebe.rebalance.PartitionRebalanceOutcome;
+import io.camunda.zeebe.rebalance.PartitionRebalanceProgress;
+import io.camunda.zeebe.rebalance.RebalanceOutcome;
+import io.camunda.zeebe.rebalance.RebalanceStatus;
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+final class ClusterRebalanceMapper {
+
+  private ClusterRebalanceMapper() {}
+
+  static ClusterRebalanceServices.ClusterRebalanceRequest toServiceRequest(
+      final @Nullable ClusterRebalanceRequest body) {
+    if (body == null) {
+      return ClusterRebalanceServices.ClusterRebalanceRequest.withDefaultSettings();
+    }
+    return new ClusterRebalanceServices.ClusterRebalanceRequest(
+        Boolean.TRUE.equals(body.getDryRun()),
+        body.getReplicationLagThreshold(),
+        duration("replicationTimeout", body.getReplicationTimeout()),
+        body.getMaxTransferAttempts(),
+        duration("leaderWaitTimeout", body.getLeaderWaitTimeout()));
+  }
+
+  private static @Nullable Duration duration(final String field, final @Nullable String value) {
+    if (value == null) {
+      return null;
+    }
+    final Duration parsed;
+    try {
+      parsed = Duration.parse(value);
+    } catch (final DateTimeParseException e) {
+      throw new ServiceException(
+          "%s must be an ISO-8601 duration such as PT30S but was '%s'".formatted(field, value),
+          Status.INVALID_ARGUMENT);
+    }
+    if (parsed.isNegative() || parsed.isZero()) {
+      throw new ServiceException(
+          "%s must be a positive ISO-8601 duration but was '%s'".formatted(field, value),
+          Status.INVALID_ARGUMENT);
+    }
+    return parsed;
+  }
+
+  static ClusterBalanceResponse toClusterBalanceResponse(final RebalanceStatus status) {
+    final var leadershipStatus = status.leadershipStatus();
+    final var response =
+        ClusterBalanceResponse.Builder.create()
+            .state(toStateEnum(leadershipStatus.state()))
+            .partitions(
+                leadershipStatus.partitions().stream()
+                    .map(ClusterRebalanceMapper::toPartition)
+                    .toList());
+    final var lastCompleted = status.lastCompleted();
+    final var running = status.running();
+    return response
+        .runningRebalance(running == null ? null : toRunningRebalance(running))
+        .lastCompletedRebalance(lastCompleted == null ? null : toCompletedRebalance(lastCompleted))
+        .build();
+  }
+
+  private static ClusterRunningRebalance toRunningRebalance(final RebalanceStatus.Running running) {
+    return ClusterRunningRebalance.Builder.create()
+        .rebalanceId(running.rebalanceId())
+        .partitions(
+            running.partitions().stream()
+                .map(ClusterRebalanceMapper::toRebalancePartition)
+                .toList())
+        .startedAt(ResponseMapper.formatDate(running.startedAt().atOffset(ZoneOffset.UTC)))
+        .dryRun(running.dryRun())
+        .cancelRequested(running.cancelRequested())
+        .build();
+  }
+
+  private static ClusterRebalanceOperationPartition toRebalancePartition(
+      final PartitionRebalance partition) {
+    final var outcome = partition.outcome();
+    return ClusterRebalanceOperationPartition.Builder.create()
+        .partitionId(partition.partitionId())
+        .physicalTenantId(partition.physicalTenantId())
+        .currentLeader(partition.currentLeaderId())
+        .desiredLeader(partition.desiredLeaderId())
+        .progress(toProgressEnum(partition.progress()))
+        .result(outcome == null ? null : toPartitionResultEnum(outcome))
+        .build();
+  }
+
+  private static ClusterRebalanceOperationPartition.ProgressEnum toProgressEnum(
+      final PartitionRebalanceProgress progress) {
+    return switch (progress) {
+      case PENDING -> ClusterRebalanceOperationPartition.ProgressEnum.PENDING;
+      case TRANSFERRING -> ClusterRebalanceOperationPartition.ProgressEnum.TRANSFERRING;
+      case COMPLETED -> ClusterRebalanceOperationPartition.ProgressEnum.COMPLETED;
+    };
+  }
+
+  private static ClusterRebalanceOperationPartition.ResultEnum toPartitionResultEnum(
+      final PartitionRebalanceOutcome outcome) {
+    return switch (outcome) {
+      case TRANSFERRED -> ClusterRebalanceOperationPartition.ResultEnum.TRANSFERRED;
+      case ALREADY_LEADER -> ClusterRebalanceOperationPartition.ResultEnum.ALREADY_LEADER;
+      case NOT_MEMBER -> ClusterRebalanceOperationPartition.ResultEnum.NOT_MEMBER;
+      case NOT_REPLICATING -> ClusterRebalanceOperationPartition.ResultEnum.NOT_REPLICATING;
+      case UNREACHABLE -> ClusterRebalanceOperationPartition.ResultEnum.UNREACHABLE;
+      case NOT_COORDINATOR -> ClusterRebalanceOperationPartition.ResultEnum.NOT_COORDINATOR;
+      case STALE_CONFIGURATION -> ClusterRebalanceOperationPartition.ResultEnum.STALE_CONFIGURATION;
+      case TRANSFER_IN_PROGRESS ->
+          ClusterRebalanceOperationPartition.ResultEnum.TRANSFER_IN_PROGRESS;
+      case LAG_TOO_HIGH -> ClusterRebalanceOperationPartition.ResultEnum.LAG_TOO_HIGH;
+      case LEADER_INITIALIZING -> ClusterRebalanceOperationPartition.ResultEnum.LEADER_INITIALIZING;
+      case CONFIGURATION_CHANGE_IN_PROGRESS ->
+          ClusterRebalanceOperationPartition.ResultEnum.CONFIGURATION_CHANGE_IN_PROGRESS;
+      case PAUSE_FAILED -> ClusterRebalanceOperationPartition.ResultEnum.PAUSE_FAILED;
+      case REPLICATION_TIMED_OUT ->
+          ClusterRebalanceOperationPartition.ResultEnum.REPLICATION_TIMED_OUT;
+      case TIMEOUT_NOW_EXHAUSTED ->
+          ClusterRebalanceOperationPartition.ResultEnum.TIMEOUT_NOW_EXHAUSTED;
+      case LEADER_CHANGED -> ClusterRebalanceOperationPartition.ResultEnum.LEADER_CHANGED;
+      case NO_LEADER -> ClusterRebalanceOperationPartition.ResultEnum.NO_LEADER;
+      case NO_RESPONSE -> ClusterRebalanceOperationPartition.ResultEnum.NO_RESPONSE;
+      case CANCELLED -> ClusterRebalanceOperationPartition.ResultEnum.CANCELLED;
+    };
+  }
+
+  static RebalanceCancellationResponse toRebalanceCancellationResponse(
+      final CancelRebalanceResponse cancellation) {
+    return RebalanceCancellationResponse.Builder.create()
+        .wasRunning(cancellation.wasRunning())
+        .build();
+  }
+
+  private static ClusterBalanceResponse.StateEnum toStateEnum(
+      final ClusterLeadershipStatus.State state) {
+    return switch (state) {
+      case BALANCED -> ClusterBalanceResponse.StateEnum.BALANCED;
+      case BALANCING -> ClusterBalanceResponse.StateEnum.BALANCING;
+      case UNBALANCED -> ClusterBalanceResponse.StateEnum.UNBALANCED;
+    };
+  }
+
+  private static ClusterRebalancePartition toPartition(final PartitionLeadershipStatus partition) {
+    return ClusterRebalancePartition.Builder.create()
+        .partitionId(partition.partitionId())
+        .physicalTenantId(partition.physicalTenantId())
+        .currentLeader(partition.currentLeaderId())
+        .desiredLeader(partition.desiredLeaderId())
+        .state(toPartitionStateEnum(partition.state()))
+        .build();
+  }
+
+  private static ClusterRebalancePartition.StateEnum toPartitionStateEnum(
+      final PartitionLeadershipStatus.State state) {
+    return switch (state) {
+      case TRANSFERRING -> ClusterRebalancePartition.StateEnum.TRANSFERRING;
+      case UNBALANCED -> ClusterRebalancePartition.StateEnum.UNBALANCED;
+      case BALANCED -> ClusterRebalancePartition.StateEnum.BALANCED;
+    };
+  }
+
+  private static ClusterCompletedRebalance toCompletedRebalance(
+      final RebalanceStatus.Completed completed) {
+    return ClusterCompletedRebalance.Builder.create()
+        .rebalanceId(completed.rebalanceId())
+        .partitions(
+            completed.partitions().stream()
+                .map(ClusterRebalanceMapper::toRebalancePartition)
+                .toList())
+        .startedAt(ResponseMapper.formatDate(completed.startedAt().atOffset(ZoneOffset.UTC)))
+        .finishedAt(ResponseMapper.formatDate(completed.finishedAt().atOffset(ZoneOffset.UTC)))
+        .result(toResultEnum(completed.outcome()))
+        .build();
+  }
+
+  private static ClusterCompletedRebalance.ResultEnum toResultEnum(final RebalanceOutcome result) {
+    return switch (result) {
+      case COMPLETED -> ClusterCompletedRebalance.ResultEnum.COMPLETED;
+      case CANCELLED -> ClusterCompletedRebalance.ResultEnum.CANCELLED;
+      case FAILED -> ClusterCompletedRebalance.ResultEnum.FAILED;
+    };
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceMapper.java
@@ -38,12 +38,12 @@ final class ClusterRebalanceMapper {
   private ClusterRebalanceMapper() {}
 
   static ClusterRebalanceServices.ClusterRebalanceRequest toServiceRequest(
-      final @Nullable ClusterRebalanceRequest body) {
+      final boolean dryRun, final @Nullable ClusterRebalanceRequest body) {
     if (body == null) {
-      return ClusterRebalanceServices.ClusterRebalanceRequest.withDefaultSettings();
+      return ClusterRebalanceServices.ClusterRebalanceRequest.withDefaultSettings(dryRun);
     }
     return new ClusterRebalanceServices.ClusterRebalanceRequest(
-        Boolean.TRUE.equals(body.getDryRun()),
+        dryRun,
         body.getReplicationLagThreshold(),
         duration("replicationTimeout", body.getReplicationTimeout()),
         body.getMaxTransferAttempts(),

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceControllerTest.java
@@ -59,14 +59,15 @@ class ClusterRebalanceControllerTest extends RestControllerTest {
   @Test
   void shouldTriggerWithConfiguredDefaultsWhenNoBodyIsGiven() {
     // given
-    when(clusterRebalanceServices.triggerRebalance(ClusterRebalanceRequest.withDefaultSettings()))
+    when(clusterRebalanceServices.triggerRebalance(
+            ClusterRebalanceRequest.withDefaultSettings(false)))
         .thenReturn(CompletableFuture.completedFuture(idleStatus()));
 
     // when / then
     webClient.post().uri(REBALANCE_URL).exchange().expectStatus().isAccepted();
 
     verify(clusterRebalanceServices)
-        .triggerRebalance(ClusterRebalanceRequest.withDefaultSettings());
+        .triggerRebalance(ClusterRebalanceRequest.withDefaultSettings(false));
   }
 
   @Test
@@ -84,7 +85,6 @@ class ClusterRebalanceControllerTest extends RestControllerTest {
         .bodyValue(
             """
             {
-              "dryRun": false,
               "replicationLagThreshold": 8388608,
               "replicationTimeout": "PT10S",
               "maxTransferAttempts": 3,
@@ -110,14 +110,7 @@ class ClusterRebalanceControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(idleStatus()));
 
     // when
-    webClient
-        .post()
-        .uri(REBALANCE_URL)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{\"dryRun\": true}")
-        .exchange()
-        .expectStatus()
-        .isAccepted();
+    webClient.post().uri(REBALANCE_URL + "?dryRun=true").exchange().expectStatus().isAccepted();
 
     // then
     assertThat(captor.getValue().dryRun()).isTrue();
@@ -151,9 +144,7 @@ class ClusterRebalanceControllerTest extends RestControllerTest {
     // when / then
     webClient
         .post()
-        .uri(REBALANCE_URL)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{\"dryRun\": true}")
+        .uri(REBALANCE_URL + "?dryRun=true")
         .exchange()
         .expectStatus()
         .isAccepted()
@@ -572,7 +563,8 @@ class ClusterRebalanceControllerTest extends RestControllerTest {
   @Test
   void shouldMapAConflictToHttp409() {
     // given
-    when(clusterRebalanceServices.triggerRebalance(ClusterRebalanceRequest.withDefaultSettings()))
+    when(clusterRebalanceServices.triggerRebalance(
+            ClusterRebalanceRequest.withDefaultSettings(false)))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new ServiceException("a rebalance is already running", Status.ALREADY_EXISTS)));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceControllerTest.java
@@ -1,0 +1,656 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.service.ClusterRebalanceServices;
+import io.camunda.service.ClusterRebalanceServices.ClusterRebalanceRequest;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.rebalance.CancelRebalanceResponse;
+import io.camunda.zeebe.rebalance.ClusterLeadershipStatus;
+import io.camunda.zeebe.rebalance.PartitionLeadershipStatus;
+import io.camunda.zeebe.rebalance.PartitionRebalance;
+import io.camunda.zeebe.rebalance.PartitionRebalanceOutcome;
+import io.camunda.zeebe.rebalance.PartitionRebalanceProgress;
+import io.camunda.zeebe.rebalance.RebalanceOutcome;
+import io.camunda.zeebe.rebalance.RebalanceOverrides;
+import io.camunda.zeebe.rebalance.RebalanceStatus;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(ClusterRebalanceController.class)
+class ClusterRebalanceControllerTest extends RestControllerTest {
+
+  private static final String REBALANCE_URL = "/cluster/v2/rebalance";
+
+  @MockitoBean ClusterRebalanceServices clusterRebalanceServices;
+  @MockitoBean ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setup() {
+    when(serviceRegistry.clusterRebalanceServices()).thenReturn(clusterRebalanceServices);
+  }
+
+  @Test
+  void shouldTriggerWithConfiguredDefaultsWhenNoBodyIsGiven() {
+    // given
+    when(clusterRebalanceServices.triggerRebalance(ClusterRebalanceRequest.withDefaultSettings()))
+        .thenReturn(CompletableFuture.completedFuture(idleStatus()));
+
+    // when / then
+    webClient.post().uri(REBALANCE_URL).exchange().expectStatus().isAccepted();
+
+    verify(clusterRebalanceServices)
+        .triggerRebalance(ClusterRebalanceRequest.withDefaultSettings());
+  }
+
+  @Test
+  void shouldMapEveryOverrideOnTrigger() {
+    // given
+    final var captor = ArgumentCaptor.forClass(ClusterRebalanceRequest.class);
+    when(clusterRebalanceServices.triggerRebalance(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(idleStatus()));
+
+    // when
+    webClient
+        .post()
+        .uri(REBALANCE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "dryRun": false,
+              "replicationLagThreshold": 8388608,
+              "replicationTimeout": "PT10S",
+              "maxTransferAttempts": 3,
+              "leaderWaitTimeout": "PT1M"
+            }
+            """)
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+
+    // then
+    assertThat(captor.getValue())
+        .isEqualTo(
+            new ClusterRebalanceRequest(
+                false, 8388608L, Duration.ofSeconds(10), 3, Duration.ofMinutes(1)));
+  }
+
+  @Test
+  void shouldPreserveDryRunSemantics() {
+    // given
+    final var captor = ArgumentCaptor.forClass(ClusterRebalanceRequest.class);
+    when(clusterRebalanceServices.triggerRebalance(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(idleStatus()));
+
+    // when
+    webClient
+        .post()
+        .uri(REBALANCE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"dryRun\": true}")
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+
+    // then
+    assertThat(captor.getValue().dryRun()).isTrue();
+  }
+
+  @Test
+  void shouldReportADryRunTriggerResponseAsThePlanUnderRunningRebalance() {
+    // given
+    final var member1 = MemberId.from("1");
+    final var member2 = MemberId.from("2");
+    final var previousCompletion =
+        new RebalanceStatus.Completed(
+            6L, RebalanceOutcome.COMPLETED, List.of(), Instant.EPOCH, Instant.EPOCH.plusSeconds(1));
+    final var dryRunResponse =
+        new RebalanceStatus(
+            new RebalanceStatus.Running(
+                7L,
+                RebalanceOverrides.none(),
+                true,
+                false,
+                List.of(
+                    new PartitionRebalance(
+                        "default", 1, member1, member2, PartitionRebalanceProgress.PENDING)),
+                Instant.EPOCH.plusSeconds(2)),
+            previousCompletion,
+            ClusterLeadershipStatus.aggregateOf(List.of()));
+    when(clusterRebalanceServices.triggerRebalance(
+            new ClusterRebalanceRequest(true, null, null, null, null)))
+        .thenReturn(CompletableFuture.completedFuture(dryRunResponse));
+
+    // when / then
+    webClient
+        .post()
+        .uri(REBALANCE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"dryRun\": true}")
+        .exchange()
+        .expectStatus()
+        .isAccepted()
+        .expectBody()
+        .json(
+            """
+            {
+              "state": "BALANCED",
+              "partitions": [],
+              "runningRebalance": {
+                "rebalanceId": 7,
+                "dryRun": true,
+                "startedAt": "1970-01-01T00:00:02.000Z",
+                "cancelRequested": false,
+                "partitions": [
+                  { "partitionId": 1, "physicalTenantId": "default", "currentLeader": "1", "desiredLeader": "2", "progress": "PENDING", "result": null }
+                ]
+              },
+              "lastCompletedRebalance": {
+                "rebalanceId": 6,
+                "startedAt": "1970-01-01T00:00:00.000Z",
+                "finishedAt": "1970-01-01T00:00:01.000Z",
+                "result": "COMPLETED",
+                "partitions": []
+              }
+            }
+            """,
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectAnInvalidDurationSyntax() {
+    // when / then
+    webClient
+        .post()
+        .uri(REBALANCE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"replicationTimeout\": \"not-a-duration\"}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @ParameterizedTest
+  @MethodSource("zeroOrNegativeDurations")
+  void shouldRejectAZeroOrNegativeDuration(final String field, final String value) {
+    // when / then
+    webClient
+        .post()
+        .uri(REBALANCE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"%s\": \"%s\"}".formatted(field, value))
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  private static List<Arguments> zeroOrNegativeDurations() {
+    return List.of(
+        Arguments.of("replicationTimeout", "PT0S"),
+        Arguments.of("replicationTimeout", "-PT10S"),
+        Arguments.of("leaderWaitTimeout", "PT0S"),
+        Arguments.of("leaderWaitTimeout", "-PT1M"));
+  }
+
+  @Test
+  void shouldRejectANonPositiveMaxTransferAttempts() {
+    // when / then
+    webClient
+        .post()
+        .uri(REBALANCE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"maxTransferAttempts\": 0}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void shouldRejectANegativeReplicationLagThreshold() {
+    // when / then
+    webClient
+        .post()
+        .uri(REBALANCE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"replicationLagThreshold\": -1}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void shouldReportTheCompleteLiveBalanceAndCompletedHistory() {
+    // given
+    final var memberA = MemberId.from("0");
+    final var memberB = MemberId.from("1");
+    final var status =
+        new RebalanceStatus(
+            null,
+            new RebalanceStatus.Completed(
+                7L,
+                RebalanceOutcome.COMPLETED,
+                List.of(
+                    new PartitionRebalance(
+                        "default",
+                        2,
+                        memberA,
+                        memberB,
+                        PartitionRebalanceProgress.COMPLETED,
+                        PartitionRebalanceOutcome.TRANSFERRED)),
+                Instant.EPOCH,
+                Instant.EPOCH.plusSeconds(5)),
+            new ClusterLeadershipStatus(
+                ClusterLeadershipStatus.State.UNBALANCED,
+                List.of(
+                    new PartitionLeadershipStatus(
+                        "default",
+                        1,
+                        memberA,
+                        memberB,
+                        PartitionLeadershipStatus.State.TRANSFERRING))));
+    when(clusterRebalanceServices.getRebalanceStatus())
+        .thenReturn(CompletableFuture.completedFuture(status));
+
+    // when / then
+    webClient
+        .get()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "state": "UNBALANCED",
+              "partitions": [
+                { "partitionId": 1, "physicalTenantId": "default", "currentLeader": "0", "desiredLeader": "1", "state": "TRANSFERRING" }
+              ],
+              "runningRebalance": null,
+              "lastCompletedRebalance": {
+                "rebalanceId": 7,
+                "startedAt": "1970-01-01T00:00:00.000Z",
+                "finishedAt": "1970-01-01T00:00:05.000Z",
+                "result": "COMPLETED",
+                "partitions": [
+                  { "partitionId": 2, "physicalTenantId": "default", "currentLeader": "0", "desiredLeader": "1", "progress": "COMPLETED", "result": "TRANSFERRED" }
+                ]
+              }
+            }
+            """,
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReportTheRunningRebalanceSeparatelyFromLiveBalance() {
+    // given
+    final var member0 = MemberId.from("0");
+    final var member1 = MemberId.from("1");
+    final var member2 = MemberId.from("2");
+    final var status =
+        new RebalanceStatus(
+            new RebalanceStatus.Running(
+                8L,
+                RebalanceOverrides.none(),
+                false,
+                true,
+                List.of(
+                    new PartitionRebalance(
+                        "default", 1, member1, member2, PartitionRebalanceProgress.TRANSFERRING),
+                    new PartitionRebalance(
+                        "default",
+                        2,
+                        member2,
+                        member2,
+                        PartitionRebalanceProgress.COMPLETED,
+                        PartitionRebalanceOutcome.ALREADY_LEADER)),
+                Instant.EPOCH.plusSeconds(3)),
+            null,
+            new ClusterLeadershipStatus(
+                ClusterLeadershipStatus.State.UNBALANCED,
+                List.of(
+                    new PartitionLeadershipStatus(
+                        "default",
+                        1,
+                        member2,
+                        member0,
+                        PartitionLeadershipStatus.State.UNBALANCED))));
+    when(clusterRebalanceServices.getRebalanceStatus())
+        .thenReturn(CompletableFuture.completedFuture(status));
+
+    // when / then
+    webClient
+        .get()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "state": "UNBALANCED",
+              "partitions": [
+                { "partitionId": 1, "physicalTenantId": "default", "currentLeader": "2", "desiredLeader": "0", "state": "UNBALANCED" }
+              ],
+              "runningRebalance": {
+                "rebalanceId": 8,
+                "dryRun": false,
+                "startedAt": "1970-01-01T00:00:03.000Z",
+                "cancelRequested": true,
+                "partitions": [
+                  { "partitionId": 1, "physicalTenantId": "default", "currentLeader": "1", "desiredLeader": "2", "progress": "TRANSFERRING", "result": null },
+                  { "partitionId": 2, "physicalTenantId": "default", "currentLeader": "2", "desiredLeader": "2", "progress": "COMPLETED", "result": "ALREADY_LEADER" }
+                ]
+              },
+              "lastCompletedRebalance": null
+            }
+            """,
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldOmitCompletedHistoryWhenAbsent() {
+    // given
+    when(clusterRebalanceServices.getRebalanceStatus())
+        .thenReturn(CompletableFuture.completedFuture(idleStatus()));
+
+    // when / then
+    webClient
+        .get()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "state": "BALANCED",
+              "partitions": [],
+              "runningRebalance": null,
+              "lastCompletedRebalance": null
+            }
+            """,
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldOmitCurrentLeaderWhenAbsent() {
+    // given
+    final var status =
+        new RebalanceStatus(
+            null,
+            null,
+            new ClusterLeadershipStatus(
+                ClusterLeadershipStatus.State.UNBALANCED,
+                List.of(
+                    new PartitionLeadershipStatus(
+                        "default",
+                        1,
+                        null,
+                        MemberId.from("1"),
+                        PartitionLeadershipStatus.State.UNBALANCED))));
+    when(clusterRebalanceServices.getRebalanceStatus())
+        .thenReturn(CompletableFuture.completedFuture(status));
+
+    // when / then
+    webClient
+        .get()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "state": "UNBALANCED",
+              "partitions": [
+                { "partitionId": 1, "physicalTenantId": "default", "currentLeader": null, "desiredLeader": "1", "state": "UNBALANCED" }
+              ],
+              "runningRebalance": null,
+              "lastCompletedRebalance": null
+            }
+            """,
+            JsonCompareMode.STRICT);
+  }
+
+  @ParameterizedTest
+  @MethodSource("allPartitionOutcomes")
+  void shouldMapEveryCompletedPartitionOutcomeToTheDocumentedEnum(
+      final PartitionRebalanceOutcome outcome, final String documented) {
+    // given
+    final var status =
+        new RebalanceStatus(
+            null,
+            new RebalanceStatus.Completed(
+                7L,
+                RebalanceOutcome.COMPLETED,
+                List.of(
+                    new PartitionRebalance(
+                        "default",
+                        1,
+                        MemberId.from("0"),
+                        MemberId.from("1"),
+                        PartitionRebalanceProgress.COMPLETED,
+                        outcome)),
+                Instant.EPOCH,
+                Instant.EPOCH),
+            ClusterLeadershipStatus.aggregateOf(List.of()));
+    when(clusterRebalanceServices.getRebalanceStatus())
+        .thenReturn(CompletableFuture.completedFuture(status));
+
+    // when / then
+    webClient
+        .get()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.lastCompletedRebalance.partitions[0].result")
+        .isEqualTo(documented);
+  }
+
+  private static List<Arguments> allPartitionOutcomes() {
+    return List.of(
+        Arguments.of(PartitionRebalanceOutcome.TRANSFERRED, "TRANSFERRED"),
+        Arguments.of(PartitionRebalanceOutcome.ALREADY_LEADER, "ALREADY_LEADER"),
+        Arguments.of(PartitionRebalanceOutcome.NOT_MEMBER, "NOT_MEMBER"),
+        Arguments.of(PartitionRebalanceOutcome.NOT_REPLICATING, "NOT_REPLICATING"),
+        Arguments.of(PartitionRebalanceOutcome.UNREACHABLE, "UNREACHABLE"),
+        Arguments.of(PartitionRebalanceOutcome.NOT_COORDINATOR, "NOT_COORDINATOR"),
+        Arguments.of(PartitionRebalanceOutcome.STALE_CONFIGURATION, "STALE_CONFIGURATION"),
+        Arguments.of(PartitionRebalanceOutcome.TRANSFER_IN_PROGRESS, "TRANSFER_IN_PROGRESS"),
+        Arguments.of(PartitionRebalanceOutcome.LAG_TOO_HIGH, "LAG_TOO_HIGH"),
+        Arguments.of(PartitionRebalanceOutcome.LEADER_INITIALIZING, "LEADER_INITIALIZING"),
+        Arguments.of(
+            PartitionRebalanceOutcome.CONFIGURATION_CHANGE_IN_PROGRESS,
+            "CONFIGURATION_CHANGE_IN_PROGRESS"),
+        Arguments.of(PartitionRebalanceOutcome.PAUSE_FAILED, "PAUSE_FAILED"),
+        Arguments.of(PartitionRebalanceOutcome.REPLICATION_TIMED_OUT, "REPLICATION_TIMED_OUT"),
+        Arguments.of(PartitionRebalanceOutcome.TIMEOUT_NOW_EXHAUSTED, "TIMEOUT_NOW_EXHAUSTED"),
+        Arguments.of(PartitionRebalanceOutcome.LEADER_CHANGED, "LEADER_CHANGED"),
+        Arguments.of(PartitionRebalanceOutcome.NO_LEADER, "NO_LEADER"),
+        Arguments.of(PartitionRebalanceOutcome.NO_RESPONSE, "NO_RESPONSE"),
+        Arguments.of(PartitionRebalanceOutcome.CANCELLED, "CANCELLED"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("allBalanceStates")
+  void shouldMapEveryClusterLeadershipStateToTheDocumentedEnum(
+      final ClusterLeadershipStatus.State state, final String documented) {
+    // given
+    when(clusterRebalanceServices.getRebalanceStatus())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new RebalanceStatus(null, null, new ClusterLeadershipStatus(state, List.of()))));
+
+    // when / then
+    webClient
+        .get()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.state")
+        .isEqualTo(documented);
+  }
+
+  private static List<Arguments> allBalanceStates() {
+    return List.of(
+        Arguments.of(ClusterLeadershipStatus.State.BALANCED, "BALANCED"),
+        Arguments.of(ClusterLeadershipStatus.State.BALANCING, "BALANCING"),
+        Arguments.of(ClusterLeadershipStatus.State.UNBALANCED, "UNBALANCED"));
+  }
+
+  @Test
+  void shouldReportThatARunningRebalanceWasCancelled() {
+    // given
+    when(clusterRebalanceServices.cancelRebalance())
+        .thenReturn(CompletableFuture.completedFuture(new CancelRebalanceResponse(true)));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.wasRunning")
+        .isEqualTo(true);
+  }
+
+  @Test
+  void shouldReportThatNoRebalanceWasRunningToCancel() {
+    // given
+    when(clusterRebalanceServices.cancelRebalance())
+        .thenReturn(CompletableFuture.completedFuture(new CancelRebalanceResponse(false)));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.wasRunning")
+        .isEqualTo(false);
+  }
+
+  @Test
+  void shouldMapAConflictToHttp409() {
+    // given
+    when(clusterRebalanceServices.triggerRebalance(ClusterRebalanceRequest.withDefaultSettings()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("a rebalance is already running", Status.ALREADY_EXISTS)));
+
+    // when / then
+    webClient.post().uri(REBALANCE_URL).exchange().expectStatus().isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  void shouldMapAnUnavailableCoordinatorToHttp503() {
+    // given
+    when(clusterRebalanceServices.getRebalanceStatus())
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("no coordinator is available", Status.UNAVAILABLE)));
+
+    // when / then
+    webClient
+        .get()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void shouldMapATimeoutToHttp504() {
+    // given
+    when(clusterRebalanceServices.getRebalanceStatus())
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(
+                    "the coordinator did not answer in time", Status.DEADLINE_EXCEEDED)));
+
+    // when / then
+    webClient
+        .get()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+  }
+
+  @Test
+  void shouldMapAnInternalCoordinatorFailureToHttp500() {
+    // given
+    when(clusterRebalanceServices.cancelRebalance())
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("the coordinator failed internally", Status.INTERNAL)));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void shouldMapAnUnusableCoordinatorReplyToHttp502() {
+    // given
+    when(clusterRebalanceServices.cancelRebalance())
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("the coordinator gave no answer", Status.ABORTED)));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(REBALANCE_URL)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.BAD_GATEWAY);
+  }
+
+  private static RebalanceStatus idleStatus() {
+    return RebalanceStatus.idle();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceForwardingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceForwardingIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+final class ClusterRebalanceForwardingIT {
+
+  private static final String REBALANCE_PATH = "cluster/v2/rebalance";
+
+  @AutoClose private TestCluster cluster;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @Test
+  void shouldForwardARequestFromANonCoordinatorToTheCoordinator() throws Exception {
+    // given
+    cluster =
+        TestCluster.builder()
+            .withBrokersCount(2)
+            .withEmbeddedGateway(true)
+            .withPartitionsCount(1)
+            .withReplicationFactor(2)
+            .build();
+    cluster.start().awaitCompleteTopology();
+
+    final var coordinator = cluster.brokers().get(MemberId.from("0"));
+    final var nonCoordinator = cluster.brokers().get(MemberId.from("1"));
+
+    // when
+    final var fromNonCoordinator = getRebalance(nonCoordinator.restAddress());
+
+    // then
+    assertThat(fromNonCoordinator.statusCode()).isEqualTo(200);
+    final var fromCoordinator = getRebalance(coordinator.restAddress());
+    assertThat(fromNonCoordinator.body()).isEqualTo(fromCoordinator.body());
+  }
+
+  private HttpResponse<String> getRebalance(final URI restAddress) throws Exception {
+    final var request = HttpRequest.newBuilder(restAddress.resolve(REBALANCE_PATH)).GET().build();
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterConfigurationCoordinatorCheck.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterConfigurationCoordinatorCheck.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferCoordinatorCheck;
 import io.atomix.raft.LeadershipTransferResult;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
@@ -23,10 +23,10 @@ import org.jspecify.annotations.Nullable;
 public final class ClusterConfigurationCoordinatorCheck
     implements LeadershipTransferCoordinatorCheck {
 
-  private final Supplier<@Nullable ClusterConfiguration> clusterConfiguration;
+  private final Supplier<@Nullable CurrentClusterConfiguration> clusterConfiguration;
 
   public ClusterConfigurationCoordinatorCheck(
-      final Supplier<@Nullable ClusterConfiguration> clusterConfiguration) {
+      final Supplier<@Nullable CurrentClusterConfiguration> clusterConfiguration) {
     this.clusterConfiguration = clusterConfiguration;
   }
 
@@ -39,11 +39,11 @@ public final class ClusterConfigurationCoordinatorCheck
     }
     // A future version this node hasn't seen yet may have changed who the coordinator is, so it
     // must not be validated against this (older) membership either.
-    if (configurationVersion != configuration.version()) {
+    if (configurationVersion != configuration.globalConfiguration().version()) {
       return Optional.of(LeadershipTransferResult.STALE_CONFIGURATION);
     }
     final var expected =
-        ClusterConfigurationCoordinatorSupplier.ofMembers(configuration.members().keySet())
+        ClusterConfigurationCoordinatorSupplier.ofMembers(configuration.getMembers())
             .getDefaultCoordinator();
     return expected.equals(coordinator)
         ? Optional.empty()

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterLeadershipStatus.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ClusterLeadershipStatus.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The cluster's current leadership/balance status (whether all partitions are on their desired
+ * leaders).
+ */
+@NullMarked
+public record ClusterLeadershipStatus(State state, List<PartitionLeadershipStatus> partitions) {
+  public static ClusterLeadershipStatus aggregateOf(
+      final List<PartitionLeadershipStatus> partitions) {
+    var clusterState = State.BALANCED;
+    for (final var partition : partitions) {
+      clusterState =
+          switch (partition.state()) {
+            case TRANSFERRING -> State.BALANCING;
+            case UNBALANCED -> clusterState == State.BALANCING ? clusterState : State.UNBALANCED;
+            case BALANCED -> clusterState;
+          };
+    }
+    return new ClusterLeadershipStatus(clusterState, partitions);
+  }
+
+  public enum State {
+    BALANCING,
+    UNBALANCED,
+    BALANCED
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalancePlanner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalancePlanner.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/** Decides what a rebalance will do to each partition. */
+public final class PartitionBalancePlanner {
+
+  private final PartitionLeaders partitionLeaders;
+
+  public PartitionBalancePlanner(final PartitionLeaders partitionLeaders) {
+    this.partitionLeaders = partitionLeaders;
+  }
+
+  public List<PartitionRebalance> plan(final CurrentClusterConfiguration configuration) {
+    return configuration.partitionGroups().entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .flatMap(entry -> planGroup(entry.getKey(), entry.getValue()))
+        .toList();
+  }
+
+  private Stream<PartitionRebalance> planGroup(
+      final String physicalTenantId, final PartitionGroupConfiguration group) {
+    final var groupLeaders = partitionLeaders.forGroup(physicalTenantId);
+    return group
+        .partitionIds()
+        .mapToObj(partitionId -> planPartition(physicalTenantId, group, groupLeaders, partitionId));
+  }
+
+  private PartitionRebalance planPartition(
+      final String physicalTenantId,
+      final PartitionGroupConfiguration group,
+      final PartitionLeaders.PartitionGroupLeaders groupLeaders,
+      final int partitionId) {
+    final var desiredLeader =
+        group
+            .getDesiredLeader(partitionId)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No member of physical tenant %s's partition group is eligible to lead "
+                            + "partition %d, so it cannot be planned"
+                                .formatted(physicalTenantId, partitionId)));
+    final var currentLeader = groupLeaders.currentLeader(partitionId);
+    if (currentLeader.map(desiredLeader::equals).orElse(false)) {
+      return PartitionRebalance.alreadyLeader(physicalTenantId, partitionId, desiredLeader);
+    }
+    return PartitionRebalance.pending(
+        physicalTenantId, partitionId, currentLeader.orElse(null), desiredLeader);
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalancePlanner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalancePlanner.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 
 /** Decides what a rebalance will do to each partition. */
 public final class PartitionBalancePlanner {
@@ -35,6 +36,44 @@ public final class PartitionBalancePlanner {
     return group
         .partitionIds()
         .mapToObj(partitionId -> planPartition(physicalTenantId, group, groupLeaders, partitionId));
+  }
+
+  /**
+   * {@code transferring} is the single partition a running rebalance currently has in flight, if
+   * any (it will be marked {@link PartitionLeadershipStatus.State#TRANSFERRING} in the returned
+   * status).
+   */
+  public ClusterLeadershipStatus leadershipStatus(
+      final CurrentClusterConfiguration configuration,
+      final @Nullable PartitionRebalance currentTransfer) {
+    final var partitions =
+        plan(configuration).stream()
+            .map(partition -> toLeadershipStatus(partition, currentTransfer))
+            .toList();
+    return ClusterLeadershipStatus.aggregateOf(partitions);
+  }
+
+  private PartitionLeadershipStatus toLeadershipStatus(
+      final PartitionRebalance partition, final @Nullable PartitionRebalance currentTransfer) {
+    final var state =
+        isSamePartition(partition, currentTransfer)
+            ? PartitionLeadershipStatus.State.TRANSFERRING
+            : partition.isBalanced()
+                ? PartitionLeadershipStatus.State.BALANCED
+                : PartitionLeadershipStatus.State.UNBALANCED;
+    return new PartitionLeadershipStatus(
+        partition.physicalTenantId(),
+        partition.partitionId(),
+        partition.currentLeader(),
+        partition.desiredLeader(),
+        state);
+  }
+
+  private boolean isSamePartition(
+      final PartitionRebalance left, final @Nullable PartitionRebalance right) {
+    return right != null
+        && left.physicalTenantId().equals(right.physicalTenantId())
+        && left.partitionId() == right.partitionId();
   }
 
   private PartitionRebalance planPartition(

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionLeadershipStatus.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionLeadershipStatus.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.rebalance;
+
+import io.atomix.cluster.MemberId;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/** One partition's current leadership/balance status. */
+@NullMarked
+public record PartitionLeadershipStatus(
+    String physicalTenantId,
+    int partitionId,
+    @Nullable MemberId currentLeader,
+    MemberId desiredLeader,
+    State state) {
+
+  /** The ID of the current leader, or {@code null} if the partition has none. */
+  public @Nullable String currentLeaderId() {
+    return currentLeader == null ? null : currentLeader.id();
+  }
+
+  /** The ID of the desired leader. */
+  public String desiredLeaderId() {
+    return desiredLeader.id();
+  }
+
+  public enum State {
+    TRANSFERRING,
+    UNBALANCED,
+    BALANCED
+  }
+}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalance.java
@@ -87,6 +87,16 @@ public record PartitionRebalance(
     return Objects.equals(desiredLeader, currentLeader);
   }
 
+  /** The ID of the current leader, or {@code null} if the partition has none. */
+  public @Nullable String currentLeaderId() {
+    return currentLeader == null ? null : currentLeader.id();
+  }
+
+  /** The ID of the desired leader. */
+  public String desiredLeaderId() {
+    return desiredLeader.id();
+  }
+
   /** Completes the partition with a given outcome. */
   public PartitionRebalance completed(final PartitionRebalanceOutcome completedOutcome) {
     return new PartitionRebalance(

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -154,7 +154,89 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
               .setStartedAt(toTimestamp(lastCompleted.startedAt()))
               .setFinishedAt(toTimestamp(lastCompleted.finishedAt())));
     }
+    builder.setLeadershipStatus(encodeClusterLeadershipStatus(status.leadershipStatus()));
     return builder.build();
+  }
+
+  private Rebalance.ClusterLeadershipStatus encodeClusterLeadershipStatus(
+      final ClusterLeadershipStatus status) {
+    return Rebalance.ClusterLeadershipStatus.newBuilder()
+        .setState(encodeClusterLeadershipState(status.state()))
+        .addAllPartitions(
+            status.partitions().stream().map(this::encodePartitionLeadershipStatus).toList())
+        .build();
+  }
+
+  private ClusterLeadershipStatus decodeClusterLeadershipStatus(
+      final Rebalance.ClusterLeadershipStatus status) {
+    return new ClusterLeadershipStatus(
+        decodeClusterLeadershipState(status.getState()),
+        status.getPartitionsList().stream().map(this::decodePartitionLeadershipStatus).toList());
+  }
+
+  private Rebalance.ClusterLeadershipStatus.State encodeClusterLeadershipState(
+      final ClusterLeadershipStatus.State state) {
+    return switch (state) {
+      case BALANCING -> Rebalance.ClusterLeadershipStatus.State.BALANCING;
+      case UNBALANCED -> Rebalance.ClusterLeadershipStatus.State.UNBALANCED;
+      case BALANCED -> Rebalance.ClusterLeadershipStatus.State.BALANCED;
+    };
+  }
+
+  private ClusterLeadershipStatus.State decodeClusterLeadershipState(
+      final Rebalance.ClusterLeadershipStatus.State state) {
+    return switch (state) {
+      case BALANCING -> ClusterLeadershipStatus.State.BALANCING;
+      case UNBALANCED -> ClusterLeadershipStatus.State.UNBALANCED;
+      case BALANCED -> ClusterLeadershipStatus.State.BALANCED;
+      case STATE_UNSPECIFIED, UNRECOGNIZED ->
+          throw new DecodingFailed("Cluster leadership state is missing or unrecognized: " + state);
+    };
+  }
+
+  private Rebalance.PartitionLeadershipStatus encodePartitionLeadershipStatus(
+      final PartitionLeadershipStatus partition) {
+    final var builder =
+        Rebalance.PartitionLeadershipStatus.newBuilder()
+            .setPhysicalTenantId(partition.physicalTenantId())
+            .setPartitionId(partition.partitionId())
+            .setDesiredLeader(partition.desiredLeader().id())
+            .setState(encodePartitionLeadershipState(partition.state()));
+    if (partition.currentLeader() != null) {
+      builder.setCurrentLeader(partition.currentLeader().id());
+    }
+    return builder.build();
+  }
+
+  private PartitionLeadershipStatus decodePartitionLeadershipStatus(
+      final Rebalance.PartitionLeadershipStatus partition) {
+    return new PartitionLeadershipStatus(
+        partition.getPhysicalTenantId(),
+        partition.getPartitionId(),
+        partition.hasCurrentLeader() ? MemberId.from(partition.getCurrentLeader()) : null,
+        MemberId.from(partition.getDesiredLeader()),
+        decodePartitionLeadershipState(partition.getState()));
+  }
+
+  private Rebalance.PartitionLeadershipStatus.State encodePartitionLeadershipState(
+      final PartitionLeadershipStatus.State state) {
+    return switch (state) {
+      case TRANSFERRING -> Rebalance.PartitionLeadershipStatus.State.TRANSFERRING;
+      case UNBALANCED -> Rebalance.PartitionLeadershipStatus.State.UNBALANCED;
+      case BALANCED -> Rebalance.PartitionLeadershipStatus.State.BALANCED;
+    };
+  }
+
+  private PartitionLeadershipStatus.State decodePartitionLeadershipState(
+      final Rebalance.PartitionLeadershipStatus.State state) {
+    return switch (state) {
+      case TRANSFERRING -> PartitionLeadershipStatus.State.TRANSFERRING;
+      case UNBALANCED -> PartitionLeadershipStatus.State.UNBALANCED;
+      case BALANCED -> PartitionLeadershipStatus.State.BALANCED;
+      case STATE_UNSPECIFIED, UNRECOGNIZED ->
+          throw new DecodingFailed(
+              "Partition leadership state is missing or unrecognized: " + state);
+    };
   }
 
   private Rebalance.PartitionRebalance encodePartition(final PartitionRebalance partition) {
@@ -268,7 +350,8 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
   private RebalanceStatus decodeStatus(final Rebalance.RebalanceStatusResponse status) {
     return new RebalanceStatus(
         status.hasRunning() ? decodeRunning(status.getRunning()) : null,
-        status.hasLastCompleted() ? decodeCompleted(status.getLastCompleted()) : null);
+        status.hasLastCompleted() ? decodeCompleted(status.getLastCompleted()) : null,
+        decodeClusterLeadershipStatus(status.getLeadershipStatus()));
   }
 
   private RebalanceStatus.Running decodeRunning(final Rebalance.RunningRebalance running) {

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -140,7 +140,8 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
               .setOverrides(encodeOverrides(running.overrides()))
               .setDryRun(running.dryRun())
               .setCancelRequested(running.cancelRequested())
-              .addAllPartitions(running.partitions().stream().map(this::encodePartition).toList()));
+              .addAllPartitions(running.partitions().stream().map(this::encodePartition).toList())
+              .setStartedAt(toTimestamp(running.startedAt())));
     }
     final var lastCompleted = status.lastCompleted();
     if (lastCompleted != null) {
@@ -148,7 +149,6 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
           Rebalance.CompletedRebalance.newBuilder()
               .setRebalanceId(lastCompleted.rebalanceId())
               .setOutcome(encodeOutcome(lastCompleted.outcome()))
-              .setDryRun(lastCompleted.dryRun())
               .addAllPartitions(
                   lastCompleted.partitions().stream().map(this::encodePartition).toList())
               .setStartedAt(toTimestamp(lastCompleted.startedAt()))
@@ -360,14 +360,14 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
         decodeOverrides(running.getOverrides()),
         running.getDryRun(),
         running.getCancelRequested(),
-        running.getPartitionsList().stream().map(this::decodePartition).toList());
+        running.getPartitionsList().stream().map(this::decodePartition).toList(),
+        fromTimestamp(running.getStartedAt()));
   }
 
   private RebalanceStatus.Completed decodeCompleted(final Rebalance.CompletedRebalance completed) {
     return new RebalanceStatus.Completed(
         completed.getRebalanceId(),
         decodeOutcome(completed.getOutcome()),
-        completed.getDryRun(),
         completed.getPartitionsList().stream().map(this::decodePartition).toList(),
         fromTimestamp(completed.getStartedAt()),
         fromTimestamp(completed.getFinishedAt()));

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
@@ -20,6 +20,8 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Nulls;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -43,6 +45,7 @@ public final class RebalanceCoordinator
   private final MemberId localMemberId;
   private final ConcurrencyControl executor;
   private final RebalanceRunner runner;
+  private final PartitionBalancePlanner balancePlanner;
   private final LongSupplier rebalanceIdGenerator;
   private final Clock clock;
   private final ClusterRebalanceMetrics metrics;
@@ -60,12 +63,14 @@ public final class RebalanceCoordinator
       final MemberId localMemberId,
       final ConcurrencyControl executor,
       final RebalanceRunner runner,
+      final PartitionBalancePlanner balancePlanner,
       final LongSupplier rebalanceIdGenerator,
       final Clock clock,
       final ClusterRebalanceMetrics metrics) {
     this.localMemberId = localMemberId;
     this.executor = executor;
     this.runner = runner;
+    this.balancePlanner = balancePlanner;
     this.rebalanceIdGenerator = rebalanceIdGenerator;
     this.clock = clock;
     this.metrics = metrics;
@@ -132,10 +137,10 @@ public final class RebalanceCoordinator
           if (rebalance.dryRun()) {
             // A dry run only reads the plan, so it is over within the request and answers with the
             // plan itself.
-            start(rebalance, () -> result.complete(status()));
+            start(rebalance, completed -> result.complete(status(completed)));
           } else {
             result.complete(status());
-            start(rebalance, () -> {});
+            start(rebalance, ignored -> {});
           }
         });
     return result;
@@ -176,27 +181,33 @@ public final class RebalanceCoordinator
     return result;
   }
 
-  private void start(final RebalanceRun rebalance, final Runnable whenFinished) {
+  private void start(
+      final RebalanceRun rebalance, final Consumer<RebalanceStatus.Completed> whenFinished) {
     final ActorFuture<Void> run;
     try {
       run = runner.run(rebalance);
     } catch (final Exception e) {
-      finish(rebalance, e);
-      whenFinished.run();
+      final var completed = finish(rebalance, e);
+      if (completed != null) {
+        whenFinished.accept(completed);
+      }
       return;
     }
     executor.runOnCompletion(
         run,
         (ignored, error) -> {
-          finish(rebalance, error);
-          whenFinished.run();
+          final var completed = finish(rebalance, error);
+          if (completed != null) {
+            whenFinished.accept(completed);
+          }
         });
   }
 
-  private void finish(final RebalanceRun rebalance, final @Nullable Throwable error) {
+  private RebalanceStatus.@Nullable Completed finish(
+      final RebalanceRun rebalance, final @Nullable Throwable error) {
     if (running != rebalance) {
       // We stopped coordinating while the rebalance was in flight, so its state is already gone
-      return;
+      return null;
     }
     running = null;
     final RebalanceOutcome outcome;
@@ -208,7 +219,7 @@ public final class RebalanceCoordinator
     }
     final var finishedAt = clock.instant();
     rebalance.finish(finishedAt);
-    lastCompleted =
+    final var completed =
         new RebalanceStatus.Completed(
             rebalance.id(),
             outcome,
@@ -216,8 +227,12 @@ public final class RebalanceCoordinator
             rebalance.partitions(),
             rebalance.startedAt(),
             finishedAt);
+    if (!rebalance.dryRun()) {
+      lastCompleted = completed;
+    }
     metrics.observeElapsed(outcome, Duration.between(rebalance.startedAt(), finishedAt));
     LOG.info("Rebalance {} finished as {}", rebalance.id(), outcome);
+    return completed;
   }
 
   private static RebalanceOutcome aggregateOutcome(final RebalanceRun rebalance) {
@@ -283,6 +298,10 @@ public final class RebalanceCoordinator
   }
 
   private RebalanceStatus status() {
+    return status(lastCompleted);
+  }
+
+  private RebalanceStatus status(final RebalanceStatus.@Nullable Completed completed) {
     final var inFlight = running;
     final var runningStatus =
         inFlight == null
@@ -293,6 +312,18 @@ public final class RebalanceCoordinator
                 inFlight.dryRun(),
                 inFlight.isCancelRequested(),
                 inFlight.partitions());
-    return new RebalanceStatus(runningStatus, lastCompleted);
+    return new RebalanceStatus(runningStatus, completed, leadershipStatus(inFlight));
+  }
+
+  private ClusterLeadershipStatus leadershipStatus(final @Nullable RebalanceRun inFlight) {
+    final var transferring =
+        inFlight == null
+            ? null
+            : inFlight.partitions().stream()
+                .filter(
+                    partition -> partition.progress() == PartitionRebalanceProgress.TRANSFERRING)
+                .findFirst()
+                .orElse(null);
+    return balancePlanner.leadershipStatus(Objects.requireNonNull(configuration), transferring);
   }
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.util.Nulls;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Objects;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.LongSupplier;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -136,11 +136,22 @@ public final class RebalanceCoordinator
           LOG.info("Starting {}rebalance {}", rebalance.dryRun() ? "dry-run " : "", rebalance.id());
           if (rebalance.dryRun()) {
             // A dry run only reads the plan, so it is over within the request and answers with the
-            // plan itself.
-            start(rebalance, completed -> result.complete(status(completed)));
+            // plan itself as a completed snapshot under `running`; it is never retained as
+            // `lastCompleted`.
+            start(
+                rebalance,
+                (completed, error) -> {
+                  if (error != null) {
+                    result.completeExceptionally(error);
+                  } else {
+                    result.complete(
+                        new RebalanceStatus(
+                            runningSnapshot(rebalance), lastCompleted, leadershipStatus(running)));
+                  }
+                });
           } else {
             result.complete(status());
-            start(rebalance, ignored -> {});
+            start(rebalance, (completed, error) -> {});
           }
         });
     return result;
@@ -182,14 +193,15 @@ public final class RebalanceCoordinator
   }
 
   private void start(
-      final RebalanceRun rebalance, final Consumer<RebalanceStatus.Completed> whenFinished) {
+      final RebalanceRun rebalance,
+      final BiConsumer<RebalanceStatus.Completed, @Nullable Throwable> whenFinished) {
     final ActorFuture<Void> run;
     try {
       run = runner.run(rebalance);
     } catch (final Exception e) {
       final var completed = finish(rebalance, e);
       if (completed != null) {
-        whenFinished.accept(completed);
+        whenFinished.accept(completed, e);
       }
       return;
     }
@@ -198,7 +210,7 @@ public final class RebalanceCoordinator
         (ignored, error) -> {
           final var completed = finish(rebalance, error);
           if (completed != null) {
-            whenFinished.accept(completed);
+            whenFinished.accept(completed, error);
           }
         });
   }
@@ -221,16 +233,11 @@ public final class RebalanceCoordinator
     rebalance.finish(finishedAt);
     final var completed =
         new RebalanceStatus.Completed(
-            rebalance.id(),
-            outcome,
-            rebalance.dryRun(),
-            rebalance.partitions(),
-            rebalance.startedAt(),
-            finishedAt);
+            rebalance.id(), outcome, rebalance.partitions(), rebalance.startedAt(), finishedAt);
     if (!rebalance.dryRun()) {
       lastCompleted = completed;
+      metrics.observeElapsed(outcome, Duration.between(rebalance.startedAt(), finishedAt));
     }
-    metrics.observeElapsed(outcome, Duration.between(rebalance.startedAt(), finishedAt));
     LOG.info("Rebalance {} finished as {}", rebalance.id(), outcome);
     return completed;
   }
@@ -303,16 +310,18 @@ public final class RebalanceCoordinator
 
   private RebalanceStatus status(final RebalanceStatus.@Nullable Completed completed) {
     final var inFlight = running;
-    final var runningStatus =
-        inFlight == null
-            ? null
-            : new RebalanceStatus.Running(
-                inFlight.id(),
-                inFlight.overrides(),
-                inFlight.dryRun(),
-                inFlight.isCancelRequested(),
-                inFlight.partitions());
+    final var runningStatus = inFlight == null ? null : runningSnapshot(inFlight);
     return new RebalanceStatus(runningStatus, completed, leadershipStatus(inFlight));
+  }
+
+  private static RebalanceStatus.Running runningSnapshot(final RebalanceRun rebalance) {
+    return new RebalanceStatus.Running(
+        rebalance.id(),
+        rebalance.overrides(),
+        rebalance.dryRun(),
+        rebalance.isCancelRequested(),
+        rebalance.partitions(),
+        rebalance.startedAt());
   }
 
   private ClusterLeadershipStatus leadershipStatus(final @Nullable RebalanceRun inFlight) {

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
@@ -13,16 +13,20 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * The current status of the rebalance coordinator (any running rebalance, and the last completed
- * rebalance).
+ * rebalance), together with the cluster's current leadership status.
  *
  * @param running the currently running rebalance, or {@code null}
  * @param lastCompleted the last rebalance this coordinator finished, or {@code null} if it has not
  *     finished one since becoming coordinator (not preserved over restarts)
+ * @param leadershipStatus the cluster's current leadership status, independent of {@code running}
  */
-public record RebalanceStatus(@Nullable Running running, @Nullable Completed lastCompleted) {
-  /** No running rebalance, no previously completed rebalance. */
+public record RebalanceStatus(
+    @Nullable Running running,
+    @Nullable Completed lastCompleted,
+    ClusterLeadershipStatus leadershipStatus) {
+
   public static RebalanceStatus idle() {
-    return new RebalanceStatus(null, null);
+    return new RebalanceStatus(null, null, ClusterLeadershipStatus.aggregateOf(List.of()));
   }
 
   /**

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceStatus.java
@@ -30,7 +30,9 @@ public record RebalanceStatus(
   }
 
   /**
-   * Status of the currently running rebalance.
+   * Status of the currently running rebalance, or - as the synchronous response to a successful
+   * dry-run trigger - the completed plan snapshot of that dry run. In the latter case, a subsequent
+   * status request reports no running rebalance.
    *
    * @param rebalanceId identifies this rebalance in the coordinator's logs
    * @param overrides any overrides for rebalance settings applying to this run
@@ -39,29 +41,28 @@ public record RebalanceStatus(
    *     in-flight transfer finishes)
    * @param partitions every partition this rebalance covers and where it has got to with each, or
    *     empty while the rebalance is still being planned
+   * @param startedAt when this rebalance was created
    */
   public record Running(
       long rebalanceId,
       RebalanceOverrides overrides,
       boolean dryRun,
       boolean cancelRequested,
-      List<PartitionRebalance> partitions) {}
+      List<PartitionRebalance> partitions,
+      Instant startedAt) {}
 
   /**
-   * Outcome of the last completed rebalance.
+   * Outcome of the last completed non-dry-run rebalance.
    *
    * @param rebalanceId identifies this rebalance in the coordinator's logs
    * @param outcome the outcome of the rebalance
-   * @param dryRun true if this rebalance was a dry-run (no pauses or transfers were performed)
-   * @param partitions every partition the rebalance covered and what became of each; for a dry run,
-   *     the plan it would have carried out
+   * @param partitions every partition the rebalance covered and what became of each
    * @param startedAt when this rebalance was created
    * @param finishedAt when this rebalance finished
    */
   public record Completed(
       long rebalanceId,
       RebalanceOutcome outcome,
-      boolean dryRun,
       List<PartitionRebalance> partitions,
       Instant startedAt,
       Instant finishedAt) {}

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -17,20 +17,16 @@ import io.atomix.raft.protocol.LeadershipTransferResultRequest;
 import io.atomix.raft.protocol.LeadershipTransferResultResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,6 +91,7 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
   private final MemberId localMemberId;
   private final ConcurrencyControl executor;
   private final PartitionLeaders partitionLeaders;
+  private final PartitionBalancePlanner planner;
   private final LeadershipTransferProtocol transfers;
   private final ClusterRebalanceMetrics metrics;
   private final Duration leaderWaitTimeout;
@@ -119,6 +116,7 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
     this.localMemberId = localMemberId;
     this.executor = executor;
     this.partitionLeaders = partitionLeaders;
+    planner = new PartitionBalancePlanner(partitionLeaders);
     this.transfers = transfers;
     this.metrics = metrics;
     this.leaderWaitTimeout = leaderWaitTimeout;
@@ -128,7 +126,7 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
 
   @Override
   public ActorFuture<Void> run(final RebalanceRun rebalance) {
-    rebalance.plan(plan(rebalance.configuration()));
+    rebalance.plan(planner.plan(rebalance.configuration()));
     logPlan(rebalance);
     publish(rebalance);
     final ActorFuture<Void> completion = executor.createFuture();
@@ -151,44 +149,6 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
             partition, Objects.requireNonNull(partition.outcome()), Duration.ZERO);
       }
     }
-  }
-
-  /** Decides what the rebalance will do to each partition. */
-  private List<PartitionRebalance> plan(final CurrentClusterConfiguration configuration) {
-    return configuration.partitionGroups().entrySet().stream()
-        .sorted(Map.Entry.comparingByKey())
-        .flatMap(entry -> planGroup(entry.getKey(), entry.getValue()))
-        .toList();
-  }
-
-  private Stream<PartitionRebalance> planGroup(
-      final String physicalTenantId, final PartitionGroupConfiguration group) {
-    final var groupLeaders = partitionLeaders.forGroup(physicalTenantId);
-    return group
-        .partitionIds()
-        .mapToObj(partitionId -> planPartition(physicalTenantId, group, groupLeaders, partitionId));
-  }
-
-  private PartitionRebalance planPartition(
-      final String physicalTenantId,
-      final PartitionGroupConfiguration group,
-      final PartitionLeaders.PartitionGroupLeaders groupLeaders,
-      final int partitionId) {
-    final var desiredLeader =
-        group
-            .getDesiredLeader(partitionId)
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "No member of physical tenant %s's partition group is eligible to lead "
-                            + "partition %d, so it cannot be planned"
-                                .formatted(physicalTenantId, partitionId)));
-    final var currentLeader = groupLeaders.currentLeader(partitionId);
-    if (currentLeader.map(desiredLeader::equals).orElse(false)) {
-      return PartitionRebalance.alreadyLeader(physicalTenantId, partitionId, desiredLeader);
-    }
-    return PartitionRebalance.pending(
-        physicalTenantId, partitionId, currentLeader.orElse(null), desiredLeader);
   }
 
   /** Process the first partition that the rebalance still has to transfer. */

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -128,11 +128,11 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
   public ActorFuture<Void> run(final RebalanceRun rebalance) {
     rebalance.plan(planner.plan(rebalance.configuration()));
     logPlan(rebalance);
-    publish(rebalance);
     final ActorFuture<Void> completion = executor.createFuture();
     if (rebalance.dryRun()) {
       completion.asNullable().complete(null);
     } else {
+      publish(rebalance);
       observePlanned(rebalance);
       transferFrom(rebalance, 0, completion);
     }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -356,7 +356,7 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
         LeadershipTransferInitiateRequest.builder()
             .withDesiredLeader(desiredLeader)
             .withCoordinator(localMemberId)
-            .withCoordinatorConfigVersion(rebalance.configuration().version())
+            .withCoordinatorConfigVersion(rebalance.configuration().globalConfiguration().version())
             .withCorrelationId(rebalance.id());
     final var overrides = rebalance.overrides();
     if (overrides.replicationLagThreshold() != null) {

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -63,6 +63,7 @@ message RunningRebalance {
   bool cancelRequested = 4;
   // Empty until the rebalance has been planned.
   repeated PartitionRebalance partitions = 5;
+  google.protobuf.Timestamp startedAt = 6;
 }
 
 message CompletedRebalance {
@@ -77,10 +78,9 @@ message CompletedRebalance {
 
   uint64 rebalanceId = 1;
   RebalanceOutcome outcome = 2;
-  bool dryRun = 3;
-  repeated PartitionRebalance partitions = 4;
-  google.protobuf.Timestamp startedAt = 5;
-  google.protobuf.Timestamp finishedAt = 6;
+  repeated PartitionRebalance partitions = 3;
+  google.protobuf.Timestamp startedAt = 4;
+  google.protobuf.Timestamp finishedAt = 5;
 }
 
 message PartitionRebalance {

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -23,6 +23,37 @@ message RebalanceStatusResponse {
   RunningRebalance running = 1;
   // Absent until a rebalance has run on this coordinator.
   CompletedRebalance lastCompleted = 2;
+  // The cluster's current leadership/balance status (independent of any running
+  // rebalance)
+  ClusterLeadershipStatus leadershipStatus = 3;
+}
+
+message ClusterLeadershipStatus {
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    BALANCING = 1;
+    UNBALANCED = 2;
+    BALANCED = 3;
+  }
+
+  State state = 1;
+  repeated PartitionLeadershipStatus partitions = 2;
+}
+
+message PartitionLeadershipStatus {
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    TRANSFERRING = 1;
+    UNBALANCED = 2;
+    BALANCED = 3;
+  }
+
+  string physicalTenantId = 1;
+  uint32 partitionId = 2;
+  // Absent while the partition has no current leader.
+  optional string currentLeader = 3;
+  string desiredLeader = 4;
+  State state = 5;
 }
 
 message RunningRebalance {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ClusterConfigurationCoordinatorCheckTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ClusterConfigurationCoordinatorCheckTest.java
@@ -11,9 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
-import java.util.Map;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import org.junit.jupiter.api.Test;
 
 final class ClusterConfigurationCoordinatorCheckTest {
@@ -28,23 +27,8 @@ final class ClusterConfigurationCoordinatorCheckTest {
     final var check = new ClusterConfigurationCoordinatorCheck(() -> configuration);
 
     // when
-    final var rejection = check.validate(COORDINATOR, configuration.version());
-
-    // then
-    assertThat(rejection).isEmpty();
-  }
-
-  @Test
-  void shouldAcceptACoordinatorThatDoesNotReplicateThisPartition() {
-    // given
-    final var configuration =
-        ClusterConfiguration.init()
-            .addMember(COORDINATOR, MemberState.initializeAsActive(Map.of()))
-            .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of()));
-    final var check = new ClusterConfigurationCoordinatorCheck(() -> configuration);
-
-    // when
-    final var rejection = check.validate(COORDINATOR, configuration.version());
+    final var rejection =
+        check.validate(COORDINATOR, configuration.globalConfiguration().version());
 
     // then
     assertThat(rejection)
@@ -59,7 +43,8 @@ final class ClusterConfigurationCoordinatorCheckTest {
     final var check = new ClusterConfigurationCoordinatorCheck(() -> configuration);
 
     // when
-    final var rejection = check.validate(OTHER_MEMBER, configuration.version());
+    final var rejection =
+        check.validate(OTHER_MEMBER, configuration.globalConfiguration().version());
 
     // then
     assertThat(rejection).contains(LeadershipTransferResult.NOT_COORDINATOR);
@@ -72,7 +57,8 @@ final class ClusterConfigurationCoordinatorCheckTest {
     final var check = new ClusterConfigurationCoordinatorCheck(() -> configuration);
 
     // when
-    final var rejection = check.validate(COORDINATOR, configuration.version() - 1);
+    final var rejection =
+        check.validate(COORDINATOR, configuration.globalConfiguration().version() - 1);
 
     // then
     assertThat(rejection).contains(LeadershipTransferResult.STALE_CONFIGURATION);
@@ -85,7 +71,8 @@ final class ClusterConfigurationCoordinatorCheckTest {
     final var check = new ClusterConfigurationCoordinatorCheck(() -> configuration);
 
     // when
-    final var rejection = check.validate(COORDINATOR, configuration.version() + 1);
+    final var rejection =
+        check.validate(COORDINATOR, configuration.globalConfiguration().version() + 1);
 
     // then
     assertThat(rejection)
@@ -98,7 +85,8 @@ final class ClusterConfigurationCoordinatorCheckTest {
   @Test
   void shouldRefuseEveryRequesterWithoutAConfigurationToCheckAgainst() {
     // given
-    final var check = new ClusterConfigurationCoordinatorCheck(ClusterConfiguration::uninitialized);
+    final var check =
+        new ClusterConfigurationCoordinatorCheck(CurrentClusterConfiguration::uninitialized);
 
     // when
     final var rejection = check.validate(COORDINATOR, 1);
@@ -107,10 +95,12 @@ final class ClusterConfigurationCoordinatorCheckTest {
     assertThat(rejection).contains(LeadershipTransferResult.STALE_CONFIGURATION);
   }
 
-  private static ClusterConfiguration configurationOf(final MemberId... members) {
-    var configuration = ClusterConfiguration.init();
+  private static CurrentClusterConfiguration configurationOf(final MemberId... members) {
+    var configuration = CurrentClusterConfiguration.init();
     for (final var member : members) {
-      configuration = configuration.addMember(member, MemberState.initializeAsActive(Map.of()));
+      configuration =
+          configuration.updateGlobalConfiguration(
+              global -> global.addMember(member, BrokerState.initializeAsActive()));
     }
     return configuration;
   }

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
@@ -25,6 +25,21 @@ final class ProtoBufRebalanceSerializerTest {
 
   private static final Instant STARTED_AT = Instant.parse("2024-01-01T00:00:00Z");
   private static final Instant FINISHED_AT = Instant.parse("2024-01-01T00:00:05Z");
+  private static final ClusterLeadershipStatus LEADERSHIP_STATUS =
+      ClusterLeadershipStatus.aggregateOf(
+          List.of(
+              new PartitionLeadershipStatus(
+                  "default",
+                  1,
+                  MemberId.from("0"),
+                  MemberId.from("1"),
+                  PartitionLeadershipStatus.State.TRANSFERRING),
+              new PartitionLeadershipStatus(
+                  "tenant-a",
+                  2,
+                  MemberId.from("2"),
+                  MemberId.from("2"),
+                  PartitionLeadershipStatus.State.BALANCED)));
 
   private final ProtoBufRebalanceSerializer serializer = new ProtoBufRebalanceSerializer();
 
@@ -108,7 +123,8 @@ final class ProtoBufRebalanceSerializerTest {
                 false,
                 List.of(PartitionRebalance.alreadyLeader("tenant-a", 2, MemberId.from("2"))),
                 STARTED_AT,
-                FINISHED_AT));
+                FINISHED_AT),
+            LEADERSHIP_STATUS);
 
     // when
     final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
@@ -124,7 +140,8 @@ final class ProtoBufRebalanceSerializerTest {
     final var status =
         new RebalanceStatus(
             null,
-            new RebalanceStatus.Completed(7, outcome, false, List.of(), STARTED_AT, FINISHED_AT));
+            new RebalanceStatus.Completed(7, outcome, false, List.of(), STARTED_AT, FINISHED_AT),
+            LEADERSHIP_STATUS);
 
     // when
     final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
@@ -145,7 +162,8 @@ final class ProtoBufRebalanceSerializerTest {
         new RebalanceStatus(
             null,
             new RebalanceStatus.Completed(
-                7, RebalanceOutcome.COMPLETED, false, List.of(partition), STARTED_AT, FINISHED_AT));
+                7, RebalanceOutcome.COMPLETED, false, List.of(partition), STARTED_AT, FINISHED_AT),
+            LEADERSHIP_STATUS);
 
     // when
     final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
@@ -170,7 +188,8 @@ final class ProtoBufRebalanceSerializerTest {
         new RebalanceStatus(
             null,
             new RebalanceStatus.Completed(
-                7, RebalanceOutcome.COMPLETED, false, List.of(partition), STARTED_AT, FINISHED_AT));
+                7, RebalanceOutcome.COMPLETED, false, List.of(partition), STARTED_AT, FINISHED_AT),
+            LEADERSHIP_STATUS);
 
     // when
     final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));
@@ -189,7 +208,8 @@ final class ProtoBufRebalanceSerializerTest {
         new RebalanceStatus(
             null,
             new RebalanceStatus.Completed(
-                7, RebalanceOutcome.COMPLETED, true, List.of(partition), STARTED_AT, FINISHED_AT));
+                7, RebalanceOutcome.COMPLETED, true, List.of(partition), STARTED_AT, FINISHED_AT),
+            LEADERSHIP_STATUS);
 
     // when
     final var decoded = serializer.decodeRebalanceStatusResponse(serializer.encodeResponse(status));

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializerTest.java
@@ -116,11 +116,11 @@ final class ProtoBufRebalanceSerializerTest {
                         1,
                         MemberId.from("0"),
                         MemberId.from("1"),
-                        PartitionRebalanceProgress.TRANSFERRING))),
+                        PartitionRebalanceProgress.TRANSFERRING)),
+                STARTED_AT),
             new RebalanceStatus.Completed(
                 41,
                 RebalanceOutcome.CANCELLED,
-                false,
                 List.of(PartitionRebalance.alreadyLeader("tenant-a", 2, MemberId.from("2"))),
                 STARTED_AT,
                 FINISHED_AT),
@@ -140,7 +140,7 @@ final class ProtoBufRebalanceSerializerTest {
     final var status =
         new RebalanceStatus(
             null,
-            new RebalanceStatus.Completed(7, outcome, false, List.of(), STARTED_AT, FINISHED_AT),
+            new RebalanceStatus.Completed(7, outcome, List.of(), STARTED_AT, FINISHED_AT),
             LEADERSHIP_STATUS);
 
     // when
@@ -162,7 +162,7 @@ final class ProtoBufRebalanceSerializerTest {
         new RebalanceStatus(
             null,
             new RebalanceStatus.Completed(
-                7, RebalanceOutcome.COMPLETED, false, List.of(partition), STARTED_AT, FINISHED_AT),
+                7, RebalanceOutcome.COMPLETED, List.of(partition), STARTED_AT, FINISHED_AT),
             LEADERSHIP_STATUS);
 
     // when
@@ -188,7 +188,7 @@ final class ProtoBufRebalanceSerializerTest {
         new RebalanceStatus(
             null,
             new RebalanceStatus.Completed(
-                7, RebalanceOutcome.COMPLETED, false, List.of(partition), STARTED_AT, FINISHED_AT),
+                7, RebalanceOutcome.COMPLETED, List.of(partition), STARTED_AT, FINISHED_AT),
             LEADERSHIP_STATUS);
 
     // when
@@ -208,7 +208,7 @@ final class ProtoBufRebalanceSerializerTest {
         new RebalanceStatus(
             null,
             new RebalanceStatus.Completed(
-                7, RebalanceOutcome.COMPLETED, true, List.of(partition), STARTED_AT, FINISHED_AT),
+                7, RebalanceOutcome.COMPLETED, List.of(partition), STARTED_AT, FINISHED_AT),
             LEADERSHIP_STATUS);
 
     // when

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
@@ -30,6 +30,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -50,6 +51,8 @@ final class RebalanceCoordinatorTest {
   private final TestConcurrencyControl executor = new TestConcurrencyControl();
   private final AtomicLong nextRebalanceId = new AtomicLong(100);
   private final Clock clock = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+  private final PartitionBalancePlanner balancePlanner =
+      new PartitionBalancePlanner(physicalTenantId -> partitionId -> Optional.empty());
 
   @Test
   void shouldRefuseRequestsBeforeAnyConfigurationArrives() {
@@ -176,6 +179,25 @@ final class RebalanceCoordinatorTest {
                 List.of(PLAN),
                 FIXED_INSTANT,
                 FIXED_INSTANT));
+  }
+
+  @Test
+  void shouldNotRetainADryRunAsTheLastCompletedRebalance() {
+    // given
+    final var coordinator = coordinatingWith(new PlanningRunner());
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+    final var completed = coordinator.getRebalanceStatus().join().lastCompleted();
+
+    // when
+    final var dryRun =
+        coordinator
+            .triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), true))
+            .join();
+
+    // then
+    assertThat(dryRun.lastCompleted().rebalanceId()).isEqualTo(101);
+    assertThat(dryRun.lastCompleted().dryRun()).isTrue();
+    assertThat(coordinator.getRebalanceStatus().join().lastCompleted()).isEqualTo(completed);
   }
 
   @Test
@@ -412,6 +434,7 @@ final class RebalanceCoordinatorTest {
             LOWEST_ID_MEMBER,
             executor,
             runner,
+            balancePlanner,
             nextRebalanceId::getAndIncrement,
             stepClock,
             new ClusterRebalanceMetrics(new SimpleMeterRegistry()));
@@ -503,6 +526,7 @@ final class RebalanceCoordinatorTest {
         localMemberId,
         executor,
         runner,
+        balancePlanner,
         nextRebalanceId::getAndIncrement,
         clock,
         new ClusterRebalanceMetrics(new SimpleMeterRegistry()));

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -135,12 +136,7 @@ final class RebalanceCoordinatorTest {
     assertThat(status.lastCompleted())
         .isEqualTo(
             new RebalanceStatus.Completed(
-                100,
-                RebalanceOutcome.COMPLETED,
-                false,
-                List.of(PLAN),
-                FIXED_INSTANT,
-                FIXED_INSTANT));
+                100, RebalanceOutcome.COMPLETED, List.of(PLAN), FIXED_INSTANT, FIXED_INSTANT));
   }
 
   @Test
@@ -162,23 +158,25 @@ final class RebalanceCoordinatorTest {
   void shouldAnswerADryRunWithThePlanItWouldHaveCarriedOut() {
     // given
     final var coordinator = coordinatingWith(new PlanningRunner());
+    final var overrides = RebalanceOverrides.none();
 
     // when
     final var triggered =
-        coordinator.triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), true));
+        coordinator.triggerRebalance(new TriggerRebalanceRequest(overrides, true));
 
     // then
     final var status = triggered.join();
-    assertThat(status.running()).isNull();
-    assertThat(status.lastCompleted())
-        .isEqualTo(
-            new RebalanceStatus.Completed(
-                100,
-                RebalanceOutcome.COMPLETED,
-                true,
-                List.of(PLAN),
-                FIXED_INSTANT,
-                FIXED_INSTANT));
+    final var running = status.running();
+    assertThat(running).isNotNull();
+    assertThat(running.rebalanceId()).isEqualTo(100);
+    assertThat(running.dryRun()).isTrue();
+    assertThat(running.cancelRequested()).isFalse();
+    assertThat(running.partitions()).containsExactly(PLAN);
+    assertThat(status.lastCompleted()).isNull();
+
+    final var afterPlanning = coordinator.getRebalanceStatus().join();
+    assertThat(afterPlanning.running()).isNull();
+    assertThat(afterPlanning.lastCompleted()).isNull();
   }
 
   @Test
@@ -186,7 +184,7 @@ final class RebalanceCoordinatorTest {
     // given
     final var coordinator = coordinatingWith(new PlanningRunner());
     coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
-    final var completed = coordinator.getRebalanceStatus().join().lastCompleted();
+    final var realCompletion = coordinator.getRebalanceStatus().join().lastCompleted();
 
     // when
     final var dryRun =
@@ -195,9 +193,71 @@ final class RebalanceCoordinatorTest {
             .join();
 
     // then
-    assertThat(dryRun.lastCompleted().rebalanceId()).isEqualTo(101);
-    assertThat(dryRun.lastCompleted().dryRun()).isTrue();
-    assertThat(coordinator.getRebalanceStatus().join().lastCompleted()).isEqualTo(completed);
+    assertThat(dryRun.running()).isNotNull();
+    assertThat(dryRun.running().rebalanceId()).isEqualTo(101);
+    assertThat(dryRun.running().dryRun()).isTrue();
+    assertThat(dryRun.lastCompleted()).isEqualTo(realCompletion);
+
+    final var afterDryRun = coordinator.getRebalanceStatus().join();
+    assertThat(afterDryRun.running()).isNull();
+    assertThat(afterDryRun.lastCompleted()).isEqualTo(realCompletion);
+  }
+
+  @Test
+  void shouldFailTheTriggerFutureWhenDryRunPlanningFails() {
+    // given
+    final var failure = new RuntimeException("planning blew up");
+    final var coordinator = coordinatingWith(new FailingRunner(failure));
+
+    // when
+    final var triggered =
+        coordinator.triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), true));
+
+    // then
+    assertThatThrownBy(triggered::join).hasCause(failure);
+    final var status = coordinator.getRebalanceStatus().join();
+    assertThat(status.running()).isNull();
+    assertThat(status.lastCompleted()).isNull();
+  }
+
+  @Test
+  void shouldNotChangeElapsedTimerCountsForADryRun() {
+    // given
+    final var registry = new SimpleMeterRegistry();
+    final var coordinator =
+        new RebalanceCoordinator(
+            LOWEST_ID_MEMBER,
+            executor,
+            new PlanningRunner(),
+            balancePlanner,
+            nextRebalanceId::getAndIncrement,
+            clock,
+            new ClusterRebalanceMetrics(registry));
+    configurationWithBothMembers(coordinator);
+    final var countsBefore = elapsedTimerCounts(registry);
+
+    // when
+    coordinator
+        .triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), true))
+        .join();
+
+    // then
+    assertThat(elapsedTimerCounts(registry)).isEqualTo(countsBefore);
+  }
+
+  private static Map<RebalanceOutcome, Long> elapsedTimerCounts(
+      final SimpleMeterRegistry registry) {
+    final Map<RebalanceOutcome, Long> counts = new EnumMap<>(RebalanceOutcome.class);
+    for (final var outcome : RebalanceOutcome.values()) {
+      counts.put(
+          outcome,
+          registry
+              .get("zeebe.cluster.rebalance.elapsed")
+              .tag("result", outcome.name())
+              .timer()
+              .count());
+    }
+    return counts;
   }
 
   @Test
@@ -230,7 +290,7 @@ final class RebalanceCoordinatorTest {
     assertThat(status.join().lastCompleted())
         .isEqualTo(
             new RebalanceStatus.Completed(
-                100, RebalanceOutcome.FAILED, false, List.of(PLAN), FIXED_INSTANT, FIXED_INSTANT));
+                100, RebalanceOutcome.FAILED, List.of(PLAN), FIXED_INSTANT, FIXED_INSTANT));
   }
 
   @Test
@@ -264,12 +324,7 @@ final class RebalanceCoordinatorTest {
     assertThat(status.join().lastCompleted())
         .isEqualTo(
             new RebalanceStatus.Completed(
-                100,
-                RebalanceOutcome.CANCELLED,
-                false,
-                List.of(PLAN),
-                FIXED_INSTANT,
-                FIXED_INSTANT));
+                100, RebalanceOutcome.CANCELLED, List.of(PLAN), FIXED_INSTANT, FIXED_INSTANT));
   }
 
   @Test
@@ -290,7 +345,7 @@ final class RebalanceCoordinatorTest {
     assertThat(status.join().lastCompleted())
         .isEqualTo(
             new RebalanceStatus.Completed(
-                100, RebalanceOutcome.CANCELLED, false, List.of(), FIXED_INSTANT, FIXED_INSTANT));
+                100, RebalanceOutcome.CANCELLED, List.of(), FIXED_INSTANT, FIXED_INSTANT));
   }
 
   @Test
@@ -312,7 +367,7 @@ final class RebalanceCoordinatorTest {
     assertThat(status.join().lastCompleted())
         .isEqualTo(
             new RebalanceStatus.Completed(
-                100, RebalanceOutcome.CANCELLED, false, List.of(), FIXED_INSTANT, FIXED_INSTANT));
+                100, RebalanceOutcome.CANCELLED, List.of(), FIXED_INSTANT, FIXED_INSTANT));
   }
 
   @Test
@@ -454,7 +509,7 @@ final class RebalanceCoordinatorTest {
     assertThat(status.join().lastCompleted())
         .isEqualTo(
             new RebalanceStatus.Completed(
-                100, RebalanceOutcome.COMPLETED, false, List.of(PLAN), startedAt, finishedAt));
+                100, RebalanceOutcome.COMPLETED, List.of(PLAN), startedAt, finishedAt));
   }
 
   @Test
@@ -769,6 +824,21 @@ final class RebalanceCoordinatorTest {
     public ActorFuture<Void> run(final RebalanceRun rebalance) {
       rebalance.plan(List.of(PLAN));
       return CompletableActorFuture.completed();
+    }
+  }
+
+  private static final class FailingRunner implements RebalanceRunner {
+
+    private final RuntimeException failure;
+
+    private FailingRunner(final RuntimeException failure) {
+      this.failure = failure;
+    }
+
+    @Override
+    public ActorFuture<Void> run(final RebalanceRun rebalance) {
+      rebalance.plan(List.of(PLAN));
+      throw failure;
     }
   }
 }

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
@@ -104,7 +104,9 @@ final class RebalanceForwardingTest {
             new RebalanceOverrides(2048L, Duration.ofSeconds(20), 3, null), true);
     COORDINATOR.status =
         new RebalanceStatus(
-            new RebalanceStatus.Running(9, request.overrides(), true, false, List.of()), null);
+            new RebalanceStatus.Running(9, request.overrides(), true, false, List.of()),
+            null,
+            RebalanceStatus.idle().leadershipStatus());
 
     // when
     final var response = sender.triggerRebalance(request).join();
@@ -126,7 +128,8 @@ final class RebalanceForwardingTest {
                 false,
                 List.of(PartitionRebalance.alreadyLeader("default", 1, MemberId.from("1"))),
                 Instant.parse("2024-01-01T00:00:00Z"),
-                Instant.parse("2024-01-01T00:00:05Z")));
+                Instant.parse("2024-01-01T00:00:05Z")),
+            RebalanceStatus.idle().leadershipStatus());
 
     // when
     final var response = sender.getRebalanceStatus().join();

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceForwardingTest.java
@@ -104,7 +104,8 @@ final class RebalanceForwardingTest {
             new RebalanceOverrides(2048L, Duration.ofSeconds(20), 3, null), true);
     COORDINATOR.status =
         new RebalanceStatus(
-            new RebalanceStatus.Running(9, request.overrides(), true, false, List.of()),
+            new RebalanceStatus.Running(
+                9, request.overrides(), true, false, List.of(), Instant.EPOCH),
             null,
             RebalanceStatus.idle().leadershipStatus());
 
@@ -125,7 +126,6 @@ final class RebalanceForwardingTest {
             new RebalanceStatus.Completed(
                 8,
                 RebalanceOutcome.COMPLETED,
-                false,
                 List.of(PartitionRebalance.alreadyLeader("default", 1, MemberId.from("1"))),
                 Instant.parse("2024-01-01T00:00:00Z"),
                 Instant.parse("2024-01-01T00:00:05Z")),

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
@@ -260,6 +261,35 @@ final class SequentialRebalanceRunnerTest {
     // then
     assertThat(transfers.initiated).isEmpty();
     assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.PENDING);
+  }
+
+  @Test
+  void shouldReturnTheCompletePlanForADryRunWithoutTouchingExecutionMetrics() {
+    // given
+    final var groupLeaders = leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>());
+    groupLeaders.put(1, MEMBER_2);
+    groupLeaders.put(2, MEMBER_1);
+    start(twoPartitionsConfiguration());
+    final var partitionStateGaugeBefore = partitionStateGauge(1);
+    final var partitionDurationSamplesBefore = totalPartitionDurationSamples();
+
+    // when
+    final var rebalance = planDryRun(twoPartitionsConfiguration());
+
+    // then
+    assertThat(rebalance.partitions()).hasSize(2);
+    assertThat(partitionStateGauge(1))
+        .as("a dry run must not replace the gauges left behind by a real rebalance")
+        .isEqualTo(partitionStateGaugeBefore);
+    assertThat(totalPartitionDurationSamples())
+        .as("a dry run must not record any partition-duration sample")
+        .isEqualTo(partitionDurationSamplesBefore);
+  }
+
+  private long totalPartitionDurationSamples() {
+    return registry.find("zeebe.cluster.rebalance.partition.duration").timers().stream()
+        .mapToLong(Timer::count)
+        .sum();
   }
 
   @Test

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -311,6 +311,24 @@ final class SequentialRebalanceRunnerTest {
   }
 
   @Test
+  void shouldSendTheGlobalConfigVersion() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration =
+        groupConfiguration(GROUP, Map.of(COORDINATOR, 1, MEMBER_1, 2, MEMBER_2, 3));
+
+    // when
+    start(configuration);
+
+    // then
+    final var leaderCheck = new ClusterConfigurationCoordinatorCheck(() -> configuration);
+    assertThat(
+            leaderCheck.validate(
+                COORDINATOR, transfers.lastInitiated().request().coordinatorConfigVersion()))
+        .isEmpty();
+  }
+
+  @Test
   void shouldApplyTheRebalancesOverridesToEachTransfer() {
     // given
     leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);


### PR DESCRIPTION
Exposes coordinated leadership rebalancing through the cluster-wide v2 REST API at `/cluster/v2/rebalance`.

The supported requests are:

- Trigger a rebalance: accepts an optional dry-run flag and per-rebalance overrides for the replication lag threshold, replication timeout, maximum transfer attempts and leader wait timeout. An absent body uses the configured settings. Returns the initial rebalance status.
- Get rebalance status: reports the current balance of each partition, any running rebalance and the last completed rebalance.
- Cancel current rebalance: stops a running rebalance once any transfer in flight has finished, and returns whether a rebalance was running.

Requests use the cluster-admin security chain and are forwarded to the current rebalance coordinator.

Examples:

#### Trigger a rebalance

`POST http://localhost:8080/cluster/v2/rebalance` -> `202 Accepted`

Request:

```jsonc
{
  "dryRun": false, // Whether to plan the rebalance without transferring leadership
  "replicationLagThreshold": 1024, // Maximum permitted lag of the desired leader, in bytes
  "replicationTimeout": "PT60S", // Maximum time to wait for the desired leader to catch up, as an ISO-8601 duration
  "maxTransferAttempts": 3, // Maximum attempts to prompt the desired leader to take over
  "leaderWaitTimeout": "PT30S" // Maximum time to wait for a partition to acquire a leader, as an ISO-8601 duration
}
```

Response:

```jsonc
{
  "state": "BALANCING", // BALANCED, BALANCING, or UNBALANCED
  "partitions": [
    {
      "physicalTenantId": "",
      "partitionId": 0,
      "currentLeader": null, // Current broker ID, or null if leaderless
      "desiredLeader": 0, // Highest-priority broker ID
      "state": "TRANSFERRING" // BALANCED, TRANSFERRING, or UNBALANCED
    }
  ],
  "runningRebalance": {
    "rebalanceId": 123,
    "startedAt": "2026-08-20T09:30:00Z",
    "dryRun": false,
    "cancelRequested": false,
    "partitions": [
      {
        "physicalTenantId": "",
        "partitionId": 0,
        "currentLeader": null, // Leader last observed by this rebalance
        "desiredLeader": 0, // Leader selected by the plan
        "progress": "TRANSFERRING", // PENDING, TRANSFERRING, or COMPLETED
        "result": null // Terminal result, or null until completed
      }
    ]
  },
  "lastCompletedRebalance": null // Last completed non-dry-run rebalance, or null
}
```

#### Get rebalance status

`GET http://localhost:8080/cluster/v2/rebalance` -> `200 OK`

Response:

```jsonc
{
  "state": "BALANCED", // BALANCED, BALANCING, or UNBALANCED
  "partitions": [...], // Current per-partition balance state, as above
  "runningRebalance": null, // Running rebalance, or null
  "lastCompletedRebalance": {
    "rebalanceId": 123,
    "startedAt": "2026-08-20T09:30:00Z",
    "finishedAt": "2026-08-20T09:30:05Z",
    "result": "COMPLETED", // COMPLETED, CANCELLED, or FAILED
    "partitions": [...] // Final per-partition progress and results
  }
}
```

#### Cancel the current rebalance

`DELETE http://localhost:8080/cluster/v2/rebalance` -> `200 OK`

Response:

```jsonc
{
  "wasRunning": false // Whether a running rebalance was asked to stop
}
```

Closes #56818.

BREAKING CHANGE: Non-backwards compatible changes to the in-development rebalance protocol - specifically updates to the CompletedRebalance message schema. This protocol is new for 8.10 and until this endpoint is merged there's no way for trigger the rebalances that actually cause this protocol to be used.