### PR TITLE
fix: Optimize CCSM ITs fail to boot under CSL — authentication bean rejects the context

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -110,6 +110,12 @@ jobs:
       matrix:
         includedGroups: [ 'ccsm-test' ]
         cslEnabled: [ 'false', 'true' ]
+        # This entry deliberately omits cslEnabled so it merges into both matrix values above,
+        # instead of two near-duplicate entries repeating excludedGroups/profiles. Do not add
+        # cslEnabled back to only one of them: the other combination would then have no include
+        # entry supplying `profiles`, so `-P` would swallow the next Maven argument instead of
+        # activating `ccsm-it` (which wires up src/it/java and failsafe) — Maven only warns on an
+        # unknown profile, so that job would go green having run zero ITs.
         include:
           - includedGroups: 'ccsm-test'
             excludedGroups: ''
@@ -208,6 +214,8 @@ jobs:
       matrix:
         includedGroups: [ 'ccsm-test' ]
         cslEnabled: [ 'false', 'true' ]
+        # See the identical comment on the Elasticsearch job above: this entry deliberately omits
+        # cslEnabled so it merges into both matrix values instead of duplicating itself per value.
         include:
           - includedGroups: 'ccsm-test'
             excludedGroups: 'openSearchSingleTestFailOK'

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -109,12 +109,16 @@ jobs:
       fail-fast: false
       matrix:
         includedGroups: [ 'ccsm-test' ]
-        cslEnabled: [ 'false' ]
+        cslEnabled: [ 'false', 'true' ]
         include:
           - includedGroups: 'ccsm-test'
             excludedGroups: ''
             profiles: 'ccsm-it'
             cslEnabled: 'false'
+          - includedGroups: 'ccsm-test'
+            excludedGroups: ''
+            profiles: 'ccsm-it'
+            cslEnabled: 'true'
     steps:
       - name: Checkout repository
         # Credentials stay: the next step fetches from origin.
@@ -208,12 +212,16 @@ jobs:
       fail-fast: false
       matrix:
         includedGroups: [ 'ccsm-test' ]
-        cslEnabled: [ 'false' ]
+        cslEnabled: [ 'false', 'true' ]
         include:
           - includedGroups: 'ccsm-test'
             excludedGroups: 'openSearchSingleTestFailOK'
             profiles: 'ccsm-it'
             cslEnabled: 'false'
+          - includedGroups: 'ccsm-test'
+            excludedGroups: 'openSearchSingleTestFailOK'
+            profiles: 'ccsm-it'
+            cslEnabled: 'true'
     steps:
       - name: Checkout repository
         # Credentials stay: the next step fetches from origin.

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -114,11 +114,6 @@ jobs:
           - includedGroups: 'ccsm-test'
             excludedGroups: ''
             profiles: 'ccsm-it'
-            cslEnabled: 'false'
-          - includedGroups: 'ccsm-test'
-            excludedGroups: ''
-            profiles: 'ccsm-it'
-            cslEnabled: 'true'
     steps:
       - name: Checkout repository
         # Credentials stay: the next step fetches from origin.
@@ -217,11 +212,6 @@ jobs:
           - includedGroups: 'ccsm-test'
             excludedGroups: 'openSearchSingleTestFailOK'
             profiles: 'ccsm-it'
-            cslEnabled: 'false'
-          - includedGroups: 'ccsm-test'
-            excludedGroups: 'openSearchSingleTestFailOK'
-            profiles: 'ccsm-it'
-            cslEnabled: 'true'
     steps:
       - name: Checkout repository
         # Credentials stay: the next step fetches from origin.

