### PR TITLE
feat: integrate Tailwind CSS into shadcn routes and components

### DIFF
--- a/.claude/skills/design-system-migrator/SKILL.md
+++ b/.claude/skills/design-system-migrator/SKILL.md
@@ -13,7 +13,7 @@ cutover. Do not replace, move, or delete the Carbon implementation unless explic
 requested.
 
 For general application architecture, defer to `frontend-feature`. This skill overrides
-its Carbon-only component and route guidance during design-system migration.
+its Carbon-only component, route, and SCSS guidance during design-system migration.
 
 ## Route conventions
 
@@ -28,7 +28,8 @@ its Carbon-only component and route guidance during design-system migration.
 - Keep route files thin. They wire loaders and page components into TanStack Router;
   feature logic stays in the pod area.
 - Do not add Carbon providers or global Carbon styles to shadcn routes. The
-  `src/routes/shadcn/route.tsx` layout owns `C4Provider` and design-system styles.
+  `src/routes/shadcn/route.tsx` layout owns `C4Provider`, design-system styles, and the
+  Tailwind stylesheet.
 - Do not change the Carbon route while creating its shadcn counterpart.
 
 Example mapping:
@@ -65,13 +66,28 @@ src/tasklist/modules/available-tasks/
     Filters.test.tsx
 ```
 
+## Styling conventions
+
+- Style shadcn routes and components exclusively with Tailwind utility classes.
+- Do not create or import SCSS, CSS modules, feature CSS files, or styled-components for
+  shadcn routes or components. Translate existing Carbon styles into Tailwind classes
+  instead of copying their stylesheets.
+- Use `cn` from `#/shared/cn` for conditional classes and when combining classes that may
+  conflict.
+- The route-level imports of `@camunda/design-system/styles.css` and
+  `src/shared/theme/tailwind.css` are infrastructure owned by
+  `src/routes/shadcn/route.tsx`; they are not a pattern for feature-level styling.
+- These restrictions apply only to the shadcn implementation. Leave the existing Carbon
+  implementation and its styling approach intact.
+
 ## Migration workflow
 
-1. Read the Carbon route, components, tests, and styles; record their behavior.
+1. Read the Carbon route, components, tests, and styles; record their behavior and visual
+   requirements.
 2. Add the mirrored route under `src/routes/shadcn/`.
 3. Add migrated components under the relevant sibling `shadcn.components/` folder.
 4. Preserve behavior and accessibility while replacing Carbon primitives with
-   `@camunda/design-system` primitives.
+   `@camunda/design-system` primitives and translating styles into Tailwind classes.
 5. Add or migrate tests beside the shadcn components and under `src/routes/shadcn/`.
    These paths run in the `shadcn` Vitest browser instance.
 6. Leave the Carbon route, components, and tests intact.

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -32,6 +32,7 @@
 		"@carbon/type": "11.65.0",
 		"@devbookhq/splitter": "1.4.2",
 		"@monaco-editor/react": "4.7.0",
+		"@tailwindcss/vite": "4.3.3",
 		"@tanstack/react-query": "5.101.4",
 		"@tanstack/react-query-devtools": "5.101.4",
 		"@tanstack/react-router": "1.170.29",
@@ -64,6 +65,8 @@
 		"react-transition-group": "4.4.5",
 		"sass": "1.102.0",
 		"styled-components": "6.5.3",
+		"tailwind-merge": "3.6.0",
+		"tailwindcss": "4.3.3",
 		"xstate": "5.32.5",
 		"zod": "4.4.3"
 	},

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/route.tsx
@@ -8,10 +8,15 @@
 
 import {C4Provider} from '@camunda/design-system';
 import '@camunda/design-system/styles.css';
+import appCss from '#/shared/theme/tailwind.css?url';
 import {createFileRoute, Outlet} from '@tanstack/react-router';
 
 const Route = createFileRoute('/shadcn')({
 	component: RouteComponent,
+	head: () => ({
+		meta: [],
+		links: [{rel: 'stylesheet', href: appCss}],
+	}),
 });
 
 function RouteComponent() {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/cn.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/cn.ts
@@ -6,6 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {twMerge} from 'tailwind-merge';
+
 type ClassValue = string | undefined | null | false | Record<string, unknown>;
 
 function cn(...args: ClassValue[]): string {
@@ -23,7 +25,7 @@ function cn(...args: ClassValue[]): string {
 		}
 	}
 
-	return classes.join(' ');
+	return twMerge(classes.join(' '));
 }
 
 export {cn};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/theme/tailwind.css
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/theme/tailwind.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/theme/tailwind.css
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/theme/tailwind.css
@@ -1,1 +1,9 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 @import 'tailwindcss';

