### PR TITLE
test: cover the membership resolution context propagator wiring for OIDC

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthBeansConfigurationConverterWiringTest.java
@@ -75,23 +75,23 @@ class BasicAuthBeansConfigurationConverterWiringTest {
     PhysicalTenantContext.setPhysicalTenantId(request, "tenant-a");
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-    final Map<String, String> tenantSeenBy = new HashMap<>();
+    final Map<String, String> tenantSeenByLookup = new HashMap<>();
     when(membershipPort.groupIds(any()))
         .thenAnswer(
             invocation -> {
-              tenantSeenBy.put("groupIds", PhysicalTenantContext.current());
+              tenantSeenByLookup.put("groupIds", PhysicalTenantContext.current());
               return List.of("group-1");
             });
     when(membershipPort.roleIds(any()))
         .thenAnswer(
             invocation -> {
-              tenantSeenBy.put("roleIds", PhysicalTenantContext.current());
+              tenantSeenByLookup.put("roleIds", PhysicalTenantContext.current());
               return List.of("role-1");
             });
     when(membershipPort.tenantIds(any()))
         .thenAnswer(
             invocation -> {
-              tenantSeenBy.put("tenantIds", PhysicalTenantContext.current());
+              tenantSeenByLookup.put("tenantIds", PhysicalTenantContext.current());
               return List.of("tenant-1");
             });
 
@@ -110,7 +110,7 @@ class BasicAuthBeansConfigurationConverterWiringTest {
     assertThat(authentication.authenticatedGroupIds()).containsExactly("group-1");
     assertThat(authentication.authenticatedRoleIds()).containsExactly("role-1");
     assertThat(authentication.authenticatedTenantIds()).containsExactly("tenant-1");
-    assertThat(tenantSeenBy)
+    assertThat(tenantSeenByLookup)
         .containsEntry("groupIds", "tenant-a")
         .containsEntry("roleIds", "tenant-a")
         .containsEntry("tenantIds", "tenant-a");

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
+import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.OidcProviderConfigurationPort;
 import io.camunda.security.core.port.out.MembershipPort;
@@ -110,15 +111,7 @@ class OidcOverrideBeansConfigurationConverterWiringTest {
     RequestContextHolder.resetRequestAttributes();
 
     // then every lookup uses the tenant from login time. Without the wrapping it would throw here.
-    assertThat(authentication.authenticatedMappingRuleIds()).containsExactly("mapping-rule-1");
-    assertThat(authentication.authenticatedGroupIds()).containsExactly("group-1");
-    assertThat(authentication.authenticatedRoleIds()).containsExactly("role-1");
-    assertThat(authentication.authenticatedTenantIds()).containsExactly("tenant-1");
-    assertThat(tenantSeenByLookup)
-        .containsEntry("mappingRuleIds", "tenant-a")
-        .containsEntry("groupIds", "tenant-a")
-        .containsEntry("roleIds", "tenant-a")
-        .containsEntry("tenantIds", "tenant-a");
+    assertMembershipResolvedAgainstTenant(authentication, tenantSeenByLookup, "tenant-a");
   }
 
   @Test
@@ -138,21 +131,29 @@ class OidcOverrideBeansConfigurationConverterWiringTest {
     RequestContextHolder.resetRequestAttributes();
 
     // then the scoped converter's lists resolve against the tenant from login too
-    assertThat(authentication.authenticatedMappingRuleIds()).containsExactly("mapping-rule-1");
-    assertThat(authentication.authenticatedGroupIds()).containsExactly("group-1");
-    assertThat(authentication.authenticatedRoleIds()).containsExactly("role-1");
-    assertThat(authentication.authenticatedTenantIds()).containsExactly("tenant-1");
-    assertThat(tenantSeenByLookup)
-        .containsEntry("mappingRuleIds", "tenanta")
-        .containsEntry("groupIds", "tenanta")
-        .containsEntry("roleIds", "tenanta")
-        .containsEntry("tenantIds", "tenanta");
+    assertMembershipResolvedAgainstTenant(authentication, tenantSeenByLookup, "tenanta");
   }
 
   @AfterEach
   void clearRequestScope() {
     // if a test fails early, the request it bound would leak into the next test
     RequestContextHolder.resetRequestAttributes();
+  }
+
+  /** Asserts all four lazy lists resolved, each lookup having observed {@code tenant}. */
+  private static void assertMembershipResolvedAgainstTenant(
+      final CamundaAuthentication authentication,
+      final Map<String, String> tenantSeenByLookup,
+      final String tenant) {
+    assertThat(authentication.authenticatedMappingRuleIds()).containsExactly("mapping-rule-1");
+    assertThat(authentication.authenticatedGroupIds()).containsExactly("group-1");
+    assertThat(authentication.authenticatedRoleIds()).containsExactly("role-1");
+    assertThat(authentication.authenticatedTenantIds()).containsExactly("tenant-1");
+    assertThat(tenantSeenByLookup)
+        .containsEntry("mappingRuleIds", tenant)
+        .containsEntry("groupIds", tenant)
+        .containsEntry("roleIds", tenant)
+        .containsEntry("tenantIds", tenant);
   }
 
   /** Records the physical tenant each membership lookup observes, keyed by lookup name. */

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
@@ -95,31 +95,7 @@ class OidcOverrideBeansConfigurationConverterWiringTest {
     PhysicalTenantContext.setPhysicalTenantId(loginRequest, "tenant-a");
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(loginRequest));
 
-    final Map<String, String> tenantSeenByLookup = new HashMap<>();
-    when(membershipPort.mappingRuleIds(any()))
-        .thenAnswer(
-            invocation -> {
-              tenantSeenByLookup.put("mappingRuleIds", PhysicalTenantContext.current());
-              return List.of("mapping-rule-1");
-            });
-    when(membershipPort.groupIds(any()))
-        .thenAnswer(
-            invocation -> {
-              tenantSeenByLookup.put("groupIds", PhysicalTenantContext.current());
-              return List.of("group-1");
-            });
-    when(membershipPort.roleIds(any()))
-        .thenAnswer(
-            invocation -> {
-              tenantSeenByLookup.put("roleIds", PhysicalTenantContext.current());
-              return List.of("role-1");
-            });
-    when(membershipPort.tenantIds(any()))
-        .thenAnswer(
-            invocation -> {
-              tenantSeenByLookup.put("tenantIds", PhysicalTenantContext.current());
-              return List.of("tenant-1");
-            });
+    final Map<String, String> tenantSeenByLookup = recordTenantPerLookup();
 
     final var cslProperties = new CamundaSecurityLibraryProperties();
     cslProperties.getAuthentication().getOidc().setUsernameClaim(USERNAME_CLAIM);
@@ -145,14 +121,80 @@ class OidcOverrideBeansConfigurationConverterWiringTest {
         .containsEntry("tenantIds", "tenant-a");
   }
 
+  @Test
+  void shouldResolveScopedRegistrationMembershipAgainstTenantCapturedAtLogin() {
+    // given a login on a physical tenant's own OIDC registration, converted with the real
+    // propagator. This converter is built per registration id, separately from the root one above.
+    final var loginRequest = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(loginRequest, "tenant-a");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(loginRequest));
+
+    final Map<String, String> tenantSeenByLookup = recordTenantPerLookup();
+    final var authentication =
+        converter(USERNAME_CLAIM, USERNAME_CLAIM, new PhysicalTenantMembershipContextPropagator())
+            .convert(login("auth0", Map.of(USERNAME_CLAIM, "alice")));
+
+    // when the request has ended before any list is read
+    RequestContextHolder.resetRequestAttributes();
+
+    // then the scoped converter's lists resolve against the tenant from login too
+    assertThat(authentication.authenticatedMappingRuleIds()).containsExactly("mapping-rule-1");
+    assertThat(authentication.authenticatedGroupIds()).containsExactly("group-1");
+    assertThat(authentication.authenticatedRoleIds()).containsExactly("role-1");
+    assertThat(authentication.authenticatedTenantIds()).containsExactly("tenant-1");
+    assertThat(tenantSeenByLookup)
+        .containsEntry("mappingRuleIds", "tenant-a")
+        .containsEntry("groupIds", "tenant-a")
+        .containsEntry("roleIds", "tenant-a")
+        .containsEntry("tenantIds", "tenant-a");
+  }
+
   @AfterEach
   void clearRequestScope() {
     // if a test fails early, the request it bound would leak into the next test
     RequestContextHolder.resetRequestAttributes();
   }
 
+  /** Records the physical tenant each membership lookup observes, keyed by lookup name. */
+  private Map<String, String> recordTenantPerLookup() {
+    final Map<String, String> tenantSeenByLookup = new HashMap<>();
+    when(membershipPort.mappingRuleIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenByLookup.put("mappingRuleIds", PhysicalTenantContext.current());
+              return List.of("mapping-rule-1");
+            });
+    when(membershipPort.groupIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenByLookup.put("groupIds", PhysicalTenantContext.current());
+              return List.of("group-1");
+            });
+    when(membershipPort.roleIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenByLookup.put("roleIds", PhysicalTenantContext.current());
+              return List.of("role-1");
+            });
+    when(membershipPort.tenantIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenByLookup.put("tenantIds", PhysicalTenantContext.current());
+              return List.of("tenant-1");
+            });
+    return tenantSeenByLookup;
+  }
+
   private CamundaAuthenticationConverter<Authentication> converter(
       final String rootUsernameClaim, final String scopedUsernameClaim) {
+    return converter(
+        rootUsernameClaim, scopedUsernameClaim, MembershipResolutionContextPropagator.identity());
+  }
+
+  private CamundaAuthenticationConverter<Authentication> converter(
+      final String rootUsernameClaim,
+      final String scopedUsernameClaim,
+      final MembershipResolutionContextPropagator propagator) {
     when(oidcProviderRepository.getOidcAuthenticationConfigurations()).thenReturn(Map.of());
     // authorizedClientRepository returns no client, so the converter falls back to ID-token
     // (principal) claims, which is the interactive-login path this test exercises.
@@ -180,7 +222,7 @@ class OidcOverrideBeansConfigurationConverterWiringTest {
         request,
         oidcProviderRepository,
         membershipPort,
-        MembershipResolutionContextPropagator.identity(),
+        propagator,
         environment);
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
@@ -8,9 +8,11 @@
 package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
@@ -18,31 +20,41 @@ import io.camunda.security.core.port.in.OidcProviderConfigurationPort;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
  * Verifies the {@code oidcUserAuthenticationConverter} bean is wired so interactive login (issue
  * #57776) selects claim mapping by registration id and normalizes URI-valued identity claims. This
  * drives the real bean factory method (not the converter in isolation), so reverting the wiring
  * back to the plain root converter fails these tests.
+ *
+ * <p>Also checks that OIDC login wraps its lazy membership lists with the host's propagator, so the
+ * lists still work after the request that created them has ended.
  */
 @ExtendWith(MockitoExtension.class)
 class OidcOverrideBeansConfigurationConverterWiringTest {
 
   private static final String SCOPED_PREFIX =
       "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.auth0";
+  private static final String USERNAME_CLAIM = "preferred_username";
 
   @Mock private OAuth2AuthorizedClientRepository authorizedClientRepository;
   @Mock private OidcAccessTokenDecoderFactory accessTokenDecoderFactory;
@@ -74,6 +86,69 @@ class OidcOverrideBeansConfigurationConverterWiringTest {
 
     // then — the root iss is normalized so the default converter can resolve it
     assertThat(result.authenticatedUsername()).isEqualTo("https://root-idp");
+  }
+
+  @Test
+  void shouldResolveMembershipAgainstTenantCapturedAtLoginAfterRequestScopeEnds() {
+    // given a login that carries a physical tenant, converted with the real propagator
+    final var loginRequest = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(loginRequest, "tenant-a");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(loginRequest));
+
+    final Map<String, String> tenantSeenByLookup = new HashMap<>();
+    when(membershipPort.mappingRuleIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenByLookup.put("mappingRuleIds", PhysicalTenantContext.current());
+              return List.of("mapping-rule-1");
+            });
+    when(membershipPort.groupIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenByLookup.put("groupIds", PhysicalTenantContext.current());
+              return List.of("group-1");
+            });
+    when(membershipPort.roleIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenByLookup.put("roleIds", PhysicalTenantContext.current());
+              return List.of("role-1");
+            });
+    when(membershipPort.tenantIds(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantSeenByLookup.put("tenantIds", PhysicalTenantContext.current());
+              return List.of("tenant-1");
+            });
+
+    final var cslProperties = new CamundaSecurityLibraryProperties();
+    cslProperties.getAuthentication().getOidc().setUsernameClaim(USERNAME_CLAIM);
+    final var authentication =
+        new OidcOverrideBeansConfiguration(cslProperties)
+            .tokenClaimsConverter(
+                cslProperties, membershipPort, new PhysicalTenantMembershipContextPropagator())
+            .convert(Map.of(USERNAME_CLAIM, "alice"));
+
+    // when the request has ended before any list is read, as happens when a stored session writes
+    // the authentication out
+    RequestContextHolder.resetRequestAttributes();
+
+    // then every lookup uses the tenant from login time. Without the wrapping it would throw here.
+    assertThat(authentication.authenticatedMappingRuleIds()).containsExactly("mapping-rule-1");
+    assertThat(authentication.authenticatedGroupIds()).containsExactly("group-1");
+    assertThat(authentication.authenticatedRoleIds()).containsExactly("role-1");
+    assertThat(authentication.authenticatedTenantIds()).containsExactly("tenant-1");
+    assertThat(tenantSeenByLookup)
+        .containsEntry("mappingRuleIds", "tenant-a")
+        .containsEntry("groupIds", "tenant-a")
+        .containsEntry("roleIds", "tenant-a")
+        .containsEntry("tenantIds", "tenant-a");
+  }
+
+  @AfterEach
+  void clearRequestScope() {
+    // if a test fails early, the request it bound would leak into the next test
+    RequestContextHolder.resetRequestAttributes();
   }
 
   private CamundaAuthenticationConverter<Authentication> converter(

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
@@ -126,7 +126,7 @@ class OidcOverrideBeansConfigurationConverterWiringTest {
     // given a login on a physical tenant's own OIDC registration, converted with the real
     // propagator. This converter is built per registration id, separately from the root one above.
     final var loginRequest = new MockHttpServletRequest();
-    PhysicalTenantContext.setPhysicalTenantId(loginRequest, "tenant-a");
+    PhysicalTenantContext.setPhysicalTenantId(loginRequest, "tenanta");
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(loginRequest));
 
     final Map<String, String> tenantSeenByLookup = recordTenantPerLookup();
@@ -143,10 +143,10 @@ class OidcOverrideBeansConfigurationConverterWiringTest {
     assertThat(authentication.authenticatedRoleIds()).containsExactly("role-1");
     assertThat(authentication.authenticatedTenantIds()).containsExactly("tenant-1");
     assertThat(tenantSeenByLookup)
-        .containsEntry("mappingRuleIds", "tenant-a")
-        .containsEntry("groupIds", "tenant-a")
-        .containsEntry("roleIds", "tenant-a")
-        .containsEntry("tenantIds", "tenant-a");
+        .containsEntry("mappingRuleIds", "tenanta")
+        .containsEntry("groupIds", "tenanta")
+        .containsEntry("roleIds", "tenanta")
+        .containsEntry("tenantIds", "tenanta");
   }
 
   @AfterEach

--- a/authentication/src/test/java/io/camunda/authentication/config/WebSecurityConfigPropagatorImportTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/WebSecurityConfigPropagatorImportTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
+import io.camunda.security.core.port.out.MembershipPort;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.convention.TestBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Checks that a booted application actually gets the host's propagator, under either authentication
+ * method.
+ */
+class WebSecurityConfigPropagatorImportTest {
+
+  abstract static class BaseTest {
+    @MockitoBean MembershipPort membershipPort;
+
+    @Autowired MembershipResolutionContextPropagator propagator;
+
+    @Test
+    void shouldImportThePhysicalTenantPropagator() {
+      // given a context booted the way production boots
+      // when the propagator is resolved
+      // then it is the host's, not the library's no-op default
+      assertThat(propagator).isInstanceOf(PhysicalTenantMembershipContextPropagator.class);
+    }
+  }
+
+  // Empty bodies on purpose: each subclass contributes only a context, inheriting BaseTest's single
+  // assertion so it runs once per authentication method. Both name their method explicitly rather
+  // than leaning on the library default, which could move and quietly collapse the two into one.
+  @Nested
+  @SpringBootTest(
+      classes = WebSecurityConfigTestContext.class,
+      properties = "camunda.security.authentication.method=basic")
+  @ActiveProfiles("consolidated-auth")
+  class BasicAuthTest extends BaseTest {}
+
+  @Nested
+  @SpringBootTest(
+      classes = WebSecurityConfigTestContext.class,
+      properties = "camunda.security.authentication.method=oidc")
+  @ActiveProfiles("consolidated-auth")
+  class OidcAuthTest extends BaseTest {
+    @TestBean private ClientRegistrationRepository clientRegistrationRepository;
+    @MockitoBean private JwtDecoder jwtDecoder;
+
+    static ClientRegistrationRepository clientRegistrationRepository() {
+      final var dummyRegistration =
+          ClientRegistration.withRegistrationId("test")
+              .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+              .clientId("test-client")
+              .redirectUri("{baseUrl}/sso-callback")
+              .authorizationUri("https://example.com/authorize")
+              .tokenUri("https://example.com/token")
+              .issuerUri("https://example.com")
+              .build();
+      return new InMemoryClientRegistrationRepository(dummyRegistration);
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/WebSecurityConfigPropagatorImportTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/WebSecurityConfigPropagatorImportTest.java
@@ -56,7 +56,18 @@ class WebSecurityConfigPropagatorImportTest {
   @Nested
   @SpringBootTest(
       classes = WebSecurityConfigTestContext.class,
-      properties = "camunda.security.authentication.method=oidc")
+      properties = {
+        "camunda.security.authentication.method=oidc",
+        // The scoped API chain for the implicit "default" physical tenant builds its own
+        // issuer-aware decoder from this config, separately from the mocked JwtDecoder and dummy
+        // ClientRegistrationRepository below (which only satisfy the cluster chain). A provider
+        // must be declared, with a well-formed but unreachable URI; resolution is lazy, so nothing
+        // is fetched. See SessionAuthenticationRefreshTest for the same fixture shape.
+        "camunda.security.authentication.oidc.client-id=example",
+        "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+        "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+        "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com"
+      })
   @ActiveProfiles("consolidated-auth")
   class OidcAuthTest extends BaseTest {
     @TestBean private ClientRegistrationRepository clientRegistrationRepository;

--- a/authentication/src/test/java/io/camunda/authentication/config/WebSecurityConfigPropagatorImportTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/WebSecurityConfigPropagatorImportTest.java
@@ -46,9 +46,8 @@ class WebSecurityConfigPropagatorImportTest {
     }
   }
 
-  // Empty bodies on purpose: each subclass contributes only a context, inheriting BaseTest's single
-  // assertion so it runs once per authentication method. Both name their method explicitly rather
-  // than leaning on the library default, which could move and quietly collapse the two into one.
+  // Each subclass adds only what its context needs to boot and inherits BaseTest's assertion, so
+  // that assertion runs once per authentication method.
   @Nested
   @SpringBootTest(
       classes = WebSecurityConfigTestContext.class,

--- a/authentication/src/test/java/io/camunda/authentication/config/WebSecurityConfigPropagatorImportTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/WebSecurityConfigPropagatorImportTest.java
@@ -9,6 +9,7 @@ package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.authentication.config.controllers.DummyOidcClientRegistration;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
@@ -17,10 +18,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.convention.TestBean;
@@ -65,16 +63,7 @@ class WebSecurityConfigPropagatorImportTest {
     @MockitoBean private JwtDecoder jwtDecoder;
 
     static ClientRegistrationRepository clientRegistrationRepository() {
-      final var dummyRegistration =
-          ClientRegistration.withRegistrationId("test")
-              .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-              .clientId("test-client")
-              .redirectUri("{baseUrl}/sso-callback")
-              .authorizationUri("https://example.com/authorize")
-              .tokenUri("https://example.com/token")
-              .issuerUri("https://example.com")
-              .build();
-      return new InMemoryClientRegistrationRepository(dummyRegistration);
+      return DummyOidcClientRegistration.repository();
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/DummyOidcClientRegistration.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/DummyOidcClientRegistration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config.controllers;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+/**
+ * A single-registration {@link ClientRegistrationRepository} that satisfies the OIDC filter chain's
+ * dependencies without a real IdP, for slice tests booted under {@code method=oidc}.
+ */
+public final class DummyOidcClientRegistration {
+
+  private DummyOidcClientRegistration() {}
+
+  public static ClientRegistrationRepository repository() {
+    final var dummyRegistration =
+        ClientRegistration.withRegistrationId("test")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .clientId("test-client")
+            .redirectUri("{baseUrl}/sso-callback")
+            .authorizationUri("https://example.com/authorize")
+            .tokenUri("https://example.com/token")
+            .issuerUri("https://example.com")
+            .build();
+    return new InMemoryClientRegistrationRepository(dummyRegistration);
+  }
+}


### PR DESCRIPTION
## Description

The propagator wiring was correct but untested, so three regressions could ship
silently:

- `tokenClaimsConverter(...)` could stop passing the propagator to
  `LazyTokenClaimsConverter`
- `oidcUserAuthenticationConverter(...)` could stop passing it to the converters
  built per registration id, used when a physical tenant configures its own OIDC
  provider
- `WebSecurityConfig` could stop importing
  `MembershipResolutionContextPropagatorConfiguration`

Any of them drops every lazy membership list back to the library's no-op
propagator. The list then resolves after the request scope is gone — most
visibly when a persistent web session is serialised — asks for the current
physical tenant, finds nothing bound, and login breaks for physical tenants.

Each was verified by mutation: introduced locally, every one left the whole
module green beforehand, and each now fails exactly one test.

## Tests

- `OidcOverrideBeansConfigurationConverterWiringTest` — one teardown test per
  OIDC converter: the default one from `tokenClaimsConverter(...)`, and the one
  built per registration id for a physical tenant's own provider. Each builds the
  converter from the real bean while a request stamped with a physical tenant is
  in scope, ends the request, then reads all four lazy membership lists and checks
  each resolved against the tenant from login.
- `WebSecurityConfigPropagatorImportTest` — boots a context that imports
  `WebSecurityConfig` without naming the propagator configuration, so the bean can
  only arrive through that import. Runs once per authentication method, which also
  catches the propagator being scoped back to a single method.

Closes #60442
