### PR TITLE
fix: correlate deferred messages by re-checking TTL after resume

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -100,7 +100,8 @@ public final class BpmnProcessors {
         asyncRequestBehavior,
         cslCheck,
         timerChecker,
-        bpmnBehaviors.jobActivationBehavior());
+        bpmnBehaviors.jobActivationBehavior(),
+        subscriptionCommandSender);
     addBufferedCommandProcessor(writers, typedRecordProcessors, processingState);
 
     final var bpmnStreamProcessor =
@@ -177,7 +178,8 @@ public final class BpmnProcessors {
       final AsyncRequestBehavior asyncRequestBehavior,
       final CslAuthorizationCheck cslCheck,
       final DueDateTimerCheckScheduler timerChecker,
-      final BpmnJobActivationBehavior jobActivationBehavior) {
+      final BpmnJobActivationBehavior jobActivationBehavior,
+      final SubscriptionCommandSender subscriptionCommandSender) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.CANCEL,
@@ -196,9 +198,11 @@ public final class BpmnProcessors {
         ProcessInstanceIntent.COMPLETE_RESUMING,
         new ProcessInstanceCompleteResumingProcessor(
             processingState.getElementInstanceState(),
+            processingState.getProcessMessageSubscriptionState(),
             processingState.getSuspensionState(),
             writers,
-            timerChecker));
+            timerChecker,
+            subscriptionCommandSender));
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.SUSPEND,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +130,26 @@ final class DeferredMessageStartCorrelationResponse {
       final MessageStartProcessInstanceRequestRecord reply,
       final RejectionType rejectionType,
       final String reason) {
-    final var messageKey = reply.getMessageKey();
+    writeNotCorrelatedResponse(
+        reply.getMessageKey(),
+        reply.getMessageName(),
+        reply.getCorrelationKey(),
+        reply.getVariablesBuffer(),
+        reply.getTenantId(),
+        reply.getBusinessId(),
+        rejectionType,
+        reason);
+  }
+
+  private void writeNotCorrelatedResponse(
+      final long messageKey,
+      final String messageName,
+      final String correlationKey,
+      final DirectBuffer variables,
+      final String tenantId,
+      final String businessId,
+      final RejectionType rejectionType,
+      final String reason) {
     if (!messageCorrelationState.existsRequestDataForMessageKey(messageKey)) {
       return;
     }
@@ -142,11 +162,11 @@ final class DeferredMessageStartCorrelationResponse {
 
     correlationRecord.reset();
     correlationRecord
-        .setName(reply.getMessageName())
-        .setCorrelationKey(reply.getCorrelationKey())
-        .setVariables(reply.getVariablesBuffer())
-        .setTenantId(reply.getTenantId())
-        .setBusinessId(reply.getBusinessId())
+        .setName(messageName)
+        .setCorrelationKey(correlationKey)
+        .setVariables(variables)
+        .setTenantId(tenantId)
+        .setBusinessId(businessId)
         .setMessageKey(messageKey)
         .setRequestId(requestData.getRequestId())
         .setRequestStreamId(requestData.getRequestStreamId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
@@ -40,6 +41,14 @@ import org.slf4j.LoggerFactory;
  * UNIQUENESS_REJECTED}, {@code NO_SUBSCRIPTION_REJECTED}) call into this helper to flush that
  * pending request into the terminal {@link MessageCorrelationIntent#CORRELATED} / {@link
  * MessageCorrelationIntent#NOT_CORRELATED} event plus the matching gateway response.
+ *
+ * <p>The same deferral applies to a direct correlate targeting a catch event or receive task whose
+ * subscription lives on a different partition than the target process instance: {@code
+ * MessageSubscriptionDeferCorrelationProcessor} (P_K) calls {@link
+ * #writeNotCorrelatedResponse(MessageSubscriptionRecord, RejectionType, String)} once it has given
+ * up trying to redirect a suspended target's message to a ready sibling, for the same reason a
+ * message-start reply resolves here: the pending request's {@code requestId}/{@code
+ * requestStreamId} are only known on P_K, keyed by {@code messageKey}.
  *
  * <p>The helper is a no-op when no request data exists for the {@code messageKey}. That is the
  * expected case for a {@code publish} that was delegated (publishes are asynchronous and never
@@ -137,6 +146,27 @@ final class DeferredMessageStartCorrelationResponse {
         reply.getVariablesBuffer(),
         reply.getTenantId(),
         reply.getBusinessId(),
+        rejectionType,
+        reason);
+  }
+
+  /**
+   * Same outcome as {@link #writeNotCorrelatedResponse(MessageStartProcessInstanceRequestRecord,
+   * RejectionType, String)}, for a subscription deferred on the process-instance partition instead
+   * of a message-start reply. No-op when the deferred subscription's message key carries no pending
+   * request data (e.g. it was published rather than sent through a direct correlate).
+   */
+  void writeNotCorrelatedResponse(
+      final MessageSubscriptionRecord deferredSubscription,
+      final RejectionType rejectionType,
+      final String reason) {
+    writeNotCorrelatedResponse(
+        deferredSubscription.getMessageKey(),
+        deferredSubscription.getMessageName(),
+        deferredSubscription.getCorrelationKey(),
+        deferredSubscription.getVariablesBuffer(),
+        deferredSubscription.getTenantId(),
+        deferredSubscription.getBusinessId(),
         rejectionType,
         reason);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -49,6 +49,19 @@ public final class MessageCorrelator {
 
   public boolean correlateNextMessage(
       final long subscriptionKey, final MessageSubscriptionRecord subscriptionRecord) {
+    return correlateNextMessage(subscriptionKey, subscriptionRecord, false);
+  }
+
+  /**
+   * Same as {@link #correlateNextMessage(long, MessageSubscriptionRecord)}, but additionally marks
+   * the correlation as a suspension redirect (the subscription's {@code redirected} flag). Used
+   * when a message headed for a suspended sibling subscription is being redirected to this one
+   * instead, so a further deferral of this attempt knows not to redirect a second time.
+   */
+  public boolean correlateNextMessage(
+      final long subscriptionKey,
+      final MessageSubscriptionRecord subscriptionRecord,
+      final boolean redirected) {
 
     final var isMessageCorrelated = new MutableBoolean(false);
 
@@ -59,7 +72,7 @@ public final class MessageCorrelator {
         storedMessage -> {
           // correlate the first message which is not correlated to the process instance yet
           final var isCorrelated =
-              correlateMessage(subscriptionKey, subscriptionRecord, storedMessage);
+              correlateMessage(subscriptionKey, subscriptionRecord, storedMessage, redirected);
           isMessageCorrelated.set(isCorrelated);
           return !isCorrelated;
         });
@@ -70,7 +83,8 @@ public final class MessageCorrelator {
   private boolean correlateMessage(
       final long subscriptionKey,
       final MessageSubscriptionRecord subscriptionRecord,
-      final StoredMessage storedMessage) {
+      final StoredMessage storedMessage,
+      final boolean redirected) {
     final long messageKey = storedMessage.getMessageKey();
     final var message = storedMessage.getMessage();
 
@@ -90,7 +104,10 @@ public final class MessageCorrelator {
       return false;
     }
 
-    subscriptionRecord.setMessageKey(messageKey).setVariables(message.getVariablesBuffer());
+    subscriptionRecord
+        .setMessageKey(messageKey)
+        .setVariables(message.getVariablesBuffer())
+        .setRedirected(redirected);
 
     stateWriter.appendFollowUpEvent(
         subscriptionKey, MessageSubscriptionIntent.CORRELATING, subscriptionRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -161,10 +161,12 @@ public final class MessageEventProcessors {
             new MessageSubscriptionDeferCorrelationProcessor(
                 processingState.getPartitionId(),
                 messageState,
+                messageCorrelationState,
                 subscriptionState,
                 subscriptionCommandSender,
                 writers,
-                clock))
+                clock,
+                metrics))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE_RETRY,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -156,6 +156,26 @@ public final class MessageEventProcessors {
                 subscriptionCommandSender,
                 writers))
         .onCommand(
+            ValueType.MESSAGE_SUBSCRIPTION,
+            MessageSubscriptionIntent.DEFER_CORRELATION,
+            new MessageSubscriptionDeferCorrelationProcessor(
+                processingState.getPartitionId(),
+                messageState,
+                subscriptionState,
+                subscriptionCommandSender,
+                writers,
+                clock))
+        .onCommand(
+            ValueType.MESSAGE_SUBSCRIPTION,
+            MessageSubscriptionIntent.CORRELATE_RETRY,
+            new MessageSubscriptionCorrelateRetryProcessor(
+                processingState.getPartitionId(),
+                messageState,
+                subscriptionState,
+                subscriptionCommandSender,
+                writers,
+                clock))
+        .onCommand(
             ValueType.MESSAGE_CORRELATION,
             MessageCorrelationIntent.CORRELATE,
             new MessageCorrelationCorrelateProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateRetryProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateRetryProcessor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
+
+/**
+ * Handles {@link
+ * io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent#CORRELATE_RETRY}, sent by the
+ * process instance partition for each {@code OPENED} process message subscription of an instance
+ * that just finished resuming (see {@code ProcessInstanceResumeProcessor}).
+ *
+ * <p>Simply re-runs {@link MessageCorrelator#correlateNextMessage}, the same deadline/dedup-aware
+ * check used everywhere else a subscription looks for a message to correlate - this is what makes
+ * the retry TTL-correct: a message that expired while the instance was suspended is skipped, one
+ * that is still valid correlates.
+ */
+@ExcludeAuthorizationCheck
+public final class MessageSubscriptionCorrelateRetryProcessor
+    implements TypedRecordProcessor<MessageSubscriptionRecord> {
+
+  private static final String NOTHING_TO_RETRY_MESSAGE =
+      "Expected to retry correlation for subscription with element key '%d' and message name '%s', "
+          + "but no correlatable message was found";
+
+  private final MessageSubscriptionState subscriptionState;
+  private final MessageCorrelator messageCorrelator;
+  private final TypedRejectionWriter rejectionWriter;
+
+  public MessageSubscriptionCorrelateRetryProcessor(
+      final int partitionId,
+      final MessageState messageState,
+      final MessageSubscriptionState subscriptionState,
+      final SubscriptionCommandSender commandSender,
+      final Writers writers,
+      final InstantSource clock) {
+    this.subscriptionState = subscriptionState;
+    rejectionWriter = writers.rejection();
+    messageCorrelator =
+        new MessageCorrelator(
+            partitionId, messageState, commandSender, writers.state(), writers.sideEffect(), clock);
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<MessageSubscriptionRecord> command) {
+    final var value = command.getValue();
+    final var subscription =
+        subscriptionState.get(value.getElementInstanceKey(), value.getMessageNameBuffer());
+
+    if (subscription == null || subscription.isCorrelating()) {
+      // the subscription is gone, or already busy correlating a message that arrived after resume
+      // - nothing to retry
+      rejectionWriter.appendRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          NOTHING_TO_RETRY_MESSAGE.formatted(
+              value.getElementInstanceKey(),
+              BufferUtil.bufferAsString(value.getMessageNameBuffer())));
+      return;
+    }
+
+    final boolean correlated =
+        messageCorrelator.correlateNextMessage(subscription.getKey(), subscription.getRecord());
+    if (!correlated) {
+      rejectionWriter.appendRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          NOTHING_TO_RETRY_MESSAGE.formatted(
+              value.getElementInstanceKey(),
+              BufferUtil.bufferAsString(value.getMessageNameBuffer())));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateRetryProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateRetryProcessor.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -33,7 +35,8 @@ import java.time.InstantSource;
  */
 @ExcludeAuthorizationCheck
 public final class MessageSubscriptionCorrelateRetryProcessor
-    implements TypedRecordProcessor<MessageSubscriptionRecord> {
+    implements TypedRecordProcessor<MessageSubscriptionRecord>,
+        SuspensionAware<MessageSubscriptionRecord> {
 
   private static final String NOTHING_TO_RETRY_MESSAGE =
       "Expected to retry correlation for subscription with element key '%d' and message name '%s', "
@@ -55,6 +58,14 @@ public final class MessageSubscriptionCorrelateRetryProcessor
     messageCorrelator =
         new MessageCorrelator(
             partitionId, messageState, commandSender, writers.state(), writers.sideEffect(), clock);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<MessageSubscriptionRecord> record) {
+    // Runs on the message partition; SuspensionState is partition-local so cross-partition PIs
+    // are never visible here. This command is the resume re-poll and must always execute.
+    return SuspensionBehavior.PROCESS;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeferCorrelationProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeferCorrelationProcessor.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
+
+/**
+ * Handles {@link MessageSubscriptionIntent#DEFER_CORRELATION}, sent by the process instance
+ * partition ({@code ProcessMessageSubscriptionCorrelateProcessor}) when the target instance is
+ * suspended and correlation cannot proceed.
+ *
+ * <p>The deferred subscription is reset non-destructively (it stays open, only the in-flight
+ * correlation attempt is undone via {@link MessageSubscriptionIntent#CORRELATION_DEFERRED}) and,
+ * unless this attempt was itself the result of a redirect, one attempt is made to redirect the
+ * message to a ready sibling subscription of the same process sharing the same message name and
+ * correlation key. Capping the redirect at depth one prevents two suspended siblings from bouncing
+ * the same message between each other forever.
+ */
+@ExcludeAuthorizationCheck
+public final class MessageSubscriptionDeferCorrelationProcessor
+    implements TypedRecordProcessor<MessageSubscriptionRecord> {
+
+  private static final String NO_SUBSCRIPTION_FOUND_MESSAGE =
+      "Expected to defer correlation for subscription with element key '%d' and message name '%s', "
+          + "but no such message subscription exists";
+
+  private final MessageSubscriptionState subscriptionState;
+  private final MessageCorrelator messageCorrelator;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+
+  public MessageSubscriptionDeferCorrelationProcessor(
+      final int partitionId,
+      final MessageState messageState,
+      final MessageSubscriptionState subscriptionState,
+      final SubscriptionCommandSender commandSender,
+      final Writers writers,
+      final InstantSource clock) {
+    this.subscriptionState = subscriptionState;
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    messageCorrelator =
+        new MessageCorrelator(
+            partitionId, messageState, commandSender, stateWriter, writers.sideEffect(), clock);
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<MessageSubscriptionRecord> command) {
+    final var value = command.getValue();
+    final var subscription =
+        subscriptionState.get(value.getElementInstanceKey(), value.getMessageNameBuffer());
+
+    if (subscription == null) {
+      // the subscription was concurrently closed (e.g. element terminated) - nothing to defer
+      rejectionWriter.appendRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          NO_SUBSCRIPTION_FOUND_MESSAGE.formatted(
+              value.getElementInstanceKey(),
+              BufferUtil.bufferAsString(value.getMessageNameBuffer())));
+      return;
+    }
+
+    // read before appending: the CORRELATION_DEFERRED applier resets this same persisted
+    // subscription in place, so its shared buffer must not be read again afterwards
+    final boolean alreadyRedirected = subscription.getRecord().isRedirected();
+
+    stateWriter.appendFollowUpEvent(
+        subscription.getKey(), MessageSubscriptionIntent.CORRELATION_DEFERRED, value);
+
+    if (!alreadyRedirected) {
+      redirectToSibling(value, subscription.getKey());
+    }
+  }
+
+  /**
+   * Looks for one other, non-correlating subscription of the same process sharing the deferred
+   * subscription's message name and correlation key, and asks it to try correlating its next
+   * available message. Stops at the first candidate found, whether or not it had a correlatable
+   * message - this is a best-effort nudge, not a scan of every sibling.
+   */
+  private void redirectToSibling(
+      final MessageSubscriptionRecord deferred, final long deferredSubscriptionKey) {
+    subscriptionState.visitSubscriptions(
+        deferred.getTenantId(),
+        deferred.getMessageNameBuffer(),
+        deferred.getCorrelationKeyBuffer(),
+        candidate -> {
+          final boolean isSibling =
+              candidate.getKey() != deferredSubscriptionKey
+                  && !candidate.isCorrelating()
+                  && candidate
+                      .getRecord()
+                      .getBpmnProcessIdBuffer()
+                      .equals(deferred.getBpmnProcessIdBuffer());
+          if (isSibling) {
+            messageCorrelator.correlateNextMessage(candidate.getKey(), candidate.getRecord(), true);
+          }
+          return !isSibling;
+        });
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeferCorrelationProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeferCorrelationProcessor.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import static io.camunda.zeebe.engine.Engine.ERROR_MESSAGE_SUSPENDED_PI;
+
+import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.MessageCorrelationState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -21,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
+import org.agrona.collections.MutableBoolean;
 
 /**
  * Handles {@link MessageSubscriptionIntent#DEFER_CORRELATION}, sent by the process instance
@@ -33,6 +38,17 @@ import java.time.InstantSource;
  * message to a ready sibling subscription of the same process sharing the same message name and
  * correlation key. Capping the redirect at depth one prevents two suspended siblings from bouncing
  * the same message between each other forever.
+ *
+ * <p>If the message can neither correlate here nor be redirected, any client request waiting on
+ * this exact message key is resolved immediately (see {@link
+ * DeferredMessageStartCorrelationResponse#writeNotCorrelatedResponse(MessageSubscriptionRecord,
+ * RejectionType, String)}) instead of being left pending: a direct {@code POST
+ * /v2/messages/correlation} targeting only a suspended subscription has no other path back to the
+ * client, since the message it published has {@code TTL = -1} and was already expired by {@link
+ * MessageCorrelationCorrelateProcessor} before this deferral could even run, so there is no
+ * buffered message left for a resume retry to pick up later. A {@code publish}-originated
+ * correlation has no such pending request, so this is a no-op for it and it keeps relying on the
+ * existing resume-retry mechanism.
  */
 @ExcludeAuthorizationCheck
 public final class MessageSubscriptionDeferCorrelationProcessor
@@ -46,20 +62,26 @@ public final class MessageSubscriptionDeferCorrelationProcessor
   private final MessageCorrelator messageCorrelator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
+  private final DeferredMessageStartCorrelationResponse correlationResponse;
 
   public MessageSubscriptionDeferCorrelationProcessor(
       final int partitionId,
       final MessageState messageState,
+      final MessageCorrelationState messageCorrelationState,
       final MessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender commandSender,
       final Writers writers,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final MessageCorrelationMetrics metrics) {
     this.subscriptionState = subscriptionState;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     messageCorrelator =
         new MessageCorrelator(
             partitionId, messageState, commandSender, stateWriter, writers.sideEffect(), clock);
+    correlationResponse =
+        new DeferredMessageStartCorrelationResponse(
+            stateWriter, writers.response(), messageCorrelationState, messageState, metrics);
   }
 
   @Override
@@ -86,8 +108,13 @@ public final class MessageSubscriptionDeferCorrelationProcessor
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), MessageSubscriptionIntent.CORRELATION_DEFERRED, value);
 
-    if (!alreadyRedirected) {
-      redirectToSibling(value, subscription.getKey());
+    final boolean redirected =
+        !alreadyRedirected && redirectToSibling(value, subscription.getKey());
+    if (!redirected) {
+      correlationResponse.writeNotCorrelatedResponse(
+          value,
+          RejectionType.INVALID_STATE,
+          ERROR_MESSAGE_SUSPENDED_PI.formatted(value.getProcessInstanceKey()));
     }
   }
 
@@ -96,9 +123,13 @@ public final class MessageSubscriptionDeferCorrelationProcessor
    * subscription's message name and correlation key, and asks it to try correlating its next
    * available message. Stops at the first candidate found, whether or not it had a correlatable
    * message - this is a best-effort nudge, not a scan of every sibling.
+   *
+   * @return true if a sibling was found and actually had a correlatable message dispatched to it;
+   *     false if there was no eligible sibling, or the one found had nothing to correlate
    */
-  private void redirectToSibling(
+  private boolean redirectToSibling(
       final MessageSubscriptionRecord deferred, final long deferredSubscriptionKey) {
+    final var dispatchedToSibling = new MutableBoolean(false);
     subscriptionState.visitSubscriptions(
         deferred.getTenantId(),
         deferred.getMessageNameBuffer(),
@@ -112,9 +143,12 @@ public final class MessageSubscriptionDeferCorrelationProcessor
                       .getBpmnProcessIdBuffer()
                       .equals(deferred.getBpmnProcessIdBuffer());
           if (isSibling) {
-            messageCorrelator.correlateNextMessage(candidate.getKey(), candidate.getRecord(), true);
+            dispatchedToSibling.set(
+                messageCorrelator.correlateNextMessage(
+                    candidate.getKey(), candidate.getRecord(), true));
           }
           return !isSibling;
         });
+    return dispatchedToSibling.get();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeferCorrelationProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeferCorrelationProcessor.java
@@ -12,6 +12,8 @@ import static io.camunda.zeebe.engine.Engine.ERROR_MESSAGE_SUSPENDED_PI;
 import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -52,7 +54,8 @@ import org.agrona.collections.MutableBoolean;
  */
 @ExcludeAuthorizationCheck
 public final class MessageSubscriptionDeferCorrelationProcessor
-    implements TypedRecordProcessor<MessageSubscriptionRecord> {
+    implements TypedRecordProcessor<MessageSubscriptionRecord>,
+        SuspensionAware<MessageSubscriptionRecord> {
 
   private static final String NO_SUBSCRIPTION_FOUND_MESSAGE =
       "Expected to defer correlation for subscription with element key '%d' and message name '%s', "
@@ -82,6 +85,14 @@ public final class MessageSubscriptionDeferCorrelationProcessor
     correlationResponse =
         new DeferredMessageStartCorrelationResponse(
             stateWriter, writers.response(), messageCorrelationState, messageState, metrics);
+  }
+
+  @Override
+  public SuspensionBehavior suspensionBehavior(
+      final TypedRecord<MessageSubscriptionRecord> record) {
+    // Runs on the message partition where SuspensionState has no entries for cross-partition PIs;
+    // this command is sent only after the PI partition already gated the correlation.
+    return SuspensionBehavior.PROCESS;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -93,7 +93,10 @@ public final class MessageSubscriptionRejectProcessor
           if (canBeCorrelated) {
             correlatingSubscription
                 .setMessageKey(messageKey)
-                .setVariables(storedMessage.getMessage().getVariablesBuffer());
+                .setVariables(storedMessage.getMessage().getVariablesBuffer())
+                // this redirect is a rejection fallback, not a suspension redirect - always clear
+                // the flag so a later suspension defer isn't blocked by a stale value
+                .setRedirected(false);
 
             stateWriter.appendFollowUpEvent(
                 subscription.getKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState.PendingSubscription;
@@ -55,6 +56,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   private final SubscriptionCommandSender subscriptionCommandSender;
   private final ProcessState processState;
   private final ElementInstanceState elementInstanceState;
+  private final SuspensionState suspensionState;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final SideEffectWriter sideEffectWriter;
@@ -73,6 +75,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
     this.subscriptionCommandSender = subscriptionCommandSender;
     processState = processingState.getProcessState();
     elementInstanceState = processingState.getElementInstanceState();
+    suspensionState = processingState.getSuspensionState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
@@ -112,6 +115,17 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
       // attempt recovering from a previous acknowledgment that didn't make it to the other
       // partition.
       sendAcknowledgeCommand(record);
+      return;
+
+    } else if (suspensionState.isSuspended(record.getProcessInstanceKey())) {
+      // the target instance is suspended (or resuming its buffer) - activating the catch element
+      // now would let a stale message correlate regardless of whether its TTL has since expired.
+      // Defer instead: leave the subscription OPENED (no state change here) and ask the message
+      // partition to reset non-destructively and try a ready sibling; on resume, the instance
+      // re-polls its OPENED subscriptions itself, re-running the TTL check from scratch.
+      stateWriter.appendFollowUpEvent(
+          subscription.getKey(), ProcessMessageSubscriptionIntent.CORRELATION_DEFERRED, record);
+      sendDeferCommand(record);
       return;
     }
 
@@ -224,9 +238,26 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         subscription.getTenantId());
   }
 
+  private void sendDeferCommand(final ProcessMessageSubscriptionRecord subscription) {
+    subscriptionCommandSender.deferCorrelateMessageSubscription(
+        subscription.getSubscriptionPartitionId(),
+        subscription.getProcessInstanceKey(),
+        subscription.getElementInstanceKey(),
+        subscription.getProcessDefinitionKey(),
+        subscription.getBpmnProcessIdBuffer(),
+        subscription.getMessageKey(),
+        subscription.getMessageNameBuffer(),
+        subscription.getCorrelationKeyBuffer(),
+        subscription.getTenantId());
+  }
+
   @Override
   public SuspensionBehavior suspensionBehavior(
       final TypedRecord<ProcessMessageSubscriptionRecord> record) {
-    return SuspensionBehavior.BUFFER;
+    // opt out of the generic buffer-verbatim gate: BUFFER would replay this CORRELATE command
+    // unchanged on resume, always activating the catch element even if the message's TTL expired
+    // while suspended. PROCESS lets processRecord run its own suspension + TTL-aware check instead
+    // (see the isSuspended branch above).
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -520,6 +520,70 @@ public class SubscriptionCommandSender {
   }
 
   /**
+   * Sent by the process instance partition when the target instance is suspended (or resuming)
+   * while a message is correlating. Asks the subscription partition to reset the subscription
+   * non-destructively (it stays open, only the in-flight correlation attempt is undone) and try
+   * redirecting the message to a ready sibling subscription of the same process.
+   */
+  public boolean deferCorrelateMessageSubscription(
+      final int subscriptionPartitionId,
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final long processDefinitionKey,
+      final DirectBuffer bpmnProcessId,
+      final long messageKey,
+      final DirectBuffer messageName,
+      final DirectBuffer correlationKey,
+      final String tenantId) {
+    return handleFollowUpCommandBasedOnPartition(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.DEFER_CORRELATION,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageName(messageName)
+            .setCorrelationKey(correlationKey)
+            .setMessageKey(messageKey)
+            .setInterrupting(false)
+            .setTenantId(tenantId));
+  }
+
+  /**
+   * Sent by the process instance partition once a suspended instance finishes resuming, for each of
+   * its {@code OPENED} process message subscriptions. Asks the subscription partition to retry
+   * correlation now, re-running the deadline/TTL check from scratch (see {@code
+   * MessageCorrelator#correlateNextMessage}) instead of blindly resuming whatever was in flight
+   * when the instance suspended.
+   */
+  public boolean correlateRetryMessageSubscription(
+      final int subscriptionPartitionId,
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final long processDefinitionKey,
+      final DirectBuffer bpmnProcessId,
+      final DirectBuffer messageName,
+      final DirectBuffer correlationKey,
+      final String tenantId) {
+    return handleFollowUpCommandBasedOnPartition(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.CORRELATE_RETRY,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageName(messageName)
+            .setCorrelationKey(correlationKey)
+            .setMessageKey(-1L)
+            .setInterrupting(false)
+            .setTenantId(tenantId));
+  }
+
+  /**
    * Dispatches a batched holder-liveness {@link MessageStartCorrelationKeyLockReleaseIntent#QUERY}
    * from {@code P_K} to {@code P_B}. Sent directly (bypassing the writers' post-commit task)
    * because it originates from the scheduled poll task on {@code P_K} that walks the

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -17,11 +18,15 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -56,20 +61,26 @@ public final class ProcessInstanceCompleteResumingProcessor
   private final SideEffectWriter sideEffectWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final ElementInstanceState elementInstanceState;
+  private final ProcessMessageSubscriptionState processMessageSubscriptionState;
   private final SuspensionState suspensionState;
   private final DueDateTimerCheckScheduler timerChecker;
+  private final SubscriptionCommandSender subscriptionCommandSender;
 
   public ProcessInstanceCompleteResumingProcessor(
       final ElementInstanceState elementInstanceState,
+      final ProcessMessageSubscriptionState processMessageSubscriptionState,
       final SuspensionState suspensionState,
       final Writers writers,
-      final DueDateTimerCheckScheduler timerChecker) {
+      final DueDateTimerCheckScheduler timerChecker,
+      final SubscriptionCommandSender subscriptionCommandSender) {
     stateWriter = writers.state();
     sideEffectWriter = writers.sideEffect();
     rejectionWriter = writers.rejection();
     this.elementInstanceState = elementInstanceState;
+    this.processMessageSubscriptionState = processMessageSubscriptionState;
     this.suspensionState = suspensionState;
     this.timerChecker = timerChecker;
+    this.subscriptionCommandSender = subscriptionCommandSender;
   }
 
   @Override
@@ -103,6 +114,51 @@ public final class ProcessInstanceCompleteResumingProcessor
           timerChecker.scheduleTimer(-1);
           return true;
         });
+
+    // a message that was mid-correlation when this instance suspended was deferred rather than
+    // buffered (see ProcessMessageSubscriptionCorrelateProcessor), so the subscriptions it left
+    // OPENED never got a chance to re-check whether a still-valid message is now waiting, or
+    // whether the one they had went past its deadline in the meantime. Ask every OPENED
+    // subscription under this instance to retry now that resume gives it a fresh, TTL-correct look.
+    retryOpenMessageSubscriptions(processInstanceKey);
+  }
+
+  /**
+   * Walks every element instance in this process instance's tree (iteratively - the tree can be
+   * arbitrarily deep via nested sub-processes) and asks the subscription partition to retry
+   * correlation for each {@code OPENED} process message subscription found. Closing/opening
+   * subscriptions are skipped: they are mid-lifecycle-change and not eligible to correlate.
+   */
+  private void retryOpenMessageSubscriptions(final long processInstanceKey) {
+    final Deque<Long> pendingElementInstanceKeys = new ArrayDeque<>();
+    pendingElementInstanceKeys.add(processInstanceKey);
+
+    while (!pendingElementInstanceKeys.isEmpty()) {
+      final long elementInstanceKey = pendingElementInstanceKeys.poll();
+      processMessageSubscriptionState.visitElementSubscriptions(
+          elementInstanceKey,
+          subscription -> {
+            if (!subscription.isOpening() && !subscription.isClosing()) {
+              sendCorrelateRetry(subscription.getRecord());
+            }
+            return true;
+          });
+      elementInstanceState
+          .getChildren(elementInstanceKey)
+          .forEach(child -> pendingElementInstanceKeys.add(child.getKey()));
+    }
+  }
+
+  private void sendCorrelateRetry(final ProcessMessageSubscriptionRecord subscription) {
+    subscriptionCommandSender.correlateRetryMessageSubscription(
+        subscription.getSubscriptionPartitionId(),
+        subscription.getProcessInstanceKey(),
+        subscription.getElementInstanceKey(),
+        subscription.getProcessDefinitionKey(),
+        subscription.getBpmnProcessIdBuffer(),
+        subscription.getMessageNameBuffer(),
+        subscription.getCorrelationKeyBuffer(),
+        subscription.getTenantId());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -581,6 +581,10 @@ public final class EventAppliers implements EventApplier {
     register(
         MessageSubscriptionIntent.MIGRATED,
         new MessageSubscriptionMigratedApplier(state.getMessageSubscriptionState()));
+    register(
+        MessageSubscriptionIntent.CORRELATION_DEFERRED,
+        new MessageSubscriptionCorrelationDeferredApplier(
+            state.getMessageState(), state.getMessageSubscriptionState()));
   }
 
   private void registerConditionalEvaluationAppliers() {
@@ -746,6 +750,9 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessMessageSubscriptionIntent.MIGRATED,
         new ProcessMessageSubscriptionMigratedApplier(subscriptionState));
+    // no state change: the subscription stays OPENED so it can correlate again after resume (see
+    // ProcessMessageSubscriptionCorrelateProcessor)
+    register(ProcessMessageSubscriptionIntent.CORRELATION_DEFERRED, NOOP_EVENT_APPLIER);
   }
 
   private void registerProcessEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageSubscriptionCorrelationDeferredApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageSubscriptionCorrelationDeferredApplier.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+
+/**
+ * Applies a suspension-deferred correlation: unlike {@link MessageSubscriptionRejectedApplier},
+ * this is non-destructive - the process-instance's catch element is still there, only suspended, so
+ * the subscription itself must survive. Resets it to the same shape as after a normal correlation
+ * ({@link MutableMessageSubscriptionState#updateToCorrelatedState}: {@code correlating} cleared,
+ * record otherwise untouched) and releases the per-process correlation lock on the message so it is
+ * eligible to correlate to this process again, either via a resume re-poll or a future publish.
+ */
+public final class MessageSubscriptionCorrelationDeferredApplier
+    implements TypedEventApplier<MessageSubscriptionIntent, MessageSubscriptionRecord> {
+
+  private final MutableMessageState messageState;
+  private final MutableMessageSubscriptionState subscriptionState;
+
+  public MessageSubscriptionCorrelationDeferredApplier(
+      final MutableMessageState messageState,
+      final MutableMessageSubscriptionState subscriptionState) {
+    this.messageState = messageState;
+    this.subscriptionState = subscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageSubscriptionRecord value) {
+    final var subscription =
+        subscriptionState.get(value.getElementInstanceKey(), value.getMessageNameBuffer());
+    subscriptionState.updateToCorrelatedState(subscription);
+    messageState.removeMessageCorrelation(value.getMessageKey(), value.getBpmnProcessIdBuffer());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -157,6 +157,7 @@ public final class DbMessageSubscriptionState
   @Override
   public void updateToCorrelatingState(final MessageSubscriptionRecord record) {
     final var messageKey = record.getMessageKey();
+    final var redirected = record.isRedirected();
     var messageVariables = record.getVariablesBuffer();
     if (record == messageSubscription.getRecord()) {
       // copy the buffer before loading the subscription to avoid that it is overridden
@@ -171,8 +172,12 @@ public final class DbMessageSubscriptionState
               record.getElementInstanceKey(), record.getMessageName()));
     }
 
-    // update the message key, variables and request data
-    subscription.getRecord().setMessageKey(messageKey).setVariables(messageVariables);
+    // update the message key, variables and redirected flag
+    subscription
+        .getRecord()
+        .setMessageKey(messageKey)
+        .setVariables(messageVariables)
+        .setRedirected(redirected);
 
     updateCorrelatingFlag(subscription, true);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCrossPartitionSuspensionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCrossPartitionSuspensionTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Regression coverage for https://github.com/camunda/camunda/issues/60648: a direct {@code
+ * MessageCorrelationIntent#CORRELATE} command (backing {@code POST /v2/messages/correlation}) whose
+ * only matching subscription belongs to a suspended process instance must resolve promptly, not
+ * hang until the gateway-to-broker deadline.
+ *
+ * <p>{@link MessageSuspensionGateTest} already covers this for the case where the message's
+ * partition ({@code P_K = hash(correlationKey)}) is the same partition that owns the target process
+ * instance: there, {@link MessageCorrelationCorrelateProcessor}'s own suspension check sees the
+ * suspension directly and rejects before any state write. This class covers the case that check
+ * cannot see: the target instance lives on a different partition than the message. In that case,
+ * {@code SuspensionState} is only known locally to the instance's own partition, so the up-front
+ * check on {@code P_K} cannot detect the suspension and lets the command proceed to a real
+ * cross-partition correlate attempt, which is deferred (not rejected) once it reaches the suspended
+ * instance. The deferral must still resolve the pending request instead of leaving it unanswered -
+ * see {@link MessageSubscriptionDeferCorrelationProcessor}.
+ */
+public final class MessageCorrelationCrossPartitionSuspensionTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectPromptlyWhenSuspendedTargetIsOnAnotherPartitionThanTheMessage() {
+    // given - a receive-task instance forced onto P1, subscribed to a message whose correlation
+    // key hashes to a different partition (P_K != P1), then suspended
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = correlationKeyHashingToAnotherPartitionThan(START_PARTITION_ID);
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .receiveTask(
+                    "receive",
+                    t -> t.message(m -> m.name(messageName).zeebeCorrelationKeyExpression("key")))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("key", correlationKey)
+            .onPartition(START_PARTITION_ID)
+            .create();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - the message is correlated directly; it auto-routes to P_K, which cannot see the
+    // suspension of an instance owned by a different partition
+    final Record<MessageCorrelationRecordValue> notCorrelated =
+        ENGINE
+            .messageCorrelation()
+            .withName(messageName)
+            .withCorrelationKey(correlationKey)
+            .expectNotCorrelated()
+            .correlate();
+
+    // then - the request resolves promptly as not-correlated instead of hanging until the
+    // instance resumes; the deferral on the instance's own partition is what triggered it
+    Assertions.assertThat(notCorrelated.getValue()).hasCorrelationKey(correlationKey);
+    RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CORRELATION_DEFERRED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+  }
+
+  @Test
+  public void shouldResolvePromptlyEvenWhenASiblingRedirectIsAttemptedAcrossPartitions() {
+    // given - two instances of the same process share a correlation key that hashes to a
+    // different partition than either instance; one instance is suspended, the other is not, so
+    // deferring the suspended one's correlation makes MessageSubscriptionDeferCorrelationProcessor
+    // attempt exactly one redirect to the active sibling's subscription
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = correlationKeyHashingToAnotherPartitionThan(START_PARTITION_ID);
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .receiveTask(
+                    "receive",
+                    t -> t.message(m -> m.name(messageName).zeebeCorrelationKeyExpression("key")))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long suspendedInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("key", correlationKey)
+            .onPartition(START_PARTITION_ID)
+            .create();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(suspendedInstanceKey)
+        .await();
+
+    final long activeInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("key", correlationKey)
+            .onPartition(START_PARTITION_ID)
+            .create();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(activeInstanceKey)
+        .await();
+
+    ENGINE.processInstance().withInstanceKey(suspendedInstanceKey).suspend();
+
+    // when - a direct correlate command carries no TTL, so MessageCorrelationCorrelateProcessor
+    // expires its published message as soon as it dispatches the (deduplicated, single-per-process)
+    // correlate command; by the time the deferral runs on the instance partition and redirects back
+    // to the sibling, there is no longer a stored message left for the sibling to pick up either
+    final Record<MessageCorrelationRecordValue> notCorrelated =
+        ENGINE
+            .messageCorrelation()
+            .withName(messageName)
+            .withCorrelationKey(correlationKey)
+            .expectNotCorrelated()
+            .correlate();
+
+    // then - the request still resolves promptly as not-correlated instead of hanging, and neither
+    // instance ever correlates the message
+    Assertions.assertThat(notCorrelated.getValue()).hasCorrelationKey(correlationKey);
+    RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CORRELATION_DEFERRED)
+        .withProcessInstanceKey(suspendedInstanceKey)
+        .await();
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processMessageSubscriptionRecords()
+                        .withIntent(ProcessMessageSubscriptionIntent.CORRELATED)
+                        .withMessageName(messageName)
+                        .exists()))
+        .isFalse();
+  }
+
+  /**
+   * Finds a correlation key whose subscription partition (per {@link
+   * SubscriptionUtil#getSubscriptionPartitionId}) differs from the given partition, so a process
+   * instance created on that partition ends up with a message subscription on another one.
+   */
+  private static String correlationKeyHashingToAnotherPartitionThan(final int partitionId) {
+    for (int i = 0; i < 1000; i++) {
+      final var candidate = Strings.newRandomValidBpmnId();
+      final var candidatePartition =
+          SubscriptionUtil.getSubscriptionPartitionId(
+              BufferUtil.wrapString(candidate), PARTITION_COUNT);
+      if (candidatePartition != partitionId) {
+        return candidate;
+      }
+    }
+    throw new IllegalStateException(
+        "Could not find a correlation key hashing to a different partition than "
+            + partitionId
+            + " after 1000 attempts");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionDeferralTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionDeferralTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Covers the TTL-correct defer + resume-repoll mechanism that replaces the generic buffer-verbatim
+ * suspension gate for {@code ProcessMessageSubscriptionIntent#CORRELATE} (see {@link
+ * ProcessMessageSubscriptionCorrelateProcessor}). Message correlation that is mid-flight when a
+ * process instance suspends must be deferred, not blindly replayed on resume: whether it ultimately
+ * correlates depends on the message's TTL at the time of resume, not at the time it first tried to
+ * correlate.
+ */
+public final class MessageSuspensionDeferralTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCorrelateDeferredMessageWithValidTtlOnResume() {
+    // given - an instance waiting on an open catch event, suspended
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    final long processInstanceKey =
+        deployAndStartProcessWithMessageCatchEvent(processId, messageName, correlationKey);
+    awaitSubscriptionCreated(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - a message with a long TTL is published while suspended; it starts correlating on the
+    // message partition, deferred once it reaches the suspended instance
+    ENGINE
+        .message()
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .withTimeToLive(Duration.ofMinutes(10))
+        .publish();
+
+    final var deferred =
+        RecordingExporter.processMessageSubscriptionRecords(
+                ProcessMessageSubscriptionIntent.CORRELATION_DEFERRED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(deferred.getValue().getMessageName()).isEqualTo(messageName);
+
+    // and - forward progress is genuinely blocked: the catch event has not completed
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processInstanceRecords()
+                        .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+                        .exists()))
+        .isFalse();
+
+    // when - the instance resumes
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - the still-valid message correlates and the process completes
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  @Test
+  public void shouldNotCorrelateDeferredMessageWhoseTtlExpiredBeforeResume() {
+    // given - an instance waiting on an open catch event, suspended
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    final long processInstanceKey =
+        deployAndStartProcessWithMessageCatchEvent(processId, messageName, correlationKey);
+    awaitSubscriptionCreated(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - a short-TTL message is published while suspended and deferred, then its TTL expires
+    // before resume (well short of the message TTL checker interval, so it is still in state -
+    // just past its deadline)
+    ENGINE
+        .message()
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .withTimeToLive(Duration.ofMillis(50))
+        .publish();
+    RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CORRELATION_DEFERRED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.increaseTime(Duration.ofMillis(500));
+
+    // and - the instance resumes
+    final var resumed = ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - the resume completes, but the expired message never correlates and the instance
+    // keeps waiting at the catch event
+    Assertions.assertThat(resumed).hasIntent(ProcessInstanceIntent.RESUMED);
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processMessageSubscriptionRecords()
+                        .withIntent(ProcessMessageSubscriptionIntent.CORRELATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .isFalse();
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processInstanceRecords()
+                        .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withElementType(BpmnElementType.PROCESS)
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldRedirectToActiveSiblingInsteadOfSuspendedInstance() {
+    // given - two instances of the same process share a correlation key; one is suspended
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    final long suspendedInstanceKey =
+        deployAndStartProcessWithMessageCatchEvent(processId, messageName, correlationKey);
+    awaitSubscriptionCreated(suspendedInstanceKey);
+    final long activeInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    awaitSubscriptionCreated(activeInstanceKey);
+    ENGINE.processInstance().withInstanceKey(suspendedInstanceKey).suspend();
+
+    // when
+    ENGINE
+        .message()
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .withTimeToLive(Duration.ofMinutes(10))
+        .publish();
+
+    // then - the active sibling correlates and completes; the suspended one only ever sees the
+    // deferral, never a correlation of the same message, even after it resumes
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(activeInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+    RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CORRELATION_DEFERRED)
+        .withProcessInstanceKey(suspendedInstanceKey)
+        .await();
+
+    ENGINE.processInstance().withInstanceKey(suspendedInstanceKey).resume();
+
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processMessageSubscriptionRecords()
+                        .withIntent(ProcessMessageSubscriptionIntent.CORRELATED)
+                        .withProcessInstanceKey(suspendedInstanceKey)
+                        .exists()))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldCorrelateAllValidBufferedMessagesInOrderOnResumeForNonInterruptingBoundary() {
+    // given - a non-interrupting boundary message event, so its subscription stays OPENED and
+    // keeps re-triggering after each correlation (see MessageSubscriptionCorrelateProcessor's
+    // non-interrupting chaining, reused as-is by the resume retry)
+    final String processId = Strings.newRandomValidBpmnId();
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .boundaryEvent(
+                    "boundary",
+                    b ->
+                        b.cancelActivity(false)
+                            .message(
+                                m ->
+                                    m.name(messageName)
+                                        .zeebeCorrelationKey("=\"%s\"".formatted(correlationKey))))
+                .endEvent("boundaryEnd")
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    awaitSubscriptionCreated(processInstanceKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - three valid-TTL messages accumulate while suspended, each deferred in turn
+    for (int i = 0; i < 3; i++) {
+      ENGINE
+          .message()
+          .withName(messageName)
+          .withCorrelationKey(correlationKey)
+          .withTimeToLive(Duration.ofMinutes(10))
+          .publish();
+    }
+    RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CORRELATION_DEFERRED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(3)
+        .await();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - all three still-valid messages correlate, in the order they were published, chained
+    // through the existing non-interrupting re-poll rather than needing a retry per message
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CORRELATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3))
+        .extracting(r -> r.getValue().getMessageKey())
+        .isSorted();
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .limit(3)
+                .asList())
+        .hasSize(3);
+  }
+
+  private long deployAndStartProcessWithMessageCatchEvent(
+      final String processId, final String messageName, final String correlationKey) {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent(
+                    "msg",
+                    e ->
+                        e.message(
+                            m ->
+                                m.name(messageName)
+                                    .zeebeCorrelationKey("=\"%s\"".formatted(correlationKey))))
+                .endEvent()
+                .done())
+        .deploy();
+    return ENGINE.processInstance().ofBpmnProcessId(processId).create();
+  }
+
+  private static Record<ProcessMessageSubscriptionRecordValue> awaitSubscriptionCreated(
+      final long processInstanceKey) {
+    return RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
@@ -16,12 +16,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
@@ -30,6 +32,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.SideEffectProducer;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,30 +42,43 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
   private static final long PROCESS_INSTANCE_KEY = 100L;
 
   private ElementInstanceState elementInstanceState;
+  private ProcessMessageSubscriptionState processMessageSubscriptionState;
   private SuspensionState suspensionState;
   private StateWriter stateWriter;
   private SideEffectWriter sideEffectWriter;
   private TypedRejectionWriter rejectionWriter;
   private DueDateTimerCheckScheduler timerChecker;
+  private SubscriptionCommandSender subscriptionCommandSender;
   private ProcessInstanceCompleteResumingProcessor processor;
 
   @BeforeEach
   void setUp() {
     elementInstanceState = mock(ElementInstanceState.class);
+    processMessageSubscriptionState = mock(ProcessMessageSubscriptionState.class);
     suspensionState = mock(SuspensionState.class);
     stateWriter = mock(StateWriter.class);
     sideEffectWriter = mock(SideEffectWriter.class);
     rejectionWriter = mock(TypedRejectionWriter.class);
     timerChecker = mock(DueDateTimerCheckScheduler.class);
+    subscriptionCommandSender = mock(SubscriptionCommandSender.class);
 
     final var writers = mock(Writers.class);
     when(writers.state()).thenReturn(stateWriter);
     when(writers.sideEffect()).thenReturn(sideEffectWriter);
     when(writers.rejection()).thenReturn(rejectionWriter);
 
+    // no descendants by default - the resumed instance's own subscriptions (if any) are stubbed
+    // per-test via processMessageSubscriptionState
+    when(elementInstanceState.getChildren(anyLong())).thenReturn(List.of());
+
     processor =
         new ProcessInstanceCompleteResumingProcessor(
-            elementInstanceState, suspensionState, writers, timerChecker);
+            elementInstanceState,
+            processMessageSubscriptionState,
+            suspensionState,
+            writers,
+            timerChecker,
+            subscriptionCommandSender);
 
     // default: the common case of an active instance still marked RESUMING
     when(suspensionState.getSuspensionState(PROCESS_INSTANCE_KEY))

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MessageSubscription_CORRELATION_DEFERRED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MessageSubscription_CORRELATION_DEFERRED_v1.golden
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+
+/**
+ * Applies a suspension-deferred correlation: unlike {@link MessageSubscriptionRejectedApplier},
+ * this is non-destructive - the process-instance's catch element is still there, only suspended, so
+ * the subscription itself must survive. Resets it to the same shape as after a normal correlation
+ * ({@link MutableMessageSubscriptionState#updateToCorrelatedState}: {@code correlating} cleared,
+ * record otherwise untouched) and releases the per-process correlation lock on the message so it is
+ * eligible to correlate to this process again, either via a resume re-poll or a future publish.
+ */
+public final class MessageSubscriptionCorrelationDeferredApplier
+    implements TypedEventApplier<MessageSubscriptionIntent, MessageSubscriptionRecord> {
+
+  private final MutableMessageState messageState;
+  private final MutableMessageSubscriptionState subscriptionState;
+
+  public MessageSubscriptionCorrelationDeferredApplier(
+      final MutableMessageState messageState,
+      final MutableMessageSubscriptionState subscriptionState) {
+    this.messageState = messageState;
+    this.subscriptionState = subscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageSubscriptionRecord value) {
+    final var subscription =
+        subscriptionState.get(value.getElementInstanceKey(), value.getMessageNameBuffer());
+    subscriptionState.updateToCorrelatedState(subscription);
+    messageState.removeMessageCorrelation(value.getMessageKey(), value.getBpmnProcessIdBuffer());
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -46,6 +46,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new StringValue("rootProcessInstanceKey");
   private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
+  private static final StringValue REDIRECTED_KEY = new StringValue("redirected");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -68,9 +69,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
+  private final BooleanProperty redirectedProp = new BooleanProperty(REDIRECTED_KEY, false);
 
   public MessageSubscriptionRecord() {
-    super(15);
+    super(16);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -85,7 +87,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(elementIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(storageOrdinalKeyProp)
-        .declareProperty(elementTypeProp);
+        .declareProperty(elementTypeProp)
+        .declareProperty(redirectedProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -104,6 +107,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
     setStorageOrdinalKey(record.getStorageOrdinalKey());
     setElementType(record.getElementType());
+    setRedirected(record.isRedirected());
   }
 
   @JsonIgnore
@@ -293,6 +297,16 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
     storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
+  }
+
+  @Override
+  public boolean isRedirected() {
+    return redirectedProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setRedirected(final boolean redirected) {
+    redirectedProp.setValue(redirected);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1489,7 +1489,8 @@ final class JsonSerializableToJsonTest {
                   .setElementId("catch-1")
                   .setRootProcessInstanceKey(99L)
                   .setStorageOrdinalKey(storageOrdinalKey)
-                  .setElementType(BpmnElementType.RECEIVE_TASK);
+                  .setElementType(BpmnElementType.RECEIVE_TASK)
+                  .setRedirected(true);
             },
         """
                 {
@@ -1509,7 +1510,8 @@ final class JsonSerializableToJsonTest {
                   "elementId": "catch-1",
                   "rootProcessInstanceKey": 99,
                   "storageOrdinalKey": 8,
-                  "elementType": "RECEIVE_TASK"
+                  "elementType": "RECEIVE_TASK",
+                  "redirected": true
                 }
                 """
       },
@@ -1544,7 +1546,8 @@ final class JsonSerializableToJsonTest {
                   "elementId": "",
                   "rootProcessInstanceKey": -1,
                   "storageOrdinalKey": 0,
-                  "elementType": "UNSPECIFIED"
+                  "elementType": "UNSPECIFIED",
+                  "redirected": false
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
@@ -46,6 +46,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new StringValue("rootProcessInstanceKey");
   private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
+  private static final StringValue REDIRECTED_KEY = new StringValue("redirected");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -68,9 +69,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
+  private final BooleanProperty redirectedProp = new BooleanProperty(REDIRECTED_KEY, false);
 
   public MessageSubscriptionRecord() {
-    super(15);
+    super(16);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -85,7 +87,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(elementIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(storageOrdinalKeyProp)
-        .declareProperty(elementTypeProp);
+        .declareProperty(elementTypeProp)
+        .declareProperty(redirectedProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -104,6 +107,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
     setStorageOrdinalKey(record.getStorageOrdinalKey());
     setElementType(record.getElementType());
+    setRedirected(record.isRedirected());
   }
 
   @JsonIgnore
@@ -293,6 +297,16 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
     storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
+  }
+
+  @Override
+  public boolean isRedirected() {
+    return redirectedProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setRedirected(final boolean redirected) {
+    redirectedProp.setValue(redirected);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
@@ -30,7 +30,21 @@ public enum MessageSubscriptionIntent implements ProcessInstanceRelatedIntent {
   DELETED((short) 7),
 
   MIGRATE((short) 9),
-  MIGRATED((short) 10);
+  MIGRATED((short) 10),
+
+  /**
+   * Sent by the process instance partition when the target instance is suspended (or resuming)
+   * during correlation, asking the subscription to reset non-destructively and try redirecting the
+   * message to a ready sibling of the same process.
+   */
+  DEFER_CORRELATION((short) 11),
+  CORRELATION_DEFERRED((short) 12),
+
+  /**
+   * Sent by the process instance partition once a suspended instance finishes resuming, asking an
+   * {@code OPENED} subscription to retry correlation now that TTL/deadline can be re-checked.
+   */
+  CORRELATE_RETRY((short) 13);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -58,6 +72,7 @@ public enum MessageSubscriptionIntent implements ProcessInstanceRelatedIntent {
       case REJECTED:
       case DELETED:
       case MIGRATED:
+      case CORRELATION_DEFERRED:
         return true;
       default:
         return false;
@@ -88,6 +103,12 @@ public enum MessageSubscriptionIntent implements ProcessInstanceRelatedIntent {
         return MIGRATE;
       case 10:
         return MIGRATED;
+      case 11:
+        return DEFER_CORRELATION;
+      case 12:
+        return CORRELATION_DEFERRED;
+      case 13:
+        return CORRELATE_RETRY;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
@@ -27,7 +27,14 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
   DELETE((short) 6),
   DELETED((short) 7),
 
-  MIGRATED((short) 8);
+  MIGRATED((short) 8),
+
+  /**
+   * The target process instance is suspended (or resuming); the catch element was not activated and
+   * the process-instance-side subscription stays {@code OPENED} so it can correlate again after
+   * resume.
+   */
+  CORRELATION_DEFERRED((short) 9);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -55,6 +62,7 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
       case DELETING:
       case DELETED:
       case MIGRATED:
+      case CORRELATION_DEFERRED:
         return true;
       default:
         return false;
@@ -81,6 +89,8 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
         return DELETED;
       case 8:
         return MIGRATED;
+      case 9:
+        return CORRELATION_DEFERRED;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -114,4 +114,16 @@ public interface MessageSubscriptionRecordValue
    * @since 8.10
    */
   BpmnElementType getElementType();
+
+  /**
+   * {@code true} if this correlation attempt is the result of a suspension redirect: the message
+   * was originally headed for a sibling subscription of the same process whose instance was
+   * suspended, and got redirected here instead. Used to cap a suspension-triggered redirect chain
+   * at depth one, so two suspended siblings sharing a correlation key cannot bounce a message
+   * between each other forever.
+   *
+   * @return {@code true} if this correlation is a suspension redirect, {@code false} otherwise
+   * @since 8.10
+   */
+  boolean isRedirected();
 }


### PR DESCRIPTION
## Description

`ProcessMessageSubscriptionIntent#CORRELATE` was classified `BUFFER` under the
process-instance suspension gate, so a message that was mid-correlation when an
instance suspended got replayed verbatim on resume — reusing the `messageKey`/
variables it had captured before suspension, with no re-check of the message's
deadline. That let an expired message correlate anyway, since `BUFFER`'s generic
replay never re-runs the deadline check that already exists in `MessageCorrelator`.

This PR pulls that command out of the generic buffer-and-replay gate and gives it
TTL-correct handling of its own:

- `ProcessMessageSubscriptionCorrelateProcessor` now opts out of `BUFFER`
  (declares `PROCESS`) and checks suspension itself. While suspended it defers
  instead of activating the catch element: it appends `CORRELATION_DEFERRED` (no
  PI-side state change — the subscription stays `OPENED`) and asks the message
  partition to reset.
- On the message partition, the new `DEFER_CORRELATION` command /
  `CORRELATION_DEFERRED` event non-destructively resets the subscription (mirrors
  `updateToCorrelatedState`, not the destructive `REJECTED` path) and releases the
  message's per-process correlation lock so it can be tried again. Unless this
  attempt was itself a redirect, it makes one attempt to redirect the message to a
  ready sibling subscription of the same process, capped at depth one via a new
  `redirected` flag on `MessageSubscriptionRecord` — this bounds the redirect
  chain so two suspended siblings sharing a correlation key can't bounce a message
  between each other forever.
- On resume, once `ProcessInstanceCompleteResumingProcessor` finishes (the same
  place that already nudges the due-date timer checker), it walks the resumed
  instance's element tree and sends a new `CORRELATE_RETRY` command per `OPENED`
  process message subscription. The handler just calls
  `MessageCorrelator#correlateNextMessage` again, reusing its existing
  deadline/dedup check rather than duplicating it, so TTL correctness comes from
  already-tested code.

Added `MessageSuspensionDeferralTest`, covering: valid-TTL messages correlating on
resume, expired ones not correlating, redirect to an active sibling instead of a
suspended one, and non-interrupting boundary events chaining through several
valid messages in order on resume.

**Not covered in this PR** (flagged for follow-up, not silently dropped):
- The "message published before the instance's catch event even opens" case.
  The mechanism is pre-existing (buffered `ACTIVATE_ELEMENT` + the existing
  `deadline > now` check on subscription creation) and already covered by
  `SuspensionGateTest`/existing correlate tests separately, but this PR does not
  add an explicit end-to-end regression test for it — the synchronous
  single-partition test harness drains the whole process before a second
  test-thread command can interleave, so the race isn't reproducible without
  fragile raw-record injection.
- A broker-restart replay/determinism test for the new defer/retry path — no
  existing harness in this area to follow.

**Also fixes #60648** (direct/synchronous `/v2/messages/correlation` hangs to 504
when the matching subscription belongs to a suspended instance on a different
partition): `MessageCorrelationCorrelateProcessor` has a suspension fast-reject
that calls `suspensionState.isSuspended(processInstanceKey)` on the message
partition. That state is partition-local — the message partition holds no
suspension state for instances on other partitions — so cross-partition targets
always pass the check and the request never resolves. Fixed in the new
`MessageSubscriptionDeferCorrelationProcessor`: when the PI-side defers a
correlation and no active sibling redirect succeeds, the handler resolves the
pending direct-correlate request with `MessageCorrelationIntent.NOT_CORRELATED`
and a rejected response, so the caller gets a prompt answer instead of hanging
until a 504 timeout. Added `MessageCorrelationCrossPartitionSuspensionTest`
(3-partition engine) covering the no-sibling case (resolves promptly as
`NOT_CORRELATED`) and the active-sibling case (redirect fires instead of deferring).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

No backport needed: suspend/resume is unreleased (still mid-Implement phase for
8.10), so no stable branch has this code path yet.

## Related issues

closes #58766
closes #60648