--- a/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
@@ -16,6 +16,7 @@ import viteReact from '@vitejs/plugin-react';
 import sbom from 'rollup-plugin-sbom';
 import {playwright} from '@vitest/browser-playwright';
 import path from 'node:path';
+import tailwindcss from '@tailwindcss/vite';
 
 const injectCustomCss: PluginOption = {
 	name: 'inject-custom-css',
@@ -34,6 +35,7 @@ const injectCustomCss: PluginOption = {
 
 const basePlugins: PluginOption[] = [
 	devtools(),
+	tailwindcss(),
 	tanstackRouter({
 		target: 'react',
 		autoCodeSplitting: true,

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -43,6 +43,7 @@
 				"@carbon/type": "11.65.0",
 				"@devbookhq/splitter": "1.4.2",
 				"@monaco-editor/react": "4.7.0",
+				"@tailwindcss/vite": "4.3.3",
 				"@tanstack/react-query": "5.101.4",
 				"@tanstack/react-query-devtools": "5.101.4",
 				"@tanstack/react-router": "1.170.29",
@@ -75,6 +76,8 @@
 				"react-transition-group": "4.4.5",
 				"sass": "1.102.0",
 				"styled-components": "6.5.3",
+				"tailwind-merge": "3.6.0",
+				"tailwindcss": "4.3.3",
 				"xstate": "5.32.5",
 				"zod": "4.4.3"
 			},
@@ -2196,7 +2199,6 @@
 			"version": "0.143.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
 			"integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
-			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
@@ -4620,7 +4622,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -5058,6 +5059,536 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@tailwindcss/node": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+			"integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/remapping": "^2.3.5",
+				"enhanced-resolve": "^5.24.1",
+				"jiti": "^2.7.0",
+				"lightningcss": "1.32.0",
+				"magic-string": "^0.30.21",
+				"source-map-js": "^1.2.1",
+				"tailwindcss": "4.3.3"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/node/node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@tailwindcss/oxide": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+			"integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			},
+			"optionalDependencies": {
+				"@tailwindcss/oxide-android-arm64": "4.3.3",
+				"@tailwindcss/oxide-darwin-arm64": "4.3.3",
+				"@tailwindcss/oxide-darwin-x64": "4.3.3",
+				"@tailwindcss/oxide-freebsd-x64": "4.3.3",
+				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+				"@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+				"@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+				"@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+				"@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+				"@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-android-arm64": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+			"integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-darwin-arm64": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+			"integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-darwin-x64": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+			"integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-freebsd-x64": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+			"integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+			"integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+			"integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+			"integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+			"integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+			"integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+			"integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+			"bundleDependencies": [
+				"@napi-rs/wasm-runtime",
+				"@emnapi/core",
+				"@emnapi/runtime",
+				"@tybys/wasm-util",
+				"@emnapi/wasi-threads",
+				"tslib"
+			],
+			"cpu": [
+				"wasm32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.11.1",
+				"@emnapi/runtime": "^1.11.1",
+				"@emnapi/wasi-threads": "^1.2.2",
+				"@napi-rs/wasm-runtime": "^1.1.4",
+				"@tybys/wasm-util": "^0.10.2",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+			"integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+			"integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/vite": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+			"integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@tailwindcss/node": "4.3.3",
+				"@tailwindcss/oxide": "4.3.3",
+				"tailwindcss": "4.3.3"
+			},
+			"peerDependencies": {
+				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
 		"node_modules/@tanstack/devtools": {
@@ -8147,7 +8678,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
 			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-			"devOptional": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
@@ -8480,6 +9010,19 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/enhanced-resolve": {
+			"version": "5.24.5",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+			"integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.3.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
 		},
 		"node_modules/entities": {
 			"version": "4.5.0",
@@ -9204,6 +9747,12 @@
 			"peerDependencies": {
 				"csstype": "^3.0.10"
 			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC"
 		},
 		"node_modules/graphql": {
 			"version": "16.13.2",
@@ -10225,7 +10774,6 @@
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
 			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
-			"devOptional": true,
 			"license": "MPL-2.0",
 			"dependencies": {
 				"detect-libc": "^2.0.3"
@@ -11454,7 +12002,6 @@
 			"version": "3.3.18",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
 			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -12013,7 +12560,6 @@
 			"version": "8.5.26",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
 			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -12638,7 +13184,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
 			"integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@oxc-project/types": "=0.143.0",
@@ -13309,6 +13854,25 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
+			}
+		},
+		"node_modules/tailwindcss": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+			"integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+			"license": "MIT"
+		},
+		"node_modules/tapable": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/tiny-invariant": {
@@ -13983,7 +14547,6 @@
 			"version": "8.2.1",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
 			"integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.33.0",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds Tailwind support for Shadcn routes so we have a unified way of styling in the unified webapp components

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #60210