--- a/optimize/backend/src/it/java/io/camunda/optimize/CcsmOidcTestFixture.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/CcsmOidcTestFixture.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import java.util.Map;
+
+/**
+ * The static OIDC client registration CSL needs to boot under the {@code ccsm-test} group,
+ * mirroring the fixture already shipped in {@code
+ * optimize/backend/src/it/resources/application-ccsm.yaml} and the unit test {@code
+ * CslSecurityChainSelectionTest}. Kept as one constant so the values used across the Java-side
+ * fixtures ({@link CcsmOidcTestFixture#STATIC_OIDC_PROPERTIES}'s callers) can't drift apart from
+ * each other.
+ */
+public final class CcsmOidcTestFixture {
+
+  public static final Map<String, String> STATIC_OIDC_PROPERTIES =
+      Map.of(
+          "camunda.security.authentication.oidc.client-id",
+          "it-client",
+          "camunda.security.authentication.oidc.client-secret",
+          "it-secret",
+          "camunda.security.authentication.oidc.authorization-uri",
+          "https://idp.example.com/authorize",
+          "camunda.security.authentication.oidc.token-uri",
+          "https://idp.example.com/token",
+          "camunda.security.authentication.oidc.jwk-set-uri",
+          "https://idp.example.com/jwks");
+
+  private CcsmOidcTestFixture() {}
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,21 +36,17 @@ public class ExtraConfigurationConfigImportIT extends AbstractCCSMIT {
 
   @Override
   protected void startAndUseNewOptimizeInstance() {
-    startAndUseNewOptimizeInstance(
-        Map.of(
-            "spring.config.location",
-            configDir.toAbsolutePath() + "/",
-            "camunda.security.authentication.oidc.client-id",
-            "it-client",
-            "camunda.security.authentication.oidc.client-secret",
-            "it-secret",
-            "camunda.security.authentication.oidc.authorization-uri",
-            "https://idp.example.com/authorize",
-            "camunda.security.authentication.oidc.token-uri",
-            "https://idp.example.com/token",
-            "camunda.security.authentication.oidc.jwk-set-uri",
-            "https://idp.example.com/jwks"),
-        ConfigurationServiceConstants.CCSM_PROFILE);
+    // spring.config.location (rather than additional-location) is required here: it replaces
+    // Spring Boot's default config search locations, which is exactly what
+    // shouldLoadOptimizeConfigFromExtraFile needs so the temp configDir's override stays
+    // authoritative over the classpath default. That means the classpath application-ccsm.yaml
+    // fixture carrying CSL's OIDC client registration never loads for this restarted instance, so
+    // the same values are supplied directly as property-map entries instead (outside the
+    // config-file search-location mechanism, so this substitution doesn't affect precedence).
+    final Map<String, String> properties =
+        new HashMap<>(CcsmOidcTestFixture.STATIC_OIDC_PROPERTIES);
+    properties.put("spring.config.location", configDir.toAbsolutePath() + "/");
+    startAndUseNewOptimizeInstance(properties, ConfigurationServiceConstants.CCSM_PROFILE);
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
@@ -36,7 +36,7 @@ public class ExtraConfigurationConfigImportIT extends AbstractCCSMIT {
   @Override
   protected void startAndUseNewOptimizeInstance() {
     startAndUseNewOptimizeInstance(
-        Map.of("spring.config.location", configDir.toAbsolutePath() + "/"),
+        Map.of("spring.config.additional-location", configDir.toAbsolutePath() + "/"),
         ConfigurationServiceConstants.CCSM_PROFILE);
   }
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/ExtraConfigurationConfigImportIT.java
@@ -36,7 +36,19 @@ public class ExtraConfigurationConfigImportIT extends AbstractCCSMIT {
   @Override
   protected void startAndUseNewOptimizeInstance() {
     startAndUseNewOptimizeInstance(
-        Map.of("spring.config.additional-location", configDir.toAbsolutePath() + "/"),
+        Map.of(
+            "spring.config.location",
+            configDir.toAbsolutePath() + "/",
+            "camunda.security.authentication.oidc.client-id",
+            "it-client",
+            "camunda.security.authentication.oidc.client-secret",
+            "it-secret",
+            "camunda.security.authentication.oidc.authorization-uri",
+            "https://idp.example.com/authorize",
+            "camunda.security.authentication.oidc.token-uri",
+            "https://idp.example.com/token",
+            "camunda.security.authentication.oidc.jwk-set-uri",
+            "https://idp.example.com/jwks"),
         ConfigurationServiceConstants.CCSM_PROFILE);
   }
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/security/CslDefaultEnabledIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/security/CslDefaultEnabledIT.java
@@ -13,11 +13,13 @@ import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.AbstractIT;
+import io.camunda.optimize.CcsmOidcTestFixture;
 import io.camunda.optimize.ExtraConfigurationConfigImportIT;
 import io.camunda.optimize.rest.security.ccsm.CCSMSecurityConfigurerAdapter;
 import io.camunda.optimize.rest.security.csl.OptimizeCamundaSecurityConfig;
 import io.camunda.optimize.test.optimize.HealthClient;
 import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -60,21 +62,10 @@ public class CslDefaultEnabledIT extends AbstractIT {
 
   @Override
   protected void startAndUseNewOptimizeInstance() {
-    startAndUseNewOptimizeInstance(
-        Map.of(
-            "optimize.security.csl.enabled",
-            "true",
-            "camunda.security.authentication.oidc.client-id",
-            "it-client",
-            "camunda.security.authentication.oidc.client-secret",
-            "it-secret",
-            "camunda.security.authentication.oidc.authorization-uri",
-            "https://idp.example.com/authorize",
-            "camunda.security.authentication.oidc.token-uri",
-            "https://idp.example.com/token",
-            "camunda.security.authentication.oidc.jwk-set-uri",
-            "https://idp.example.com/jwks"),
-        CCSM_PROFILE);
+    final Map<String, String> properties =
+        new HashMap<>(CcsmOidcTestFixture.STATIC_OIDC_PROPERTIES);
+    properties.put("optimize.security.csl.enabled", "true");
+    startAndUseNewOptimizeInstance(properties, CCSM_PROFILE);
   }
 
   @BeforeEach

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
@@ -36,11 +37,13 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
   }
 
   @BeforeEach
+  @Order(1)
   public void bootWithCslDisabled() {
     startAndUseNewOptimizeInstance();
   }
 
   @BeforeEach
+  @Order(2)
   public void configurePublicApiToken() {
     embeddedOptimizeExtension
         .getConfigurationService()

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
@@ -21,6 +21,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+/**
+ * Reader: before trusting this class as proof that the variable-labels endpoint validates input or
+ * looks up definitions correctly, know that it no longer does. It used to exercise that logic
+ * (null/blank key rejection, a valid request succeeding, a nonexistent definition 404ing) via
+ * Optimize's legacy static {@code api.accessToken} mechanism. Since CSL became the default CCSM
+ * security chain (camunda/camunda#58483), that legacy static-token mechanism is rejected before any
+ * of that validation/lookup logic runs (see {@code
+ * OptimizeSecurityConfigCompatibilityPostProcessor}'s {@code OPTIMIZE_API_ACCESS_TOKEN} handling),
+ * so every test below now only proves CSL's rejection, not the original behavior. That original
+ * coverage is not replicated elsewhere; reproducing it would require an authenticated request via a
+ * real OIDC bearer token, and minting one needs WireMock-backed JWKS infrastructure that is
+ * disproportionate for this class (see {@code CslDefaultEnabledIT}'s javadoc). Treat this as a
+ * known coverage gap worth a follow-up, not evidence the endpoint is tested.
+ */
 public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
 
   private static final String TEST_ACCESS_TOKEN = "test-access-token";

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.optimize.service.variable;
 
+import static io.camunda.optimize.rest.providers.GenericExceptionMapper.BAD_REQUEST_ERROR_CODE;
+import static io.camunda.optimize.rest.providers.GenericExceptionMapper.NOT_FOUND_ERROR_CODE;
+import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.CCSM_PROFILE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.AbstractCCSMIT;
@@ -14,30 +17,28 @@ import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.query.variable.DefinitionVariableLabelsDto;
 import io.camunda.optimize.dto.optimize.query.variable.LabelDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import io.camunda.optimize.dto.optimize.rest.ErrorResponseDto;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-/**
- * Reader: before trusting this class as proof that the variable-labels endpoint validates input or
- * looks up definitions correctly, know that it no longer does. It used to exercise that logic
- * (null/blank key rejection, a valid request succeeding, a nonexistent definition 404ing) via
- * Optimize's legacy static {@code api.accessToken} mechanism. Since CSL became the default CCSM
- * security chain (camunda/camunda#58483), that legacy static-token mechanism is rejected before any
- * of that validation/lookup logic runs (see {@code
- * OptimizeSecurityConfigCompatibilityPostProcessor}'s {@code OPTIMIZE_API_ACCESS_TOKEN} handling),
- * so every test below now only proves CSL's rejection, not the original behavior. That original
- * coverage is not replicated elsewhere; reproducing it would require an authenticated request via a
- * real OIDC bearer token, and minting one needs WireMock-backed JWKS infrastructure that is
- * disproportionate for this class (see {@code CslDefaultEnabledIT}'s javadoc). Treat this as a
- * known coverage gap worth a follow-up, not evidence the endpoint is tested.
- */
 public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
 
   private static final String TEST_ACCESS_TOKEN = "test-access-token";
+
+  @Override
+  protected void startAndUseNewOptimizeInstance() {
+    startAndUseNewOptimizeInstance(Map.of("optimize.security.csl.enabled", "false"), CCSM_PROFILE);
+  }
+
+  @BeforeEach
+  public void bootWithCslDisabled() {
+    startAndUseNewOptimizeInstance();
+  }
 
   @BeforeEach
   public void configurePublicApiToken() {
@@ -60,10 +61,11 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
             .withBearerToken(TEST_ACCESS_TOKEN)
             .execute();
 
-    // then: CSL rejects the legacy static access token before any input validation runs — the
-    // static-token mechanism this test used to exercise is obsolete under CSL (see
-    // OptimizeSecurityConfigCompatibilityPostProcessor's OPTIMIZE_API_ACCESS_TOKEN handling)
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+    assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
+    assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
   }
 
   @Test
@@ -79,10 +81,11 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
             .withBearerToken(TEST_ACCESS_TOKEN)
             .execute();
 
-    // then: CSL rejects the legacy static access token before any input validation runs — the
-    // static-token mechanism this test used to exercise is obsolete under CSL (see
-    // OptimizeSecurityConfigCompatibilityPostProcessor's OPTIMIZE_API_ACCESS_TOKEN handling)
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+    assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
+    assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
   }
 
   @Test
@@ -114,10 +117,8 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
             .withBearerToken(TEST_ACCESS_TOKEN)
             .execute();
 
-    // then: CSL rejects the legacy static access token before any input validation runs — the
-    // static-token mechanism this test used to exercise is obsolete under CSL (see
-    // OptimizeSecurityConfigCompatibilityPostProcessor's OPTIMIZE_API_ACCESS_TOKEN handling)
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
   }
 
   @Test
@@ -134,9 +135,9 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
             .withBearerToken(TEST_ACCESS_TOKEN)
             .execute();
 
-    // then: CSL rejects the legacy static access token before any input validation runs — the
-    // static-token mechanism this test used to exercise is obsolete under CSL (see
-    // OptimizeSecurityConfigCompatibilityPostProcessor's OPTIMIZE_API_ACCESS_TOKEN handling)
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+    assertThat(errorResponse.getErrorCode()).isEqualTo(NOT_FOUND_ERROR_CODE);
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
@@ -36,15 +35,15 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
     startAndUseNewOptimizeInstance(Map.of("optimize.security.csl.enabled", "false"), CCSM_PROFILE);
   }
 
+  // A single @BeforeEach makes the restart-then-configure dependency explicit in code, rather
+  // than relying on JUnit Jupiter's execution order for multiple @BeforeEach methods in one
+  // class, which is deterministic but intentionally unspecified (@Order has no effect on
+  // @BeforeEach/@AfterEach — it only orders @Test methods, extension fields, and test classes).
+  // Splitting this into two methods previously relied on that unspecified order to configure the
+  // access token on the instance this restart just created, rather than one about to be replaced.
   @BeforeEach
-  @Order(1)
-  public void bootWithCslDisabled() {
+  public void bootWithCslDisabledAndConfigurePublicApiToken() {
     startAndUseNewOptimizeInstance();
-  }
-
-  @BeforeEach
-  @Order(2)
-  public void configurePublicApiToken() {
     embeddedOptimizeExtension
         .getConfigurationService()
         .getOptimizeApiConfiguration()

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.optimize.service.variable;
 
-import static io.camunda.optimize.rest.providers.GenericExceptionMapper.BAD_REQUEST_ERROR_CODE;
-import static io.camunda.optimize.rest.providers.GenericExceptionMapper.NOT_FOUND_ERROR_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.AbstractCCSMIT;
@@ -16,7 +14,6 @@ import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.query.variable.DefinitionVariableLabelsDto;
 import io.camunda.optimize.dto.optimize.query.variable.LabelDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
-import io.camunda.optimize.dto.optimize.rest.ErrorResponseDto;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -49,11 +46,10 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
             .withBearerToken(TEST_ACCESS_TOKEN)
             .execute();
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
-    assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
-    assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
+    // then: CSL rejects the legacy static access token before any input validation runs — the
+    // static-token mechanism this test used to exercise is obsolete under CSL (see
+    // OptimizeSecurityConfigCompatibilityPostProcessor's OPTIMIZE_API_ACCESS_TOKEN handling)
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
   }
 
   @Test
@@ -69,11 +65,10 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
             .withBearerToken(TEST_ACCESS_TOKEN)
             .execute();
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
-    assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
-    assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
+    // then: CSL rejects the legacy static access token before any input validation runs — the
+    // static-token mechanism this test used to exercise is obsolete under CSL (see
+    // OptimizeSecurityConfigCompatibilityPostProcessor's OPTIMIZE_API_ACCESS_TOKEN handling)
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
   }
 
   @Test
@@ -105,8 +100,10 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
             .withBearerToken(TEST_ACCESS_TOKEN)
             .execute();
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    // then: CSL rejects the legacy static access token before any input validation runs — the
+    // static-token mechanism this test used to exercise is obsolete under CSL (see
+    // OptimizeSecurityConfigCompatibilityPostProcessor's OPTIMIZE_API_ACCESS_TOKEN handling)
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
   }
 
   @Test
@@ -123,9 +120,9 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
             .withBearerToken(TEST_ACCESS_TOKEN)
             .execute();
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
-    assertThat(errorResponse.getErrorCode()).isEqualTo(NOT_FOUND_ERROR_CODE);
+    // then: CSL rejects the legacy static access token before any input validation runs — the
+    // static-token mechanism this test used to exercise is obsolete under CSL (see
+    // OptimizeSecurityConfigCompatibilityPostProcessor's OPTIMIZE_API_ACCESS_TOKEN handling)
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
@@ -30,6 +30,12 @@ public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
 
   private static final String TEST_ACCESS_TOKEN = "test-access-token";
 
+  // This class is inherently about the legacy static api.accessToken mechanism, which CSL's bearer
+  // chain does not support (no unprotected-API escape hatch on /api/public/**). Without pinning
+  // cslEnabled=false, the token would be rejected before any of the endpoint logic these tests
+  // target ever runs, turning every assertion here into an unrelated 401. Pin explicitly rather
+  // than rely on the ambient CI matrix value. api.accessToken having no CSL equivalent is a
+  // product gap, tracked separately at camunda/camunda#60639.
   @Override
   protected void startAndUseNewOptimizeInstance() {
     startAndUseNewOptimizeInstance(Map.of("optimize.security.csl.enabled", "false"), CCSM_PROFILE);

--- a/optimize/backend/src/it/resources/application-ccsm.yaml
+++ b/optimize/backend/src/it/resources/application-ccsm.yaml
@@ -1,3 +1,10 @@
+# This file shadows optimize/backend/src/main/resources/application-ccsm.yaml rather than
+# supplementing it: Spring resolves classpath:/application-ccsm.yaml to the first match, and
+# target/test-classes precedes target/classes on the failsafe classpath. That means CCSM ITs never
+# load the production ccsm profile file at all — anything added there later will silently never
+# reach them. Harmless today because nothing reads camunda.identity.* here without a null-safe
+# fallback, but worth knowing before debugging a "why didn't my ccsm config change apply to ITs"
+# mystery (camunda/camunda#60184).
 camunda:
   security:
     authentication:

--- a/optimize/backend/src/it/resources/application-ccsm.yaml
+++ b/optimize/backend/src/it/resources/application-ccsm.yaml
@@ -1,0 +1,9 @@
+camunda:
+  security:
+    authentication:
+      oidc:
+        client-id: it-client
+        client-secret: it-secret
+        authorization-uri: https://idp.example.com/authorize
+        token-uri: https://idp.example.com/token
+        jwk-set-uri: https://idp.example.com/jwks

--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeApplicationDetector.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeApplicationDetector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import org.springframework.boot.SpringApplication;
+
+/**
+ * Shared guard for Optimize's {@code EnvironmentPostProcessor}s.
+ *
+ * <p>Spring Boot's {@code SpringFactoriesLoader} discovers every {@code EnvironmentPostProcessor}
+ * on the classpath for every {@code SpringApplication} started in the JVM, independent of
+ * {@code @ComponentScan} or which class is that application's primary source. {@code
+ * camunda-authentication} and {@code camunda-zeebe} (dist) are test-scope dependencies of
+ * optimize-backend (pulled in via zeebe-qa-util for the embedded broker Optimize's own CCSM ITs
+ * boot), so Optimize's {@code META-INF/spring.factories} entries are also visible to that broker's
+ * unrelated {@code SpringApplication} (camunda/camunda#60184). Every {@code
+ * EnvironmentPostProcessor} that only makes sense for Optimize's own webapp must guard on this
+ * before touching the environment.
+ */
+public final class OptimizeApplicationDetector {
+
+  private OptimizeApplicationDetector() {}
+
+  // True only when `application` is genuinely Optimize's own SpringApplication — i.e. Main.class
+  // (the sole primary source of both Main#main and AbstractIT#startAndUseNewOptimizeInstance) is
+  // among its sources. A null application (defensive: the interface contract allows it, and some
+  // callers construct a post-processor directly without going through Spring Boot's own bootstrap)
+  // is never treated as Optimize's own.
+  public static boolean isOptimizeApplication(final SpringApplication application) {
+    return application != null && application.getAllSources().contains(Main.class);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/SpringPropertiesPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/SpringPropertiesPostProcessor.java
@@ -26,6 +26,12 @@ public class SpringPropertiesPostProcessor implements EnvironmentPostProcessor {
   @Override
   public void postProcessEnvironment(
       final ConfigurableEnvironment environment, final SpringApplication application) {
+    if (!OptimizeApplicationDetector.isOptimizeApplication(application)) {
+      // See OptimizeApplicationDetector: without this guard, Optimize's server.http2.enabled
+      // default also leaks (lowest precedence) into any other SpringApplication sharing the
+      // classpath, e.g. the embedded broker Optimize's own CCSM ITs boot alongside themselves.
+      return;
+    }
     final Map<String, Object> propertiesToAddMap = createSpringProperties();
     addToDefaultProperties(environment.getPropertySources(), propertiesToAddMap);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.rest.security.csl;
 
+import io.camunda.optimize.Main;
 import io.camunda.security.api.model.config.SessionConfiguration;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -75,6 +76,19 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   @Override
   public void postProcessEnvironment(
       final ConfigurableEnvironment env, final SpringApplication application) {
+    if (!isOptimizeApplication(application)) {
+      // EnvironmentPostProcessors are discovered classpath-wide by Spring Boot's
+      // SpringFactoriesLoader for every SpringApplication in the JVM, independent of
+      // @ComponentScan or which class is that application's primary source. camunda-authentication
+      // and camunda-zeebe (dist) are test-scope dependencies of optimize-backend (pulled in via
+      // zeebe-qa-util for the embedded broker Optimize's own CCSM ITs boot), so this class's
+      // META-INF/spring.factories entry is visible to that broker's SpringApplication too. Without
+      // this guard, Optimize's OIDC-only bridge defaults silently overrode the broker's own
+      // explicit BASIC-auth configuration, which then genuinely conflicted with the broker's
+      // separately-configured initial demo user (camunda/camunda#60184).
+      return;
+    }
+
     final boolean cslEnabled =
         !"false".equalsIgnoreCase(env.getProperty(CSL_ENABLED_PROPERTY, "true"));
     // Canonicalize to a literal "true"/"false" so every @ConditionalOnProperty on this flag (CSL
@@ -111,6 +125,15 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
               + " (always-on defaults plus values derived from legacy Optimize config).",
           derived.size());
     }
+  }
+
+  // True only when `application` is genuinely Optimize's own SpringApplication — i.e. Main.class
+  // (the sole primary source of both Main#main and AbstractIT#startAndUseNewOptimizeInstance) is
+  // among its sources. A null application (defensive: the interface contract allows it, and some
+  // callers construct this processor directly without going through Spring Boot's own bootstrap)
+  // is never treated as Optimize's own.
+  private static boolean isOptimizeApplication(final SpringApplication application) {
+    return application != null && application.getAllSources().contains(Main.class);
   }
 
   // Reached only when an operator explicitly sets the flag to false: every other path now

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.optimize.rest.security.csl;
 
-import io.camunda.optimize.Main;
+import io.camunda.optimize.OptimizeApplicationDetector;
 import io.camunda.security.api.model.config.SessionConfiguration;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -76,16 +76,11 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   @Override
   public void postProcessEnvironment(
       final ConfigurableEnvironment env, final SpringApplication application) {
-    if (!isOptimizeApplication(application)) {
-      // EnvironmentPostProcessors are discovered classpath-wide by Spring Boot's
-      // SpringFactoriesLoader for every SpringApplication in the JVM, independent of
-      // @ComponentScan or which class is that application's primary source. camunda-authentication
-      // and camunda-zeebe (dist) are test-scope dependencies of optimize-backend (pulled in via
-      // zeebe-qa-util for the embedded broker Optimize's own CCSM ITs boot), so this class's
-      // META-INF/spring.factories entry is visible to that broker's SpringApplication too. Without
-      // this guard, Optimize's OIDC-only bridge defaults silently overrode the broker's own
-      // explicit BASIC-auth configuration, which then genuinely conflicted with the broker's
-      // separately-configured initial demo user (camunda/camunda#60184).
+    if (!OptimizeApplicationDetector.isOptimizeApplication(application)) {
+      // See OptimizeApplicationDetector: without this guard, Optimize's OIDC-only bridge defaults
+      // silently overrode the embedded broker's own explicit BASIC-auth configuration, which then
+      // genuinely conflicted with the broker's separately-configured initial demo user
+      // (camunda/camunda#60184).
       return;
     }
 
@@ -125,15 +120,6 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
               + " (always-on defaults plus values derived from legacy Optimize config).",
           derived.size());
     }
-  }
-
-  // True only when `application` is genuinely Optimize's own SpringApplication — i.e. Main.class
-  // (the sole primary source of both Main#main and AbstractIT#startAndUseNewOptimizeInstance) is
-  // among its sources. A null application (defensive: the interface contract allows it, and some
-  // callers construct this processor directly without going through Spring Boot's own bootstrap)
-  // is never treated as Optimize's own.
-  private static boolean isOptimizeApplication(final SpringApplication application) {
-    return application != null && application.getAllSources().contains(Main.class);
   }
 
   // Reached only when an operator explicitly sets the flag to false: every other path now

--- a/optimize/backend/src/test/java/io/camunda/optimize/SpringPropertiesPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/SpringPropertiesPostProcessorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.env.StandardEnvironment;
+
+class SpringPropertiesPostProcessorTest {
+
+  private static final SpringApplication OPTIMIZE_APPLICATION = new SpringApplication(Main.class);
+
+  private final SpringPropertiesPostProcessor processor = new SpringPropertiesPostProcessor();
+
+  @Test
+  void shouldBridgeServerHttp2EnabledForOptimizesOwnApplication() {
+    final StandardEnvironment env = new StandardEnvironment();
+
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(SpringPropertiesPostProcessor.SPRING_HTTP2_ENABLED_PROPERTY))
+        .isNotNull();
+  }
+
+  @Test
+  void shouldSkipEntirelyWhenApplicationIsNotOptimizesOwn() {
+    // given a different SpringApplication booted in the same JVM/classpath (e.g. the embedded
+    // TestStandaloneBroker Optimize's own CCSM ITs start), which never asked for Optimize's
+    // server.http2.enabled default (camunda/camunda#60184)
+    final StandardEnvironment env = new StandardEnvironment();
+    final SpringApplication notOptimize = new SpringApplication(StandardEnvironment.class);
+
+    processor.postProcessEnvironment(env, notOptimize);
+
+    assertThat(env.getProperty(SpringPropertiesPostProcessor.SPRING_HTTP2_ENABLED_PROPERTY))
+        .isNull();
+  }
+
+  @Test
+  void shouldSkipEntirelyWhenApplicationIsNull() {
+    final StandardEnvironment env = new StandardEnvironment();
+
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(SpringPropertiesPostProcessor.SPRING_HTTP2_ENABLED_PROPERTY))
+        .isNull();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -228,7 +228,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "https://public-api-idp.example.com/keys");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
     assertThat(env.getProperty(OIDC + "authorization-uri"))
@@ -252,7 +252,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("camunda.identity.issuerBackendUrl", backend);
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "jwk-set-uri"))
         .isEqualTo(backend + "/protocol/openid-connect/certs");
@@ -270,7 +270,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put(OIDC + "authorization-uri", "https://idp.example.com/authorize");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "authorization-uri"))
         .isEqualTo("https://idp.example.com/authorize");
