### PR TITLE
refactor: duplicate components used in mcp-processes for redesign

### DIFF
--- a/identity/client/src/App.tsx
+++ b/identity/client/src/App.tsx
@@ -13,7 +13,8 @@ import AppRoot from "./components/global/AppRoot";
 import GlobalRoutes from "src/components/global/GlobalRoutes";
 import { LoginPage } from "src/pages/login/LoginPage.tsx";
 import Forbidden from "src/pages/forbidden/index.tsx";
-import { NotificationProvider } from "src/components/notifications";
+import { NotificationProvider as NotificationProviderV1 } from "src/components/notifications";
+import NotificationProviderV2 from "src/components/notificationsV2/NotificationProvider";
 import { Paths } from "src/components/global/routePaths";
 import { SetupPage } from "src/pages/setup/SetupPage";
 import { cleanServiceWorkers } from "src/utility/cleanServiceWorkers.ts";
@@ -22,6 +23,11 @@ import { DocsUrlProvider } from "./components/documentation/DocsUrlContext.tsx";
 import { docsUrl } from "src/configuration";
 import { queryClient } from "src/utility/api/queryClient";
 import ErrorNotificationBridge from "src/utility/api/ErrorNotificationBridge";
+import { IS_NEW_DESIGN_SYSTEM_ENABLED } from "./feature-flags.ts";
+
+const NotificationProvider = IS_NEW_DESIGN_SYSTEM_ENABLED
+  ? NotificationProviderV2
+  : NotificationProviderV1;
 
 const App: FC = () => {
   useEffect(() => {

--- a/identity/client/src/components/documentationV2/index.tsx
+++ b/identity/client/src/components/documentationV2/index.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from "styled-components";
+import { Link as BaseLink } from "@carbon/react";
+import { FC, ReactNode } from "react";
+import useTranslate from "../../utility/localization";
+import { useDocsUrl } from "../documentation/DocsUrlContext";
+import { Launch } from "@carbon/react/icons";
+
+export const DocumentationDescription = styled.p`
+  margin-top: var(--cds-spacing-04);
+  max-width: none;
+  text-align: left;
+`;
+
+const Link = styled(BaseLink)`
+  .cds--link__icon {
+    margin-inline-start: 0.25rem;
+  }
+`;
+
+export const LightLink = styled(Link)`
+  display: inline;
+  color: var(--cds-link-inverse) !important;
+`;
+
+type DocumentationLinkProps = {
+  children?: ReactNode;
+  light?: boolean;
+  path?: string;
+  withIcon?: boolean;
+};
+
+export const documentationHref = (
+  docsUrl: string,
+  path: DocumentationLinkProps["path"],
+) => `${docsUrl}${path}`;
+
+export const DocumentationLink: FC<DocumentationLinkProps> = ({
+  path = "",
+  light = false,
+  withIcon = false,
+  children,
+}) => {
+  const LinkComponent = light ? LightLink : Link;
+  const { Translate } = useTranslate();
+  const docsUrl = useDocsUrl();
+
+  return (
+    <LinkComponent
+      href={documentationHref(docsUrl, path)}
+      data-test="documentation-link"
+      target="_blank"
+      renderIcon={withIcon ? () => <Launch aria-label="Launch" /> : undefined}
+    >
+      {children || <Translate>documentation</Translate>}
+    </LinkComponent>
+  );
+};

--- a/identity/client/src/components/entityListV2/EntityList.tsx
+++ b/identity/client/src/components/entityListV2/EntityList.tsx
@@ -1,0 +1,547 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, Fragment, ReactNode, useMemo } from "react";
+import {
+  Button,
+  DataTable,
+  DataTableSkeleton,
+  Link,
+  OverflowMenu,
+  OverflowMenuItem,
+  Table,
+  TableBody,
+  TableCell,
+  TableExpandHeader,
+  TableExpandRow,
+  TableExpandedRow,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSelectAll,
+  TableSelectRow,
+  TableToolbar,
+  TableToolbarContent,
+  Pagination,
+  Tooltip,
+} from "@carbon/react";
+import styled from "styled-components";
+import { ButtonKind } from "@carbon/react/lib/components/Button/Button";
+import { Add, CarbonIconType } from "@carbon/react/icons";
+import { DocumentationLink } from "src/components/documentationV2";
+import Flex from "src/components/layoutV2/Flex";
+import useTranslate from "src/utility/localization";
+import { StyledTableContainer } from "./components";
+import { PageResult, SortConfig } from "src/utility/api";
+import SearchBar from "./SearchBar";
+
+const StyledTableCell = styled(TableCell)<{ $isClickable?: boolean }>`
+  cursor: ${({ $isClickable }) => ($isClickable ? "pointer" : "auto")};
+`;
+
+const TooltipTrigger = styled.button`
+  all: unset;
+`;
+
+const StyledToolTip = styled(Tooltip)`
+  .cds--tooltip-content {
+    max-inline-size: 28rem;
+  }
+`;
+
+export type EntityData = {
+  [key: string]: string | object | boolean | number | null;
+} & {
+  id?: string;
+};
+
+type HeaderData<D extends EntityData> = {
+  [K in keyof D as D[K] extends string | ReactNode ? K : never]: D[K];
+};
+
+export type DataTableHeader<D extends EntityData> = {
+  header: string;
+  key: Extract<keyof HeaderData<D>, string | ReactNode>;
+  isSortable?: boolean;
+};
+
+export type EntityListHeader<D extends EntityData> = DataTableHeader<D> & {
+  key: Extract<keyof HeaderData<D>, string>;
+};
+
+type TextMenuItem<D> = {
+  label: string;
+  onClick: (entity: D) => void;
+  isDangerous?: boolean;
+  disabled?: boolean | ((entity: D) => boolean);
+  hidden?: boolean;
+};
+
+type MenuItem<D> = TextMenuItem<D> & {
+  icon?: CarbonIconType;
+};
+
+type EntityListProps<D extends EntityData> = {
+  description?: ReactNode | string;
+  documentationPath?: string;
+  searchPlaceholder?: string;
+  searchKey?: string;
+  data: D[] | null | undefined;
+  headers: DataTableHeader<D>[];
+  addEntityLabel?: string | null;
+  addEntityDisabled?: boolean;
+  onAddEntity?: () => void;
+  onEntityClick?: (element: D) => void;
+  menuItems?:
+    | [MenuItem<D>]
+    | [MenuItem<D>, MenuItem<D>]
+    | [TextMenuItem<D>, TextMenuItem<D>, TextMenuItem<D>];
+  loading?: boolean;
+  isInsideModal?: boolean;
+  title?: ReactNode;
+  batchSelection?: {
+    onSelect: (selected: D) => unknown;
+    onUnselect: (selected: D) => unknown;
+    onSelectAll: (selected: D[]) => unknown;
+    isSelected: (selected: D) => boolean;
+  };
+  maxDisplayCellLength?: number;
+  setPageNumber?: (page: number) => void;
+  setPageSize?: (pageSize: number) => void;
+  pageSizes?: number[];
+  page?:
+    | ({ pageNumber: number; pageSize: number } & Partial<PageResult>)
+    | undefined;
+  setSort?: (sort: SortConfig[] | undefined) => void;
+  setSearch?: (search: Record<string, string> | undefined) => void;
+  renderExpandedRow?: (entity: D) => ReactNode;
+};
+
+const MAX_ICON_ACTIONS = 2;
+const PAGESIZES = [10, 20, 30, 40, 50];
+
+const EntityList = <D extends EntityData>({
+  title,
+  isInsideModal = false,
+  description,
+  documentationPath,
+  headers,
+  data,
+  addEntityLabel,
+  addEntityDisabled,
+  onAddEntity,
+  onEntityClick,
+  menuItems,
+  loading,
+  batchSelection,
+  searchPlaceholder,
+  searchKey,
+  maxDisplayCellLength = 50,
+  setPageNumber = () => {},
+  setPageSize = () => {},
+  pageSizes = PAGESIZES,
+  page: pageData,
+  setSort = () => {},
+  setSearch = () => {},
+  renderExpandedRow,
+}: EntityListProps<D>): ReturnType<FC> => {
+  const { t } = useTranslate("components");
+
+  const hasMenu = menuItems && menuItems.length > 0;
+  const isExpandable = !!renderExpandedRow;
+
+  const [index, tableData] = useMemo(() => {
+    const entityIndex: { [id: string]: D } = {};
+    const entityTableData: (D & { id: string })[] = [];
+
+    data?.forEach((dataset) => {
+      const id = dataset.id || (Date.now() + Math.random()).toString();
+      entityIndex[id] = dataset;
+      entityTableData.push({ ...dataset, id });
+    });
+
+    return [entityIndex, entityTableData];
+  }, [data]);
+
+  const areRowsEmpty = !tableData || tableData.length === 0;
+
+  const isEntityClickable = onEntityClick !== undefined;
+
+  const handleEntityClick = (id: string) => () => {
+    const textSelection = window.getSelection();
+
+    if (
+      isEntityClickable &&
+      (!textSelection || textSelection.toString().length === 0)
+    )
+      onEntityClick(index[id]);
+  };
+
+  const handleMenuItemClick =
+    (id: string, onClick: MenuItem<D>["onClick"]) => () =>
+      onClick(index[id]);
+
+  const selectedLength =
+    (batchSelection && data?.filter(batchSelection.isSelected).length) || 0;
+
+  const tableContainerProps = isInsideModal
+    ? { $compact: true }
+    : {
+        title,
+        description:
+          !description && !documentationPath ? undefined : (
+            <>
+              {description && <p>{description}</p>}
+              {documentationPath && (
+                <DocumentationLink path={documentationPath}>
+                  {t("Learn more")}
+                </DocumentationLink>
+              )}
+            </>
+          ),
+      };
+
+  const rowColSpan =
+    headers.length +
+    (isExpandable ? 1 : 0) +
+    (batchSelection ? 1 : 0) +
+    (hasMenu ? 1 : 0);
+
+  return (
+    <DataTable
+      rows={tableData}
+      headers={headers}
+      isSortable
+      sortRow={() => {
+        return 0;
+      }}
+    >
+      {({
+        rows,
+        getHeaderProps,
+        getRowProps,
+        getExpandedRowProps,
+        getToolbarProps,
+        getTableProps,
+      }) => (
+        <StyledTableContainer {...tableContainerProps}>
+          <>
+            {(searchKey || addEntityLabel) && (
+              <TableToolbar {...getToolbarProps()}>
+                <TableToolbarContent>
+                  {searchKey && (
+                    <SearchBar
+                      searchKey={searchKey}
+                      searchPlaceholder={searchPlaceholder}
+                      onSearch={setSearch}
+                    />
+                  )}
+                  {addEntityLabel && (
+                    <Button
+                      renderIcon={Add}
+                      onClick={onAddEntity}
+                      disabled={addEntityDisabled}
+                    >
+                      {addEntityLabel}
+                    </Button>
+                  )}
+                </TableToolbarContent>
+              </TableToolbar>
+            )}
+            {loading && (
+              <DataTableSkeleton
+                columnCount={headers.length}
+                headers={headers}
+                showHeader={false}
+                showToolbar={false}
+                style={{ padding: 0 }}
+              />
+            )}
+
+            {!loading && (
+              <Table {...getTableProps()}>
+                <TableHead>
+                  <TableRow>
+                    {isExpandable && <TableExpandHeader />}
+                    {batchSelection && (
+                      <TableSelectAll
+                        id="select-all"
+                        name="select-all"
+                        checked={selectedLength === data?.length}
+                        indeterminate={
+                          selectedLength > 0 && selectedLength !== data?.length
+                        }
+                        onSelect={() => {
+                          if (data) {
+                            if (selectedLength === data.length) {
+                              batchSelection.onSelectAll([]);
+                            } else {
+                              batchSelection.onSelectAll(data);
+                            }
+                          }
+                        }}
+                      />
+                    )}
+                    {headers.map((header) => {
+                      return (
+                        <TableHeader
+                          {...getHeaderProps({
+                            header: header,
+                            isSortable: !!header.isSortable,
+                            onClick: (_, { sortHeaderKey, sortDirection }) => {
+                              if (sortDirection === "NONE") {
+                                setSort(undefined);
+                                return;
+                              }
+
+                              setSort([
+                                {
+                                  field: sortHeaderKey,
+                                  order: sortDirection,
+                                },
+                              ]);
+                            },
+                          })}
+                          key={`applications-header-${header.header}`}
+                        >
+                          {header.header}
+                        </TableHeader>
+                      );
+                    })}
+                    {hasMenu && <TableExpandHeader />}
+                  </TableRow>
+                </TableHead>
+                {areRowsEmpty && !loading && (
+                  <TableBody>
+                    <TableRow>
+                      <StyledTableCell colSpan={rowColSpan}>
+                        {t("No results found")}
+                      </StyledTableCell>
+                    </TableRow>
+                  </TableBody>
+                )}
+                {!areRowsEmpty && (
+                  <TableBody>
+                    {rows.map((row) => {
+                      const { id: rowId, cells, isExpanded } = row;
+
+                      const cellContent = (
+                        <>
+                          {batchSelection && (
+                            <TableSelectRow
+                              id={`select-${rowId}`}
+                              name={`select-${rowId}`}
+                              checked={batchSelection.isSelected(index[rowId])}
+                              onSelect={() => {
+                                const item = index[rowId];
+
+                                if (batchSelection.isSelected(item)) {
+                                  batchSelection.onUnselect(item);
+                                } else {
+                                  batchSelection.onSelect(item);
+                                }
+                              }}
+                            />
+                          )}
+                          {cells.map(({ id: cellId, value }, index) => {
+                            const displayValue = Array.isArray(value)
+                              ? value.join(", ")
+                              : value;
+
+                            const truncatedValue =
+                              displayValue &&
+                              displayValue.toString().length >
+                                maxDisplayCellLength ? (
+                                <StyledToolTip
+                                  label={displayValue}
+                                  autoAlign
+                                  align="bottom"
+                                >
+                                  <TooltipTrigger>
+                                    {displayValue
+                                      .substring(0, maxDisplayCellLength)
+                                      .concat("…")}
+                                  </TooltipTrigger>
+                                </StyledToolTip>
+                              ) : (
+                                displayValue
+                              );
+
+                            return (
+                              <StyledTableCell
+                                key={cellId}
+                                onClick={handleEntityClick(rowId)}
+                                $isClickable={isEntityClickable}
+                              >
+                                {index === 0 && isEntityClickable ? (
+                                  <Link>{displayValue}</Link>
+                                ) : (
+                                  truncatedValue
+                                )}
+                              </StyledTableCell>
+                            );
+                          })}
+                          {hasMenu && (
+                            <TableCell>
+                              {menuItems?.length > MAX_ICON_ACTIONS ? (
+                                <OverflowMenu flipped>
+                                  {getVisibleMenuItems(
+                                    menuItems,
+                                    index[rowId],
+                                  ).map(
+                                    ({
+                                      label,
+                                      onClick,
+                                      isDangerous,
+                                      disabled,
+                                    }) => (
+                                      <OverflowMenuItem
+                                        key={`${label}-${rowId}`}
+                                        itemText={<p>{label}</p>}
+                                        isDelete={isDangerous}
+                                        disabled={resolveMenuItemFlag(
+                                          disabled,
+                                          index[rowId],
+                                        )}
+                                        onClick={handleMenuItemClick(
+                                          rowId,
+                                          onClick,
+                                        )}
+                                      />
+                                    ),
+                                  )}
+                                </OverflowMenu>
+                              ) : (
+                                <Flex>
+                                  {getVisibleMenuItems(
+                                    menuItems,
+                                    index[rowId],
+                                  ).map((menuItem) => {
+                                    const {
+                                      label,
+                                      onClick,
+                                      icon,
+                                      isDangerous,
+                                      disabled,
+                                    } = menuItem as MenuItem<D>;
+
+                                    const kind: ButtonKind = isDangerous
+                                      ? "danger--ghost"
+                                      : "ghost";
+                                    const hasIconOnly = !!icon && !isDangerous;
+
+                                    return (
+                                      <Button
+                                        key={`${label}-${rowId}`}
+                                        kind={kind}
+                                        size="md"
+                                        disabled={resolveMenuItemFlag(
+                                          disabled,
+                                          index[rowId],
+                                        )}
+                                        hasIconOnly={hasIconOnly}
+                                        renderIcon={icon}
+                                        tooltipAlignment="end"
+                                        iconDescription={label}
+                                        onClick={handleMenuItemClick(
+                                          rowId,
+                                          onClick,
+                                        )}
+                                      >
+                                        {hasIconOnly ? "" : label}
+                                      </Button>
+                                    );
+                                  })}
+                                </Flex>
+                              )}
+                            </TableCell>
+                          )}
+                        </>
+                      );
+
+                      if (!isExpandable) {
+                        return <TableRow key={rowId}>{cellContent}</TableRow>;
+                      }
+
+                      return (
+                        <Fragment key={rowId}>
+                          <TableExpandRow
+                            // > Warning: A props object containing a "key" prop is being spread into JSX.
+                            // A key is already configured in the fragment. Overwriting the
+                            // key prevents the error from being reported.
+                            {...getRowProps({ row })}
+                            key={undefined}
+                          >
+                            {cellContent}
+                          </TableExpandRow>
+                          <TableExpandedRow
+                            colSpan={rowColSpan}
+                            {...getExpandedRowProps({ row })}
+                          >
+                            {isExpanded &&
+                              index[rowId] &&
+                              renderExpandedRow(index[rowId])}
+                          </TableExpandedRow>
+                        </Fragment>
+                      );
+                    })}
+                  </TableBody>
+                )}
+              </Table>
+            )}
+          </>
+          {!!pageData?.totalItems &&
+            pageData.totalItems > Math.min(...pageSizes) && (
+              <Pagination
+                backwardText={t("Previous page")}
+                forwardText={t("Next page")}
+                itemsPerPageText={t("Items per page:")}
+                page={pageData.pageNumber}
+                pageNumberText={t("Page Number")}
+                pageSize={pageData.pageSize}
+                pageSizes={pageSizes}
+                totalItems={pageData.totalItems}
+                onChange={({
+                  page,
+                  pageSize,
+                }: {
+                  page: number;
+                  pageSize: number;
+                }) => {
+                  setPageNumber(page);
+                  setPageSize(pageSize);
+                }}
+              />
+            )}
+        </StyledTableContainer>
+      )}
+    </DataTable>
+  );
+};
+
+function getVisibleMenuItems<D>(
+  menuItems: (MenuItem<D> | TextMenuItem<D>)[] | undefined,
+  entity: D | undefined,
+): (MenuItem<D> | TextMenuItem<D>)[] {
+  if (!menuItems) {
+    return [];
+  }
+  return menuItems.filter((item) => !resolveMenuItemFlag(item.hidden, entity));
+}
+
+function resolveMenuItemFlag<D>(
+  flag: boolean | ((entity: D) => boolean) | undefined,
+  entity: D | undefined,
+): boolean {
+  if (typeof flag === "function") {
+    return entity !== undefined && flag(entity);
+  }
+  return !!flag;
+}
+
+export default EntityList;

--- a/identity/client/src/components/entityListV2/SearchBar.tsx
+++ b/identity/client/src/components/entityListV2/SearchBar.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { TableToolbarSearch } from "@carbon/react";
+import { FC, useEffect, useState } from "react";
+
+import useDebounce from "react-debounced";
+
+type SearchBarProps = {
+  searchKey: string;
+  onSearch: (value: Record<string, string> | undefined) => void;
+  searchPlaceholder?: string;
+  debounce?: number;
+};
+
+export default function SearchBar({
+  searchPlaceholder,
+  searchKey,
+  onSearch,
+  debounce = 300,
+}: SearchBarProps): ReturnType<FC> {
+  const [search, setSearchState] = useState<string>("");
+  const debounceFn = useDebounce(debounce);
+
+  useEffect(() => {
+    if (!searchKey) {
+      return;
+    }
+
+    if (!search || search.trim().length === 0) {
+      debounceFn(() => onSearch(undefined));
+      return;
+    }
+
+    debounceFn(() => onSearch({ [searchKey]: search }));
+  }, [debounceFn, onSearch, search, searchKey]);
+
+  return (
+    <TableToolbarSearch
+      placeholder={searchPlaceholder}
+      value={search}
+      persistent
+      onChange={(_, value = "") => {
+        setSearchState(value);
+      }}
+      onFocus={(event, handleExpand) => {
+        handleExpand(event, true);
+      }}
+      onBlur={(event, handleExpand) => {
+        const { value } = event.target;
+        if (!value) {
+          handleExpand(event, false);
+        }
+      }}
+    />
+  );
+}

--- a/identity/client/src/components/entityListV2/components.tsx
+++ b/identity/client/src/components/entityListV2/components.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from "styled-components";
+import { TableContainer } from "@carbon/react";
+
+export const DocumentationDescription = styled.p`
+  margin-top: var(--cds-spacing-04);
+  max-width: none;
+  text-align: left;
+`;
+
+export const StyledTableContainer = styled(TableContainer)`
+  .cds--skeleton {
+    padding: 0;
+  }
+`;

--- a/identity/client/src/components/entityListV2/index.ts
+++ b/identity/client/src/components/entityListV2/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export { default } from "./EntityList";
+export * from "./components";

--- a/identity/client/src/components/fallbacksV2/DetailPageFallback.tsx
+++ b/identity/client/src/components/fallbacksV2/DetailPageFallback.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, ReactNode } from "react";
+import Flex from "src/components/layoutV2/Flex";
+import {
+  BreadcrumbSkeleton,
+  Section,
+  SkeletonIcon,
+  SkeletonText,
+  TabsSkeleton,
+} from "@carbon/react";
+import { cssSize } from "src/utility/style";
+import { StackPage } from "src/components/layoutV2/Page";
+import styled from "styled-components";
+
+const StyledSkeletonText = styled(SkeletonText)`
+  margin-top: ${cssSize(1)};
+`;
+
+const StyledTabsSkeleton = styled(TabsSkeleton)`
+  ul {
+    display: flex;
+    flex-direction: row;
+  }
+`;
+
+const TabContent = styled.div`
+  padding: ${cssSize(1)};
+`;
+
+type DetailPageHeaderFallbackProps = { hasOverflowMenu?: boolean };
+
+export const DetailPageHeaderFallback: FC<DetailPageHeaderFallbackProps> = ({
+  hasOverflowMenu = true,
+}) => {
+  return (
+    <Flex>
+      <StyledSkeletonText heading width={cssSize(20)} />
+      {hasOverflowMenu && <SkeletonIcon />}
+    </Flex>
+  );
+};
+
+type DetailPageFallbackProps = {
+  children?: ReactNode;
+  hasBreadcrumb?: boolean;
+};
+
+const DetailPageFallback: FC<DetailPageFallbackProps> = ({
+  children,
+  hasBreadcrumb = false,
+}) => (
+  <StackPage>
+    <>
+      {hasBreadcrumb && <BreadcrumbSkeleton />}
+      <DetailPageHeaderFallback />
+      <Section>
+        <StyledTabsSkeleton />
+        <TabContent>{children}</TabContent>
+      </Section>
+    </>
+  </StackPage>
+);
+
+export default DetailPageFallback;

--- a/identity/client/src/components/fallbacksV2/ListPageFallback.tsx
+++ b/identity/client/src/components/fallbacksV2/ListPageFallback.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { DataTableSkeleton } from "@carbon/react";
+import Page from "src/components/layoutV2/Page";
+import styled from "styled-components";
+
+const StyledPage = styled(Page)`
+  .cds--data-table-header__description {
+    display: none;
+  }
+`;
+
+type ListPageFallbackProps = { columns?: number };
+
+const ListPageFallback: FC<ListPageFallbackProps> = ({ columns = 2 }) => (
+  <StyledPage>
+    <DataTableSkeleton columnCount={columns} />
+  </StyledPage>
+);
+
+export default ListPageFallback;

--- a/identity/client/src/components/fallbacksV2/index.tsx
+++ b/identity/client/src/components/fallbacksV2/index.tsx
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export { default as ListPageFallback } from "./ListPageFallback";
+export { default as DetailPageFallback } from "./DetailPageFallback";
+export { DetailPageHeaderFallback } from "./DetailPageFallback";

--- a/identity/client/src/components/layoutV2/Flex.tsx
+++ b/identity/client/src/components/layoutV2/Flex.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from "styled-components";
+
+const spacingOptions = {
+  small: "var(--cds-spacing-02)",
+  medium: "var(--cds-spacing-04)",
+  large: "var(--cds-spacing-06)",
+  none: "0px",
+};
+
+const Flex = styled.div<{
+  spacing?: keyof typeof spacingOptions;
+  justify?: "center" | "space-between" | "space-around" | "normal";
+  align?: "center" | "normal" | "start" | "end";
+  direction?: "column" | "row";
+}>`
+  display: flex;
+  align-items: ${({ align = "center" }) => align};
+  gap: ${({ spacing = "medium" }) => spacingOptions[spacing]};
+  justify-content: ${({ justify = "normal" }) => justify};
+  flex-direction: ${({ direction = "row" }) => direction};
+`;
+
+export default Flex;

--- a/identity/client/src/components/layoutV2/Page.tsx
+++ b/identity/client/src/components/layoutV2/Page.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, MouseEvent, ReactNode } from "react";
+import styled from "styled-components";
+import { Breadcrumb, BreadcrumbItem, Content, Stack } from "@carbon/react";
+import { styles } from "@carbon/elements";
+import { useNavigate } from "react-router-dom";
+import { DocumentationLink } from "src/components/documentationV2";
+import useTranslate from "src/utility/localization";
+
+const PageTitle = styled.h2`
+  font-size: ${styles.heading04.fontSize};
+  font-weight: ${styles.heading04.fontWeight};
+`;
+
+const PageSubTitle = styled.div`
+  font-size: ${styles.bodyCompact01.fontSize};
+  font-weight: ${styles.bodyCompact01.fontWeight};
+  letter-spacing: ${styles.bodyCompact01.letterSpacing};
+  line-height: ${styles.bodyCompact01.lineHeight};
+  color: var(--cds-text-secondary);
+`;
+
+const StackWithMargin = styled(Stack)`
+  margin-bottom: var(--cds-spacing-07);
+`;
+
+const Page = styled(Content)`
+  height: 100%;
+  padding: var(--cds-spacing-08);
+`;
+
+type PageHeaderProps = {
+  title: string;
+  linkText: string;
+  docsLinkPath?: string;
+  shouldShowDocumentationLink?: boolean;
+};
+
+export const PageHeader: FC<PageHeaderProps> = ({
+  title,
+  linkText,
+  docsLinkPath,
+  shouldShowDocumentationLink = true,
+}) => {
+  const { Translate } = useTranslate();
+
+  return (
+    <StackWithMargin gap="4">
+      <PageTitle>{title}</PageTitle>
+      {shouldShowDocumentationLink && (
+        <PageSubTitle>
+          <Translate i18nKey="moreInfo" values={{ linkText }}>
+            For more information, see documentation on{" "}
+            <DocumentationLink path={docsLinkPath} withIcon>
+              {linkText}
+            </DocumentationLink>
+          </Translate>
+        </PageSubTitle>
+      )}
+    </StackWithMargin>
+  );
+};
+
+type BreadcrumbsProps = {
+  items: {
+    href: string;
+    title: ReactNode;
+  }[];
+};
+
+export const Breadcrumbs: FC<BreadcrumbsProps> = ({ items }) => {
+  const navigate = useNavigate();
+  const onClick = (href: string) => (e: MouseEvent<HTMLLIElement>) => {
+    void navigate(href);
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return (
+    <Breadcrumb>
+      {items.map(({ href, title }) => (
+        <BreadcrumbItem href={href} onClick={onClick(href)} key={href}>
+          {title}
+        </BreadcrumbItem>
+      ))}
+    </Breadcrumb>
+  );
+};
+
+export const StackPage: FC<{ children?: ReactNode }> = ({ children }) => (
+  <Page>
+    <Stack gap="6">{children}</Stack>
+  </Page>
+);
+
+export default Page;

--- a/identity/client/src/components/layoutV2/PageEmptyState.tsx
+++ b/identity/client/src/components/layoutV2/PageEmptyState.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { Add } from "@carbon/react/icons";
+import { FC } from "react";
+import { documentationHref } from "src/components/documentationV2";
+import { useDocsUrl } from "../documentation/DocsUrlContext";
+import useTranslate from "src/utility/localization";
+
+type PageEmptyStateProps = {
+  resourceTypeTranslationKey: string;
+  docsLinkPath?: string;
+  handleClick: () => void;
+};
+
+const PageEmptyState: FC<PageEmptyStateProps> = ({
+  resourceTypeTranslationKey,
+  docsLinkPath = "",
+  handleClick,
+}) => {
+  const { t } = useTranslate();
+  const docsUrl = useDocsUrl();
+
+  const resourceTypeText = t(resourceTypeTranslationKey).toLowerCase();
+
+  return (
+    <C3EmptyState
+      heading={t("emptyStateTitleCreate", {
+        resourceType: resourceTypeText,
+      })}
+      description={t("emptyStateSubtitleCreate", {
+        resourceType: resourceTypeText,
+      })}
+      button={{
+        label: t("emptyStateButtonCreate", {
+          resourceType: resourceTypeText,
+        }),
+        onClick: handleClick,
+        icon: Add,
+      }}
+      link={{
+        href: documentationHref(docsUrl, docsLinkPath),
+        label: t("emptyStateLearnText", {
+          resourceType: resourceTypeText,
+        }),
+      }}
+    />
+  );
+};
+
+export default PageEmptyState;

--- a/identity/client/src/components/notificationsV2/InlineNotification.tsx
+++ b/identity/client/src/components/notificationsV2/InlineNotification.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from "styled-components";
+import { FC } from "react";
+import {
+  ActionableNotification,
+  InlineNotification as CarbonInlineNotification,
+} from "@carbon/react";
+import useTranslate from "src/utility/localization";
+import type { NotificationOptions } from "../notifications/NotificationContext";
+
+const StyledInlineNotification = styled(CarbonInlineNotification)`
+  max-width: 100%;
+  margin: var(--cds-spacing-05) 0 var(--cds-spacing-05);
+`;
+
+const StyledActionableNotification = styled(ActionableNotification)`
+  max-width: 100%;
+  margin: var(--cds-spacing-05) 0 var(--cds-spacing-05);
+`;
+
+type InlineNotificationProps = NotificationOptions & {
+  actionButton?: {
+    label: string;
+    onClick: () => void;
+  };
+};
+
+export const InlineNotification: FC<InlineNotificationProps> = ({
+  kind = "info",
+  title,
+  role,
+  actionButton,
+}) => {
+  const props = {
+    kind,
+    hideCloseButton: true,
+    lowContrast: true,
+    role: role ?? (kind === "error" ? "alert" : "status"),
+    title,
+  };
+
+  return actionButton ? (
+    <StyledActionableNotification
+      {...props}
+      inline
+      actionButtonLabel={actionButton?.label}
+      onActionButtonClick={actionButton?.onClick}
+    />
+  ) : (
+    <StyledInlineNotification {...props} />
+  );
+};
+
+export const TranslatedInlineNotification: FC<InlineNotificationProps> = ({
+  title,
+  actionButton,
+  ...notificationProps
+}) => {
+  const { t } = useTranslate();
+
+  return (
+    <InlineNotification
+      title={t(title)}
+      actionButton={
+        actionButton && { ...actionButton, label: t(actionButton.label) }
+      }
+      {...notificationProps}
+    />
+  );
+};
+
+type ErrorInlineNotificationProps = Omit<InlineNotificationProps, "kind">;
+
+export const ErrorInlineNotification: FC<ErrorInlineNotificationProps> = ({
+  title,
+  role,
+  actionButton,
+}) => (
+  <InlineNotification
+    kind="error"
+    title={title}
+    role={role}
+    actionButton={actionButton}
+  />
+);
+
+export const TranslatedErrorInlineNotification: FC<
+  Omit<InlineNotificationProps, "kind">
+> = ({ title, actionButton, ...messageProps }) => {
+  const { t } = useTranslate();
+
+  return (
+    <ErrorInlineNotification
+      title={t(title)}
+      actionButton={
+        actionButton && { ...actionButton, label: t(actionButton.label) }
+      }
+      {...messageProps}
+    />
+  );
+};
+
+export default InlineNotification;

--- a/identity/client/src/components/notificationsV2/Notification.tsx
+++ b/identity/client/src/components/notificationsV2/Notification.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useRef, useState } from "react";
+import { CSSTransition } from "react-transition-group";
+import styled from "styled-components";
+import { ToastNotification } from "@carbon/react";
+import type { NotificationOptions } from "../notifications/NotificationContext";
+
+const NOTIFICATION_TIMEOUT = 10000;
+const TRANSITION_DURATION = 300;
+
+const StyledCSSTransition = styled(CSSTransition)`
+  margin-bottom: var(--cds-spacing-03);
+
+  &.toast-enter {
+    transform: translateX(120%);
+  }
+
+  &.toast-enter-active {
+    transform: translateX(0);
+    transition: transform ${TRANSITION_DURATION}ms ease-in-out;
+  }
+
+  &.toast-exit-active {
+    transform: translateX(120%);
+    transition: transform ${TRANSITION_DURATION}ms ease-in-out;
+  }
+
+  &.toast-exit-done {
+    display: none;
+  }
+`;
+
+export type NotificationProps = NotificationOptions & {
+  onClose: () => void;
+};
+
+const Notification: FC<NotificationProps> = ({
+  kind = "info",
+  title,
+  subtitle,
+  role,
+  onClose,
+}) => {
+  const [show, setShow] = useState(false);
+  // https://github.com/reactjs/react-transition-group/issues/668#issuecomment-695162879
+  const nodeRef = useRef(null);
+
+  useEffect(() => {
+    setShow(true);
+    setTimeout(() => setShow(false), NOTIFICATION_TIMEOUT);
+  }, []);
+
+  return (
+    <StyledCSSTransition
+      in={show}
+      timeout={TRANSITION_DURATION}
+      classNames="toast"
+      onExited={onClose}
+      unmountOnExit
+      nodeRef={nodeRef}
+    >
+      <div ref={nodeRef}>
+        <ToastNotification
+          kind={kind}
+          lowContrast
+          onClose={() => {
+            setShow(false);
+            return false;
+          }}
+          role={role || (kind === "error" ? "alert" : "status")}
+          title={title}
+          subtitle={subtitle}
+        />
+      </div>
+    </StyledCSSTransition>
+  );
+};
+
+export default Notification;

