### PR TITLE
fix: ensure incident notification still sent after partial bulk update failure

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -205,13 +205,13 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   @Override
   public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate bulk) {
     final var docUpdatesStream = bulk.stream();
-    return bulkUpdate(docUpdatesStream);
+    return bulkUpdate(docUpdatesStream, Refresh.WaitFor);
   }
 
   @Override
   public CompletionStage<List<String>> bulkUpdate(final NonIncidentBulkUpdate bulk) {
     final var docUpdatesStream = bulk.stream();
-    return bulkUpdate(docUpdatesStream);
+    return bulkUpdate(docUpdatesStream, Refresh.False);
   }
 
   @Override
@@ -250,7 +250,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   }
 
   private CompletableFuture<List<String>> bulkUpdate(
-      final Stream<DocumentUpdate> docUpdatesStream) {
+      final Stream<DocumentUpdate> docUpdatesStream, final Refresh refresh) {
     final var updates = docUpdatesStream.map(this::createUpdateOperation).toList();
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(List.of());
@@ -260,7 +260,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
         new BulkRequest.Builder()
             .operations(updates)
             .source(s -> s.fetch(false))
-            .refresh(Refresh.WaitFor)
+            .refresh(refresh)
             .build();
 
     return client

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.WillCloseWhenClosed;
 import org.slf4j.Logger;
 
@@ -203,33 +204,14 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
 
   @Override
   public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate bulk) {
-    final var updates = bulk.stream().map(this::createUpdateOperation).toList();
-    if (updates.isEmpty()) {
-      return CompletableFuture.completedFuture(List.of());
-    }
+    final var docUpdatesStream = bulk.stream();
+    return bulkUpdate(docUpdatesStream);
+  }
 
-    final var request =
-        new BulkRequest.Builder()
-            .operations(updates)
-            .source(s -> s.fetch(false))
-            .refresh(Refresh.WaitFor)
-            .build();
-
-    return client
-        .bulk(request)
-        .thenComposeAsync(
-            r -> {
-              if (r.errors()) {
-                return CompletableFuture.failedFuture(collectBulkErrors(r.items()));
-              }
-
-              return CompletableFuture.completedFuture(
-                  r.items().stream()
-                      .filter(f -> f.result() != null && f.result().equalsIgnoreCase("updated"))
-                      .map(BulkResponseItem::id)
-                      .toList());
-            },
-            executor);
+  @Override
+  public CompletionStage<List<String>> bulkUpdate(final NonIncidentBulkUpdate bulk) {
+    final var docUpdatesStream = bulk.stream();
+    return bulkUpdate(docUpdatesStream);
   }
 
   @Override
@@ -265,6 +247,37 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
 
     return fetchUnboundedDocumentCollection(
         request, IncidentEntity.class, h -> new ActiveIncident(h.id(), h.source().getTreePath()));
+  }
+
+  private CompletableFuture<List<String>> bulkUpdate(
+      final Stream<DocumentUpdate> docUpdatesStream) {
+    final var updates = docUpdatesStream.map(this::createUpdateOperation).toList();
+    if (updates.isEmpty()) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
+    final var request =
+        new BulkRequest.Builder()
+            .operations(updates)
+            .source(s -> s.fetch(false))
+            .refresh(Refresh.WaitFor)
+            .build();
+
+    return client
+        .bulk(request)
+        .thenComposeAsync(
+            r -> {
+              if (r.errors()) {
+                return CompletableFuture.failedFuture(collectBulkErrors(r.items()));
+              }
+
+              return CompletableFuture.completedFuture(
+                  r.items().stream()
+                      .filter(f -> f.result() != null && f.result().equalsIgnoreCase("updated"))
+                      .map(BulkResponseItem::id)
+                      .toList());
+            },
+            executor);
   }
 
   private CompletionStage<RefreshResponse> refreshPostImporterQueueIndex() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -95,9 +95,18 @@ public interface IncidentUpdateRepository extends AutoCloseable {
    * affected indices are refreshed. This ensures you will later read your own writes.
    *
    * @param update the bulk update to execute
-   * @return the number of documents updated
+   * @return the ids of the documents updated
    */
   CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate update);
+
+  /**
+   * Executes the given bulk update against the underlying document store, waiting until the
+   * affected indices are refreshed. This ensures you will later read your own writes.
+   *
+   * @param update the bulk update to execute
+   * @return the ids of the documents updated
+   */
+  CompletionStage<List<String>> bulkUpdate(final NonIncidentBulkUpdate update);
 
   /**
    * Returns the tree path as tokenized by an analyze request to the underlying document store.
@@ -144,26 +153,34 @@ public interface IncidentUpdateRepository extends AutoCloseable {
   record ActiveIncident(String id, String treePath) {}
 
   /**
+   * Gather the updates for documents that are not incidents, such as flow node instances and list
+   * view documents. This allows us to collect all the update queries into one, and pass it down to
+   * the store specific implementation
+   */
+  record NonIncidentBulkUpdate(
+      Collection<DocumentUpdate> listViewRequests,
+      Collection<DocumentUpdate> flowNodeInstanceRequests) {
+    public NonIncidentBulkUpdate() {
+      this(new ConcurrentLinkedQueue<>(), new ConcurrentLinkedQueue<>());
+    }
+
+    public Stream<DocumentUpdate> stream() {
+      return Stream.concat(listViewRequests.stream(), flowNodeInstanceRequests.stream()).distinct();
+    }
+  }
+
+  /**
    * A search store agnostic representation of a bulk update for this task. It allows us to collect
    * all the update queries into one, and pass it down to the store specific implementation to
    * execute.
    */
