### PR TITLE
feat: scope exporting state changes to a single physical tenant

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -258,7 +258,12 @@ public sealed interface ClusterConfigurationManagementRequest {
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record ExportingStateChangeRequest(ExportingState state, boolean dryRun)
+  /**
+   * @param physicalTenantId the physical tenant to change, or empty for every physical tenant of
+   *     the cluster
+   */
+  record ExportingStateChangeRequest(
+      ExportingState state, Optional<String> physicalTenantId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record CancelChangeRequest(long changeId) implements ClusterConfigurationManagementRequest {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExportingStateChangeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExportingStateChangeRequestTransformer.java
@@ -7,54 +7,84 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ExportingStateChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
- * Plans the default physical tenant's partition group and no other. Nothing constructs this request
- * today — no endpoint and no other transformer reaches it — so the scope has never had to be
- * decided; a caller that wires it up on a multi-tenant cluster has to.
+ * Changes the exporting state, either for a single physical tenant or, when none is given, for
+ * every physical tenant of the cluster.
  */
 public final class ExportingStateChangeRequestTransformer implements ConfigurationChangeRequest {
 
   private final ExportingState targetState;
+  private final Optional<String> physicalTenantId;
 
   public ExportingStateChangeRequestTransformer(final ExportingState targetState) {
+    this(targetState, Optional.empty());
+  }
+
+  public ExportingStateChangeRequestTransformer(
+      final ExportingState targetState, final Optional<String> physicalTenantId) {
     this.targetState = targetState;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
-  public Either<Exception, List<Phase>> phases(final CurrentClusterConfiguration configuration) {
-    return operations(configuration.toLegacyDefault()).map(CurrentClusterConfiguration::toPhases);
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (physicalTenantId.isPresent()
+        && !clusterConfiguration.hasPartitionGroup(physicalTenantId.get())) {
+      return Either.left(
+          new NotFound(
+              "Expected to change the exporting state of physical tenant '%s', but there's no such tenant"
+                  .formatted(physicalTenantId.get())));
+    }
+
+    final Map<String, List<PartitionGroupOperation>> operationsPerGroup = new LinkedHashMap<>();
+    clusterConfiguration.partitionGroups().entrySet().stream()
+        .filter(
+            group -> physicalTenantId.isEmpty() || physicalTenantId.get().equals(group.getKey()))
+        .forEach(
+            group -> {
+              final var operations = exportingStateChangeOperations(group.getValue());
+              if (!operations.isEmpty()) {
+                operationsPerGroup.put(group.getKey(), operations);
+              }
+            });
+
+    if (operationsPerGroup.isEmpty()) {
+      return Either.right(List.of());
+    }
+    return Either.right(List.of(new PartitionGroupParallelPhase(operationsPerGroup)));
   }
 
-  private Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
-      final ClusterConfiguration clusterConfiguration) {
-    // One operation per partition-owning member that is not already fully in the target state.
-    // A member already converged (all its partitions in the target state) is skipped so that
-    // re-sending the request is an idempotent no-op that yields an empty plan.
-    final List<ClusterConfigurationChangeOperation> operations =
-        clusterConfiguration.members().entrySet().stream()
-            .filter(e -> needsChange(e.getValue()))
-            .map(
-                e ->
-                    (ClusterConfigurationChangeOperation)
-                        new ExportingStateChangeOperation(e.getKey(), targetState))
-            .toList();
-    return Either.right(operations);
+  private List<PartitionGroupOperation> exportingStateChangeOperations(
+      final PartitionGroupConfiguration group) {
+    return group.members().entrySet().stream()
+        .filter(e -> needsChange(e.getValue()))
+        .map(
+            e ->
+                (PartitionGroupOperation)
+                    new ExportingStateChangeOperation(e.getKey(), targetState))
+        .toList();
   }
 
-  private boolean needsChange(final MemberState memberState) {
-    return memberState.partitions().values().stream().anyMatch(this::notInTargetState);
+  private boolean needsChange(final BrokerPartitionState brokerPartitionState) {
+    return brokerPartitionState.partitions().values().stream().anyMatch(this::notInTargetState);
   }
 
   private boolean notInTargetState(final PartitionState partitionState) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1628,11 +1628,12 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodeExportingStateChangeRequest(final ExportingStateChangeRequest request) {
-    return Requests.ExportingStateChangeRequest.newBuilder()
-        .setState(encodeExportingState(request.state()))
-        .setDryRun(request.dryRun())
-        .build()
-        .toByteArray();
+    final var builder =
+        Requests.ExportingStateChangeRequest.newBuilder()
+            .setState(encodeExportingState(request.state()))
+            .setDryRun(request.dryRun());
+    request.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
+    return builder.build().toByteArray();
   }
 
   @Override
@@ -1641,7 +1642,11 @@ public class ProtoBufSerializer
     try {
       final var request = Requests.ExportingStateChangeRequest.parseFrom(encodedRequest);
       return new ExportingStateChangeRequest(
-          decodeExportingState(request.getState()), request.getDryRun());
+          decodeExportingState(request.getState()),
+          request.hasPhysicalTenantId()
+              ? Optional.of(request.getPhysicalTenantId())
+              : Optional.empty(),
+          request.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -146,6 +146,7 @@ enum Mode {
 message ExportingStateChangeRequest {
   topology_protocol.ExportingStateEnum state = 1;
   bool dryRun = 2;
+  optional string physicalTenantId = 3;
 }
 
 message ModeChangeRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExportingStateChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExportingStateChangeRequestTransformerTest.java
@@ -7,129 +7,251 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
-import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ExportingStateChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 final class ExportingStateChangeRequestTransformerTest {
 
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
 
-  private MemberState memberWith(final ExportingState state, final int... partitionIds) {
-    final var config = new DynamicPartitionConfig(new ExportingConfig(state, Map.of()));
-    final var partitions = new java.util.HashMap<Integer, PartitionState>();
-    for (final int partitionId : partitionIds) {
-      partitions.put(partitionId, PartitionState.active(1, config));
-    }
-    return MemberState.initializeAsActive(partitions);
-  }
+  private final DynamicPartitionConfig exportingConfig =
+      new DynamicPartitionConfig(new ExportingConfig(ExportingState.EXPORTING, Map.of()));
+  private final DynamicPartitionConfig pausedConfig =
+      new DynamicPartitionConfig(new ExportingConfig(ExportingState.PAUSED, Map.of()));
 
   @Test
-  void shouldGenerateOneOperationPerPartitionOwningMemberNotInTargetState() {
-    // given — both members export, request pauses
+  void shouldGenerateOperationsForAllPhysicalTenantsWhenNoneIsGiven() {
+    // given
     final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
     final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, memberWith(ExportingState.EXPORTING, 1))
-            .addMember(id1, memberWith(ExportingState.EXPORTING, 2));
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(exportingConfig),
+                TENANT_B, groupWithMembers(exportingConfig)));
 
     // when
-    final var result = plannedOperations(transformer, clusterConfiguration);
+    final var result = transformer.phases(clusterConfiguration);
 
-    // then
+    // then — one phase carrying both groups, so their partitions change concurrently
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactlyInAnyOrder(
-            new ExportingStateChangeOperation(id0, ExportingState.PAUSED),
-            new ExportingStateChangeOperation(id1, ExportingState.PAUSED));
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations())
+        .containsOnlyKeys(TENANT_A, TENANT_B)
+        .allSatisfy(
+            (groupId, operations) ->
+                assertThat(operations)
+                    .containsExactlyInAnyOrder(
+                        new ExportingStateChangeOperation(id0, ExportingState.PAUSED),
+                        new ExportingStateChangeOperation(id1, ExportingState.PAUSED)));
   }
 
   @Test
-  void shouldSkipMemberAlreadyFullyInTargetState() {
-    // given — id0 exporting, id1 already paused
+  void shouldSkipPhysicalTenantsAlreadyInTheTargetState() {
+    // given — tenant-b already paused, tenant-a is not
     final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
     final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, memberWith(ExportingState.EXPORTING, 1))
-            .addMember(id1, memberWith(ExportingState.PAUSED, 2));
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(exportingConfig),
+                TENANT_B, groupWithMembers(pausedConfig)));
 
     // when
-    final var result = plannedOperations(transformer, clusterConfiguration);
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — the group that has nothing to do is left out of the phase entirely
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
+  }
+
+  @Test
+  void shouldSkipAMemberAlreadyFullyInTheTargetState() {
+    // given — within tenant-a, id0 is still exporting and id1 is already paused
+    final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
+    final var group =
+        PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+            .addMember(
+                id0,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, exportingConfig))))
+            .addMember(
+                id1,
+                BrokerPartitionState.initialize(Map.of(2, PartitionState.active(1, pausedConfig))));
+    final var clusterConfiguration = withPartitionGroups(Map.of(TENANT_A, group));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
 
     // then — only the member not yet in the target state gets an operation
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations().get(TENANT_A))
         .containsExactly(new ExportingStateChangeOperation(id0, ExportingState.PAUSED));
   }
 
   @Test
