### PR TITLE
feat: submit and await exporting state changes through the dynamic API

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeAwaiter.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeAwaiter.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.zeebe.util.Unit.unit;
+
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.util.Either;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Awaits completion of a cluster configuration change submitted through a {@link
+ * ClusterConfigurationManagementRequestSender}, polling the cluster topology until the change has
+ * been fully applied. Useful for callers that need a synchronous request/response contract on top
+ * of the otherwise asynchronous cluster configuration change mechanism.
+ */
+@NullMarked
+public final class ClusterConfigurationChangeAwaiter {
+
+  private final ClusterConfigurationManagementRequestSender requestSender;
+  private final Duration pollInterval;
+  private final Duration timeout;
+
+  public ClusterConfigurationChangeAwaiter(
+      final ClusterConfigurationManagementRequestSender requestSender,
+      final Duration pollInterval,
+      final Duration timeout) {
+    this.requestSender = requestSender;
+    this.pollInterval = pollInterval;
+    this.timeout = timeout;
+  }
+
+  /**
+   * Completes once the change submitted via {@code submission} has been fully applied. Fails if
+   * submission failed, the change failed to apply or was cancelled, its outcome could not be
+   * observed before it aged out of the bounded history window, or the timeout elapses first.
+   */
+  public CompletableFuture<Void> awaitCompletion(
+      final CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+          submission) {
+    final long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    return submission.thenCompose(response -> onSubmitted(response, deadlineNanos));
+  }
+
+  private CompletableFuture<Void> onSubmitted(
+      final Either<ErrorResponse, ClusterConfigurationChangeResponse> response,
+      final long deadlineNanos) {
+    if (response.isLeft()) {
+      return CompletableFuture.failedFuture(errorFrom(response.getLeft()));
+    }
+
+    final var change = response.get();
+    // An empty plan means the cluster is already in the requested state: nothing to await.
+    final var phases =
+        change.response() != null
+            ? change.response().phases()
+            : change.legacyResponse().plannedChanges();
+    if (phases.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    return awaitChange(change.changeId(), deadlineNanos);
+  }
+
+  private CompletableFuture<Void> awaitChange(final long changeId, final long deadlineNanos) {
+    return requestSender
+        .getTopology()
+        .thenCompose(
+            topology -> {
+              if (topology.isLeft()) {
+                return CompletableFuture.failedFuture(errorFrom(topology.getLeft()));
+              }
+
+              return switch (progressOf(topology.get(), changeId)) {
+                case COMPLETED -> CompletableFuture.completedFuture(unit());
+                case FAILED ->
+                    CompletableFuture.failedFuture(
+                        new IllegalStateException(
+                            "Cluster configuration change " + changeId + " failed to apply"));
+                case CANCELLED ->
+                    CompletableFuture.failedFuture(
+                        new IllegalStateException(
+                            "Cluster configuration change " + changeId + " was cancelled"));
+                case UNKNOWN ->
+                    CompletableFuture.failedFuture(
+                        new IllegalStateException(
+                            "Cluster configuration change "
+                                + changeId
+                                + " has an unknown outcome: it aged out of the bounded history"
+                                + " window before it could be observed"));
+                case PENDING -> {
+                  if (System.nanoTime() >= deadlineNanos) {
+                    yield CompletableFuture.failedFuture(
+                        new TimeoutException(
+                            "Timed out waiting for cluster configuration change " + changeId));
+                  }
+                  yield CompletableFuture.supplyAsync(() -> null, delayedExecutor())
+                      .thenCompose(ignored -> awaitChange(changeId, deadlineNanos));
+                }
+              };
+            });
+  }
+
+  /**
+   * Determines the progress of the change we submitted, identified by {@code changeId}, from the
+   * {@link io.camunda.zeebe.dynamic.config.state.PhasedChangeState} of whichever member answered
+   * this poll of {@link ClusterConfigurationManagementRequestSender#getTopology()} (normally the
+   * coordinator, but a coordinator failover between submission and awaiting can change who that
+   * is). Plans can now run concurrently (scoped to disjoint physical tenants), so a newer id
+   * resolving does not imply ours has: unlike the single-pending-plan model, {@code changeId} must
+   * be looked up directly rather than compared against "the last completed change".
+   */
+  private static Progress progressOf(
+      final CurrentClusterConfiguration configuration, final long changeId) {
+    final var phasedChangeState = configuration.phasedChangeState();
+    if (phasedChangeState.pending().containsKey(changeId)) {
+      return Progress.PENDING;
+    }
+
+    final var completed = phasedChangeState.historyFor(changeId);
+    if (completed.isPresent()) {
+      return switch (completed.get().status()) {
+        case COMPLETED -> Progress.COMPLETED;
+        case CANCELLED -> Progress.CANCELLED;
+        case FAILED -> Progress.FAILED;
+      };
+    }
+
+    if (!phasedChangeState.wasIssued(changeId)) {
+      // The member we polled has not gossiped changeId yet: from its perspective the change has
+      // not started, which is indistinguishable from still pending.
+      return Progress.PENDING;
+    }
+
+    // Resolved (issued, not pending, no history entry): it aged out of the bounded history window
+    // before we polled its outcome. The window retains at most 10 terminal records (across
+    // COMPLETED, FAILED, and CANCELLED), so with concurrent per-tenant plans any of those can be
+    // evicted before the next poll — we genuinely cannot tell which one this was, so report it as
+    // UNKNOWN rather than asserting either COMPLETED (hides a real failure) or FAILED (asserts a
+    // failure that may not have happened).
+    return Progress.UNKNOWN;
+  }
+
+  private static Exception errorFrom(final ErrorResponse error) {
+    return error.toException();
+  }
+
+  private Executor delayedExecutor() {
+    return CompletableFuture.delayedExecutor(pollInterval.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  private enum Progress {
+    PENDING,
+    COMPLETED,
+    FAILED,
+    CANCELLED,
+    UNKNOWN
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
@@ -95,6 +96,9 @@ public interface ClusterConfigurationManagementApi {
       ExporterEnableRequest enableRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> modeChange(ModeChangeRequest modeChangeRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> changeExportingState(
+      ExportingStateChangeRequest exportingStateChangeRequest);
 
   ActorFuture<CurrentClusterConfiguration> cancelTopologyChange(
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
@@ -300,6 +301,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.MODE_CHANGE.topic(),
         request,
         serializer::encodeModeChangeRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      changeExportingState(final ExportingStateChangeRequest request) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.EXPORTING_STATE_CHANGE.topic(),
+        request,
+        serializer::encodeExportingStateChangeRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
@@ -256,6 +257,15 @@ public final class ClusterConfigurationManagementRequestsHandler
       final ModeChangeRequest modeChangeRequest) {
     return handleRequest(
         modeChangeRequest.dryRun(), new ModeChangeRequestTransformer(modeChangeRequest));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> changeExportingState(
+      final ExportingStateChangeRequest exportingStateChangeRequest) {
+    return handleRequest(
+        exportingStateChangeRequest.dryRun(),
+        new ExportingStateChangeRequestTransformer(
+            exportingStateChangeRequest.state(), exportingStateChangeRequest.physicalTenantId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -54,6 +54,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerForceRemoveBrokersRequestHandler();
     registerPurgeRequestHandler();
     registerModeChangeHandler();
+    registerExportingStateChangeHandler();
     registerRestoreHandler();
     registerClusterRestoreHandler();
     registerForceRemoveZoneHandler();
@@ -235,6 +236,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.MODE_CHANGE.topic(),
         serializer::decodeModeChangeRequest,
         request -> mapResponse(clusterConfigurationManagementApi.modeChange(request)),
+        this::encodeResponse);
+  }
+
+  private void registerExportingStateChangeHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.EXPORTING_STATE_CHANGE.topic(),
+        serializer::decodeExportingStateChangeRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.changeExportingState(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -26,6 +26,7 @@ public enum ClusterConfigurationRequestTopics {
   UPDATE_ROUTING_STATE("topology-cluster-update-routing-state"),
   UPDATE_PARTITION_DISTRIBUTION("topology-cluster-update-partition-distribution"),
   MODE_CHANGE("topology-mode-change"),
+  EXPORTING_STATE_CHANGE("topology-exporting-state-change"),
   RESTORE("cluster-restore"),
   CLUSTER_ADMIN_RESTORE("cluster-admin-restore"),
   ZONE_MIGRATION("topology-cluster-zone-migration"),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/DynamicConfigExportingStateController.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/DynamicConfigExportingStateController.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Applies exporting state changes through dynamic cluster configuration, scoped to the physical
+ * tenant a {@link ByTenant} was resolved for, so that a pause survives restarts and applies to
+ * partitions that join later.
+ *
+ * <p>The poll interval and timeout used while awaiting the change are configurable so tests do not
+ * have to wait on production defaults.
+ */
+@NullMarked
+public final class DynamicConfigExportingStateController implements ExportingStateController {
+
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(200);
+  private static final Duration TIMEOUT = Duration.ofSeconds(60);
+
+  private final ClusterConfigurationManagementRequestSender requestSender;
+  private final ClusterConfigurationChangeAwaiter changeAwaiter;
+
+  public DynamicConfigExportingStateController(
+      final ClusterConfigurationManagementRequestSender requestSender) {
+    this(requestSender, POLL_INTERVAL, TIMEOUT);
+  }
+
+  public DynamicConfigExportingStateController(
+      final ClusterConfigurationManagementRequestSender requestSender,
+      final Duration pollInterval,
+      final Duration timeout) {
+    this.requestSender = requestSender;
+    changeAwaiter = new ClusterConfigurationChangeAwaiter(requestSender, pollInterval, timeout);
+  }
+
+  @Override
+  public ExportingStateController.ByTenant getByTenant(final String physicalTenantId) {
+    return new TenantController(physicalTenantId);
+  }
+
+  private CompletableFuture<Void> changeState(
+      final String physicalTenantId, final ExportingState targetState) {
+    return changeAwaiter.awaitCompletion(
+        requestSender.changeExportingState(
+            new ExportingStateChangeRequest(targetState, Optional.of(physicalTenantId), false)));
+  }
+
+  private CompletableFuture<ExportingStatus> queryStatus(final String physicalTenantId) {
+    return requestSender
+        .getTopology()
+        .thenApply(
+            topology -> {
+              if (topology.isLeft()) {
+                throw topology.getLeft().toException();
+              }
+              return aggregateStatus(physicalTenantId, topology.get());
+            });
+  }
+
+  /**
+   * Exporting state is stored per partition replica, so replicas can disagree mid-rollout; {@link
+   * ExportingStatus#aggregate(java.util.Collection)} folds them into a single status, or {@code
+   * MIXED} when they don't agree. A physical tenant that does not exist, or is disabled, has no
+   * live status to report — {@link #changeState} already rejects both the same way (the coordinator
+   * plans against {@link CurrentClusterConfiguration#activePartitionGroups()}), and folding either
+   * into {@code MIXED} would look indistinguishable from a real, converged tenant that merely
+   * disagrees, so both are rejected here as {@link NotFound} instead.
+   */
+  private static ExportingStatus aggregateStatus(
+      final String physicalTenantId, final CurrentClusterConfiguration configuration) {
+    final PartitionGroupConfiguration group = configuration.partitionGroup(physicalTenantId);
+    if (group == null || group.isDisabled()) {
+      throw new NotFound(
+          "Expected to query the exporting status of physical tenant '%s', but there's no such tenant"
+              .formatted(physicalTenantId));
+    }
+    return ExportingStatus.aggregate(
+        group.members().values().stream()
+            .flatMap(member -> member.partitions().values().stream())
+            .map(DynamicConfigExportingStateController::exportingStateOf)
+            .toList());
+  }
+
+  /**
+   * A partition's {@code exporting} config is {@code null} until something initializes it (e.g.
+   * {@code ExporterStateInitializer} on the local member after restart, or the receiving side of a
+   * gossip update from a peer that has not run that initializer yet, or a peer still on a wire
+   * format that predates this field). {@link ExportingStateChangeRequestTransformer} already treats
+   * that as equivalent to {@link ExportingState#UNKNOWN} rather than dereferencing it; this mirrors
+   * that instead of risking a {@link NullPointerException}.
+   */
+  private static ExportingState exportingStateOf(final PartitionState partition) {
+    final var config = partition.config();
+    return config.isInitialized() ? config.exporting().state() : ExportingState.UNKNOWN;
+  }
+
+  private final class TenantController implements ExportingStateController.ByTenant {
+
+    private final String physicalTenantId;
+
+    private TenantController(final String physicalTenantId) {
+      this.physicalTenantId = physicalTenantId;
+    }
+
+    @Override
+    public CompletableFuture<Void> pauseExporting() {
+      return changeState(physicalTenantId, ExportingState.PAUSED);
+    }
+
+    @Override
+    public CompletableFuture<Void> softPauseExporting() {
+      return changeState(physicalTenantId, ExportingState.SOFT_PAUSED);
+    }
+
+    @Override
+    public CompletableFuture<Void> resumeExporting() {
+      return changeState(physicalTenantId, ExportingState.EXPORTING);
+    }
+
+    @Override
+    public CompletableFuture<ExportingStatus> getExportingStatus() {
+      return queryStatus(physicalTenantId);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ErrorResponse.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ErrorResponse.java
@@ -9,6 +9,26 @@ package io.camunda.zeebe.dynamic.config.api;
 
 public record ErrorResponse(ErrorCode code, String message) {
 
+  /**
+   * Maps this error response to the corresponding typed {@link
+   * ClusterConfigurationRequestFailedException} subtype so callers can distinguish, for example, a
+   * {@link ClusterConfigurationRequestFailedException.NotFound} (missing or disabled tenant) from
+   * an {@link ClusterConfigurationRequestFailedException.InternalError}.
+   */
+  public RuntimeException toException() {
+    return switch (code) {
+      case INVALID_REQUEST ->
+          new ClusterConfigurationRequestFailedException.InvalidRequest(message);
+      case OPERATION_NOT_ALLOWED ->
+          new ClusterConfigurationRequestFailedException.OperationNotAllowed(message);
+      case CONCURRENT_MODIFICATION ->
+          new ClusterConfigurationRequestFailedException.ConcurrentModificationException(message);
+      case INTERNAL_ERROR -> new ClusterConfigurationRequestFailedException.InternalError(message);
+      case INVALID_STATE -> new ClusterConfigurationRequestFailedException.InvalidState(message);
+      case NOT_FOUND -> new ClusterConfigurationRequestFailedException.NotFound(message);
+    };
+  }
+
   public enum ErrorCode {
     INVALID_REQUEST,
     OPERATION_NOT_ALLOWED,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExportingStateController.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExportingStateController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Resolves the {@link ByTenant} controller for a physical tenant, so callers pick their scope once
+ * and then issue operations without repeating it.
+ *
+ * <p>This is the intended single abstraction for changing exporting state: once endpoint wiring is
+ * complete, the {@code /actuator/exporting} and {@code /actuator/partitions} endpoints and the v2
+ * exporting API will all go through it, so they cannot drift on how a change is submitted or
+ * awaited.
+ */
+@NullMarked
+@FunctionalInterface
+public interface ExportingStateController {
+
+  ByTenant getByTenant(String physicalTenantId);
+
+  /**
+   * Controls exporting for the partitions of the single physical tenant this instance was resolved
+   * for, mirroring the exporting operations of {@code BrokerAdminService}. The returned futures
+   * complete once the requested state has actually been applied, so callers can expose a
+   * synchronous request/response contract. The returned futures are guaranteed to terminate within
+   * a timeout.
+   */
+  interface ByTenant {
+
+    CompletableFuture<Void> pauseExporting();
+
+    CompletableFuture<Void> softPauseExporting();
+
+    CompletableFuture<Void> resumeExporting();
+
+    /**
+     * Returns the exporting status aggregated over every partition replica, so callers can confirm
+     * a pause took effect instead of relying on their own bookkeeping.
+     */
+    CompletableFuture<ExportingStatus> getExportingStatus();
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExportingStatus.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExportingStatus.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The exporting status aggregated over every replica of every partition of a physical tenant.
+ *
+ * <p>Pause and resume are applied to all replicas, so a status is only meaningful for backup
+ * tooling if all replicas agree; when they don't, the tenant is {@link #MIXED} and the operation is
+ * still in flight or was only partially applied.
+ */
+@NullMarked
+public enum ExportingStatus {
+  /** All replicas are actively exporting and committing their position. */
+  EXPORTING,
+  /** All replicas are paused, nothing is being exported. */
+  PAUSED,
+  /** All replicas keep exporting but do not commit their position. */
+  SOFT_PAUSED,
+  /** Replicas report different phases, so the tenant is in no single well-defined phase. */
+  MIXED;
+
+  /**
+   * Aggregates the states of the individual replicas: a single status if they all agree, {@link
+   * #MIXED} otherwise. {@link ExportingState#UNKNOWN} means the replica has never been touched by a
+   * state-change operation, which is equivalent to actively exporting.
+   */
+  public static ExportingStatus aggregate(final Collection<ExportingState> replicaStates) {
+    return aggregateStates(
+        replicaStates.stream()
+            .map(state -> state == ExportingState.UNKNOWN ? ExportingState.EXPORTING : state)
+            .collect(Collectors.toSet()));
+  }
+
+  /**
+   * Throws on a state this enum does not know rather than folding it into {@link #MIXED}: a state
+   * added to {@link ExportingState} would otherwise be reported as a benign "pause still in flight"
+   * forever, and the mismatch would never surface. Failing the request makes it a visible error
+   * instead. This enum is not the only thing that would need updating anyway -- a new state also
+   * needs a status to map onto in the REST response.
+   */
+  private static ExportingStatus aggregateStates(final Set<ExportingState> reportedStates) {
+    if (reportedStates.size() != 1) {
+      return MIXED;
+    }
+
+    final var state = reportedStates.iterator().next();
+    return switch (state) {
+      case EXPORTING -> EXPORTING;
+      case PAUSED -> PAUSED;
+      case SOFT_PAUSED -> SOFT_PAUSED;
+      case UNKNOWN ->
+          throw new IllegalArgumentException(
+              "Expected a partition replica to report a known exporting state, but got UNKNOWN "
+                  + "after normalization to EXPORTING");
+    };
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
@@ -1197,6 +1198,115 @@ abstract class ClusterConfigurationManagementApiTestBase {
                 .getMember(coordinatorId)
                 .mode())
         .isEqualTo(Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldApplyExportingStateChangeEndToEndForLocalMember() {
+    // given — the coordinator is active and exporting in the default group
+    setCurrentTopology(
+        ClusterConfiguration.init()
+            .addMember(
+                coordinatorId,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when — pause exporting
+    clientApi
+        .changeExportingState(
+            new ExportingStateChangeRequest(
+                ExportingState.PAUSED,
+                Optional.of(CurrentClusterConfiguration.DEFAULT_GROUP),
+                false))
+        .join()
+        .get();
+
+    // then — the plan is applied and the coordinator's partition is now paused
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(
+            config
+                .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                .getMember(coordinatorId)
+                .partitions()
+                .get(1)
+                .config()
+                .exporting()
+                .state())
+        .isEqualTo(ExportingState.PAUSED);
+  }
+
+  @Test
+  void shouldApplyExportingStateChangeToEveryPhysicalTenantInOnePlan() {
+    // given
+    wireTwoPhysicalTenants();
+
+    // when
+    clientApi
+        .changeExportingState(
+            new ExportingStateChangeRequest(ExportingState.PAUSED, Optional.empty(), false))
+        .join()
+        .get();
+
+    // then
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(
+            config
+                .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                .getMember(coordinatorId)
+                .partitions()
+                .get(1)
+                .config()
+                .exporting()
+                .state())
+        .isEqualTo(ExportingState.PAUSED);
+    assertThat(
+            config
+                .partitionGroup(TENANT_B)
+                .getMember(coordinatorId)
+                .partitions()
+                .get(1)
+                .config()
+                .exporting()
+                .state())
+        .isEqualTo(ExportingState.PAUSED);
+  }
+
+  @Test
+  void shouldApplyExportingStateChangeToOnlyTheRequestedPhysicalTenant() {
+    // given
+    wireTwoPhysicalTenants();
+
+    // when
+    clientApi
+        .changeExportingState(
+            new ExportingStateChangeRequest(ExportingState.PAUSED, Optional.of(TENANT_B), false))
+        .join()
+        .get();
+
+    // then
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(
+            config
+                .partitionGroup(TENANT_B)
+                .getMember(coordinatorId)
+                .partitions()
+                .get(1)
+                .config()
+                .exporting()
+                .state())
+        .isEqualTo(ExportingState.PAUSED);
+    assertThat(
+            config
+                .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                .getMember(coordinatorId)
+                .partitions()
+                .get(1)
+                .config()
+                .exporting()
+                .state())
+        .isEqualTo(ExportingState.UNKNOWN);
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeAwaiterTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeAwaiterTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ExportingStateChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.util.Either;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+final class ClusterConfigurationChangeAwaiterTest {
+
+  private final ClusterConfigurationManagementRequestSender sender =
+      mock(ClusterConfigurationManagementRequestSender.class);
+  private final ClusterConfigurationChangeAwaiter awaiter =
+      new ClusterConfigurationChangeAwaiter(sender, Duration.ofMillis(1), Duration.ofSeconds(10));
+
+  @Test
+  void shouldCompleteImmediatelyWhenPlanIsEmpty() {
+    // when
+    final var result = awaiter.awaitCompletion(emptyPlan());
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void shouldCompleteWhenChangeCompletes() {
+    // given
+    when(sender.getTopology())
+        .thenReturn(
+            topology(nextId(), pending(), history(completed(7, PhasedChangePlanStatus.COMPLETED))));
+
+    // when
+    final var result = awaiter.awaitCompletion(plan(7));
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void shouldPollUntilChangeCompletes() {
+    // given
+    when(sender.getTopology())
+        .thenReturn(topology(nextId(), pending(pendingPlan(7)), history()))
+        .thenReturn(topology(nextId(), pending(pendingPlan(7)), history()))
+        .thenReturn(
+            topology(nextId(), pending(), history(completed(7, PhasedChangePlanStatus.COMPLETED))));
+
+    // when
+    final var result = awaiter.awaitCompletion(plan(7));
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(1));
+    verify(sender, atLeast(3)).getTopology();
+  }
+
+  @Test
+  void shouldWaitWhenThisReplicaHasNotGossipedTheChangeYet() {
+    // given — nextId has not caught up to changeId 7 on this replica yet
+    when(sender.getTopology())
+        .thenReturn(topology(1L, pending(), history()))
+        .thenReturn(
+            topology(nextId(), pending(), history(completed(7, PhasedChangePlanStatus.COMPLETED))));
+
+    // when
+    final var result = awaiter.awaitCompletion(plan(7));
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(1));
+    verify(sender, atLeast(2)).getTopology();
+  }
+
+  @Test
+  void shouldFailWithAnUnknownOutcomeWhenTheChangeHasAgedOutOfTheHistoryWindow() {
+    // given — changeId 7 was issued (nextId has advanced past it) but neither pending nor
+    // history mention it any more: it aged out of the bounded history window before we could
+    // observe how it resolved
+    when(sender.getTopology()).thenReturn(topology(nextId(), pending(), history()));
+
+    // when
+    final var result = awaiter.awaitCompletion(plan(7));
+
+    // then — distinct from both a genuine failure and a genuine completion: we cannot tell which
+    // one this was, so it must not be asserted as either
+    assertThat(result)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("unknown outcome");
+  }
+
+  @Test
+  void shouldFailWhenChangeFailed() {
+    // given
+    when(sender.getTopology())
+        .thenReturn(
+            topology(nextId(), pending(), history(completed(7, PhasedChangePlanStatus.FAILED))));
+
+    // when
+    final var result = awaiter.awaitCompletion(plan(7));
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class);
+  }
+
+  @Test
+  void shouldFailWhenChangeWasCancelled() {
+    // given
+    when(sender.getTopology())
+        .thenReturn(
+            topology(nextId(), pending(), history(completed(7, PhasedChangePlanStatus.CANCELLED))));
+
+    // when
+    final var result = awaiter.awaitCompletion(plan(7));
+
+    // then — distinct from a genuine failure, so an operator-triggered cancel isn't misreported
+    // as the plan failing to apply
+    assertThat(result)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("cancelled");
+  }
+
+  @Test
+  void shouldFailWhenSubmitFails() {
+    // given
+    final var submission =
+        CompletableFuture.completedFuture(
+            Either.<ErrorResponse, ClusterConfigurationChangeResponse>left(
+                new ErrorResponse(ErrorCode.INVALID_REQUEST, "nope")));
+
+    // when
+    final var result = awaiter.awaitCompletion(submission);
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class);
+  }
+
+  @Test
+  void shouldFallbackToLegacyResponseWhenCurrentConfigurationResponseIsMissing() {
+    // given
+    when(sender.getTopology())
+        .thenReturn(
+            topology(nextId(), pending(), history(completed(7, PhasedChangePlanStatus.COMPLETED))));
+    final var submission =
+        CompletableFuture.completedFuture(
+            Either.<ErrorResponse, ClusterConfigurationChangeResponse>right(
+                new ClusterConfigurationChangeResponse(
+                    7,
+                    new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                        Map.of(),
+                        Map.of(),
+                        List.of(
+                            new ExportingStateChangeOperation(
+                                MemberId.from("0"), ExportingState.PAUSED))),
+                    null)));
+
+    // when
+    final var result = awaiter.awaitCompletion(submission);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void shouldFailWhenChangeNeverCompletes() {
+    // given
+    final var timingOutAwaiter =
+        new ClusterConfigurationChangeAwaiter(sender, Duration.ofMillis(1), Duration.ofMillis(5));
+    when(sender.getTopology()).thenReturn(topology(nextId(), pending(pendingPlan(7)), history()));
+
+    // when
+    final var result = timingOutAwaiter.awaitCompletion(plan(7));
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .isInstanceOf(TimeoutException.class);
+  }
+
+  private CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> emptyPlan() {
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new ClusterConfigurationChangeResponse(
+                0,
+                new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                    Map.of(), Map.of(), List.of()),
+                new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
+                    CurrentClusterConfiguration.init(),
+                    CurrentClusterConfiguration.init(),
+                    List.of()))));
+  }
+
+  private CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> plan(
+      final long changeId) {
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new ClusterConfigurationChangeResponse(
+                changeId,
+                new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                    Map.of(),
+                    Map.of(),
+                    List.of(
+                        new ExportingStateChangeOperation(
+                            MemberId.from("0"), ExportingState.PAUSED))),
+                new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
+                    CurrentClusterConfiguration.init(),
+                    CurrentClusterConfiguration.init(),
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                "default",
+                                List.of(
+                                    new ExportingStateChangeOperation(
+                                        MemberId.from("0"), ExportingState.PAUSED)))))))));
+  }
+
+  private CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> topology(
+      final long nextId,
+      final Map<Long, PhasedChangePlan> pending,
+      final List<CompletedPhasedChange> history) {
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new CurrentClusterConfiguration(
+                CurrentClusterConfiguration.INITIAL_VERSION,
+                GlobalConfiguration.init(),
+                Map.of(),
+                new PhasedChangeState(nextId, pending, history))));
+  }
+
+  private long nextId() {
+    return 8L;
+  }
+
+  private Map<Long, PhasedChangePlan> pending(final PhasedChangePlan... plans) {
+    return Arrays.stream(plans).collect(Collectors.toMap(PhasedChangePlan::id, p -> p));
+  }
+
+  private List<CompletedPhasedChange> history(final CompletedPhasedChange... changes) {
+    return List.of(changes);
+  }
+
+  private PhasedChangePlan pendingPlan(final long changeId) {
+    return PhasedChangePlan.init(changeId, List.of(new GlobalPhase(List.of())), Instant.now());
+  }
+
+  private CompletedPhasedChange completed(
+      final long changeId, final PhasedChangePlanStatus status) {
+    return new CompletedPhasedChange(changeId, status, Instant.now(), Instant.now());
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/DynamicConfigExportingStateControllerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/DynamicConfigExportingStateControllerTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.util.Either;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+final class DynamicConfigExportingStateControllerTest {
+
+  private static final String OTHER_TENANT = "tenant-b";
+
+  private final ClusterConfigurationManagementRequestSender requestSender =
+      mock(ClusterConfigurationManagementRequestSender.class);
+  private final DynamicConfigExportingStateController exportingStateController =
+      new DynamicConfigExportingStateController(
+          requestSender, Duration.ofMillis(1), Duration.ofSeconds(10));
+  private final ExportingStateController.ByTenant controller =
+      exportingStateController.getByTenant(DEFAULT_PHYSICAL_TENANT_ID);
+
+  @ParameterizedTest
+  @MethodSource("operations")
+  void shouldSubmitExpectedTargetStateForTheResolvedTenant(
+      final Function<ExportingStateController.ByTenant, CompletableFuture<Void>> operation,
+      final ExportingState expectedState) {
+    // given
+    final var captor = ArgumentCaptor.forClass(ExportingStateChangeRequest.class);
+    when(requestSender.changeExportingState(captor.capture())).thenReturn(emptyPlan());
+
+    // when
+    operation.apply(controller).join();
+
+    // then
+    assertThat(captor.getValue().state()).isEqualTo(expectedState);
+    assertThat(captor.getValue().physicalTenantId()).contains(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  @ParameterizedTest
+  @MethodSource("operations")
+  void shouldSubmitTheTenantItWasResolvedFor(
+      final Function<ExportingStateController.ByTenant, CompletableFuture<Void>> operation,
+      final ExportingState ignoredExpectedState) {
+    // given — a controller resolved for a non-default tenant
+    final var otherController = exportingStateController.getByTenant(OTHER_TENANT);
+    final var captor = ArgumentCaptor.forClass(ExportingStateChangeRequest.class);
+    when(requestSender.changeExportingState(captor.capture())).thenReturn(emptyPlan());
+
+    // when
+    operation.apply(otherController).join();
+
+    // then
+    assertThat(captor.getValue().physicalTenantId()).contains(OTHER_TENANT);
+  }
+
+  @ParameterizedTest
+  @MethodSource("operations")
+  void shouldFailIfSubmissionIsRejected(
+      final Function<ExportingStateController.ByTenant, CompletableFuture<Void>> operation,
+      final ExportingState expectedState) {
+    // given
+    when(requestSender.changeExportingState(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(new ErrorResponse(ErrorResponse.ErrorCode.INVALID_REQUEST, "nope"))));
+
+    // when
+    final var thrown = catchThrowable(() -> operation.apply(controller).join());
+
+    // then
+    assertThat(thrown).hasMessageContaining("nope");
+  }
+
+  @ParameterizedTest
+  @MethodSource("operations")
+  void shouldPollUntilTheSubmittedChangeCompletes(
+      final Function<ExportingStateController.ByTenant, CompletableFuture<Void>> operation,
+      final ExportingState ignoredExpectedState) {
+    // given — the submission plans a real change, so the controller must poll for it to resolve
+    // rather than short-circuiting on an empty plan
+    when(requestSender.changeExportingState(any())).thenReturn(pendingPlan(7));
+    when(requestSender.getTopology())
+        .thenReturn(topologyWithChange(pending(7)))
+        .thenReturn(topologyWithChange(completed(7, PhasedChangePlanStatus.COMPLETED)));
+
+    // when
+    final var result = operation.apply(controller);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(1));
+    verify(requestSender, atLeast(2)).getTopology();
+  }
+
+  @Test
+  void shouldAggregateStatusWhenReplicasAgree() {
+    // given
+    when(requestSender.getTopology())
+        .thenReturn(
+            topology(
+                Map.of(
+                    DEFAULT_PHYSICAL_TENANT_ID,
+                    Map.of(MemberId.from("0"), ExportingState.SOFT_PAUSED))));
+
+    // when
+    final var status = controller.getExportingStatus();
+
+    // then
+    assertThat(status).succeedsWithin(Duration.ofSeconds(1)).isEqualTo(ExportingStatus.SOFT_PAUSED);
+  }
+
+  @Test
+  void shouldReportMixedStatusWhenReplicasDisagree() {
+    // given
+    when(requestSender.getTopology())
+        .thenReturn(
+            topology(
+                Map.of(
+                    DEFAULT_PHYSICAL_TENANT_ID,
+                    Map.of(
+                        MemberId.from("0"), ExportingState.PAUSED,
+                        MemberId.from("1"), ExportingState.EXPORTING))));
+
+    // when
+    final var status = controller.getExportingStatus();
+
+    // then
+    assertThat(status).succeedsWithin(Duration.ofSeconds(1)).isEqualTo(ExportingStatus.MIXED);
+  }
+
+  @Test
+  void shouldReportExportingStatusWhenNeverControlledByConfig() {
+    // given - a replica config never touched by a state-change operation is UNKNOWN
+    when(requestSender.getTopology())
+        .thenReturn(
+            topology(
+                Map.of(
+                    DEFAULT_PHYSICAL_TENANT_ID,
+                    Map.of(MemberId.from("0"), ExportingState.UNKNOWN))));
+
+    // when
+    final var status = controller.getExportingStatus();
+
+    // then
+    assertThat(status).succeedsWithin(Duration.ofSeconds(1)).isEqualTo(ExportingStatus.EXPORTING);
+  }
+
+  @Test
+  void shouldAggregateStatusOnlyForTheResolvedTenant() {
+    // given — the default tenant is paused, tenant-b is exporting; the controller was resolved
+    // for tenant-b only
+    final var tenantBController = exportingStateController.getByTenant(OTHER_TENANT);
+    when(requestSender.getTopology())
+        .thenReturn(
+            topology(
+                Map.of(
+                    DEFAULT_PHYSICAL_TENANT_ID,
+                    Map.of(MemberId.from("0"), ExportingState.PAUSED),
+                    OTHER_TENANT,
+                    Map.of(MemberId.from("1"), ExportingState.EXPORTING))));
+
+    // when
+    final var status = tenantBController.getExportingStatus();
+
+    // then
+    assertThat(status).succeedsWithin(Duration.ofSeconds(1)).isEqualTo(ExportingStatus.EXPORTING);
+  }
+
+  @Test
+  void shouldFailStatusQueryWhenTheResolvedTenantIsAbsentFromTheTopology() {
+    // given — the topology has no partition group for tenant-b yet
+    final var tenantBController = exportingStateController.getByTenant(OTHER_TENANT);
+    when(requestSender.getTopology())
+        .thenReturn(
+            topology(
+                Map.of(
+                    DEFAULT_PHYSICAL_TENANT_ID,
+                    Map.of(MemberId.from("0"), ExportingState.EXPORTING))));
+
+    // when
+    final var thrown = catchThrowable(() -> tenantBController.getExportingStatus().join());
+
+    // then — same rejection as changeState(), rather than folding "no such tenant" into MIXED
+    assertThat(thrown)
+        .hasCauseInstanceOf(ClusterConfigurationRequestFailedException.NotFound.class);
+  }
+
+  @Test
+  void shouldFailStatusQueryForADisabledTenant() {
+    // given — tenant-b is disabled (still present, retained but frozen) and reports a
+    // seemingly-converged state that changeState() would reject as not found
+    final var tenantBController = exportingStateController.getByTenant(OTHER_TENANT);
+    final var disabledGroup = group(Map.of(MemberId.from("0"), ExportingState.PAUSED)).disable();
+    when(requestSender.getTopology())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new CurrentClusterConfiguration(
+                        CurrentClusterConfiguration.INITIAL_VERSION,
+                        GlobalConfiguration.init(),
+                        Map.of(OTHER_TENANT, disabledGroup),
+                        PhasedChangeState.empty()))));
+
+    // when
+    final var thrown = catchThrowable(() -> tenantBController.getExportingStatus().join());
+
+    // then — matches changeState()'s rejection of the same tenant, instead of reporting a frozen
+    // status that would look indistinguishable from a real, converged one
+    assertThat(thrown)
+        .hasCauseInstanceOf(ClusterConfigurationRequestFailedException.NotFound.class);
+  }
+
+  private static CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> topology(
+      final Map<String, Map<MemberId, ExportingState>> statesByTenantAndMember) {
+    final Map<String, PartitionGroupConfiguration> partitionGroups =
+        statesByTenantAndMember.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> group(entry.getValue())));
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new CurrentClusterConfiguration(
+                CurrentClusterConfiguration.INITIAL_VERSION,
+                GlobalConfiguration.init(),
+                partitionGroups,
+                PhasedChangeState.empty())));
+  }
+
+  private static PartitionGroupConfiguration group(
+      final Map<MemberId, ExportingState> statesByMember) {
+    var group = PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION);
+    for (final var entry : statesByMember.entrySet()) {
+      group =
+          group.addMember(
+              entry.getKey(),
+              BrokerPartitionState.initialize(
+                  Map.of(
+                      1,
+                      PartitionState.active(
+                          1,
+                          DynamicPartitionConfig.init()
+                              .updateExporting(config -> config.withState(entry.getValue()))))));
+    }
+    return group;
+  }
+
+  private static Stream<Arguments> operations() {
+    return Stream.of(
+        Arguments.of(
+            (Function<ExportingStateController.ByTenant, CompletableFuture<Void>>)
+                ExportingStateController.ByTenant::pauseExporting,
+            ExportingState.PAUSED),
+        Arguments.of(
+            (Function<ExportingStateController.ByTenant, CompletableFuture<Void>>)
+                ExportingStateController.ByTenant::softPauseExporting,
+            ExportingState.SOFT_PAUSED),
+        Arguments.of(
+            (Function<ExportingStateController.ByTenant, CompletableFuture<Void>>)
+                ExportingStateController.ByTenant::resumeExporting,
+            ExportingState.EXPORTING));
+  }
+
+  private CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> emptyPlan() {
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new ClusterConfigurationChangeResponse(
+                0,
+                new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                    Map.of(), Map.of(), List.of()),
+                new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
+                    CurrentClusterConfiguration.init(),
+                    CurrentClusterConfiguration.init(),
+                    List.of()))));
+  }
+
+  private CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> pendingPlan(
+      final long changeId) {
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new ClusterConfigurationChangeResponse(
+                changeId,
+                new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                    Map.of(), Map.of(), List.of()),
+                new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
+                    CurrentClusterConfiguration.init(),
+                    CurrentClusterConfiguration.init(),
+                    List.of(new GlobalPhase(List.of()))))));
+  }
+
+  private CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> topologyWithChange(
+      final PhasedChangePlan pending) {
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new CurrentClusterConfiguration(
+                CurrentClusterConfiguration.INITIAL_VERSION,
+                GlobalConfiguration.init(),
+                Map.of(),
+                new PhasedChangeState(
+                    pending.id() + 1, Map.of(pending.id(), pending), List.of()))));
+  }
+
+  private CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> topologyWithChange(
+      final CompletedPhasedChange completed) {
+    return CompletableFuture.completedFuture(
+        Either.right(
+            new CurrentClusterConfiguration(
+                CurrentClusterConfiguration.INITIAL_VERSION,
+                GlobalConfiguration.init(),
+                Map.of(),
+                new PhasedChangeState(completed.id() + 1, Map.of(), List.of(completed)))));
+  }
+
+  private PhasedChangePlan pending(final long changeId) {
+    return PhasedChangePlan.init(changeId, List.of(new GlobalPhase(List.of())), Instant.now());
+  }
+
+  private CompletedPhasedChange completed(
+      final long changeId, final PhasedChangePlanStatus status) {
+    return new CompletedPhasedChange(changeId, status, Instant.now(), Instant.now());
+  }
+}


