### PR TITLE
feat: let an operator discard a disabled physical tenant so its broker can leave

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -107,7 +107,8 @@ public class DynamicClusterServices {
         clusterCommunicationService,
         ClusterConfigurationCoordinatorSupplier.from(
             brokerTopologyManager::getClusterConfiguration),
-        new ProtoBufSerializer());
+        new ProtoBufSerializer(),
+        clusterMembershipService.getLocalMember().id());
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -53,6 +53,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
@@ -426,6 +427,11 @@ final class ClusterApiUtils {
               new Operation()
                   .operation(OperationEnum.BROKER_REMOVE)
                   .brokers(List.of(brokerIdValue(memberRemoveOperation.memberToRemove())));
+          case final RemovePhysicalTenantOperation ignored ->
+              // A partition-group operation, so physicalTenantId here is already the target group.
+              new Operation()
+                  .operation(OperationEnum.REMOVE_PHYSICAL_TENANT)
+                  .physicalTenant(physicalTenantId);
           case final PartitionDisableExporterOperation disableExporterOperation ->
               new Operation()
                   .operation(OperationEnum.PARTITION_DISABLE_EXPORTER)
@@ -1080,6 +1086,10 @@ final class ClusterApiUtils {
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.AWAIT_MODE_CHANGE)
                   .brokerId(brokerIdValue(modeChange.memberId()));
+          case final RemovePhysicalTenantOperation removal ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.REMOVE_PHYSICAL_TENANT)
+                  .brokerId(brokerIdValue(removal.memberId()));
           default ->
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.UNKNOWN);

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemovePhysicalTenantRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
@@ -623,6 +624,27 @@ public class ClusterEndpoint {
       final var forceRemoveRequest = new ForceZoneRemoveRequest(zoneId, dryRun);
       return ClusterApiUtils.mapOperationResponse(
           requestSender.forceRemoveZone(forceRemoveRequest).join());
+    } catch (final Exception exception) {
+      return ClusterApiUtils.mapError(exception);
+    }
+  }
+
+  /**
+   * Discards a disabled physical tenant, allowing a broker still holding its partitions to leave
+   * the cluster. Does not delete the tenant's data; it stays on the brokers' disks until reclaimed
+   * out of band.
+   */
+  @DeleteMapping(path = "/physical-tenants/{physicalTenantId}")
+  public ResponseEntity<?> removePhysicalTenant(
+      @PathVariable final String physicalTenantId,
+      @RequestParam(defaultValue = "false") final boolean dryRun,
+      @RequestParam(defaultValue = "false") final boolean force) {
+    try {
+      return ClusterApiUtils.mapOperationResponse(
+          requestSender
+              .removePhysicalTenant(
+                  new RemovePhysicalTenantRequest(physicalTenantId, dryRun, force))
+              .join());
     } catch (final Exception exception) {
       return ClusterApiUtils.mapError(exception);
     }

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -445,6 +445,39 @@ paths:
           $ref: 'components.yaml#/responses/TimeoutError'
       x-added-in-version: "8.10.0"
 
+  /physical-tenants/{physicalTenantId}:
+    delete:
+      summary: Remove a disabled physical tenant
+      description: Discards the given disabled physical tenant, so that brokers still holding its
+        partitions may leave the cluster. The tenant must already be disabled, i.e. removed from
+        the brokers' static configuration. Removal is permanent — the tenant id cannot be brought
+        back — and does not delete the tenant's data, which stays on the brokers' disks until
+        reclaimed out of band. A normal request runs on the elected coordinator; with force, it is
+        executed by whichever broker received it — the bail-out for a disaster where the
+        coordinator is unreachable.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantId'
+        - $ref: '#/components/parameters/DryRunParameter'
+        - $ref: '#/components/parameters/ForceParameter'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+      x-added-in-version: "8.10.0"
+
 components:
   parameters:
     BrokerId:
@@ -461,6 +494,13 @@ components:
       description: Name of the zone
       schema:
         type: string
+    PhysicalTenantId:
+      name: physicalTenantId
+      required: true
+      in: path
+      description: Id of the physical tenant
+      schema:
+        $ref: 'components.yaml#/schemas/PhysicalTenantId'
     PartitionId:
       name: partitionId
       required: true

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -588,6 +588,7 @@ schemas:
           - EXIT_RECOVERY
           - AWAIT_MODE_CHANGE
           - EXPORTING_STATE_CHANGE
+          - REMOVE_PHYSICAL_TENANT
       brokerId:
         $ref: "components.yaml#/schemas/BrokerId"
       partitionId:

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -58,6 +58,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
@@ -1236,6 +1237,7 @@ final class ClusterApiUtilsTest {
         new DeleteHistoryOperation(memberId1),
         new UpdateRoutingState(memberId1, emptyRoutingState),
         new UpdateIncarnationNumberOperation(memberId1),
+        new RemovePhysicalTenantOperation(memberId1),
         new PreScalingOperation(memberId1, memberCollection),
         new PostScalingOperation(memberId1, memberCollection),
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -15,12 +15,14 @@ import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliers;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliers;
+import io.camunda.zeebe.dynamic.config.changes.appliers.RemovePhysicalTenantApplier;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -378,22 +380,43 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(
         () -> {
           partitionGroupChangeAppliers.put(groupId, appliers);
-          scopeReconcilers.computeIfAbsent(
-              new Scope.Group(groupId), ignored -> newGroupScopeReconciler(groupId));
           reconcile(persistedCurrentConfiguration.getConfiguration());
         });
+  }
+
+  /**
+   * The single place group-scoped {@link ScopeReconciler}s are created — registering a group's
+   * appliers via {@link #registerPartitionGroupChangeAppliers} does not create one. Every live
+   * group keeps a reconciler on every broker, whether or not the broker registered that group's
+   * appliers — a broker can be named in a group operation without ever hosting the group (a
+   * disabled physical tenant's forced removal executes on whichever broker received the request,
+   * and no broker runs a disabled tenant). Removed groups are tombstones that can never have work
+   * again, and they accumulate over a cluster's lifetime, so no new reconciler is created for one —
+   * an existing one persisting is fine, since reconcilers are deliberately never removed except on
+   * {@link #close}. A reconciler with nothing pending is a no-op per pass.
+   */
+  private void ensurePartitionGroupScopeReconcilers(final CurrentClusterConfiguration config) {
+    config
+        .partitionGroups()
+        .forEach(
+            (groupId, group) -> {
+              if (!group.isRemoved()) {
+                scopeReconcilers.computeIfAbsent(
+                    new Scope.Group(groupId), ignored -> newGroupScopeReconciler(groupId));
+              }
+            });
   }
 
   void removePartitionGroupChangeAppliers(final String groupId) {
     executor.run(
         () -> {
           partitionGroupChangeAppliers.remove(groupId);
-          // Deliberately not removing this group's ScopeReconciler here: it's only ever fetched
-          // via computeIfAbsent in registerPartitionGroupChangeAppliers above, so it survives a
-          // remove/register round-trip unmolested. PartitionManagerImpl/RecoveryPartitionManager
-          // re-register their change appliers on every recovery/processing mode transition;
-          // discarding the ScopeReconciler here would discard its in-flight retry/backoff state
-          // on every such transition, leaving a broker stuck mid-transition (see
+          // Deliberately not removing this group's ScopeReconciler here: it's created solely by
+          // ensurePartitionGroupScopeReconcilers, so it survives a remove/register round-trip
+          // unmolested. PartitionManagerImpl/RecoveryPartitionManager re-register their change
+          // appliers on every recovery/processing mode transition; discarding the ScopeReconciler
+          // here would discard its in-flight retry/backoff state on every such transition, leaving
+          // a broker stuck mid-transition (see
           // ModeChangeAcceptanceIT#shouldCycleBetweenRecoveryAndProcessing).
         });
   }
@@ -486,6 +509,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
    */
   private void reconcile(final CurrentClusterConfiguration config) {
     final var pendingIds = config.phasedChangeState().pending().keySet();
+    ensurePartitionGroupScopeReconcilers(config);
     if (isLocalMemberCoordinator()) {
       for (final var planId : List.copyOf(pendingIds)) {
         planAdvancers.computeIfAbsent(planId, this::newPlanAdvancer).maybeAdvance(config);
@@ -537,6 +561,21 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private boolean isLocalMemberCoordinator() {
     return coordinatorSupplier != null
         && localMemberId.equals(coordinatorSupplier.getDefaultCoordinator());
+  }
+
+  /**
+   * A {@code RemovePhysicalTenantOperation} is dispatchable even with no {@code appliers}
+   * registered for the group, since it is a pure configuration edit with no broker-side executor.
+   * Every other operation still requires a registered appliers set, returning {@code
+   * Optional.empty()} — leaving it pending — otherwise.
+   */
+  private static Optional<PartitionGroupConfigurationChangeApplier> applierFor(
+      final PartitionGroupOperation operation,
+      final @Nullable PartitionGroupConfigurationChangeAppliers appliers) {
+    if (operation instanceof RemovePhysicalTenantOperation) {
+      return Optional.of(new RemovePhysicalTenantApplier());
+    }
+    return Optional.ofNullable(appliers).map(a -> a.getApplier(operation));
   }
 
   private record GlobalOperation(
@@ -641,14 +680,16 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
 
     @Override
     public Optional<Operation> nextOperation(final CurrentClusterConfiguration config) {
-      final var appliers = partitionGroupChangeAppliers.get(groupId);
       final var group = config.partitionGroup(groupId);
-      if (appliers == null || group == null) {
+      if (group == null) {
         return Optional.empty();
       }
       return group
           .pendingChangesFor(localMemberId)
-          .map(operation -> new GroupOperation(groupId, operation, appliers.getApplier(operation)));
+          .flatMap(
+              operation ->
+                  applierFor(operation, partitionGroupChangeAppliers.get(groupId))
+                      .map(applier -> new GroupOperation(groupId, operation, applier)));
     }
 
     @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantAvailabilityInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantAvailabilityInitializer.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Disables a physical tenant on the coordinator once it is no longer present in the local static
@@ -39,6 +41,9 @@ import java.util.stream.Collectors;
 public class PhysicalTenantAvailabilityInitializer
     extends ClusterConfigurationModifier.CoordinatorOnly<CurrentClusterConfiguration> {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PhysicalTenantAvailabilityInitializer.class);
+
   private final Set<String> staticTenantIds;
 
   public PhysicalTenantAvailabilityInitializer(final StaticConfiguration staticConfiguration) {
@@ -55,6 +60,14 @@ public class PhysicalTenantAvailabilityInitializer
     var result = configuration;
     for (final var groupId : configuration.partitionGroups().keySet()) {
       final boolean isKnownLocally = staticTenantIds.contains(groupId);
+      if (isKnownLocally && configuration.partitionGroup(groupId).isRemoved()) {
+        LOG.warn(
+            "Physical tenant '{}' is listed in the local static configuration, but it was "
+                + "explicitly removed; removal is permanent, so re-adding '{}' to the static "
+                + "configuration has no effect. Delete it from the static configuration.",
+            groupId,
+            groupId);
+      }
       result =
           result.updatePartitionGroupConfig(
               groupId,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemovePhysicalTenantRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
@@ -73,6 +74,9 @@ public interface ClusterConfigurationManagementApi {
       ClusterZoneMigrationRequest zoneMigrationRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> purge(PurgeRequest purgeRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> removePhysicalTenant(
+      RemovePhysicalTenantRequest removePhysicalTenantRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> forceRemoveBrokers(
       ForceRemoveBrokersRequest forceRemoveBrokersRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -210,6 +210,26 @@ public sealed interface ClusterConfigurationManagementRequest {
       implements ClusterConfigurationManagementRequest {}
 
   /**
+   * Discards a disabled physical tenant, so that a broker still holding its partitions may leave
+   * the cluster. Until this is called, a disabled tenant blocks a broker removal exactly as an
+   * enabled one does — disabling is a safety barrier against losing a tenant's data by accident,
+   * not a statement that the data is expendable.
+   *
+   * <p>The tenant must already be disabled, i.e. absent from the brokers' static configuration.
+   *
+   * @param force when true, the request is executed by whichever broker receives it instead of
+   *     being routed to the elected coordinator — the operator's bail-out for when the coordinator
+   *     is unreachable. Normally left false, so the request runs on the coordinator like any other
+   *     configuration change.
+   */
+  record RemovePhysicalTenantRequest(String physicalTenantId, boolean dryRun, boolean force)
+      implements ClusterConfigurationManagementRequest {
+    public RemovePhysicalTenantRequest {
+      assertNonEmpty("physicalTenantId").accept(physicalTenantId);
+    }
+  }
+
+  /**
    * Force-evicts a failed zone's brokers from the member set and drops the zone from the persisted
    * {@code ZoneAwareConfig}, in one atomic change.
    */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
@@ -25,6 +26,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemovePhysicalTenantRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
@@ -42,14 +44,17 @@ public final class ClusterConfigurationManagementRequestSender {
   private final ClusterCommunicationService communicationService;
   private final ClusterConfigurationCoordinatorSupplier coordinatorSupplier;
   private final ClusterConfigurationRequestsSerializer serializer;
+  private final MemberId localMemberId;
 
   public ClusterConfigurationManagementRequestSender(
       final ClusterCommunicationService communicationService,
       final ClusterConfigurationCoordinatorSupplier coordinatorSupplier,
-      final ClusterConfigurationRequestsSerializer serializer) {
+      final ClusterConfigurationRequestsSerializer serializer,
+      final MemberId localMemberId) {
     this.communicationService = communicationService;
     this.coordinatorSupplier = coordinatorSupplier;
     this.serializer = serializer;
+    this.localMemberId = localMemberId;
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> addMembers(
@@ -160,6 +165,26 @@ public final class ClusterConfigurationManagementRequestSender {
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getNextCoordinatorExcluding(
             forceRemoveBrokersRequest.membersToRemove()),
+        TIMEOUT);
+  }
+
+  /**
+   * Sent to the default coordinator like any other change, unless the request is {@code force}d. A
+   * forced request is the operator's bail-out for a disaster where the elected coordinator is
+   * unreachable: it must be handled by whichever broker actually received this HTTP call — i.e.
+   * this local member — rather than by the (possibly dead) default coordinator, since sending it
+   * there would simply reproduce the failure the operator is trying to route around.
+   */
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      removePhysicalTenant(final RemovePhysicalTenantRequest removePhysicalTenantRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.REMOVE_PHYSICAL_TENANT.topic(),
+        removePhysicalTenantRequest,
+        serializer::encodeRemovePhysicalTenantRequest,
+        serializer::decodeTopologyChangeResponse,
+        removePhysicalTenantRequest.force()
+            ? localMemberId
+            : coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemovePhysicalTenantRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
@@ -192,6 +193,17 @@ public final class ClusterConfigurationManagementRequestsHandler
         forceRemoveBrokersRequest.dryRun(),
         new ForceRemoveBrokersRequestTransformer(
             forceRemoveBrokersRequest.membersToRemove(), localMemberId));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> removePhysicalTenant(
+      final RemovePhysicalTenantRequest removePhysicalTenantRequest) {
+    return handleRequest(
+        removePhysicalTenantRequest.dryRun(),
+        new RemovePhysicalTenantRequestTransformer(
+            removePhysicalTenantRequest.physicalTenantId(),
+            localMemberId,
+            removePhysicalTenantRequest.force()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -53,6 +53,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerZoneMigrationHandler();
     registerForceRemoveBrokersRequestHandler();
     registerPurgeRequestHandler();
+    registerRemovePhysicalTenantRequestHandler();
     registerModeChangeHandler();
     registerRestoreHandler();
     registerClusterRestoreHandler();
@@ -178,6 +179,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.FORCE_REMOVE_BROKERS.topic(),
         serializer::decodeForceRemoveBrokersRequest,
         request -> mapResponse(clusterConfigurationManagementApi.forceRemoveBrokers(request)),
+        this::encodeResponse);
+  }
+
+  private void registerRemovePhysicalTenantRequestHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.REMOVE_PHYSICAL_TENANT.topic(),
+        serializer::decodeRemovePhysicalTenantRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.removePhysicalTenant(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -23,6 +23,7 @@ public enum ClusterConfigurationRequestTopics {
   PATCH_CLUSTER("topology-cluster-patch"),
   PURGE("topology-cluster-purge"),
   FORCE_REMOVE_BROKERS("topology-broker-force-remove"),
+  REMOVE_PHYSICAL_TENANT("topology-physical-tenant-remove"),
   UPDATE_ROUTING_STATE("topology-cluster-update-routing-state"),
   UPDATE_PARTITION_DISTRIBUTION("topology-cluster-update-partition-distribution"),
   MODE_CHANGE("topology-mode-change"),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemovePhysicalTenantRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemovePhysicalTenantRequestTransformer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Discards a disabled physical tenant, so that a broker still holding its partitions may leave the
+ * cluster. Does not delete the tenant's data — it stays on the brokers' disks, unreachable through
+ * this configuration, until reclaimed out of band.
+ *
+ * <p>Normally the request runs on the elected coordinator like any other configuration change,
+ * exactly as {@link #isForced()} returning {@code false} implies. With {@code force}, it instead
+ * executes on whichever broker received it, naming that broker as {@code coordinator} regardless of
+ * whether it holds the election — the operator's bail-out for a disaster where the elected
+ * coordinator is unreachable.
+ *
+ * <p>{@link #applyToDisabledTenants()} returns {@code true}, since a disabled tenant is exactly
+ * what this request targets and the configuration it is evaluated against would otherwise have
+ * already filtered it out.
+ */
+public class RemovePhysicalTenantRequestTransformer implements ConfigurationChangeRequest {
+
+  private final String physicalTenantId;
+  private final MemberId coordinator;
+  private final boolean force;
+
+  public RemovePhysicalTenantRequestTransformer(
+      final String physicalTenantId, final MemberId coordinator, final boolean force) {
+    this.physicalTenantId = physicalTenantId;
+    this.coordinator = coordinator;
+    this.force = force;
+  }
+
+  @Override
+  public Either<Exception, List<Phase>> phases(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    if (!clusterConfiguration.hasPartitionGroup(physicalTenantId)) {
+      return Either.left(
+          new NotFound(
+              "Expected to remove physical tenant '%s', but there's no such tenant"
+                  .formatted(physicalTenantId)));
+    }
+    if (clusterConfiguration.partitionGroup(physicalTenantId).isRemoved()) {
+      return Either.left(
+          new InvalidRequest(
+              "Expected to remove physical tenant '%s', but it has already been removed"
+                  .formatted(physicalTenantId)));
+    }
+    if (!clusterConfiguration.partitionGroup(physicalTenantId).isDisabled()) {
+      return Either.left(
+          new InvalidRequest(
+              "Expected to remove physical tenant '%s', but it is still enabled. Remove it from the brokers' static configuration first, so that it is disabled, and then retry"
+                  .formatted(physicalTenantId)));
+    }
+    return Either.right(
+        List.of(
+            new PartitionGroupParallelPhase(
+                Map.of(
+                    physicalTenantId, List.of(new RemovePhysicalTenantOperation(coordinator))))));
+  }
+
+  @Override
+  public boolean applyToDisabledTenants() {
+    return true;
+  }
+
+  @Override
+  public boolean isForced() {
+    return force;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionPreRestoreApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionRestoreApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.RemovePhysicalTenantApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.StartPartitionScaleUpApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateIncarnationNumberApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateRoutingStateApplier;
@@ -42,6 +43,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
@@ -118,6 +120,7 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
       case final UpdateRoutingState op ->
           new UpdateRoutingStateApplier(op, partitionScalingChangeExecutor);
       case final UpdateIncarnationNumberOperation ignored -> new UpdateIncarnationNumberApplier();
+      case final RemovePhysicalTenantOperation ignored -> new RemovePhysicalTenantApplier();
       case final DeleteHistoryOperation ignored ->
           new DeleteHistoryApplier(partitionChangeExecutor);
       case final ModeChangeOperation op ->

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplier.java
@@ -16,7 +16,9 @@ import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 
 /**
@@ -63,24 +65,42 @@ public final class MemberLeaveApplier implements GlobalConfigurationChangeApplie
     }
 
     final var partitionsByGroup = new TreeMap<String, Object>();
+    final var disabledGroups = new TreeSet<String>();
     currentClusterConfiguration
         .partitionGroups()
         .forEach(
             (groupId, group) -> {
+              // A removed tenant's member map is already empty, so it is excluded naturally.
               final var broker = group.getMember(memberId);
               if (broker != null && !broker.partitions().isEmpty()) {
                 partitionsByGroup.put(groupId, broker.partitions());
+                if (group.isDisabled()) {
+                  disabledGroups.add(groupId);
+                }
               }
             });
     if (!partitionsByGroup.isEmpty()) {
       return Either.left(
           new IllegalStateException(
-              "Expected to remove member %s, but the member still has partitions assigned. Partitions by group: %s"
-                  .formatted(memberId, partitionsByGroup)));
+              "Expected to remove member %s, but the member still has partitions assigned. Partitions by group: %s%s"
+                  .formatted(memberId, partitionsByGroup, disabledTenantHint(disabledGroups))));
     }
 
     return Either.right(
         config -> config.updateMember(memberId, broker -> broker.setState(State.LEAVING)));
+  }
+
+  /**
+   * Explains why an operator can't just wait or retry: a disabled tenant runs on no broker, so no
+   * plan can move its partitions off the departing one. The only ways forward are to re-enable it
+   * and scale down normally, or remove it and discard its data.
+   */
+  private static String disabledTenantHint(final Set<String> disabledGroups) {
+    if (disabledGroups.isEmpty()) {
+      return "";
+    }
+    return ". Physical tenant(s) %s are disabled, so no operation can move their partitions off this broker: either re-add them to the brokers' static configuration and retry, or remove those physical tenants to discard their data"
+        .formatted(disabledGroups);
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/RemovePhysicalTenantApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/RemovePhysicalTenantApplier.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * Applier for {@code PartitionGroupOperation.RemovePhysicalTenantOperation}. Tombstones a disabled
+ * physical tenant as explicitly discarded ({@link PartitionGroupConfiguration#remove()}), which is
+ * what allows a broker still holding that tenant's partitions to leave the cluster (see {@code
+ * MemberLeaveApplier}).
+ *
+ * <p>Purely a configuration edit, with no broker-side effect: the tenant runs nowhere, so there is
+ * nothing to ask a broker to do and nothing to wait for. See {@code
+ * ClusterConfigurationManagerImpl} for how this applier gets dispatched even though no broker ever
+ * registers one for a disabled tenant's group.
+ */
+public final class RemovePhysicalTenantApplier implements PartitionGroupConfigurationChangeApplier {
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    if (currentPartitionGroupConfiguration.isRemoved()) {
+      // Idempotent: REMOVED is terminal, so a second removal is a no-op, not an error.
+      return Either.right(UnaryOperator.identity());
+    }
+    if (!currentPartitionGroupConfiguration.isDisabled()) {
+      // A tenant still enabled is still in static configuration, so
+      // PhysicalTenantProvisioningInitializer would just re-create it; require disabling first.
+      return Either.left(
+          new IllegalStateException(
+              "Expected to remove a physical tenant, but it is still enabled. Remove it from the "
+                  + "brokers' static configuration first, so that it is disabled, and then retry"));
+    }
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    return CompletableActorFuture.completed(PartitionGroupConfiguration::remove);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemovePhysicalTenantRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
@@ -39,6 +40,8 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeScaleRequest(BrokerScaleRequest scaleRequest);
 
   byte[] encodePurgeRequest(PurgeRequest purgeRequest);
+
+  byte[] encodeRemovePhysicalTenantRequest(RemovePhysicalTenantRequest removePhysicalTenantRequest);
 
   byte[] encodeCancelChangeRequest(
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);
@@ -110,6 +113,9 @@ public interface ClusterConfigurationRequestsSerializer {
       byte[] encodedRequest);
 
   ClusterConfigurationManagementRequest.PurgeRequest decodePurgeRequest(byte[] encodedRequest);
+
+  ClusterConfigurationManagementRequest.RemovePhysicalTenantRequest
+      decodeRemovePhysicalTenantRequest(byte[] encodedRequest);
 
   byte[] encodeResponse(ClusterConfigurationChangeResponse response);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemovePhysicalTenantRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
@@ -86,6 +87,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.*;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
@@ -611,6 +613,8 @@ public class ProtoBufSerializer
               Topology.UpdatePartitionDistributorConfigOperation.newBuilder()
                   .setConfig(encodePartitionDistributorConfig(msg.config()))
                   .build());
+      case final RemovePhysicalTenantOperation ignored ->
+          builder.setRemovePhysicalTenant(Topology.RemovePhysicalTenantOperation.newBuilder());
       case final ModeChangeOperation modeChangeOperation ->
           builder.setModeChange(
               Topology.ModeChangeOperation.newBuilder()
@@ -959,6 +963,8 @@ public class ProtoBufSerializer
               () ->
                   new IllegalStateException(
                       "UpdatePartitionDistributorConfig operation has empty config"));
+    } else if (topologyChangeOperation.hasRemovePhysicalTenant()) {
+      return new RemovePhysicalTenantOperation(memberId);
     } else if (topologyChangeOperation.hasModeChange()) {
       final var modeChangeProto = topologyChangeOperation.getModeChange();
       return new ModeChangeOperation(memberId, fromProtoTopologyMode(modeChangeProto.getMode()));
@@ -1054,6 +1060,28 @@ public class ProtoBufSerializer
     final var builder = Requests.PurgeRequest.newBuilder().setDryRun(req.dryRun());
     req.physicalTenantId().ifPresent(builder::setPhysicalTenantId);
     return builder.build().toByteArray();
+  }
+
+  @Override
+  public byte[] encodeRemovePhysicalTenantRequest(final RemovePhysicalTenantRequest req) {
+    return Requests.RemovePhysicalTenantRequest.newBuilder()
+        .setDryRun(req.dryRun())
+        .setPhysicalTenantId(req.physicalTenantId())
+        .setForce(req.force())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
+  public RemovePhysicalTenantRequest decodeRemovePhysicalTenantRequest(
+      final byte[] encodedRequest) {
+    try {
+      final var request = Requests.RemovePhysicalTenantRequest.parseFrom(encodedRequest);
+      return new RemovePhysicalTenantRequest(
+          request.getPhysicalTenantId(), request.getDryRun(), request.getForce());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
   }
 
   @Override
@@ -2015,12 +2043,36 @@ public class ProtoBufSerializer
       final TenantAvailability availability) {
     return Topology.TenantAvailability.newBuilder()
         .setVersion(availability.version())
-        .setDisabled(availability.disabled())
+        .setState(toProtoTenantAvailabilityState(availability.state()))
         .build();
   }
 
+  private static Topology.TenantAvailabilityState toProtoTenantAvailabilityState(
+      final TenantAvailability.State state) {
+    return switch (state) {
+      case ENABLED -> Topology.TenantAvailabilityState.TENANT_ENABLED;
+      case DISABLED -> Topology.TenantAvailabilityState.TENANT_DISABLED;
+      case REMOVED -> Topology.TenantAvailabilityState.TENANT_REMOVED;
+    };
+  }
+
+  /**
+   * An unrecognized state decodes as {@code DISABLED} rather than {@code ENABLED}: if a future peer
+   * introduces a state this broker does not know, treating the tenant as out of service is the safe
+   * reading — a disabled tenant blocks a broker removal, it does not silently permit one.
+   */
+  private static TenantAvailability.State fromProtoTenantAvailabilityState(
+      final Topology.TenantAvailabilityState state) {
+    return switch (state) {
+      case TENANT_ENABLED -> TenantAvailability.State.ENABLED;
+      case TENANT_REMOVED -> TenantAvailability.State.REMOVED;
+      default -> TenantAvailability.State.DISABLED;
+    };
+  }
+
   private TenantAvailability decodeTenantAvailability(final Topology.TenantAvailability proto) {
-    return new TenantAvailability(proto.getVersion(), proto.getDisabled());
+    return new TenantAvailability(
+        proto.getVersion(), fromProtoTenantAvailabilityState(proto.getState()));
   }
 
   private Topology.BrokerState encodeBrokerState(final BrokerState brokerState) {
@@ -2344,6 +2396,8 @@ public class ProtoBufSerializer
                   .setPartitionId(op.partitionId())
                   .addAllBackupIds(op.backupIds())
                   .build());
+      case final RemovePhysicalTenantOperation ignored ->
+          builder.setRemovePhysicalTenant(Topology.RemovePhysicalTenantOperation.newBuilder());
     }
     return builder.build();
   }
@@ -2445,6 +2499,8 @@ public class ProtoBufSerializer
           memberId,
           proto.getPartitionRestore().getPartitionId(),
           new TreeSet<>(proto.getPartitionRestore().getBackupIdsList()));
+    } else if (proto.hasRemovePhysicalTenant()) {
+      return new RemovePhysicalTenantOperation(memberId);
     } else {
       throw new IllegalStateException("Unknown partition group change operation: " + proto);
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -336,7 +336,7 @@ public record PartitionGroupConfiguration(
   }
 
   public boolean isDisabled() {
-    return availability.disabled();
+    return availability.state() != TenantAvailability.State.ENABLED;
   }
 
   /**
@@ -351,10 +351,49 @@ public record PartitionGroupConfiguration(
 
   /**
    * Marks this tenant as enabled again. Does not change {@code version} or touch {@code members}.
-   * Returns {@code this} if already enabled.
+   * Returns {@code this} if already enabled, or if it has been removed — see {@link
+   * TenantAvailability#enable()}.
    */
   public PartitionGroupConfiguration enable() {
     return withAvailability(availability.enable());
+  }
+
+  /**
+   * Whether an operator has explicitly discarded this tenant. A removed tenant is also {@link
+   * #isDisabled() disabled}; the difference matters only for leaving the cluster, since a broker
+   * holding only removed tenants' partitions may leave it, unlike one holding merely disabled ones.
+   */
+  public boolean isRemoved() {
+    return availability.state() == TenantAvailability.State.REMOVED;
+  }
+
+  /**
+   * Marks this tenant as explicitly discarded, terminally — see {@link TenantAvailability}. Returns
+   * {@code this} if already removed.
+   *
+   * <p>Clears {@code members} and {@code routingState} rather than retaining them, since a removed
+   * tenant is never re-enabled and so has nothing left to resume. This still converges: the group
+   * version bumps once the operation's plan completes ({@link #advance()}), so the
+   * higher-versioned, cleared copy wins wholesale over a peer that has not seen the removal yet
+   * ({@link #merge(PartitionGroupConfiguration)}).
+   *
+   * <p>{@code incarnationNumber} stays put because removal purges no data — it stays on disk,
+   * unreachable through this configuration but not deleted by it. {@code pendingChanges} and {@code
+   * version} stay untouched too, so the {@link #advance()} call right after this one still sees,
+   * and completes, the operation it belongs to.
+   */
+  public PartitionGroupConfiguration remove() {
+    if (isRemoved()) {
+      return this;
+    }
+    return new PartitionGroupConfiguration(
+        version,
+        incarnationNumber,
+        Map.of(),
+        Optional.empty(),
+        pendingChanges,
+        lastChange,
+        availability.remove());
   }
 
   private PartitionGroupConfiguration withAvailability(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupOperation.java
@@ -43,6 +43,16 @@ public sealed interface PartitionGroupOperation extends ClusterConfigurationChan
   record UpdateIncarnationNumberOperation(MemberId memberId)
       implements io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation {}
 
+  /**
+   * Records that an operator has explicitly discarded this physical tenant, allowing a broker
+   * holding its partitions to leave the cluster.
+   *
+   * @param memberId the broker applying this operation — usually the coordinator, but a forced
+   *     request names whichever broker received it, since the coordinator may be unreachable
+   */
+  record RemovePhysicalTenantOperation(MemberId memberId)
+      implements io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation {}
+
   record ModeChangeOperation(MemberId memberId, Mode mode)
       implements io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/TenantAvailability.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/TenantAvailability.java
@@ -10,42 +10,60 @@ package io.camunda.zeebe.dynamic.config.state;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Whether a physical tenant (a {@link PartitionGroupConfiguration}) is currently disabled — i.e.
- * removed from every broker's local static configuration, but still retaining its partition
- * assignment and data so it can resume where it left off if the tenant is reconfigured.
+ * Whether a physical tenant (a {@link PartitionGroupConfiguration}) is currently running, and if
+ * not why. The three cases are mutually exclusive, so they are one {@link State} rather than
+ * independent flags.
  *
  * <p>{@code version} is this sub-record's own version, deliberately independent of the enclosing
- * {@link PartitionGroupConfiguration#version()}: toggling availability must not bump the group
- * version, since availability changes are orthogonal to partition-assignment/plan-boundary changes.
- * Merge is highest-own-version-wins ({@link #merge(TenantAvailability)}), the same pattern as
- * {@link BrokerPartitionState}, and must be applied independently of whichever branch of {@link
+ * {@link PartitionGroupConfiguration#version()}: changing availability must not bump the group
+ * version, since availability is orthogonal to partition-assignment/plan-boundary changes. Merge is
+ * highest-own-version-wins ({@link #merge(TenantAvailability)}), the same pattern as {@link
+ * BrokerPartitionState}, and must be applied independently of whichever branch of {@link
  * PartitionGroupConfiguration#merge(PartitionGroupConfiguration)} is taken — otherwise an unrelated
- * bump of the group's top-level version could silently overwrite a more recently toggled value.
+ * bump of the group's top-level version could silently overwrite a more recently changed value.
  *
- * @param version this sub-record's own version, bumped only by {@link #disable()}/{@link #enable()}
- * @param disabled whether the tenant is currently disabled
+ * <p>That independent version is also why a removal converges instead of vanishing: {@link
+ * CurrentClusterConfiguration#merge(CurrentClusterConfiguration)} unions the partition-group map by
+ * key, so a deleted group would just be resurrected by gossip from any broker that still holds a
+ * copy. Recording the removal here and bumping this version instead lets it win over every stale
+ * copy.
+ *
+ * @param version this sub-record's own version, bumped on every state change
+ * @param state whether the tenant is running, and if not why
  */
 @NullMarked
-public record TenantAvailability(long version, boolean disabled) {
+public record TenantAvailability(long version, State state) {
 
   public static final long INITIAL_VERSION = 0;
 
   public static TenantAvailability enabled() {
-    return new TenantAvailability(INITIAL_VERSION, false);
+    return new TenantAvailability(INITIAL_VERSION, State.ENABLED);
   }
 
   /**
-   * Returns a disabled instance with an incremented version, or {@code this} if already disabled.
+   * Returns a {@link State#DISABLED} instance with an incremented version, or {@code this} if the
+   * tenant is already out of service — whether disabled or removed.
    */
   public TenantAvailability disable() {
-    return disabled ? this : new TenantAvailability(version + 1, true);
+    return state == State.ENABLED ? new TenantAvailability(version + 1, State.DISABLED) : this;
   }
 
   /**
-   * Returns an enabled instance with an incremented version, or {@code this} if already enabled.
+   * Returns an {@link State#ENABLED} instance with an incremented version, or {@code this} if
+   * already enabled. Returns {@code this} for a removed tenant: {@link State#REMOVED} is terminal
+   * and is not undone by the tenant reappearing in static configuration.
    */
   public TenantAvailability enable() {
-    return disabled ? new TenantAvailability(version + 1, false) : this;
+    return state == State.DISABLED ? new TenantAvailability(version + 1, State.ENABLED) : this;
+  }
+
+  /**
+   * Returns a {@link State#REMOVED} instance with an incremented version, or {@code this} if
+   * already removed. The version bump is what makes the removal survive a merge with a peer that
+   * has not seen it yet.
+   */
+  public TenantAvailability remove() {
+    return state == State.REMOVED ? this : new TenantAvailability(version + 1, State.REMOVED);
   }
 
   /**
@@ -53,5 +71,34 @@ public record TenantAvailability(long version, boolean disabled) {
    */
   TenantAvailability merge(final TenantAvailability other) {
     return version >= other.version ? this : other;
+  }
+
+  /** Why a physical tenant is or is not running. */
+  public enum State {
+    /** Configured on the brokers and running normally. */
+    ENABLED,
+    /**
+     * Removed from every broker's local static configuration, but still retaining its partition
+     * assignment and data so it can resume where it left off if the tenant is reconfigured.
+     * Disabling is a safety barrier against losing a tenant's data by accident, not a statement
+     * that the data is expendable — which is why a disabled tenant still stops a broker holding its
+     * partitions from leaving the cluster.
+     */
+    DISABLED,
+    /**
+     * Explicitly discarded by an operator. Like {@link #DISABLED} the tenant runs nowhere, so
+     * {@link PartitionGroupConfiguration#isDisabled()} excludes it just the same; unlike {@link
+     * #DISABLED}, a broker holding only removed tenants' partitions may leave the cluster.
+     *
+     * <p><strong>Terminal</strong>, and that is load-bearing: data left on disk is only safe
+     * because this id can never be re-enabled ({@link TenantAvailability#enable()} is a no-op) or
+     * re-provisioned ({@code PhysicalTenantProvisioningInitializer} skips ids already present in
+     * {@code CurrentClusterConfiguration#partitionGroups()}).
+     *
+     * <p>This is also why {@code PhysicalTenantAvailabilityInitializer} — which re-derives
+     * availability from the coordinator's own static configuration — cannot undo a removal even if
+     * coordinatorship moves to a broker that still lists the tenant.
+     */
+    REMOVED
   }
 }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -32,6 +32,14 @@ message PurgeRequest {
   optional string physicalTenantId = 2;
 }
 
+// Discards a disabled physical tenant, so a broker still holding its partitions may leave the
+// cluster.
+message RemovePhysicalTenantRequest {
+  bool dryRun = 1;
+  string physicalTenantId = 2;
+  bool force = 3;
+}
+
 message LeavePartitionRequest {
   string memberId = 1;
   int32 partitionId = 2;

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -46,12 +46,13 @@ message PartitionGroupConfiguration {
   TenantAvailability availability = 7;
 }
 
-// Whether a physical tenant is currently disabled (removed from local static configuration, but
-// retaining its partition assignment and data). Carries its own version, independent of the
-// enclosing PartitionGroupConfiguration.version.
+// Whether a physical tenant is running, and if not why. Carries its own version, independent of the
+// enclosing PartitionGroupConfiguration.version — that independent version is what makes a removal
+// converge, since the group itself cannot be deleted: the partitionGroups map is merged by union of
+// its keys, so a peer that has not seen the removal would put a deleted group straight back.
 message TenantAvailability {
   int64 version = 1;
-  bool disabled = 2;
+  TenantAvailabilityState state = 2;
 }
 
 // Broker lifecycle state. Holds State and timestamps; no partition assignment.
@@ -159,6 +160,7 @@ message PartitionGroupChangeOperation {
     ExportingStateChangeOperation exporterStateChange = 18;
     PartitionPreRestoreOperation partitionPreRestore = 19;
     PartitionRestoreOperation partitionRestore = 20;
+    RemovePhysicalTenantOperation removePhysicalTenant = 21;
   }
 }
 
@@ -271,12 +273,19 @@ message TopologyChangeOperation {
     ExportingStateChangeOperation exporterStateChange = 26;
     PartitionPreRestoreOperation partitionPreRestore = 27;
     PartitionRestoreOperation partitionRestore = 28;
+    RemovePhysicalTenantOperation removePhysicalTenant = 29;
   }
 }
 
 message UpdatePartitionDistributorConfigOperation {
   PartitionDistributorConfig config = 1;
 }
+
+// Records that an operator explicitly discarded a disabled physical tenant, so that a broker still
+// holding its partitions may leave the cluster. No fields: the target group's id comes from the
+// PartitionGroupParallelPhase map key that carries this operation, same as every other
+// PartitionGroupChangeOperation.
+message RemovePhysicalTenantOperation {}
 
 message CompletedTopologyChangeOperation {
   TopologyChangeOperation operation = 1;
@@ -444,4 +453,13 @@ enum Mode {
   MODE_UNKNOWN = 0;
   MODE_PROCESSING = 1;
   MODE_RECOVERING = 2;
+}
+
+// TENANT_ENABLED is 0 so that a tenant with no availability recorded reads as running, which is what
+// the field's absence has always meant. TENANT_REMOVED is terminal: a removed tenant is never
+// re-enabled, and its partition group is retained as a tombstone rather than deleted.
+enum TenantAvailabilityState {
+  TENANT_ENABLED = 0;
+  TENANT_DISABLED = 1;
+  TENANT_REMOVED = 2;
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
@@ -235,7 +235,8 @@ abstract class ClusterConfigurationManagementApiTestBase {
             gateway.getCommunicationService(),
             ClusterConfigurationCoordinatorSupplier.from(
                 () -> manager.getMultiConfiguration().join()),
-            new ProtoBufSerializer());
+            new ProtoBufSerializer(),
+            gateway.getMembershipService().getLocalMember().id());
 
     final var validatorRegistry = new RequestValidatorRegistry();
     validatorRegistry.registerValidator(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantAvailabilityInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantAvailabilityInitializerTest.java
@@ -112,6 +112,25 @@ final class PhysicalTenantAvailabilityInitializerTest {
   }
 
   @Test
+  void shouldLeaveARemovedTenantRemovedWhenStaticConfigurationListsItAgain() {
+    // given — tenantA was explicitly removed, but its id is (still or again) listed in the local
+    // static configuration
+    final var existing = Set.of(partition("tenantA", 1, Set.of(member(0))));
+    final var removedConfiguration =
+        configurationWith(existing)
+            .updatePartitionGroupConfig("tenantA", PartitionGroupConfiguration::remove);
+    final var staticConfiguration = staticConfigWith(List.of(tenantPartitionIds("tenantA", 1)));
+    final var initializer = new PhysicalTenantAvailabilityInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(removedConfiguration).join();
+
+    // then — removal is terminal: the tenant stays removed, it is not re-enabled
+    assertThat(result.partitionGroup("tenantA").isRemoved()).isTrue();
+    assertThat(result.partitionGroup("tenantA").isDisabled()).isTrue();
+  }
+
+  @Test
   void shouldLeaveANotYetProvisionedTenantAlone() {
     // given — the local static configuration lists tenantB, but it has no group yet (provisioning's
     // job, not this initializer's)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantDisabledRemovalTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantDisabledRemovalTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterPatchRequestTransformer;
 import io.camunda.zeebe.dynamic.config.api.ForceRemoveBrokersRequestTransformer;
+import io.camunda.zeebe.dynamic.config.api.RemovePhysicalTenantRequestTransformer;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeResult;
@@ -49,25 +50,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Records the dead end described in <a
- * href="https://github.com/camunda/camunda/issues/60344">#60344 </a>: a broker holding a
- * <em>disabled</em> physical tenant's partitions cannot be removed from the cluster by any route.
+ * Verifies that a broker holding a <em>disabled</em> physical tenant's partitions cannot leave the
+ * cluster, by any route, until that tenant has been explicitly removed: the coordinator excludes a
+ * disabled tenant's partitions from every plan, yet {@code MemberLeaveApplier} still refuses a
+ * member leave while any group — including a disabled one — still assigns it partitions.
  *
- * <p>The two mechanisms that produce it are individually correct. The coordinator hands {@code
- * ConfigurationChangeRequest#phases} a configuration with disabled partition groups removed (see
- * {@code CurrentClusterConfiguration#withoutDisabledPartitionGroups}), so no plan can ever move a
- * disabled tenant's partitions — it must not, since no broker runs that tenant and any operation
- * targeting it would stall forever. Their assignment nevertheless remains in the configuration, and
- * {@code MemberLeaveApplier} checks every partition group, so it refuses the member leave that ends
- * both the graceful and the forced removal.
+ * <p>Exercised through the coordinator ({@link #simulate}/{@link #apply}) rather than by inspecting
+ * a transformer's output directly, since the refusal only appears once the plan runs through the
+ * validating appliers.
  *
- * <p>Driven through the coordinator rather than the transformers: the plan itself is fine, and the
- * refusal comes from the appliers the coordinator runs the plan through during validation.
- * Asserting on a transformer's output would show nothing at all.
- *
- * <p>The control case is the same removal with the tenant enabled. It is what makes these tests
- * about the disabled flag rather than about multi-tenancy: with the tenant running, the graceful
- * removal moves its partition off the departing broker and completes.
+ * <p>The control case runs the same removal with the tenant enabled, to isolate the disabled flag
+ * as the cause rather than multi-tenancy in general.
  */
 final class PhysicalTenantDisabledRemovalTest {
 
@@ -154,6 +147,135 @@ final class PhysicalTenantDisabledRemovalTest {
         .containsOnlyKeys(BARE_0, BARE_1);
   }
 
+  /**
+   * Once the operator has discarded the disabled tenant, the broker holding its partitions can
+   * leave.
+   */
+  @Test
+  void shouldGracefullyRemoveABrokerAfterTheDisabledTenantIsRemoved() {
+    // given — a disabled tenant whose partitions sit on broker 2, explicitly discarded
+    wire(BARE_0, disable(TENANT_A, twoTenants()));
+    apply(new RemovePhysicalTenantRequestTransformer(TENANT_A, BARE_0, false));
+
+    // when — broker 2 is asked to leave gracefully, exactly as it was refused before
+    final var configuration =
+        simulate(
+                new ClusterPatchRequestTransformer(
+                    Set.of(), Set.of(BARE_2), Optional.empty(), Optional.empty()))
+            .join()
+            .finalMultiConfiguration();
+
+    // then — the broker is gone, and the discarded tenant's old assignment is cleared rather than
+    // carried forward: only the tombstone itself remains
+    assertThat(configuration.globalConfiguration().members())
+        .describedAs("brokers left in the cluster")
+        .containsOnlyKeys(BARE_0, BARE_1);
+    assertThat(configuration.partitionGroup(TENANT_A).isRemoved())
+        .describedAs("tenant '%s' is tombstoned as discarded", TENANT_A)
+        .isTrue();
+    assertThat(replicasOf(configuration, TENANT_A))
+        .describedAs("assignment of the discarded tenant '%s'", TENANT_A)
+        .isEmpty();
+  }
+
+  /**
+   * The disaster scenario a forced request exists for: the coordinator is unreachable, so the
+   * removal is executed by whichever broker actually received the request instead. Here that is
+   * broker 2, not the coordinator, and the removal still completes on it.
+   */
+  @Test
+  void shouldRemoveADisabledTenantOnWhicheverBrokerReceivedTheRequest() {
+    // given — broker 2, not the coordinator (broker 0), receives the request
+    wire(BARE_2, disable(TENANT_A, twoTenants()));
+
+    // when — the request is forced, naming broker 2 itself as the executing member
+    apply(new RemovePhysicalTenantRequestTransformer(TENANT_A, BARE_2, true));
+
+    // then — the removal completes locally on broker 2 despite it not being the coordinator
+    assertThat(configuration().partitionGroup(TENANT_A).isRemoved())
+        .describedAs("tenant '%s' is tombstoned as discarded", TENANT_A)
+        .isTrue();
+  }
+
+  /**
+   * The normal case, mirroring the disaster scenario above: without {@code force}, a removal
+   * received by a broker that does not hold the election is rejected exactly like any other
+   * configuration change, rather than silently executing wherever it happened to land.
+   */
+  @Test
+  void shouldRejectANonForcedRemovalReceivedByABrokerThatIsNotTheCoordinator() {
+    // given — broker 2, not the coordinator (broker 0), receives the request
+    wire(BARE_2, disable(TENANT_A, twoTenants()));
+
+    // when — the request is not forced, so broker 2 must be the coordinator to execute it
+    final var result =
+        simulate(new RemovePhysicalTenantRequestTransformer(TENANT_A, BARE_2, false));
+
+    // then — the request is rejected because broker 2 does not hold the election
+    assertThat(result)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("is not the coordinator");
+  }
+
+  /**
+   * A removal only makes sense for a tenant that is out of configuration; an enabled one is a typo.
+   */
+  @Test
+  void shouldRejectRemovingAnEnabledPhysicalTenant() {
+    // given — the tenant is still running
+    wire(BARE_0, twoTenants());
+
+    // when / then — the request is refused, and says how to make it valid
+    assertThat(simulate(new RemovePhysicalTenantRequestTransformer(TENANT_A, BARE_0, false)))
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("still enabled");
+  }
+
+  @Test
+  void shouldRejectRemovingAnUnknownPhysicalTenant() {
+    // given
+    wire(BARE_0, twoTenants());
+
+    // when / then
+    assertThat(simulate(new RemovePhysicalTenantRequestTransformer("nosuchtenant", BARE_0, false)))
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("no such tenant");
+  }
+
+  /**
+   * A removal must survive a merge with a peer that has not seen it yet; see {@link
+   * io.camunda.zeebe.dynamic.config.state.TenantAvailability}.
+   */
+  @Test
+  void shouldKeepTheRemovalWhenMergingWithAPeerThatHasNotSeenIt() {
+    // given — a configuration in which the tenant has been discarded, and the stale peer it came
+    // from
+    wire(BARE_0, disable(TENANT_A, twoTenants()));
+    final var stale = configuration();
+    apply(new RemovePhysicalTenantRequestTransformer(TENANT_A, BARE_0, false));
+    final var removed = configuration();
+
+    // when — the two are merged in both directions
+    // then — the removal survives either way, and the tenant's group is still there to be merged
+    assertThat(removed.merge(stale).partitionGroup(TENANT_A).isRemoved())
+        .describedAs("removal merged against a stale peer")
+        .isTrue();
+    assertThat(stale.merge(removed).partitionGroup(TENANT_A).isRemoved())
+        .describedAs("stale peer merged against the removal")
+        .isTrue();
+  }
+
+  /** Applies a request for real, so its effect is in the configuration the next request reads. */
+  private void apply(final ConfigurationChangeRequest request) {
+    coordinator.applyOperations(request).join();
+  }
+
+  private CurrentClusterConfiguration configuration() {
+    return coordinator.getClusterConfiguration().join();
+  }
 
   /**
    * A dry run rather than a real apply: applying would drive each operation on the broker named by

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantDisabledRemovalTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantDisabledRemovalTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.BARE_0;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.BARE_1;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.BARE_2;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterPatchRequestTransformer;
+import io.camunda.zeebe.dynamic.config.api.ForceRemoveBrokersRequestTransformer;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeResult;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Records the dead end described in <a
+ * href="https://github.com/camunda/camunda/issues/60344">#60344 </a>: a broker holding a
+ * <em>disabled</em> physical tenant's partitions cannot be removed from the cluster by any route.
+ *
+ * <p>The two mechanisms that produce it are individually correct. The coordinator hands {@code
+ * ConfigurationChangeRequest#phases} a configuration with disabled partition groups removed (see
+ * {@code CurrentClusterConfiguration#withoutDisabledPartitionGroups}), so no plan can ever move a
+ * disabled tenant's partitions — it must not, since no broker runs that tenant and any operation
+ * targeting it would stall forever. Their assignment nevertheless remains in the configuration, and
+ * {@code MemberLeaveApplier} checks every partition group, so it refuses the member leave that ends
+ * both the graceful and the forced removal.
+ *
+ * <p>Driven through the coordinator rather than the transformers: the plan itself is fine, and the
+ * refusal comes from the appliers the coordinator runs the plan through during validation.
+ * Asserting on a transformer's output would show nothing at all.
+ *
+ * <p>The control case is the same removal with the tenant enabled. It is what makes these tests
+ * about the disabled flag rather than about multi-tenancy: with the tenant running, the graceful
+ * removal moves its partition off the departing broker and completes.
+ */
+final class PhysicalTenantDisabledRemovalTest {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int PARTITION_ID = 1;
+
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @TempDir private Path tmp;
+
+  private ClusterConfigurationManagerImpl manager;
+  private ConfigurationChangeCoordinatorImpl coordinator;
+
+  /**
+   * The graceful route, {@code PATCH /actuator/cluster} with {@code brokers.remove}. Broker 2 holds
+   * nothing of the default tenant, so the only thing standing between it and the door is the
+   * disabled tenant's assignment.
+   */
+  @Test
+  void shouldRejectGracefulBrokerRemovalWhenADisabledTenantIsAssignedToIt() {
+    // given — three brokers, and only the disabled tenant is replicated on broker 2
+    wire(BARE_0, disable(TENANT_A, twoTenants()));
+
+    // when — broker 2 is asked to leave gracefully
+    final var result =
+        simulate(
+            new ClusterPatchRequestTransformer(
+                Set.of(), Set.of(BARE_2), Optional.empty(), Optional.empty()));
+
+    // then — the member leave refuses the whole plan, naming the tenant that is in the way but not
+    // that it is disabled, nor what the operator is expected to do about it
+    assertThat(result)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("still has partitions assigned")
+        .withMessageContaining(TENANT_A);
+  }
+
+  /**
+   * The forced route, {@code POST /actuator/cluster/brokers?force=true}. This is the case that has
+   * no graceful alternative: an operator reaches for it once the broker is already gone, so
+   * re-enabling the tenant to move its partitions off is not on the table.
+   */
+  @Test
+  void shouldRejectForcedBrokerRemovalWhenADisabledTenantIsAssignedToIt() {
+    // given — the same cluster, with the same tenant disabled
+    wire(BARE_0, disable(TENANT_A, twoTenants()));
+
+    // when — broker 2 is force-removed, as it would be after failing
+    final var result = simulate(new ForceRemoveBrokersRequestTransformer(Set.of(BARE_2), BARE_0));
+
+    // then — the recovery path is refused for the same reason as the graceful one
+    assertThat(result)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("still has partitions assigned")
+        .withMessageContaining(TENANT_A);
+  }
+
+  /**
+   * The control: with the tenant enabled the very same request succeeds, because the plan is free
+   * to move the tenant's partition off the departing broker first.
+   */
+  @Test
+  void shouldGracefullyRemoveABrokerWhenTheTenantIsEnabled() {
+    // given — the same cluster, with no tenant disabled
+    wire(BARE_0, twoTenants());
+
+    // when — broker 2 is asked to leave gracefully
+    final var configuration =
+        simulate(
+                new ClusterPatchRequestTransformer(
+                    Set.of(), Set.of(BARE_2), Optional.empty(), Optional.empty()))
+            .join()
+            .finalMultiConfiguration();
+
+    // then — the tenant's partition has moved to the retained brokers and broker 2 has left
+    assertThat(replicasOf(configuration, TENANT_A))
+        .describedAs("replicas of tenant '%s' partition", TENANT_A)
+        .containsExactlyInAnyOrder(BARE_0, BARE_1);
+    assertThat(configuration.globalConfiguration().members())
+        .describedAs("brokers left in the cluster")
+        .containsOnlyKeys(BARE_0, BARE_1);
+  }
+
+
+  /**
+   * A dry run rather than a real apply: applying would drive each operation on the broker named by
+   * it, and a forced removal's brokers are by definition not running. The dry run still puts the
+   * whole plan through the real appliers — the member leave among them — so it fails here exactly
+   * as it does on a live cluster.
+   */
+  private ActorFuture<ConfigurationChangeResult> simulate(
+      final ConfigurationChangeRequest request) {
+    return coordinator.simulateOperations(request);
+  }
+
+  /** The brokers replicating the given physical tenant's only partition. */
+  private Set<MemberId> replicasOf(
+      final CurrentClusterConfiguration configuration, final String physicalTenantId) {
+    return configuration.partitionGroup(physicalTenantId).members().entrySet().stream()
+        .filter(member -> member.getValue().partitions().containsKey(PARTITION_ID))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+  }
+
+  private CurrentClusterConfiguration disable(
+      final String physicalTenantId, final CurrentClusterConfiguration configuration) {
+    return configuration.updatePartitionGroupConfig(
+        physicalTenantId, PartitionGroupConfiguration::disable);
+  }
+
+  /**
+   * Three brokers running two tenants, placed so that broker 2 holds only tenant A's partition:
+   * removing it is a no-op for the default tenant, which leaves the disabled tenant as the sole
+   * reason the removal can fail.
+   */
+  private CurrentClusterConfiguration twoTenants() {
+    final var base = CurrentClusterConfiguration.fromLegacy(cluster(Set.of(BARE_0, BARE_1)));
+    return new CurrentClusterConfiguration(
+        base.version(),
+        base.globalConfiguration(),
+        Map.of(
+            DEFAULT_GROUP,
+            base.partitionGroup(DEFAULT_GROUP),
+            TENANT_A,
+            CurrentClusterConfiguration.fromLegacy(cluster(Set.of(BARE_1, BARE_2)))
+                .partitionGroup(DEFAULT_GROUP)),
+        base.phasedChangeState());
+  }
+
+  /**
+   * A three-broker cluster in which {@code replicas} replicate partition 1. The member set is
+   * cluster-wide, so it is the same for both tenants however their partitions are placed.
+   */
+  private ClusterConfiguration cluster(final Set<MemberId> replicas) {
+    var topology = ClusterConfiguration.init();
+    for (final var member : Set.of(BARE_0, BARE_1, BARE_2)) {
+      topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
+    }
+    var priority = replicas.size();
+    for (final var replica : replicas) {
+      final var state = PartitionState.active(priority--, partitionConfig);
+      topology = topology.updateMember(replica, member -> member.addPartition(PARTITION_ID, state));
+    }
+    return topology;
+  }
+
+  /**
+   * Registers change appliers only for the tenants that are enabled, which is what a broker does: a
+   * tenant absent from local static configuration — the reason it is disabled in the first place —
+   * has its appliers deregistered, and that is why no operation targeting it can ever complete.
+   */
+  private void wire(final MemberId localMemberId, final CurrentClusterConfiguration seed) {
+    manager =
+        new ClusterConfigurationManagerImpl(
+            executor,
+            localMemberId,
+            PersistedCurrentClusterConfiguration.ofFile(
+                tmp.resolve("config.meta"), new ProtoBufSerializer()),
+            new TopologyManagerMetrics(new SimpleMeterRegistry()),
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+    manager.setCurrentConfigurationGossiper(ignored -> {});
+    manager.registerGlobalChangeAppliers(
+        new GlobalConfigurationChangeAppliersImpl(
+            new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
+    seed.activePartitionGroups()
+        .keySet()
+        .forEach(
+            groupId ->
+                manager.registerPartitionGroupChangeAppliers(
+                    groupId,
+                    new PartitionGroupConfigurationChangeAppliersImpl(
+                        new NoopPartitionChangeExecutor(),
+                        new NoopPartitionScalingChangeExecutor(),
+                        new NoopModeChangeExecutor(),
+                        new NoopRestoreChangeExecutor())));
+    coordinator = new ConfigurationChangeCoordinatorImpl(manager, localMemberId, executor);
+    manager.updateMultiConfiguration(ignored -> seed).join();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/RemovePhysicalTenantApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/RemovePhysicalTenantApplierTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class RemovePhysicalTenantApplierTest {
+
+  private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
+  private final RemovePhysicalTenantApplier applier = new RemovePhysicalTenantApplier();
+
+  private static PartitionGroupConfiguration group() {
+    return new PartitionGroupConfiguration(
+        1, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithAMember() {
+    return new PartitionGroupConfiguration(
+        1,
+        0,
+        Map.of(
+            MemberId.from("1"),
+            new BrokerPartitionState(
+                1,
+                Instant.EPOCH,
+                Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())),
+                Mode.PROCESSING)),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  @Test
+  void shouldRecordTheRemovalOfADisabledTenantAndClearItsAssignment() {
+    // given — a disabled tenant whose partition is still assigned to a member
+    final var group = groupWithAMember().disable();
+
+    // when
+    assertThat(applier.init(globalConfiguration, group)).isRight();
+    final var updated = applier.apply().join().apply(group);
+
+    // then
+    Assertions.assertThat(updated.isRemoved()).isTrue();
+    Assertions.assertThat(updated.isDisabled())
+        .describedAs("a removed tenant stays disabled, so every existing reader still excludes it")
+        .isTrue();
+    Assertions.assertThat(updated.members())
+        .describedAs("removal clears the old assignment rather than retaining it")
+        .isEmpty();
+  }
+
+  /**
+   * A running tenant is still in the coordinator's static configuration, so {@code
+   * PhysicalTenantProvisioningInitializer} would provision it again on the next configuration
+   * initialization — as a fresh, empty group, while the data of the one discarded here stayed
+   * orphaned on disk.
+   */
+  @Test
+  void shouldRejectRemovingAnEnabledTenant() {
+    // given — the tenant is still running
+    final var group = group();
+
+    // when / then
+    assertThat(applier.init(globalConfiguration, group))
+        .isLeft()
+        .left()
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  /**
+   * A restarted change may re-apply an operation it already completed, so a second removal is a
+   * no-op rather than a failure — the tombstone is permanent, so it cannot mean anything new.
+   */
+  @Test
+  void shouldTolerateRemovingAnAlreadyRemovedTenant() {
+    // given — the tenant has been discarded once already
+    final var group = group().disable().remove();
+
+    // when / then
+    assertThat(applier.init(globalConfiguration, group)).isRight();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.dynamic.config.protocol.Topology.ExporterStateEnum;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
@@ -48,11 +49,13 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOp
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
@@ -690,6 +693,73 @@ final class ProtoBufSerializerTest {
     final var encoded = protoBufSerializer.encodeCurrentClusterConfiguration(configuration);
 
     // then
+    final var decoded = protoBufSerializer.decodeCurrentClusterConfiguration(encoded);
+    assertThat(decoded).isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeARemovedPhysicalTenant() {
+    // given — a tombstoned tenant, built from a group that had a member before removal cleared it
+    final var group =
+        new PartitionGroupConfiguration(
+                1,
+                0,
+                Map.of(
+                    MemberId.from("1"),
+                    new BrokerPartitionState(
+                        1,
+                        Instant.EPOCH,
+                        Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())),
+                        Mode.PROCESSING)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty())
+            .disable()
+            .remove();
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", group),
+            new PhasedChangeState(1L, Map.of(), List.of()));
+
+    // when
+    final var encoded = protoBufSerializer.encodeCurrentClusterConfiguration(configuration);
+
+    // then — the tombstone, and the cleared assignment behind it, survive a round trip; a restarted
+    // broker reading a stale, non-empty assignment back would re-arm the block the removal lifted
+    final var decoded = protoBufSerializer.decodeCurrentClusterConfiguration(encoded);
+    assertThat(decoded).isEqualTo(configuration);
+    assertThat(decoded.partitionGroup("tenant-a").isRemoved()).isTrue();
+    assertThat(decoded.partitionGroup("tenant-a").members())
+        .describedAs("removal clears the old assignment rather than retaining it")
+        .isEmpty();
+  }
+
+  @Test
+  void shouldEncodeAndDecodePartitionGroupChangeOperationForRemovePhysicalTenant() {
+    // given
+    final var groupId = "tenant-a";
+    final var plan =
+        new PhasedChangePlan(
+            1,
+            0,
+            List.of(
+                new PartitionGroupParallelPhase(
+                    Map.of(
+                        groupId, List.of(new RemovePhysicalTenantOperation(MemberId.from("1")))))),
+            Instant.now());
+    final var configuration =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of(),
+            new PhasedChangeState(2L, Map.of(plan.id(), plan), List.of()));
+
+    // when
+    final var encoded = protoBufSerializer.encodeCurrentClusterConfiguration(configuration);
+
+    // then — a coordinator restart mid-plan has to be able to read the operation back
     final var decoded = protoBufSerializer.decodeCurrentClusterConfiguration(encoded);
     assertThat(decoded).isEqualTo(configuration);
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -241,6 +241,34 @@ class PartitionGroupConfigurationTest {
       assertThat(reEnabled.version()).isEqualTo(config.version());
       assertThat(reEnabled.members()).isEqualTo(config.members());
     }
+
+    /**
+     * Unlike {@code disable()}/{@code enable()}, removal clears the old assignment rather than
+     * preserving it; see {@link PartitionGroupConfiguration#remove()}.
+     */
+    @Test
+    void shouldRemoveClearingMembersWithoutChangingGroupVersion() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(1, 1))).disable();
+
+      // when
+      final var removed = config.remove();
+
+      // then
+      assertThat(removed.isRemoved()).isTrue();
+      assertThat(removed.isDisabled()).describedAs("a removed tenant stays disabled").isTrue();
+      assertThat(removed.version()).isEqualTo(config.version());
+      assertThat(removed.members()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenAlreadyRemoved() {
+      // given
+      final var removed = group(1, Map.of(MEMBER_0, broker(1, 1))).disable().remove();
+
+      // when / then
+      assertThat(removed.remove()).isSameAs(removed);
+    }
   }
 
   @Nested

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/TenantAvailabilityTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/TenantAvailabilityTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.dynamic.config.state.TenantAvailability.State;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,7 @@ class TenantAvailabilityTest {
 
     @Test
     void shouldBeEnabledInitially() {
-      assertThat(TenantAvailability.enabled().disabled()).isFalse();
+      assertThat(TenantAvailability.enabled().state()).isEqualTo(State.ENABLED);
     }
 
     @Test
@@ -31,7 +32,7 @@ class TenantAvailabilityTest {
       final var disabled = enabled.disable();
 
       // then
-      assertThat(disabled.disabled()).isTrue();
+      assertThat(disabled.state()).isEqualTo(State.DISABLED);
       assertThat(disabled.version()).isEqualTo(enabled.version() + 1);
     }
 
@@ -44,7 +45,7 @@ class TenantAvailabilityTest {
       final var enabled = disabled.enable();
 
       // then
-      assertThat(enabled.disabled()).isFalse();
+      assertThat(enabled.state()).isEqualTo(State.ENABLED);
       assertThat(enabled.version()).isEqualTo(disabled.version() + 1);
     }
 
@@ -70,6 +71,68 @@ class TenantAvailabilityTest {
 
       // then
       assertThat(stillEnabled).isEqualTo(enabled);
+    }
+  }
+
+  @Nested
+  class Removal {
+
+    @Test
+    void shouldRemoveADisabledTenantAndBumpTheVersion() {
+      // given
+      final var disabled = TenantAvailability.enabled().disable();
+
+      // when
+      final var removed = disabled.remove();
+
+      // then
+      assertThat(removed.state()).isEqualTo(State.REMOVED);
+      assertThat(removed.version())
+          .describedAs("bumped, so the removal wins over a peer that has not seen it")
+          .isEqualTo(disabled.version() + 1);
+    }
+
+    /** {@link State#REMOVED} is terminal; see its javadoc for why that matters. */
+    @Test
+    void shouldNotBeReEnabled() {
+      // given
+      final var removed = TenantAvailability.enabled().disable().remove();
+
+      // when / then
+      assertThat(removed.enable()).isSameAs(removed);
+      assertThat(removed.enable().state()).isEqualTo(State.REMOVED);
+    }
+
+    @Test
+    void shouldStayRemovedWhenDisabledAgain() {
+      // given
+      final var removed = TenantAvailability.enabled().disable().remove();
+
+      // when / then — the availability initializer re-derives this on every initialization
+      assertThat(removed.disable()).isSameAs(removed);
+    }
+
+    @Test
+    void shouldBeUnchangedWhenAlreadyRemoved() {
+      // given
+      final var removed = TenantAvailability.enabled().disable().remove();
+
+      // when / then
+      assertThat(removed.remove()).isSameAs(removed);
+    }
+
+    /**
+     * A removal must survive a merge with a peer that has not seen it yet; see the class javadoc.
+     */
+    @Test
+    void shouldWinOverAStaleCopyOfTheSameTenant() {
+      // given
+      final var stale = TenantAvailability.enabled().disable();
+      final var removed = stale.remove();
+
+      // when / then
+      assertThat(removed.merge(stale).state()).isEqualTo(State.REMOVED);
+      assertThat(stale.merge(removed).state()).isEqualTo(State.REMOVED);
     }
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -265,8 +265,8 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   @Provide
   Arbitrary<TenantAvailability> tenantAvailabilities() {
     final var version = Arbitraries.longs().greaterOrEqual(0);
-    final var disabled = Arbitraries.of(true, false);
-    return Combinators.combine(version, disabled).as(TenantAvailability::new);
+    final var state = Arbitraries.of(TenantAvailability.State.values());
+    return Combinators.combine(version, state).as(TenantAvailability::new);
   }
 
   @Provide


### PR DESCRIPTION
## Problem

A broker holding a disabled physical tenant's partitions couldn't leave the cluster, gracefully or forced. Disabling is a safety barrier (retain assignment + data), so `MemberLeaveApplier` blocks the leave; no plan can move the partitions either, since nothing runs a disabled tenant. Reproduced in `PhysicalTenantDisabledRemovalTest`.

## Design

`DELETE /actuator/cluster/physical-tenants/{id}` tombstones a disabled tenant as `TenantAvailability.State.REMOVED`; only then does `MemberLeaveApplier` let a broker holding its partitions go. Disabled-but-not-removed still blocks on both paths — discarding is always an explicit, separate act, never inferred from a broker-removal request.

- **Tri-state, not two booleans.** `ENABLED/DISABLED/REMOVED` on `TenantAvailability`. `REMOVED` implies disabled, so every existing `isDisabled()` reader keeps excluding it for free; removed-but-not-disabled is now unrepresentable instead of runtime-rejected.
- **Tombstone, not deletion.** Deleting the group doesn't converge — `CurrentClusterConfiguration#merge` unions the group map by key, so a stale peer resurrects it. The tombstone's own version merges independently and wins over every stale copy. `remove()` also clears `members`/`routingState`, converging through the group-version bump on plan completion (`advance()`), so a removed tenant's config footprint is constant-size rather than its old replica set.
- **`REMOVED` is terminal.** `enable()` is a no-op, which stops `PhysicalTenantAvailabilityInitializer` undoing a removal on a coordinatorship handoff; the tombstone keeps the group in `partitionGroups()`, so `PhysicalTenantProvisioningInitializer` won't re-create it. Re-adding a removed id to static configuration consequently does nothing — the availability initializer now WARNs instead of staying silent, telling the operator to delete the entry.
- **`RemovePhysicalTenantOperation` is an ordinary `PartitionGroupOperation`** — no interface changes; the applier returns `PartitionGroupConfiguration::remove`. The real gap: a disabled tenant runs nowhere, so no broker has appliers or a `ScopeReconciler` for its group — both were side effects of `PartitionManagerImpl` hosting it. `ClusterConfigurationManagerImpl` now owns each in one place: `nextOperation` resolves a removal to its applier directly, registered or not (a pure config edit needs no broker-side executor; every other operation keeps stall-if-unregistered, which stays visible and recoverable), and every non-removed group keeps a `ScopeReconciler` on every broker, created solely in `reconcile()` — registration no longer creates reconcilers as a side effect.
- **Coordinator by default, `?force=true` as the bail-out.** A normal removal runs on the elected coordinator like any other configuration change, subject to the standard not-coordinator rejection. With `force`, the request is routed to — and executed by — whichever broker received the actuator call instead of the default coordinator, and the tombstone reaches the rest of the cluster via gossip. That's the escape hatch for the disaster scenario: a disabled tenant pins a dead region's brokers and the elected coordinator is itself among the dead, so the operator sends `DELETE ...?force=true` to any surviving broker, then force-removes the dead brokers. The every-broker `ScopeReconciler` guarantee above is what makes the operation executable on a non-coordinator. (`dryRun` supported as on the other cluster endpoints.)

## Not done here

- No data deletion — the data stays on disk until reclaimed out of band.
- No check that every broker has actually stopped running the tenant (disabling only takes effect on that broker's own restart).

## Testing

`PhysicalTenantDisabledRemovalTest` drives everything through the real coordinator: graceful/forced rejection before removal, success after, forced removal executed by a non-coordinator broker (the disaster case), and rejection of a non-forced removal on a non-coordinator. Unit coverage on `TenantAvailability`, `PartitionGroupConfiguration#remove`, `RemovePhysicalTenantApplier`, the initializer's terminal-state handling, and serializer round-trips. Full module suite green (1007 tests) except the pre-existing `ZoneAwareClusterConfigurationManagementApiTest` port-bind flake (unrelated, 41/41 in isolation).

BREAKING CHANGE: reshapes protobuf messages that are new in (unreleased) 8.10 — `TenantAvailability` becomes a state enum instead of two booleans, `RemovePhysicalTenantOperation` moves from global to partition-group operations, and `RemovePhysicalTenantRequest` gains `force`. No released version carries these messages.

Closes #60344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
