### PR TITLE
ci: harden two more apt-get-under-sudo call sites against mirror stalls

### DIFF
--- a/.github/actions/codeowners-setup-cli/action.yml
+++ b/.github/actions/codeowners-setup-cli/action.yml
@@ -34,7 +34,11 @@ runs:
 
         mkdir -p "${target_dir}"
         echo "Downloading codeowners-cli ${version} from ${download_url}"
-        curl -fsSL "${download_url}" -o "${archive_path}"
+        # --retry-all-errors: retry on any failure, not just the curl-default subset (a
+        # mid-transfer "Recv failure: Connection reset by peer" isn't retried by default),
+        # see https://github.com/camunda/camunda/actions/runs/32242321929/job/96035501009
+        curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 60 --retry-all-errors \
+          "${download_url}" -o "${archive_path}"
         tar -xzf "${archive_path}" -C "${target_dir}"
         chmod +x "${target_dir}/codeowners-cli"
         rm -f "${archive_path}"

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -229,13 +229,27 @@ runs:
       githubServer: false
       servers: ${{ steps.maven.outputs.servers }}
       mirrors: ${{ steps.maven.outputs.mirrors }}
+  - uses: ./.github/actions/apt-fast-mirror-failover
+    if: inputs.time-zone != '' && runner.os == 'Linux'
+  # tzdata is not installed in self-hosted runners. `timeout` runs inside the sudo'd
+  # root process tree so it can self-terminate a hung apt-get without nick-fields/retry
+  # having to kill across the privilege boundary -- doing that externally throws
+  # `kill EPERM` and crashes instead of retrying, see
+  # https://github.com/nick-fields/retry/issues/124.
+  - name: Install tzdata
+    if: inputs.time-zone != '' && runner.os == 'Linux'
+    uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    with:
+      max_attempts: 3
+      retry_wait_seconds: 10
+      timeout_minutes: 2
+      shell: bash
+      command: sudo timeout 115 bash -c "apt-get update && apt-get install -y tzdata"
   - name: Set Time Zone
     if: inputs.time-zone != '' && runner.os == 'Linux'
     env:
       TZ_IDENTIFIER: ${{ inputs.time-zone }}
     run: |
-      # tzdata is not installed in self-hosted runners
-      sudo apt-get update && sudo apt-get install -y tzdata
       echo ${TZ_IDENTIFIER} | sudo tee /etc/timezone
       sudo rm -rf /etc/localtime
       sudo ln -s /usr/share/zoneinfo/${TZ_IDENTIFIER} /etc/localtime

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -482,7 +482,7 @@ jobs:
             if ! command -v google-chrome >/dev/null 2>&1; then
               sudo timeout 90 bash -c "apt-get update && apt-get install -y --no-install-recommends wget gnupg ca-certificates"
 
-              sudo timeout 30 bash -c 'wget -qO- https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor --yes -o /usr/share/keyrings/google-chrome.gpg'
+              sudo timeout 30 bash -o pipefail -c 'wget -qO- https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor --yes -o /usr/share/keyrings/google-chrome.gpg'
 
               echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
                 | sudo tee /etc/apt/sources.list.d/google-chrome.list >/dev/null

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -459,28 +459,35 @@ jobs:
       - name: Print metadata
         uses: ./.github/actions/print-metadata
 
+      - uses: ./.github/actions/apt-fast-mirror-failover
+      # Every network-bound, sudo'd step below is wrapped in its own `sudo timeout ...`
+      # so a hang self-terminates inside the sudo'd root process tree instead of
+      # requiring nick-fields/retry to kill across the privilege boundary -- doing
+      # that externally throws `kill EPERM` and crashes instead of retrying, see
+      # https://github.com/nick-fields/retry/issues/124. Budgeted against the 7-minute
+      # outer timeout: 90s + 30s + 180s = 300s worst case, leaving 2 minutes of headroom
+      # for the (fast, non-network) tee/verification steps and process overhead.
+      # google-chrome-stable itself gets the largest share (180s): it and its
+      # dependencies are a much bigger download than the other two apt calls.
       - name: Install Google Chrome
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 3
           retry_wait_seconds: 15
-          timeout_minutes: 5
+          timeout_minutes: 7
           shell: bash
           command: |
             set -euo pipefail
 
             if ! command -v google-chrome >/dev/null 2>&1; then
-              sudo apt-get update
-              sudo apt-get install -y --no-install-recommends wget gnupg ca-certificates
+              sudo timeout 90 bash -c "apt-get update && apt-get install -y --no-install-recommends wget gnupg ca-certificates"
 
-              wget -qO- https://dl.google.com/linux/linux_signing_key.pub \
-                | sudo gpg --dearmor --yes -o /usr/share/keyrings/google-chrome.gpg
+              sudo timeout 30 bash -c 'wget -qO- https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor --yes -o /usr/share/keyrings/google-chrome.gpg'
 
               echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
                 | sudo tee /etc/apt/sources.list.d/google-chrome.list >/dev/null
 
