### PR TITLE
feat: add cluster-wide runtime backup REST endpoints

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -34,6 +34,8 @@ import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterHistoryBackupServices;
 import io.camunda.service.ClusterRecoveryServices;
+import io.camunda.service.ClusterRuntimeBackupServices;
+import io.camunda.service.ClusterRuntimeBackupServices.PhysicalTenantBackupPort;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
 import io.camunda.service.ClusterVariableServices;
@@ -86,7 +88,9 @@ import io.camunda.zeebe.gateway.admin.ExportingRequestBroadcaster;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
@@ -166,6 +170,9 @@ public class CamundaServicesConfiguration {
     // Collected here as well as bound per tenant, so the cluster-wide ClusterRecoveryServices can
     // resolve the restore environment of a tenant named in a cluster-admin restore's overrides.
     final Map<String, TenantRestoreEnvironment> restoreEnvironmentByTenant = new HashMap<>();
+    // Collected here as well as bound per tenant, so the cluster-wide ClusterRuntimeBackupServices
+    // fans out over the very ports the per-tenant services use.
+    final List<PhysicalTenantBackupPort> runtimeBackupPorts = new ArrayList<>();
 
     physicalTenantResolver
         .getAll()
@@ -194,6 +201,11 @@ public class CamundaServicesConfiguration {
                       tenantConfig.getData().getSecondaryStorage().getType().name(),
                       tenantConfig.getData().getPrimaryStorage().getBackup().isContinuous());
               restoreEnvironmentByTenant.put(tenantId, restoreEnvironment);
+
+              // -- per-tenant runtime-backup port: the broker-facing backup API plus the
+              // deployment-time backup-id mode, shared by the per-tenant and cluster-wide services
+              final var runtimeBackupPort = runtimeBackupPort(tenantId, tenantConfig, brokerClient);
+              runtimeBackupPorts.add(runtimeBackupPort);
 
               // -- per-tenant process cache --
               final var processCacheConfig = tenantConfig.getApi().getRest().getProcessCache();
@@ -321,8 +333,7 @@ public class CamundaServicesConfiguration {
                   .backupServices(
                       tenantId,
                       runtimeBackupServices(
-                          tenantId,
-                          tenantConfig,
+                          runtimeBackupPort,
                           brokerClient,
                           securityContextProvider,
                           authorizationChecker,
@@ -581,24 +592,22 @@ public class CamundaServicesConfiguration {
         new ClusterExportingServices(
             exportingRequestBroadcaster, physicalTenantResolver.getAll().keySet()));
 
+    builder.clusterRuntimeBackupServices(new ClusterRuntimeBackupServices(runtimeBackupPorts));
+
     return builder.build();
   }
 
   /**
-   * Builds the per-tenant {@link RuntimeBackupServices}, mirroring the wiring of the {@code
-   * backupRuntime} actuator ({@code BackupEndpoint}): backup ids must be omitted (they are
-   * generated from the current timestamp plus the configured offset) whenever continuous backups, a
-   * backup schedule, or a checkpoint interval is configured for the physical tenant.
+   * Builds the per-tenant runtime-backup port, mirroring the wiring of the {@code backupRuntime}
+   * actuator ({@code BackupEndpoint}): backup ids must be omitted (they are generated from the
+   * current timestamp plus the configured offset) whenever continuous backups, a backup schedule,
+   * or a checkpoint interval is configured for the physical tenant.
+   *
+   * <p>The port is what both the per-tenant and the cluster-wide service are built on, so the mode
+   * the per-tenant endpoint enforces is by construction the mode the cluster-wide one reports.
    */
-  private static RuntimeBackupServices runtimeBackupServices(
-      final String tenantId,
-      final Camunda tenantConfig,
-      final BrokerClient brokerClient,
-      final SecurityContextProvider securityContextProvider,
-      final AuthorizationChecker authorizationChecker,
-      final AuthorizationsConfiguration authorizationsConfig,
-      final ApiServicesExecutorProvider executor,
-      final BrokerRequestAuthorizationConverter converter) {
+  private static PhysicalTenantBackupPort runtimeBackupPort(
+      final String tenantId, final Camunda tenantConfig, final BrokerClient brokerClient) {
     final var backupCfg = tenantConfig.getData().getPrimaryStorage().getBackup();
     final var backupIdGenerated =
         backupCfg.isContinuous()
@@ -607,14 +616,25 @@ public class CamundaServicesConfiguration {
                 && !backupCfg.getCheckpointInterval().isZero());
     final var backupApi =
         new BackupRequestHandler(brokerClient, new CheckpointIdGenerator(backupCfg.getOffset()));
+    return new PhysicalTenantBackupPort(tenantId, backupApi, backupIdGenerated);
+  }
+
+  private static RuntimeBackupServices runtimeBackupServices(
+      final PhysicalTenantBackupPort port,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final AuthorizationChecker authorizationChecker,
+      final AuthorizationsConfiguration authorizationsConfig,
+      final ApiServicesExecutorProvider executor,
+      final BrokerRequestAuthorizationConverter converter) {
     return new RuntimeBackupServices(
-        tenantId,
+        port.physicalTenantId(),
         brokerClient,
         securityContextProvider,
-        backupApi,
+        port.api(),
         authorizationChecker,
         authorizationsConfig,
-        backupIdGenerated,
+        port.backupIdGenerated(),
         executor,
         converter);
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/GatewayErrorMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/GatewayErrorMapper.java
@@ -103,7 +103,15 @@ public class GatewayErrorMapper {
     return problemDetail;
   }
 
-  protected static HttpStatus mapStatus(final Status status) {
+  /**
+   * The single source of truth for how a {@link Status} reaches the caller as an HTTP status.
+   *
+   * <p>Public because a cluster-wide response can carry an error status with a domain body instead
+   * of a problem detail — the cluster-wide backup trigger does, to name the physical tenants whose
+   * backups are running — and such a response must answer with the same status a problem detail
+   * would have.
+   */
+  public static HttpStatus mapStatus(final Status status) {
     return switch (status) {
       case ABORTED -> HttpStatus.BAD_GATEWAY;
       case UNAVAILABLE, RESOURCE_EXHAUSTED -> HttpStatus.SERVICE_UNAVAILABLE;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -45,6 +45,9 @@ public class ClusterAdminBasicAuthenticationIT {
   public static final String PATH_CLUSTER_STATUS = "cluster/v2/status";
   public static final String PATH_CLUSTER_HISTORY_BACKUPS = "cluster/v2/backups/history";
   public static final String PATH_CLUSTER_HISTORY_BACKUP = "cluster/v2/backups/history/1";
+  public static final String PATH_CLUSTER_RUNTIME_BACKUPS = "cluster/v2/backups/runtime";
+  public static final String PATH_CLUSTER_RUNTIME_BACKUP = "cluster/v2/backups/runtime/1";
+  public static final String PATH_CLUSTER_RUNTIME_BACKUP_STATE = "cluster/v2/backups/runtime/state";
   public static final String PATH_V2_AUTHENTICATION_ME = "v2/authentication/me";
 
   private static final String CLUSTER_ADMIN_USER = "cluster-operator";
@@ -197,6 +200,27 @@ public class ClusterAdminBasicAuthenticationIT {
   @ParameterizedTest
   @ValueSource(strings = {PATH_CLUSTER_HISTORY_BACKUPS, PATH_CLUSTER_HISTORY_BACKUP})
   void shouldRejectClusterHistoryBackupEndpointWithoutCredentials(final String path)
+      throws Exception {
+    // when
+    final HttpResponse<String> response = send(clusterUri(path), null);
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  /**
+   * The runtime backup endpoints need no secondary storage, so unlike the history ones they have no
+   * storage gate that could answer before the chain does — the chain is the only thing standing
+   * between an unauthenticated caller and a cluster-wide backup.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        PATH_CLUSTER_RUNTIME_BACKUPS,
+        PATH_CLUSTER_RUNTIME_BACKUP,
+        PATH_CLUSTER_RUNTIME_BACKUP_STATE
+      })
+  void shouldRejectClusterRuntimeBackupEndpointWithoutCredentials(final String path)
       throws Exception {
     // when
     final HttpResponse<String> response = send(clusterUri(path), null);

--- a/service/src/main/java/io/camunda/service/ClusterHistoryBackupServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterHistoryBackupServices.java
@@ -12,16 +12,13 @@ import io.camunda.service.backup.HistoryBackupRequests;
 import io.camunda.service.backup.HistoryBackupSnapshot;
 import io.camunda.service.backup.HistoryBackupState;
 import io.camunda.service.backup.HistoryBackupStateCode;
-import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -245,38 +242,15 @@ public final class ClusterHistoryBackupServices {
             .map(
                 tenant ->
                     CompletableFuture.supplyAsync(() -> perTenant.apply(tenant), executor)
-                        .handle((value, error) -> new Outcome<>(tenant, value, error)))
+                        .handle(
+                            (value, error) ->
+                                new PhysicalTenantFanOut.Outcome<>(tenant, value, error)))
             .toList();
     return CompletableFuture.allOf(outcomes.toArray(CompletableFuture[]::new))
-        .thenApply(ignored -> collect(outcomes.stream().map(CompletableFuture::join).toList()));
-  }
-
-  private static <T> List<T> collect(final List<Outcome<T>> outcomes) {
-    final var failures = outcomes.stream().filter(outcome -> outcome.error() != null).toList();
-    if (!failures.isEmpty()) {
-      throw combine(failures, outcomes.size());
-    }
-    return outcomes.stream().map(Outcome::value).toList();
-  }
-
-  /**
-   * Folds the failures of a fan-out into the one exception the request answers with. A shared
-   * status is kept — so a request narrowed to a single tenant answers exactly what the per-tenant
-   * endpoint would — while genuinely different causes have no honest status other than 500.
-   */
-  private static ServiceException combine(
-      final List<? extends Outcome<?>> failures, final int targeted) {
-    final var statuses = new LinkedHashSet<Status>();
-    final var detail = new StringJoiner("; ");
-    for (final var failure : failures) {
-      final var cause = ErrorMapper.mapError(failure.error());
-      statuses.add(cause.getStatus());
-      detail.add("'%s': %s".formatted(failure.physicalTenantId(), cause.getMessage()));
-    }
-    return new ServiceException(
-        "Expected to serve every targeted physical tenant, but %d of %d failed — %s"
-            .formatted(failures.size(), targeted, detail),
-        statuses.size() == 1 ? statuses.iterator().next() : Status.INTERNAL);
+        .thenApply(
+            ignored ->
+                PhysicalTenantFanOut.requireEveryTenant(
+                    outcomes.stream().map(CompletableFuture::join).toList()));
   }
 
   private static List<ClusterHistoryBackup> groupByBackupId(
@@ -331,9 +305,6 @@ public final class ClusterHistoryBackupServices {
       return CompletableFuture.failedFuture(e);
     }
   }
-
-  private record Outcome<T>(
-      String physicalTenantId, @Nullable T value, @Nullable Throwable error) {}
 
   private record PhysicalTenantBackups(String physicalTenantId, List<HistoryBackupState> backups) {}
 

--- a/service/src/main/java/io/camunda/service/ClusterRuntimeBackupServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRuntimeBackupServices.java
@@ -14,12 +14,13 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.zeebe.backup.client.api.BackupApi;
 import io.camunda.zeebe.backup.client.api.BackupStatus;
 import io.camunda.zeebe.backup.client.api.State;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -139,8 +140,8 @@ public final class ClusterRuntimeBackupServices {
 
   /**
    * Lists the backups of every targeted physical tenant, grouped by backup id, most recent id
-   * first. A tenant that holds none of the matching ids simply contributes no entry, so each
-   * group's folded state accounts for the listed tenants alone.
+   * first. Every group reports every targeted tenant, so a backup only some tenants hold folds to
+   * {@code INCOMPLETE} here just as it does on a single-id read.
    *
    * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
    */
@@ -444,9 +445,20 @@ public final class ClusterRuntimeBackupServices {
         .toList();
   }
 
+  /**
+   * Groups the tenants' backups by backup id, most recent id first, reporting every targeted tenant
+   * under every id — including the tenants that hold nothing for it.
+   *
+   * <p>Listing only the holders would make the same {@link ClusterRuntimeBackup} mean two different
+   * things: a backup half the cluster is missing would read {@code COMPLETED} in a listing and
+   * {@code INCOMPLETE} when looked up directly. An operator scanning the listing for the backups
+   * the cluster can actually be restored from has to be able to trust the state, so a tenant that
+   * holds nothing for an id contributes {@link State#DOES_NOT_EXIST} here, exactly as it does on
+   * the single-id read.
+   */
   private static List<ClusterRuntimeBackup> groupByBackupId(
       final List<PhysicalTenantBackupPort> targets, final List<List<BackupStatus>> perTenant) {
-    final Map<Long, List<PhysicalTenantRuntimeBackup>> byBackupId =
+    final Map<Long, Map<String, BackupStatus>> holdersByBackupId =
         new TreeMap<>(Comparator.reverseOrder());
     zip(targets, perTenant, PhysicalTenantBackups::new)
         .forEach(
@@ -455,14 +467,35 @@ public final class ClusterRuntimeBackupServices {
                     .backups()
                     .forEach(
                         backup ->
-                            byBackupId
-                                .computeIfAbsent(backup.backupId(), id -> new ArrayList<>())
-                                .add(
-                                    new PhysicalTenantRuntimeBackup(
-                                        tenant.physicalTenantId(), backup))));
-    return byBackupId.entrySet().stream()
-        .map(entry -> toClusterBackup(entry.getKey(), List.copyOf(entry.getValue())))
+                            holdersByBackupId
+                                .computeIfAbsent(backup.backupId(), id -> new HashMap<>())
+                                .put(tenant.physicalTenantId(), backup)));
+    return holdersByBackupId.entrySet().stream()
+        .map(entry -> toClusterBackup(entry.getKey(), everyTenant(targets, entry)))
         .toList();
+  }
+
+  /**
+   * Reports each targeted tenant's backup for one id, filling in the tenants that hold none. The
+   * filled-in entry carries no partition detail: a listing asks each tenant for the backups it has,
+   * so there is nothing to report per partition for one it does not.
+   */
+  private static List<PhysicalTenantRuntimeBackup> everyTenant(
+      final List<PhysicalTenantBackupPort> targets,
+      final Map.Entry<Long, Map<String, BackupStatus>> holders) {
+    return targets.stream()
+        .map(
+            target ->
+                new PhysicalTenantRuntimeBackup(
+                    target.physicalTenantId(),
+                    holders
+                        .getValue()
+                        .getOrDefault(target.physicalTenantId(), absent(holders.getKey()))))
+        .toList();
+  }
+
+  private static BackupStatus absent(final long backupId) {
+    return new BackupStatus(backupId, State.DOES_NOT_EXIST, Optional.empty(), List.of());
   }
 
   private static ClusterRuntimeBackup toClusterBackup(

--- a/service/src/main/java/io/camunda/service/ClusterRuntimeBackupServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRuntimeBackupServices.java
@@ -28,6 +28,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.jspecify.annotations.NullMarked;
@@ -66,6 +67,11 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public final class ClusterRuntimeBackupServices {
 
+  /**
+   * The {@code BackupIdPrefix} schema of the REST contract, enforced before any tenant is asked.
+   */
+  private static final Pattern BACKUP_ID_PREFIX = Pattern.compile("^\\d*\\*$");
+
   private final SortedMap<String, PhysicalTenantBackupPort> portsByPhysicalTenant;
 
   public ClusterRuntimeBackupServices(final Collection<PhysicalTenantBackupPort> ports) {
@@ -99,7 +105,7 @@ public final class ClusterRuntimeBackupServices {
           final var targets = targets(physicalTenantId);
           requireBackupIdMatchesEveryTenantsMode(targets, backupId);
           return onEveryTenant(targets, target -> take(target, backupId))
-              .thenApply(ClusterRuntimeBackupServices::toTaken);
+              .thenApply(outcomes -> toTaken(outcomes, backupId));
         });
   }
 
@@ -115,6 +121,7 @@ public final class ClusterRuntimeBackupServices {
     return validated(
         () -> {
           final var targets = targets(physicalTenantId);
+          requirePositiveBackupId(backupId);
           return onEveryTenant(
                   targets, target -> target.api().getStatus(target.physicalTenantId(), backupId))
               .thenApply(PhysicalTenantFanOut::requireEveryTenant)
@@ -160,11 +167,13 @@ public final class ClusterRuntimeBackupServices {
   public CompletableFuture<Void> deleteBackup(
       final @Nullable String physicalTenantId, final long backupId) {
     return validated(
-        () ->
-            onEveryTenant(
-                    targets(physicalTenantId),
-                    target -> target.api().deleteBackup(target.physicalTenantId(), backupId))
-                .thenApply(ClusterRuntimeBackupServices::everyTenantSucceeded));
+        () -> {
+          final var targets = targets(physicalTenantId);
+          requirePositiveBackupId(backupId);
+          return onEveryTenant(
+                  targets, target -> target.api().deleteBackup(target.physicalTenantId(), backupId))
+              .thenApply(ClusterRuntimeBackupServices::everyTenantSucceeded);
+        });
   }
 
   /**
@@ -271,6 +280,15 @@ public final class ClusterRuntimeBackupServices {
               .formatted(generatingIds),
           Status.INVALID_ARGUMENT);
     }
+    requirePositiveBackupId(backupId);
+  }
+
+  /**
+   * Rejects an id the {@code BackupId} schema does not allow, so it never reaches a tenant. Without
+   * this, {@code 0} and negative ids read back as a 404 — indistinguishable from an id that is
+   * merely absent, when the request could never have been served at all.
+   */
+  private static void requirePositiveBackupId(final long backupId) {
     if (backupId <= 0) {
       throw new ServiceException(
           "A backupId must be > 0, but was %d".formatted(backupId), Status.INVALID_ARGUMENT);
@@ -286,14 +304,20 @@ public final class ClusterRuntimeBackupServices {
         .toList();
   }
 
-  /** Mirrors {@link RuntimeBackupServices#listBackups}'s prefix contract. */
+  /**
+   * Enforces the whole shape the {@code BackupIdPrefix} schema publishes — digits followed by a
+   * single wildcard — not merely that it ends in one. Backup ids are numbers, so a prefix like
+   * {@code abc*} can never match anything: answering the documented 400 tells the caller its
+   * request was malformed, where passing it to the store returns an empty list that reads as "no
+   * backups".
+   */
   private static String requireValidPrefix(final @Nullable String prefix) {
     if (prefix == null) {
       return BackupApi.WILDCARD;
     }
-    if (!prefix.endsWith(BackupApi.WILDCARD)) {
+    if (!BACKUP_ID_PREFIX.matcher(prefix).matches()) {
       throw new ServiceException(
-          "Expected a prefix ending with '*', but got '%s'".formatted(prefix),
+          "Expected a prefix of digits ending with a single '*', but got '%s'".formatted(prefix),
           Status.INVALID_ARGUMENT);
     }
     return prefix;
@@ -354,23 +378,10 @@ public final class ClusterRuntimeBackupServices {
     }
   }
 
-  private static ClusterRuntimeBackupTaken toTaken(final List<Outcome<Long>> outcomes) {
+  private static ClusterRuntimeBackupTaken toTaken(
+      final List<Outcome<Long>> outcomes, final @Nullable Long requestedBackupId) {
     final var perTenant =
-        outcomes.stream()
-            .map(
-                outcome ->
-                    outcome.isFailure()
-                        ? new PhysicalTenantRuntimeBackupTaken(
-                            outcome.physicalTenantId(),
-                            TakeOutcome.FAILED,
-                            null,
-                            outcome.cause().getMessage())
-                        : new PhysicalTenantRuntimeBackupTaken(
-                            outcome.physicalTenantId(),
-                            TakeOutcome.TRIGGERED,
-                            outcome.requireValue(),
-                            null))
-            .toList();
+        outcomes.stream().map(outcome -> toTenantOutcome(outcome, requestedBackupId)).toList();
     final var failureStatuses =
         outcomes.stream()
             .filter(Outcome::isFailure)
@@ -379,6 +390,36 @@ public final class ClusterRuntimeBackupServices {
     return new ClusterRuntimeBackupTaken(
         perTenant,
         failureStatuses.isEmpty() ? null : PhysicalTenantFanOut.sharedStatus(failureStatuses));
+  }
+
+  /**
+   * Classifies what one physical tenant did with the trigger.
+   *
+   * <p>A failure whose status says the broker may still have accepted the request — the connection
+   * was cut mid-flight, or the gateway timed out waiting — is reported as {@link
+   * TakeOutcome#UNKNOWN} rather than {@code FAILED}, and keeps the requested id. Calling it {@code
+   * FAILED} would tell the operator no backup is running on that tenant, which is the one thing
+   * this response exists not to get wrong: a backup left running under an id nobody was told about
+   * is exactly the silent partial trigger ADR 003 D4 forbids.
+   *
+   * <p>The residual gap is a tenant that generates its own ids: the id is generated behind {@link
+   * BackupApi}, so a call that never completes has none to report and the caller has to list that
+   * tenant's backups to find it. Closing that needs the port to surface the id it attempted.
+   */
+  private static PhysicalTenantRuntimeBackupTaken toTenantOutcome(
+      final Outcome<Long> outcome, final @Nullable Long requestedBackupId) {
+    if (!outcome.isFailure()) {
+      return new PhysicalTenantRuntimeBackupTaken(
+          outcome.physicalTenantId(), TakeOutcome.TRIGGERED, outcome.requireValue(), null);
+    }
+    final var cause = outcome.cause();
+    final var indeterminate =
+        cause.getStatus() == Status.ABORTED || cause.getStatus() == Status.DEADLINE_EXCEEDED;
+    return new PhysicalTenantRuntimeBackupTaken(
+        outcome.physicalTenantId(),
+        indeterminate ? TakeOutcome.UNKNOWN : TakeOutcome.FAILED,
+        indeterminate ? requestedBackupId : null,
+        cause.getMessage());
   }
 
   /**
@@ -526,9 +567,11 @@ public final class ClusterRuntimeBackupServices {
       List<PhysicalTenantRuntimeBackupTaken> physicalTenants, @Nullable Status failureStatus) {}
 
   /**
-   * @param backupId the id the backup is running under — the requested one, or the one the tenant
-   *     generated. Null when the tenant was not triggered.
-   * @param reason why the tenant was not triggered, null when it was
+   * @param backupId the id to monitor or delete this tenant's backup by — the one it is running
+   *     under when {@code TRIGGERED}, or the requested one to check when {@code UNKNOWN}. Null when
+   *     the tenant is known not to be running one, and when an {@code UNKNOWN} tenant generates its
+   *     own ids and never reported the one it generated.
+   * @param reason why the tenant did not report a triggered backup, null when it did
    */
   public record PhysicalTenantRuntimeBackupTaken(
       String physicalTenantId,
@@ -536,13 +579,17 @@ public final class ClusterRuntimeBackupServices {
       @Nullable Long backupId,
       @Nullable String reason) {}
 
-  /**
-   * Whether a physical tenant's backup was triggered. There is no code for a tenant that could not
-   * be reached — an unreachable tenant is a {@code FAILED} one, with the reason saying so.
-   */
+  /** What one physical tenant did with a trigger request. */
   public enum TakeOutcome {
+    /** The backup is running on this tenant. Not that it completed — poll its status for that. */
     TRIGGERED,
-    FAILED
+    /** This tenant is running no backup for this request, and nothing has to be cleaned up. */
+    FAILED,
+    /**
+     * The broker may or may not have accepted the request: the connection was cut mid-flight, or
+     * the gateway timed out waiting. Check this tenant's backups before retrying.
+     */
+    UNKNOWN
   }
 
   /** What each physical tenant reports for one backup id, plus the state folded over them. */

--- a/service/src/main/java/io/camunda/service/ClusterRuntimeBackupServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRuntimeBackupServices.java
@@ -498,8 +498,6 @@ public final class ClusterRuntimeBackupServices {
         Status.NOT_FOUND);
   }
 
-  private record PhysicalTenantBackups(String physicalTenantId, List<BackupStatus> backups) {}
-
   /** Turns a rejection raised before the fan-out starts into a failed future. */
   private static <T> CompletableFuture<T> validated(final Supplier<CompletableFuture<T>> request) {
     try {
@@ -508,6 +506,8 @@ public final class ClusterRuntimeBackupServices {
       return CompletableFuture.failedFuture(e);
     }
   }
+
+  private record PhysicalTenantBackups(String physicalTenantId, List<BackupStatus> backups) {}
 
   /**
    * One physical tenant's runtime-backup port, plus the backup-id mode it is configured in — the

--- a/service/src/main/java/io/camunda/service/ClusterRuntimeBackupServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterRuntimeBackupServices.java
@@ -1,0 +1,563 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.service.PhysicalTenantFanOut.Outcome;
+import io.camunda.service.RuntimeBackupServices.RuntimeBackupState;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.backup.client.api.BackupApi;
+import io.camunda.zeebe.backup.client.api.BackupStatus;
+import io.camunda.zeebe.backup.client.api.State;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Runtime (primary-storage) backups across every physical tenant of the cluster, or across the one
+ * a request narrows to (ADR 003 D2 and D4, {@code
+ * docs/adr/management/003-physical-tenant-management-endpoint-inventory.md}).
+ *
+ * <p>Unlike {@link RuntimeBackupServices} this takes no {@code CamundaAuthentication} and performs
+ * no per-tenant authorization: per ADR 002 D4 the cluster-admin security chain is the only gate,
+ * and taking no authentication at all makes that structurally true rather than a convention a later
+ * edit can break.
+ *
+ * <p>A cluster-wide backup is a <em>set of independent per-tenant backups</em>, not an atomic
+ * snapshot of the cluster, and that shapes every operation here:
+ *
+ * <ul>
+ *   <li><b>Triggering is all-or-error, and never silent.</b> There is nothing to roll back a
+ *       triggered backup with, so instead of hiding a partial trigger behind an error, {@link
+ *       #takeBackup} always reports what each targeted tenant did — including the id to monitor or
+ *       delete the backups that <em>are</em> running by. Only the caller can decide what to do with
+ *       them.
+ *   <li><b>Absence is a successful observation.</b> A backup that exists on one physical tenant and
+ *       not another is normal, so a tenant that was reached and holds nothing reports {@link
+ *       State#DOES_NOT_EXIST} and folds into an {@code INCOMPLETE} cluster-wide state rather than
+ *       failing the request.
+ *   <li><b>Every other failure is all-or-nothing.</b> A tenant whose state cannot be observed fails
+ *       the whole request; a caller works around a broken tenant by narrowing to the others.
+ * </ul>
+ *
+ * <p>{@link BackupApi} is asynchronous, so the fan-out needs no executor of its own: it starts one
+ * request per targeted tenant and waits for all of them.
+ */
+@NullMarked
+public final class ClusterRuntimeBackupServices {
+
+  private final SortedMap<String, PhysicalTenantBackupPort> portsByPhysicalTenant;
+
+  public ClusterRuntimeBackupServices(final Collection<PhysicalTenantBackupPort> ports) {
+    // Sorted so every response lists physical tenants in the same, assertable order.
+    portsByPhysicalTenant =
+        new TreeMap<>(
+            ports.stream()
+                .collect(
+                    Collectors.toMap(
+                        PhysicalTenantBackupPort::physicalTenantId, Function.identity())));
+  }
+
+  /**
+   * Triggers a backup on every targeted physical tenant, and reports what each one did.
+   *
+   * <p>The returned future completes successfully even when tenants failed — a partial trigger is
+   * an outcome to report, not an error to swallow. {@link
+   * ClusterRuntimeBackupTaken#failureStatus()} carries the status the request should answer with,
+   * and is {@code null} only when every targeted tenant was triggered. A request rejected before
+   * any tenant was triggered fails the future instead, so a caller can tell "nothing is running"
+   * from "some of it is".
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   * @param backupId the id to use on every targeted tenant, or {@code null} to have every targeted
+   *     tenant generate its own
+   */
+  public CompletableFuture<ClusterRuntimeBackupTaken> takeBackup(
+      final @Nullable String physicalTenantId, final @Nullable Long backupId) {
+    return validated(
+        () -> {
+          final var targets = targets(physicalTenantId);
+          requireBackupIdMatchesEveryTenantsMode(targets, backupId);
+          return onEveryTenant(targets, target -> take(target, backupId))
+              .thenApply(ClusterRuntimeBackupServices::toTaken);
+        });
+  }
+
+  /**
+   * Reports what every targeted physical tenant holds for the given backup id, plus the state
+   * folded over all of them. Fails with {@link Status#NOT_FOUND} only when no targeted tenant holds
+   * it.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<ClusterRuntimeBackup> getBackup(
+      final @Nullable String physicalTenantId, final long backupId) {
+    return validated(
+        () -> {
+          final var targets = targets(physicalTenantId);
+          return onEveryTenant(
+                  targets, target -> target.api().getStatus(target.physicalTenantId(), backupId))
+              .thenApply(PhysicalTenantFanOut::requireEveryTenant)
+              .thenApply(
+                  statuses -> {
+                    final var perTenant = zip(targets, statuses, PhysicalTenantRuntimeBackup::new);
+                    if (perTenant.stream()
+                        .allMatch(tenant -> tenant.backup().status() == State.DOES_NOT_EXIST)) {
+                      throw noTenantHolds(backupId, targets);
+                    }
+                    return toClusterBackup(backupId, perTenant);
+                  });
+        });
+  }
+
+  /**
+   * Lists the backups of every targeted physical tenant, grouped by backup id, most recent id
+   * first. A tenant that holds none of the matching ids simply contributes no entry, so each
+   * group's folded state accounts for the listed tenants alone.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<List<ClusterRuntimeBackup>> listBackups(
+      final @Nullable String physicalTenantId, final @Nullable String prefix) {
+    return validated(
+        () -> {
+          final var targets = targets(physicalTenantId);
+          final var queried = requireValidPrefix(prefix);
+          return onEveryTenant(
+                  targets, target -> target.api().listBackups(target.physicalTenantId(), queried))
+              .thenApply(PhysicalTenantFanOut::requireEveryTenant)
+              .thenApply(perTenant -> groupByBackupId(targets, perTenant));
+        });
+  }
+
+  /**
+   * Deletes the backup from every targeted physical tenant. A tenant that does not hold it has
+   * already reached the requested end state, which is why this reports no per-tenant outcome — the
+   * same reason {@code DELETE /v2/backups/runtime/{backupId}} answers 204 for an unknown id.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<Void> deleteBackup(
+      final @Nullable String physicalTenantId, final long backupId) {
+    return validated(
+        () ->
+            onEveryTenant(
+                    targets(physicalTenantId),
+                    target -> target.api().deleteBackup(target.physicalTenantId(), backupId))
+                .thenApply(ClusterRuntimeBackupServices::everyTenantSucceeded));
+  }
+
+  /**
+   * Reports the checkpoint and backup state of every targeted physical tenant. Like {@link
+   * RuntimeBackupServices#getRuntimeState}, this fails the whole request if either sub-request
+   * fails on any tenant, instead of contributing an empty section a caller could not tell apart
+   * from "nothing to report yet".
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<ClusterRuntimeBackupStates> getRuntimeState(
+      final @Nullable String physicalTenantId) {
+    return runtimeStates(physicalTenantId, ClusterRuntimeBackupServices::readRuntimeState);
+  }
+
+  /**
+   * Force-writes the checkpoint and backup metadata of every targeted physical tenant to its backup
+   * store, then reports the updated state.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<ClusterRuntimeBackupStates> syncRuntimeState(
+      final @Nullable String physicalTenantId) {
+    return runtimeStates(physicalTenantId, ClusterRuntimeBackupServices::writeRuntimeState);
+  }
+
+  /**
+   * Resets the runtime backup state of every targeted physical tenant.
+   *
+   * @param physicalTenantId the single tenant to target, or {@code null} for every tenant
+   */
+  public CompletableFuture<Void> deleteRuntimeState(final @Nullable String physicalTenantId) {
+    return validated(
+        () ->
+            onEveryTenant(
+                    targets(physicalTenantId),
+                    target -> target.api().deleteRuntimeState(target.physicalTenantId()))
+                .thenApply(ClusterRuntimeBackupServices::everyTenantSucceeded));
+  }
+
+  private CompletableFuture<ClusterRuntimeBackupStates> runtimeStates(
+      final @Nullable String physicalTenantId,
+      final Function<PhysicalTenantBackupPort, CompletionStage<RuntimeBackupState>> perTenant) {
+    return validated(
+        () -> {
+          final var targets = targets(physicalTenantId);
+          return onEveryTenant(targets, perTenant)
+              .thenApply(PhysicalTenantFanOut::requireEveryTenant)
+              .thenApply(
+                  states ->
+                      new ClusterRuntimeBackupStates(
+                          zip(targets, states, PhysicalTenantRuntimeBackupState::new)));
+        });
+  }
+
+  /**
+   * Resolves the physical tenants a request targets, rejecting an id this cluster does not know
+   * before any tenant is contacted — so an unknown id is never mistaken for a tenant that failed.
+   */
+  private List<PhysicalTenantBackupPort> targets(final @Nullable String physicalTenantId) {
+    if (physicalTenantId == null) {
+      return List.copyOf(portsByPhysicalTenant.values());
+    }
+    final var port = portsByPhysicalTenant.get(physicalTenantId);
+    if (port == null) {
+      throw new ServiceException(
+          "Expected to target physical tenant '%s', but this cluster only has %s"
+              .formatted(physicalTenantId, portsByPhysicalTenant.keySet()),
+          Status.NOT_FOUND);
+    }
+    return List.of(port);
+  }
+
+  /**
+   * Rejects a backup id that not every targeted tenant can accept, before anything is triggered.
+   *
+   * <p>Backup id generation is configured per physical tenant, so a cluster can mix the two modes.
+   * There is no honest way to serve such a cluster in one call — an id can be supplied to all
+   * tenants or to none — so the request names the tenants standing in the way and the caller drives
+   * them one at a time through the per-tenant endpoints (ADR 003, Consequences).
+   */
+  private static void requireBackupIdMatchesEveryTenantsMode(
+      final List<PhysicalTenantBackupPort> targets, final @Nullable Long backupId) {
+    if (backupId == null) {
+      final var requiringAnId = physicalTenantIds(targets, port -> !port.backupIdGenerated());
+      if (!requiringAnId.isEmpty()) {
+        throw new ServiceException(
+            ("A backupId is required because the physical tenants %s take manually triggered "
+                    + "backups. Omit it only when every targeted physical tenant generates its own "
+                    + "ids, which continuous backups and a backup or checkpoint schedule do.")
+                .formatted(requiringAnId),
+            Status.INVALID_ARGUMENT);
+      }
+      return;
+    }
+
+    final var generatingIds =
+        physicalTenantIds(targets, PhysicalTenantBackupPort::backupIdGenerated);
+    if (!generatingIds.isEmpty()) {
+      throw new ServiceException(
+          ("Cannot take a backup with an explicit backupId because the physical tenants %s generate "
+                  + "their own ids, having continuous backups and/or a backup or checkpoint "
+                  + "schedule enabled. Take a backup without specifying a backupId.")
+              .formatted(generatingIds),
+          Status.INVALID_ARGUMENT);
+    }
+    if (backupId <= 0) {
+      throw new ServiceException(
+          "A backupId must be > 0, but was %d".formatted(backupId), Status.INVALID_ARGUMENT);
+    }
+  }
+
+  private static List<String> physicalTenantIds(
+      final List<PhysicalTenantBackupPort> targets,
+      final Predicate<PhysicalTenantBackupPort> matching) {
+    return targets.stream()
+        .filter(matching)
+        .map(PhysicalTenantBackupPort::physicalTenantId)
+        .toList();
+  }
+
+  /** Mirrors {@link RuntimeBackupServices#listBackups}'s prefix contract. */
+  private static String requireValidPrefix(final @Nullable String prefix) {
+    if (prefix == null) {
+      return BackupApi.WILDCARD;
+    }
+    if (!prefix.endsWith(BackupApi.WILDCARD)) {
+      throw new ServiceException(
+          "Expected a prefix ending with '*', but got '%s'".formatted(prefix),
+          Status.INVALID_ARGUMENT);
+    }
+    return prefix;
+  }
+
+  private static CompletionStage<Long> take(
+      final PhysicalTenantBackupPort target, final @Nullable Long backupId) {
+    return backupId == null
+        ? target.api().takeBackup(target.physicalTenantId())
+        : target.api().takeBackup(target.physicalTenantId(), backupId);
+  }
+
+  private static CompletionStage<RuntimeBackupState> readRuntimeState(
+      final PhysicalTenantBackupPort target) {
+    final var checkpointState =
+        target.api().getCheckpointState(target.physicalTenantId()).toCompletableFuture();
+    final var ranges =
+        target.api().getBackupRanges(target.physicalTenantId()).toCompletableFuture();
+    return checkpointState.thenCombine(ranges, RuntimeBackupState::new);
+  }
+
+  private static CompletionStage<RuntimeBackupState> writeRuntimeState(
+      final PhysicalTenantBackupPort target) {
+    final var ranges = target.api().syncMetadata(target.physicalTenantId()).toCompletableFuture();
+    final var checkpointState =
+        target.api().getCheckpointState(target.physicalTenantId()).toCompletableFuture();
+    return checkpointState.thenCombine(ranges, RuntimeBackupState::new);
+  }
+
+  /**
+   * Starts one request per targeted physical tenant and waits for all of them, keeping the targets'
+   * order. Unlike the read paths, this does not decide what a failure means — that is the caller's,
+   * because triggering a backup and reading one answer a failed tenant differently.
+   */
+  private <T> CompletableFuture<List<Outcome<T>>> onEveryTenant(
+      final List<PhysicalTenantBackupPort> targets,
+      final Function<PhysicalTenantBackupPort, CompletionStage<T>> perTenant) {
+    final var outcomes = targets.stream().map(target -> attempt(target, perTenant)).toList();
+    return CompletableFuture.allOf(outcomes.toArray(CompletableFuture[]::new))
+        .thenApply(ignored -> outcomes.stream().map(CompletableFuture::join).toList());
+  }
+
+  /**
+   * {@link BackupApi} validates the topology before it returns a future, so a tenant with too few
+   * reachable partitions throws instead of failing its future. Catching that here keeps one broken
+   * tenant from aborting the fan-out before the healthy tenants are even asked.
+   */
+  private static <T> CompletableFuture<Outcome<T>> attempt(
+      final PhysicalTenantBackupPort target,
+      final Function<PhysicalTenantBackupPort, CompletionStage<T>> perTenant) {
+    try {
+      return perTenant
+          .apply(target)
+          .toCompletableFuture()
+          .handle((value, error) -> new Outcome<>(target.physicalTenantId(), value, error));
+    } catch (final RuntimeException e) {
+      return CompletableFuture.completedFuture(Outcome.failed(target.physicalTenantId(), e));
+    }
+  }
+
+  private static ClusterRuntimeBackupTaken toTaken(final List<Outcome<Long>> outcomes) {
+    final var perTenant =
+        outcomes.stream()
+            .map(
+                outcome ->
+                    outcome.isFailure()
+                        ? new PhysicalTenantRuntimeBackupTaken(
+                            outcome.physicalTenantId(),
+                            TakeOutcome.FAILED,
+                            null,
+                            outcome.cause().getMessage())
+                        : new PhysicalTenantRuntimeBackupTaken(
+                            outcome.physicalTenantId(),
+                            TakeOutcome.TRIGGERED,
+                            outcome.requireValue(),
+                            null))
+            .toList();
+    final var failureStatuses =
+        outcomes.stream()
+            .filter(Outcome::isFailure)
+            .map(outcome -> outcome.cause().getStatus())
+            .toList();
+    return new ClusterRuntimeBackupTaken(
+        perTenant,
+        failureStatuses.isEmpty() ? null : PhysicalTenantFanOut.sharedStatus(failureStatuses));
+  }
+
+  /**
+   * Enforces the all-or-nothing rule for the operations that produce no value, whose successful
+   * outcomes carry none: a {@code CompletionStage<Void>} completes with {@code null}.
+   */
+  private static @Nullable Void everyTenantSucceeded(final List<? extends Outcome<?>> outcomes) {
+    PhysicalTenantFanOut.requireNoTenantFailed(outcomes);
+    return null;
+  }
+
+  /**
+   * Pairs each targeted physical tenant with its own result. {@link #onEveryTenant} keeps the
+   * targets' order, which is what makes pairing by position sound.
+   */
+  private static <T, R> List<R> zip(
+      final List<PhysicalTenantBackupPort> targets,
+      final List<T> results,
+      final BiFunction<String, T, R> pair) {
+    return IntStream.range(0, targets.size())
+        .mapToObj(i -> pair.apply(targets.get(i).physicalTenantId(), results.get(i)))
+        .toList();
+  }
+
+  private static List<ClusterRuntimeBackup> groupByBackupId(
+      final List<PhysicalTenantBackupPort> targets, final List<List<BackupStatus>> perTenant) {
+    final Map<Long, List<PhysicalTenantRuntimeBackup>> byBackupId =
+        new TreeMap<>(Comparator.reverseOrder());
+    zip(targets, perTenant, PhysicalTenantBackups::new)
+        .forEach(
+            tenant ->
+                tenant
+                    .backups()
+                    .forEach(
+                        backup ->
+                            byBackupId
+                                .computeIfAbsent(backup.backupId(), id -> new ArrayList<>())
+                                .add(
+                                    new PhysicalTenantRuntimeBackup(
+                                        tenant.physicalTenantId(), backup))));
+    return byBackupId.entrySet().stream()
+        .map(entry -> toClusterBackup(entry.getKey(), List.copyOf(entry.getValue())))
+        .toList();
+  }
+
+  private static ClusterRuntimeBackup toClusterBackup(
+      final long backupId, final List<PhysicalTenantRuntimeBackup> physicalTenants) {
+    final var state = fold(physicalTenants);
+    return new ClusterRuntimeBackup(
+        backupId,
+        state,
+        state == State.FAILED ? collectFailureReason(physicalTenants) : null,
+        physicalTenants);
+  }
+
+  /**
+   * Folds the physical tenants' states into the cluster-wide one, by the same rules {@code
+   * BackupRequestHandler} folds a tenant's partitions into the tenant's state: a cluster-wide
+   * backup relates to its tenants' backups exactly as a tenant's backup relates to its partitions',
+   * so an operator reads one state code either way.
+   *
+   * <p>{@code INCOMPLETE} is checked ahead of those rules because only a tenant state can carry it
+   * — a partition never does — and a tenant that is itself incomplete makes the whole set
+   * incomplete.
+   */
+  private static State fold(final List<PhysicalTenantRuntimeBackup> physicalTenants) {
+    if (physicalTenants.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected at least one physical tenant to fold a backup state from");
+    }
+    final var states =
+        physicalTenants.stream()
+            .map(tenant -> tenant.backup().status())
+            .collect(Collectors.toCollection(() -> EnumSet.noneOf(State.class)));
+
+    if (states.contains(State.FAILED)) {
+      return State.FAILED;
+    }
+    if (states.contains(State.INCOMPLETE)) {
+      return State.INCOMPLETE;
+    }
+    if ((states.contains(State.IN_PROGRESS) || states.contains(State.COMPLETED))
+        && states.contains(State.DOES_NOT_EXIST)
+        && !states.contains(State.DELETED)) {
+      return State.INCOMPLETE;
+    }
+    if (states.contains(State.DELETED)) {
+      return State.DELETED;
+    }
+    if (states.contains(State.IN_PROGRESS)) {
+      return State.IN_PROGRESS;
+    }
+    if (states.contains(State.DOES_NOT_EXIST)) {
+      return State.DOES_NOT_EXIST;
+    }
+    return State.COMPLETED;
+  }
+
+  private static String collectFailureReason(
+      final List<PhysicalTenantRuntimeBackup> physicalTenants) {
+    return physicalTenants.stream()
+        .filter(tenant -> tenant.backup().status() == State.FAILED)
+        .map(
+            tenant ->
+                "Backup on physical tenant '%s' failed due to %s. "
+                    .formatted(
+                        tenant.physicalTenantId(),
+                        tenant.backup().failureReason().orElse("Unknown reason")))
+        .collect(Collectors.joining());
+  }
+
+  private static ServiceException noTenantHolds(
+      final long backupId, final List<PhysicalTenantBackupPort> targets) {
+    return new ServiceException(
+        "Expected to find a runtime backup with id '%d', but none of the physical tenants %s holds it"
+            .formatted(backupId, physicalTenantIds(targets, port -> true)),
+        Status.NOT_FOUND);
+  }
+
+  private record PhysicalTenantBackups(String physicalTenantId, List<BackupStatus> backups) {}
+
+  /** Turns a rejection raised before the fan-out starts into a failed future. */
+  private static <T> CompletableFuture<T> validated(final Supplier<CompletableFuture<T>> request) {
+    try {
+      return request.get();
+    } catch (final ServiceException e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  /**
+   * One physical tenant's runtime-backup port, plus the backup-id mode it is configured in — the
+   * deployment-time choice that decides whether this tenant accepts an explicit backup id.
+   */
+  public record PhysicalTenantBackupPort(
+      String physicalTenantId, BackupApi api, boolean backupIdGenerated) {}
+
+  /**
+   * What each targeted physical tenant did with one trigger request.
+   *
+   * @param failureStatus the status the request should answer with, or {@code null} when every
+   *     targeted tenant was triggered
+   */
+  public record ClusterRuntimeBackupTaken(
+      List<PhysicalTenantRuntimeBackupTaken> physicalTenants, @Nullable Status failureStatus) {}
+
+  /**
+   * @param backupId the id the backup is running under — the requested one, or the one the tenant
+   *     generated. Null when the tenant was not triggered.
+   * @param reason why the tenant was not triggered, null when it was
+   */
+  public record PhysicalTenantRuntimeBackupTaken(
+      String physicalTenantId,
+      TakeOutcome outcome,
+      @Nullable Long backupId,
+      @Nullable String reason) {}
+
+  /**
+   * Whether a physical tenant's backup was triggered. There is no code for a tenant that could not
+   * be reached — an unreachable tenant is a {@code FAILED} one, with the reason saying so.
+   */
+  public enum TakeOutcome {
+    TRIGGERED,
+    FAILED
+  }
+
+  /** What each physical tenant reports for one backup id, plus the state folded over them. */
+  public record ClusterRuntimeBackup(
+      long backupId,
+      State state,
+      @Nullable String failureReason,
+      List<PhysicalTenantRuntimeBackup> physicalTenants) {}
+
+  public record PhysicalTenantRuntimeBackup(String physicalTenantId, BackupStatus backup) {}
+
+  /** The checkpoint and backup state of each targeted physical tenant, aggregated over none. */
+  public record ClusterRuntimeBackupStates(
+      List<PhysicalTenantRuntimeBackupState> physicalTenants) {}
+
+  public record PhysicalTenantRuntimeBackupState(
+      String physicalTenantId, RuntimeBackupState state) {}
+}

--- a/service/src/main/java/io/camunda/service/PhysicalTenantFanOut.java
+++ b/service/src/main/java/io/camunda/service/PhysicalTenantFanOut.java
@@ -36,11 +36,19 @@ final class PhysicalTenantFanOut {
    * the whole request if any tenant failed.
    */
   static <T> List<T> requireEveryTenant(final List<Outcome<T>> outcomes) {
+    requireNoTenantFailed(outcomes);
+    return outcomes.stream().map(Outcome::requireValue).toList();
+  }
+
+  /**
+   * The same rule for a call that produces no value, whose successful outcomes therefore carry no
+   * value to return — a {@code CompletionStage<Void>} completes with {@code null}.
+   */
+  static void requireNoTenantFailed(final List<? extends Outcome<?>> outcomes) {
     final var failures = outcomes.stream().filter(Outcome::isFailure).toList();
     if (!failures.isEmpty()) {
       throw combine(failures, outcomes.size());
     }
-    return outcomes.stream().map(Outcome::requireValue).toList();
   }
 
   /** Folds the failures of a fan-out into the one exception the request answers with. */

--- a/service/src/main/java/io/camunda/service/PhysicalTenantFanOut.java
+++ b/service/src/main/java/io/camunda/service/PhysicalTenantFanOut.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.StringJoiner;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * What every cluster-wide service does with the per-physical-tenant outcomes of one fan-out: name
+ * the tenants that failed, and answer with a single status.
+ *
+ * <p>Shared rather than copied per service because the status rule is what a caller scripts
+ * against: where every failing tenant agrees on a status the request answers with it, so a request
+ * narrowed to one tenant collapses to exactly what that tenant's own endpoint would have answered.
+ * Only genuinely different causes have no honest status other than 500.
+ */
+@NullMarked
+final class PhysicalTenantFanOut {
+
+  private PhysicalTenantFanOut() {}
+
+  /**
+   * Enforces the all-or-nothing rule: returns every tenant's value in the outcomes' order, or fails
+   * the whole request if any tenant failed.
+   */
+  static <T> List<T> requireEveryTenant(final List<Outcome<T>> outcomes) {
+    final var failures = outcomes.stream().filter(Outcome::isFailure).toList();
+    if (!failures.isEmpty()) {
+      throw combine(failures, outcomes.size());
+    }
+    return outcomes.stream().map(Outcome::requireValue).toList();
+  }
+
+  /** Folds the failures of a fan-out into the one exception the request answers with. */
+  static ServiceException combine(final List<? extends Outcome<?>> failures, final int targeted) {
+    final var statuses = new LinkedHashSet<Status>();
+    final var detail = new StringJoiner("; ");
+    for (final var failure : failures) {
+      final var cause = failure.cause();
+      statuses.add(cause.getStatus());
+      detail.add("'%s': %s".formatted(failure.physicalTenantId(), cause.getMessage()));
+    }
+    return new ServiceException(
+        "Expected to serve every targeted physical tenant, but %d of %d failed — %s"
+            .formatted(failures.size(), targeted, detail),
+        sharedStatus(statuses));
+  }
+
+  /**
+   * The one status a set of failures agrees on, or {@link Status#INTERNAL} when they disagree and
+   * no single status is honest.
+   */
+  static Status sharedStatus(final Collection<Status> statuses) {
+    final var distinct = new LinkedHashSet<>(statuses);
+    return distinct.size() == 1 ? distinct.iterator().next() : Status.INTERNAL;
+  }
+
+  /**
+   * One physical tenant's outcome, successful or not. Carries the tenant id so a failure on a
+   * ten-tenant cluster tells the operator which tenant failed, not just that one did — the exact
+   * toil the cluster-wide endpoints exist to remove.
+   */
+  record Outcome<T>(String physicalTenantId, @Nullable T value, @Nullable Throwable error) {
+
+    static <T> Outcome<T> failed(final String physicalTenantId, final Throwable error) {
+      return new Outcome<>(physicalTenantId, null, error);
+    }
+
+    boolean isFailure() {
+      return error != null;
+    }
+
+    T requireValue() {
+      if (value == null) {
+        throw new IllegalStateException(
+            "Expected physical tenant '%s' to have succeeded".formatted(physicalTenantId));
+      }
+      return value;
+    }
+
+    /**
+     * The failure mapped to a {@link ServiceException}, so both its status and its message are the
+     * ones the tenant's own endpoint would have answered with.
+     *
+     * <p>Maps through {@link ErrorMapper} rather than matching on the raw throwable because a
+     * {@link java.util.concurrent.CompletableFuture} wraps a dependency's failure in a {@link
+     * java.util.concurrent.CompletionException} — only the recursive unwrap reaches the real cause.
+     */
+    ServiceException cause() {
+      if (error == null) {
+        throw new IllegalStateException(
+            "Expected physical tenant '%s' to have failed".formatted(physicalTenantId));
+      }
+      return ErrorMapper.mapError(error);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -18,6 +18,7 @@ import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterHistoryBackupServices;
 import io.camunda.service.ClusterRecoveryServices;
+import io.camunda.service.ClusterRuntimeBackupServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
 import io.camunda.service.ClusterVariableServices;
@@ -106,6 +107,7 @@ public record DefaultServiceRegistry(
     Map<String, UserTaskServices> userTaskByTenant,
     Map<String, VariableServices> variableByTenant,
     @Nullable ClusterHistoryBackupServices clusterHistoryBackupServices,
+    ClusterRuntimeBackupServices clusterRuntimeBackupServices,
     ClusterRecoveryServices clusterRecoveryServices,
     ClusterStatusServices clusterStatusServices,
     ClusterTopologyServices clusterTopologyServices,
@@ -339,6 +341,11 @@ public record DefaultServiceRegistry(
   }
 
   @Override
+  public ClusterRuntimeBackupServices clusterRuntimeBackupServices() {
+    return clusterRuntimeBackupServices;
+  }
+
+  @Override
   public ClusterStatusServices clusterStatusServices() {
     return clusterStatusServices;
   }
@@ -443,6 +450,7 @@ public record DefaultServiceRegistry(
     private final Map<String, UserTaskServices> userTaskByTenant = new HashMap<>();
     private final Map<String, VariableServices> variableByTenant = new HashMap<>();
     private @Nullable ClusterHistoryBackupServices clusterHistoryBackupServices;
+    private ClusterRuntimeBackupServices clusterRuntimeBackupServices;
     private ClusterRecoveryServices clusterRecoveryServices;
     private ClusterStatusServices clusterStatusServices;
     private ClusterTopologyServices clusterTopologyServices;
@@ -669,6 +677,11 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder clusterRuntimeBackupServices(final ClusterRuntimeBackupServices service) {
+      clusterRuntimeBackupServices = service;
+      return this;
+    }
+
     public Builder clusterRecoveryServices(final ClusterRecoveryServices service) {
       clusterRecoveryServices = service;
       return this;
@@ -737,6 +750,7 @@ public record DefaultServiceRegistry(
           Map.copyOf(userTaskByTenant),
           Map.copyOf(variableByTenant),
           clusterHistoryBackupServices,
+          clusterRuntimeBackupServices,
           clusterRecoveryServices,
           clusterStatusServices,
           clusterTopologyServices,

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -18,6 +18,7 @@ import io.camunda.service.ClockServices;
 import io.camunda.service.ClusterExportingServices;
 import io.camunda.service.ClusterHistoryBackupServices;
 import io.camunda.service.ClusterRecoveryServices;
+import io.camunda.service.ClusterRuntimeBackupServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
 import io.camunda.service.ClusterVariableServices;
@@ -155,6 +156,8 @@ public interface ServiceRegistry {
    *     cluster-wide storage type, so the two can disagree; both paths answer 403.
    */
   ClusterHistoryBackupServices clusterHistoryBackupServices();
+
+  ClusterRuntimeBackupServices clusterRuntimeBackupServices();
 
   ClusterStatusServices clusterStatusServices();
 

--- a/service/src/test/java/io/camunda/service/ClusterRuntimeBackupServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRuntimeBackupServicesTest.java
@@ -37,6 +37,8 @@ import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * The contract of the cluster-wide runtime backup endpoints: a partial trigger is reported rather
@@ -249,14 +251,87 @@ public class ClusterRuntimeBackupServicesTest {
         .satisfies(result -> assertThat(result.failureStatus()).isNull());
   }
 
+  /**
+   * A cut connection may or may not have been accepted, so calling it {@code FAILED} would tell the
+   * operator no backup is running where one might be — the silent partial trigger this response
+   * exists to prevent.
+   */
   @Test
-  public void shouldRejectANonPositiveBackupId() {
+  public void shouldReportAnIndeterminateTriggerAsUnknownKeepingTheRequestedId() {
+    // given
+    when(apiA.takeBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(42L));
+    when(apiB.takeBackup(TENANT_B, 42L))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("the connection was cut prematurely", Status.ABORTED)));
+
     // when
-    final var taken = services.takeBackup(null, 0L);
+    final var taken = services.takeBackup(null, 42L);
+
+    // then the tenant is neither triggered nor failed, and carries the id to check it under
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              assertThat(result.failureStatus()).isEqualTo(Status.ABORTED);
+              assertThat(result.physicalTenants())
+                  .extracting("physicalTenantId", "outcome", "backupId")
+                  .containsExactly(
+                      tuple(TENANT_A, TakeOutcome.TRIGGERED, 42L),
+                      tuple(TENANT_B, TakeOutcome.UNKNOWN, 42L));
+            });
+  }
+
+  @Test
+  public void shouldReportATimedOutTriggerAsUnknown() {
+    // given a gateway-to-broker timeout, which is equally indeterminate
+    when(apiA.takeBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(42L));
+    when(apiB.takeBackup(TENANT_B, 42L))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("request timed out", Status.DEADLINE_EXCEEDED)));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
 
     // then
-    assertThat(failureOf(taken).getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
-    verify(apiA, never()).takeBackup(anyString(), anyLong());
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result ->
+                assertThat(result.physicalTenants())
+                    .extracting("physicalTenantId", "outcome")
+                    .containsExactly(
+                        tuple(TENANT_A, TakeOutcome.TRIGGERED),
+                        tuple(TENANT_B, TakeOutcome.UNKNOWN)));
+  }
+
+  /**
+   * A definite failure must not carry an id: reporting one would send the operator looking for a
+   * backup that is certainly not there.
+   */
+  @Test
+  public void shouldReportNoIdForADefiniteFailure() {
+    // given
+    when(apiA.takeBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(42L));
+    when(apiB.takeBackup(TENANT_B, 42L))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("already exists", Status.ALREADY_EXISTS)));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result ->
+                assertThat(result.physicalTenants())
+                    .extracting("physicalTenantId", "outcome", "backupId")
+                    .containsExactly(
+                        tuple(TENANT_A, TakeOutcome.TRIGGERED, 42L),
+                        tuple(TENANT_B, TakeOutcome.FAILED, null)));
   }
 
   // -- get --
@@ -395,14 +470,33 @@ public class ClusterRuntimeBackupServicesTest {
             });
   }
 
-  @Test
-  public void shouldRejectAPrefixWithoutAWildcard() {
+  /**
+   * The published {@code BackupIdPrefix} is digits plus one wildcard, and backup ids are numbers,
+   * so anything else can never match. Rejecting it says the request was malformed, where passing it
+   * to the store returns an empty list that reads as "no such backups".
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"17", "abc*", "1**", "*17", "17*x", "*-suffix", "1 *"})
+  public void shouldRejectAPrefixTheContractDoesNotAllow(final String prefix) {
     // when
-    final var backups = services.listBackups(null, "17");
+    final var backups = services.listBackups(null, prefix);
 
     // then
     assertThat(failureOf(backups).getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
     verify(apiA, never()).listBackups(anyString(), anyString());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"*", "17*"})
+  public void shouldAcceptAPrefixTheContractAllows(final String prefix) {
+    // given
+    when(apiA.listBackups(TENANT_A, prefix))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(apiB.listBackups(TENANT_B, prefix))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when - then
+    assertThat(services.listBackups(null, prefix)).succeedsWithin(TIMEOUT);
   }
 
   // -- delete --
@@ -540,6 +634,28 @@ public class ClusterRuntimeBackupServicesTest {
     // then the other tenant is never contacted
     assertThat(deleted).succeedsWithin(TIMEOUT);
     verify(apiB, never()).deleteBackup(anyString(), anyLong());
+  }
+
+  /**
+   * The {@code BackupId} schema allows only positive ids, so an id outside it is a request error.
+   * Let through, it reads back as a 404 — indistinguishable from an id that is merely absent, when
+   * the request could never have been served at all.
+   */
+  @ParameterizedTest
+  @ValueSource(longs = {0L, -1L})
+  public void shouldRejectANonPositiveBackupIdOnEveryOperation(final long backupId) {
+    // when - then
+    assertThat(failureOf(services.getBackup(null, backupId)).getStatus())
+        .isEqualTo(Status.INVALID_ARGUMENT);
+    assertThat(failureOf(services.deleteBackup(null, backupId)).getStatus())
+        .isEqualTo(Status.INVALID_ARGUMENT);
+    assertThat(failureOf(services.takeBackup(null, backupId)).getStatus())
+        .isEqualTo(Status.INVALID_ARGUMENT);
+
+    // and no tenant is contacted
+    verify(apiA, never()).getStatus(anyString(), anyLong());
+    verify(apiA, never()).deleteBackup(anyString(), anyLong());
+    verify(apiA, never()).takeBackup(anyString(), anyLong());
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/ClusterRuntimeBackupServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRuntimeBackupServicesTest.java
@@ -1,0 +1,613 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ClusterRuntimeBackupServices.PhysicalTenantBackupPort;
+import io.camunda.service.ClusterRuntimeBackupServices.TakeOutcome;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.backup.client.api.BackupApi;
+import io.camunda.zeebe.backup.client.api.BackupStatus;
+import io.camunda.zeebe.backup.client.api.PartitionBackupStatus;
+import io.camunda.zeebe.backup.client.api.State;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRangesResponse;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The contract of the cluster-wide runtime backup endpoints: a partial trigger is reported rather
+ * than hidden, absence is a successful observation that folds to {@code INCOMPLETE}, and every
+ * other failure is all-or-nothing.
+ */
+public class ClusterRuntimeBackupServicesTest {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+
+  /**
+   * Generous on purpose. The first assertion that reaches a failure path pays the class loading of
+   * {@code ErrorMapper}'s dependency graph on a worker thread, which costs seconds on a cold JVM. A
+   * bound near that cost makes the test flaky without saying anything about the code under test,
+   * which has no timing behaviour of its own.
+   */
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+  private final BackupApi apiA = mock(BackupApi.class);
+  private final BackupApi apiB = mock(BackupApi.class);
+
+  private ClusterRuntimeBackupServices services;
+
+  @BeforeEach
+  public void before() {
+    services = manualOnBothTenants();
+  }
+
+  // -- take --
+
+  @Test
+  public void shouldTriggerTheBackupOnEveryPhysicalTenantInTenantIdOrder() {
+    // given
+    when(apiA.takeBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(42L));
+    when(apiB.takeBackup(TENANT_B, 42L)).thenReturn(CompletableFuture.completedFuture(42L));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              assertThat(result.failureStatus()).isNull();
+              assertThat(result.physicalTenants())
+                  .extracting("physicalTenantId", "outcome", "backupId")
+                  .containsExactly(
+                      tuple(TENANT_A, TakeOutcome.TRIGGERED, 42L),
+                      tuple(TENANT_B, TakeOutcome.TRIGGERED, 42L));
+            });
+  }
+
+  /**
+   * The whole reason the trigger reports per-tenant outcomes: an operator who is not told which
+   * tenants are running a backup cannot monitor or delete them, and there is nothing that could
+   * roll them back.
+   */
+  @Test
+  public void shouldReportTheTriggeredTenantsWhenAnotherTenantFails() {
+    // given
+    when(apiA.takeBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(42L));
+    when(apiB.takeBackup(TENANT_B, 42L))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("already exists", Status.ALREADY_EXISTS)));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then the request fails as a whole, but says what is running
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              assertThat(result.failureStatus()).isEqualTo(Status.ALREADY_EXISTS);
+              assertThat(result.physicalTenants())
+                  .extracting("physicalTenantId", "outcome", "backupId")
+                  .containsExactly(
+                      tuple(TENANT_A, TakeOutcome.TRIGGERED, 42L),
+                      tuple(TENANT_B, TakeOutcome.FAILED, null));
+              assertThat(result.physicalTenants().get(1).reason()).contains("already exists");
+            });
+  }
+
+  /**
+   * A tenant whose topology is incomplete throws before returning a future, and must not abort the
+   * fan-out before the healthy tenants are even asked — otherwise one broken tenant makes the
+   * cluster-wide trigger useless instead of partially effective.
+   */
+  @Test
+  public void shouldTriggerTheHealthyTenantsWhenAnotherRejectsSynchronously() {
+    // given
+    when(apiA.takeBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(42L));
+    when(apiB.takeBackup(TENANT_B, 42L))
+        .thenThrow(new ServiceException("incomplete topology", Status.UNAVAILABLE));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              assertThat(result.failureStatus()).isEqualTo(Status.UNAVAILABLE);
+              assertThat(result.physicalTenants())
+                  .extracting("physicalTenantId", "outcome")
+                  .containsExactly(
+                      tuple(TENANT_A, TakeOutcome.TRIGGERED), tuple(TENANT_B, TakeOutcome.FAILED));
+            });
+    verify(apiA).takeBackup(TENANT_A, 42L);
+  }
+
+  @Test
+  public void shouldAnswerInternalWhenTheFailedTenantsDisagreeOnAStatus() {
+    // given a two-tenant cluster where both fail, for different reasons
+    when(apiA.takeBackup(TENANT_A, 42L))
+        .thenReturn(
+            CompletableFuture.failedFuture(new ServiceException("gone", Status.UNAVAILABLE)));
+    when(apiB.takeBackup(TENANT_B, 42L))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("already exists", Status.ALREADY_EXISTS)));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then no single status is honest
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(result -> assertThat(result.failureStatus()).isEqualTo(Status.INTERNAL));
+  }
+
+  @Test
+  public void shouldGenerateAnIdPerPhysicalTenantWhenEveryTenantGeneratesIds() {
+    // given both tenants take scheduled backups, so each generates its own id
+    services = servicesWith(generating(TENANT_A, apiA), generating(TENANT_B, apiB));
+    when(apiA.takeBackup(TENANT_A)).thenReturn(CompletableFuture.completedFuture(101L));
+    when(apiB.takeBackup(TENANT_B)).thenReturn(CompletableFuture.completedFuture(202L));
+
+    // when
+    final var taken = services.takeBackup(null, null);
+
+    // then the response carries an id per tenant, because there is no cluster-wide one
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result ->
+                assertThat(result.physicalTenants())
+                    .extracting("physicalTenantId", "backupId")
+                    .containsExactly(tuple(TENANT_A, 101L), tuple(TENANT_B, 202L)));
+  }
+
+  @Test
+  public void shouldRejectAnExplicitIdWhenAPhysicalTenantGeneratesIds() {
+    // given a cluster mixing the two backup-id modes
+    services = servicesWith(manual(TENANT_A, apiA), generating(TENANT_B, apiB));
+
+    // when
+    final var taken = services.takeBackup(null, 42L);
+
+    // then the tenant standing in the way is named, and nothing is triggered anywhere
+    assertThat(failureOf(taken))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
+              assertThat(e.getMessage()).contains(TENANT_B).doesNotContain(TENANT_A);
+            });
+    verify(apiA, never()).takeBackup(anyString(), anyLong());
+    verify(apiB, never()).takeBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldRejectAMissingIdWhenAPhysicalTenantTakesManualBackups() {
+    // given a cluster mixing the two backup-id modes
+    services = servicesWith(manual(TENANT_A, apiA), generating(TENANT_B, apiB));
+
+    // when
+    final var taken = services.takeBackup(null, null);
+
+    // then
+    assertThat(failureOf(taken))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
+              assertThat(e.getMessage()).contains(TENANT_A).doesNotContain(TENANT_B);
+            });
+    verify(apiA, never()).takeBackup(anyString());
+    verify(apiB, never()).takeBackup(anyString());
+  }
+
+  /**
+   * A cluster mixing the modes can still be driven one tenant at a time, which is the escape hatch
+   * ADR 003 leaves for it — so narrowing must judge only the named tenant's mode.
+   */
+  @Test
+  public void shouldAcceptAnExplicitIdWhenNarrowedToAManualTenantOfAMixedCluster() {
+    // given
+    services = servicesWith(manual(TENANT_A, apiA), generating(TENANT_B, apiB));
+    when(apiA.takeBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(42L));
+
+    // when
+    final var taken = services.takeBackup(TENANT_A, 42L);
+
+    // then
+    assertThat(taken)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(result -> assertThat(result.failureStatus()).isNull());
+  }
+
+  @Test
+  public void shouldRejectANonPositiveBackupId() {
+    // when
+    final var taken = services.takeBackup(null, 0L);
+
+    // then
+    assertThat(failureOf(taken).getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
+    verify(apiA, never()).takeBackup(anyString(), anyLong());
+  }
+
+  // -- get --
+
+  @Test
+  public void shouldFoldABackupOnlyOnePhysicalTenantHoldsToIncomplete() {
+    // given a backup one tenant holds and the other does not — a supported outcome, not a failure
+    when(apiA.getStatus(TENANT_A, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.COMPLETED)));
+    when(apiB.getStatus(TENANT_B, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.DOES_NOT_EXIST)));
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then every targeted tenant is reported, and the cluster-wide state says it is not usable
+    assertThat(backup)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              assertThat(result.state()).isEqualTo(State.INCOMPLETE);
+              assertThat(result.physicalTenants())
+                  .extracting("physicalTenantId")
+                  .containsExactly(TENANT_A, TENANT_B);
+            });
+  }
+
+  @Test
+  public void shouldFoldABackupEveryPhysicalTenantCompletedToCompleted() {
+    // given
+    when(apiA.getStatus(TENANT_A, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.COMPLETED)));
+    when(apiB.getStatus(TENANT_B, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.COMPLETED)));
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then
+    assertThat(backup)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(result -> assertThat(result.state()).isEqualTo(State.COMPLETED));
+  }
+
+  @Test
+  public void shouldFoldToFailedAndNameTheFailedPhysicalTenant() {
+    // given
+    when(apiA.getStatus(TENANT_A, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.COMPLETED)));
+    when(apiB.getStatus(TENANT_B, 42L))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                failedBackup(42L, "the store rejected the snapshot")));
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then
+    assertThat(backup)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              assertThat(result.state()).isEqualTo(State.FAILED);
+              assertThat(result.failureReason())
+                  .contains(TENANT_B)
+                  .contains("the store rejected the snapshot");
+            });
+  }
+
+  @Test
+  public void shouldReportNotFoundWhenNoPhysicalTenantHoldsTheBackup() {
+    // given
+    when(apiA.getStatus(TENANT_A, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.DOES_NOT_EXIST)));
+    when(apiB.getStatus(TENANT_B, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.DOES_NOT_EXIST)));
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(backup).getStatus()).isEqualTo(Status.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldFailTheWholeReadWhenAPhysicalTenantCannotBeObserved() {
+    // given
+    when(apiA.getStatus(TENANT_A, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.COMPLETED)));
+    when(apiB.getStatus(TENANT_B, 42L))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("connection refused", Status.UNAVAILABLE)));
+
+    // when
+    final var backup = services.getBackup(null, 42L);
+
+    // then a partly observable cluster is not a partial success
+    assertThat(failureOf(backup))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE);
+              assertThat(e.getMessage()).contains(TENANT_B);
+            });
+  }
+
+  // -- list --
+
+  @Test
+  public void shouldGroupTheListingByBackupIdMostRecentFirst() {
+    // given tenantA holds two backups and tenantB only the older one
+    when(apiA.listBackups(TENANT_A, "*"))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(backup(43L, State.IN_PROGRESS), backup(42L, State.COMPLETED))));
+    when(apiB.listBackups(TENANT_B, "*"))
+        .thenReturn(CompletableFuture.completedFuture(List.of(backup(42L, State.COMPLETED))));
+
+    // when
+    final var backups = services.listBackups(null, null);
+
+    // then only the tenants holding an id are listed under it, and its state folds over those alone
+    assertThat(backups)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              assertThat(result).extracting("backupId").containsExactly(43L, 42L);
+              assertThat(result.get(0).state()).isEqualTo(State.IN_PROGRESS);
+              assertThat(result.get(0).physicalTenants())
+                  .extracting("physicalTenantId")
+                  .containsExactly(TENANT_A);
+              assertThat(result.get(1).state()).isEqualTo(State.COMPLETED);
+              assertThat(result.get(1).physicalTenants())
+                  .extracting("physicalTenantId")
+                  .containsExactly(TENANT_A, TENANT_B);
+            });
+  }
+
+  @Test
+  public void shouldRejectAPrefixWithoutAWildcard() {
+    // when
+    final var backups = services.listBackups(null, "17");
+
+    // then
+    assertThat(failureOf(backups).getStatus()).isEqualTo(Status.INVALID_ARGUMENT);
+    verify(apiA, never()).listBackups(anyString(), anyString());
+  }
+
+  // -- delete --
+
+  @Test
+  public void shouldDeleteFromEveryPhysicalTenant() {
+    // given
+    when(apiA.deleteBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(null));
+    when(apiB.deleteBackup(TENANT_B, 42L)).thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    final var deleted = services.deleteBackup(null, 42L);
+
+    // then
+    assertThat(deleted).succeedsWithin(TIMEOUT);
+    verify(apiA).deleteBackup(TENANT_A, 42L);
+    verify(apiB).deleteBackup(TENANT_B, 42L);
+  }
+
+  @Test
+  public void shouldFailTheWholeDeleteWhenAPhysicalTenantCannotBeReached() {
+    // given
+    when(apiA.deleteBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(null));
+    when(apiB.deleteBackup(TENANT_B, 42L))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("connection refused", Status.UNAVAILABLE)));
+
+    // when
+    final var deleted = services.deleteBackup(null, 42L);
+
+    // then
+    assertThat(failureOf(deleted).getStatus()).isEqualTo(Status.UNAVAILABLE);
+  }
+
+  // -- state --
+
+  @Test
+  public void shouldReportTheRuntimeStateOfEveryPhysicalTenantSeparately() {
+    // given
+    final var checkpointsA = mock(CheckpointStateResponse.class);
+    final var checkpointsB = mock(CheckpointStateResponse.class);
+    final var ranges = mock(BackupRangesResponse.class);
+    when(apiA.getCheckpointState(TENANT_A))
+        .thenReturn(CompletableFuture.completedFuture(checkpointsA));
+    when(apiB.getCheckpointState(TENANT_B))
+        .thenReturn(CompletableFuture.completedFuture(checkpointsB));
+    when(apiA.getBackupRanges(TENANT_A)).thenReturn(CompletableFuture.completedFuture(ranges));
+    when(apiB.getBackupRanges(TENANT_B)).thenReturn(CompletableFuture.completedFuture(ranges));
+
+    // when
+    final var states = services.getRuntimeState(null);
+
+    // then nothing is folded: checkpoint ids only mean anything within one tenant's partitions
+    assertThat(states)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result ->
+                assertThat(result.physicalTenants())
+                    .extracting("physicalTenantId")
+                    .containsExactly(TENANT_A, TENANT_B));
+  }
+
+  @Test
+  public void shouldFailTheWholeStateReadWhenOneSubRequestFails() {
+    // given a tenant whose ranges cannot be read, though its checkpoint state can
+    when(apiA.getCheckpointState(TENANT_A))
+        .thenReturn(CompletableFuture.completedFuture(mock(CheckpointStateResponse.class)));
+    when(apiB.getCheckpointState(TENANT_B))
+        .thenReturn(CompletableFuture.completedFuture(mock(CheckpointStateResponse.class)));
+    when(apiA.getBackupRanges(TENANT_A))
+        .thenReturn(CompletableFuture.completedFuture(mock(BackupRangesResponse.class)));
+    when(apiB.getBackupRanges(TENANT_B))
+        .thenReturn(
+            CompletableFuture.failedFuture(new ServiceException("gone", Status.UNAVAILABLE)));
+
+    // when
+    final var states = services.getRuntimeState(null);
+
+    // then a half-read tenant would be indistinguishable from one with nothing to report
+    assertThat(failureOf(states))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.UNAVAILABLE);
+              assertThat(e.getMessage()).contains(TENANT_B);
+            });
+  }
+
+  @Test
+  public void shouldSyncTheRuntimeStateOfEveryPhysicalTenant() {
+    // given
+    when(apiA.syncMetadata(TENANT_A))
+        .thenReturn(CompletableFuture.completedFuture(mock(BackupRangesResponse.class)));
+    when(apiB.syncMetadata(TENANT_B))
+        .thenReturn(CompletableFuture.completedFuture(mock(BackupRangesResponse.class)));
+    when(apiA.getCheckpointState(TENANT_A))
+        .thenReturn(CompletableFuture.completedFuture(mock(CheckpointStateResponse.class)));
+    when(apiB.getCheckpointState(TENANT_B))
+        .thenReturn(CompletableFuture.completedFuture(mock(CheckpointStateResponse.class)));
+
+    // when
+    final var states = services.syncRuntimeState(null);
+
+    // then
+    assertThat(states).succeedsWithin(TIMEOUT);
+    verify(apiA).syncMetadata(TENANT_A);
+    verify(apiB).syncMetadata(TENANT_B);
+  }
+
+  @Test
+  public void shouldDeleteTheRuntimeStateOfEveryPhysicalTenant() {
+    // given
+    when(apiA.deleteRuntimeState(TENANT_A)).thenReturn(CompletableFuture.completedFuture(null));
+    when(apiB.deleteRuntimeState(TENANT_B)).thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    final var deleted = services.deleteRuntimeState(null);
+
+    // then
+    assertThat(deleted).succeedsWithin(TIMEOUT);
+    verify(apiA).deleteRuntimeState(TENANT_A);
+    verify(apiB).deleteRuntimeState(TENANT_B);
+  }
+
+  // -- narrowing --
+
+  @Test
+  public void shouldNarrowTheFanOutToTheNamedPhysicalTenant() {
+    // given
+    when(apiA.deleteBackup(TENANT_A, 42L)).thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    final var deleted = services.deleteBackup(TENANT_A, 42L);
+
+    // then the other tenant is never contacted
+    assertThat(deleted).succeedsWithin(TIMEOUT);
+    verify(apiB, never()).deleteBackup(anyString(), anyLong());
+  }
+
+  @Test
+  public void shouldRejectAnUnknownPhysicalTenantBeforeContactingAnyTenant() {
+    // when
+    final var backup = services.getBackup("nosuchtenant", 42L);
+
+    // then an unknown id is a request error, never a tenant that failed
+    assertThat(failureOf(backup))
+        .satisfies(
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(Status.NOT_FOUND);
+              assertThat(e.getMessage()).contains("nosuchtenant");
+            });
+    verify(apiA, never()).getStatus(anyString(), anyLong());
+    verify(apiB, never()).getStatus(anyString(), anyLong());
+  }
+
+  private ClusterRuntimeBackupServices manualOnBothTenants() {
+    return servicesWith(manual(TENANT_A, apiA), manual(TENANT_B, apiB));
+  }
+
+  private static ClusterRuntimeBackupServices servicesWith(
+      final PhysicalTenantBackupPort a, final PhysicalTenantBackupPort b) {
+    // Deliberately unsorted, so the sorted response order is a property of the service.
+    return new ClusterRuntimeBackupServices(List.of(b, a));
+  }
+
+  private static PhysicalTenantBackupPort manual(
+      final String physicalTenantId, final BackupApi api) {
+    return new PhysicalTenantBackupPort(physicalTenantId, api, false);
+  }
+
+  private static PhysicalTenantBackupPort generating(
+      final String physicalTenantId, final BackupApi api) {
+    return new PhysicalTenantBackupPort(physicalTenantId, api, true);
+  }
+
+  private static BackupStatus backup(final long backupId, final State state) {
+    return new BackupStatus(backupId, state, Optional.empty(), List.of(partition(state, null)));
+  }
+
+  private static BackupStatus failedBackup(final long backupId, final String reason) {
+    return new BackupStatus(
+        backupId, State.FAILED, Optional.of(reason), List.of(partition(State.FAILED, reason)));
+  }
+
+  private static PartitionBackupStatus partition(final State state, final String failureReason) {
+    return new PartitionBackupStatus(
+        1,
+        state == State.INCOMPLETE
+            ? BackupStatusCode.DOES_NOT_EXIST
+            : BackupStatusCode.valueOf(state.name()),
+        Optional.ofNullable(failureReason),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        OptionalLong.empty(),
+        OptionalLong.empty(),
+        OptionalInt.empty(),
+        Optional.empty());
+  }
+
+  private static ServiceException failureOf(final CompletableFuture<?> future) {
+    final var thrown = catchThrowable(() -> future.get(TIMEOUT.toMillis(), MILLISECONDS));
+    assertThat(thrown).isNotNull();
+    final var cause = thrown.getCause();
+    assertThat(cause).isInstanceOf(ServiceException.class);
+    return (ServiceException) cause;
+  }
+}

