### PR TITLE
feat: stop flattening Optimize object variables by default on Self-Managed

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.github.netmikey.logunit</groupId>
       <artifactId>logunit-log4j2</artifactId>
-      <version>2.0.0</version>
+      <version>${logunit.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
@@ -382,6 +382,10 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
   @Test
   public void zeebeVariableImport_updateObjectVariable() {
     // given
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getConfiguredZeebe()
+        .setIncludeObjectVariableValue(true);
     final Map<String, Object> objectVar = new HashMap<>();
     objectVar.put("name", "Pond");
     objectVar.put("age", 28);

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -78,6 +78,7 @@
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <mockserver.version>7.5.0</mockserver.version>
     <assertj.version>3.27.7</assertj.version>
+    <logunit.version>2.0.0</logunit.version>
     <google-java-format.plugin.version>1.36.1</google-java-format.plugin.version>
     <!-- This is the default profile used for the DB selection in tests -->
     <database.type>elasticsearch</database.type>
@@ -158,7 +159,7 @@
     <dependency>
       <groupId>io.github.netmikey.logunit</groupId>
       <artifactId>logunit-core</artifactId>
-      <version>2.0.0</version>
+      <version>${logunit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>io.github.netmikey.logunit</groupId>
       <artifactId>logunit-log4j2</artifactId>
-      <version>2.0.0</version>
+      <version>${logunit.version}</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -113,6 +113,13 @@
       <artifactId>log4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.github.netmikey.logunit</groupId>
+      <artifactId>logunit-log4j2</artifactId>
+      <version>${logunit.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Utilities -->
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationValidator.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationValidator.java
@@ -9,9 +9,12 @@ package io.camunda.optimize.service.util.configuration;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConfigurationValidator {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigurationValidator.class);
   private static final Pattern INVALID_INDEX_PREFIX_CHARS = Pattern.compile("[\\\\/*?\"<>| _]");
 
   public void validate(final ConfigurationService configurationService) {
@@ -19,6 +22,23 @@ public class ConfigurationValidator {
 
     validateIndexPrefix(configurationService.getElasticSearchConfiguration().getIndexPrefix());
     validateIndexPrefix(configurationService.getOpenSearchConfiguration().getIndexPrefix());
+    warnIfObjectVariableValuesAreNotImported(configurationService);
+  }
+
+  private void warnIfObjectVariableValuesAreNotImported(
+      final ConfigurationService configurationService) {
+    final ZeebeConfiguration zeebeConfiguration = configurationService.getConfiguredZeebe();
+    final boolean isImportingZeebeVariables =
+        zeebeConfiguration.isEnabled() && zeebeConfiguration.isVariableImportEnabled();
+    if (isImportingZeebeVariables && !zeebeConfiguration.isIncludeObjectVariableValue()) {
+      LOG.warn(
+          "Optimize is not importing object variable values (zeebe.includeObjectVariableValue "
+              + "is false). As of Camunda 8.10, this is the default for Self-Managed. Object "
+              + "variables will not be flattened into report-usable fields and their raw value "
+              + "will not be stored. If you rely on this, set zeebe.includeObjectVariableValue "
+              + "to true (or the CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE environment "
+              + "variable) to opt in.");
+    }
   }
 
   private void validateIndexPrefix(final String indexPrefix) {

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -158,7 +158,7 @@ zeebe:
   # The max page size for importing Zeebe data
   maxImportPageSize: ${CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE:200}
   # Determines whether Optimize should convert and store object variables from Zeebe
-  includeObjectVariableValue: ${CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE:true}
+  includeObjectVariableValue: ${CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE:false}
   # Indicates whether variable import is enabled
   variableImportEnabled: ${CAMUNDA_OPTIMIZE_ZEEBE_VARIABLE_IMPORT_ENABLED:true}
   importConfig:

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
@@ -631,6 +631,7 @@ public class ConfigurationServiceTest {
     assertThat(underTest.getConfiguredZeebe().getName()).isEqualTo("zeebe-record");
     assertThat(underTest.getConfiguredZeebe().getPartitionCount()).isEqualTo(1);
     assertThat(underTest.getConfiguredZeebe().getMaxImportPageSize()).isEqualTo(200);
+    assertThat(underTest.getConfiguredZeebe().isIncludeObjectVariableValue()).isFalse();
     assertThat(underTest.getElasticSearchConfiguration().getSecurityUsername()).isNull();
     assertThat(underTest.getElasticSearchConfiguration().getSecurityPassword()).isNull();
     assertThat(underTest.getElasticSearchConfiguration().getSecuritySSLCertificate()).isNull();

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationValidatorTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationValidatorTest.java
@@ -14,17 +14,25 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.event.Level;
 
 public class ConfigurationValidatorTest {
+
+  @RegisterExtension
+  final LogCapturer logs =
+      LogCapturer.create().captureForType(ConfigurationValidator.class, Level.WARN);
 
   private ConfigurationService configurationService;
   private EmailAuthenticationConfiguration emailAuthConfig;
   private ElasticSearchConfiguration elasticSearchConfiguration;
   private OpenSearchConfiguration openSearchConfiguration;
+  private ZeebeConfiguration zeebeConfiguration;
 
   private ConfigurationValidator configurationValidator;
 
@@ -34,9 +42,14 @@ public class ConfigurationValidatorTest {
     emailAuthConfig = mock(EmailAuthenticationConfiguration.class);
     elasticSearchConfiguration = mock(ElasticSearchConfiguration.class);
     openSearchConfiguration = mock(OpenSearchConfiguration.class);
+    zeebeConfiguration = mock(ZeebeConfiguration.class);
     when(configurationService.getElasticSearchConfiguration())
         .thenReturn(elasticSearchConfiguration);
     when(configurationService.getOpenSearchConfiguration()).thenReturn(openSearchConfiguration);
+    when(configurationService.getConfiguredZeebe()).thenReturn(zeebeConfiguration);
+    when(zeebeConfiguration.isEnabled()).thenReturn(true);
+    when(zeebeConfiguration.isVariableImportEnabled()).thenReturn(true);
+    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(false);
 
     configurationValidator = new ConfigurationValidator();
   }
@@ -103,5 +116,77 @@ public class ConfigurationValidatorTest {
     assertThatCode(() -> configurationValidator.validate(configurationService))
         .hasMessageContaining("Optimize indexPrefix must not begin with invalid characters [. +].")
         .isInstanceOf(OptimizeConfigurationException.class);
+  }
+
+  @Test
+  public void validateShouldWarnWhenObjectVariableValuesAreNotImported() {
+    // given
+    when(configurationService.getEmailAuthenticationConfiguration()).thenReturn(emailAuthConfig);
+    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(false);
+
+    // when
+    configurationValidator.validate(configurationService);
+
+    // then
+    logs.assertContains(
+        entry ->
+            entry.getLevel() == Level.WARN
+                && entry.getMessage().contains("zeebe.includeObjectVariableValue"),
+        "expected a WARN log about object variable values not being imported");
+  }
+
+  @Test
+  public void validateShouldNotWarnWhenObjectVariableValuesAreImported() {
+    // given
+    when(configurationService.getEmailAuthenticationConfiguration()).thenReturn(emailAuthConfig);
+    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(true);
+
+    // when
+    configurationValidator.validate(configurationService);
+
+    // then
+    logs.assertDoesNotContain(
+        entry ->
+            entry.getLevel() == Level.WARN
+                && entry.getMessage().contains("zeebe.includeObjectVariableValue"),
+        "expected no WARN log when object variable values are imported");
+  }
+
+  @Test
+  public void validateShouldNotWarnWhenZeebeImportIsDisabled() {
+    // given
+    when(configurationService.getEmailAuthenticationConfiguration()).thenReturn(emailAuthConfig);
+    when(zeebeConfiguration.isEnabled()).thenReturn(false);
+    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(false);
+
+    // when
+    configurationValidator.validate(configurationService);
+
+    // then
+    logs.assertDoesNotContain(
+        entry ->
+            entry.getLevel() == Level.WARN
+                && entry.getMessage().contains("zeebe.includeObjectVariableValue"),
+        "expected no WARN log when Zeebe import is disabled, regardless of "
+            + "includeObjectVariableValue");
+  }
+
+  @Test
+  public void validateShouldNotWarnWhenZeebeVariableImportIsDisabled() {
+    // given
+    when(configurationService.getEmailAuthenticationConfiguration()).thenReturn(emailAuthConfig);
+    when(zeebeConfiguration.isVariableImportEnabled()).thenReturn(false);
+    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(false);
+
+    // when
+    configurationValidator.validate(configurationService);
+
+    // then
+    logs.assertDoesNotContain(
+        entry ->
+            entry.getLevel() == Level.WARN
+                && entry.getMessage().contains("zeebe.includeObjectVariableValue"),
+        "expected no WARN log when Zeebe variable import is disabled, regardless of "
+            + "includeObjectVariableValue");
   }
 }


### PR DESCRIPTION
Self-Managed inherited `zeebe.includeObjectVariableValue=true`, flattening every object variable and storing its raw value. This measured 5.9-48.8x more Optimize storage than SaaS on identical workloads. SaaS has run with this disabled for years via its controller; this makes it the application default instead.

Adds a startup WARN when object variable values aren't being imported, so the behavior change isn't silent.

Closes camunda/camunda#60583.