### PR TITLE
fix: keep the CSL compat bridge from overriding explicit OIDC endpoints

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -220,12 +220,13 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   }
 
   // True when the host configured the OIDC endpoints directly instead of leaving CSL to discover
-  // them from an issuer-uri. Any one of them is enough: CSL builds the registration from whichever
-  // are present, and a partially configured registration is the host's decision to own.
+  // them from an issuer-uri. All three are required: CSL accepts either an issuer-uri or the
+  // complete trio, so withholding the derived issuer-uri from a partial set would turn a working
+  // startup into a ClientRegistration failure.
   private static boolean hasExplicitOidcEndpoints(final ConfigurableEnvironment env) {
     return !isBlank(env.getProperty(OIDC_PREFIX + "authorization-uri"))
-        || !isBlank(env.getProperty(OIDC_PREFIX + "jwk-set-uri"))
-        || !isBlank(env.getProperty(OIDC_PREFIX + "token-uri"));
+        && !isBlank(env.getProperty(OIDC_PREFIX + "jwk-set-uri"))
+        && !isBlank(env.getProperty(OIDC_PREFIX + "token-uri"));
   }
 
   private static boolean isAuth0Configured(final ConfigurableEnvironment env) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -164,18 +164,15 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     if (isAuth0Configured(env)) {
       return;
     }