--- a/service/src/test/java/io/camunda/service/ClusterRuntimeBackupServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterRuntimeBackupServicesTest.java
@@ -453,20 +453,76 @@ public class ClusterRuntimeBackupServicesTest {
     // when
     final var backups = services.listBackups(null, null);
 
-    // then only the tenants holding an id are listed under it, and its state folds over those alone
+    // then every group reports every targeted tenant, so the id only tenantA holds is INCOMPLETE
     assertThat(backups)
         .succeedsWithin(TIMEOUT)
         .satisfies(
             result -> {
               assertThat(result).extracting("backupId").containsExactly(43L, 42L);
-              assertThat(result.get(0).state()).isEqualTo(State.IN_PROGRESS);
+              assertThat(result.get(0).state()).isEqualTo(State.INCOMPLETE);
               assertThat(result.get(0).physicalTenants())
-                  .extracting("physicalTenantId")
-                  .containsExactly(TENANT_A);
+                  .extracting("physicalTenantId", "backup.status")
+                  .containsExactly(
+                      tuple(TENANT_A, State.IN_PROGRESS), tuple(TENANT_B, State.DOES_NOT_EXIST));
               assertThat(result.get(1).state()).isEqualTo(State.COMPLETED);
               assertThat(result.get(1).physicalTenants())
                   .extracting("physicalTenantId")
                   .containsExactly(TENANT_A, TENANT_B);
+            });
+  }
+
+  /**
+   * The state of a listed group has to mean what it means on a single-id read, or an operator
+   * scanning the listing for the backups the cluster can be restored from cannot trust it.
+   */
+  @Test
+  public void shouldFoldAListedGroupTheSameWayASingleIdReadDoes() {
+    // given a backup only one tenant holds, and both a listing and a direct read of it
+    when(apiA.listBackups(TENANT_A, "*"))
+        .thenReturn(CompletableFuture.completedFuture(List.of(backup(42L, State.COMPLETED))));
+    when(apiB.listBackups(TENANT_B, "*")).thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(apiA.getStatus(TENANT_A, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.COMPLETED)));
+    when(apiB.getStatus(TENANT_B, 42L))
+        .thenReturn(CompletableFuture.completedFuture(backup(42L, State.DOES_NOT_EXIST)));
+
+    // when
+    final var listed = services.listBackups(null, null);
+    final var read = services.getBackup(null, 42L);
+
+    // then both say the same thing about the same backup
+    assertThat(listed)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(result -> assertThat(result.get(0).state()).isEqualTo(State.INCOMPLETE));
+    assertThat(read)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(result -> assertThat(result.state()).isEqualTo(State.INCOMPLETE));
+  }
+
+  /**
+   * A listing asks each tenant for the backups it has, so a tenant that holds nothing for a listed
+   * id has no partition detail to report — unlike the single-id read, where the broker answers per
+   * partition.
+   */
+  @Test
+  public void shouldReportNoPartitionDetailForATenantHoldingNothingInAListing() {
+    // given
+    when(apiA.listBackups(TENANT_A, "*"))
+        .thenReturn(CompletableFuture.completedFuture(List.of(backup(42L, State.COMPLETED))));
+    when(apiB.listBackups(TENANT_B, "*")).thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when
+    final var backups = services.listBackups(null, null);
+
+    // then
+    assertThat(backups)
+        .succeedsWithin(TIMEOUT)
+        .satisfies(
+            result -> {
+              final var absent = result.get(0).physicalTenants().get(1);
+              assertThat(absent.physicalTenantId()).isEqualTo(TENANT_B);
+              assertThat(absent.backup().backupId()).isEqualTo(42L);
+              assertThat(absent.backup().partitions()).isEmpty();
             });
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -424,6 +424,517 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
 
+  /cluster/v2/backups/runtime:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: takeRuntimeBackupAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Take a runtime backup on one or every physical tenant
+      description: >-
+        Triggers a runtime backup on every physical tenant of the cluster, or on the one named by
+        `physicalTenantId`. A cluster-wide backup is a set of independent per-tenant backups, not an
+        atomic snapshot of the cluster: they are neither coordinated nor rolled back together, and
+        each tenant stores its own, so the same `backupId` can be used for all of them.
+
+
+        Every targeted physical tenant must be in the same backup-id mode. `backupId` must be
+        omitted when every targeted tenant generates its own ids (because continuous backups and/or
+        a backup or checkpoint schedule is enabled for it), and is required when none of them does.
+        A cluster whose targeted tenants mix the two modes is rejected with 400 and has to be driven
+        one tenant at a time through `POST /v2/backups/runtime`. In generated-id mode each tenant
+        generates its own id, so the response reports an id per physical tenant rather than one for
+        the cluster.
+
+
+        The trigger is all-or-error, and never silent about a partial trigger: if any targeted tenant
+        cannot be triggered the response carries an error status, but its body still lists every
+        targeted tenant — which ones were triggered, under which `backupId` to monitor or delete
+        them, and why the others failed. Nothing is rolled back, so the backups that were triggered
+        keep running and have to be deleted explicitly. A request rejected before any tenant was
+        triggered answers with a problem detail instead, and nothing is running.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Use `POST /v2/backups/runtime` to act as a single physical tenant.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: 'backups.yaml#/components/schemas/TakeRuntimeBackupRequest'
+      responses:
+        "202":
+          description: The backup was triggered on every targeted physical tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
+        "400":
+          description: >-
+            The request names a `backupId` while at least one targeted physical tenant generates its
+            own ids, or omits it while at least one does not, or the id is not a positive number. No
+            tenant was triggered. A targeted tenant that rejects the request as invalid during the
+            fan-out answers with the same status but the cluster body, listing the tenants that were
+            triggered.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: >-
+            The requested `physicalTenantId` does not exist in this cluster, so no tenant was
+            triggered.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "409":
+          description: >-
+            At least one targeted physical tenant already holds a backup with this id or a higher
+            one. Backups are triggered without a preceding check, so the tenants that accepted the
+            id are listed in the body and keep running; delete them before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
+        "500":
+          description: >-
+            At least one targeted physical tenant could not be triggered, and the failures do not
+            agree on a single status. The body lists the tenants that were triggered and keep
+            running.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "503":
+          description: >-
+            At least one targeted physical tenant could not be reached. The body lists the tenants
+            that were triggered and keep running.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
+        "504":
+          description: >-
+            The request from gateway to broker timed out on at least one targeted physical tenant.
+            The body lists the tenants that were triggered and keep running.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
+      x-added-in-version: "8.10"
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: listRuntimeBackupsAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: List runtime backups across physical tenants
+      description: >-
+        Lists the runtime backups of every physical tenant of the cluster, or of the one named by
+        `physicalTenantId`, grouped by backup id. A backup id that only some physical tenants hold is
+        a supported outcome rather than a degraded one, so only the tenants that hold it are listed
+        under it, and the group's aggregated state accounts for those tenants alone. Tenants that
+        generate their own backup ids never share one, so each of their backups forms its own group.
+
+
+        The request is all-or-nothing: a physical tenant whose backups cannot be read fails the whole
+        request rather than silently dropping out of the listing. Narrow the request with
+        `physicalTenantId` to list the backups of the tenants that can still be read.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Use `GET /v2/backups/runtime` to act as a single physical tenant.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+        - name: prefix
+          in: query
+          required: false
+          description: |
+            A prefix that backup ids must match, ending in a single '*'. If omitted, all
+            backups are returned.
+          schema:
+            $ref: 'backups.yaml#/components/schemas/BackupIdPrefix'
+      responses:
+        "200":
+          description: >-
+            The runtime backups of every targeted physical tenant, grouped by backup id and sorted in
+            descending order of backup id, as the per-physical-tenant listing is. Empty when every
+            targeted tenant was read and none of them holds a matching backup.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClusterRuntimeBackupInfo'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
+  /cluster/v2/backups/runtime/state:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: getRuntimeBackupStateAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Get runtime backup state across physical tenants
+      description: >-
+        Reports the checkpoint and backup state of every partition of every physical tenant of the
+        cluster, or of the one named by `physicalTenantId`, grouped by physical tenant. Checkpoint
+        ids and log positions only mean anything within one physical tenant's partitions, so nothing
+        is aggregated across tenants.
+
+
+        The request is all-or-nothing: a physical tenant whose state cannot be read fails the whole
+        request rather than contributing an empty section, which an operator making a delete or
+        restore decision could not tell apart from "nothing to report yet". Narrow the request with
+        `physicalTenantId` to read the tenants that can still be reached.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Use `GET /v2/backups/runtime/state` to act as a single physical tenant.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      responses:
+        "200":
+          description: >-
+            The runtime backup state of every targeted physical tenant, ordered by physical tenant
+            id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterRuntimeBackupState'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+    delete:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: deleteRuntimeBackupStateAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Delete runtime backup state across physical tenants
+      description: >-
+        Resets the runtime backup state of every partition of every physical tenant of the cluster,
+        or of the one named by `physicalTenantId`, clearing all checkpoint info, backup info,
+        checkpoint metadata, and backup ranges. Used when switching backup stores.
+
+
+        The request is all-or-nothing: a physical tenant whose state cannot be reset fails the whole
+        request, and the resets that already succeeded on other tenants are not undone. Narrow the
+        request with `physicalTenantId` to reset the tenants that can still be reached.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Use `DELETE /v2/backups/runtime/state` to act as a single physical tenant.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      responses:
+        "204":
+          description: The runtime backup state was reset on every targeted physical tenant.
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          description: >-
+            The state could not be reset on every targeted physical tenant, so it may still be set
+            on some of them. The resets that already succeeded are not undone, so a retry has only
+            the remaining tenants left to reach.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
+  /cluster/v2/backups/runtime/state/sync:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: syncRuntimeBackupStateAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Force-write runtime backup state across physical tenants
+      description: >-
+        Force-writes the checkpoint and backup metadata of every partition of every physical tenant
+        of the cluster, or of the one named by `physicalTenantId`, to that tenant's backup store,
+        independent of any backup being taken or confirmed, and returns the updated state per
+        physical tenant.
+
+
+        The request is all-or-nothing: a physical tenant whose metadata cannot be written fails the
+        whole request, and the writes that already succeeded on other tenants are not undone. The
+        operation is idempotent, so retrying the same call is the correct remedy. Narrow the request
+        with `physicalTenantId` to write the tenants that can still be reached.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Use `POST /v2/backups/runtime/state/sync` to act as a single physical tenant.
+      parameters:
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      responses:
+        "200":
+          description: >-
+            The updated runtime backup state of every targeted physical tenant, ordered by physical
+            tenant id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterRuntimeBackupState'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+        "504":
+          description: >-
+            The request from gateway to broker timed out on at least one targeted physical tenant.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+      x-added-in-version: "8.10"
+
+  /cluster/v2/backups/runtime/{backupId}:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: getRuntimeBackupAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Get a runtime backup across physical tenants
+      description: >-
+        Reports what every physical tenant of the cluster, or the one named by `physicalTenantId`,
+        holds for the given backup id, plus the state aggregated over all of them. A tenant that was
+        reached and does not hold this backup reports `DOES_NOT_EXIST`, which is a successful
+        observation rather than a failure — so a backup only some tenants hold aggregates to
+        `INCOMPLETE`, the same way a backup only some partitions hold does within one tenant.
+
+
+        The request is all-or-nothing: a physical tenant whose state cannot be read fails the whole
+        request. Narrow the request with `physicalTenantId` to read the tenants that can still be
+        reached.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Use `GET /v2/backups/runtime/{backupId}` to act as a single physical tenant.
+      parameters:
+        - name: backupId
+          in: path
+          required: true
+          description: The id of the backup.
+          schema:
+            $ref: 'backups.yaml#/components/schemas/BackupId'
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      responses:
+        "200":
+          description: >-
+            Every targeted physical tenant was read, and at least one holds the backup. Each tenant
+            reports either the backup or `DOES_NOT_EXIST`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterRuntimeBackupInfo'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: >-
+            The requested `physicalTenantId` does not exist in this cluster, or every targeted
+            physical tenant was read and none of them holds a backup with the given id.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+    delete:
+      x-eventually-consistent: false
+      tags:
+        - Backup
+      operationId: deleteRuntimeBackupAsClusterAdmin
+      x-required-permissions: [ ]
+      security:
+        - bearerAuth: [ ]
+        - basicAuth: [ ]
+      summary: Delete a runtime backup across physical tenants
+      description: >-
+        Deletes the runtime backup with the given id from every physical tenant of the cluster, or
+        from the one named by `physicalTenantId`. A tenant that does not hold the backup has already
+        reached the requested end state, so it counts as deleted rather than as a failure — the same
+        as deleting an unknown backup id through the per-physical-tenant endpoint.
+
+
+        The request is all-or-nothing: a physical tenant the backup cannot be deleted from fails the
+        whole request, and the deletions that already succeeded on other tenants are not undone.
+        Narrow the request with `physicalTenantId` to delete from the tenants that can still be
+        reached.
+
+
+        Requires the cluster-admin security chain. Although this operation lists `bearerAuth` /
+        `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an
+        Orchestration Cluster user's credentials — only the separate cluster-admin credentials are
+        valid here. Use `DELETE /v2/backups/runtime/{backupId}` to act as a single physical tenant.
+      parameters:
+        - name: backupId
+          in: path
+          required: true
+          description: The id of the backup.
+          schema:
+            $ref: 'backups.yaml#/components/schemas/BackupId'
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+      responses:
+        "204":
+          description: No targeted physical tenant holds the backup any more.
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "404":
+          description: The requested `physicalTenantId` does not exist in this cluster.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          description: >-
+            The backup could not be deleted from every targeted physical tenant, so it may still
+            exist on some of them. The deletions that already succeeded are not undone, so a retry
+            has only the remaining tenants left to reach.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
   /cluster/v2/backups/history:
     servers:
       - url: "{schema}://{host}:{port}"
@@ -938,6 +1449,169 @@ components:
           type: array
           items:
             $ref: 'cluster.yaml#/components/schemas/Partition'
+
+    ClusterTakeRuntimeBackupResponse:
+      description: >-
+        The outcome of triggering a runtime backup on every targeted physical tenant. Returned both
+        when every tenant was triggered and when only some were, so a partial trigger is never
+        silent: the status code says whether the request succeeded, the body says what is running.
+      type: object
+      required:
+        - physicalTenants
+      properties:
+        physicalTenants:
+          description: >-
+            The outcome for each targeted physical tenant, ordered by physical tenant id. Carries no
+            cluster-level backup id: in generated-id mode each tenant generates its own.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterRuntimeBackupTakeResult'
+
+    ClusterRuntimeBackupTakeResult:
+      description: >-
+        Whether one physical tenant's runtime backup was triggered, and under which id it can be
+        monitored and deleted.
+      type: object
+      required:
+        - physicalTenantId
+        - backupId
+        - outcome
+        - reason
+      properties:
+        physicalTenantId:
+          description: The id of the physical tenant.
+          type: string
+          example: default
+        backupId:
+          description: >-
+            The id of the backup triggered on this physical tenant, which is the requested id, or the
+            id the tenant generated when ids are generated. Null when the tenant was not triggered.
+          nullable: true
+          allOf:
+            - $ref: 'backups.yaml#/components/schemas/BackupId'
+        outcome:
+          description: Whether the backup was triggered on this physical tenant.
+          allOf:
+            - $ref: '#/components/schemas/ClusterRuntimeBackupTakeOutcome'
+        reason:
+          description: >-
+            Why the backup could not be triggered on this physical tenant. Null when it was
+            triggered.
+          type: string
+          nullable: true
+          example: ""
+
+    ClusterRuntimeBackupTakeOutcome:
+      title: Cluster Runtime Backup Take Outcome
+      description: >-
+        Whether a physical tenant's runtime backup was triggered. `TRIGGERED` says the backup is
+        running, not that it completed — poll `GET /cluster/v2/backups/runtime/{backupId}` for that.
+        A `FAILED` tenant is running no backup for this request, and the ones that were triggered are
+        not rolled back.
+      type: string
+      enum:
+        - TRIGGERED
+        - FAILED
+      example: TRIGGERED
+
+    ClusterRuntimeBackupInfo:
+      description: >-
+        A runtime backup id, what each physical tenant reports for it, and the state aggregated over
+        the reported tenants — folded from the per-tenant states by the same rules a per-tenant state
+        is folded from its partitions.
+      type: object
+      required:
+        - backupId
+        - state
+        - failureReason
+        - physicalTenants
+      properties:
+        backupId:
+          description: The id of the backup.
+          allOf:
+            - $ref: 'backups.yaml#/components/schemas/BackupId'
+        state:
+          description: >-
+            The state aggregated over the physical tenants listed below, which is every targeted
+            tenant when looking a backup id up directly, and only the tenants holding the id within
+            a listing.
+          allOf:
+            - $ref: 'backups.yaml#/components/schemas/StateCode'
+        failureReason:
+          description: Reason for failure if the aggregated state is 'FAILED'.
+          type: string
+          nullable: true
+          example: ""
+        physicalTenants:
+          description: >-
+            What each physical tenant reports for this backup id, ordered by physical tenant id. When
+            looking a backup id up directly, every targeted tenant is listed, including the ones
+            reporting `DOES_NOT_EXIST`. Within a listing, only the tenants that hold the id are
+            listed.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterRuntimeBackupTenantInfo'
+
+    ClusterRuntimeBackupTenantInfo:
+      description: What a single physical tenant reports for a runtime backup id.
+      type: object
+      required:
+        - physicalTenantId
+        - state
+        - failureReason
+        - details
+      properties:
+        physicalTenantId:
+          description: The id of the physical tenant.
+          type: string
+          example: default
+        state:
+          description: The state of the backup on this physical tenant, aggregated over its partitions.
+          allOf:
+            - $ref: 'backups.yaml#/components/schemas/StateCode'
+        failureReason:
+          description: Reason for failure if the state is 'FAILED'.
+          type: string
+          nullable: true
+          example: ""
+        details:
+          description: >-
+            Detailed status of the backup per partition of this physical tenant. Always contains
+            every partition of the tenant, including when the tenant holds no such backup.
+          type: array
+          items:
+            $ref: 'backups.yaml#/components/schemas/PartitionBackupInfo'
+
+    ClusterRuntimeBackupState:
+      description: >-
+        The checkpoint and backup state of each physical tenant. Nothing is aggregated across
+        tenants: checkpoint ids and log positions only mean anything within one tenant's partitions.
+      type: object
+      required:
+        - physicalTenants
+      properties:
+        physicalTenants:
+          description: >-
+            The runtime backup state of each targeted physical tenant, ordered by physical tenant id.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterRuntimeBackupTenantState'
+
+    ClusterRuntimeBackupTenantState:
+      description: The checkpoint and backup state of one physical tenant.
+      type: object
+      required:
+        - physicalTenantId
+        - state
+      properties:
+        physicalTenantId:
+          description: The id of the physical tenant.
+          type: string
+          example: default
+        state:
+          description: The checkpoint and backup state of this physical tenant's partitions.
+          allOf:
+            - $ref: 'backups.yaml#/components/schemas/RuntimeBackupState'
 
     ClusterTakeHistoryBackupResponse:
       description: >-

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -574,10 +574,13 @@ paths:
       summary: List runtime backups across physical tenants
       description: >-
         Lists the runtime backups of every physical tenant of the cluster, or of the one named by
-        `physicalTenantId`, grouped by backup id. A backup id that only some physical tenants hold is
-        a supported outcome rather than a degraded one, so only the tenants that hold it are listed
-        under it, and the group's aggregated state accounts for those tenants alone. Tenants that
-        generate their own backup ids never share one, so each of their backups forms its own group.
+        `physicalTenantId`, grouped by backup id. Every group reports every targeted tenant,
+        including the ones holding nothing for that id, so a backup only some tenants hold aggregates
+        to `INCOMPLETE` here exactly as it does when looked up directly — the state of a listed group
+        can be trusted to say whether the cluster can be restored from it. A backup id that only some
+        physical tenants hold is a supported outcome rather than a degraded one; tenants that
+        generate their own backup ids never share one, so in that mode each backup forms its own
+        group and the other tenants report `DOES_NOT_EXIST` under it.
 
 
         The request is all-or-nothing: a physical tenant whose backups cannot be read fails the whole
@@ -1537,7 +1540,7 @@ components:
     ClusterRuntimeBackupInfo:
       description: >-
         A runtime backup id, what each physical tenant reports for it, and the state aggregated over
-        the reported tenants — folded from the per-tenant states by the same rules a per-tenant state
+        every targeted tenant — folded from the per-tenant states by the same rules a per-tenant state
         is folded from its partitions.
       type: object
       required:
@@ -1552,9 +1555,10 @@ components:
             - $ref: 'backups.yaml#/components/schemas/BackupId'
         state:
           description: >-
-            The state aggregated over the physical tenants listed below, which is every targeted
-            tenant when looking a backup id up directly, and only the tenants holding the id within
-            a listing.
+            The state aggregated over every targeted physical tenant, whether the backup id was
+            looked up directly or listed. A tenant holding nothing for this id counts as
+            `DOES_NOT_EXIST`, so the aggregate is `INCOMPLETE` unless every targeted tenant holds
+            the backup.
           allOf:
             - $ref: 'backups.yaml#/components/schemas/StateCode'
         failureReason:
@@ -1564,10 +1568,8 @@ components:
           example: ""
         physicalTenants:
           description: >-
-            What each physical tenant reports for this backup id, ordered by physical tenant id. When
-            looking a backup id up directly, every targeted tenant is listed, including the ones
-            reporting `DOES_NOT_EXIST`. Within a listing, only the tenants that hold the id are
-            listed.
+            What each physical tenant reports for this backup id, ordered by physical tenant id.
+            Every targeted tenant is listed, including the ones reporting `DOES_NOT_EXIST`.
           type: array
           items:
             $ref: '#/components/schemas/ClusterRuntimeBackupTenantInfo'
@@ -1596,8 +1598,11 @@ components:
           example: ""
         details:
           description: >-
-            Detailed status of the backup per partition of this physical tenant. Always contains
-            every partition of the tenant, including when the tenant holds no such backup.
+            Detailed status of the backup per partition of this physical tenant. Contains every
+            partition of the tenant when the backup id was looked up directly, including for a tenant
+            that holds no such backup. Empty for a tenant that holds nothing for a listed id: a
+            listing asks each tenant for the backups it has, so there is nothing to report per
+            partition for one it does not.
           type: array
           items:
             $ref: 'backups.yaml#/components/schemas/PartitionBackupInfo'

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -535,6 +535,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "502":
+          description: >-
+            The connection to the broker was cut mid-flight on at least one targeted physical tenant,
+            which may or may not have accepted the request. Those tenants are reported as `UNKNOWN`
+            with the id to check them under, and the tenants that were triggered keep running.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
         "503":
           description: >-
             At least one targeted physical tenant could not be reached. The body lists the tenants
@@ -545,8 +554,9 @@ paths:
                 $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
         "504":
           description: >-
-            The request from gateway to broker timed out on at least one targeted physical tenant.
-            The body lists the tenants that were triggered and keep running.
+            The request from gateway to broker timed out on at least one targeted physical tenant,
+            which may or may not have accepted it. Those tenants are reported as `UNKNOWN` with the id
+            to check them under, and the tenants that were triggered keep running.
           content:
             application/json:
               schema:
@@ -861,6 +871,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClusterRuntimeBackupInfo'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "404":
@@ -914,6 +926,8 @@ paths:
       responses:
         "204":
           description: No targeted physical tenant holds the backup any more.
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "404":
@@ -1484,19 +1498,21 @@ components:
           example: default
         backupId:
           description: >-
-            The id of the backup triggered on this physical tenant, which is the requested id, or the
-            id the tenant generated when ids are generated. Null when the tenant was not triggered.
+            The id to monitor or delete this physical tenant's backup by: the id it is running under
+            when `TRIGGERED` — the requested one, or the one the tenant generated when ids are
+            generated — and the requested id to check when `UNKNOWN`. Null when the tenant is known to
+            be running no backup, and also when an `UNKNOWN` tenant generates its own ids, because
+            the id it may be running under was never reported; list that tenant's backups to find it.
           nullable: true
           allOf:
             - $ref: 'backups.yaml#/components/schemas/BackupId'
         outcome:
-          description: Whether the backup was triggered on this physical tenant.
+          description: What this physical tenant did with the trigger.
           allOf:
             - $ref: '#/components/schemas/ClusterRuntimeBackupTakeOutcome'
         reason:
           description: >-
-            Why the backup could not be triggered on this physical tenant. Null when it was
-            triggered.
+            Why this physical tenant reported no triggered backup. Null when it was triggered.
           type: string
           nullable: true
           example: ""
@@ -1504,14 +1520,18 @@ components:
     ClusterRuntimeBackupTakeOutcome:
       title: Cluster Runtime Backup Take Outcome
       description: >-
-        Whether a physical tenant's runtime backup was triggered. `TRIGGERED` says the backup is
-        running, not that it completed — poll `GET /cluster/v2/backups/runtime/{backupId}` for that.
-        A `FAILED` tenant is running no backup for this request, and the ones that were triggered are
-        not rolled back.
+        What a physical tenant did with the trigger. `TRIGGERED` says the backup is running, not that
+        it completed — poll `GET /cluster/v2/backups/runtime/{backupId}` for that. A `FAILED` tenant
+        is running no backup for this request and needs no cleanup. `UNKNOWN` means the broker may or
+        may not have accepted the request — the connection was cut mid-flight, or the gateway timed
+        out waiting — so that tenant's backups have to be checked before retrying; it is reported
+        separately from `FAILED` precisely because calling it failed would claim nothing is running
+        there. Tenants that were triggered are never rolled back.
       type: string
       enum:
         - TRIGGERED
         - FAILED
+        - UNKNOWN
       example: TRIGGERED
 
     ClusterRuntimeBackupInfo:

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -510,6 +510,14 @@ paths:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1exporting~1pause'
   /cluster/v2/exporting/resume:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1exporting~1resume'
+  /cluster/v2/backups/runtime:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1backups~1runtime'
+  /cluster/v2/backups/runtime/state:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1backups~1runtime~1state'
+  /cluster/v2/backups/runtime/state/sync:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1backups~1runtime~1state~1sync'
+  /cluster/v2/backups/runtime/{backupId}:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1backups~1runtime~1{backupId}'
   /cluster/v2/backups/history:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1backups~1history'
   /cluster/v2/backups/history/{backupId}:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRuntimeBackupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRuntimeBackupController.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.mapping.http.GatewayErrorMapper;
+import io.camunda.gateway.protocol.model.TakeRuntimeBackupRequest;
+import io.camunda.service.ClusterRuntimeBackupServices.ClusterRuntimeBackupTaken;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
+import io.camunda.zeebe.gateway.rest.mapper.BackupResponseMapper;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Runtime (primary-storage) backups across every physical tenant of the cluster, authenticated by
+ * the cluster-admin security chain (ADR 003 D2).
+ *
+ * <p>Every operation narrows to a single physical tenant when the request names one, which is the
+ * only way to keep working while another tenant is broken: the reads and deletes are
+ * all-or-nothing.
+ *
+ * <p>Unlike {@link ClusterHistoryBackupController} this needs no {@code @RequiresSecondaryStorage}
+ * gate: runtime backups are taken from the brokers' primary storage, which every cluster has
+ * whatever its secondary storage is.
+ */
+@CamundaRestController
+@ClusterScoped
+@RequestMapping("/cluster/v2/backups/runtime")
+@NullMarked
+public final class ClusterRuntimeBackupController {
+
+  private final ServiceRegistry serviceRegistry;
+
+  public ClusterRuntimeBackupController(final ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  /**
+   * Answers 202 when every targeted physical tenant was triggered, and an error status otherwise —
+   * but with the same body either way, because a partial trigger leaves backups running that the
+   * caller has to know about to monitor or delete (ADR 003 D4). A request rejected before any
+   * tenant was triggered fails in the service instead and answers with a problem detail, so the two
+   * cases stay distinguishable.
+   */
+  @CamundaPostMapping
+  public CompletableFuture<ResponseEntity<Object>> takeBackup(
+      @RequestParam(required = false) final @Nullable String physicalTenantId,
+      @RequestBody(required = false) final @Nullable TakeRuntimeBackupRequest request) {
+    final var backupId =
+        Optional.ofNullable(request).map(TakeRuntimeBackupRequest::getBackupId).orElse(null);
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterRuntimeBackupServices()
+                .takeBackup(targetPhysicalTenant(physicalTenantId), backupId),
+        ClusterRuntimeBackupController::toTakeBackupResponse);
+  }
+
+  @CamundaGetMapping
+  public CompletableFuture<ResponseEntity<Object>> listBackups(
+      @RequestParam(required = false) final @Nullable String physicalTenantId,
+      @RequestParam(required = false) final @Nullable String prefix) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterRuntimeBackupServices()
+                .listBackups(targetPhysicalTenant(physicalTenantId), prefix),
+        BackupResponseMapper::toClusterRuntimeBackupInfoList,
+        HttpStatus.OK);
+  }
+
+  @CamundaGetMapping(path = "/state")
+  public CompletableFuture<ResponseEntity<Object>> getRuntimeBackupState(
+      @RequestParam(required = false) final @Nullable String physicalTenantId) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterRuntimeBackupServices()
+                .getRuntimeState(targetPhysicalTenant(physicalTenantId)),
+        BackupResponseMapper::toClusterRuntimeBackupState,
+        HttpStatus.OK);
+  }
+
+  @CamundaPostMapping(
+      path = "/state/sync",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> syncRuntimeBackupState(
+      @RequestParam(required = false) final @Nullable String physicalTenantId) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterRuntimeBackupServices()
+                .syncRuntimeState(targetPhysicalTenant(physicalTenantId)),
+        BackupResponseMapper::toClusterRuntimeBackupState,
+        HttpStatus.OK);
+  }
+
+  @CamundaDeleteMapping(path = "/state")
+  public CompletableFuture<ResponseEntity<Object>> deleteRuntimeBackupState(
+      @RequestParam(required = false) final @Nullable String physicalTenantId) {
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () ->
+            serviceRegistry
+                .clusterRuntimeBackupServices()
+                .deleteRuntimeState(targetPhysicalTenant(physicalTenantId)));
+  }
+
+  @CamundaGetMapping(path = "/{backupId}")
+  public CompletableFuture<ResponseEntity<Object>> getBackup(
+      @PathVariable final long backupId,
+      @RequestParam(required = false) final @Nullable String physicalTenantId) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .clusterRuntimeBackupServices()
+                .getBackup(targetPhysicalTenant(physicalTenantId), backupId),
+        BackupResponseMapper::toClusterRuntimeBackupInfo,
+        HttpStatus.OK);
+  }
+
+  @CamundaDeleteMapping(path = "/{backupId}")
+  public CompletableFuture<ResponseEntity<Object>> deleteBackup(
+      @PathVariable final long backupId,
+      @RequestParam(required = false) final @Nullable String physicalTenantId) {
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () ->
+            serviceRegistry
+                .clusterRuntimeBackupServices()
+                .deleteBackup(targetPhysicalTenant(physicalTenantId), backupId));
+  }
+
+  private static ResponseEntity<Object> toTakeBackupResponse(
+      final ClusterRuntimeBackupTaken taken) {
+    final var status =
+        taken.failureStatus() == null
+            ? HttpStatus.ACCEPTED
+            : GatewayErrorMapper.mapStatus(taken.failureStatus());
+    return ResponseEntity.status(status)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(BackupResponseMapper.toClusterTakeRuntimeBackupResponse(taken));
+  }
+
+  /**
+   * Resolves which physical tenant an operation targets: the named tenant, or {@code null} when the
+   * request names none and the operation therefore spans every physical tenant of the cluster. A
+   * blank id names no tenant, so it is cluster-wide as well rather than a request the cluster-admin
+   * API rejects — the same handling the other cluster-admin endpoints apply.
+   */
+  private static @Nullable String targetPhysicalTenant(final @Nullable String physicalTenantId) {
+    return physicalTenantId == null || physicalTenantId.isBlank() ? null : physicalTenantId;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/BackupResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/BackupResponseMapper.java
@@ -312,6 +312,7 @@ public final class BackupResponseMapper {
     return switch (outcome) {
       case TRIGGERED -> ClusterRuntimeBackupTakeOutcome.TRIGGERED;
       case FAILED -> ClusterRuntimeBackupTakeOutcome.FAILED;
+      case UNKNOWN -> ClusterRuntimeBackupTakeOutcome.UNKNOWN;
     };
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/BackupResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/BackupResponseMapper.java
@@ -15,7 +15,14 @@ import io.camunda.gateway.protocol.model.ClusterHistoryBackupInfo;
 import io.camunda.gateway.protocol.model.ClusterHistoryBackupTakeResult;
 import io.camunda.gateway.protocol.model.ClusterHistoryBackupTenantInfo;
 import io.camunda.gateway.protocol.model.ClusterHistoryBackupTenantState;
+import io.camunda.gateway.protocol.model.ClusterRuntimeBackupInfo;
+import io.camunda.gateway.protocol.model.ClusterRuntimeBackupState;
+import io.camunda.gateway.protocol.model.ClusterRuntimeBackupTakeOutcome;
+import io.camunda.gateway.protocol.model.ClusterRuntimeBackupTakeResult;
+import io.camunda.gateway.protocol.model.ClusterRuntimeBackupTenantInfo;
+import io.camunda.gateway.protocol.model.ClusterRuntimeBackupTenantState;
 import io.camunda.gateway.protocol.model.ClusterTakeHistoryBackupResponse;
+import io.camunda.gateway.protocol.model.ClusterTakeRuntimeBackupResponse;
 import io.camunda.gateway.protocol.model.HistoryBackupInfo;
 import io.camunda.gateway.protocol.model.HistoryBackupSnapshotInfo;
 import io.camunda.gateway.protocol.model.HistoryBackupStateCode;
@@ -32,6 +39,12 @@ import io.camunda.service.ClusterHistoryBackupServices.ClusterHistoryBackupTaken
 import io.camunda.service.ClusterHistoryBackupServices.PhysicalTenantBackupState;
 import io.camunda.service.ClusterHistoryBackupServices.PhysicalTenantBackupTaken;
 import io.camunda.service.ClusterHistoryBackupServices.TenantBackupStateCode;
+import io.camunda.service.ClusterRuntimeBackupServices.ClusterRuntimeBackup;
+import io.camunda.service.ClusterRuntimeBackupServices.ClusterRuntimeBackupStates;
+import io.camunda.service.ClusterRuntimeBackupServices.ClusterRuntimeBackupTaken;
+import io.camunda.service.ClusterRuntimeBackupServices.PhysicalTenantRuntimeBackup;
+import io.camunda.service.ClusterRuntimeBackupServices.PhysicalTenantRuntimeBackupTaken;
+import io.camunda.service.ClusterRuntimeBackupServices.TakeOutcome;
 import io.camunda.service.RuntimeBackupServices;
 import io.camunda.service.backup.HistoryBackupSnapshot;
 import io.camunda.service.backup.HistoryBackupState;
@@ -272,6 +285,79 @@ public final class BackupResponseMapper {
       case INCOMPLETE -> HistoryBackupStateCode.INCOMPLETE;
       case INCOMPATIBLE -> HistoryBackupStateCode.INCOMPATIBLE;
     };
+  }
+
+  public static ClusterTakeRuntimeBackupResponse toClusterTakeRuntimeBackupResponse(
+      final ClusterRuntimeBackupTaken taken) {
+    return ClusterTakeRuntimeBackupResponse.Builder.create()
+        .physicalTenants(
+            taken.physicalTenants().stream()
+                .map(BackupResponseMapper::toClusterRuntimeBackupTakeResult)
+                .toList())
+        .build();
+  }
+
+  private static ClusterRuntimeBackupTakeResult toClusterRuntimeBackupTakeResult(
+      final PhysicalTenantRuntimeBackupTaken taken) {
+    return ClusterRuntimeBackupTakeResult.Builder.create()
+        .physicalTenantId(taken.physicalTenantId())
+        .backupId(taken.backupId())
+        .outcome(toClusterRuntimeBackupTakeOutcome(taken.outcome()))
+        .reason(taken.reason())
+        .build();
+  }
+
+  private static ClusterRuntimeBackupTakeOutcome toClusterRuntimeBackupTakeOutcome(
+      final TakeOutcome outcome) {
+    return switch (outcome) {
+      case TRIGGERED -> ClusterRuntimeBackupTakeOutcome.TRIGGERED;
+      case FAILED -> ClusterRuntimeBackupTakeOutcome.FAILED;
+    };
+  }
+
+  public static ClusterRuntimeBackupInfo toClusterRuntimeBackupInfo(
+      final ClusterRuntimeBackup backup) {
+    return ClusterRuntimeBackupInfo.Builder.create()
+        .backupId(backup.backupId())
+        .state(toStateCode(backup.state()))
+        .failureReason(backup.failureReason())
+        .physicalTenants(
+            backup.physicalTenants().stream()
+                .map(BackupResponseMapper::toClusterRuntimeBackupTenantInfo)
+                .toList())
+        .build();
+  }
+
+  public static List<ClusterRuntimeBackupInfo> toClusterRuntimeBackupInfoList(
+      final List<ClusterRuntimeBackup> backups) {
+    return backups.stream().map(BackupResponseMapper::toClusterRuntimeBackupInfo).toList();
+  }
+
+  private static ClusterRuntimeBackupTenantInfo toClusterRuntimeBackupTenantInfo(
+      final PhysicalTenantRuntimeBackup backup) {
+    final var status = backup.backup();
+    return ClusterRuntimeBackupTenantInfo.Builder.create()
+        .physicalTenantId(backup.physicalTenantId())
+        .state(toStateCode(status.status()))
+        .failureReason(status.failureReason().orElse(null))
+        .details(
+            status.partitions().stream().map(BackupResponseMapper::toPartitionBackupInfo).toList())
+        .build();
+  }
+
+  public static ClusterRuntimeBackupState toClusterRuntimeBackupState(
+      final ClusterRuntimeBackupStates states) {
+    return ClusterRuntimeBackupState.Builder.create()
+        .physicalTenants(
+            states.physicalTenants().stream()
+                .map(
+                    state ->
+                        ClusterRuntimeBackupTenantState.Builder.create()
+                            .physicalTenantId(state.physicalTenantId())
+                            .state(toRuntimeBackupState(state.state()))
+                            .build())
+                .toList())
+        .build();
   }
 
   public static ClusterTakeHistoryBackupResponse toClusterTakeHistoryBackupResponse(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRuntimeBackupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRuntimeBackupControllerTest.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ClusterRuntimeBackupServices;
+import io.camunda.service.ClusterRuntimeBackupServices.ClusterRuntimeBackup;
+import io.camunda.service.ClusterRuntimeBackupServices.ClusterRuntimeBackupTaken;
+import io.camunda.service.ClusterRuntimeBackupServices.PhysicalTenantRuntimeBackup;
+import io.camunda.service.ClusterRuntimeBackupServices.PhysicalTenantRuntimeBackupTaken;
+import io.camunda.service.ClusterRuntimeBackupServices.TakeOutcome;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.backup.client.api.BackupStatus;
+import io.camunda.zeebe.backup.client.api.PartitionBackupStatus;
+import io.camunda.zeebe.backup.client.api.State;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(ClusterRuntimeBackupController.class)
+public class ClusterRuntimeBackupControllerTest extends RestControllerTest {
+
+  private static final String BASE_URL = "/cluster/v2/backups/runtime";
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+
+  @MockitoBean private ClusterRuntimeBackupServices clusterRuntimeBackupServices;
+  @MockitoBean private ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setup() {
+    when(serviceRegistry.clusterRuntimeBackupServices()).thenReturn(clusterRuntimeBackupServices);
+  }
+
+  @Test
+  void takeBackupShouldReturnAcceptedWithThePerPhysicalTenantOutcome() {
+    // given
+    when(clusterRuntimeBackupServices.takeBackup(isNull(), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterRuntimeBackupTaken(
+                    List.of(triggered(TENANT_A, 17L), triggered(TENANT_B, 17L)), null)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.ACCEPTED)
+        .expectBody()
+        .jsonPath("$.physicalTenants[0].physicalTenantId")
+        .isEqualTo(TENANT_A)
+        .jsonPath("$.physicalTenants[0].backupId")
+        .isEqualTo(17)
+        .jsonPath("$.physicalTenants[0].outcome")
+        .isEqualTo("TRIGGERED")
+        .jsonPath("$.physicalTenants[1].physicalTenantId")
+        .isEqualTo(TENANT_B);
+  }
+
+  @Test
+  void takeBackupShouldTriggerEveryTenantsOwnIdWhenNoBodyIsSent() {
+    // given a cluster that generates its ids, so each tenant answers with its own
+    when(clusterRuntimeBackupServices.takeBackup(isNull(), isNull()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterRuntimeBackupTaken(
+                    List.of(triggered(TENANT_A, 101L), triggered(TENANT_B, 202L)), null)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.ACCEPTED)
+        .expectBody()
+        .jsonPath("$.physicalTenants[0].backupId")
+        .isEqualTo(101)
+        .jsonPath("$.physicalTenants[1].backupId")
+        .isEqualTo(202);
+
+    verify(clusterRuntimeBackupServices).takeBackup(isNull(), isNull());
+  }
+
+  /**
+   * The point of ADR 003 D4: the error status says the request failed, and the body says which
+   * backups are nevertheless running — without it an operator cannot find them, let alone delete
+   * them.
+   */
+  @Test
+  void takeBackupShouldReportTheTriggeredTenantsAlongsideAnErrorStatus() {
+    // given
+    when(clusterRuntimeBackupServices.takeBackup(isNull(), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterRuntimeBackupTaken(
+                    List.of(
+                        triggered(TENANT_A, 17L),
+                        new PhysicalTenantRuntimeBackupTaken(
+                            TENANT_B, TakeOutcome.FAILED, null, "already exists")),
+                    Status.ALREADY_EXISTS)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("$.physicalTenants[0].outcome")
+        .isEqualTo("TRIGGERED")
+        .jsonPath("$.physicalTenants[0].backupId")
+        .isEqualTo(17)
+        .jsonPath("$.physicalTenants[1].outcome")
+        .isEqualTo("FAILED")
+        .jsonPath("$.physicalTenants[1].reason")
+        .isEqualTo("already exists");
+  }
+
+  @Test
+  void takeBackupShouldReturnServiceUnavailableWhenATenantCouldNotBeReached() {
+    // given
+    when(clusterRuntimeBackupServices.takeBackup(isNull(), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterRuntimeBackupTaken(
+                    List.of(
+                        triggered(TENANT_A, 17L),
+                        new PhysicalTenantRuntimeBackupTaken(
+                            TENANT_B, TakeOutcome.FAILED, null, "connection refused")),
+                    Status.UNAVAILABLE)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+        .expectBody()
+        .jsonPath("$.physicalTenants[0].outcome")
+        .isEqualTo("TRIGGERED");
+  }
+
+  /**
+   * A rejection that predates the fan-out answers with a problem detail, not the cluster body:
+   * there is nothing running for the body to report, and that difference is what tells a caller
+   * whether it has backups to clean up.
+   */
+  @Test
+  void takeBackupShouldReturnProblemDetailWhenTheBackupIdModesAreMixed() {
+    // given
+    when(clusterRuntimeBackupServices.takeBackup(isNull(), eq(17L)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(
+                    "the physical tenants [tenantb] generate their own ids",
+                    Status.INVALID_ARGUMENT)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.detail")
+        .isEqualTo("the physical tenants [tenantb] generate their own ids");
+  }
+
+  @Test
+  void getBackupShouldReturnOkWithTheAggregatedStateAndEveryPhysicalTenant() {
+    // given a backup only one physical tenant holds — a supported outcome, not a failure
+    when(clusterRuntimeBackupServices.getBackup(isNull(), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterRuntimeBackup(
+                    17L,
+                    State.INCOMPLETE,
+                    null,
+                    List.of(
+                        backupOn(TENANT_A, 17L, State.COMPLETED),
+                        backupOn(TENANT_B, 17L, State.DOES_NOT_EXIST)))));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.backupId")
+        .isEqualTo(17)
+        .jsonPath("$.state")
+        .isEqualTo("INCOMPLETE")
+        .jsonPath("$.physicalTenants[0].state")
+        .isEqualTo("COMPLETED")
+        .jsonPath("$.physicalTenants[0].details[0].partitionId")
+        .isEqualTo(1)
+        .jsonPath("$.physicalTenants[1].physicalTenantId")
+        .isEqualTo(TENANT_B)
+        .jsonPath("$.physicalTenants[1].state")
+        .isEqualTo("DOES_NOT_EXIST");
+  }
+
+  @Test
+  void getBackupShouldReturnNotFoundWhenNoPhysicalTenantHoldsIt() {
+    // given
+    when(clusterRuntimeBackupServices.getBackup(isNull(), anyLong()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("none of [tenanta, tenantb] holds it", Status.NOT_FOUND)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Test
+  void listBackupsShouldReturnOkWithTheBackupsGroupedByBackupId() {
+    // given
+    when(clusterRuntimeBackupServices.listBackups(isNull(), isNull()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(
+                    new ClusterRuntimeBackup(
+                        17L,
+                        State.COMPLETED,
+                        null,
+                        List.of(backupOn(TENANT_A, 17L, State.COMPLETED))))));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$[0].backupId")
+        .isEqualTo(17)
+        .jsonPath("$[0].state")
+        .isEqualTo("COMPLETED")
+        .jsonPath("$[0].physicalTenants[0].physicalTenantId")
+        .isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void listBackupsShouldPassThePrefixThrough() {
+    // given
+    when(clusterRuntimeBackupServices.listBackups(isNull(), eq("17*")))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "?prefix=17*")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterRuntimeBackupServices).listBackups(isNull(), eq("17*"));
+  }
+
+  @Test
+  void deleteBackupShouldReturnNoContent() {
+    // given
+    when(clusterRuntimeBackupServices.deleteBackup(isNull(), eq(17L)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when - then
+    webClient
+        .delete()
+        .uri(BASE_URL + "/17")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+  }
+
+  @Test
+  void deleteRuntimeStateShouldReturnNoContent() {
+    // given
+    when(clusterRuntimeBackupServices.deleteRuntimeState(isNull()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when - then
+    webClient
+        .delete()
+        .uri(BASE_URL + "/state")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(clusterRuntimeBackupServices).deleteRuntimeState(isNull());
+  }
+
+  /** The literal {@code /state} path must not be read as a {@code {backupId}}. */
+  @Test
+  void getRuntimeStateShouldNotBeRoutedToTheBackupIdHandler() {
+    // given
+    when(clusterRuntimeBackupServices.getRuntimeState(isNull()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("'tenantb': connection refused", Status.UNAVAILABLE)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/state")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+
+    verify(clusterRuntimeBackupServices).getRuntimeState(isNull());
+    verify(clusterRuntimeBackupServices, never()).getBackup(any(), anyLong());
+  }
+
+  @Test
+  void syncRuntimeStateShouldPassTheNarrowedTenantThrough() {
+    // given
+    when(clusterRuntimeBackupServices.syncRuntimeState(eq(TENANT_A)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("'tenanta': connection refused", Status.UNAVAILABLE)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL + "/state/sync?physicalTenantId=" + TENANT_A)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+
+    verify(clusterRuntimeBackupServices).syncRuntimeState(TENANT_A);
+  }
+
+  @Test
+  void shouldNarrowToThePhysicalTenantNamedByTheQueryParameter() {
+    // given
+    when(clusterRuntimeBackupServices.getBackup(eq(TENANT_A), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterRuntimeBackup(
+                    17L,
+                    State.COMPLETED,
+                    null,
+                    List.of(backupOn(TENANT_A, 17L, State.COMPLETED)))));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "/17?physicalTenantId=" + TENANT_A)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterRuntimeBackupServices).getBackup(TENANT_A, 17L);
+  }
+
+  /** A blank id names no tenant, so it is cluster-wide rather than a rejected request. */
+  @Test
+  void shouldTreatABlankPhysicalTenantIdAsClusterWide() {
+    // given
+    when(clusterRuntimeBackupServices.listBackups(isNull(), isNull()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "?physicalTenantId=")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterRuntimeBackupServices).listBackups(isNull(), isNull());
+  }
+
+  @Test
+  void shouldReturnNotFoundForAnUnknownPhysicalTenantId() {
+    // given
+    when(clusterRuntimeBackupServices.listBackups(eq("nosuchtenant"), isNull()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("this cluster only has [tenanta]", Status.NOT_FOUND)));
+
+    // when - then
+    webClient
+        .get()
+        .uri(BASE_URL + "?physicalTenantId=nosuchtenant")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  private static PhysicalTenantRuntimeBackupTaken triggered(
+      final String physicalTenantId, final long backupId) {
+    return new PhysicalTenantRuntimeBackupTaken(
+        physicalTenantId, TakeOutcome.TRIGGERED, backupId, null);
+  }
+
+  private static PhysicalTenantRuntimeBackup backupOn(
+      final String physicalTenantId, final long backupId, final State state) {
+    return new PhysicalTenantRuntimeBackup(
+        physicalTenantId,
+        new BackupStatus(
+            backupId,
+            state,
+            Optional.empty(),
+            List.of(
+                new PartitionBackupStatus(
+                    1,
+                    state == State.COMPLETED
+                        ? BackupStatusCode.COMPLETED
+                        : BackupStatusCode.DOES_NOT_EXIST,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.empty(),
+                    OptionalLong.empty(),
+                    OptionalInt.empty(),
+                    Optional.empty()))));
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRuntimeBackupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRuntimeBackupControllerTest.java
@@ -182,6 +182,45 @@ public class ClusterRuntimeBackupControllerTest extends RestControllerTest {
   }
 
   /**
+   * A tenant whose broker connection was cut may or may not be running a backup, so it is reported
+   * as `UNKNOWN` with the id to check it under — not as failed, which would claim there is nothing
+   * to clean up.
+   */
+  @Test
+  void takeBackupShouldReportAnIndeterminateTenantAsUnknownWithTheIdToCheck() {
+    // given
+    when(clusterRuntimeBackupServices.takeBackup(isNull(), eq(17L)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterRuntimeBackupTaken(
+                    List.of(
+                        triggered(TENANT_A, 17L),
+                        new PhysicalTenantRuntimeBackupTaken(
+                            TENANT_B, TakeOutcome.UNKNOWN, 17L, "the connection was cut")),
+                    Status.ABORTED)));
+
+    // when - then
+    webClient
+        .post()
+        .uri(BASE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupId\": 17}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.BAD_GATEWAY)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("$.physicalTenants[1].outcome")
+        .isEqualTo("UNKNOWN")
+        .jsonPath("$.physicalTenants[1].backupId")
+        .isEqualTo(17)
+        .jsonPath("$.physicalTenants[1].reason")
+        .isEqualTo("the connection was cut");
+  }
+
+  /**
    * A rejection that predates the fan-out answers with a problem detail, not the cluster body:
    * there is nothing running for the body to report, and that difference is what tells a caller
    * whether it has backups to clean up.

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterRuntimeBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterRuntimeBackupIT.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.StreamSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The cluster-wide runtime backup endpoints against two physical tenants, each with its own
+ * filesystem backup store.
+ *
+ * <p>Exercises what a mocked-port test cannot: that one call really does take a backup on every
+ * tenant's own partitions and store, that a backup only one tenant holds reads cluster-wide as
+ * {@code INCOMPLETE} rather than as a failure, and that a partially-triggered request names the
+ * tenants whose backups are running.
+ *
+ * <p>No secondary storage is needed for any of it, which is why these endpoints have no storage
+ * gate — so both tenants use {@link Storage#none()}.
+ */
+@Timeout(240)
+@ZeebeIntegration
+final class ClusterRuntimeBackupIT {
+
+  private static final String TENANT_A = "tenanta";
+
+  private static final Duration BACKUP_TIMEOUT = Duration.ofSeconds(60);
+  private static final ObjectMapper JSON = new ObjectMapper();
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+  /**
+   * Backup ids must ascend within a physical tenant, and a deleted backup does not release its id
+   * because checkpoint ids stay monotonic. The tests share one broker, so each takes the next id
+   * from here instead of a literal — that keeps them passing in whatever order JUnit runs them.
+   */
+  private static final AtomicLong NEXT_BACKUP_ID = new AtomicLong(500);
+
+  @TempDir private static Path defaultBackupDir;
+  @TempDir private static Path tenantABackupDir;
+
+  // autoStart = false because the backup stores live in @TempDir directories, which JUnit injects
+  // only after this field is initialized; the configuration is therefore applied in @BeforeAll.
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      // Unauthenticated: this test is about the fan-out contract, not the cluster-admin chain,
+      // which
+      // ClusterAdminBasicAuthenticationIT covers against a real secondary storage. It also lets the
+      // test stage a single-tenant backup through that tenant's own /v2 endpoint.
+      new TestStandaloneBroker().withUnauthenticatedAccess();
+
+  private static URI clusterBackupsUri;
+  private static URI tenantABackupsUri;
+
+  @BeforeAll
+  static void startBrokerWithATenantOwnedBackupStoreEach() {
+    PhysicalTenantsITHelper.builder()
+        .withTenant(DEFAULT_TENANT_ID, Storage.none())
+        .withTenant(TENANT_A, Storage.none())
+        .build()
+        .configure(BROKER);
+    BROKER
+        .withDataConfig(
+            data -> filesystemStore(data.getPrimaryStorage().getBackup(), defaultBackupDir))
+        .withPtConfig(
+            TENANT_A,
+            camunda ->
+                filesystemStore(
+                    camunda.getData().getPrimaryStorage().getBackup(), tenantABackupDir));
+    // autoStart is off, so readiness is awaited here rather than by the extension.
+    BROKER.start().await(TestHealthProbe.READY);
+
+    final var base = BROKER.restAddress().toString().replaceAll("/+$", "");
+    clusterBackupsUri = URI.create(base + "/cluster/v2/backups/runtime");
+    tenantABackupsUri = URI.create(base + "/physical-tenants/" + TENANT_A + "/v2/backups/runtime");
+  }
+
+  private static void filesystemStore(final PrimaryStorageBackup backup, final Path basePath) {
+    backup.setStore(BackupStoreType.FILESYSTEM);
+    backup.getFilesystem().setBasePath(basePath.toString());
+  }
+
+  @Test
+  void shouldTakeReadAndDeleteABackupOnEveryPhysicalTenant() throws Exception {
+    // given
+    final long backupId = NEXT_BACKUP_ID.incrementAndGet();
+
+    // when
+    final var taken = takeClusterBackup(backupId);
+
+    // then every tenant reports the requested id, in tenant id order
+    assertThat(taken.statusCode()).isEqualTo(202);
+    final var outcomes = JSON.readTree(taken.body()).get("physicalTenants");
+    assertThat(physicalTenantIds(outcomes)).containsExactly(DEFAULT_TENANT_ID, TENANT_A);
+    assertThat(outcomes)
+        .allSatisfy(
+            outcome -> {
+              assertThat(outcome.get("outcome").asText()).isEqualTo("TRIGGERED");
+              assertThat(outcome.get("backupId").asLong()).isEqualTo(backupId);
+            });
+
+    // and the aggregated state eventually reports the whole cluster as backed up
+    Awaitility.await("the cluster-wide backup completes on every physical tenant")
+        .atMost(BACKUP_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var status = getClusterBackup(backupId);
+              assertThat(status.statusCode()).isEqualTo(200);
+              final var body = JSON.readTree(status.body());
+              assertThat(body.get("state").asText()).isEqualTo("COMPLETED");
+              assertThat(body.get("physicalTenants"))
+                  .allSatisfy(
+                      tenant -> assertThat(tenant.get("state").asText()).isEqualTo("COMPLETED"));
+            });
+
+    // and the listing groups both tenants under that one id
+    final var listed = listClusterBackups();
+    assertThat(listed.statusCode()).isEqualTo(200);
+    final var group = groupOf(JSON.readTree(listed.body()), backupId);
+    assertThat(physicalTenantIds(group.get("physicalTenants")))
+        .containsExactly(DEFAULT_TENANT_ID, TENANT_A);
+
+    // when deleted cluster-wide
+    assertThat(deleteClusterBackup(backupId).statusCode()).isEqualTo(204);
+
+    // then it is gone from every physical tenant, including through the tenant's own path
+    Awaitility.await("the backup is gone from every physical tenant")
+        .atMost(BACKUP_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              assertThat(getClusterBackup(backupId).statusCode()).isEqualTo(404);
+              assertThat(get(tenantABackupUri(backupId), null).statusCode()).isEqualTo(404);
+            });
+  }
+
+  /**
+   * A backup only one physical tenant holds is a supported outcome — a tenant's own operator can
+   * take one, and so can a narrowed cluster-admin request — so reading it cluster-wide reports
+   * every targeted tenant instead of 404, and says the set is not usable as a whole.
+   */
+  @Test
+  void shouldReportABackupOnlyOnePhysicalTenantHoldsAsIncomplete() throws Exception {
+    // given a backup staged through tenantA's own endpoint
+    final long backupId = NEXT_BACKUP_ID.incrementAndGet();
+    assertThat(takeTenantABackup(backupId).statusCode()).isEqualTo(202);
+
+    // when - then
+    Awaitility.await("the cluster-wide read reports the backup as incomplete")
+        .atMost(BACKUP_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var status = getClusterBackup(backupId);
+              assertThat(status.statusCode()).isEqualTo(200);
+              final var read = JSON.readTree(status.body());
+              assertThat(read.get("state").asText()).isEqualTo("INCOMPLETE");
+              assertThat(fieldOf(read.get("physicalTenants"), TENANT_A, "state"))
+                  .isEqualTo("COMPLETED");
+              assertThat(fieldOf(read.get("physicalTenants"), DEFAULT_TENANT_ID, "state"))
+                  .isEqualTo("DOES_NOT_EXIST");
+            });
+
+    assertThat(deleteClusterBackup(backupId).statusCode()).isEqualTo(204);
+  }
+
+  /**
+   * The guarantee of ADR 003 D4: a request only some tenants accepted answers with an error status,
+   * and still names the tenants whose backups are now running so they can be cleaned up.
+   */
+  @Test
+  void shouldNameTheTriggeredPhysicalTenantsWhenAnotherRejectsTheId() throws Exception {
+    // given an id tenantA already holds
+    final long backupId = NEXT_BACKUP_ID.incrementAndGet();
+    assertThat(takeTenantABackup(backupId).statusCode()).isEqualTo(202);
+    Awaitility.await("tenantA holds the id")
+        .atMost(BACKUP_TIMEOUT)
+        .untilAsserted(
+            () -> assertThat(get(tenantABackupUri(backupId), null).statusCode()).isEqualTo(200));
+
+    // when the same id is requested cluster-wide
+    final var taken = takeClusterBackup(backupId);
+
+    // then the request fails, but says which tenant is now running a backup under that id
+    assertThat(taken.statusCode()).isNotEqualTo(202);
+    final var outcomes = JSON.readTree(taken.body()).get("physicalTenants");
+    assertThat(outcomes).isNotNull();
+    assertThat(fieldOf(outcomes, DEFAULT_TENANT_ID, "outcome")).isEqualTo("TRIGGERED");
+    assertThat(fieldOf(outcomes, TENANT_A, "outcome")).isEqualTo("FAILED");
+
+    assertThat(deleteClusterBackup(backupId).statusCode()).isEqualTo(204);
+  }
+
+  @Test
+  void shouldReportTheRuntimeStateOfEveryPhysicalTenant() throws Exception {
+    // when
+    final var state = get(uri("/state"), null);
+
+    // then every tenant contributes its own checkpoint and backup state, folded into nothing
+    assertThat(state.statusCode()).isEqualTo(200);
+    final var tenants = JSON.readTree(state.body()).get("physicalTenants");
+    assertThat(physicalTenantIds(tenants)).containsExactly(DEFAULT_TENANT_ID, TENANT_A);
+    assertThat(tenants)
+        .allSatisfy(tenant -> assertThat(tenant.get("state").get("ranges")).isNotNull());
+  }
+
+  @Test
+  void shouldRejectAnUnknownPhysicalTenant() throws Exception {
+    // when
+    final var listed = get(uri("?physicalTenantId=nosuchtenant"), null);
+
+    // then an unknown id is a request error, never a tenant that failed
+    assertThat(listed.statusCode()).isEqualTo(404);
+  }
+
+  private static URI tenantABackupUri(final long backupId) {
+    return URI.create(tenantABackupsUri + "/" + backupId);
+  }
+
+  private static URI uri(final String suffix) {
+    return URI.create(clusterBackupsUri + suffix);
+  }
+
+  private static HttpResponse<String> takeClusterBackup(final long backupId)
+      throws IOException, InterruptedException {
+    final var request =
+        HttpRequest.newBuilder(clusterBackupsUri)
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString("{\"backupId\": " + backupId + "}"))
+            .build();
+    return HTTP.send(request, BodyHandlers.ofString());
+  }
+
+  private static HttpResponse<String> takeTenantABackup(final long backupId)
+      throws IOException, InterruptedException {
+    final var request =
+        HttpRequest.newBuilder(tenantABackupsUri)
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString("{\"backupId\": " + backupId + "}"))
+            .build();
+    return HTTP.send(request, BodyHandlers.ofString());
+  }
+
+  private static HttpResponse<String> getClusterBackup(final long backupId)
+      throws IOException, InterruptedException {
+    return get(uri("/" + backupId), null);
+  }
+
+  private static HttpResponse<String> listClusterBackups()
+      throws IOException, InterruptedException {
+    return get(clusterBackupsUri, null);
+  }
+
+  private static HttpResponse<String> deleteClusterBackup(final long backupId)
+      throws IOException, InterruptedException {
+    final var request = HttpRequest.newBuilder(uri("/" + backupId)).DELETE().build();
+    return HTTP.send(request, BodyHandlers.ofString());
+  }
+
+  private static HttpResponse<String> get(final URI uri, final String authorizationHeader)
+      throws IOException, InterruptedException {
+    final var builder = HttpRequest.newBuilder(uri).GET();
+    if (authorizationHeader != null) {
+      builder.header("Authorization", authorizationHeader);
+    }
+    return HTTP.send(builder.build(), BodyHandlers.ofString());
+  }
+
+  private static List<String> physicalTenantIds(final JsonNode entries) {
+    return StreamSupport.stream(entries.spliterator(), false)
+        .map(entry -> entry.get("physicalTenantId").asText())
+        .toList();
+  }
+
+  private static JsonNode groupOf(final JsonNode groups, final long backupId) {
+    return StreamSupport.stream(groups.spliterator(), false)
+        .filter(group -> group.get("backupId").asLong() == backupId)
+        .findFirst()
+        .orElseThrow(
+            () -> new AssertionError("Expected backup '%d' to be listed".formatted(backupId)));
+  }
+
+  private static String fieldOf(
+      final JsonNode entries, final String physicalTenantId, final String field) {
+    return StreamSupport.stream(entries.spliterator(), false)
+        .filter(entry -> entry.get("physicalTenantId").asText().equals(physicalTenantId))
+        .map(entry -> entry.get(field).asText())
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new AssertionError(
+                    "Expected physical tenant '%s' to be reported".formatted(physicalTenantId)));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterRuntimeBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterRuntimeBackupIT.java
@@ -190,6 +190,17 @@ final class ClusterRuntimeBackupIT {
                   .isEqualTo("DOES_NOT_EXIST");
             });
 
+    // and the listing says the same thing about it, rather than reporting it as complete because
+    // only the tenant holding it was counted
+    final var listed = listClusterBackups();
+    assertThat(listed.statusCode()).isEqualTo(200);
+    final var group = groupOf(JSON.readTree(listed.body()), backupId);
+    assertThat(group.get("state").asText()).isEqualTo("INCOMPLETE");
+    assertThat(physicalTenantIds(group.get("physicalTenants")))
+        .containsExactly(DEFAULT_TENANT_ID, TENANT_A);
+    assertThat(fieldOf(group.get("physicalTenants"), DEFAULT_TENANT_ID, "state"))
+        .isEqualTo("DOES_NOT_EXIST");
+
     assertThat(deleteClusterBackup(backupId).statusCode()).isEqualTo(204);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterRuntimeBackupIdModeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/ClusterRuntimeBackupIdModeIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The cluster-wide trigger against a cluster whose physical tenants disagree on where backup ids
+ * come from: tenantA takes continuous backups and therefore generates its own ids, while the
+ * default tenant is driven manually and requires one.
+ *
+ * <p>A separate broker from {@link ClusterRuntimeBackupIT} because the backup-id mode is a
+ * deployment-time choice — which is exactly what makes this worth a full-stack test: only running
+ * the real configuration proves that the per-tenant backup config reaches the cluster-wide trigger,
+ * and that a mixed cluster is rejected outright rather than half triggered (ADR 003, Consequences).
+ */
+@Timeout(180)
+@ZeebeIntegration
+final class ClusterRuntimeBackupIdModeIT {
+
+  private static final String TENANT_A = "tenanta";
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+  @TempDir private static Path defaultBackupDir;
+  @TempDir private static Path tenantABackupDir;
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      // Unauthenticated: this test is about the backup-id modes, not the cluster-admin chain, which
+      // ClusterAdminBasicAuthenticationIT covers against a real secondary storage.
+      new TestStandaloneBroker().withUnauthenticatedAccess();
+
+  private static URI clusterBackupsUri;
+
+  @BeforeAll
+  static void startBrokerWithTenantsInDifferentBackupIdModes() {
+    PhysicalTenantsITHelper.builder()
+        .withTenant(DEFAULT_TENANT_ID, Storage.none())
+        .withTenant(TENANT_A, Storage.none())
+        .build()
+        .configure(BROKER);
+    // A physical tenant's config starts from the global one, so `continuous` has to be set on the
+    // tenant that should generate its ids -- setting it globally would put both tenants in that
+    // mode
+    // and there would be nothing mixed about the cluster.
+    BROKER
+        .withDataConfig(
+            data -> filesystemStore(data.getPrimaryStorage().getBackup(), defaultBackupDir))
+        .withPtConfig(
+            TENANT_A,
+            camunda -> {
+              final var backup = camunda.getData().getPrimaryStorage().getBackup();
+              filesystemStore(backup, tenantABackupDir);
+              backup.setContinuous(true);
+            });
+    BROKER.start().await(TestHealthProbe.READY);
+
+    clusterBackupsUri =
+        URI.create(
+            BROKER.restAddress().toString().replaceAll("/+$", "") + "/cluster/v2/backups/runtime");
+  }
+
+  private static void filesystemStore(final PrimaryStorageBackup backup, final Path basePath) {
+    backup.setStore(BackupStoreType.FILESYSTEM);
+    backup.getFilesystem().setBasePath(basePath.toString());
+  }
+
+  @Test
+  void shouldRejectAnExplicitBackupIdNamingTheTenantThatGeneratesIds() throws Exception {
+    // when
+    final var taken = takeClusterBackup("{\"backupId\": 42}");
+
+    // then nothing was triggered anywhere, and the operator is told which tenant is in the way
+    assertThat(taken.statusCode()).isEqualTo(400);
+    assertThat(JSON.readTree(taken.body()).get("detail").asText()).contains(TENANT_A);
+  }
+
+  @Test
+  void shouldRejectAMissingBackupIdNamingTheTenantThatRequiresOne() throws Exception {
+    // when
+    final var taken = takeClusterBackup(null);
+
+    // then
+    assertThat(taken.statusCode()).isEqualTo(400);
+    assertThat(JSON.readTree(taken.body()).get("detail").asText()).contains(DEFAULT_TENANT_ID);
+  }
+
+  /**
+   * The escape hatch a mixed cluster is left with: each tenant can still be driven on its own
+   * through the cluster-admin API, in the mode that tenant is configured for.
+   */
+  @Test
+  void shouldAcceptAnExplicitBackupIdWhenNarrowedToTheManuallyDrivenTenant() throws Exception {
+    // when
+    final var request =
+        HttpRequest.newBuilder(
+                URI.create(clusterBackupsUri + "?physicalTenantId=" + DEFAULT_TENANT_ID))
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString("{\"backupId\": 42}"))
+            .build();
+    final var taken = HTTP.send(request, BodyHandlers.ofString());
+
+    // then
+    assertThat(taken.statusCode()).isEqualTo(202);
+    assertThat(JSON.readTree(taken.body()).get("physicalTenants"))
+        .singleElement()
+        .satisfies(
+            outcome -> {
+              assertThat(outcome.get("physicalTenantId").asText()).isEqualTo(DEFAULT_TENANT_ID);
+              assertThat(outcome.get("outcome").asText()).isEqualTo("TRIGGERED");
+              assertThat(outcome.get("backupId").asLong()).isEqualTo(42L);
+            });
+  }
+
+  private static HttpResponse<String> takeClusterBackup(final String body)
+      throws IOException, InterruptedException {
+    final var builder = HttpRequest.newBuilder(clusterBackupsUri);
+    if (body == null) {
+      builder.POST(BodyPublishers.noBody());
+    } else {
+      builder.header("Content-Type", "application/json").POST(BodyPublishers.ofString(body));
+    }
+    return HTTP.send(builder.build(), BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
## Description

Adds the seven cluster-wide siblings of the per-tenant runtime backup endpoints under `/cluster/v2/backups/runtime` (trigger, get, list, delete, plus state read/sync/reset) per ADR 003 D2, each fanning out over every physical tenant or over the one named by `?physicalTenantId=`, so an operator drives backups with one authorized call instead of iterating tenants or using the unauthenticated management port. Three parts of the contract needed deciding: backup-id modes must agree, so an explicit id is accepted only if no targeted tenant generates its own and omitting it only if all of them do, with a mixed cluster rejected 400 naming the tenants in the way; a partial trigger is never silent, so the trigger answers an error status but still lists which tenants were triggered and under which id (nothing can roll a triggered backup back), which is why the error responses declare both `application/json` and `application/problem+json` and why `GatewayErrorMapper.mapStatus` becomes public; and reads fold the per-tenant states into a cluster-wide one by the same rules that fold a tenant's partitions, so a backup only some tenants hold reads as `INCOMPLETE` rather than 404 — unlike the history sibling, whose state has no code to fold into.
Authorization is the cluster-admin chain and nothing else (ADR 002 D4): the service takes no `CamundaAuthentication` at all, making that structural rather than conventional. Commits are reviewable in order — a prep refactor extracting the shared fan-out folding, then contract → service → transport → tests, the
last adding two integration tests over a real two-tenant broker.

## Related issues

closes #57739 
