### PR TITLE
Hard-delete agent definitions when the owning process definition is deleted

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentDefinitionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentDefinitionMapper.java
@@ -18,4 +18,6 @@ public interface AgentDefinitionMapper {
   Long count(AgentDefinitionDbQuery query);
 
   List<AgentDefinitionDbModel> search(AgentDefinitionDbQuery query);
+
+  int deleteByProcessDefinitionKeys(List<Long> processDefinitionKeys, int limit);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -58,6 +58,7 @@ public class RdbmsWriterFactory {
         mapperBundle.correlatedMessageSubscriptionMapper(),
         mapperBundle.clusterVariableMapper(),
         mapperBundle.historyDeletionMapper(),
+        mapperBundle.agentDefinitionMapper(),
         mapperBundle.agentHistoryMapper(),
         mapperBundle.agentInstanceMapper(),
         mapperBundle.waitStateMapper());

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
 import io.camunda.db.rdbms.sql.AgentHistoryMapper;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
@@ -115,6 +116,7 @@ public class RdbmsWriters implements AutoCloseable {
       final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
       final ClusterVariableMapper clusterVariableMapper,
       final HistoryDeletionMapper historyDeletionMapper,
+      final AgentDefinitionMapper agentDefinitionMapper,
       final AgentHistoryMapper agentHistoryMapper,
       final AgentInstanceMapper agentInstanceMapper,
       final WaitStateMapper waitStateMapper) {
@@ -191,7 +193,9 @@ public class RdbmsWriters implements AutoCloseable {
         new HistoryDeletionWriter(executionQueue, historyDeletionMapper));
     writers.put(GlobalListenerWriter.class, new GlobalListenerWriter(executionQueue));
     writers.put(DeployedResourceWriter.class, new DeployedResourceWriter(executionQueue));
-    writers.put(AgentDefinitionWriter.class, new AgentDefinitionWriter(executionQueue));
+    writers.put(
+        AgentDefinitionWriter.class,
+        new AgentDefinitionWriter(agentDefinitionMapper, executionQueue));
     writers.put(
         AgentHistoryWriter.class,
         new AgentHistoryWriter(executionQueue, agentHistoryMapper, vendorDatabaseProperties));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriter.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.util.List;
 
 public class AgentDefinitionWriter implements RdbmsWriter {
 
@@ -29,5 +30,11 @@ public class AgentDefinitionWriter implements RdbmsWriter {
             agentDefinition.agentDefinitionKey(),
             "io.camunda.db.rdbms.sql.AgentDefinitionMapper.insert",
             agentDefinition));
+  }
+
+  public int deleteByProcessDefinitionKeys(
+      final List<Long> processDefinitionKeys, final int limit) {
+    throw new UnsupportedOperationException(
+        "AgentDefinitionWriter#deleteByProcessDefinitionKeys is not implemented yet");
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
 import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
@@ -16,9 +17,12 @@ import java.util.List;
 
 public class AgentDefinitionWriter implements RdbmsWriter {
 
+  private final AgentDefinitionMapper mapper;
   private final ExecutionQueue executionQueue;
 
-  public AgentDefinitionWriter(final ExecutionQueue executionQueue) {
+  public AgentDefinitionWriter(
+      final AgentDefinitionMapper mapper, final ExecutionQueue executionQueue) {
+    this.mapper = mapper;
     this.executionQueue = executionQueue;
   }
 
@@ -34,7 +38,6 @@ public class AgentDefinitionWriter implements RdbmsWriter {
 
   public int deleteByProcessDefinitionKeys(
       final List<Long> processDefinitionKeys, final int limit) {
-    throw new UnsupportedOperationException(
-        "AgentDefinitionWriter#deleteByProcessDefinitionKeys is not implemented yet");
+    return mapper.deleteByProcessDefinitionKeys(processDefinitionKeys, limit);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -158,11 +158,15 @@ public class HistoryDeletionService {
         rdbmsWriters
             .getMessageSubscriptionWriter()
             .deleteStartEventSubscriptionsByProcessDefinitionKeys(processDefinitionKeys, limit);
+    final int deletedAgentDefinitions =
+        rdbmsWriters
+            .getAgentDefinitionWriter()
+            .deleteByProcessDefinitionKeys(processDefinitionKeys, limit);
     // remove process definition key variable name lookup rows
     rdbmsWriters
         .getVariableWriter()
         .deleteLookupByProcessDefinitionKeys(processDefinitionKeys, limit);
-    if (deletedSubscriptions >= limit) {
+    if (deletedSubscriptions >= limit || deletedAgentDefinitions >= limit) {
       return List.of();
     }
 

--- a/db/rdbms/src/main/resources/mapper/AgentDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentDefinitionMapper.xml
@@ -159,4 +159,44 @@
     </if>
   </sql>
 
+  <delete id="deleteByProcessDefinitionKeys">
+    DELETE FROM ${prefix}AGENT_DEFINITION
+    WHERE PROCESS_DEFINITION_KEY IN
+    <foreach collection="processDefinitionKeys" item="key" open="(" separator="," close=")">
+      #{key}
+    </foreach>
+    LIMIT #{limit}
+  </delete>
+
+  <delete id="deleteByProcessDefinitionKeys" databaseId="mssql">
+    DELETE TOP (#{limit})
+    FROM ${prefix}AGENT_DEFINITION
+    WHERE PROCESS_DEFINITION_KEY IN
+    <foreach collection="processDefinitionKeys" item="key" open="(" separator="," close=")">
+      #{key}
+    </foreach>
+  </delete>
+
+  <delete id="deleteByProcessDefinitionKeys" databaseId="oracle">
+    DELETE FROM ${prefix}AGENT_DEFINITION
+    WHERE rowid IN (SELECT rowid
+                    FROM ${prefix}AGENT_DEFINITION
+                    WHERE PROCESS_DEFINITION_KEY IN
+                    <foreach collection="processDefinitionKeys" item="key" open="(" separator="," close=")">
+                      #{key}
+                    </foreach>
+                    AND ROWNUM &lt;= #{limit})
+  </delete>
+
+  <delete id="deleteByProcessDefinitionKeys" databaseId="postgresql">
+    DELETE FROM ${prefix}AGENT_DEFINITION
+    WHERE ctid IN (SELECT ctid
+                   FROM ${prefix}AGENT_DEFINITION
+                   WHERE PROCESS_DEFINITION_KEY IN
+                   <foreach collection="processDefinitionKeys" item="key" open="(" separator="," close=")">
+                     #{key}
+                   </foreach>
+                   LIMIT #{limit})
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentDefinitionWriterTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.db.rdbms.sql.AgentDefinitionMapper;
 import io.camunda.db.rdbms.write.domain.AgentDefinitionDbModel.AgentDefinitionDbModelBuilder;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
@@ -21,8 +22,9 @@ import org.junit.jupiter.api.Test;
 
 class AgentDefinitionWriterTest {
 
+  private final AgentDefinitionMapper mapper = mock(AgentDefinitionMapper.class);
   private final ExecutionQueue executionQueue = mock(ExecutionQueue.class);
-  private final AgentDefinitionWriter writer = new AgentDefinitionWriter(executionQueue);
+  private final AgentDefinitionWriter writer = new AgentDefinitionWriter(mapper, executionQueue);
 
   @Test
   void shouldCreateAgentDefinition() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -273,6 +273,36 @@ public class HistoryDeletionServiceTest {
   }
 
   @Test
+  void shouldNotDeleteProcessDefinitionIfAgentDefinitionsNotFullyDeleted() {
+    // given
+    final var partitionId = 1;
+    final var processDefinitionKey = 1L;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(
+                        processDefinitionKey, HistoryDeletionTypeDbModel.PROCESS_DEFINITION))));
+    when(processInstanceDbReaderMock.search(any())).thenReturn(SearchQueryResult.empty());
+    when(rdbmsWritersMock
+            .getMessageSubscriptionWriter()
+            .deleteStartEventSubscriptionsByProcessDefinitionKeys(
+                List.of(processDefinitionKey), LIMIT))
+        .thenReturn(LIMIT - 1); // fully deleted, so this dependant must not cause the deferral
+    when(rdbmsWritersMock
+            .getAgentDefinitionWriter()
+            .deleteByProcessDefinitionKeys(List.of(processDefinitionKey), LIMIT))
+        .thenReturn(LIMIT); // not fully deleted
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(rdbmsWritersMock.getProcessDefinitionWriter(), never()).deleteByKeys(anyList());
+    verify(rdbmsWritersMock.getHistoryDeletionWriter(), never()).deleteByResourceKeys(anyList());
+  }
+
+  @Test
   void shouldApplyExponentialBackoffIfNothingToDelete() {
     // given
     final var partitionId = 1;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -220,6 +220,31 @@ public class HistoryDeletionServiceTest {
   }
 
   @Test
+  void shouldDeleteAgentDefinitionsWhenDeletingProcessDefinition() {
+    // given
+    final var partitionId = 1;
+    final var processDefinitionKey1 = 1L;
+    final var processDefinitionKey2 = 2L;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(
+                        processDefinitionKey1, HistoryDeletionTypeDbModel.PROCESS_DEFINITION),
+                    createModel(
+                        processDefinitionKey2, HistoryDeletionTypeDbModel.PROCESS_DEFINITION))));
+    when(processInstanceDbReaderMock.search(any())).thenReturn(SearchQueryResult.empty());
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(rdbmsWritersMock.getAgentDefinitionWriter())
+        .deleteByProcessDefinitionKeys(
+            eq(List.of(processDefinitionKey1, processDefinitionKey2)), anyInt());
+  }
+
+  @Test
   void shouldNotDeleteProcessDefinitionIfStartEventSubscriptionsNotFullyDeleted() {
     // given
     final var partitionId = 1;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -638,6 +638,60 @@ public class DeleteProcessDefinitionHistoryIT {
     awaitAgentDefinitionCount(otherProcessDefinitionKey, 1);
   }
 
+  @Test
+  void shouldNotDeleteAgentDefinitionsWhenDeletingProcessDefinitionWithoutHistory() {
+    // given - a deployed process with an agent-calling element
+    final var processId = Strings.newRandomValidBpmnId();
+    final var process =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeAiAgentSubProcessDefinition()
+                .endEvent("end")
+                .done(),
+            processId + ".bpmn");
+    final var processDefinitionKey = process.getProcessDefinitionKey();
+
+    // and - deploy-time creation of the agent definition has completed
+    awaitAgentDefinitionCount(processDefinitionKey, 1);
+
+    // when - the process definition is deleted without history (undeploy only, no hard delete)
+    final DeleteResourceResponse result =
+        camundaClient
+            .newDeleteResourceCommand(processDefinitionKey)
+            .deleteHistory(false)
+            .send()
+            .join();
+    assertThat(result.getCreateBatchOperationResponse()).isNull();
+
+    // then - the process definition is marked as deleted in secondary storage, which confirms
+    // the deletion pipeline has run
+    Awaitility.await("Process definition should be marked as deleted")
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var deleted =
+                  camundaClient
+                      .newProcessDefinitionSearchRequest()
+                      .filter(
+                          f ->
+                              f.processDefinitionKey(processDefinitionKey)
+                                  .state(ProcessDefinitionState.DELETED))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(deleted).hasSize(1);
+            });
+
+    // and - its agent definition is untouched, because undeploy without history must not remove
+    // secondary storage data
+    awaitAgentDefinitionCount(processDefinitionKey, 1);
+  }
+
   private void awaitAgentDefinitionCount(final long processDefinitionKey, final int expectedCount) {
     // under physical-tenant mode, camundaClient routes deploys through the tenant-scoped REST
     // path, so the process (and its agent definitions) land in that tenant's own store, not

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.historydeletion;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.util.TestHelper.assertAllProcessInstanceDependantDataDeleted;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
@@ -28,7 +29,11 @@ import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.configuration.HistoryDeletion;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
+import io.camunda.search.query.AgentDefinitionQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;
@@ -58,6 +63,9 @@ public class DeleteProcessDefinitionHistoryIT {
               });
 
   private static final Duration DELETION_TIMEOUT = Duration.ofSeconds(30);
+  private static final String AGENT_ELEMENT_ID = "agentAhsp";
+  private static final String AGENT_ELEMENT_ID_V1_1 = "agentAhspV1First";
+  private static final String AGENT_ELEMENT_ID_V1_2 = "agentAhspV1Second";
   private static CamundaClient camundaClient;
 
   @Test
@@ -549,6 +557,109 @@ public class DeleteProcessDefinitionHistoryIT {
             .join()
             .items();
     assertThat(remainingSubscriptions).hasSize(1);
+  }
+
+  @Test
+  void shouldDeleteAgentDefinitionsWhenDeletingProcessDefinitionWithHistory() {
+    // given - two versions of one process, each with an agent-calling element, plus a second,
+    // unrelated process with its own agent-calling element
+    final var processId = Strings.newRandomValidBpmnId();
+    // v1 has two agent-calling elements, so the delete assertion below proves a whole version's
+    // agent definitions are removed together, not just one
+    final var processV1 =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .adHocSubProcess(AGENT_ELEMENT_ID_V1_1, p -> p.task("agentTask1"))
+                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeAiAgentSubProcessDefinition()
+                .adHocSubProcess(AGENT_ELEMENT_ID_V1_2, p -> p.task("agentTask2"))
+                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeAiAgentSubProcessDefinition()
+                .endEvent("end")
+                .done(),
+            processId + "-v1.bpmn");
+    final var processDefinitionKeyV1 = processV1.getProcessDefinitionKey();
+
+    final var processV2 =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTaskV2"))
+                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeAiAgentSubProcessDefinition()
+                .endEvent("end")
+                .done(),
+            processId + "-v2.bpmn");
+    final var processDefinitionKeyV2 = processV2.getProcessDefinitionKey();
+
+    assertThat(processDefinitionKeyV2)
+        .describedAs(
+            "v1 and v2 differ only by inner task id, so Zeebe treats them as distinct deployments")
+        .isNotEqualTo(processDefinitionKeyV1);
+    assertThat(processV1.getVersion()).isEqualTo(1);
+    assertThat(processV2.getVersion()).isEqualTo(2);
+
+    final var otherProcessId = Strings.newRandomValidBpmnId();
+    final var otherProcess =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(otherProcessId)
+                .startEvent()
+                .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeAiAgentSubProcessDefinition()
+                .endEvent("end")
+                .done(),
+            otherProcessId + ".bpmn");
+    final var otherProcessDefinitionKey = otherProcess.getProcessDefinitionKey();
+
+    // and - deploy-time creation of all agent definitions has completed (v1 has two, v2 and the
+    // other process have one each)
+    awaitAgentDefinitionCount(processDefinitionKeyV1, 2);
+    awaitAgentDefinitionCount(processDefinitionKeyV2, 1);
+    awaitAgentDefinitionCount(otherProcessDefinitionKey, 1);
+
+    // when - only v1's history is hard-deleted
+    camundaClient
+        .newDeleteResourceCommand(processDefinitionKeyV1)
+        .deleteHistory(true)
+        .send()
+        .join();
+    assertProcessDefinitionDeleted(camundaClient, processDefinitionKeyV1);
+
+    // then - both of v1's agent definitions are gone, while v2's and the other process's survive
+    awaitAgentDefinitionCount(processDefinitionKeyV1, 0);
+    awaitAgentDefinitionCount(processDefinitionKeyV2, 1);
+    awaitAgentDefinitionCount(otherProcessDefinitionKey, 1);
+  }
+
+  private void awaitAgentDefinitionCount(final long processDefinitionKey, final int expectedCount) {
+    Awaitility.await(
+            "Agent definitions for process definition "
+                + processDefinitionKey
+                + " should number "
+                + expectedCount)
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        BROKER
+                            .bean(PhysicalTenantSearchClientReaders.class)
+                            .readersByPhysicalTenant()
+                            .get(DEFAULT_PHYSICAL_TENANT_ID)
+                            .agentDefinitionReader()
+                            .search(
+                                AgentDefinitionQuery.of(
+                                    b ->
+                                        b.filter(
+                                            f -> f.processDefinitionKeys(processDefinitionKey))),
+                                ResourceAccessChecks.disabled())
+                            .items())
+                    .hasSize(expectedCount));
   }
 
   /** Asserts that a process definition has been deleted from secondary storage. */

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.search.enums.MessageSubscriptionType;
 import io.camunda.client.api.search.enums.ProcessDefinitionState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.configuration.HistoryDeletion;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