@@ -290,7 +290,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "camunda.identity.issuerBackendUrl",
         "http://identity.svc:18080/auth/realms/camunda-platform");
 
-    processor.postProcessEnvironment(environmentWith(legacy), null);
+    processor.postProcessEnvironment(environmentWith(legacy), OPTIMIZE_APPLICATION);
 
     logs.assertContains("camunda.identity.issuerBackendUrl");
     logs.assertContains("Browser login cannot work against an internal URL");
@@ -305,7 +305,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "  http://identity.svc:18080/auth/realms/camunda-platform//  ");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "token-uri"))
         .isEqualTo(
@@ -325,7 +325,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put(OIDC + "issuer-uri", "");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "authorization-uri"))
         .isEqualTo(backend + "/protocol/openid-connect/auth");
@@ -348,7 +348,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put(OIDC + "issuer-uri", "");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "client-id")).isNull();
     assertThat(env.getProperty(OIDC + "client-secret")).isNull();
@@ -369,7 +369,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put(OIDC + "token-uri", "");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "client-id")).isNull();
     assertThat(env.getProperty(OIDC + "client-secret")).isNull();
@@ -387,7 +387,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "http://identity.svc:18080/auth/realms/camunda-platform");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri"))
         .isEqualTo("https://public.example.com/auth/realms/camunda-platform");
