### PR TITLE
fix: match RDBMS error message filters with ES/OS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/LiteralSubstringStringTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/LiteralSubstringStringTypeHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.typehandler;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.StringTypeHandler;
+
+public class LiteralSubstringStringTypeHandler extends StringTypeHandler {
+
+  @Override
+  public void setNonNullParameter(
+      final PreparedStatement ps, final int i, final String parameter, final JdbcType jdbcType)
+      throws SQLException {
+    ps.setString(i, transformParameter(parameter));
+  }
+
+  public static String transformParameter(final String parameter) {
+    return "%" + parameter.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%";
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -62,9 +62,6 @@
       <when test="operation.operator.name().equals('EXISTS')">
         ${column} IS NOT NULL
       </when>
-      <when test="operation.operator.name().equals('NOT_EXISTS')">
-        ${column} IS NULL
-      </when>
       <when test="operation.operator.name().equals('IN')">
         <foreach collection="operation.values" item="value" open="(" separator=" OR " close=")">
           ${column} LIKE #{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -49,6 +49,40 @@
       </when>
     </choose>
   </sql>
+  <sql id="errorMessageOperationCondition">
+    <choose>
+      <when test="operation.operator.name().equals('EQUALS')">
+        ${column} LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}
+          ESCAPE ${escapeChar}
+      </when>
+      <when test="operation.operator.name().equals('NOT_EQUALS')">
+        ${column} NOT LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}
+          ESCAPE ${escapeChar}
+      </when>
+      <when test="operation.operator.name().equals('EXISTS')">
+        ${column} IS NOT NULL
+      </when>
+      <when test="operation.operator.name().equals('NOT_EXISTS')">
+        ${column} IS NULL
+      </when>
+      <when test="operation.operator.name().equals('IN')">
+        <foreach collection="operation.values" item="value" open="(" separator=" OR " close=")">
+          ${column} LIKE #{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}
+            ESCAPE ${escapeChar}
+        </foreach>
+      </when>
+      <when test="operation.operator.name().equals('NOT_IN')">
+        <foreach collection="operation.values" item="value" open="(" separator=" AND " close=")">
+          ${column} NOT LIKE #{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}
+            ESCAPE ${escapeChar}
+        </foreach>
+      </when>
+      <when test="operation.operator.name().equals('LIKE')">
+        ${column} LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler}
+          ESCAPE ${escapeChar}
+      </when>
+    </choose>
+  </sql>
   <!--
     Oracle treats empty strings as NULL. When filtering with EQUALS '' or NOT_EQUALS '',
     we must use IS NULL / IS NOT NULL instead, because NULL = '' evaluates to UNKNOWN in SQL.

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -49,37 +49,6 @@
       </when>
     </choose>
   </sql>
-  <sql id="errorMessageOperationCondition">
-    <choose>
-      <when test="operation.operator.name().equals('EQUALS')">
-        ${column} LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}
-          ESCAPE ${escapeChar}
-      </when>
-      <when test="operation.operator.name().equals('NOT_EQUALS')">
-        ${column} NOT LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}
-          ESCAPE ${escapeChar}
-      </when>
-      <when test="operation.operator.name().equals('EXISTS')">
-        ${column} IS NOT NULL
-      </when>
-      <when test="operation.operator.name().equals('IN')">
-        <foreach collection="operation.values" item="value" open="(" separator=" OR " close=")">
-          ${column} LIKE #{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}
-            ESCAPE ${escapeChar}
-        </foreach>
-      </when>
-      <when test="operation.operator.name().equals('NOT_IN')">
-        <foreach collection="operation.values" item="value" open="(" separator=" AND " close=")">
-          ${column} NOT LIKE #{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler}
-            ESCAPE ${escapeChar}
-        </foreach>
-      </when>
-      <when test="operation.operator.name().equals('LIKE')">
-        ${column} LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler}
-          ESCAPE ${escapeChar}
-      </when>
-    </choose>
-  </sql>
   <!--
     Oracle treats empty strings as NULL. When filtering with EQUALS '' or NOT_EQUALS '',
     we must use IS NULL / IS NOT NULL instead, because NULL = '' evaluates to UNKNOWN in SQL.
