### PR TITLE
fix: remove redundant load-test override for object variable flattening

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-optimize.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-optimize.yaml
@@ -60,14 +60,6 @@ optimize:
     - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
       value: "1000" # default 200
 
-    # Disable object variable flattening: Optimize's own default (true) turns
-    # every object variable into multiple stored variables (one per property,
-    # plus the raw serialized value), causing outsized ES storage on top of
-    # Optimize's already-higher per-variable cost. SaaS already disables this
-    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-      value: "false" # default true
-
   tolerations:
     - key: nodepool
       operator: Equal

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -77,8 +77,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -143,8 +141,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-elasticsearch-stable-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -77,8 +77,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -143,8 +141,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-elasticsearch-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -83,8 +83,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -155,8 +153,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-opensearch-stable-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/deployment.yaml
@@ -83,8 +83,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -155,8 +153,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-opensearch-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -77,8 +77,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -143,8 +141,6 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
-            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-rdbms-optimize-camunda-platform-identity-env-vars


### PR DESCRIPTION
Stacked on camunda/camunda#60587 — retarget to `main` once that merges.

Removes the now-redundant `CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE` override from the `main` load-test setup, since the application default now matches it. `stable-87/88/89` are untouched — they still need it.

Closes camunda/camunda#60586.