@@ -37,6 +38,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;
+import java.util.Optional;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -637,6 +639,12 @@ public class DeleteProcessDefinitionHistoryIT {
   }
 
   private void awaitAgentDefinitionCount(final long processDefinitionKey, final int expectedCount) {
+    // under physical-tenant mode, camundaClient routes deploys through the tenant-scoped REST
+    // path, so the process (and its agent definitions) land in that tenant's own store, not
+    // "default" - read back from the same physical tenant the client wrote to
+    final var physicalTenantId =
+        Optional.ofNullable(CamundaMultiDBExtension.getPhysicalTenant())
+            .orElse(DEFAULT_PHYSICAL_TENANT_ID);
     Awaitility.await(
             "Agent definitions for process definition "
                 + processDefinitionKey
@@ -650,7 +658,7 @@ public class DeleteProcessDefinitionHistoryIT {
                         BROKER
                             .bean(PhysicalTenantSearchClientReaders.class)
                             .readersByPhysicalTenant()
-                            .get(DEFAULT_PHYSICAL_TENANT_ID)
+                            .get(physicalTenantId)
                             .agentDefinitionReader()
                             .search(
                                 AgentDefinitionQuery.of(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
@@ -14,12 +14,14 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
 import io.camunda.db.rdbms.write.service.HistoryDeletionService;
+import io.camunda.it.rdbms.db.fixtures.AgentDefinitionFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.history.ProcessInstanceHistory;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.Duration;
 import java.time.InstantSource;
 import org.junit.jupiter.api.Tag;
@@ -176,6 +178,74 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     assertThat(rdbmsService.getVariableReader().findLookupVariableNames(targetPdKey)).isEmpty();
     assertThat(rdbmsService.getVariableReader().findLookupVariableNames(controlPdKey))
         .containsExactly(controlVarName);
+  }
+
+  @TestTemplate
+  public void shouldDeleteAgentDefinitionsWhenDeletingProcessDefinition(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var writers = rdbmsService.createWriter(0);
+    final var historyDeletionService =
+        new HistoryDeletionService(
+            writers,
+            rdbmsService.getHistoryDeletionDbReader(),
+            rdbmsService.getProcessInstanceReader(),
+            rdbmsService.getDecisionInstanceReader(),
+            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10000),
+            InstantSource.system());
+
+    // target process definition — no live process instances so it is eligible for deletion
+    final var targetProcDef =
+        ProcessDefinitionFixtures.createAndSaveRandomProcessDefinition(writers, b -> b);
+    final long targetPdKey = targetProcDef.processDefinitionKey();
+    final var targetAgentDefinition =
+        AgentDefinitionFixtures.createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.processDefinitionKey(targetPdKey));
+
+    // control process definition whose agent definition must survive (not scheduled for deletion)
+    final var controlProcDef =
+        ProcessDefinitionFixtures.createAndSaveRandomProcessDefinition(writers, b -> b);
+    final long controlPdKey = controlProcDef.processDefinitionKey();
+    final var controlAgentDefinition =
+        AgentDefinitionFixtures.createAndSaveRandomAgentDefinition(
+            testApplication, b -> b.processDefinitionKey(controlPdKey));
+
+    // schedule target process definition for deletion (no live process instances)
+    final var deletionModel =
+        new HistoryDeletionDbModel.Builder()
+            .resourceKey(targetPdKey)
+            .resourceType(HistoryDeletionDbModel.HistoryDeletionTypeDbModel.PROCESS_DEFINITION)
+            .batchOperationKey(ProcessInstanceFixtures.nextKey())
+            .partitionId(0)
+            .build();
+    writers.getHistoryDeletionWriter().create(deletionModel);
+    writers.flush();
+
+    // pre-condition: the target agent definition exists
+    assertThat(
+            rdbmsService
+                .getAgentDefinitionDbReader()
+                .getByKey(
+                    targetAgentDefinition.agentDefinitionKey(), ResourceAccessChecks.disabled()))
+        .isNotNull();
+
+    // when
+    historyDeletionService.deleteHistory(0);
+
+    // then: target agent definition removed; control untouched
+    assertThat(
+            rdbmsService
+                .getAgentDefinitionDbReader()
+                .getByKey(
+                    targetAgentDefinition.agentDefinitionKey(), ResourceAccessChecks.disabled()))
+        .isNull();
+    assertThat(
+            rdbmsService
+                .getAgentDefinitionDbReader()
+                .getByKey(
+                    controlAgentDefinition.agentDefinitionKey(), ResourceAccessChecks.disabled()))
+        .isNotNull();
   }
 
   private void auditLogsNotDeleted(final RdbmsService rdbmsService, final long processInstanceKey) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.historydeletion;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.handlers.batchoperation.AbstractOperationHandler;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
@@ -52,6 +53,7 @@ public class HistoryDeletionJob implements BackgroundTask {
   private final DecisionRequirementsIndex decisionRequirementsIndex;
   private final DecisionIndex decisionIndex;
   private final MessageSubscriptionTemplate messageSubscriptionTemplate;
+  private final AgentDefinitionIndex agentDefinitionIndex;
 
   public HistoryDeletionJob(
       final List<ProcessInstanceDependant> processInstanceDependants,
@@ -76,6 +78,7 @@ public class HistoryDeletionJob implements BackgroundTask {
     decisionIndex = resourceProvider.getIndexDescriptor(DecisionIndex.class);
     messageSubscriptionTemplate =
         resourceProvider.getIndexTemplateDescriptor(MessageSubscriptionTemplate.class);
+    agentDefinitionIndex = resourceProvider.getIndexDescriptor(AgentDefinitionIndex.class);
   }
 
   @Override
@@ -196,8 +199,9 @@ public class HistoryDeletionJob implements BackgroundTask {
   }
 
   /**
-   * This method will delete a batch of process definitions by deleting the process definitions from
-   * the process index
+   * This method will delete a batch of process definitions by deleting their dependants (message
+   * subscriptions, agent definitions) and then the process definitions themselves from the process
+   * index.
    *
    * @param batch The batch of entities to delete
    * @return A future containing the list of history-deletion IDs that were processed
@@ -214,6 +218,12 @@ public class HistoryDeletionJob implements BackgroundTask {
             messageSubscriptionTemplate.getIndexPattern(),
             MessageSubscriptionTemplate.PROCESS_KEY,
             processDefinitions)
+        .thenCompose(
+            ignored ->
+                deleterRepository.deleteDocumentsByField(
+                    agentDefinitionIndex.getFullQualifiedName(),
+                    AgentDefinitionIndex.PROCESS_DEFINITION_KEY,
+                    processDefinitions))
         .thenCompose(
             ignored ->
                 deleterRepository.deleteDocumentsById(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.exporter.handlers.batchoperation.AbstractOperationHandler;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.index.AgentDefinitionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
@@ -55,6 +56,7 @@ final class HistoryDeletionJobTest {
   private DecisionInstanceTemplate decisionInstanceTemplate;
   private DecisionRequirementsIndex decisionRequirementsIndex;
   private DecisionIndex decisionIndex;
+  private AgentDefinitionIndex agentDefinitionIndex;
 
   @BeforeEach
   void setUp() {
@@ -74,6 +76,7 @@ final class HistoryDeletionJobTest {
     decisionRequirementsIndex =
         resourceProvider.getIndexDescriptor(DecisionRequirementsIndex.class);
     decisionIndex = resourceProvider.getIndexDescriptor(DecisionIndex.class);
+    agentDefinitionIndex = resourceProvider.getIndexDescriptor(AgentDefinitionIndex.class);
     job = new HistoryDeletionJob(dependants, executor, repository, LOGGER, resourceProvider);
     when(repository.createAuditLogCleanupEntries(anyList(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -352,6 +355,42 @@ final class HistoryDeletionJobTest {
     verify(repository)
         .deleteDocumentsById(
             historyDeletionIndex.getFullQualifiedName(), List.of(processInstanceEntity.getId()));
+  }
+
+  @Test
+  void shouldDeleteAgentDefinitionsWhenDeletingProcessDefinitionHistory() {
+    // given
+    final var entity1 =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    final var entity2 =
+        new HistoryDeletionEntity()
+            .setId("id2")
+            .setResourceKey(2L)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(
+            CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity1, entity2))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository)
+        .deleteDocumentsByField(
+            agentDefinitionIndex.getFullQualifiedName(),
+            AgentDefinitionIndex.PROCESS_DEFINITION_KEY,
+            List.of(entity1.getResourceKey(), entity2.getResourceKey()));
   }
 
   @Test


### PR DESCRIPTION
## Description

Hard-deleting a process definition's history did not remove its agent definitions. Delete resource (undeploy) cleaned them up on the engine side only, but they are kept in secondary storage to retain history. This PR adds agent-definition deletion to the history-deletion path in both storages, ES/OS and RDBMS. It deletes by `processDefinitionKey`. It mirrors the existing decision-requirements delete in ES/OS and the variable-name-lookup delete in RDBMS.

RDBMS deletes agent definitions in batches, using the existing `LIMIT` pattern. If a batch hits the limit, the process-definition row delete waits for the next pass. That's the same behavior the message-subscription delete already has.

Two things the diff does not show:

- This PR branches off #60470, not `main`. That PR adds the RDBMS read path for agent definitions and the mapper interface this PR extends. Without it, the tests here would not compile. Rebase onto `main` once #60470 merges.
- The `DeleteProcessDefinitionHistoryIT` test (`@MultiDbTest`) is a full round trip through the engine: deploy a process, hard-delete its history, then check the public API. This overlaps with a separate, already-blocked E2E task for this issue. That overlap is on purpose. It's the only way to prove the agent definitions are gone from the API, for both storages. Please don't flag it as scope creep.

Out of scope: this PR does not add a test proving the RDBMS limit check treats each dependent delete independently, instead of summing them. That behavior is not new. `HistoryDeletionService` already works this way for the subscription delete.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #59074