@@ -404,7 +404,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "http://identity.svc:18080/auth/realms/camunda-platform/");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "token-uri"))
         .isEqualTo(
@@ -433,7 +433,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
     assertThat(env.getProperty(OIDC + "jwk-set-uri"))
@@ -459,7 +459,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
     assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("helm-secret");
@@ -486,7 +486,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
     logs.assertContains(
@@ -508,7 +508,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri"))
         .isEqualTo("https://public.example.com/auth/realms/camunda-platform");

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -29,6 +29,7 @@ import org.springframework.core.env.StandardEnvironment;
 class OptimizeSecurityConfigCompatibilityPostProcessorTest {
 
   private static final String OIDC = "camunda.security.authentication.oidc.";
+  private static final SpringApplication OPTIMIZE_APPLICATION = new SpringApplication(Main.class);
 
   @RegisterExtension
   final LogCapturer logs =
@@ -37,8 +38,6 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
 
   private final OptimizeSecurityConfigCompatibilityPostProcessor processor =
       new OptimizeSecurityConfigCompatibilityPostProcessor();
-
-  private static final SpringApplication OPTIMIZE_APPLICATION = new SpringApplication(Main.class);
 
   private static StandardEnvironment environmentWith(final Map<String, Object> legacy) {
     final StandardEnvironment env = new StandardEnvironment();

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.service.util.configuration.ConfigurationServic
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.OPENSEARCH_DATABASE_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.optimize.Main;
 import io.camunda.security.api.model.config.SessionConfiguration;
 import io.github.netmikey.logunit.api.LogCapturer;
 import java.util.HashMap;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.event.Level;
+import org.springframework.boot.SpringApplication;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 
@@ -35,6 +37,8 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
 
   private final OptimizeSecurityConfigCompatibilityPostProcessor processor =
       new OptimizeSecurityConfigCompatibilityPostProcessor();
+
+  private static final SpringApplication OPTIMIZE_APPLICATION = new SpringApplication(Main.class);
 
   private static StandardEnvironment environmentWith(final Map<String, Object> legacy) {
     final StandardEnvironment env = new StandardEnvironment();
@@ -56,7 +60,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.authentication.method")).isNull();
     assertThat(env.getProperty(OIDC + "client-id")).isNull();
@@ -77,7 +81,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("optimize.security.csl.enabled", "flase");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.authentication.method")).isEqualTo("oidc");
     logs.assertDoesNotContain(
@@ -94,12 +98,44 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     final Map<String, Object> legacy = new HashMap<>();
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.authentication.method")).isEqualTo("oidc");
     logs.assertDoesNotContain(
         entry -> entry.getLevel() == Level.WARN,
         "expected no deprecation warning when the flag is simply left at its default");
+  }
+
+  @Test
+  void shouldSkipEntirelyWhenApplicationIsNotOptimizesOwn() {
+    // given a different SpringApplication booted in the same JVM/classpath (e.g. the embedded
+    // TestStandaloneBroker Optimize's own CCSM ITs start for import tests, see
+    // camunda/camunda#60184) that never asked for Optimize's OIDC-only bridge defaults
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", "http://localhost:18080/realm");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    final SpringApplication notOptimize = new SpringApplication(StandardEnvironment.class);
+
+    processor.postProcessEnvironment(env, notOptimize);
+
+    assertThat(env.getProperty("camunda.security.authentication.method")).isNull();
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    // left exactly as the caller set it: the guard returns before canonicalization runs, so a
+    // foreign application never even sees this processor's usual normalization of the flag
+    assertThat(env.getProperty("optimize.security.csl.enabled")).isEqualTo("true");
+    logs.assertDoesNotContain(
+        entry -> true, "expected no deprecation warnings for an application that isn't Optimize");
+  }
+
+  @Test
+  void shouldSkipEntirelyWhenApplicationIsNull() {
+    // given no SpringApplication at all (defensive: postProcessEnvironment's contract allows null)
+    final StandardEnvironment env = environmentWith(cslEnabledConfig());
+
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.authentication.method")).isNull();
   }
 
   @Test
@@ -111,7 +147,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE", "optimize-api");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.authentication.method")).isEqualTo("oidc");
     assertThat(env.getProperty("camunda.security.authentication.catch-all-unhandled-paths-enabled"))
@@ -149,7 +185,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri"))
         .isEqualTo("http://localhost:18080/auth/realms/camunda-platform");
@@ -491,7 +527,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
     assertThat(env.getProperty(OIDC + "client-id")).isNull();
@@ -515,7 +551,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo("http://legacy.example.com/realm");
     assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("legacy-client");
@@ -552,7 +588,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
     assertThat(env.getProperty(OIDC + "client-id")).isNull();
@@ -580,7 +616,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put(OIDC + "issuer-uri", "");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "client-id")).isNull();
     assertThat(env.getProperty(OIDC + "client-secret")).isNull();
@@ -602,7 +638,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "helm-secret");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("cloud-client");
     assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo("https://weblogin.example.com/");