-    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", OIDC_PREFIX + "issuer-uri");
+    mapIssuerUri(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL");
     mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", OIDC_PREFIX + "client-secret");
-    // Only when the host has not configured the OIDC endpoints itself. An issuer-uri makes CSL
-    // resolve the endpoints through OIDC discovery, dialing the browser-facing issuer from inside
-    // the pod; explicit authorization-uri/jwk-set-uri/token-uri exist precisely to avoid that, for
-    // instance to keep the back-channel on an in-cluster URL, or where the pod's truststore cannot
-    // validate the public certificate. Deriving an issuer-uri on top would silently override that
-    // choice and reintroduce the discovery call.
-    if (!hasExplicitOidcEndpoints(env)) {
-      mapIfCslKeyUnset(env, derived, "camunda.identity.issuer", OIDC_PREFIX + "issuer-uri");
+    // Only when that env var is absent: application-ccsm.yaml mirrors it into
+    // camunda.identity.issuer for every docker-compose CCSM install, so feeding both would
+    // double-warn for a value the operator only set once.
+    if (isBlank(env.getProperty("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL"))) {
+      mapIssuerUri(env, derived, "camunda.identity.issuer");
     }
 
     // The Helm chart's Optimize ConfigMap can legitimately render clientId/CAMUNDA_IDENTITY_
@@ -217,6 +214,28 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     bridgeAuth0RedirectAndContextPath(env, derived, clusterId);
     bridgeAuth0Credentials(env, derived, auth0ClientId);
     bridgeAuth0SaasOrgAndCluster(env, derived, clusterId);
+  }
+
+  // Bridges a legacy issuer source into issuer-uri. The key is deprecated either way, so the
+  // warning
+  // is emitted whenever it is set, but the value only feeds issuer-uri when the host has not
+  // configured the OIDC endpoints itself. An issuer-uri makes CSL resolve the endpoints through
+  // discovery, dialing the browser-facing issuer from inside the pod; explicit
+  // authorization-uri/jwk-set-uri/token-uri exist precisely to avoid that, for instance to keep the
+  // back-channel on an in-cluster URL, or where the pod's truststore cannot validate the public
+  // certificate. Deriving an issuer-uri on top would silently override that choice.
+  private void mapIssuerUri(
+      final ConfigurableEnvironment env,
+      final Map<String, Object> derived,
+      final String legacyKey) {
+    final String value = env.getProperty(legacyKey);
+    if (isBlank(value)) {
+      return;
+    }
+    warnDeprecated(legacyKey, OIDC_PREFIX + "issuer-uri");
+    if (!hasExplicitOidcEndpoints(env)) {
+      derived.putIfAbsent(OIDC_PREFIX + "issuer-uri", value);
+    }
   }
 
   // True when the host configured the OIDC endpoints directly instead of leaving CSL to discover

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -168,7 +168,15 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", OIDC_PREFIX + "client-secret");
-    mapIfCslKeyUnset(env, derived, "camunda.identity.issuer", OIDC_PREFIX + "issuer-uri");
+    // Only when the host has not configured the OIDC endpoints itself. An issuer-uri makes CSL
+    // resolve the endpoints through OIDC discovery, dialing the browser-facing issuer from inside
+    // the pod; explicit authorization-uri/jwk-set-uri/token-uri exist precisely to avoid that, for
+    // instance to keep the back-channel on an in-cluster URL, or where the pod's truststore cannot
+    // validate the public certificate. Deriving an issuer-uri on top would silently override that
+    // choice and reintroduce the discovery call.
+    if (!hasExplicitOidcEndpoints(env)) {
+      mapIfCslKeyUnset(env, derived, "camunda.identity.issuer", OIDC_PREFIX + "issuer-uri");
+    }
 
     // The Helm chart's Optimize ConfigMap can legitimately render clientId/CAMUNDA_IDENTITY_
     // CLIENT_SECRET while leaving camunda.identity.issuer blank. Bridging a client-id/secret with
@@ -177,7 +185,8 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     // all-or-nothing on the issuer-uri: withhold both credentials rather than trade a login problem
     // for a boot failure. Mirrors bridgeAuth0SaasOrgAndCluster's all-or-nothing precedent below.
     if (!derived.containsKey(OIDC_PREFIX + "issuer-uri")
-        && isBlank(env.getProperty(OIDC_PREFIX + "issuer-uri"))) {
+        && isBlank(env.getProperty(OIDC_PREFIX + "issuer-uri"))
+        && !hasExplicitOidcEndpoints(env)) {
       final String clientId = env.getProperty("camunda.identity.clientId");
       final String clientSecret = env.getProperty("CAMUNDA_IDENTITY_CLIENT_SECRET");
       if (!isBlank(clientId) || !isBlank(clientSecret)) {
@@ -208,6 +217,15 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     bridgeAuth0RedirectAndContextPath(env, derived, clusterId);
     bridgeAuth0Credentials(env, derived, auth0ClientId);
     bridgeAuth0SaasOrgAndCluster(env, derived, clusterId);
+  }
+
+  // True when the host configured the OIDC endpoints directly instead of leaving CSL to discover
+  // them from an issuer-uri. Any one of them is enough: CSL builds the registration from whichever
+  // are present, and a partially configured registration is the host's decision to own.
+  private static boolean hasExplicitOidcEndpoints(final ConfigurableEnvironment env) {
+    return !isBlank(env.getProperty(OIDC_PREFIX + "authorization-uri"))
+        || !isBlank(env.getProperty(OIDC_PREFIX + "jwk-set-uri"))
+        || !isBlank(env.getProperty(OIDC_PREFIX + "token-uri"));
   }
 
   private static boolean isAuth0Configured(final ConfigurableEnvironment env) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -216,14 +216,10 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     bridgeAuth0SaasOrgAndCluster(env, derived, clusterId);
   }
 
-  // Bridges a legacy issuer source into issuer-uri. The key is deprecated either way, so the
-  // warning
-  // is emitted whenever it is set, but the value only feeds issuer-uri when the host has not
-  // configured the OIDC endpoints itself. An issuer-uri makes CSL resolve the endpoints through
-  // discovery, dialing the browser-facing issuer from inside the pod; explicit
-  // authorization-uri/jwk-set-uri/token-uri exist precisely to avoid that, for instance to keep the
-  // back-channel on an in-cluster URL, or where the pod's truststore cannot validate the public
-  // certificate. Deriving an issuer-uri on top would silently override that choice.
+  // Bridges a legacy issuer source into issuer-uri, but only when the host left the OIDC endpoints
+  // to CSL: an issuer-uri makes CSL discover them by dialing the browser-facing issuer from inside
+  // the pod, which is what explicit endpoints exist to avoid. The key is deprecated either way, so
+  // the warning is emitted whenever it is set.
   private void mapIssuerUri(
       final ConfigurableEnvironment env,
       final Map<String, Object> derived,
@@ -238,10 +234,8 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     }
   }
 