--- a/identity/client/src/components/notificationsV2/NotificationContainer.tsx
+++ b/identity/client/src/components/notificationsV2/NotificationContainer.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from "styled-components";
+import { FC, ReactNode } from "react";
+import { TransitionGroup } from "react-transition-group";
+
+const NotificationWrapper = styled.div`
+  position: fixed;
+  top: 3.5rem;
+  right: var(--cds-spacing-03);
+  z-index: 10000;
+  max-width: 100%;
+`;
+
+const NotificationContainer: FC<{ children?: ReactNode }> = ({ children }) => (
+  <NotificationWrapper>
+    <TransitionGroup>{children}</TransitionGroup>
+  </NotificationWrapper>
+);
+
+export default NotificationContainer;

--- a/identity/client/src/components/notificationsV2/NotificationProvider.tsx
+++ b/identity/client/src/components/notificationsV2/NotificationProvider.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, ReactNode, useMemo, useState } from "react";
+import Notification from "./Notification";
+import NotificationContainer from "./NotificationContainer";
+import NotificationContext, {
+  EnqueueNotification,
+  NotificationOptions,
+} from "../notifications/NotificationContext";
+
+const NotificationProvider: FC<{ children?: ReactNode }> = ({ children }) => {
+  const [notifications, setNotifications] = useState<
+    (NotificationOptions & { id: string })[]
+  >([]);
+  const contextValue: { enqueueNotification: EnqueueNotification } = useMemo(
+    () => ({
+      enqueueNotification: (notification) =>
+        setNotifications((prevNotifications) => [
+          { ...notification, id: (Date.now() + Math.random()).toString() },
+          ...prevNotifications,
+        ]),
+    }),
+    [],
+  );
+
+  const removeNotification = (id: string) => () => {
+    setNotifications((prevNotifications) =>
+      prevNotifications.filter((notification) => notification.id !== id),
+    );
+  };
+
+  return (
+    <NotificationContext.Provider value={contextValue}>
+      <NotificationContainer>
+        {notifications.map(({ id, ...notificationProps }) => (
+          <Notification
+            key={id}
+            onClose={removeNotification(id)}
+            {...notificationProps}
+          />
+        ))}
+      </NotificationContainer>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export default NotificationProvider;

--- a/identity/client/src/pages/mcp-processes/ListV2.tsx
+++ b/identity/client/src/pages/mcp-processes/ListV2.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useMemo } from "react";
+import useTranslate from "src/utility/localization";
+import Page, { PageHeader } from "src/components/layoutV2/Page";
+import EntityList, {
+  type DataTableHeader,
+} from "src/components/entityListV2/EntityList";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+import { useMcpProcessTools, type McpProcessTool } from "./useMcpProcessTools";
+import { ExpandedToolDetails } from "./componentsV2/ExpandedToolDetails";
+
+type ListProps = {
+  isTenantsApiEnabled: boolean;
+};
+
+const List: FC<ListProps> = ({ isTenantsApiEnabled }) => {
+  const { t } = useTranslate("mcpProcesses");
+  const { t: tComponents } = useTranslate();
+
+  const {
+    processTools,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+    ...paginationProps
+  } = useMcpProcessTools();
+
+  const headers = useMemo<DataTableHeader<McpProcessTool>[]>(() => {
+    const columns: DataTableHeader<McpProcessTool>[] = [
+      { header: t("toolName"), key: "toolName", isSortable: true },
+      { header: t("toolDescription"), key: "toolDescription" },
+      { header: t("processName"), key: "processDefinitionName" },
+      { header: t("version"), key: "processDefinitionVersion" },
+    ];
+
+    if (isTenantsApiEnabled) {
+      columns.push({ header: t("tenant"), key: "tenantId" });
+    }
+
+    return columns;
+  }, [isTenantsApiEnabled, t]);
+
+  return (
+    <Page>
+      <PageHeader
+        title={tComponents("mcpProcesses")}
+        linkText={tComponents("mcpProcesses").toLowerCase()}
+        docsLinkPath="/components/admin/mcp-processes/"
+      />
+      <EntityList
+        data={processTools}
+        headers={headers}
+        loading={loading}
+        searchKey="toolName"
+        searchPlaceholder={t("searchByToolName")}
+        renderExpandedRow={(entity) => <ExpandedToolDetails tool={entity} />}
+        {...paginationProps}
+      />
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title={t("mcpProcessesCouldNotLoad")}
+          actionButton={{
+            label: tComponents("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+    </Page>
+  );
+};
+
+export default List;

--- a/identity/client/src/pages/mcp-processes/componentsV2/ExpandedToolDetails.tsx
+++ b/identity/client/src/pages/mcp-processes/componentsV2/ExpandedToolDetails.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { styles } from "@carbon/elements";
+import styled from "styled-components";
+import useTranslate from "src/utility/localization";
+import type { McpProcessTool } from "../useMcpProcessTools";
+
+const SectionHeading = styled.h3`
+  font-size: ${styles.heading01.fontSize};
+  font-weight: ${styles.heading01.fontWeight};
+  line-height: ${styles.heading01.lineHeight};
+  letter-spacing: ${styles.heading01.letterSpacing};
+`;
+
+const SectionBody = styled.p`
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-inline-size: 80ch; // Keep descriptions at a readable line length
+
+  &[data-fallback="true"] {
+    font-style: italic;
+    color: var(--cds-text-secondary);
+  }
+
+  &:not(:last-child) {
+    margin-block-end: var(--cds-spacing-06);
+  }
+`;
+
+export const ExpandedToolDetails: FC<{ tool: McpProcessTool }> = ({ tool }) => {
+  const { t } = useTranslate("mcpProcesses");
+  const properties = tool.toolProperties;
+
+  return (
+    <>
+      <SectionHeading>{t("toolPurpose")}</SectionHeading>
+      <SectionBody data-fallback={!properties.purpose}>
+        {properties.purpose ?? t("informationMissing")}
+      </SectionBody>
+
+      <SectionHeading>{t("toolResults")}</SectionHeading>
+      <SectionBody data-fallback={!properties.results}>
+        {properties.results ?? t("informationMissing")}
+      </SectionBody>
+
+      <SectionHeading>{t("toolWhenToUse")}</SectionHeading>
+      <SectionBody data-fallback={!properties.whenToUse}>
+        {properties.whenToUse ?? t("informationMissing")}
+      </SectionBody>
+
+      <SectionHeading>{t("toolWhenNotToUse")}</SectionHeading>
+      <SectionBody data-fallback={!properties.whenNotToUse}>
+        {properties.whenNotToUse ?? t("informationMissing")}
+      </SectionBody>
+    </>
+  );
+};

--- a/identity/client/src/pages/mcp-processes/index.tsx
+++ b/identity/client/src/pages/mcp-processes/index.tsx
@@ -8,9 +8,13 @@
 
 import { FC, lazy, Suspense } from "react";
 import { ListPageFallback } from "src/components/fallbacks";
+import { ListPageFallback as ListPageFallbackV2 } from "src/components/fallbacksV2";
 import PageRoutes from "src/components/router/PageRoutes";
+import { IS_NEW_DESIGN_SYSTEM_ENABLED } from "src/feature-flags";
 
-const List = lazy(() => import("./List"));
+const List = lazy(() =>
+  IS_NEW_DESIGN_SYSTEM_ENABLED ? import("./ListV2") : import("./List"),
+);
 
 type McpProcessesProps = {
   isTenantsApiEnabled: boolean;
@@ -19,7 +23,15 @@ type McpProcessesProps = {
 const McpProcesses: FC<McpProcessesProps> = ({ isTenantsApiEnabled }) => (
   <PageRoutes
     indexElement={
-      <Suspense fallback={<ListPageFallback />}>
+      <Suspense
+        fallback={
+          IS_NEW_DESIGN_SYSTEM_ENABLED ? (
+            <ListPageFallbackV2 />
+          ) : (
+            <ListPageFallback />
+          )
+        }
+      >
         <List isTenantsApiEnabled={isTenantsApiEnabled} />
       </Suspense>
     }


### PR DESCRIPTION
## Description

This PR prepares the "MCP Processes" page in Admin for the design system redesign. It **duplicates** all UI components of the app and every shared component they consume into a "V2". 
If the `IS_NEW_DESIGN_SYSTEM_ENABLED` is enabled, the V2 components are used. I already had to duplicate the `documentation` and `notification` component stuff. Both have a React context:
- For the documentation, I have been able to reuse the same context and provider between v1 and v2.
- For notifications, the context provider renders the notification components and thus cannot be shared. Here, I share the context itself and render the v1 or v2 provider in `App.tsx` based on the feature flag.

## Related issues

relates #60414
