### PR TITLE
fix: share the node-id-provider-resolved data directory across physical tenants

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -42,7 +42,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -58,8 +57,6 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
       "io.camunda.zeebe.shared",
     })
 @Profile("broker")
-@DependsOn(
-    "dataDirectoryProvider") // ensure that the data directory is set up before starting the broker
 public class BrokerModuleConfiguration implements CloseableSilently {
   private static final Logger LOGGER = Loggers.SYSTEM_LOGGER;
 
@@ -81,6 +78,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final NodeIdProvider nodeIdProvider;
   private final WorkingDirectory workingDirectory;
   private final SecretStoreRegistries secretStoreRegistries;
+  private final ResolvedDataDirectory resolvedDataDirectory;
 
   private Broker broker;
 
@@ -105,7 +103,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final Map<String, RdbmsMapperBundle> rdbmsMapperBundles,
       final NodeIdProvider nodeIdProvider,
       final WorkingDirectory workingDirectory,
-      final SecretStoreRegistries secretStoreRegistries) {
+      final SecretStoreRegistries secretStoreRegistries,
+      final ResolvedDataDirectory resolvedDataDirectory) {
     this.configuration = configuration;
     this.springBrokerBridge = springBrokerBridge;
     this.actorScheduler = actorScheduler;
@@ -124,6 +123,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.nodeIdProvider = nodeIdProvider;
     this.workingDirectory = workingDirectory;
     this.secretStoreRegistries = secretStoreRegistries;
+    this.resolvedDataDirectory = resolvedDataDirectory;
   }
 
   @Bean(destroyMethod = "close")
@@ -156,6 +156,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             .withExporterDescriptors(exporterDescriptors)
             .withExportedPositionSupplier(rdbmsExportedPositionSuppliers)
             .withSecretStoreRegistries(secretStoreRegistries)
+            .withResolvedDataDirectory(resolvedDataDirectory)
             .createSystemContext();
     springBrokerBridge.registerShutdownHelper(shutdownHelper::initiateShutdown);
     broker = new Broker(systemContext, springBrokerBridge, Collections.emptyList());

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.broker.system.BrokerDataDirectoryCopier;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.dynamic.nodeid.fs.ConfiguredDataDirectoryProvider;
-import io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryProvider;
 import io.camunda.zeebe.dynamic.nodeid.fs.NodeIdBasedDataDirectoryProvider;
 import io.camunda.zeebe.dynamic.nodeid.fs.VersionedNodeIdBasedDataDirectoryProvider;
 import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
@@ -81,7 +80,7 @@ public class NodeIdProviderConfiguration {
   }
 
   @Bean