-  // True when the host configured the OIDC endpoints directly instead of leaving CSL to discover
-  // them from an issuer-uri. All three are required: CSL accepts either an issuer-uri or the
-  // complete trio, so withholding the derived issuer-uri from a partial set would turn a working
-  // startup into a ClientRegistration failure.
+  // All three are required: CSL accepts an issuer-uri or the complete trio, so withholding the
+  // derived issuer-uri from a partial set would turn a working startup into a registration failure.
   private static boolean hasExplicitOidcEndpoints(final ConfigurableEnvironment env) {
     return !isBlank(env.getProperty(OIDC_PREFIX + "authorization-uri"))
         && !isBlank(env.getProperty(OIDC_PREFIX + "jwk-set-uri"))

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -209,14 +209,20 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   @Test
   void shouldStillBridgeCredentialsWhenOnlyTheOidcEndpointsAreConfigured() {
     // Without an issuer-uri the bridge withholds client-id and client-secret, because CSL cannot
-    // build a registration from credentials alone. Explicit endpoints are the other way to give it
-    // one, so they must satisfy that guard rather than leave the client unconfigured.
+    // build a registration from credentials alone. The complete endpoint trio is the other way to
+    // give it one, so it must satisfy that guard rather than leave the client unconfigured.
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put("camunda.identity.clientId", "optimize");
     legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
     legacy.put(
         OIDC + "authorization-uri",
         "https://public.example.com/auth/realms/camunda-platform/protocol/openid-connect/auth");
+    legacy.put(
+        OIDC + "jwk-set-uri",
+        "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs");
+    legacy.put(
+        OIDC + "token-uri",
+        "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token");
 
     final StandardEnvironment env = environmentWith(legacy);
     processor.postProcessEnvironment(env, null);
@@ -224,6 +230,24 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
     assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("helm-secret");
     assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+  }
+
+  @Test
+  void shouldStillDeriveIssuerUriWhenTheOidcEndpointsAreIncomplete() {
+    // CSL needs an issuer-uri or all three endpoints. A host that configured only some of them
+    // relies on the derived issuer-uri to boot at all, so the derivation must stay.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put(
+        "camunda.identity.issuer", "https://public.example.com/auth/realms/camunda-platform");
+    legacy.put(
+        OIDC + "jwk-set-uri",
+        "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri"))
+        .isEqualTo("https://public.example.com/auth/realms/camunda-platform");
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -233,6 +233,36 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldNotDeriveIssuerUriFromTheLegacyEnvVarWhenTheOidcEndpointsAreConfigured() {
+    // The docker-compose CCSM shape sets CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL rather than
+    // camunda.identity.issuer. It feeds the same issuer-uri, so it has to be gated the same way,
+    // while still telling the operator the key is deprecated.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put(
+        "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL",
+        "https://public.example.com/auth/realms/camunda-platform");
+    legacy.put(
+        OIDC + "authorization-uri",
+        "https://public.example.com/auth/realms/camunda-platform/protocol/openid-connect/auth");
+    legacy.put(
+        OIDC + "jwk-set-uri",
+        "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs");
+    legacy.put(
+        OIDC + "token-uri",
+        "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL")
+                && entry.getMessage().contains(OIDC + "issuer-uri"),
+        "the key stays deprecated even when its value no longer feeds issuer-uri");
+  }
+
+  @Test
   void shouldStillDeriveIssuerUriWhenTheOidcEndpointsAreIncomplete() {
     // CSL needs an issuer-uri or all three endpoints. A host that configured only some of them
     // relies on the derived issuer-uri to boot at all, so the derivation must stay.

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -178,6 +178,55 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldNotDeriveIssuerUriWhenTheHostConfiguredTheOidcEndpoints() {
+    // The camunda-platform Helm chart renders the endpoints directly for a Keycloak setup, keeping
+    // the back-channel on the in-cluster URL. Deriving an issuer-uri from camunda.identity.issuer
+    // would make CSL discard them and resolve the endpoints over the browser-facing issuer instead,
+    // which fails wherever the pod cannot validate that certificate.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put(
+        "camunda.identity.issuer", "https://public.example.com/auth/realms/camunda-platform");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
+    legacy.put(
+        OIDC + "authorization-uri",
+        "https://public.example.com/auth/realms/camunda-platform/protocol/openid-connect/auth");
+    legacy.put(
+        OIDC + "jwk-set-uri",
+        "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs");
+    legacy.put(
+        OIDC + "token-uri",
+        "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "jwk-set-uri"))
+        .isEqualTo("http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs");
+  }
+
+  @Test
+  void shouldStillBridgeCredentialsWhenOnlyTheOidcEndpointsAreConfigured() {
+    // Without an issuer-uri the bridge withholds client-id and client-secret, because CSL cannot
+    // build a registration from credentials alone. Explicit endpoints are the other way to give it
+    // one, so they must satisfy that guard rather than leave the client unconfigured.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
+    legacy.put(
+        OIDC + "authorization-uri",
+        "https://public.example.com/auth/realms/camunda-platform/protocol/openid-connect/auth");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
+    assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("helm-secret");
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+  }
+
+  @Test
   void shouldNotBridgeHelmChartIdentityIssuerUriKeyWhenBlank() {
     // application-ccsm.yaml resolves camunda.identity.issuer to "" (via a Spring placeholder
     // default) whenever CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL is unset, which is the normal state


### PR DESCRIPTION
## Description

The CSL compatibility bridge derives `camunda.security.authentication.oidc.issuer-uri` from the
legacy issuer keys whenever the CSL key is unset. An `issuer-uri` makes CSL resolve the OIDC
endpoints through discovery — `ClientRegistrations.fromIssuerLocation`, a real HTTP call at startup,
with any explicit endpoints applied only afterwards as overrides. So the derivation silently
overrides a host that configured `authorization-uri`, `jwk-set-uri` and `token-uri` itself, which is
usually done precisely to avoid that call: to keep the back-channel in-cluster, or because the pod
cannot reach or trust the public issuer.

Observed as a startup crash-loop where the JVM truststore had been narrowed to a self-signed
database CA, leaving no public roots:

```
clientRegistrationRepository … Unable to resolve Configuration with the provided Issuer of
"https://<host>/auth/realms/camunda-platform"
Caused by: SSLHandshakeException: PKIX path building failed
```

Both legacy issuer sources — `CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL` and `camunda.identity.issuer` —
now go through one helper that withholds the value when the endpoints are configured. Two details
worth reviewing:

- **All three endpoints are required** before the derivation is skipped. CSL accepts an `issuer-uri`
  *or* the complete trio, so treating a partial set as "the host owns this" would turn a startup
  that works today into a `ClientRegistration` failure.
- **The deprecation warning is still emitted** whenever a legacy key is set. It is deprecated
  regardless of whether its value is still needed, so the helper warns and only withholds the value
  — reusing `mapIfPresent` behind the guard would have silenced it.

The Auth0 source (`CAMUNDA_OPTIMIZE_AUTH0_DOMAIN`) is deliberately left ungated: it is
platform-managed SaaS config where the pod reaches Auth0 over the public internet anyway, and no
host configures the endpoints explicitly there.

Explicit `camunda.security.*` configuration keeps precedence either way — the derived property
source is added last. This only stops the bridge filling a gap the host had already filled.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related to #58487 (Helm chart migration to `camunda.security.*`), whose Optimize ConfigMap renders
the endpoint shape this affects; chart side in camunda/camunda-platform-helm#6883.
