### PR TITLE
fix: upgrade httpclient5 to 5.6.4 to resolve CVE-2026-64607

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -398,6 +398,7 @@ public class OpensearchConnector {
       final HttpAsyncClientBuilder httpAsyncClientBuilder,
       final OpensearchProperties osConfig,
       final HttpRequestInterceptor... requestInterceptors) {
+    httpAsyncClientBuilder.disableContentCompression();
     setupAuthentication(httpAsyncClientBuilder, osConfig);
 
     LOGGER.trace("Attempt to load interceptor plugins");

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,7 +48,7 @@
     <jetty.version>12.0.36</jetty.version>
     <jackson.version>2.21.5</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
-    <apache.http5-client.version>5.5</apache.http5-client.version>
+    <apache.http5-client.version>5.6.4</apache.http5-client.version>
     <apache.http5-core.version>5.4.3</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
     <spring.boot.version>3.5.15</spring.boot.version>

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -437,6 +437,7 @@ public class OpenSearchClientBuilder {
       final HttpAsyncClientBuilder httpAsyncClientBuilder,
       final ConfigurationService configurationService,
       final HttpRequestInterceptor... requestInterceptors) {
+    httpAsyncClientBuilder.disableContentCompression();
     setupAuthentication(httpAsyncClientBuilder, configurationService);
 
     for (final HttpRequestInterceptor interceptor : requestInterceptors) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,7 +61,7 @@
     <version.hamcrest>3.0</version.hamcrest>
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
-    <version.httpclient5>5.5</version.httpclient5>
+    <version.httpclient5>5.6.4</version.httpclient5>
     <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.5.5</version.identity>

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -132,6 +132,7 @@ public final class OpensearchConnector {
 
   protected HttpAsyncClientBuilder configureHttpClient(
       final HttpAsyncClientBuilder httpAsyncClientBuilder, final ConnectConfiguration osConfig) {
+    httpAsyncClientBuilder.disableContentCompression();
     setupAuthentication(httpAsyncClientBuilder, osConfig);
     if (osConfig.getSecurity() != null && osConfig.getSecurity().isEnabled()) {
       setupSSLContext(httpAsyncClientBuilder, osConfig.getSecurity());

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -399,6 +399,7 @@ public class OpenSearchConnector {
       final HttpAsyncClientBuilder httpAsyncClientBuilder,
       final OpenSearchProperties osConfig,
       final org.apache.hc.core5.http.HttpRequestInterceptor... httpRequestInterceptors) {
+    httpAsyncClientBuilder.disableContentCompression();
     setupAuthentication(httpAsyncClientBuilder, osConfig);
 
     LOGGER.trace("Attempt to load interceptor plugins");

--- a/tasklist/qa/backup-restore-tests/pom.xml
+++ b/tasklist/qa/backup-restore-tests/pom.xml
@@ -188,6 +188,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
       <scope>test</scope>

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -137,6 +137,12 @@ public class BackupRestoreTest {
     final ApacheHttpClient5TransportBuilder builder =
         ApacheHttpClient5TransportBuilder.builder(host);
 
+    builder.setHttpClientConfigCallback(
+        httpClientBuilder -> {
+          httpClientBuilder.disableContentCompression();
+          return httpClientBuilder;
+        });
+
     final JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(CommonUtils.OBJECT_MAPPER);
     builder.setMapper(jsonpMapper);
 


### PR DESCRIPTION
## Description

Fixes [CVE-2026-64607](https://github.com/advisories/GHSA-hjcp-jmpx-g3qm) on `stable/optimize-8.7` (CVSS 5.3, connection leak → pool exhaustion DoS). This branch is on httpclient5 **5.5**; the fix is in 5.6.3, and this targets **5.6.4** to match `main`, `stable/8.9`, `stable/8.8` and `stable/8.7`.

Two commits, which must land together:

1. **Both httpclient5 version properties 5.5 → 5.6.4.** This branch pins httpclient5 in two independent places: `parent/pom.xml`'s `version.httpclient5` **and** `optimize/pom.xml`'s own `apache.http5-client.version` (which backs the `dependencyManagement` override that stops Spring Boot dictating httpcomponents versions). Bumping only one would leave the other lineage on 5.5 with the CVE open.
2. **Disable httpclient5 content compression on OpenSearch clients.** Required by (1): httpclient5 5.6 added `ContentCompressionAsyncExec`, which adds `Accept-Encoding: gzip` to every request; the OpenSearch client expects uncompressed responses and fails with `ZipException: Not in GZIP format`. Mirrors #47633 on `main`.

## ⚠️ Please read before merging — this exact jump was reverted here once

[#56792](https://github.com/camunda/camunda/pull/56792) bumped httpclient5 to 5.6.2 on this branch and was **reverted 5 hours later** by [#56963](https://github.com/camunda/camunda/pull/56963), citing an internal Slack thread. Two things about that:

- **It carried no equivalent of #47633**, so it would have hit exactly the gzip regression that commit (2) here fixes. That is the most probable cause of the revert, and it is what this PR adds.
- **#56792 merged green.** Only `Create backport PRs` failed on it — a workflow issue, not a test. So **this branch's CI did not catch the problem**, and it ran ~17 substantive checks (vs 63 and 93 on `stable/8.7` / `stable/8.8`).

**Therefore green CI on this PR is weaker evidence than it would be elsewhere.** Before merging, it would be worth either recovering the original revert rationale from that Slack thread, or deliberately exercising an Optimize OpenSearch path (upgrade/schema client) against a real OpenSearch instance.

For what it's worth, the same two-part change is now verified on the sibling branches: it took `stable/8.7` from 3 failing jobs to 0 (63 pass) and `stable/8.8` from 13 to 0 (93 pass), with the OpenSearch suites specifically going green.

## Scope limits (both matching #47633's final merged state)

- **Generic Zeebe `HttpClientFactory` deliberately untouched** — #47633's first commit disabled compression there and its last commit (`fix: undo generic client compression disable`) reverted that before merge.
- **`TestOpenSearchConnector` needs no change** — it overrides `configureHttpClient` but delegates to `super`, so it inherits the fix.
- Every `ApacheHttpClient5TransportBuilder` call site on this branch was audited; the only remaining ones without the callback are the two above, by design.

## What to scrutinise

The OpenSearch integration suites are the coverage that matters here — they are what caught the missing
compression fix on the sibling branches. Beyond that, the two exclusions listed above are the most
likely place for this to be wrong: confirm that leaving the generic `HttpClientFactory` untouched is
correct for this branch, and that no `ApacheHttpClient5TransportBuilder` call site was missed.

## Related issues

relates CVE-2026-64607, #47633, #56792, #56963, #61612