@@ -133,6 +102,111 @@
       <when test="operation.operator.name().equals('LIKE')">
         LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler}
           ESCAPE ${escapeChar}
+      </when>
+    </choose>
+  </sql>
+  <!--
+    Use LOWER on both sides. EQUALS, IN and LIKE must be case-insensitive.
+    ES/OS match_phrase is case-insensitive on the errorMessage text field.
+  -->
+  <sql id="errorMessageOperationCondition">
+    <choose>
+      <when test="operation.operator.name().equals('EQUALS')">
+        LOWER(${column}) LIKE LOWER(#{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler})
+          ESCAPE ${escapeChar}
+      </when>
+      <when test="operation.operator.name().equals('NOT_EQUALS')">
+        LOWER(${column}) NOT LIKE LOWER(#{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler})
+          ESCAPE ${escapeChar}
+      </when>
+      <when test="operation.operator.name().equals('EXISTS')">
+        ${column} IS NOT NULL
+      </when>
+      <when test="operation.operator.name().equals('IN')">
+        <foreach collection="operation.values" item="value" open="(" separator=" OR " close=")">
+          LOWER(${column}) LIKE LOWER(#{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler})
+            ESCAPE ${escapeChar}
+        </foreach>
+      </when>
+      <when test="operation.operator.name().equals('NOT_IN')">
+        <foreach collection="operation.values" item="value" open="(" separator=" AND " close=")">
+          LOWER(${column}) NOT LIKE LOWER(#{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler})
+            ESCAPE ${escapeChar}
+        </foreach>
+      </when>
+      <when test="operation.operator.name().equals('LIKE')">
+        LOWER(${column}) LIKE LOWER(#{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler})
+          ESCAPE ${escapeChar}
+      </when>
+    </choose>
+  </sql>
+  <!--
+    Oracle treats empty strings as NULL. EQUALS '' and NOT_EQUALS '' must use
+    IS NULL / IS NOT NULL. LIKE '' has the same problem: Oracle binds '' as NULL.
+  -->
+  <sql id="errorMessageOperationCondition" databaseId="oracle">
+    <choose>
+      <when test="operation.operator.name().equals('EQUALS')">
+        <choose>
+          <when test="operation.value != null and operation.value.toString().equals('')">
+            ${column} IS NULL
+          </when>
+          <otherwise>
+            LOWER(${column}) LIKE LOWER(#{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler})
+              ESCAPE ${escapeChar}
+          </otherwise>
+        </choose>
+      </when>
+      <when test="operation.operator.name().equals('NOT_EQUALS')">
+        <choose>
+          <when test="operation.value != null and operation.value.toString().equals('')">
+            ${column} IS NOT NULL
+          </when>
+          <otherwise>
+            LOWER(${column}) NOT LIKE LOWER(#{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler})
+              ESCAPE ${escapeChar}
+          </otherwise>
+        </choose>
+      </when>
+      <when test="operation.operator.name().equals('EXISTS')">
+        ${column} IS NOT NULL
+      </when>
+      <when test="operation.operator.name().equals('IN')">
+        <foreach collection="operation.values" item="value" open="(" separator=" OR " close=")">
+          <choose>
+            <when test="value != null and value.toString().equals('')">
+              ${column} IS NULL
+            </when>
+            <otherwise>
+              LOWER(${column}) LIKE LOWER(#{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler})
+                ESCAPE ${escapeChar}
+            </otherwise>
+          </choose>
+        </foreach>
+      </when>
+      <when test="operation.operator.name().equals('NOT_IN')">
+        <foreach collection="operation.values" item="value" open="(" separator=" AND " close=")">
+          <choose>
+            <when test="value != null and value.toString().equals('')">
+              ${column} IS NOT NULL
+            </when>
+            <otherwise>
+              LOWER(${column}) NOT LIKE LOWER(#{value, typeHandler=io.camunda.db.rdbms.sql.typehandler.LiteralSubstringStringTypeHandler})
+                ESCAPE ${escapeChar}
+            </otherwise>
+          </choose>
+        </foreach>
+      </when>
+      <when test="operation.operator.name().equals('LIKE')">
+        <choose>
+          <when test="operation.value != null and operation.value.toString().equals('')">
+            ${column} IS NULL
+          </when>
+          <otherwise>
+            LOWER(${column}) LIKE LOWER(#{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler})
+              ESCAPE ${escapeChar}
+          </otherwise>
+        </choose>
       </when>
     </choose>
   </sql>

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -320,15 +320,27 @@
       <!-- Error message filters -->
       <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
         <foreach collection="filter.errorMessageOperations" item="operation">
-          AND EXISTS (
-          SELECT 1
-          FROM ${prefix}INCIDENT i
-          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-          AND
-          <include refid="io.camunda.db.rdbms.sql.Commons.errorMessageOperationCondition">
-            <property name="column" value="i.ERROR_MESSAGE"/>
-          </include>
-          )
+          <choose>
+            <when test="operation.operator.name().equals('NOT_EXISTS')">
+              AND NOT EXISTS (
+              SELECT 1
+              FROM ${prefix}INCIDENT i
+              WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+              AND i.ERROR_MESSAGE IS NOT NULL
+              )
+            </when>
+            <otherwise>
+              AND EXISTS (
+              SELECT 1
+              FROM ${prefix}INCIDENT i
+              WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+              AND
+              <include refid="io.camunda.db.rdbms.sql.Commons.errorMessageOperationCondition">
+                <property name="column" value="i.ERROR_MESSAGE"/>
+              </include>
+              )
+            </otherwise>
+          </choose>
         </foreach>
       </if>
       <if test="filter.incidentErrorHashCodeOperations != null and !filter.incidentErrorHashCodeOperations.isEmpty()">

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -324,7 +324,10 @@
           SELECT 1
           FROM ${prefix}INCIDENT i
           WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-          AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+          AND
+          <include refid="io.camunda.db.rdbms.sql.Commons.errorMessageOperationCondition">
+            <property name="column" value="i.ERROR_MESSAGE"/>
+          </include>
           )
         </foreach>
       </if>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -329,8 +329,10 @@
             SELECT 1
             FROM ${prefix}INCIDENT i
             WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-            AND i.ERROR_MESSAGE
-            <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+            AND
+            <include refid="io.camunda.db.rdbms.sql.Commons.errorMessageOperationCondition">
+              <property name="column" value="i.ERROR_MESSAGE"/>
+            </include>
             )
           </otherwise>
         </choose>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapperTest.java
@@ -50,10 +50,100 @@ class ProcessDefinitionMapperTest {
         .doesNotContain("i.ERROR_MESSAGE IS NULL");
   }
 
+  @Test
+  void shouldRenderOracleEmptyEqualsAsIsNull() throws Exception {
+    // given
+    final var configuration = mapperConfiguration("oracle");
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .errorMessageOperations(Operation.eq(""))
+            .build();
+    final var query = ProcessDefinitionStatisticsDbQuery.of(builder -> builder.filter(filter));
+
+    // when
+    final var sql =
+        configuration
+            .getMappedStatement(FLOW_NODE_STATISTICS_STATEMENT)
+            .getBoundSql(query)
+            .getSql();
+
+    // then
+    assertThat(sql).contains("i.ERROR_MESSAGE IS NULL").doesNotContain("LIKE");
+  }
+
+  @Test
+  void shouldRenderOracleEmptyNotEqualsAsIsNotNull() throws Exception {
+    // given
+    final var configuration = mapperConfiguration("oracle");
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .errorMessageOperations(Operation.neq(""))
+            .build();
+    final var query = ProcessDefinitionStatisticsDbQuery.of(builder -> builder.filter(filter));
+
+    // when
+    final var sql =
+        configuration
+            .getMappedStatement(FLOW_NODE_STATISTICS_STATEMENT)
+            .getBoundSql(query)
+            .getSql();
+
+    // then
+    assertThat(sql).contains("i.ERROR_MESSAGE IS NOT NULL").doesNotContain("LIKE");
+  }
+
+  @Test
+  void shouldRenderOracleNonEmptyEqualsAsLike() throws Exception {
+    // given
+    final var configuration = mapperConfiguration("oracle");
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .errorMessageOperations(Operation.eq("expected error"))
+            .build();
+    final var query = ProcessDefinitionStatisticsDbQuery.of(builder -> builder.filter(filter));
+
+    // when
+    final var sql =
+        configuration
+            .getMappedStatement(FLOW_NODE_STATISTICS_STATEMENT)
+            .getBoundSql(query)
+            .getSql();
+
+    // then
+    assertThat(sql).contains("LOWER(i.ERROR_MESSAGE) LIKE LOWER(").contains("ESCAPE");
+  }
+
+  @Test
+  void shouldRenderEqualsAsCaseInsensitiveLike() throws Exception {
+    // given
+    final var configuration = mapperConfiguration();
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .errorMessageOperations(Operation.eq("Expected Error"))
+            .build();
+    final var query = ProcessDefinitionStatisticsDbQuery.of(builder -> builder.filter(filter));
+
+    // when
+    final var sql =
+        configuration
+            .getMappedStatement(FLOW_NODE_STATISTICS_STATEMENT)
+            .getBoundSql(query)
+            .getSql();
+
+    // then
+    assertThat(sql).contains("LOWER(i.ERROR_MESSAGE) LIKE LOWER(").contains("ESCAPE");
+  }
+
   private Configuration mapperConfiguration() throws Exception {
+    return mapperConfiguration(null);
+  }
+
+  private Configuration mapperConfiguration(final String databaseId) throws Exception {
     final var configuration = new Configuration();
+    configuration.setDatabaseId(databaseId);
     final var properties = new Properties();
     properties.setProperty("prefix", "");
+    properties.setProperty("escapeChar", "'\\\\'");
     configuration.setVariables(properties);
 
     final var mapperFiles =

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapperTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.read.domain.ProcessDefinitionStatisticsDbQuery;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Arrays;
+import java.util.Properties;
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+class ProcessDefinitionMapperTest {
+
+  private static final String MAPPER_DIRECTORY = "src/main/resources/mapper";
+  private static final String FLOW_NODE_STATISTICS_STATEMENT =
+      "io.camunda.db.rdbms.sql.ProcessDefinitionMapper.flowNodeStatistics";
+
+  @Test
+  void shouldRenderNotExistsForMissingErrorMessage() throws Exception {
+    // given
+    final var configuration = mapperConfiguration();
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .errorMessageOperations(Operation.exists(false))
+            .build();
+    final var query = ProcessDefinitionStatisticsDbQuery.of(builder -> builder.filter(filter));
+
+    // when
+    final var sql =
+        configuration
+            .getMappedStatement(FLOW_NODE_STATISTICS_STATEMENT)
+            .getBoundSql(query)
+            .getSql();
+
+    // then
+    assertThat(sql)
+        .contains("NOT EXISTS")
+        .contains("i.ERROR_MESSAGE IS NOT NULL")
+        .doesNotContain("i.ERROR_MESSAGE IS NULL");
+  }
+
+  private Configuration mapperConfiguration() throws Exception {
+    final var configuration = new Configuration();
+    final var properties = new Properties();
+    properties.setProperty("prefix", "");
+    configuration.setVariables(properties);
+
+    final var mapperFiles =
+        new File(MAPPER_DIRECTORY).listFiles((dir, name) -> name.endsWith(".xml"));
+    assertThat(mapperFiles).isNotNull();
+
+    for (final var mapperFile : Arrays.stream(mapperFiles).sorted().toList()) {
+      try (var inputStream = new FileInputStream(mapperFile)) {
+        new XMLMapperBuilder(
+                inputStream, configuration, mapperFile.getPath(), configuration.getSqlFragments())
+            .parse();
+      }
+    }
+    return configuration;
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/LiteralSubstringStringTypeHandlerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/LiteralSubstringStringTypeHandlerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.typehandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LiteralSubstringStringTypeHandlerTest {
+
+  @ParameterizedTest
+  @MethodSource("literalErrorMessages")
+  void shouldTransformLiteralErrorMessageToSubstringPattern(
+      final String input, final String expected) {
+    assertThat(LiteralSubstringStringTypeHandler.transformParameter(input)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> literalErrorMessages() {
+    return Stream.of(
+        Arguments.of("Expected result", "%Expected result%"),
+        Arguments.of("error 100%", "%error 100\\%%"),
+        Arguments.of("line_42", "%line\\_42%"),
+        Arguments.of("C:\\errors\\foo", "%C:\\\\errors\\\\foo%"),
+        Arguments.of("literal*question?", "%literal*question?%"),
+        Arguments.of("C:\\errors_100%", "%C:\\\\errors\\_100\\%%"));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
@@ -265,6 +265,42 @@ public class ProcessDefinitionStatisticsIT {
   }
 
   @Test
+  void shouldGetStatisticsAndFilterByErrorMessagePrefix() {
+    // given
+    final var processDefinitionKey =
+        TestHelper.deployResource(camundaClient, "process/incident_process_v1.bpmn")
+            .getProcesses()
+            .getFirst()
+            .getProcessDefinitionKey();
+    createInstance(processDefinitionKey);
+    createInstance(processDefinitionKey);
+    waitForProcessInstances(
+        camundaClient, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true), 2);
+
+    // then
+    Awaitility.await("should return element statistics with an incident error-message prefix")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var exactMatch =
+                  camundaClient
+                      .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+                      .filter(f -> f.errorMessage(INCIDENT_ERROR_MESSAGE_V1))
+                      .send()
+                      .join();
+              final var prefixMatch =
+                  camundaClient
+                      .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+                      .filter(f -> f.errorMessage("Expected result of the expression"))
+                      .send()
+                      .join();
+
+              assertThat(prefixMatch).isNotEmpty().containsExactlyInAnyOrderElementsOf(exactMatch);
+            });
+  }
+
+  @Test
   void shouldGetStatisticsAndFilterByIncidentHashCodeOrFilters() {
     // given
     final var processDefinitionKey =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
@@ -301,6 +301,32 @@ public class ProcessDefinitionStatisticsIT {
   }
 
   @Test
+  void shouldGetStatisticsWhenErrorMessageDoesNotExist() {
+    // given
+    final var processDefinitionKey = deployCompleteBPMN();
+    createInstance(processDefinitionKey);
+    createInstance(processDefinitionKey);
+    waitForProcessInstances(
+        camundaClient,
+        f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED),
+        2);
+
+    // when
+    final var actual =
+        camundaClient
+            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+            .filter(f -> f.errorMessage(b -> b.exists(false)))
+            .send()
+            .join();
+
+    // then
+    assertThat(actual)
+        .containsExactlyInAnyOrder(
+            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 2L),
+            new ProcessElementStatisticsImpl("EndEvent", 0L, 0L, 0L, 2L));
+  }
+
+  @Test
   void shouldGetStatisticsAndFilterByIncidentHashCodeOrFilters() {
     // given
     final var processDefinitionKey =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -49,7 +49,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -1402,7 +1401,6 @@ public class ProcessInstanceSearchIT {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
   void shouldNarrowByHashCodeWhenErrorMessageInContainsSharedPrefix() {
     // given
     final var sharedPrefix = "Expected result of the expression";


### PR DESCRIPTION
## Summary

- Align RDBMS process-instance and process-definition statistics error-message `EQUALS` and `IN` semantics with Elasticsearch/OpenSearch phrase matching.
- Escape literal SQL wildcard characters while preserving explicit `LIKE` wildcard behavior.
- Restore RDBMS coverage for shared-prefix error-message filters.

## Why

RDBMS required the complete error message while Elasticsearch and OpenSearch matched a contained phrase. The dedicated condition limits the behavior change to the two paths that already use phrase matching on those backends; incident and job error-message filters remain exact-match.

Closes #52798