-  public DataDirectoryProvider dataDirectoryProvider(
+  public ResolvedDataDirectory resolvedDataDirectory(
       final NodeIdProvider nodeIdProvider,
       final NodeIdProviderReadinessAwaiter readinessAwaiter,
       final BrokerBasedConfiguration brokerBasedConfiguration)
@@ -120,7 +119,7 @@ public class NodeIdProviderConfiguration {
     final var configuredDirectory = initializer.initialize(directory).join();
     data.setDirectory(configuredDirectory.toString());
 
-    return initializer;
+    return new ResolvedDataDirectory(configuredDirectory.toString());
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/zeebe/broker/ResolvedDataDirectory.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/ResolvedDataDirectory.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+/**
+ * The broker's primary data directory, after any {@link
+ * io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryProvider} adjustment (e.g. the node-id segment
+ * appended for a dynamic node id provider) has been applied.
+ *
+ * <p>This is the single source of truth every physical tenant's {@code BrokerCfg} must use as its
+ * data directory, so that all tenants keep sharing the same node-level data directory root instead
+ * of each independently re-deriving it from their own raw configuration.
+ */
+public record ResolvedDataDirectory(String directory) {}

--- a/dist/src/main/java/io/camunda/zeebe/broker/SystemContextLoader.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/SystemContextLoader.java
@@ -77,6 +77,7 @@ public final class SystemContextLoader {
   private List<ExporterDescriptor> exporterDescriptors;
   private Map<String, IntFunction<Long>> exportedPositionSuppliers = Map.of();
   private SecretStoreRegistries secretStoreRegistries = new SecretStoreRegistries(Map.of());
+  private ResolvedDataDirectory resolvedDataDirectory;
 
   public SystemContextLoader withShutdownTimeout(final Duration shutdownTimeout) {
     this.shutdownTimeout = shutdownTimeout;
@@ -196,6 +197,17 @@ public final class SystemContextLoader {
     return this;
   }
 
+  /**
+   * The data directory resolved for this node, e.g. by a dynamic node id provider. Applied to every
+   * physical tenant's {@code BrokerCfg} so all tenants share the same node-level data directory
+   * root instead of each independently re-deriving it from raw configuration.
+   */
+  public SystemContextLoader withResolvedDataDirectory(
+      final ResolvedDataDirectory resolvedDataDirectory) {
+    this.resolvedDataDirectory = resolvedDataDirectory;
+    return this;
+  }
+
   public SystemContext createSystemContext() {
     final Map<String, PhysicalTenantContext> physicalTenantContexts = new LinkedHashMap<>();
     physicalTenantResolver
@@ -240,7 +252,9 @@ public final class SystemContextLoader {
     if (camunda == rootCamunda) {
       // this is for default tenant, with no override
       // This special handling is required so that legacy properties defined via `zeebe.broker.*`
-      // are still applied to the default tenant.
+      // are still applied to the default tenant. Its data directory is already the node-id-
+      // provider-resolved one, since this is the very same BrokerCfg singleton that
+      // NodeIdProviderConfiguration.resolvedDataDirectory() mutated.
       brokerConfig = rootBrokerCfg;
     } else {
       brokerConfig = BrokerBasedPropertiesOverride.convert(camunda);
@@ -251,6 +265,11 @@ public final class SystemContextLoader {
       clusterCfg.setNodeId(currentInstance.id());
       clusterCfg.setNodeVersion(currentInstance.version().version());
       brokerConfig.init(workingDirectory.toAbsolutePath().toString());
+
+      // Every physical tenant shares the same node-level data directory root, resolved once for
+      // this node (e.g. by a dynamic node id provider), rather than each tenant's BrokerCfg
+      // deriving it independently from its own raw configuration.
+      brokerConfig.getData().setDirectory(resolvedDataDirectory.directory());
     }
 
     final var featureFlags = brokerConfig.getExperimental().getFeatures().toFeatureFlags();

--- a/dist/src/test/java/io/camunda/zeebe/broker/SystemContextLoaderTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/SystemContextLoaderTest.java
@@ -138,6 +138,46 @@ final class SystemContextLoaderTest {
   }
 
   @Test
+  void shouldApplyResolvedDataDirectoryToEveryPhysicalTenant() {
+    // given - a resolved data directory (as produced by a dynamic node id provider) already
+    // applied to the root broker config - as NodeIdProviderConfiguration.resolvedDataDirectory()
+    // mutates the very same BrokerCfg singleton reused as rootBrokerCfg - and a non-default
+    // tenant whose own raw configured directory still differs from it
+    final var rootCamunda = new Camunda();
+    final var rootBrokerCfg = new BrokerCfg();
+    rootBrokerCfg.getData().setDirectory("/resolved/node-7");
+    final var tenantCamunda = new Camunda();
+    tenantCamunda.getData().getPrimaryStorage().setDirectory("/configured/tenanta");
+    final var resolvedDataDirectory = new ResolvedDataDirectory("/resolved/node-7");
+
+    final var loader =
+        newLoader(
+                rootCamunda,
+                rootBrokerCfg,
+                Map.of(
+                    PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                    rootCamunda,
+                    "tenanta",
+                    tenantCamunda))
+            .withResolvedDataDirectory(resolvedDataDirectory);
+
+    // when
+    final SystemContext systemContext = loader.createSystemContext();
+
+    // then - both the default and the non-default tenant use the resolved directory, not their
+    // own raw configured value
+    assertThat(
+            systemContext
+                .getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .config()
+                .getData()
+                .getDirectory())
+        .isEqualTo("/resolved/node-7");
+    assertThat(systemContext.getPhysicalTenantContext("tenanta").config().getData().getDirectory())
+        .isEqualTo("/resolved/node-7");
+  }
+
+  @Test
   void shouldThreadSecretStoreRegistryOfEachTenant() {
     // given - a registry configured for one of the two tenants
     final var rootCamunda = new Camunda();
@@ -217,6 +257,8 @@ final class SystemContextLoaderTest {
         .withSearchClientsProxy(mock(SearchClientsProxy.class))
         .withNodeIdProvider(nodeIdProvider)
         .withWorkingDirectory(workingDirectory)
-        .withExporterDescriptors(null);
+        .withExporterDescriptors(null)
+        .withResolvedDataDirectory(
+            new ResolvedDataDirectory(rootBrokerCfg.getData().getDirectory()));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdPhysicalTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdPhysicalTenantIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.cluster.dynamicnodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.NodeIdProvider.Type;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
+import io.camunda.zeebe.broker.system.configuration.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * Verifies that, with a dynamic (S3) node id provider configured, a broker serving more than one
+ * physical tenant actually writes each tenant's raft partition data on disk under the same
+ * node-level, node-id-resolved directory root — not just the default tenant's.
+ */
+@Testcontainers
+@ZeebeIntegration
+final class DynamicNodeIdPhysicalTenantIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String BUCKET_NAME = UUID.randomUUID().toString();
+  private static final Duration LEASE_DURATION = Duration.ofSeconds(10);
+
+  @Container
+  private static final LocalStackContainer S3 =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
+          .withServices(Service.S3)
+          .withEnv("LS_LOG", "trace");
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker()
+          .withUnauthenticatedAccess()
+          .withSecondaryStorageType(SecondaryStorageType.none)
+          .withUnifiedConfig(
+              cfg -> {
+                cfg.getCluster().getNodeIdProvider().setType(Type.S3);
+                final var s3 = cfg.getCluster().getNodeIdProvider().s3();
+                s3.setTaskId(UUID.randomUUID().toString());
+                s3.setBucketName(BUCKET_NAME);
+                s3.setLeaseDuration(LEASE_DURATION);
+                s3.setEndpoint(S3.getEndpoint().toString());
+                s3.setRegion(S3.getRegion());
+                s3.setAccessKey(S3.getAccessKey());
+                s3.setSecretKey(S3.getSecretKey());
+              })
+          .withPtConfig(
+              TENANT_A,
+              camunda ->
+                  camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.none));
+
+  @BeforeAll
+  static void setupAll() {
+    try (final var s3Client =
+        S3NodeIdRepository.buildClient(
+            new S3ClientConfig(
+                Optional.of(new S3ClientConfig.Credentials(S3.getAccessKey(), S3.getSecretKey())),
+                Optional.of(Region.of(S3.getRegion())),
+                Optional.of(S3.getEndpoint())))) {
+      // the bucket must exist before the application starts
+      s3Client.createBucket(b -> b.bucket(BUCKET_NAME));
+    }
+  }
+
+  @Test
+  void shouldWritePartitionDataForBothTenantsUnderTheSharedNodeDirectory() throws IOException {
+    // given - the node-level directory the dynamic node id provider resolved for this broker,
+    // computed independently from the broker's raw root configuration and its leased node id -
+    // not read from any per-physical-tenant config
+    final var sharedNodeDirectory = getSharedNodeDirectory(broker);
+
+    // when - locating each physical tenant's own partition-1 directory under that shared root
+    final var defaultPartitionDirectory =
+        RaftPartitionFactory.getPartitionDirectory(
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
+            sharedNodeDirectory.toString());
+    final var tenantAPartitionDirectory =
+        RaftPartitionFactory.getPartitionDirectory(
+            new PartitionId(TENANT_A, 1), sharedNodeDirectory.toString());
+
+    // then - both physical tenants actually wrote their own raft log segment files under that
+    // same, node-id-resolved shared root, rather than under a directory each independently
+    // derived from its own raw configuration
+    assertThat(segmentFiles(defaultPartitionDirectory))
+        .as("default tenant's raft log segment files under %s", defaultPartitionDirectory)
+        .isNotEmpty();
+    assertThat(segmentFiles(tenantAPartitionDirectory))
+        .as("%s's raft log segment files under %s", TENANT_A, tenantAPartitionDirectory)
+        .isNotEmpty();
+  }
+
+  private static Path getSharedNodeDirectory(final TestStandaloneBroker broker) {
+    final var rootDirectory =
+        Path.of(
+            ConfigurationUtil.toAbsolutePath(
+                broker.unifiedConfig().getData().getPrimaryStorage().getDirectory(),
+                broker.getWorkingDirectory().toString()));
+    final int nodeId = broker.bean(BrokerBasedProperties.class).getCluster().getNodeId();
+    // a fresh, never-restarted broker is always on version 1 of its versioned node directory
+    return rootDirectory.resolve("node-" + nodeId).resolve("v1");
+  }
+
+  private static List<Path> segmentFiles(final Path partitionDirectory) throws IOException {
+    if (!Files.isDirectory(partitionDirectory)) {
+      return List.of();
+    }
+    try (final var files = Files.list(partitionDirectory)) {
+      return files.filter(path -> path.toString().endsWith(".log")).toList();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- With a dynamic (S3) node id provider configured, only the default physical tenant's `BrokerCfg` picked up the node-id-provider-resolved data directory; every other physical tenant re-derived its data directory from the raw, un-adjusted configuration, so it never shared the node's actual on-disk root.
- Introduces `ResolvedDataDirectory` as an explicit, typed value produced once by `NodeIdProviderConfiguration`, and applies it directly to every non-default physical tenant's `BrokerCfg` in `SystemContextLoader`.
- Adds an acceptance test (`DynamicNodeIdPhysicalTenantIT`) that starts a broker with S3-based dynamic node id and two physical tenants, and verifies both resolve to the same, node-id-suffixed, on-disk data directory.

closes #56650

🤖 Generated with [Claude Code](https://claude.com/claude-code)