-  void shouldTargetMemberWithAnyPartitionNotInTargetState() {
-    // given — id0 has one exporting and one paused partition, request pauses
-    final var config =
-        new DynamicPartitionConfig(new ExportingConfig(ExportingState.PAUSED, Map.of()));
-    final var exportingConfig =
-        new DynamicPartitionConfig(new ExportingConfig(ExportingState.EXPORTING, Map.of()));
-    final var member =
-        MemberState.initializeAsActive(
+  void shouldChangeAMemberWithAnyPartitionNotInTheTargetState() {
+    // given — id0 has one paused and one exporting partition, request pauses
+    final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
+    final var group =
+        PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+            .addMember(
+                id0,
+                BrokerPartitionState.initialize(
+                    Map.of(
+                        1, PartitionState.active(1, pausedConfig),
+                        2, PartitionState.active(1, exportingConfig))));
+    final var clusterConfiguration = withPartitionGroups(Map.of(TENANT_A, group));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — one operation for the member, not one per partition
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations().get(TENANT_A))
+        .containsExactly(new ExportingStateChangeOperation(id0, ExportingState.PAUSED));
+  }
+
+  @Test
+  void shouldGenerateOperationsOnlyForTheGivenPhysicalTenant() {
+    // given
+    final var transformer =
+        new ExportingStateChangeRequestTransformer(ExportingState.PAUSED, Optional.of(TENANT_A));
+    final var clusterConfiguration =
+        withPartitionGroups(
             Map.of(
-                1, PartitionState.active(1, config),
-                2, PartitionState.active(1, exportingConfig)));
-    final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
-    final var clusterConfiguration = ClusterConfiguration.init().addMember(id0, member);
+                TENANT_A, groupWithMembers(exportingConfig),
+                TENANT_B, groupWithMembers(exportingConfig)));
 
     // when