-              sudo apt-get update
-              sudo apt-get install -y --no-install-recommends google-chrome-stable
+              sudo timeout 180 bash -c "apt-get update && apt-get install -y --no-install-recommends google-chrome-stable"
             fi
 
             google-chrome --version

--- a/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
@@ -56,8 +56,19 @@ jobs:
             echo "AURORA_USERNAME=${{steps.secrets.outputs.AURORA_POSTGRESQL_USERNAME}}"
             echo "AURORA_PASSWORD=${{steps.secrets.outputs.AURORA_POSTGRESQL_PASSWORD}}"
           } >> "$GITHUB_ENV"
+      - uses: ./.github/actions/apt-fast-mirror-failover
+      # `timeout` runs inside the sudo'd root process tree so it can self-terminate a hung
+      # apt-get without nick-fields/retry having to kill across the privilege boundary --
+      # doing that externally throws `kill EPERM` and crashes instead of retrying, see
+      # https://github.com/nick-fields/retry/issues/124.
       - name: Install required packages
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 10
+          timeout_minutes: 2
+          shell: bash
+          command: sudo timeout 115 bash -c "apt-get update && apt-get install -y postgresql-client"
       - name: Set up database
         run: ./.github/actions/rdbms/create-aurora-database.sh
         env:


### PR DESCRIPTION
## Summary

Follow-up fixes to [#60504](https://github.com/camunda/camunda/pull/60504).

**Background (from #60504, already on `main`):** `nick-fields/retry` crashes instead of retrying when its timeout fires on a `sudo`-wrapped `apt-get` command — it can't signal-kill a root-owned process (`kill EPERM`, a known upstream bug: [nick-fields/retry#124](https://github.com/nick-fields/retry/issues/124)). Root cause is GitHub's Ubuntu runner image trying a flaky `azure.archive.ubuntu.com` mirror first ([actions/runner-images#12949](https://github.com/actions/runner-images/issues/12949)) before falling back to a working one, so `apt-get` can hang for up to ~120s per attempt. `main` already has the fix for `validate-pom-metadata`, `ci.yml`'s `shell-script-tests`, `ci-zeebe.yml`'s `strace-tests`, and the shared `apt-fast-mirror-failover` composite action.

**New in this PR:**

- `setup-build`'s optional `tzdata` install (used by Optimize's nightly/release workflows via the `time-zone` input) had the same unretried `sudo apt-get` pattern. Split into an `apt-fast-mirror-failover` step plus a `nick-fields/retry`-wrapped install using the established `sudo timeout <n> bash -c "..."` construction. See https://github.com/camunda/camunda/actions/runs/32233683501/job/96010807626
- `zeebe-aws-aurora-dispatch-tests.yml`'s "Install required packages" ran a bare `sudo apt-get update && sudo apt-get install` with no retry or timeout at all — same exposure `strace-tests` had before #60504.
- `ci-optimize.yml`'s "Install Google Chrome" already used `nick-fields/retry`, but wrapped a multi-line script mixing privileged and unprivileged commands across two separate `apt-get update`/`install` pairs plus a `wget | sudo gpg` pipe. Any one of those hanging past the outer timeout would hit the same `kill EPERM` crash, just with more places for it to happen. Each sudo'd network call is wrapped in its own `sudo timeout <n> bash -c "..."` (the wget-to-gpg pipe moved inside the same sudo'd subshell to avoid a mixed-privilege pipeline). `google-chrome-stable` gets the largest inner budget (180s) since it and its dependencies are a much bigger download than the other apt calls; the outer retry timeout is raised from 5 to 7 minutes to match (90s + 30s + 180s = 300s worst case, leaving 2 minutes of headroom for the non-network tee/verification steps).

Also included, unrelated to the apt/mirror issue above but reported alongside it:

- `codeowners-setup-cli`'s download of the `codeowners-cli` release tarball failed with `curl: (35) Recv failure: Connection reset by peer` ([run 32242321929](https://github.com/camunda/camunda/actions/runs/32242321929/job/96035501009)) — a one-off transient network blip against GitHub's release assets, not the Ubuntu mirror. curl's default `--retry` only covers a specific subset of errors (timeouts, some HTTP 4xx/5xx) and would not have retried a mid-transfer connection reset. Added `--retry-all-errors` (curl ≥ 7.71) plus `--retry-delay`/`--retry-max-time` to retry any failure within a bounded window.

## Test plan

- [x] `actionlint` on all four changed files — clean at the edited lines (all reported findings are pre-existing and unrelated, mostly unknown self-hosted runner labels)
- [x] `conftest test --rego-version v0 -o github --policy .github` on all affected workflows — 0 failures, only pre-existing unrelated warnings
- [x] `./mvnw license:format spotless:apply -T1C` — BUILD SUCCESS, no formatting diffs
- [ ] A `workflow_dispatch` or scheduled run of `zeebe-aws-aurora-dispatch-tests.yml`, and an Optimize E2E smoke run, to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