@@ -615,7 +651,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put(OIDC + "issuer-uri", "https://operator-configured.example.com/realm");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri"))
         .isEqualTo("https://operator-configured.example.com/realm");
@@ -633,7 +669,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_M2M_ACCOUNTS_AUTH0_AUDIENCE", "cloud.accounts");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.authentication.method")).isEqualTo("oidc");
     assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("cloud-client");
@@ -666,7 +702,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     // no clusterId set
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.saas.organization-id")).isNull();
     assertThat(env.getProperty("camunda.security.saas.cluster-id")).isNull();
@@ -685,7 +721,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "jwk-set-uri"))
         .isEqualTo("https://idp.example.com/.well-known/jwks.json");
@@ -707,7 +743,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-login,optimize-public-api");
   }
@@ -718,7 +754,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("camunda.identity.audience", "optimize-api");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-api");
   }
@@ -733,7 +769,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("camunda.identity.audience", "optimize-login");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     // insertion order follows the code's call order: the pre-existing API-audience bridge call
     // runs before the new Helm-chart identity-audience bridge call
@@ -751,7 +787,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("camunda.identity.audience", "optimize-login");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-login");
     logs.assertDoesNotContain(
@@ -767,7 +803,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("camunda.identity.audience", "optimize-api");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     // the CCSM-only camunda.identity.audience must not leak into the Auth0 audience set
     assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize,cloud-client");
@@ -783,7 +819,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     // The resource audience (bearer path) and the client id (login id_token aud) both survive; the
     // CCSM-only public-API audience does not.
@@ -797,7 +833,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     // No CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE configured: the login id_token must still be accepted, so
     // the client id alone is bridged into the audiences set.
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("cloud-client");
   }
