### PR TITLE
test: increase timeout for correct topology in DynamicNodeIdScalingIT

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
@@ -342,6 +342,10 @@ public class DynamicNodeIdScalingIT {
     private static final int SCALE_DOWN_TARGET_CLUSTER_SIZE_IN_ZONE = 1;
     private static final int REPLICATION_FACTOR = 1;
 
+    // the gateway is usually included in the gossip update for the removed broker (after ~5s), but
+    // can take 10s if instead falling back to its own timeout
+    private static final Duration TOPOLOGY_TIMEOUT = Duration.ofSeconds(30);
+
     @TestZeebe(autoStart = false)
     protected TestCluster testCluster =
         TestCluster.builder()
@@ -429,7 +433,7 @@ public class DynamicNodeIdScalingIT {
       // given
       shouldScaleDownCluster();
       testCluster.awaitCompleteTopology(
-          targetClusterSize(), PARTITIONS_COUNT, replicationFactor(), Duration.ofSeconds(10));
+          targetClusterSize(), PARTITIONS_COUNT, replicationFactor(), TOPOLOGY_TIMEOUT);
 
       // when
       final var clusterActuator = ClusterActuator.of(testCluster.anyGateway());
@@ -450,7 +454,7 @@ public class DynamicNodeIdScalingIT {
           .untilAsserted(
               () -> assertConfigurationChangeCompleted(clusterActuator, initialClusterSize()));
       testCluster.awaitCompleteTopology(
-          initialClusterSize(), PARTITIONS_COUNT, replicationFactor(), Duration.ofSeconds(10));
+          initialClusterSize(), PARTITIONS_COUNT, replicationFactor(), TOPOLOGY_TIMEOUT);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
@@ -364,6 +364,7 @@ public class DynamicNodeIdScalingIT {
                         cfg -> {
                           cfg.getCluster().setSize(initialClusterSize());
                           configureS3NodeIdProvider(cfg);
+                          cfg.getCluster().getMetadata().setSyncDelay(Duration.ofSeconds(1));
                         }))
             .build();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
@@ -343,8 +343,8 @@ public class DynamicNodeIdScalingIT {
     private static final int REPLICATION_FACTOR = 1;
 
     // the gateway is usually included in the gossip update for the removed broker (after ~5s), but
-    // can take 10s if instead falling back to its own timeout
-    private static final Duration TOPOLOGY_TIMEOUT = Duration.ofSeconds(30);
+    // can take 10s if instead falling back to its own timeout - so we add some headroom
+    private static final Duration TOPOLOGY_TIMEOUT = Duration.ofSeconds(20);
 
     @TestZeebe(autoStart = false)
     protected TestCluster testCluster =


### PR DESCRIPTION
When removing a broker for the scale-down tests, we wait for the gateway to show the expected topology - but 10s isn't a long enough wait to pass reliably, because when gossip doesn't select the gateway to receive the update it falls back to its own 10s timeout to remove the broker (though that still often passes, since the test's 10s timeout starts moments later).

Closes #60520.