### PR TITLE
feat: provision new physical tenants without moving existing ones on zone-aware clusters

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.util.AdditivePartitionReassigner;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.PartitionReassignmentOperationsGenerator;
+import io.camunda.zeebe.dynamic.config.util.ZoneAwareAdditivePartitionReassigner;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.HashMap;
@@ -35,7 +36,8 @@ import org.slf4j.LoggerFactory;
  * lists a physical tenant (a {@link PartitionId#group()}) that has no corresponding entry in {@link
  * CurrentClusterConfiguration#partitionGroups()}, this adds an empty {@link
  * PartitionGroupConfiguration} for it and starts a configuration change directly on that group —
- * using {@link AdditivePartitionReassigner} to place its partitions and {@link
+ * using {@link AdditivePartitionReassigner} (or, on a zone-aware cluster, {@link
+ * ZoneAwareAdditivePartitionReassigner}) to place its partitions and {@link
  * PartitionReassignmentOperationsGenerator} to turn that placement into operations.
  *
  * <p>The change is started directly on the new group via {@link
@@ -57,8 +59,9 @@ import org.slf4j.LoggerFactory;
  * brand-new tenants onto the same least-loaded brokers instead of spreading them out.
  *
  * <p>If placing this batch fails outright (e.g. the live cluster currently has fewer members than
- * the configured replication factor), the whole batch is skipped with a warning and retried on the
- * next configuration initialization; if the reassignment itself succeeds but a particular tenant's
+ * the configured replication factor, or — on a zone-aware cluster — a target member has not yet
+ * completed its zone migration), the whole batch is skipped with a warning and retried on the next
+ * configuration initialization; if the reassignment itself succeeds but a particular tenant's
  * target distribution ends up unchanged (e.g. it has no partitions configured at all), that one
  * tenant alone is skipped while the rest are still provisioned.
  */
@@ -154,26 +157,19 @@ public class PhysicalTenantProvisioningInitializer
       final Set<MemberId> targetMembers,
       final List<PartitionId> targetPartitionIds) {
 
-    final boolean isZoneAwareConfig =
+    final var zoneAwareConfig =
         configuration
             .globalConfiguration()
             .partitionDistributorConfig()
             .filter(ZoneAwareConfig.class::isInstance)
-            .isPresent();
+            .map(ZoneAwareConfig.class::cast);
 
-    if (isZoneAwareConfig) {
-      // AdditiveReassigner does not support zone-aware distribution, so we delegate to the
-      // configured distributor instead. ZoneAwareDistribution uses round robin assignment that
-      // means the existing tenants are also moved. Additive zone aware reassignment will be a
-      // followup.
-      final var sortedPartitionIds =
-          targetPartitionIds.stream().sorted(PartitionId::compareTo).toList();
-      return configuration
-          .globalConfiguration()
-          .partitionDistributorConfig()
-          .get()
-          .toDistributor()
-          .distributePartitions(targetMembers, sortedPartitionIds, replicationFactor);
+    if (zoneAwareConfig.isPresent()) {
+      // Built fresh per call, unlike the cached `reassigner` field above: the zone spec comes from
+      // gossiped state that can change (zone add/remove, reprioritization) between calls, so
+      // caching an instance risks reassigning against a stale zone configuration.
+      return new ZoneAwareAdditivePartitionReassigner(zoneAwareConfig.get().zones())
+          .reassignPartitions(configuration, targetMembers, targetPartitionIds, replicationFactor);
     }
 
     return reassigner.reassignPartitions(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassigner.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.dynamic.config.util;
 import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.accumulateLoad;
 import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.rebalanceLeaders;
 import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.selectNewPartitionMembers;
-import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateNoRemoval;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateExistingPartitionsAreNotRemoved;
 import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateTargetMembers;
 
 import io.atomix.cluster.MemberId;
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
  *
  * <p>Removing a partition or an entire group is not supported: {@code targetPartitionIds} must
  * include every existing partition id of every existing group, not just the ones being changed —
- * see {@link PartitionReassignmentSupport#validateNoRemoval}.
+ * see {@link PartitionReassignmentSupport#validateExistingPartitionsAreNotRemoved}.
  */
 public final class AdditivePartitionReassigner implements PartitionReassigner {
 
@@ -74,7 +74,7 @@ public final class AdditivePartitionReassigner implements PartitionReassigner {
 
     final Map<String, Set<PartitionMetadata>> distributionByGroup =
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(currentConfiguration);
-    validateNoRemoval(distributionByGroup, targetPartitionIds, replicationFactor);
+    validateExistingPartitionsAreNotRemoved(distributionByGroup, targetPartitionIds);
 
     // generate assignment for new partitions
     final Map<PartitionId, PartitionMetadata> currentById =

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassigner.java
@@ -31,9 +31,9 @@ import java.util.Set;
  * treated as "leave it alone" or "remove it" — or rejected outright — is defined by each
  * implementation, not by this interface: {@link AdditivePartitionReassigner} does not support
  * removal at all and rejects any call that omits an existing partition or group (see {@link
- * PartitionReassignmentSupport#validateNoRemoval}); a future implementation is expected to support
- * explicit removal, where omitting an id means exactly that. Consult the implementation's javadoc
- * for its specific policy.
+ * PartitionReassignmentSupport#validateExistingPartitionsAreNotRemoved}); a future implementation
+ * is expected to support explicit removal, where omitting an id means exactly that. Consult the
+ * implementation's javadoc for its specific policy.
  *
  * <p>The order of {@code targetPartitionIds} does not affect the result — implementations process
  * ids in their natural {@link PartitionId} order, not list order, so two calls with the same id set

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassigner.java
@@ -72,6 +72,10 @@ public interface PartitionReassigner {
    * @return the new distribution for all of {@code targetPartitionIds}
    * @throws IllegalArgumentException if {@code targetMembers} is empty, {@code replicationFactor}
    *     is not positive, or the implementation's removal policy is violated
+   * @throws IllegalStateException an implementation may also throw this for its own
+   *     configuration-specific validation failures (e.g. a zone-aware implementation rejecting a
+   *     configuration whose zones can't satisfy {@code replicationFactor}) — consult the
+   *     implementation's javadoc for which conditions apply
    */
   Set<PartitionMetadata> reassignPartitions(
       CurrentClusterConfiguration currentConfiguration,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
@@ -97,7 +97,8 @@ public final class PartitionReassignmentOperationsGenerator {
 
     // Every existing partition id of a group targetDistribution touches must be present in
     // targetDistribution — mirroring AdditivePartitionReassigner/PartitionReassignmentSupport
-    // #validateNoRemoval. Without this, a targetDistribution that silently omits an existing
+    // #validateExistingPartitionsAreNotRemoved. Without this, a targetDistribution that silently
+    // omits an existing
     // partition (e.g. a caller-side bug, or a reassigner change that starts supporting removal
     // without this generator being updated) would produce no leave operations for it at all: the
     // partition would simply be left out of the result, never mentioned again, without any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentSupport.java
@@ -306,10 +306,9 @@ public final class PartitionReassignmentSupport {
    * @throws IllegalArgumentException if any existing partition id, in any group, is missing from
    *     {@code targetPartitionIds}
    */
-  static void validateNoRemoval(
+  static void validateExistingPartitionsAreNotRemoved(
       final Map<String, Set<PartitionMetadata>> distributionByGroup,
-      final List<PartitionId> targetPartitionIds,
-      final int replicationFactor) {
+      final List<PartitionId> targetPartitionIds) {
     final Set<PartitionId> targetIdSet = Set.copyOf(targetPartitionIds);
     final var missing =
         distributionByGroup.values().stream()
@@ -323,21 +322,6 @@ public final class PartitionReassignmentSupport {
               + "removing partitions or groups is not supported by this reassigner, but is "
               + "missing: "
               + missing);
-    }
-
-    final var partitionsWithReducedReplicationFactor =
-        distributionByGroup.values().stream()
-            .flatMap(Set::stream)
-            .filter(metadata -> metadata.members().size() > replicationFactor)
-            .toList();
-
-    if (!partitionsWithReducedReplicationFactor.isEmpty()) {
-      throw new IllegalArgumentException(
-          "targetPartitionIds must not reduce the replication factor of any existing partition — "
-              + "reducing replication factor is not supported by this reassigner, but the following partitions have more members than the target replication factor: "
-              + partitionsWithReducedReplicationFactor.stream()
-                  .map(PartitionMetadata::id)
-                  .toList());
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassigner.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.accumulateLoad;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.selectNewPartitionMembers;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateNoRemoval;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateTargetMembers;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A {@link PartitionReassigner} for the case where only new partitions are being added to a
+ * zone-aware cluster — the zone-aware counterpart of {@link AdditivePartitionReassigner}. Just like
+ * that implementation, {@code targetMembers} and {@code replicationFactor} must be unchanged from
+ * every affected group's current state, every id already present in its group's current
+ * distribution is passed through unchanged, and only ids that don't exist yet are placed.
+ *
+ * <p>Each new partition's replicas are placed to satisfy the configured {@link ZoneSpec}s exactly:
+ * for every zone, {@link ZoneSpec#numberOfReplicas()} replicas are placed on that zone's
+ * least-loaded members (by the same replica-count-then-leader-count comparator {@link
+ * AdditivePartitionReassigner} uses, but restricted to that zone's candidates), updating the
+ * in-memory load view after every placement so a batch of new partitions — even across different
+ * groups — is spread evenly both within and across zones.
+ *
+ * <p>The primary is always a member of one of the zones tied for the highest configured {@link
+ * ZoneSpec#priority()} — matching {@link ZoneAwarePartitionDistributor}'s "highest-priority zone is
+ * the preferred leader location" guarantee. When a single zone holds the highest priority, every
+ * new partition's primary comes from that zone. When several zones tie for the highest priority,
+ * primary selection is spread across those tied zones by picking whichever tied-zone member
+ * currently has the lowest leader count, so leadership balances across the tied zones the same way
+ * {@link ZoneAwarePartitionDistributor}'s round-robin fallback would for an all-equal-priority
+ * configuration — without moving any existing partition to get there. Raft election priorities for
+ * a new partition are then assigned zone-by-zone from {@code replicationFactor} down to {@code 1},
+ * starting with the chosen primary's own zone (so its zone-mates are next in the failover order),
+ * then the remaining zones in priority order — mirroring {@link ZoneAwarePartitionDistributor}.
+ * Within a zone, followers are ordered by their current replica/leader load rather than by {@link
+ * MemberId} — the same load-based order {@link
+ * PartitionReassignmentSupport#selectNewPartitionMembers} already produced when picking that zone's
+ * replicas — so which follower gets the 2nd-highest (immediate failover) priority rotates across
+ * partitions instead of always landing on the same lower-id member.
+ *
+ * <p>This implementation never moves or otherwise touches an existing partition, never adjusts an
+ * existing partition's replication factor, and rejects a bare (not-yet-zoned) target member
+ * outright rather than falling back to a distributor that would move existing partitions — a zone
+ * migration must have completed on every broker before new physical tenants can be provisioned onto
+ * a zone-aware cluster this way.
+ *
+ * <p><b>Known trade-off:</b> because existing partitions are never touched and a new partition's
+ * per-zone replica set is fixed once chosen, leader-count balance across members is a greedy,
+ * per-partition choice rather than a globally corrected one — unlike {@link
+ * AdditivePartitionReassigner}, which runs a fix-up pass ({@link
+ * PartitionReassignmentSupport#rebalanceLeaders}) across already-placed new partitions afterward.
+ * Such a fix-up cannot be reused as-is here because it would be free to move a partition's primary
+ * to any co-replica regardless of zone, which could hand leadership to a lower-priority zone; a
+ * zone-restricted variant was judged unnecessary complexity for now.
+ *
+ * <p>Removing a partition or an entire group is not supported: {@code targetPartitionIds} must
+ * include every existing partition id of every existing group, not just the ones being changed —
+ * see {@link PartitionReassignmentSupport#validateNoRemoval}. This is a deliberate change from the
+ * previous zone-aware provisioning path, which delegated to a from-scratch {@link
+ * ZoneAwarePartitionDistributor} call with no notion of "current state" and therefore never
+ * enforced this: a group with more replicas than {@code replicationFactor} now blocks the whole
+ * batch here, the same as it already does for {@link AdditivePartitionReassigner} on non-zone-aware
+ * clusters, rather than being silently tolerated only on zone-aware ones.
+ *
+ * <p>Example with 2 zones (zone-a prio=1000 x 2 replicas/4 brokers, zone-b prio=500 x 2 replicas/4
+ * brokers), RF=4. {@code foo}/{@code bar} are the cluster's original tenants, placed at bootstrap
+ * by {@link ZoneAwarePartitionDistributor}; {@code alpha} is provisioned afterward by this
+ * reassigner and lands on the least-loaded remaining brokers per zone, without moving {@code foo}'s
+ * or {@code bar}'s replicas:
+ *
+ * <pre>
+ * +-----------+----------+----------+----------+----------+----------+----------+----------+----------+
+ * | Partition | zone-a_0 | zone-a_1 | zone-a_2 | zone-a_3 | zone-b_0 | zone-b_1 | zone-b_2 | zone-b_3 |
+ * +-----------+----------+----------+----------+----------+----------+----------+----------+----------+
+ * | bar-1     |    4     |    3     |          |          |    2     |    1     |          |          |
+ * | bar-2     |          |    4     |    3     |          |          |    2     |    1     |          |
+ * | bar-3     |          |          |    4     |    3     |          |          |    2     |    1     |
+ * | foo-1     |    3     |          |          |    4     |    1     |          |          |    2     |
+ * | foo-2     |    4     |    3     |          |          |    2     |    1     |          |          |
+ * | foo-3     |          |    4     |    3     |          |          |    2     |    1     |          |
+ * | alpha-1   |          |          |    4     |    3     |    1     |          |          |    2     |
+ * | alpha-2   |    3     |          |          |    4     |          |          |    2     |    1     |
+ * | alpha-3   |    4     |    3     |          |          |    2     |    1     |          |          |
+ * +-----------+----------+----------+----------+----------+----------+----------+----------+----------+
+ * </pre>
+ *
+ * (Numbers are Raft priorities; the member with priority == RF is the preferred leader.)
+ */
+public final class ZoneAwareAdditivePartitionReassigner implements PartitionReassigner {
+
+  private final List<ZoneSpec> zoneSpecs;
+  private final List<ZoneSpec> zoneSpecsByPriority;
+
+  /**
+   * @param zoneSpecs the zone specifications. May be in any order; sorted internally by {@link
+   *     ZoneSpec#priority()} descending so the highest-priority zone(s) are preferred for new
+   *     partitions' primaries.
+   */
+  public ZoneAwareAdditivePartitionReassigner(final List<ZoneSpec> zoneSpecs) {
+    this.zoneSpecs = List.copyOf(zoneSpecs);
+    ZoneSpecValidation.validateZoneSpecs(this.zoneSpecs);
+    zoneSpecsByPriority =
+        this.zoneSpecs.stream()
+            .sorted(Comparator.comparingInt(ZoneSpec::priority).reversed())
+            .toList();
+  }
+
+  @Override
+  public Set<PartitionMetadata> reassignPartitions(
+      final CurrentClusterConfiguration currentConfiguration,
+      final Set<MemberId> targetMembers,
+      final List<PartitionId> targetPartitionIds,
+      final int replicationFactor) {
+
+    // validation
+    validateTargetMembers(targetMembers, replicationFactor);
+    ZoneSpecValidation.validateReplicaSum(zoneSpecs, replicationFactor);
+    ZoneSpecValidation.validateNoBareMembers(targetMembers);
+    ZoneSpecValidation.validateKnownZonedMembers(zoneSpecs, targetMembers);
+    ZoneSpecValidation.validateZoneHasSufficientBrokers(zoneSpecs, targetMembers);
+
+    final Map<String, Set<PartitionMetadata>> distributionByGroup =
+        ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(currentConfiguration);
+    validateNoRemoval(distributionByGroup, targetPartitionIds, replicationFactor);
+
+    final Set<String> targetGroups =
+        targetPartitionIds.stream().map(PartitionId::group).collect(Collectors.toSet());
+    final Map<PartitionId, PartitionMetadata> currentById =
+        targetGroups.stream()
+            .flatMap(group -> distributionByGroup.getOrDefault(group, Set.of()).stream())
+            .collect(Collectors.toMap(PartitionMetadata::id, Function.identity()));
+
+    final Map<String, List<MemberId>> membersByZone =
+        zoneSpecs.stream()
+            .collect(
+                Collectors.toMap(
+                    ZoneSpec::name,
+                    spec ->
+                        targetMembers.stream()
+                            .filter(m -> m.isInZone(spec.name()))
+                            .sorted(MemberId.ID_COMPARATOR)
+                            .toList()));
+
+    final List<PartitionId> sortedPartitionIds =
+        targetPartitionIds.stream().distinct().sorted().toList();
+    final Set<String> activeGroupIds = currentConfiguration.activePartitionGroups().keySet();
+
+    final Map<MemberId, Integer> replicaCountByMember = new HashMap<>();
+    final Map<MemberId, Integer> leaderCountByMember = new HashMap<>();
+    // A disabled tenant's partitions are not actually running on any broker, so they must not
+    // count as load when deciding where to place a new tenant's partitions — but they still need
+    // to appear in distributionByGroup/currentById so they are correctly left untouched rather
+    // than treated as removed.
+    distributionByGroup.entrySet().stream()
+        .filter(entry -> activeGroupIds.contains(entry.getKey()))
+        .forEach(
+            entry -> accumulateLoad(entry.getValue(), replicaCountByMember, leaderCountByMember));
+
+    final Set<PartitionMetadata> result = new HashSet<>();
+    for (final PartitionId id : sortedPartitionIds) {
+      final var existing = currentById.get(id);
+      if (existing != null) {
+        // existing partitions are unchanged, add them as they are.
+        result.add(existing);
+        continue;
+      }
+      result.add(
+          placeNewPartition(
+              id, replicationFactor, membersByZone, replicaCountByMember, leaderCountByMember));
+    }
+    return result;
+  }
+
+  private PartitionMetadata placeNewPartition(
+      final PartitionId id,
+      final int replicationFactor,
+      final Map<String, List<MemberId>> membersByZone,
+      final Map<MemberId, Integer> replicaCountByMember,
+      final Map<MemberId, Integer> leaderCountByMember) {
+    final Map<String, List<MemberId>> selectedMembersByZone = new HashMap<>();
+    for (final var spec : zoneSpecsByPriority) {
+      final var placement =
+          selectNewPartitionMembers(
+              membersByZone.get(spec.name()),
+              spec.numberOfReplicas(),
+              replicaCountByMember,
+              leaderCountByMember);
+      selectedMembersByZone.put(spec.name(), placement.members());
+      placement.members().forEach(member -> replicaCountByMember.merge(member, 1, Integer::sum));
+    }
+
+    final int topPriority = zoneSpecsByPriority.getFirst().priority();
+    final List<ZoneSpec> topZones =
+        zoneSpecsByPriority.stream().filter(spec -> spec.priority() == topPriority).toList();
+    final var primaryCandidate =
+        topZones.stream()
+            .flatMap(
+                spec ->
+                    selectedMembersByZone.get(spec.name()).stream()
+                        .map(member -> Map.entry(member, spec.name())))
+            .min(
+                Comparator.<Map.Entry<MemberId, String>>comparingInt(
+                        entry -> leaderCountByMember.getOrDefault(entry.getKey(), 0))
+                    .thenComparing(Map.Entry::getKey, MemberId.ID_COMPARATOR))
+            .orElseThrow();
+    final var primary = primaryCandidate.getKey();
+    final var primaryZoneName = primaryCandidate.getValue();
+    leaderCountByMember.merge(primary, 1, Integer::sum);
+
+    final List<ZoneSpec> zoneOrder = new ArrayList<>(zoneSpecsByPriority.size());
+    zoneSpecsByPriority.stream()
+        .filter(spec -> spec.name().equals(primaryZoneName))
+        .forEach(zoneOrder::add);
+    zoneSpecsByPriority.stream()
+        .filter(spec -> !spec.name().equals(primaryZoneName))
+        .forEach(zoneOrder::add);
+
+    final Map<MemberId, Integer> priorityMap = new HashMap<>();
+    final Set<MemberId> allMembers = new HashSet<>();
+    int priorityCounter = replicationFactor;
+    for (final var spec : zoneOrder) {
+      // selectedMembersByZone's list is already ordered by selectNewPartitionMembers's
+      // replica-count-then-leader-count comparator, which evolves as more partitions are placed —
+      // preserving that order (rather than re-sorting by MemberId) is what spreads the 2nd+
+      // Raft-priority slot across a zone's members over successive partitions instead of always
+      // handing it to the same lower-id member.
+      final var zoneMembers = new ArrayList<>(selectedMembersByZone.get(spec.name()));
+      zoneMembers.remove(primary);
+      final List<MemberId> orderedZoneMembers =
+          spec.name().equals(primaryZoneName)
+              ? Stream.concat(Stream.of(primary), zoneMembers.stream()).toList()
+              : zoneMembers;
+      for (final var member : orderedZoneMembers) {
+        priorityMap.put(member, priorityCounter--);
+        allMembers.add(member);
+      }
+    }
+
+    return new PartitionMetadata(
+        id, Set.copyOf(allMembers), Map.copyOf(priorityMap), replicationFactor, primary);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassigner.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.dynamic.config.util;
 
 import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.accumulateLoad;
 import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.selectNewPartitionMembers;
-import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateNoRemoval;
+import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateExistingPartitionsAreNotRemoved;
 import static io.camunda.zeebe.dynamic.config.util.PartitionReassignmentSupport.validateTargetMembers;
 
 import io.atomix.cluster.MemberId;
@@ -76,12 +76,13 @@ import java.util.stream.Stream;
  *
  * <p>Removing a partition or an entire group is not supported: {@code targetPartitionIds} must
  * include every existing partition id of every existing group, not just the ones being changed —
- * see {@link PartitionReassignmentSupport#validateNoRemoval}. This is a deliberate change from the
- * previous zone-aware provisioning path, which delegated to a from-scratch {@link
- * ZoneAwarePartitionDistributor} call with no notion of "current state" and therefore never
- * enforced this: a group with more replicas than {@code replicationFactor} now blocks the whole
- * batch here, the same as it already does for {@link AdditivePartitionReassigner} on non-zone-aware
- * clusters, rather than being silently tolerated only on zone-aware ones.
+ * see {@link PartitionReassignmentSupport#validateExistingPartitionsAreNotRemoved}. This is a
+ * deliberate change from the previous zone-aware provisioning path, which delegated to a
+ * from-scratch {@link ZoneAwarePartitionDistributor} call with no notion of "current state" and
+ * therefore never enforced this. An unrelated group's current replica count exceeding {@code
+ * replicationFactor} is not rejected, however — another physical tenant may legitimately be mid-way
+ * through its own, independent scaling operation when a new tenant is provisioned, which has no
+ * bearing on this call: it never touches any group but the new one(s) being added.
  *
  * <p>Example with 2 zones (zone-a prio=1000 x 2 replicas/4 brokers, zone-b prio=500 x 2 replicas/4
  * brokers), RF=4. {@code foo}/{@code bar} are the cluster's original tenants, placed at bootstrap
@@ -142,7 +143,7 @@ public final class ZoneAwareAdditivePartitionReassigner implements PartitionReas
 
     final Map<String, Set<PartitionMetadata>> distributionByGroup =
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(currentConfiguration);
-    validateNoRemoval(distributionByGroup, targetPartitionIds, replicationFactor);
+    validateExistingPartitionsAreNotRemoved(distributionByGroup, targetPartitionIds);
 
     final Set<String> targetGroups =
         targetPartitionIds.stream().map(PartitionId::group).collect(Collectors.toSet());

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassigner.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassigner.java
@@ -156,11 +156,7 @@ public final class ZoneAwareAdditivePartitionReassigner implements PartitionReas
             .collect(
                 Collectors.toMap(
                     ZoneSpec::name,
-                    spec ->
-                        targetMembers.stream()
-                            .filter(m -> m.isInZone(spec.name()))
-                            .sorted(MemberId.ID_COMPARATOR)
-                            .toList()));
+                    spec -> targetMembers.stream().filter(m -> m.isInZone(spec.name())).toList()));
 
     final List<PartitionId> sortedPartitionIds =
         targetPartitionIds.stream().distinct().sorted().toList();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributor.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +103,7 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
           this.zoneSpecs.getFirst().name());
     }
 
-    validateZoneSpecs(zoneSpecs);
+    ZoneSpecValidation.validateZoneSpecs(zoneSpecs);
   }
 
   @Override
@@ -113,7 +112,7 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
       final List<PartitionId> sortedPartitionIds,
       final int replicationFactor) {
 
-    validateReplicaSum(replicationFactor);
+    ZoneSpecValidation.validateReplicaSum(zoneSpecs, replicationFactor);
 
     // As long as any bare (not-yet-migrated) member is present the cluster is either fully bare
     // (config persisted but migration not started) or mid-migration. In both cases the zone-aware
@@ -121,12 +120,12 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
     // preserves the original slot layout. On a fully bare cluster this is identical to plain
     // round-robin, so recomputing the distribution before migration is a no-op.
     if (hasBareMembers(clusterMembers)) {
-      validateKnownZonedMembers(clusterMembers);
+      ZoneSpecValidation.validateKnownZonedMembers(zoneSpecs, clusterMembers);
       return new RoundRobinPartitionDistributor(zoneSpecs.stream().map(ZoneSpec::name).toList())
           .distributePartitions(clusterMembers, sortedPartitionIds, replicationFactor);
     }
 
-    validateZoneHasSufficientBrokers(clusterMembers);
+    ZoneSpecValidation.validateZoneHasSufficientBrokers(zoneSpecs, clusterMembers);
 
     // all zones have the same priority
     if (zoneSpecsByPriority.stream().map(ZoneSpec::priority).distinct().count() == 1) {
@@ -183,48 +182,5 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
 
   private boolean hasBareMembers(final Set<MemberId> clusterMembers) {
     return clusterMembers.stream().anyMatch(member -> member.zone() == null);
-  }
-
-  private void validateKnownZonedMembers(final Set<MemberId> clusterMembers) {
-    final var zoneNames = zoneSpecs.stream().map(ZoneSpec::name).collect(Collectors.toSet());
-    for (final var member : clusterMembers) {
-      if (member.zone() != null && !zoneNames.contains(member.zone())) {
-        throw new IllegalStateException(
-            "ZoneAwarePartitionDistributor: member '%s' has zone '%s' which is not part of the configured zones"
-                .formatted(member, member.zone()));
-      }
-    }
-  }
-
-  private void validateReplicaSum(final int replicationFactor) {
-    final var totalReplicas = zoneSpecs.stream().mapToInt(ZoneSpec::numberOfReplicas).sum();
-    if (totalReplicas != replicationFactor) {
-      throw new IllegalStateException(
-          "ZoneAwarePartitionDistributor: sum of numberOfReplicas across all zones (%d) does not match replicationFactor (%d)"
-              .formatted(totalReplicas, replicationFactor));
-    }
-  }
-
-  private void validateZoneHasSufficientBrokers(final Set<MemberId> clusterMembers) {
-    for (final var spec : zoneSpecs) {
-      final long zoneCount = clusterMembers.stream().filter(m -> m.isInZone(spec.name())).count();
-      if (zoneCount < spec.numberOfReplicas()) {
-        throw new IllegalStateException(
-            "ZoneAwarePartitionDistributor: zone '%s' needs %d replicas but only has %d broker(s) in clusterMembers"
-                .formatted(spec.name(), spec.numberOfReplicas(), zoneCount));
-      }
-    }
-  }
-
-  private void validateZoneSpecs(final List<ZoneSpec> zoneSpecs) {
-    zoneSpecs.stream()
-        .collect(Collectors.groupingBy(ZoneSpec::name))
-        .forEach(
-            (name, zones) -> {
-              if (zones.size() > 1) {
-                throw new IllegalArgumentException(
-                    "Expected zone names to be unique, but got " + zones);
-              }
-            });
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneSpecValidation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneSpecValidation.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Shared {@link ZoneSpec} validation used by every zone-aware partition placement implementation —
+ * currently {@link ZoneAwarePartitionDistributor} and {@link ZoneAwareAdditivePartitionReassigner}
+ * — so the two can never drift apart on what a valid zone configuration or a valid target member
+ * set looks like.
+ */
+final class ZoneSpecValidation {
+
+  private ZoneSpecValidation() {}
+
+  /**
+   * @throws IllegalArgumentException if two zones share the same {@link ZoneSpec#name()}
+   */
+  static void validateZoneSpecs(final List<ZoneSpec> zoneSpecs) {
+    zoneSpecs.stream()
+        .collect(Collectors.groupingBy(ZoneSpec::name))
+        .forEach(
+            (name, zones) -> {
+              if (zones.size() > 1) {
+                throw new IllegalArgumentException(
+                    "Expected zone names to be unique, but got " + zones);
+              }
+            });
+  }
+
+  /**
+   * @throws IllegalStateException if the sum of every zone's {@link ZoneSpec#numberOfReplicas()}
+   *     does not equal {@code replicationFactor}
+   */
+  static void validateReplicaSum(final List<ZoneSpec> zoneSpecs, final int replicationFactor) {
+    final var totalReplicas = zoneSpecs.stream().mapToInt(ZoneSpec::numberOfReplicas).sum();
+    if (totalReplicas != replicationFactor) {
+      throw new IllegalStateException(
+          "sum of numberOfReplicas across all zones (%d) does not match replicationFactor (%d)"
+              .formatted(totalReplicas, replicationFactor));
+    }
+  }
+
+  /**
+   * @throws IllegalStateException if any zone has fewer members in {@code clusterMembers} than its
+   *     {@link ZoneSpec#numberOfReplicas()}
+   */
+  static void validateZoneHasSufficientBrokers(
+      final List<ZoneSpec> zoneSpecs, final Set<MemberId> clusterMembers) {
+    for (final var spec : zoneSpecs) {
+      final long zoneCount = clusterMembers.stream().filter(m -> m.isInZone(spec.name())).count();
+      if (zoneCount < spec.numberOfReplicas()) {
+        throw new IllegalStateException(
+            "zone '%s' needs %d replicas but only has %d broker(s) in clusterMembers"
+                .formatted(spec.name(), spec.numberOfReplicas(), zoneCount));
+      }
+    }
+  }
+
+  /**
+   * @throws IllegalStateException if any member of {@code clusterMembers} has a non-null {@link
+   *     MemberId#zone()} that is not one of {@code zoneSpecs}
+   */
+  static void validateKnownZonedMembers(
+      final List<ZoneSpec> zoneSpecs, final Set<MemberId> clusterMembers) {
+    final var zoneNames = zoneSpecs.stream().map(ZoneSpec::name).collect(Collectors.toSet());
+    for (final var member : clusterMembers) {
+      if (member.zone() != null && !zoneNames.contains(member.zone())) {
+        throw new IllegalStateException(
+            "member '%s' has zone '%s' which is not part of the configured zones"
+                .formatted(member, member.zone()));
+      }
+    }
+  }
+
+  /**
+   * @throws IllegalArgumentException if any member of {@code clusterMembers} is bare (has no zone),
+   *     e.g. because a zone migration has not completed yet on all brokers
+   */
+  static void validateNoBareMembers(final Set<MemberId> clusterMembers) {
+    final var bareMembers = clusterMembers.stream().filter(MemberId::isBare).toList();
+    if (!bareMembers.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected every member to belong to a zone, but found bare member(s) (likely a zone "
+              + "migration still in progress): "
+              + bareMembers);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializerTest.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
@@ -224,6 +226,52 @@ final class PhysicalTenantProvisioningInitializerTest {
     assertThat(result).isEqualTo(configuration);
   }
 
+  @Test
+  void shouldPlaceANewTenantOnAZoneAwareClusterByCurrentLoadNotByRoundRobinIndex() {
+    // given — a zone-aware cluster (zone-a: 1 replica/priority 100, zone-b: 1 replica/priority 50,
+    // RF 2). tenantA already has 2 partitions, both replicated onto zone-a_0, so zone-a_0 carries
+    // twice the load of zone-a_1/zone-a_2 there — a skew that only the actual current distribution
+    // shows, not the partition count or ordering. tenantZ (sorted AFTER tenantA, so it lands at
+    // list index 2) is the new tenant being provisioned.
+    //
+    // The previous implementation delegated to the full ZoneAwarePartitionDistributor, which
+    // recomputes purely from (partition's position in the sorted target list) modulo (zone broker
+    // count) — completely blind to zone-a_0's actual extra load. For tenantZ at index 2 with 3
+    // zone-a brokers, that formula picks zone-a_2. The reassigner under test instead picks
+    // zone-a's actual least-loaded member, zone-a_1.
+    final var zoneA0 = MemberId.from("zone-a", 0);
+    final var zoneA1 = MemberId.from("zone-a", 1);
+    final var zoneB0 = MemberId.from("zone-b", 0);
+    final var zoneB1 = MemberId.from("zone-b", 1);
+    final var existingTenantA =
+        Set.of(
+            partition("tenantA", 1, Set.of(zoneA0, zoneB0), zoneA0),
+            partition("tenantA", 2, Set.of(zoneA0, zoneB1), zoneA0));
+    final var zoneSpecs = List.of(new ZoneSpec("zone-a", 1, 100), new ZoneSpec("zone-b", 1, 50));
+    final var configuration =
+        configurationWithMembers(
+                existingTenantA, Set.of(zoneA0, zoneA1, MemberId.from("zone-a", 2), zoneB0, zoneB1))
+            .updateGlobalConfiguration(
+                global -> global.setPartitionDistributorConfig(new ZoneAwareConfig(zoneSpecs)));
+    final var staticConfiguration =
+        staticConfigWith(
+            List.of(tenantPartitionIds("tenantA", 2), tenantPartitionIds("tenantZ", 1)), 2);
+    final var initializer = new PhysicalTenantProvisioningInitializer(staticConfiguration);
+
+    // when
+    final var result = initializer.modify(configuration).join();
+
+    // then — tenantZ's zone-a replica lands on the actually-least-loaded zone-a_1, not on
+    // zone-a_2 (which a from-scratch, index-based recomputation would have chosen instead)
+    final var tenantZOperations =
+        result.partitionGroup("tenantZ").pendingChanges().orElseThrow().pendingOperations();
+    final var tenantZTargetMembers =
+        tenantZOperations.stream().map(ClusterConfigurationChangeOperation::memberId).toList();
+    final var tenantZZoneAMember =
+        tenantZTargetMembers.stream().filter(m -> m.isInZone("zone-a")).findFirst().orElseThrow();
+    assertThat(tenantZZoneAMember).isEqualTo(zoneA1);
+  }
+
   private StaticConfiguration staticConfigWith(final List<List<PartitionId>> tenantPartitionIds) {
     return staticConfigWith(tenantPartitionIds, 1);
   }
@@ -268,6 +316,11 @@ final class PhysicalTenantProvisioningInitializerTest {
     for (int i = 0; i < 3; i++) {
       members.add(member(i));
     }
+    return configurationWithMembers(existing, members);
+  }
+
+  private CurrentClusterConfiguration configurationWithMembers(
+      final Set<PartitionMetadata> existing, final Set<MemberId> members) {
     final var tenantConfigs =
         existing.stream()
             .map(p -> p.id().group())

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/AdditivePartitionReassignerTest.java
@@ -396,6 +396,31 @@ final class AdditivePartitionReassignerTest {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
+  @Test
+  void shouldNotRejectWhenAnUnrelatedGroupHasMoreReplicasThanTheRequestedReplicationFactor() {
+    // given — tenantA already has 3 replicas (e.g. from an earlier, independent per-tenant scale
+    // up), while tenantB is being provisioned with replicationFactor 1. tenantA is untouched and
+    // not being scaled by this call at all
+    final PartitionMetadata existingTenantA =
+        PartitionMetadataFixtures.partition(
+            "tenantA", 1, Set.of(member(0), member(1), member(2)), member(0));
+    final var configuration =
+        configurationWithExistingGroups(Map.of("tenantA", Set.of(existingTenantA)));
+    final var targetMembers = members(3);
+    final var targetPartitionIds =
+        List.of(new PartitionId("tenantA", 1), new PartitionId(NEW_GROUP, 1));
+
+    // when — this must succeed rather than reject the whole batch just because an unrelated
+    // group's current replica count happens to exceed this call's replicationFactor
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 1);
+
+    // then — tenantA's over-replicated partition is passed through completely unchanged
+    assertThat(assigned).contains(existingTenantA);
+    final var placed = findPartition(assigned, NEW_GROUP, 1);
+    assertThat(placed.members()).hasSize(1);
+  }
+
   private CurrentClusterConfiguration configurationWithExistingGroups(
       final Map<String, Set<PartitionMetadata>> existingGroups) {
     final Set<PartitionMetadata> allExisting = new HashSet<>();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassignerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassignerPropertyTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+/**
+ * Property-based tests for {@link ZoneAwareAdditivePartitionReassigner}, in the style of {@link
+ * AdditivePartitionReassignerPropertyTest}: for randomly generated valid zone configurations and
+ * inputs, the resulting distribution must satisfy a set of invariants regardless of the specific
+ * numbers involved.
+ *
+ * <p>Since {@link ZoneAwareAdditivePartitionReassigner} only ever adds new partitions on top of an
+ * unchanged broker set, replication factor, and zone configuration, the "current" distribution fed
+ * into each property is itself built by the same reassigner starting from an empty cluster — this
+ * guarantees it already satisfies the zone spec, which is a precondition the implementation relies
+ * on (it never touches an existing partition, so it can't fix up an already-invalid starting
+ * point).
+ *
+ * <p>Zone configurations are generated with 2 or 3 zones, each with a per-zone replication factor
+ * (number of replicas) between 1 and 4, and some number of extra brokers beyond that minimum.
+ * {@code topZonesTied} occasionally makes the two highest-priority zones share the same priority,
+ * exercising the primary-spreading behavior for that case as well as the single-top-zone case.
+ */
+final class ZoneAwareAdditivePartitionReassignerPropertyTest {
+
+  private static final String GROUP = "test";
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @Property(tries = 100)
+  void shouldSatisfyDistributionInvariantsWhenAddingPartitions(
+      @ForAll @IntRange(min = 2, max = 3) final int zoneCount,
+      @ForAll @IntRange(min = 1, max = 4) final int zoneAReplicas,
+      @ForAll @IntRange(min = 1, max = 4) final int zoneBReplicas,
+      @ForAll @IntRange(min = 1, max = 4) final int zoneCReplicas,
+      @ForAll @IntRange(min = 0, max = 4) final int zoneAExtraBrokers,
+      @ForAll @IntRange(min = 0, max = 4) final int zoneBExtraBrokers,
+      @ForAll @IntRange(min = 0, max = 4) final int zoneCExtraBrokers,
+      @ForAll final boolean topZonesTied,
+      @ForAll @IntRange(min = 1, max = 15) final int oldPartitionCount,
+      @ForAll @IntRange(min = 0, max = 15) final int additionalPartitionCount) {
+    final List<ZoneSpec> zoneSpecs =
+        buildZoneSpecs(zoneCount, zoneAReplicas, zoneBReplicas, zoneCReplicas, topZonesTied);
+    final int replicationFactor = zoneSpecs.stream().mapToInt(ZoneSpec::numberOfReplicas).sum();
+    final Set<MemberId> targetMembers =
+        buildTargetMembers(
+            zoneSpecs,
+            List.of(
+                zoneAReplicas + zoneAExtraBrokers,
+                zoneBReplicas + zoneBExtraBrokers,
+                zoneCReplicas + zoneCExtraBrokers));
+    final int newPartitionCount = oldPartitionCount + additionalPartitionCount;
+    final var reassigner = new ZoneAwareAdditivePartitionReassigner(zoneSpecs);
+
+    // given — an already zone-spec-compliant starting distribution, built by the reassigner
+    // itself from an empty cluster (the only kind of starting point this implementation can
+    // guarantee stays valid, since it never touches an existing partition)
+    final var oldDistribution =
+        reassigner.reassignPartitions(
+            configurationWith(targetMembers, Set.of()),
+            targetMembers,
+            partitionIds(1, oldPartitionCount),
+            replicationFactor);
+    final var currentConfiguration = configurationWith(targetMembers, oldDistribution);
+    final var targetPartitionIds = partitionIds(1, newPartitionCount);
+
+    // when
+    final var result =
+        reassigner.reassignPartitions(
+            currentConfiguration, targetMembers, targetPartitionIds, replicationFactor);
+
+    // then — leader-count (primary) balance is checked with a looser tolerance than replica
+    // placement, since primary selection for a partition is restricted to whichever members were
+    // already chosen as that partition's replicas in the top zone(s); see
+    // ZonePartitionDistributionInvariants.assertSatisfied
+    final int topPriority = zoneSpecs.stream().mapToInt(ZoneSpec::priority).max().orElseThrow();
+    final int topZoneReplicas =
+        zoneSpecs.stream()
+            .filter(spec -> spec.priority() == topPriority)
+            .mapToInt(ZoneSpec::numberOfReplicas)
+            .sum();
+    ZonePartitionDistributionInvariants.assertSatisfied(
+        result,
+        targetMembers,
+        targetPartitionIds,
+        zoneSpecs,
+        replicationFactor,
+        topZoneReplicas + 3);
+
+    assertThat(result)
+        .describedAs("No existing partition was moved or removed")
+        .containsAll(oldDistribution);
+  }
+
+  private List<ZoneSpec> buildZoneSpecs(
+      final int zoneCount,
+      final int zoneAReplicas,
+      final int zoneBReplicas,
+      final int zoneCReplicas,
+      final boolean topZonesTied) {
+    final int zoneAPriority = 300;
+    final int zoneBPriority = topZonesTied ? 300 : 200;
+    final var specs = new ArrayList<ZoneSpec>();
+    specs.add(new ZoneSpec("zone-a", zoneAReplicas, zoneAPriority));
+    specs.add(new ZoneSpec("zone-b", zoneBReplicas, zoneBPriority));
+    if (zoneCount == 3) {
+      specs.add(new ZoneSpec("zone-c", zoneCReplicas, 100));
+    }
+    return specs;
+  }
+
+  private Set<MemberId> buildTargetMembers(
+      final List<ZoneSpec> zoneSpecs, final List<Integer> membersPerZone) {
+    final Set<MemberId> members = new HashSet<>();
+    for (int z = 0; z < zoneSpecs.size(); z++) {
+      final var zoneName = zoneSpecs.get(z).name();
+      for (int i = 0; i < membersPerZone.get(z); i++) {
+        members.add(MemberId.from(zoneName, i));
+      }
+    }
+    return members;
+  }
+
+  private CurrentClusterConfiguration configurationWith(
+      final Set<MemberId> targetMembers, final Set<PartitionMetadata> distribution) {
+    final var tenantConfigs =
+        distribution.stream()
+            .map(p -> p.id().group())
+            .distinct()
+            .collect(Collectors.toMap(Function.identity(), p -> partitionConfig));
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        targetMembers, distribution, tenantConfigs, "clusterId");
+  }
+
+  private List<PartitionId> partitionIds(final int fromInclusive, final int toInclusive) {
+    return IntStream.rangeClosed(fromInclusive, toInclusive)
+        .mapToObj(i -> new PartitionId(GROUP, i))
+        .toList();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassignerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassignerTest.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every test here calls {@link ZoneAwareAdditivePartitionReassigner#reassignPartitions} with {@code
+ * targetPartitionIds} consisting of ALL partition ids from ALL groups present in the current
+ * configuration (existing ids for every group, plus any new ones) — never a subset that omits a
+ * group that already exists, mirroring {@code AdditivePartitionReassignerTest}'s convention.
+ */
+final class ZoneAwareAdditivePartitionReassignerTest {
+
+  private static final String NEW_GROUP = "tenantB";
+  private static final String ZONE_A = "zone-a";
+  private static final String ZONE_B = "zone-b";
+  private static final String ZONE_C = "zone-c";
+
+  private final DynamicPartitionConfig partitionConfig =
+      new DynamicPartitionConfig(
+          new ExportingConfig(
+              ExportingState.EXPORTING,
+              Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
+
+  @Test
+  void shouldPlaceReplicasPerZoneAccordingToZoneSpec() {
+    // given — two zones, RF 3 split 2/1, no prior state
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 1, 50)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = zoneMembers(ZONE_A, 3, ZONE_B, 3);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 4);
+
+    // when
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 3);
+
+    // then — every partition has exactly 2 replicas in zone-a and 1 in zone-b
+    assertThat(assigned).hasSize(4);
+    assigned.forEach(
+        metadata -> {
+          assertThat(metadata.members().stream().filter(m -> m.isInZone(ZONE_A)).count())
+              .isEqualTo(2);
+          assertThat(metadata.members().stream().filter(m -> m.isInZone(ZONE_B)).count())
+              .isEqualTo(1);
+        });
+  }
+
+  @Test
+  void shouldAlwaysPickPrimaryFromTheHighestPriorityZone() {
+    // given — zone-a has the highest priority
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 10)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = zoneMembers(ZONE_A, 2, ZONE_B, 2);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 6);
+
+    // when
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2);
+
+    // then
+    assigned.forEach(
+        metadata -> assertThat(metadata.getPrimary().orElseThrow().isInZone(ZONE_A)).isTrue());
+  }
+
+  @Test
+  void shouldAssignPrimaryReplicationFactorPriorityAndDecreaseByZonePriorityOrder() {
+    // given — zone-a (priority 1000, 2 replicas) then zone-b (priority 10, 1 replica), RF 3
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 2, 1000), new ZoneSpec(ZONE_B, 1, 10)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = zoneMembers(ZONE_A, 2, ZONE_B, 2);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 1);
+
+    // when
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 3);
+
+    // then — primary has priority 3, its zone-a zone-mate has 2, and zone-b's member has 1
+    final var partition = assigned.iterator().next();
+    final var primary = partition.getPrimary().orElseThrow();
+    assertThat(partition.getPriority(primary)).isEqualTo(3);
+    final var zoneAFollower =
+        partition.members().stream()
+            .filter(m -> m.isInZone(ZONE_A) && !m.equals(primary))
+            .findFirst()
+            .orElseThrow();
+    assertThat(partition.getPriority(zoneAFollower)).isEqualTo(2);
+    final var zoneBMember =
+        partition.members().stream().filter(m -> m.isInZone(ZONE_B)).findFirst().orElseThrow();
+    assertThat(partition.getPriority(zoneBMember)).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSpreadPrimariesAcrossZonesTiedForHighestPriority() {
+    // given — zone-a and zone-b are tied for the highest priority
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 1, 100), new ZoneSpec(ZONE_B, 1, 100)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = zoneMembers(ZONE_A, 2, ZONE_B, 2);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 8);
+
+    // when
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2);
+
+    // then — leadership is balanced across zone-a and zone-b, not always the same zone
+    final Map<String, Integer> leadersByZone = new HashMap<>();
+    assigned.forEach(
+        metadata -> {
+          final var primary = metadata.getPrimary().orElseThrow();
+          leadersByZone.merge(primary.zone(), 1, Integer::sum);
+        });
+    assertThat(leadersByZone.get(ZONE_A)).isEqualTo(4);
+    assertThat(leadersByZone.get(ZONE_B)).isEqualTo(4);
+  }
+
+  @Test
+  void shouldRotateWhichFollowerReceivesTheSecondHighestPriorityAcrossPartitions() {
+    // given — zone-a has exactly 3 members and needs all 3 as replicas every time, so which
+    // member is selected never varies across partitions — only the RELATIVE ORDER among them
+    // (who's primary, who's 2nd/3rd priority) can. Sorting followers by plain MemberId order would
+    // always hand the 2nd-highest priority to the same lower-id member; this asserts it rotates.
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 3, 100), new ZoneSpec(ZONE_B, 1, 10)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = zoneMembers(ZONE_A, 3, ZONE_B, 1);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 4);
+
+    // when
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 4);
+
+    // then — the member receiving the second-highest priority (replicationFactor - 1, i.e. 3) is
+    // not always the same one across partitions
+    final Set<MemberId> secondPriorityMembers = new HashSet<>();
+    assigned.forEach(
+        metadata ->
+            metadata.members().stream()
+                .filter(m -> metadata.getPriority(m) == 3)
+                .forEach(secondPriorityMembers::add));
+    assertThat(secondPriorityMembers.size()).isGreaterThan(1);
+  }
+
+  @Test
+  void shouldProduceDeterministicResultsRegardlessOfTargetMembersIterationOrder() {
+    // given — the same four zoned members, enumerated via two LinkedHashSets in opposite order
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 1, 50)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var zoneA0 = MemberId.from(ZONE_A, 0);
+    final var zoneA1 = MemberId.from(ZONE_A, 1);
+    final var zoneA2 = MemberId.from(ZONE_A, 2);
+    final var zoneB0 = MemberId.from(ZONE_B, 0);
+    final var membersInOneOrder = new LinkedHashSet<>(List.of(zoneA0, zoneA1, zoneA2, zoneB0));
+    final var membersInReverseOrder = new LinkedHashSet<>(List.of(zoneB0, zoneA2, zoneA1, zoneA0));
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 4);
+
+    // when — reassigning the exact same target members, just enumerated in a different order
+    final var first =
+        reassigner.reassignPartitions(configuration, membersInOneOrder, targetPartitionIds, 3);
+    final var second =
+        reassigner.reassignPartitions(configuration, membersInReverseOrder, targetPartitionIds, 3);
+
+    // then — the outcome is identical regardless of iteration order
+    assertThat(first).isEqualTo(second);
+  }
+
+  @Test
+  void shouldNotMoveExistingPartitionsWhenAddingNewOnes() {
+    // given — tenantB already has partition 1 placed across both zones
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 1, 100), new ZoneSpec(ZONE_B, 1, 50)));
+    final var zoneA0 = MemberId.from(ZONE_A, 0);
+    final var zoneB0 = MemberId.from(ZONE_B, 0);
+    final var existingTenantB =
+        PartitionMetadataFixtures.partition(NEW_GROUP, 1, Set.of(zoneA0, zoneB0), zoneA0);
+    final var configuration =
+        configurationWithExistingGroups(Map.of(NEW_GROUP, Set.of(existingTenantB)));
+    final var targetMembers = zoneMembers(ZONE_A, 3, ZONE_B, 3);
+
+    // when — the full target list covers the existing partition plus a new one
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 2);
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2);
+
+    // then — partition 1 is byte-for-byte unchanged
+    assertThat(assigned).contains(existingTenantB);
+  }
+
+  @Test
+  void shouldNotCountADisabledTenantsPartitionsAsLoadWhenPlacingNewTenantPartitions() {
+    // given — tenantB-existing (enabled) loads zone-a's member 0 once; tenantA (about to be
+    // disabled) loads zone-a's member 1 twice, i.e. more heavily
+    final var zoneA0 = MemberId.from(ZONE_A, 0);
+    final var zoneA1 = MemberId.from(ZONE_A, 1);
+    final var zoneB0 = MemberId.from(ZONE_B, 0);
+    final var tenantBPartitions =
+        Set.of(
+            PartitionMetadataFixtures.partition(
+                "tenantB-existing", 1, Set.of(zoneA0, zoneB0), zoneA0));
+    final var tenantAPartitions =
+        Set.of(
+            PartitionMetadataFixtures.partition("tenantA", 1, Set.of(zoneA1, zoneB0), zoneA1),
+            PartitionMetadataFixtures.partition("tenantA", 2, Set.of(zoneA1, zoneB0), zoneA1));
+    final var configuration =
+        configurationWithExistingGroups(
+                Map.of(
+                    "tenantB-existing", tenantBPartitions,
+                    "tenantA", tenantAPartitions))
+            .updatePartitionGroupConfig(
+                "tenantA",
+                io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration::disable);
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 1, 100), new ZoneSpec(ZONE_B, 1, 50)));
+
+    // when — placing one partition for a brand-new tenant, choosing zone-a's member
+    final var targetMembers = Set.of(zoneA0, zoneA1, zoneB0);
+    final var targetPartitionIds = new ArrayList<>(sortedPartitionIds("tenantB-existing", 1, 1));
+    targetPartitionIds.addAll(sortedPartitionIds("tenantA", 1, 2));
+    targetPartitionIds.add(new PartitionId(NEW_GROUP, 1));
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2);
+
+    // then — with tenantA's (disabled) load excluded, zone-a's member 1 looks less loaded (0)
+    // than member 0 (1 from tenantB-existing), so the new partition's zone-a replica lands there
+    final var placed = findPartition(assigned, NEW_GROUP, 1);
+    assertThat(placed.members()).contains(zoneA1);
+  }
+
+  @Test
+  void shouldRejectBareMembers() {
+    // given
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(List.of(new ZoneSpec(ZONE_A, 2, 100)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = Set.of(MemberId.from(ZONE_A, 0), MemberId.from("1"));
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 1);
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectUnknownZoneMembers() {
+    // given — the target members include a zone that isn't part of the configured zones
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(List.of(new ZoneSpec(ZONE_A, 2, 100)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers =
+        Set.of(MemberId.from(ZONE_A, 0), MemberId.from(ZONE_A, 1), MemberId.from(ZONE_C, 0));
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 1);
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 2))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldRejectWhenAZoneHasTooFewBrokers() {
+    // given — zone-b needs 2 replicas but only has 1 broker
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 1, 100), new ZoneSpec(ZONE_B, 2, 50)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = zoneMembers(ZONE_A, 2, ZONE_B, 1);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 1);
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 3))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldRejectWhenReplicaSumDoesNotMatchReplicationFactor() {
+    // given — zone specs sum to 2 replicas but replicationFactor 3 is requested
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(
+            List.of(new ZoneSpec(ZONE_A, 1, 100), new ZoneSpec(ZONE_B, 1, 50)));
+    final var configuration = configurationWithExistingGroups(Map.of());
+    final var targetMembers = zoneMembers(ZONE_A, 2, ZONE_B, 2);
+    final var targetPartitionIds = sortedPartitionIds(NEW_GROUP, 1, 1);
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 3))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldRejectTargetPartitionIdsThatOmitAnExistingIdOfATouchedGroup() {
+    // given — tenantB already has partitions 1 and 2
+    final var zoneA0 = MemberId.from(ZONE_A, 0);
+    final var existingTenantB =
+        Set.of(
+            PartitionMetadataFixtures.partition(NEW_GROUP, 1, Set.of(zoneA0), zoneA0),
+            PartitionMetadataFixtures.partition(NEW_GROUP, 2, Set.of(zoneA0), zoneA0));
+    final var configuration = configurationWithExistingGroups(Map.of(NEW_GROUP, existingTenantB));
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(List.of(new ZoneSpec(ZONE_A, 1, 100)));
+    final var targetMembers = zoneMembers(ZONE_A, 3, ZONE_B, 0);
+    // omits tenantB's existing partition 2 — only lists partition 1 (unchanged) and a new one
+    final var incompleteTargetPartitionIds =
+        List.of(new PartitionId(NEW_GROUP, 1), new PartitionId(NEW_GROUP, 3));
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                reassigner.reassignPartitions(
+                    configuration, targetMembers, incompleteTargetPartitionIds, 1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private CurrentClusterConfiguration configurationWithExistingGroups(
+      final Map<String, Set<PartitionMetadata>> existingGroups) {
+    final Set<PartitionMetadata> allExisting = new HashSet<>();
+    existingGroups.values().forEach(allExisting::addAll);
+    final Set<MemberId> members =
+        new HashSet<>(allExisting.stream().flatMap(m -> m.members().stream()).toList());
+    // ensure the configuration always has at least a few zoned members available
+    members.addAll(zoneMembers(ZONE_A, 5, ZONE_B, 5));
+
+    final var tenantConfig =
+        existingGroups.keySet().stream()
+            .collect(Collectors.toMap(group -> group, group -> partitionConfig));
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        members, allExisting, tenantConfig, "clusterId");
+  }
+
+  private Set<MemberId> zoneMembers(
+      final String zoneA, final int countA, final String zoneB, final int countB) {
+    final Set<MemberId> members = new HashSet<>();
+    for (int i = 0; i < countA; i++) {
+      members.add(MemberId.from(zoneA, i));
+    }
+    for (int i = 0; i < countB; i++) {
+      members.add(MemberId.from(zoneB, i));
+    }
+    return members;
+  }
+
+  private PartitionMetadata findPartition(
+      final Set<PartitionMetadata> assigned, final String group, final int number) {
+    return assigned.stream()
+        .filter(metadata -> metadata.id().equals(new PartitionId(group, number)))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private List<PartitionId> sortedPartitionIds(
+      final String group, final int fromInclusive, final int toInclusive) {
+    final List<PartitionId> ids = new ArrayList<>();
+    for (int i = fromInclusive; i <= toInclusive; i++) {
+      ids.add(new PartitionId(group, i));
+    }
+    return ids;
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassignerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwareAdditivePartitionReassignerTest.java
@@ -355,6 +355,35 @@ final class ZoneAwareAdditivePartitionReassignerTest {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
+  @Test
+  void shouldNotRejectWhenAnUnrelatedGroupHasMoreReplicasThanTheRequestedReplicationFactor() {
+    // given — tenantA already has 3 replicas in zone-a (e.g. from an earlier, independent
+    // per-tenant scale up), while tenantB (NEW_GROUP) is being provisioned with replicationFactor
+    // 1. tenantA is untouched and not being scaled by this call at all
+    final var zoneA0 = MemberId.from(ZONE_A, 0);
+    final var zoneA1 = MemberId.from(ZONE_A, 1);
+    final var zoneA2 = MemberId.from(ZONE_A, 2);
+    final var existingTenantA =
+        PartitionMetadataFixtures.partition("tenantA", 1, Set.of(zoneA0, zoneA1, zoneA2), zoneA0);
+    final var configuration =
+        configurationWithExistingGroups(Map.of("tenantA", Set.of(existingTenantA)));
+    final var reassigner =
+        new ZoneAwareAdditivePartitionReassigner(List.of(new ZoneSpec(ZONE_A, 1, 100)));
+    final var targetMembers = zoneMembers(ZONE_A, 3, ZONE_B, 0);
+    final var targetPartitionIds =
+        List.of(new PartitionId("tenantA", 1), new PartitionId(NEW_GROUP, 1));
+
+    // when — this must succeed rather than reject the whole batch just because an unrelated
+    // group's current replica count happens to exceed this call's replicationFactor
+    final var assigned =
+        reassigner.reassignPartitions(configuration, targetMembers, targetPartitionIds, 1);
+
+    // then — tenantA's over-replicated partition is passed through completely unchanged
+    assertThat(assigned).contains(existingTenantA);
+    final var placed = findPartition(assigned, NEW_GROUP, 1);
+    assertThat(placed.members()).hasSize(1);
+  }
+
   private CurrentClusterConfiguration configurationWithExistingGroups(
       final Map<String, Set<PartitionMetadata>> existingGroups) {
     final Set<PartitionMetadata> allExisting = new HashSet<>();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZonePartitionDistributionInvariants.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZonePartitionDistributionInvariants.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Shared invariant assertions used by {@link ZoneAwareAdditivePartitionReassigner}'s property-based
+ * test — the zone-aware counterpart of {@link PartitionDistributionInvariants}.
+ */
+final class ZonePartitionDistributionInvariants {
+
+  private ZonePartitionDistributionInvariants() {}
+
+  /**
+   * @param targetMembers every member eligible to receive a replica, used to zero-initialize leader
+   *     counts so a top-priority-zone member that never became primary still counts as 0 rather
+   *     than being silently excluded from the balance check
+   * @param primaryBalanceTolerance the maximum allowed gap between the most- and least-primary
+   *     -loaded member of the zone(s) tied for the highest configured priority. Unlike replica
+   *     placement, primary selection for a given partition is restricted to whichever members were
+   *     already chosen as that partition's replicas in the top zone(s), so — analogous to {@link
+   *     AdditivePartitionReassigner}'s leader-count tolerance — a tight gap of 1 is not always
+   *     achievable.
+   */
+  static void assertSatisfied(
+      final Set<PartitionMetadata> result,
+      final Set<MemberId> targetMembers,
+      final List<PartitionId> targetPartitionIds,
+      final List<ZoneSpec> zoneSpecs,
+      final int replicationFactor,
+      final int primaryBalanceTolerance) {
+    // 1. every target partition id is present in the result
+    assertThat(result.stream().map(PartitionMetadata::id).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrderElementsOf(targetPartitionIds);
+
+    // 2. every partition has exactly replicationFactor distinct replicas
+    result.forEach(
+        metadata ->
+            assertThat(Set.copyOf(metadata.members()))
+                .as(
+                    "partition %s must have %s distinct replicas, but found members %s",
+                    metadata.id(), replicationFactor, metadata.members())
+                .hasSize(replicationFactor));
+
+    // 3. every partition places exactly ZoneSpec#numberOfReplicas() replicas in each zone
+    result.forEach(
+        metadata ->
+            zoneSpecs.forEach(
+                spec -> {
+                  final long countInZone =
+                      metadata.members().stream().filter(m -> m.isInZone(spec.name())).count();
+                  assertThat(countInZone)
+                      .as(
+                          "partition %s must have %s replicas in zone '%s', but found %s",
+                          metadata.id(), spec.numberOfReplicas(), spec.name(), countInZone)
+                      .isEqualTo(spec.numberOfReplicas());
+                }));
+
+    // 4. the primary is always a member of a zone tied for the highest configured priority
+    final int topPriority = zoneSpecs.stream().mapToInt(ZoneSpec::priority).max().orElseThrow();
+    final Set<String> topZoneNames =
+        zoneSpecs.stream()
+            .filter(spec -> spec.priority() == topPriority)
+            .map(ZoneSpec::name)
+            .collect(Collectors.toSet());
+    result.forEach(
+        metadata -> {
+          final var primary = metadata.getPrimary().orElseThrow();
+          assertThat(topZoneNames)
+              .as(
+                  "partition %s's primary %s must belong to one of the top-priority zones %s",
+                  metadata.id(), primary, topZoneNames)
+              .contains(primary.zone());
+        });
+
+    // 5. primary/leader count is balanced across the top-priority zone(s)' members
+    final Map<MemberId, Integer> leaderCountByMember = new HashMap<>();
+    targetMembers.stream()
+        .filter(member -> topZoneNames.contains(member.zone()))
+        .forEach(member -> leaderCountByMember.put(member, 0));
+    result.forEach(
+        metadata ->
+            metadata
+                .getPrimary()
+                .ifPresent(primary -> leaderCountByMember.merge(primary, 1, Integer::sum)));
+    final int max =
+        leaderCountByMember.values().stream().mapToInt(Integer::intValue).max().orElse(0);
+    final int min =
+        leaderCountByMember.values().stream().mapToInt(Integer::intValue).min().orElse(0);
+    assertThat(max - min)
+        .as(
+            "primary count per top-priority-zone member must be balanced, but was %s",
+            leaderCountByMember)
+        .isLessThanOrEqualTo(primaryBalanceTolerance);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZonePartitionDistributionInvariants.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZonePartitionDistributionInvariants.java
@@ -99,14 +99,34 @@ final class ZonePartitionDistributionInvariants {
             metadata
                 .getPrimary()
                 .ifPresent(primary -> leaderCountByMember.merge(primary, 1, Integer::sum)));
-    final int max =
-        leaderCountByMember.values().stream().mapToInt(Integer::intValue).max().orElse(0);
-    final int min =
-        leaderCountByMember.values().stream().mapToInt(Integer::intValue).min().orElse(0);
+    assertBalanced(
+        leaderCountByMember, "primary count per top-priority-zone", primaryBalanceTolerance);
+
+    // 6. replica count is balanced across every zone's own available brokers — catches a
+    // reassigner that keeps piling replicas onto the same subset of a zone's brokers instead of
+    // spreading them across all brokers the zone actually has available
+    zoneSpecs.forEach(
+        spec -> {
+          final Map<MemberId, Integer> replicaCountByZoneMember = new HashMap<>();
+          targetMembers.stream()
+              .filter(member -> member.isInZone(spec.name()))
+              .forEach(member -> replicaCountByZoneMember.put(member, 0));
+          result.forEach(
+              metadata ->
+                  metadata.members().stream()
+                      .filter(member -> member.isInZone(spec.name()))
+                      .forEach(member -> replicaCountByZoneMember.merge(member, 1, Integer::sum)));
+          assertBalanced(
+              replicaCountByZoneMember, "replica count in zone '" + spec.name() + "'", 1);
+        });
+  }
+
+  private static void assertBalanced(
+      final Map<MemberId, Integer> countByMember, final String kind, final int tolerance) {
+    final int max = countByMember.values().stream().mapToInt(Integer::intValue).max().orElse(0);
+    final int min = countByMember.values().stream().mapToInt(Integer::intValue).min().orElse(0);
     assertThat(max - min)
-        .as(
-            "primary count per top-priority-zone member must be balanced, but was %s",
-            leaderCountByMember)
-        .isLessThanOrEqualTo(primaryBalanceTolerance);
+        .as("%s must be balanced, but was %s", kind, countByMember)
+        .isLessThanOrEqualTo(tolerance);
   }
 }


### PR DESCRIPTION
## Summary
- On a zone-aware cluster, provisioning a new physical tenant previously fell back to a full recompute via `ZoneAwarePartitionDistributor`, which is blind to current placement and can relocate an already-provisioned tenant's partitions as a side effect.
- Adds `ZoneAwareAdditivePartitionReassigner`, the zone-aware counterpart of `AdditivePartitionReassigner`: never touches an existing partition, places a new tenant's partitions with the exact per-zone replica counts and zone-priority-based leader-preference/failover ordering the configured `ZoneSpec`s require.
- Extracts shared zone/replica-count/broker-sufficiency validation out of `ZoneAwarePartitionDistributor` into `ZoneSpecValidation` so both implementations stay consistent.
- Wires the new reassigner into `PhysicalTenantProvisioningInitializer` in place of the full-recompute fallback.

closes #60565

🤖 Generated with [Claude Code](https://claude.com/claude-code)