@@ -809,7 +845,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE", "optimize");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     // The client id is bridged to client-id (its deprecation warning is emitted there); reusing it
     // as an audience must not emit a second "deprecated -> audiences" warning.
@@ -826,7 +862,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE", "31536000");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.http-headers.hsts.max-age-in-seconds"))
         .isEqualTo("31536000");
@@ -839,7 +875,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE", "-1");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.http-headers.hsts.disabled")).isEqualTo("true");
     assertThat(env.getProperty("camunda.security.http-headers.hsts.max-age-in-seconds")).isNull();
@@ -861,7 +897,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("security.responseHeaders.X-XSS-Protection", "0");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     logs.assertContains(
         entry -> entry.getMessage().contains("CAMUNDA_OPTIMIZE_SECURITY_AUTH_TOKEN_SECRET"),
@@ -896,7 +932,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
 
     final StandardEnvironment env = environmentWith(legacy);
     // must not throw during environment post-processing
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("camunda.security.http-headers.hsts.max-age-in-seconds")).isNull();
     assertThat(env.getProperty("camunda.security.http-headers.hsts.disabled")).isNull();
@@ -920,7 +956,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", "ccsm-client");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     // Auth0 values win, no mix with the CCSM identity values
     assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("cloud-client");
@@ -936,7 +972,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_OPTIMIZE_CONTEXT_PATH", "/legacy-path");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     // the clusterId-derived default must not shadow the operator's existing setting
     assertThat(env.getProperty("contextPath")).isNull();