-  record IncidentBulkUpdate(
-      Collection<DocumentUpdate> listViewRequests,
-      Collection<DocumentUpdate> flowNodeInstanceRequests,
-      Collection<DocumentUpdate> incidentRequests) {
+  record IncidentBulkUpdate(Collection<DocumentUpdate> incidentRequests) {
     public IncidentBulkUpdate() {
-      this(
-          new ConcurrentLinkedQueue<>(),
-          new ConcurrentLinkedQueue<>(),
-          new ConcurrentLinkedQueue<>());
+      this(new ConcurrentLinkedQueue<>());
     }
 
     public Stream<DocumentUpdate> stream() {
-      return Stream.concat(
-              Stream.concat(listViewRequests.stream(), flowNodeInstanceRequests.stream()),
-              incidentRequests.stream())
-          .distinct();
+      return incidentRequests.stream().distinct();
     }
   }
 
@@ -173,6 +190,14 @@ public interface IncidentUpdateRepository extends AutoCloseable {
    * <p>All fields are expected to be non-null, except routing.
    */
   record DocumentUpdate(String id, String index, Map<String, Object> doc, String routing) {}
+
+  /**
+   * A batch of pending incident updates fetched from the post importer queue. The {@code
+   * highestPosition} returns the greatest position of the updates fetched, and the states are keyed
+   * by incident key.
+   */
+  record PendingIncidentUpdateBatch(
+      long highestPosition, Map<Long, IncidentState> newIncidentStates) {}
 
   class NoopIncidentUpdateRepository implements IncidentUpdateRepository {
 
@@ -218,6 +243,11 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     }
 
     @Override
+    public CompletionStage<List<String>> bulkUpdate(final NonIncidentBulkUpdate update) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
     public CompletionStage<List<String>> analyzeTreePath(final String treePath) {
       return CompletableFuture.completedFuture(List.of());
     }
@@ -231,12 +261,4 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     @Override
     public void close() throws Exception {}
   }
-
-  /**
-   * A batch of pending incident updates fetched from the post importer queue. The {@code
-   * highestPosition} returns the greatest position of the updates fetched, and the states are keyed
-   * by incident key.
-   */
-  record PendingIncidentUpdateBatch(
-      long highestPosition, Map<Long, IncidentState> newIncidentStates) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.exporter.tasks.incident;
 
+import com.google.common.collect.ImmutableList;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NonIncidentBulkUpdate;
 import io.camunda.webapps.operate.TreePath;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
@@ -134,7 +136,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
    *             <ul>
    *               <li>PARALLEL: createProcessInstanceUpdates
    *             </ul>
-   *         <li>BATCH: BulkUpdate
+   *         <li>BATCH: BulkUpdate flow nodes + process instances
+   *         <li>BATCH: BulkUpdate incidents
+   *         <li>Send notifications for incidents that changed state to ACTIVE
    *       </ul>
    * </ul>
    */
@@ -324,7 +328,8 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
   private int processIncidents(
       final IncidentsState state, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
-    final var bulkUpdate = new IncidentBulkUpdate();
+    final var incidentBulkUpdate = new IncidentBulkUpdate();
+    final var nonIncidentBulkUpdate = new NonIncidentBulkUpdate();
     return mapActiveIncidentsToAffectedInstances(state)
         .thenApplyAsync(
             ignored -> {
@@ -337,15 +342,45 @@ public final class IncidentUpdateTask implements BackgroundTask {
                 // processIncident one at a time, stopping if an error is raised
                 FuturesUtil.traverseIgnoring(
                     state.getIncidentDocuments(),
-                    incident -> processIncidentInBatch(state, incident, batch, bulkUpdate),
+                    incident ->
+                        processIncidentInBatch(
+                            state, incident, batch, incidentBulkUpdate, nonIncidentBulkUpdate),
                     executor),
             executor)
-        .thenCompose(ignored -> repository.bulkUpdate(bulkUpdate))
+        .thenCompose(
+            ignored -> bulkUpdateAndNotify(state, nonIncidentBulkUpdate, incidentBulkUpdate))
+        .join();
+  }
+
+  private CompletionStage<Integer> bulkUpdateAndNotify(
+      final IncidentsState state,
+      final NonIncidentBulkUpdate nonIncidentBulkUpdate,
+      final IncidentBulkUpdate incidentBulkUpdate) {
+    // bulk update in two parts, so any errors with the non-incident updates won't leave us with a
+    // partial update of the incident documents - which might cause us to retry, but skip sending
+    // notifications for those incidents on the retry
+    return repository
+        .bulkUpdate(nonIncidentBulkUpdate)
+        .thenCompose(
+            nonIncidentUpdatedIds ->
+                repository
+                    .bulkUpdate(incidentBulkUpdate)
+                    .thenApply(
+                        incidentUpdatedIds -> mergeIds(nonIncidentUpdatedIds, incidentUpdatedIds)))
         .thenCompose(
             updatedIds ->
                 notifyIncidents(
-                    updatedIds, bulkUpdate.incidentRequests(), state.getIncidentDocuments()))
-        .join();
+                    updatedIds,
+                    incidentBulkUpdate.incidentRequests(),
+                    state.getIncidentDocuments()));
+  }
+
+  private List<String> mergeIds(
+      final List<String> nonIncidentUpdatedIds, final List<String> incidentUpdatedIds) {
+    return ImmutableList.<String>builder()
+        .addAll(nonIncidentUpdatedIds)
+        .addAll(incidentUpdatedIds)
+        .build();
   }
 
   private void seedResolvedIncidentsAsActive(
@@ -375,7 +410,8 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final IncidentsState state,
       final IncidentDocument incident,
       final IncidentUpdateRepository.PendingIncidentUpdateBatch batch,
-      final IncidentBulkUpdate bulkUpdate) {
+      final IncidentBulkUpdate incidentBulkUpdate,
+      final NonIncidentBulkUpdate nonIncidentBulkUpdate) {
     final var processInstanceKey = incident.incident().getProcessInstanceKey();
     final var treePath = state.incidentTreePaths().get(incident.id());
     final var newState = batch.newIncidentStates().get(incident.incident().getKey());
@@ -404,16 +440,19 @@ public final class IncidentUpdateTask implements BackgroundTask {
           removeProcessInstanceIds(parsedTreePath.extractFlowNodeInstanceIds(), piIds);
 
       future =
-          createProcessInstanceUpdates(state, incident, newState, piIds, bulkUpdate)
+          createProcessInstanceUpdates(state, incident, newState, piIds, nonIncidentBulkUpdate)
               .thenComposeAsync(
                   unused ->
-                      createFlowNodeInstanceUpdates(state, incident, newState, fniIds, bulkUpdate),
+                      createFlowNodeInstanceUpdates(
+                          state, incident, newState, fniIds, nonIncidentBulkUpdate),
                   executor);
     }
 
     return future.thenApplyAsync(
         unused -> {
-          bulkUpdate.incidentRequests().add(newIncidentUpdate(incident, newState, treePath));
+          incidentBulkUpdate
+              .incidentRequests()
+              .add(newIncidentUpdate(incident, newState, treePath));
           return null;
         },
         executor);
@@ -438,7 +477,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final IncidentDocument incident,
       final IncidentState newState,
       final List<String> fniIds,
-      final IncidentBulkUpdate updates) {
+      final NonIncidentBulkUpdate updates) {
     final CompletableFuture<?>[] futures = {
       CompletableFuture.completedFuture(null), CompletableFuture.completedFuture(null)
     };
@@ -513,7 +552,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final IncidentState newState,
       final String fniId,
       final Collection<String> flowNodeIndices,
-      final IncidentBulkUpdate updates,
+      final NonIncidentBulkUpdate updates,
       final Collection<String> listViewIndices) {
     final var hasIncident = IncidentState.ACTIVE == newState;
     final boolean changedState;
@@ -547,7 +586,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final IncidentDocument incident,
       final IncidentState newState,
       final List<String> piIds,
-      final IncidentBulkUpdate updates) {
+      final NonIncidentBulkUpdate updates) {
     var fetchMissingProcessInstances = CompletableFuture.completedFuture(null);
     if (!state.processInstanceIndices().keySet().containsAll(piIds)) {
       fetchMissingProcessInstances =
@@ -598,7 +637,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final String incidentId,
       final IncidentState newState,
       final String piId,
-      final IncidentBulkUpdate updates,
+      final NonIncidentBulkUpdate updates,
       final Collection<String> indexes) {
     final var hasIncident = IncidentState.ACTIVE == newState;
     final boolean changedState;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -212,37 +213,14 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
 
   @Override
   public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate bulk) {
-    final var updates = bulk.stream().map(this::createUpdateOperation).toList();
-    if (updates.isEmpty()) {
-      return CompletableFuture.completedFuture(List.of());
-    }
+    final var docUpdatesStream = bulk.stream();
+    return bulkUpdate(docUpdatesStream);
+  }
 
-    final var request =
-        new BulkRequest.Builder()
-            .operations(updates)
-            .source(s -> s.fetch(false))
-            .refresh(Refresh.WaitFor)
-            .build();
-
-    try {
-      return client
-          .bulk(request)
-          .thenComposeAsync(
-              r -> {
-                if (r.errors()) {
-                  return CompletableFuture.failedFuture(collectBulkErrors(r.items()));
-                }
-
-                return CompletableFuture.completedFuture(
-                    r.items().stream()
-                        .filter(f -> f.result() != null && f.result().equalsIgnoreCase("updated"))
-                        .map(BulkResponseItem::id)
-                        .toList());
-              },
-              executor);
-    } catch (final IOException e) {
-      return CompletableFuture.failedFuture(e);
-    }
+  @Override
+  public CompletionStage<List<String>> bulkUpdate(final NonIncidentBulkUpdate bulk) {
+    final var docUpdatesStream = bulk.stream();
+    return bulkUpdate(docUpdatesStream);
   }
 
   @Override
@@ -289,6 +267,41 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
 
     return fetchUnboundedDocumentCollection(
         request, IncidentEntity.class, h -> new ActiveIncident(h.id(), h.source().getTreePath()));
+  }
+
+  private CompletableFuture<List<String>> bulkUpdate(
+      final Stream<DocumentUpdate> docUpdatesStream) {
+    final var updates = docUpdatesStream.map(this::createUpdateOperation).toList();
+    if (updates.isEmpty()) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
+    final var request =
+        new BulkRequest.Builder()
+            .operations(updates)
+            .source(s -> s.fetch(false))
+            .refresh(Refresh.WaitFor)
+            .build();
+
+    try {
+      return client
+          .bulk(request)
+          .thenComposeAsync(
+              r -> {
+                if (r.errors()) {
+                  return CompletableFuture.failedFuture(collectBulkErrors(r.items()));
+                }
+
+                return CompletableFuture.completedFuture(
+                    r.items().stream()
+                        .filter(f -> f.result() != null && f.result().equalsIgnoreCase("updated"))
+                        .map(BulkResponseItem::id)
+                        .toList());
+              },
+              executor);
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(e);
+    }
   }
 
   private CompletableFuture<SearchResponse<PendingIncidentUpdate>> searchPendingIncidents(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -214,13 +214,13 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   @Override
   public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate bulk) {
     final var docUpdatesStream = bulk.stream();
-    return bulkUpdate(docUpdatesStream);
+    return bulkUpdate(docUpdatesStream, Refresh.WaitFor);
   }
 
   @Override
   public CompletionStage<List<String>> bulkUpdate(final NonIncidentBulkUpdate bulk) {
     final var docUpdatesStream = bulk.stream();
-    return bulkUpdate(docUpdatesStream);
+    return bulkUpdate(docUpdatesStream, Refresh.False);
   }
 
   @Override
@@ -270,7 +270,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   }
 
   private CompletableFuture<List<String>> bulkUpdate(
-      final Stream<DocumentUpdate> docUpdatesStream) {
+      final Stream<DocumentUpdate> docUpdatesStream, final Refresh refresh) {
     final var updates = docUpdatesStream.map(this::createUpdateOperation).toList();
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(List.of());
@@ -280,7 +280,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
         new BulkRequest.Builder()
             .operations(updates)
             .source(s -> s.fetch(false))
-            .refresh(Refresh.WaitFor)
+            .refresh(refresh)
             .build();
 
     try {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
@@ -16,6 +16,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepositoryIT.RoutedDocument;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.io.IOException;
@@ -63,6 +64,12 @@ final class ElasticsearchIncidentUpdateRepositoryIT extends IncidentUpdateReposi
         client,
         Runnable::run,
         LOGGER);
+  }
+
+  @Override
+  protected void refresh(final String index) throws IOException {
+    final var client = new ElasticsearchClient(transport);
+    client.indices().refresh(r -> r.index(index));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ErrorInjectingIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ErrorInjectingIncidentUpdateRepository.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
+import io.camunda.zeebe.exporter.api.ExporterException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import org.springframework.util.CollectionUtils;
+
+class ErrorInjectingIncidentUpdateRepository implements IncidentUpdateRepository {
+  private IncidentUpdateRepository realUpdateRepository;
+  private boolean failFlowNodeBulkUpdates;
+
+  void setRealUpdateRepository(final IncidentUpdateRepository realUpdateRepository) {
+    this.realUpdateRepository = realUpdateRepository;
+  }
+
+  void setFailFlowNodeBulkUpdates(final boolean failFlowNodeBulkUpdates) {
+    this.failFlowNodeBulkUpdates = failFlowNodeBulkUpdates;
+  }
+
+  @Override
+  public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
+      final long fromPosition, final int size) {
+    return realUpdateRepository.getPendingIncidentsBatch(fromPosition, size);
+  }
+
+  @Override
+  public CompletionStage<Collection<IncidentDocument>> getIncidentDocuments(
+      final List<String> incidentIds) {
+    return realUpdateRepository.getIncidentDocuments(incidentIds);
+  }
+
+  @Override
+  public CompletionStage<Collection<Document>> getFlowNodesInListView(
+      final List<String> flowNodeKeys) {
+    return realUpdateRepository.getFlowNodesInListView(flowNodeKeys);
+  }
+
+  @Override
+  public CompletionStage<Collection<Document>> getFlowNodeInstances(
+      final List<String> flowNodeKeys) {
+    return realUpdateRepository.getFlowNodeInstances(flowNodeKeys);
+  }
+
+  @Override
+  public CompletionStage<Collection<ProcessInstanceDocument>> getProcessInstances(
+      final List<String> processInstanceIds) {
+    return realUpdateRepository.getProcessInstances(processInstanceIds);
+  }
+
+  @Override
+  public CompletionStage<Set<Long>> deletedProcessInstances(final Set<Long> processInstanceKeys) {
+    return realUpdateRepository.deletedProcessInstances(processInstanceKeys);
+  }
+
+  @Override
+  public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate update) {
+    if (failFlowNodeBulkUpdates) {
+      // Simulate a failure for flow node bulk updates and ensure that they are not updated
+      // but allow the other updates to proceed (to simulate a partial update)
+      if (!CollectionUtils.isEmpty(update.flowNodeInstanceRequests())) {
+        final IncidentBulkUpdate updateWithoutFlowNodes =
+            new IncidentBulkUpdate(
+                update.listViewRequests(), Collections.emptyList(), update.incidentRequests());
+        return realUpdateRepository
+            .bulkUpdate(updateWithoutFlowNodes)
+            .thenApply(
+                updatedIds -> {
+                  throw new ExporterException("Simulated failure for flow node bulk updates");
+                });
+      }
+    }
+
+    return realUpdateRepository.bulkUpdate(update);
+  }
+
+  @Override
+  public CompletionStage<List<String>> analyzeTreePath(final String treePath) {
+    return realUpdateRepository.analyzeTreePath(treePath);
+  }
+
+  @Override
+  public CompletionStage<Collection<ActiveIncident>> getActiveIncidentsByTreePaths(
+      final Collection<String> treePathTerms) {
+    return realUpdateRepository.getActiveIncidentsByTreePaths(treePathTerms);
+  }
+
+  @Override
+  public void close() throws Exception {
+    realUpdateRepository.close();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ErrorInjectingIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ErrorInjectingIncidentUpdateRepository.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
-import org.springframework.util.CollectionUtils;
 
 class ErrorInjectingIncidentUpdateRepository implements IncidentUpdateRepository {
   private IncidentUpdateRepository realUpdateRepository;
@@ -65,20 +64,22 @@ class ErrorInjectingIncidentUpdateRepository implements IncidentUpdateRepository
 
   @Override
   public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate update) {
+    return realUpdateRepository.bulkUpdate(update);
+  }
+
+  @Override
+  public CompletionStage<List<String>> bulkUpdate(final NonIncidentBulkUpdate update) {
     if (failFlowNodeBulkUpdates) {
       // Simulate a failure for flow node bulk updates and ensure that they are not updated
       // but allow the other updates to proceed (to simulate a partial update)
-      if (!CollectionUtils.isEmpty(update.flowNodeInstanceRequests())) {
-        final IncidentBulkUpdate updateWithoutFlowNodes =
-            new IncidentBulkUpdate(
-                update.listViewRequests(), Collections.emptyList(), update.incidentRequests());
-        return realUpdateRepository
-            .bulkUpdate(updateWithoutFlowNodes)
-            .thenApply(
-                updatedIds -> {
-                  throw new ExporterException("Simulated failure for flow node bulk updates");
-                });
-      }
+      final NonIncidentBulkUpdate updateWithoutFlowNodes =
+          new NonIncidentBulkUpdate(update.listViewRequests(), Collections.emptyList());
+      return realUpdateRepository
+          .bulkUpdate(updateWithoutFlowNodes)
+          .thenApply(
+              updatedIds -> {
+                throw new ExporterException("Simulated failure for flow node bulk updates");
+              });
     }
 
     return realUpdateRepository.bulkUpdate(update);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -27,6 +27,7 @@ import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NonIncidentBulkUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.PendingIncidentUpdateBatch;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ProcessInstanceDocument;
 import io.camunda.search.schema.SearchEngineClient;
@@ -782,7 +783,7 @@ abstract class IncidentUpdateRepositoryIT {
     void shouldBulkUpdateListView() throws PersistenceException, IOException {
       // given
       final var repository = createRepository();
-      final var bulk = new IncidentBulkUpdate();
+      final var bulk = new NonIncidentBulkUpdate();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
           TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
@@ -831,7 +832,7 @@ abstract class IncidentUpdateRepositoryIT {
     void shouldBulkUpdateFlowNodeInstances() throws PersistenceException, IOException {
       // given
       final var repository = createRepository();
-      final var bulk = new IncidentBulkUpdate();
+      final var bulk = new NonIncidentBulkUpdate();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
           TargetIndex.mainIndex(flowNodeInstanceTemplate.getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -134,6 +134,8 @@ abstract class IncidentUpdateRepositoryIT {
 
   protected abstract IncidentUpdateRepository createRepository();
 
+  protected abstract void refresh(String index) throws IOException;
+
   protected abstract <T> Collection<T> search(
       final String index, final String field, final List<String> terms, final Class<T> documentType)
       throws IOException;
@@ -814,6 +816,9 @@ abstract class IncidentUpdateRepositoryIT {
 
       // then
       assertThat(result).succeedsWithin(REQUEST_TIMEOUT);
+
+      refresh(listViewTemplate.getFullQualifiedName());
+
       final var processInstances =
           search(
               listViewTemplate.getFullQualifiedName(),
@@ -863,6 +868,9 @@ abstract class IncidentUpdateRepositoryIT {
 
       // then
       assertThat(result).succeedsWithin(REQUEST_TIMEOUT);
+
+      refresh(flowNodeInstanceTemplate.getFullQualifiedName());
+
       final var flowNodes =
           search(
               flowNodeInstanceTemplate.getFullQualifiedName(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -1189,7 +1189,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
   }
 
   @TestTemplate
-  void shouldSendNotificationsWhenRetryingAfterPartialBulkUpdateFailure(
+  void shouldSendNotificationsWhenRetryingAfterPartialNonIncidentBulkUpdateFailure(
       final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
     withTask(
         config,
@@ -1301,13 +1301,13 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           }
 
           // given
-          errorInjectingRepository.setFailFlowNodeBulkUpdates(true);
+          errorInjectingRepository.setFailFlowNodeBulkUpdates(false);
 
           // when
           final var updatedSecond = job.execute();
 
           // then
-          assertThat(updatedSecond).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(4);
+          assertThat(updatedSecond).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(2);
 
           client.refresh(testPrefix);
 
@@ -1331,10 +1331,6 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verifyIncidentNotificationsSent(incidentEntity);
-
-          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
-          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(4);
-          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -52,6 +52,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
   private ExporterMetadata exporterMetadata;
   private IncidentNotifier incidentNotifier;
+  private ErrorInjectingIncidentUpdateRepository errorInjectingRepository;
 
   @Override
   @BeforeEach
@@ -59,6 +60,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
     super.setup();
     incidentNotifier = mock(IncidentNotifier.class);
     exporterMetadata = new ExporterMetadata(TestObjectMapper.objectMapper());
+    errorInjectingRepository = new ErrorInjectingIncidentUpdateRepository();
   }
 
   @Override
@@ -76,10 +78,11 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
   protected IncidentUpdateTask createBackgroundTask(
       final ExporterConfiguration config, final ExporterResourceProvider resourceProvider) {
     final var repository = createIncidentUpdateRepository(config, resourceProvider);
+    errorInjectingRepository.setRealUpdateRepository(repository);
 
     return new IncidentUpdateTask(
         exporterMetadata,
-        repository,
+        errorInjectingRepository,
         false,
         BATCH_SIZE,
         executor,
@@ -1181,6 +1184,156 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(10);
           verify(exporterMetrics).recordIncidentUpdatesDuplicateProcessInstances(2);
           verify(exporterMetrics).recordIncidentUpdatesDuplicateFlowNodeInstances(4);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
+        });
+  }
+
+  @TestTemplate
+  void shouldSendNotificationsWhenRetryingAfterPartialBulkUpdateFailure(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resources) -> {
+          final var listViewTemplate = resources.getIndexTemplateDescriptor(ListViewTemplate.class);
+
+          final var processInstanceKey = ID_GENERATOR.getAndIncrement();
+          final var treePath = String.format("PI_%d/FN_callActivity1", processInstanceKey);
+          final ProcessInstanceForListViewEntity processInstance =
+              new ProcessInstanceForListViewEntity()
+                  .setId(String.valueOf(processInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(processInstanceKey)
+                  .setProcessDefinitionKey(9999L)
+                  .setBpmnProcessId("process-1")
+                  .setTreePath(treePath);
+          store(listViewTemplate, client, processInstance);
+
+          final var flowNodeInstanceKey = ID_GENERATOR.getAndIncrement();
+
+          final FlowNodeInstanceForListViewEntity listViewFlowNodeInstance =
+              new FlowNodeInstanceForListViewEntity()
+                  .setId(String.valueOf(flowNodeInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(flowNodeInstanceKey)
+                  .setProcessInstanceKey(processInstance.getKey())
+                  .setRootProcessInstanceKey(processInstance.getKey());
+          listViewFlowNodeInstance.getJoinRelation().setParent(processInstance.getKey());
+          store(listViewTemplate, client, processInstance, listViewFlowNodeInstance);
+
+          final var flowNodeInstanceTemplate =
+              resources.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
+
+          final FlowNodeInstanceEntity flowNodeInstance =
+              new FlowNodeInstanceEntity()
+                  .setId(String.valueOf(flowNodeInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(flowNodeInstanceKey)
+                  .setProcessInstanceKey(processInstance.getKey())
+                  .setRootProcessInstanceKey(processInstance.getKey());
+          store(flowNodeInstanceTemplate, client, flowNodeInstance);
+
+          client.refresh(listViewTemplate.getFullQualifiedName());
+          client.refresh(flowNodeInstanceTemplate.getFullQualifiedName());
+
+          final var incidentTemplate = resources.getIndexTemplateDescriptor(IncidentTemplate.class);
+
+          final var incidentKey = ID_GENERATOR.getAndIncrement();
+          final IncidentEntity incidentEntity =
+              new IncidentEntity()
+                  .setId(String.valueOf(incidentKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(incidentKey)
+                  .setErrorMessage("An error happened")
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setFlowNodeInstanceKey(flowNodeInstanceKey);
+
+          store(incidentTemplate, client, incidentEntity);
+          client.refresh(incidentTemplate.getFullQualifiedName());
+
+          final var postImporterTemplate =
+              resources.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+
+          final PostImporterQueueEntity queueEntity =
+              new PostImporterQueueEntity()
+                  .setId("queue-1")
+                  .setPartitionId(PARTITION_ID)
+                  .setActionType(PostImporterActionType.INCIDENT)
+                  .setIntent("CREATED")
+                  .setKey(incidentKey)
+                  .setPosition(1L);
+
+          store(postImporterTemplate, client, queueEntity);
+          client.refresh(postImporterTemplate.getFullQualifiedName());
+
+          errorInjectingRepository.setFailFlowNodeBulkUpdates(true);
+
+          // when
+          final var updatedFirst = job.execute();
+
+          // then
+          assertThat(updatedFirst)
+              .failsWithin(EXECUTE_TIMEOUT)
+              .withThrowableThat()
+              .withRootCauseInstanceOf(ExporterException.class)
+              .withMessageContaining("Simulated failure for flow node bulk updates");
+
+          {
+            client.refresh(testPrefix);
+
+            verifyNoInteractions(incidentNotifier);
+
+            // confirm some docs updated, but not all of them
+            final var updatedProcessInstance =
+                getFromIndex(listViewTemplate, client, processInstance);
+            assertThat(updatedProcessInstance.isIncident()).isTrue();
+
+            final var updatedListViewFlowNodeInstance =
+                getChildFromIndex(
+                    listViewTemplate, client, processInstance, listViewFlowNodeInstance);
+            assertThat(updatedListViewFlowNodeInstance.isIncident()).isTrue();
+
+            final var updatedFlowNodeInstance =
+                getFromIndex(flowNodeInstanceTemplate, client, flowNodeInstance);
+            assertThat(updatedFlowNodeInstance.isIncident()).isFalse();
+
+            final var updatedIncident = getFromIndex(incidentTemplate, client, incidentEntity);
+            assertThat(updatedIncident.getState()).isNull();
+          }
+
+          // given
+          errorInjectingRepository.setFailFlowNodeBulkUpdates(true);
+
+          // when
+          final var updatedSecond = job.execute();
+
+          // then
+          assertThat(updatedSecond).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(4);
+
+          client.refresh(testPrefix);
+
+          final var updatedProcessInstance =
+              getFromIndex(listViewTemplate, client, processInstance);
+          assertThat(updatedProcessInstance.isIncident()).isTrue();
+
+          final var updatedListViewFlowNodeInstance =
+              getChildFromIndex(
+                  listViewTemplate, client, processInstance, listViewFlowNodeInstance);
+          assertThat(updatedListViewFlowNodeInstance.isIncident()).isTrue();
+
+          final var updatedFlowNodeInstance =
+              getFromIndex(flowNodeInstanceTemplate, client, flowNodeInstance);
+          assertThat(updatedFlowNodeInstance.isIncident()).isTrue();
+
+          final var updatedIncident = getFromIndex(incidentTemplate, client, incidentEntity);
+          assertThat(updatedIncident.getTreePath())
+              .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
+          assertThat(updatedIncident.getState()).isEqualTo(IncidentState.ACTIVE);
+
+          assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+          verifyIncidentNotificationsSent(incidentEntity);
+
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(4);
           verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
         });
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -27,6 +28,7 @@ import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NonIncidentBulkUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.PendingIncidentUpdateBatch;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ProcessInstanceDocument;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -67,8 +69,10 @@ final class IncidentUpdateTaskTest {
   private final IncidentUpdateRepository repository = Mockito.mock(IncidentUpdateRepository.class);
   private final CamundaExporterMetrics metrics = Mockito.mock(CamundaExporterMetrics.class);
 
-  private final ArgumentCaptor<IncidentBulkUpdate> bulkUpdateCaptor =
+  private final ArgumentCaptor<IncidentBulkUpdate> incidentBulkUpdateCaptor =
       ArgumentCaptor.forClass(IncidentBulkUpdate.class);
+  private final ArgumentCaptor<NonIncidentBulkUpdate> nonIncidentBulkUpdateCaptor =
+      ArgumentCaptor.forClass(NonIncidentBulkUpdate.class);
 
   @BeforeEach
   void beforeEach() {
@@ -210,10 +214,17 @@ final class IncidentUpdateTaskTest {
       when(repository.getActiveIncidentsByTreePaths(any()))
           .thenReturn(CompletableFuture.completedFuture(List.of()));
 
-      when(repository.bulkUpdate(any()))
+      when(repository.bulkUpdate(any(IncidentBulkUpdate.class)))
           .then(
               inv -> {
                 final IncidentBulkUpdate update = inv.getArgument(0);
+                return CompletableFuture.completedFuture(
+                    update.stream().map(DocumentUpdate::id).toList());
+              });
+      when(repository.bulkUpdate(any(NonIncidentBulkUpdate.class)))
+          .then(
+              inv -> {
+                final NonIncidentBulkUpdate update = inv.getArgument(0);
                 return CompletableFuture.completedFuture(
                     update.stream().map(DocumentUpdate::id).toList());
               });
@@ -303,7 +314,8 @@ final class IncidentUpdateTaskTest {
       assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(1);
 
       verify(metrics).recordIncidentUpdatesRetriesNeeded(1);
-      verify(repository, never()).bulkUpdate(any());
+      verify(repository, never()).bulkUpdate(any(NonIncidentBulkUpdate.class));
+      verify(repository, never()).bulkUpdate(any(IncidentBulkUpdate.class));
       verify(incidentNotifier, never()).notifyAsync(any());
       assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);
     }
@@ -338,9 +350,12 @@ final class IncidentUpdateTaskTest {
       // then - no NPE, no retry: the batch is processed with a sparse tree path rooted at the PI
       assertThat(result).succeedsWithin(TIMEOUT);
       verify(metrics, never()).recordIncidentUpdatesRetriesNeeded(anyInt());
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
-      assertThat(update.incidentRequests())
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var incidentBulkUpdate = incidentBulkUpdateCaptor.getValue();
+      assertThat(incidentBulkUpdate.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
               new DocumentUpdate(
@@ -352,13 +367,15 @@ final class IncidentUpdateTaskTest {
                       IncidentTemplate.TREE_PATH,
                       "PI_3/FNI_4"),
                   null));
+
+      final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
       // only the PI and flow node referenced by the sparse path are touched (no parent ancestry)
-      assertThat(update.listViewRequests())
+      assertThat(nonIncidentBulkUpdate.listViewRequests())
           .hasSize(2)
           .containsExactlyInAnyOrder(
               new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"),
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
-      assertThat(update.flowNodeInstanceRequests())
+      assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
               new DocumentUpdate(
@@ -395,8 +412,11 @@ final class IncidentUpdateTaskTest {
       // then - processed with the sparse fallback, not retried
       assertThat(result).succeedsWithin(TIMEOUT);
       verify(metrics, never()).recordIncidentUpdatesRetriesNeeded(anyInt());
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var update = incidentBulkUpdateCaptor.getValue();
       assertThat(update.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
@@ -492,8 +512,11 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result).succeedsWithin(TIMEOUT);
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var update = incidentBulkUpdateCaptor.getValue();
       assertThat(update.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
@@ -539,8 +562,11 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result).succeedsWithin(TIMEOUT);
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var update = nonIncidentBulkUpdateCaptor.getValue();
       assertThat(update.listViewRequests())
           .hasSize(4)
           .containsExactlyInAnyOrder(
@@ -581,8 +607,11 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result).succeedsWithin(TIMEOUT);
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var update = nonIncidentBulkUpdateCaptor.getValue();
       assertThat(update.flowNodeInstanceRequests())
           .hasSize(2)
           .containsExactlyInAnyOrder(
@@ -634,9 +663,12 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result).succeedsWithin(TIMEOUT);
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
-      assertThat(update.incidentRequests())
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var incidentBulkUpdate = incidentBulkUpdateCaptor.getValue();
+      assertThat(incidentBulkUpdate.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
               new DocumentUpdate(
@@ -648,8 +680,10 @@ final class IncidentUpdateTaskTest {
                       IncidentTemplate.TREE_PATH,
                       "PI_1/FNI_1"),
                   null));
-      assertThat(update.flowNodeInstanceRequests()).isEmpty();
-      assertThat(update.listViewRequests())
+
+      final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
+      assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests()).isEmpty();
+      assertThat(nonIncidentBulkUpdate.listViewRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
               new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"));
@@ -698,21 +732,26 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result).succeedsWithin(TIMEOUT);
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
-      assertThat(update.incidentRequests())
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var incidentBulkUpdate = incidentBulkUpdateCaptor.getValue();
+      assertThat(incidentBulkUpdate.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "5", "incidents", Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED), null));
-      assertThat(update.flowNodeInstanceRequests())
+
+      final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
+      assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests())
           .hasSize(2)
           .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null),
               new DocumentUpdate(
                   "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null));
-      assertThat(update.listViewRequests())
+      assertThat(nonIncidentBulkUpdate.listViewRequests())
           .hasSize(4)
           .containsExactlyInAnyOrder(
               new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"),
@@ -760,21 +799,26 @@ final class IncidentUpdateTaskTest {
       // then - we should mark the child process instance, the call activity, and the task as
       // incident free, but NOT the parent process instance as it still has an active incident
       assertThat(result).succeedsWithin(TIMEOUT);
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
-      assertThat(update.incidentRequests())
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var incidentBulkUpdate = incidentBulkUpdateCaptor.getValue();
+      assertThat(incidentBulkUpdate.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "5", "incidents", Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED), null));
-      assertThat(update.flowNodeInstanceRequests())
+
+      final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
+      assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests())
           .hasSize(2)
           .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null),
               new DocumentUpdate(
                   "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null));
-      assertThat(update.listViewRequests())
+      assertThat(nonIncidentBulkUpdate.listViewRequests())
           .hasSize(3)
           .containsExactlyInAnyOrder(
               new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"),
@@ -809,11 +853,17 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result).succeedsWithin(TIMEOUT);
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
-      assertThat(update.listViewRequests()).isEmpty();
-      assertThat(update.incidentRequests()).isEmpty();
-      assertThat(update.flowNodeInstanceRequests()).isEmpty();
+      final var inOrder = inOrder(repository);
+      inOrder.verify(repository).bulkUpdate(nonIncidentBulkUpdateCaptor.capture());
+      inOrder.verify(repository).bulkUpdate(incidentBulkUpdateCaptor.capture());
+
+      final var incidentBulkUpdate = incidentBulkUpdateCaptor.getValue();
+      assertThat(incidentBulkUpdate.incidentRequests()).isEmpty();
+
+      final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
+      assertThat(nonIncidentBulkUpdate.listViewRequests()).isEmpty();
+      assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests()).isEmpty();
+
       verify(incidentNotifier, times(0)).notifyAsync(any());
       verify(metrics).recordIncidentUpdatesProcessed(1);
       verify(metrics).recordIncidentUpdatesDocumentsUpdated(0);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
@@ -59,6 +59,12 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
   }
 
   @Override
+  protected void refresh(final String index) throws IOException {
+    final var client = new OpenSearchClient(transport);
+    client.indices().refresh(r -> r.index(index));
+  }
+
+  @Override
   protected <T> Collection<T> search(
       final String index, final String field, final List<String> terms, final Class<T> documentType)
       throws IOException {


### PR DESCRIPTION
## Description

This fixes one case where the incident update task can fail to send notifications for incidents.

Previously we would update the flow node instances + process instances in the same bulk update call as incidents.  If there was a glitch updating a flow node instance (e.g. due to archiver activity moving docs) then we would throw an error and retry the task.  However if the incidents had been updated ok (quite possible as they are in different indexes) then when we retry we would see that the incident was already marked as `ACTIVE` and therefore would need to send the relevant the notification.

This splits the updates into two:

* flow node instances + process instances
* incidents

There is still a possible edge-case where we have multiple incidents in a single batch and one incident update fails, but I will look into handling that in a later PR

## Related issues

refs #59931