-    final var result = plannedOperations(transformer, clusterConfiguration);
+    final var result = transformer.phases(clusterConfiguration);
 
-    // then
+    // then — tenant-b keeps exporting
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(new ExportingStateChangeOperation(id0, ExportingState.PAUSED));
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations())
+        .containsOnlyKeys(TENANT_A)
+        .hasEntrySatisfying(
+            TENANT_A,
+            operations ->
+                assertThat(operations)
+                    .containsExactlyInAnyOrder(
+                        new ExportingStateChangeOperation(id0, ExportingState.PAUSED),
+                        new ExportingStateChangeOperation(id1, ExportingState.PAUSED)));
   }
 
   @Test
-  void shouldSkipMembersWithoutPartitions() {
-    // given — id0 owns a partition, id1 owns none
-    final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
+  void shouldSucceedWithNoPhasesWhenThePartitionGroupIsAlreadyInTheTargetState() {
+    // given
+    final var transformer =
+        new ExportingStateChangeRequestTransformer(ExportingState.PAUSED, Optional.of(TENANT_A));
     final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, memberWith(ExportingState.EXPORTING, 1))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()));
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(pausedConfig)));
 
     // when
-    final var result = plannedOperations(transformer, clusterConfiguration);
-
-    // then
-    EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(new ExportingStateChangeOperation(id0, ExportingState.PAUSED));
-  }
-
-  @Test
-  void shouldReturnEmptyPlanWhenAllMembersAlreadyInTargetState() {
-    // given — everything already paused, request pauses again
-    final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
-    final var clusterConfiguration =
-        ClusterConfiguration.init()
-            .addMember(id0, memberWith(ExportingState.PAUSED, 1))
-            .addMember(id1, memberWith(ExportingState.PAUSED, 2));
-
-    // when
-    final var result = plannedOperations(transformer, clusterConfiguration);
+    final var result = transformer.phases(clusterConfiguration);
 
     // then — idempotent no-op yields an empty plan
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get()).isEmpty();
+  }
+
+  @Test
+  void shouldSucceedWithNoPhasesWhenAllPhysicalTenantsAreAlreadyInTheTargetState() {
+    // given
+    final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
+    final var clusterConfiguration =
+        withPartitionGroups(
+            Map.of(
+                TENANT_A, groupWithMembers(pausedConfig),
+                TENANT_B, groupWithMembers(pausedConfig)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — idempotent no-op yields an empty plan
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenantId() {
+    // given
+    final var transformer =
+        new ExportingStateChangeRequestTransformer(
+            ExportingState.PAUSED, Optional.of("unknown-tenant"));
+    final var clusterConfiguration =
+        withPartitionGroups(Map.of(TENANT_A, groupWithMembers(exportingConfig)));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — the tenant does not exist, so the caller gets 404 rather than 500
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown-tenant");
+  }
+
+  @Test
+  void shouldNotChangeABrokerThatHostsNoPartitionOfTheGroup() {
+    // given — id0 hosts a partition of the group, id1 owns none
+    final var transformer = new ExportingStateChangeRequestTransformer(ExportingState.PAUSED);
+    final var group =
+        PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+            .addMember(
+                id0,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, exportingConfig))))
+            .addMember(id1, BrokerPartitionState.initialize(Map.of()));
+    final var clusterConfiguration = withPartitionGroups(Map.of(TENANT_A, group));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — id1 owns no partition, so there is nothing on it to change
+    EitherAssert.assertThat(result).isRight();
+    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    assertThat(phase.groupOperations().get(TENANT_A))
+        .containsExactly(new ExportingStateChangeOperation(id0, ExportingState.PAUSED));
+  }
+
+  private PartitionGroupConfiguration groupWithMembers(final DynamicPartitionConfig config) {
+    return PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION)
+        .addMember(
+            id0, BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, config))))
+        .addMember(
+            id1, BrokerPartitionState.initialize(Map.of(1, PartitionState.active(1, config))));
+  }
+
+  private CurrentClusterConfiguration withPartitionGroups(
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        GlobalConfiguration.init(),
+        partitionGroups,
+        PhasedChangeState.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -300,11 +300,30 @@ final class ProtoBufSerializerTest {
   }
 
   @Test
-  void shouldEncodeAndDecodeExportingStateChangeRequest() {
+  void shouldEncodeAndDecodeExportingStateChangeRequestForOnePhysicalTenant() {
     // given
     final var request =
         new ExportingStateChangeRequest(
-            io.camunda.zeebe.dynamic.config.state.ExportingState.SOFT_PAUSED, false);
+            io.camunda.zeebe.dynamic.config.state.ExportingState.SOFT_PAUSED,
+            Optional.of("tenant-b"),
+            false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeExportingStateChangeRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeExportingStateChangeRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeExportingStateChangeRequestForEveryPhysicalTenant() {
+    // given — an absent tenant means every physical tenant
+    final var request =
+        new ExportingStateChangeRequest(
+            io.camunda.zeebe.dynamic.config.state.ExportingState.SOFT_PAUSED,
+            Optional.empty(),
+            false);
 
     // when
     final var encodedRequest = protoBufSerializer.encodeExportingStateChangeRequest(request);


### PR DESCRIPTION
## Description

Adds per-physical-tenant scoping for exporting state changes in `zeebe/dynamic-config`, so a future exporting-state endpoint can target a single physical tenant instead of always applying cluster-wide.

This is dynamic-config-only groundwork, split out of #59415 to keep review scoped to a single module and a single concern. #59415 additionally wires the actuator/REST endpoints onto the dynamic-config-backed `ExportingStateController`, and predates the physical-tenant partition-group model that landed on `main` since — that endpoint wiring, reconciled with the new per-tenant model (and with `feat/57740-cluster-wide-exporting-fanout`'s existing broadcaster-based cluster-wide exporting endpoints), will follow as a separate PR.

### What changed

- `ExportingStateChangeRequest` now carries `Optional<String> physicalTenantId` (empty = every physical tenant), matching the existing `ExporterEnableRequest`/`ExporterDisableRequest`/`ModeChangeRequest` convention.
- `requests.proto` / `ProtoBufSerializer` carry the new field through the wire round trip.
- `ExportingStateChangeRequestTransformer.phases(CurrentClusterConfiguration)` scopes to one physical tenant's partition group via `PartitionGroupParallelPhase`, rejects an unknown tenant with `NotFound`, targets every tenant in one parallel phase when none is requested, and skips a tenant (or a member within one) already converged. 
- The transformer's test suite is built entirely on the new partition-group model (`CurrentClusterConfiguration`/`PartitionGroupConfiguration`/`BrokerPartitionState`); no legacy `ClusterConfiguration`/`MemberState`-based fixtures remain. Serializer round-trip tests updated for the new field.

No endpoint-facing code (`ExportingServices`, `ExportingController`, `ExportingEndpoint`, `BrokerAdminService*`, `ClusterExportingServices`/`ClusterExportingController`) is touched in this PR.

## Related issues

Relates to #39743
Split out of #59415