### PR DESCRIPTION
## Description

Builds on #60541 (merged) — which added per-physical-tenant scoping for exporting state changes in `zeebe/dynamic-config` — by adding the remaining supporting classes so a per-tenant, cluster-wide exporting state change can actually be submitted and awaited end-to-end through the dynamic API.

Still dynamic-config-only groundwork: no endpoint-facing code (`ExportingServices`, `ExportingController`, `ExportingEndpoint`, `BrokerAdminService*`, `ClusterExportingServices`/`ClusterExportingController`) is touched, and no broker-side runtime wiring (applying the dynamically-configured state on exporter director startup/restart) is included — both are explicitly deferred to a follow-up.

### What changed

- `ExportingStateController` / `DynamicConfigExportingStateController`: resolves a `ByTenant` handle for one physical tenant and submits pause/soft-pause/resume through the coordinator, aggregating status from that tenant's partition group only. The original design (from #59415) was single-tenant with no scoping; this supersedes it now that the per-tenant model exists. A status query for a physical tenant that does not exist, or is disabled, is rejected with `NotFound` — matching `changeState()`'s existing rejection of the same tenant — rather than folding either case into `ExportingStatus.MIXED`, which would look indistinguishable from a real, converged tenant that merely disagrees.
- `ClusterConfigurationChangeAwaiter`: polls the topology until a submitted change resolves, giving callers a synchronous contract on top of the coordinator's async change plans. Rewritten against `PhasedChangeState`'s pending/history bookkeeping instead of the old single-pending-change model — plans now run concurrently per tenant, so "a newer change already completed" no longer implies ours did; completion is looked up by `changeId` directly. A cancelled plan is reported distinctly from a failed one.
- `ExportingStatus`: added under `dynamic.config.api` rather than moving the existing `gateway.admin.ExportingStatus`, since the endpoint code that still depends on the latter is out of scope here.
- Wires `ExportingStateChangeRequest` into the coordinator's network API end-to-end: a new `EXPORTING_STATE_CHANGE` topic, and the `ClusterConfigurationManagementApi`/`RequestsHandler`/`RequestServer`/`RequestSender` plumbing, following the existing `ModeChangeRequest` pattern.


## Related issues

Relates to #39743
Builds on #60541