@@ -950,7 +986,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("contextPath", "/explicit");
 
     final StandardEnvironment env = environmentWith(legacy);
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty("contextPath")).isEqualTo("/explicit");
   }
@@ -964,7 +1000,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     final StandardEnvironment env = environmentWith(legacy);
 
     // when
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     // then the CSL session store is active on both editions, so sessions survive a restart and are
     // shared across instances rather than being kept in memory on one of them
@@ -979,7 +1015,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     final StandardEnvironment env = environmentWith(legacy);
 
     // when
-    processor.postProcessEnvironment(env, null);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     // then the bridged default does not override them
     assertThat(env.getProperty(SessionConfiguration.PERSISTENT_ENABLED_PROPERTY))


### PR DESCRIPTION
## Summary

Optimize's CCSM integration-test suite (`ccsm-test` group) failed to boot its Spring context
when `optimize.security.csl.enabled=true` (the new default since #58483), with:

```
java.lang.IllegalStateException: Creation of initial users is not supported with `OIDC` authentication method
    at io.camunda.authentication.config.OidcOverrideBeansConfiguration.verifyOidcConfiguration
```

**Root cause:** `OptimizeSecurityConfigCompatibilityPostProcessor` is registered via
`optimize-backend`'s `META-INF/spring.factories` as a Spring Boot `EnvironmentPostProcessor`.
Spring's `SpringFactoriesLoader` discovers `EnvironmentPostProcessor`s classpath-wide for
**every** `SpringApplication` in the JVM, not just the one that declared them.
`camunda-authentication`/`camunda-zeebe` are test-scope dependencies of `optimize-backend` (for
the embedded `TestStandaloneBroker` Optimize's own CCSM ITs boot alongside themselves), so this
postprocessor's classpath entry was also visible to — and fired against — that unrelated embedded
broker, forcing `camunda.security.authentication.method=oidc` onto it as a low-precedence default.
The broker's own `.withBasicAuth()` call never materialized a competing `=basic` property (a
config-flattening helper omits fields already equal to their own default, and `BASIC` is that
default), so nothing outranked the bridge default, and the broker's environment resolved to OIDC —
activating `OidcOverrideBeansConfiguration` inside the broker's own context, whose startup guard
correctly rejected the resulting conflict with the broker's own separately-configured initial demo
user.

- Scopes the postprocessor to only act on Optimize's own `SpringApplication` (checks that
  `Main.class` is among its primary sources).
- Adds the missing IT-only OIDC fixture so CSL can boot at all under `ccsm-test`.
- Fixes two adjacent, pre-existing test gaps from the broader CSL migration surfaced by a full
  IT-suite run: `ExtraConfigurationConfigImportIT`'s config-location override was losing the OIDC
  fixture, and `PublicApiVariableLabelsIT`'s legacy static-token auth needed pinning to the legacy
  stack it actually exercises.
- Re-enables `cslEnabled=true` CI matrix coverage for the `ccsm-test` group (ES + OS).

Closes #60184

## Test plan

- [x] Full `ccsm-test` IT group passes with `optimize.security.csl.enabled=true` against a real
      Elasticsearch (258/259; the one remaining failure, `BackupServiceIT.backupApi`, is a
      local-Docker-only `path.repo` config artifact — CI's ES compose config already sets
      `path.repo`, so it does not reproduce there)
- [x] Full `ccsm-test` IT group still passes with `optimize.security.csl.enabled=false` (legacy
      escape hatch, no regression)
- [x] `OptimizeSecurityConfigCompatibilityPostProcessorTest` unit tests cover the new guard
      (application is/isn't Optimize's own `SpringApplication`, including a null-application case)
- [x] Full `optimize/backend` unit test suite passes (965 tests)
- [x] Full repo compiles (`./mvnw install -Dquickly -T1C`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)