### PR TITLE
feat: add ElasticsearchSchemaMigrationStatusProvider for upgrade-readiness

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/ElasticsearchSchemaMigrationStatusProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ElasticsearchSchemaMigrationStatusProviderConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.search.schema.ElasticsearchSchemaMigrationStatusProvider;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.zeebe.util.VersionUtil;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers the Elasticsearch/OpenSearch {@code elasticsearchSchemaMigrated} upgrade-readiness
+ * condition (camunda/product-hub#3067), built from the same per-physical-tenant {@link
+ * SearchEngineConfiguration} map {@link SearchEngineDatabaseConfiguration} already uses for schema
+ * initialization.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnSecondaryStorageType({
+  SecondaryStorageType.elasticsearch,
+  SecondaryStorageType.opensearch
+})
+public class ElasticsearchSchemaMigrationStatusProviderConfiguration {
+
+  /**
+   * The returned provider implements {@link AutoCloseable}; Spring infers and calls its {@code
+   * close()} on context shutdown to release the long-lived per-tenant search engine clients it
+   * opens.
+   */
+  @Bean
+  public ElasticsearchSchemaMigrationStatusProvider elasticsearchSchemaMigrationStatusProvider(
+      @Qualifier("searchEngineConfigurationsByTenant")
+          final Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant) {
+    return ElasticsearchSchemaMigrationStatusProvider.fromConfigs(
+        searchEngineConfigurationsByTenant, VersionUtil.getVersion());
+  }
+}

--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -27,6 +27,11 @@
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-connect</artifactId>
     </dependency>
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/ElasticsearchSchemaMigrationStatusProvider.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/ElasticsearchSchemaMigrationStatusProvider.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
+import io.camunda.search.schema.opensearch.OpensearchEngineClient;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reports whether the Elasticsearch/OpenSearch schema of every configured physical tenant has
+ * migrated to the running application version, for the upgrade-readiness endpoint. Covers both
+ * search engines: the schema (webapp-style indices, tracked via {@link SchemaMetadataStore}'s
+ * {@code schema-version} document) is identical between them, only the wire client differs.
+ *
+ * <p>Reports one entry per physical tenant.
+ */
+public final class ElasticsearchSchemaMigrationStatusProvider
+    implements MigrationStatusProvider, AutoCloseable {
+
+  public static final String CONDITION_NAME = "elasticsearchSchemaMigrated";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ElasticsearchSchemaMigrationStatusProvider.class);
+
+  private final Map<String, ElasticsearchSchemaVersionStore> versionStoresByPhysicalTenant;
+  private final Map<String, SearchEngineClient> searchEngineClientsByPhysicalTenant;
+
+  @VisibleForTesting
+  ElasticsearchSchemaMigrationStatusProvider(
+      final Map<String, ElasticsearchSchemaVersionStore> versionStoresByPhysicalTenant) {
+    this(versionStoresByPhysicalTenant, Map.of());
+  }
+
+  private ElasticsearchSchemaMigrationStatusProvider(
+      final Map<String, ElasticsearchSchemaVersionStore> versionStoresByPhysicalTenant,
+      final Map<String, SearchEngineClient> searchEngineClientsByPhysicalTenant) {
+    this.versionStoresByPhysicalTenant = versionStoresByPhysicalTenant;
+    this.searchEngineClientsByPhysicalTenant = searchEngineClientsByPhysicalTenant;
+  }
+
+  /**
+   * Builds a provider from the per-physical-tenant {@link SearchEngineConfiguration} map — the same
+   * input the search-engine schema initializer consumes. Opens one long-lived {@link
+   * SearchEngineClient} per physical tenant and holds it for the life of this provider, unlike a
+   * one-shot startup check: the upgrade-readiness endpoint calls {@link #getMigrationStatus()} on
+   * every poll, so a fresh client per call would pay a full connection-setup cost every time.
+   * {@link #close()} must be called on application shutdown to release them.
+   */
+  public static ElasticsearchSchemaMigrationStatusProvider fromConfigs(
+      final Map<String, SearchEngineConfiguration> configsByPhysicalTenant,
+      final String applicationVersion) {
+    final Map<String, ElasticsearchSchemaVersionStore> versionStores = new LinkedHashMap<>();
+    final Map<String, SearchEngineClient> searchEngineClients = new LinkedHashMap<>();
+    configsByPhysicalTenant.forEach(
+        (physicalTenantId, config) -> {
+          final var searchEngineClient = createSearchEngineClient(config);
+          searchEngineClients.put(physicalTenantId, searchEngineClient);
+          versionStores.put(
+              physicalTenantId,
+              new ElasticsearchSchemaVersionStore(
+                  searchEngineClient,
+                  config.connect().getIndexPrefix(),
+                  config.connect().getTypeEnum().isElasticSearch(),
+                  applicationVersion));
+        });
+    return new ElasticsearchSchemaMigrationStatusProvider(versionStores, searchEngineClients);
+  }
+
+  private static SearchEngineClient createSearchEngineClient(
+      final SearchEngineConfiguration config) {
+    final var connect = config.connect();
+    if (connect.getTypeEnum().isElasticSearch()) {
+      final var connector = new ElasticsearchConnector(connect);
+      return new ElasticsearchEngineClient(connector.createClient(), connector.objectMapper());
+    }
+    final var connector = new OpensearchConnector(connect);
+    return new OpensearchEngineClient(connector.createClient(), connector.objectMapper());
+  }
+
+  @Override
+  public String conditionName() {
+    return CONDITION_NAME;
+  }
+
+  @Override
+  public Map<String, MigrationConditionStatus> getMigrationStatus() {
+    final var statusesByPhysicalTenant = new LinkedHashMap<String, MigrationConditionStatus>();
+    versionStoresByPhysicalTenant.forEach(
+        (physicalTenantId, versionStore) ->
+            statusesByPhysicalTenant.put(
+                physicalTenantId, toMigrationStatus(versionStore.getCurrentSchemaVersion())));
+    return statusesByPhysicalTenant;
+  }
+
+  @Override
+  public void close() {
+    searchEngineClientsByPhysicalTenant.forEach(
+        (physicalTenantId, searchEngineClient) -> {
+          try {
+            searchEngineClient.close();
+          } catch (final Exception e) {
+            LOG.warn(
+                "Failed to close the search engine client for physical tenant '{}'.",
+                physicalTenantId,
+                e);
+          }
+        });
+  }
+
+  @VisibleForTesting
+  MigrationConditionStatus toMigrationStatus(
+      final ElasticsearchSchemaVersionStore.CurrentSchemaVersion currentSchemaVersion) {
+    return switch (currentSchemaVersion.kind()) {
+      case AVAILABLE ->
+          toMigrationStatus(
+              VersionCompatibilityCheck.check(
+                  currentSchemaVersion.schemaVersion().orElseThrow(),
+                  currentSchemaVersion.stableApplicationVersion().orElseThrow()));
+      case FRESH_DATABASE ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "no schema version recorded yet for prefix '"
+                  + currentSchemaVersion.prefix()
+                  + "' (fresh database)");
+      case READ_FAILURE ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN, currentSchemaVersion.detail().orElseThrow());
+    };
+  }
+
+  private MigrationConditionStatus toMigrationStatus(
+      final VersionCompatibilityCheck.CheckResult result) {
+    return switch (result) {
+      case final Compatible.SameVersion same ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATED,
+              "schema version " + same.version() + " matches the application version");
+      case final Compatible.PatchUpgrade patch ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "schema version " + patch.from() + " has not yet migrated to " + patch.to());
+      case final Compatible.MinorUpgrade minor ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "schema version " + minor.from() + " has not yet migrated to " + minor.to());
+      case final Incompatible incompatible ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN, "incompatible schema upgrade path: " + incompatible);
+      case final Indeterminate indeterminate ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN,
+              "cannot determine schema version compatibility: " + indeterminate);
+    };
+  }
+}

--- a/schema-manager/src/main/java/io/camunda/search/schema/ElasticsearchSchemaVersionStore.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/ElasticsearchSchemaVersionStore.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
+import io.camunda.zeebe.util.SemanticVersion;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks the Elasticsearch/OpenSearch schema version of a single physical tenant (one search engine
+ * connection + index prefix) via the {@code metadata} index's {@code schema-version} document, for
+ * the upgrade-readiness endpoint (camunda/product-hub#3067).
+ *
+ * <p>This is a read-only counterpart to {@link SchemaMetadataStore}, which already owns
+ * reading/writing that document as part of {@link SchemaManager}'s own startup/upgrade flow. Kept
+ * as a separate, narrowly-scoped class so the upgrade-readiness check never throws and never
+ * writes, regardless of what {@link SchemaManager} itself is doing concurrently.
+ */
+public class ElasticsearchSchemaVersionStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSchemaVersionStore.class);
+
+  private final SchemaMetadataStore schemaMetadataStore;
+  private final String prefix;
+
+  /**
+   * The current application version. Used to validate the upgrade path from the stored schema
+   * version.
+   */
+  private final String applicationVersion;
+
+  public ElasticsearchSchemaVersionStore(
+      final SearchEngineClient searchEngineClient,
+      final String prefix,
+      final boolean isElasticsearch,
+      final String applicationVersion) {
+    this.prefix = prefix;
+    this.applicationVersion = applicationVersion;
+    schemaMetadataStore =
+        new SchemaMetadataStore(
+            searchEngineClient, new MetadataIndex(prefix, isElasticsearch), LOG);
+  }
+
+  public CurrentSchemaVersion getCurrentSchemaVersion() {
+    if (applicationVersion == null) {
+      return CurrentSchemaVersion.readFailure(
+          prefix, new IllegalStateException("applicationVersion is not configured."));
+    }
+
+    try {
+      final var schemaVersion = schemaMetadataStore.getSchemaVersion();
+      if (schemaVersion == null) {
+        return CurrentSchemaVersion.freshDatabase(prefix);
+      }
+
+      final var comparableSchemaVersion = toStableVersion(schemaVersion).orElse(schemaVersion);
+
+      final var stableAppVersion = toStableVersion(applicationVersion);
+      return stableAppVersion
+          .map(s -> CurrentSchemaVersion.available(prefix, comparableSchemaVersion, s))
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "[Elasticsearch Schema] cannot parse application version '"
+                          + applicationVersion
+                          + "' as a semantic version"));
+    } catch (final Exception e) {
+      LOG.warn(
+          "[Elasticsearch Schema] Failed to determine current schema version for prefix '{}' "
+              + "during upgrade-readiness check.",
+          prefix,
+          e);
+      return CurrentSchemaVersion.readFailure(prefix, e);
+    }
+  }
+
+  /**
+   * Normalizes {@code version} to a stable {@code major.minor.patch} string by stripping any
+   * pre-release or build-metadata suffix (e.g. {@code 8.11.0-SNAPSHOT} → {@code 8.11.0}).
+   *
+   * @return the stable version string, or {@link Optional#empty()} if {@code version} cannot be
+   *     parsed as a semantic version (e.g. {@code "development"})
+   */
+  @VisibleForTesting
+  static Optional<String> toStableVersion(final String version) {
+    return SemanticVersion.parse(version)
+        .map(sv -> sv.major() + "." + sv.minor() + "." + sv.patch());
+  }
+
+  public record CurrentSchemaVersion(
+      CurrentSchemaVersion.Kind kind,
+      String prefix,
+      Optional<String> schemaVersion,
+      Optional<String> stableApplicationVersion,
+      Optional<String> detail) {
+
+    static CurrentSchemaVersion available(
+        final String prefix, final String schemaVersion, final String stableApplicationVersion) {
+      return new CurrentSchemaVersion(
+          Kind.AVAILABLE,
+          prefix,
+          Optional.of(schemaVersion),
+          Optional.of(stableApplicationVersion),
+          Optional.empty());
+    }
+
+    static CurrentSchemaVersion freshDatabase(final String prefix) {
+      return new CurrentSchemaVersion(
+          Kind.FRESH_DATABASE, prefix, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    static CurrentSchemaVersion readFailure(final String prefix, final Exception e) {
+      return new CurrentSchemaVersion(
+          Kind.READ_FAILURE,
+          prefix,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of("failed to read schema version: " + e.getMessage()));
+    }
+
+    public enum Kind {
+      AVAILABLE,
+      FRESH_DATABASE,
+      READ_FAILURE
+    }
+  }
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaMigrationStatusProviderTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaMigrationStatusProviderTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the Elasticsearch/OpenSearch upgrade-readiness condition. */
+class ElasticsearchSchemaMigrationStatusProviderTest {
+
+  @Test
+  void shouldReportConditionName() {
+    assertThat(provider(Map.of()).conditionName())
+        .isEqualTo(ElasticsearchSchemaMigrationStatusProvider.CONDITION_NAME);
+  }
+
+  @Test
+  void shouldReportNoTenantsWhenNoneAreConfigured() {
+    // when
+    final var statuses = provider(Map.of()).getMigrationStatus();
+
+    // then
+    assertThat(statuses).isEmpty();
+  }
+
+  @Test
+  void shouldReportEachTenantUnderItsOwnPhysicalTenantId() {
+    // given
+    final var tenantA = versionStore("8.10.0", "8.10.0");
+    final var tenantB = versionStore("8.9.0", "8.10.0");
+
+    // when
+    final var statuses =
+        provider(orderedMap("tenantA", tenantA, "tenantB", tenantB)).getMigrationStatus();
+
+    // then - no cross-tenant aggregation, each tenant reports independently
+    assertThat(statuses).hasSize(2);
+    assertThat(statuses.get("tenantA").state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(statuses.get("tenantB").state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportMigratedForSameVersion() {
+    // given - schema=8.10.0, app=8.10.0
+    final var status = singleStatus(versionStore("8.10.0", "8.10.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(status.detail()).contains("8.10.0");
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForPatchUpgrade() {
+    // given - schema=8.9.0, app=8.9.5 (not yet migrated to the running app's exact version)
+    final var status = singleStatus(versionStore("8.9.0", "8.9.5"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForMinorUpgrade() {
+    // given - schema=8.9.1, app=8.10.0
+    final var status = singleStatus(versionStore("8.9.1", "8.10.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForFreshDatabase() {
+    // given - metadata index does not exist yet (fresh installation)
+    final var status = singleStatus(versionStore(null, "8.11.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+    assertThat(status.detail()).contains("fresh database");
+  }
+
+  @Test
+  void shouldReportUnknownForIncompatibleUpgradePath() {
+    // given - schema=8.9.0, app=8.11.0 (skipped 8.10) - a real problem, not "in progress"
+    final var status = singleStatus(versionStore("8.9.0", "8.11.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownForIndeterminateSchemaVersion() {
+    // given - stored schema version is not a valid semantic version
+    final var status = singleStatus(versionStore("not-a-semver", "8.10.0"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownForUnparseableApplicationVersion() {
+    // given - app=development (not a semantic version)
+    final var status = singleStatus(versionStore("8.9.0", "development"));
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("development");
+  }
+
+  @Test
+  void shouldReportUnknownWhenReadingCurrentVersionFails() {
+    // given - the search engine call itself fails (e.g. connection refused)
+    final var searchEngineClient = mock(SearchEngineClient.class);
+    when(searchEngineClient.indexExists(anyString()))
+        .thenThrow(new RuntimeException("connection refused"));
+    final var store = new ElasticsearchSchemaVersionStore(searchEngineClient, "", true, "8.10.0");
+
+    // when
+    final var status = singleStatus(store);
+
+    // then - a read failure must never throw; it must be reported as UNKNOWN
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("connection refused");
+  }
+
+  private static ElasticsearchSchemaMigrationStatusProvider provider(
+      final Map<String, ElasticsearchSchemaVersionStore> versionStoresByPhysicalTenant) {
+    return new ElasticsearchSchemaMigrationStatusProvider(versionStoresByPhysicalTenant);
+  }
+
+  private static MigrationConditionStatus singleStatus(
+      final ElasticsearchSchemaVersionStore versionStore) {
+    return provider(Map.of("tenant", versionStore)).getMigrationStatus().get("tenant");
+  }
+
+  /**
+   * Builds an {@link ElasticsearchSchemaVersionStore} whose metadata index reports {@code
+   * schemaVersion} as already stored (or a fresh installation if {@code null}), backed by a mocked
+   * {@link SearchEngineClient}.
+   */
+  private static ElasticsearchSchemaVersionStore versionStore(
+      final String schemaVersion, final String appVersion) {
+    final var searchEngineClient = mock(SearchEngineClient.class);
+    if (schemaVersion == null) {
+      when(searchEngineClient.indexExists(anyString())).thenReturn(false);
+    } else {
+      when(searchEngineClient.indexExists(anyString())).thenReturn(true);
+      when(searchEngineClient.getDocument(anyString(), anyString()))
+          .thenReturn(Map.of(MetadataIndex.VALUE, schemaVersion));
+    }
+    return new ElasticsearchSchemaVersionStore(searchEngineClient, "", true, appVersion);
+  }
+
+  private static Map<String, ElasticsearchSchemaVersionStore> orderedMap(
+      final String keyA,
+      final ElasticsearchSchemaVersionStore valueA,
+      final String keyB,
+      final ElasticsearchSchemaVersionStore valueB) {
+    final var map = new LinkedHashMap<String, ElasticsearchSchemaVersionStore>();
+    map.put(keyA, valueA);
+    map.put(keyB, valueB);
+    return map;
+  }
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaVersionStoreIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaVersionStoreIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static io.camunda.search.schema.ElasticsearchSchemaVersionStore.CurrentSchemaVersion.Kind;
+import static io.camunda.search.schema.utils.SchemaTestUtil.searchEngineClientFromConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.schema.utils.SchemaManagerITInvocationProvider;
+import io.camunda.search.test.utils.SearchClientAdapter;
+import io.camunda.search.test.utils.SearchDBExtension;
+import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.LoggerFactory;
+
+@DisabledIfSystemProperty(
+    named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+    matches = "^(?=\\s*\\S).*$",
+    disabledReason = "Excluding from AWS OS IT CI")
+@ExtendWith(SchemaManagerITInvocationProvider.class)
+class ElasticsearchSchemaVersionStoreIT {
+
+  @TestTemplate
+  void shouldReportFreshDatabaseWhenMetadataIndexDoesNotYetExist(
+      final SearchEngineConfiguration config, final SearchClientAdapter clientAdapter)
+      throws Exception {
+    // given - a real search engine with no metadata index created yet
+    try (final var searchEngineClient = searchEngineClientFromConfig(config)) {
+      final var store =
+          new ElasticsearchSchemaVersionStore(
+              searchEngineClient,
+              config.connect().getIndexPrefix(),
+              config.connect().getTypeEnum().isElasticSearch(),
+              "8.10.0");
+
+      // when
+      final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+      // then
+      assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.FRESH_DATABASE);
+    }
+  }
+
+  @TestTemplate
+  void shouldReportRealVersionMismatchAgainstStoredSchemaVersion(
+      final SearchEngineConfiguration config, final SearchClientAdapter clientAdapter)
+      throws Exception {
+    // given - a real metadata index with an older schema version already recorded, e.g. by a
+    // previous minor version's startup
+    try (final var searchEngineClient = searchEngineClientFromConfig(config)) {
+      final var metadataIndex =
+          new MetadataIndex(
+              config.connect().getIndexPrefix(), config.connect().getTypeEnum().isElasticSearch());
+      new SchemaMetadataStore(
+              searchEngineClient, metadataIndex, LoggerFactory.getLogger(getClass()))
+          .storeSchemaVersion("8.9.0");
+
+      final var store =
+          new ElasticsearchSchemaVersionStore(
+              searchEngineClient,
+              config.connect().getIndexPrefix(),
+              config.connect().getTypeEnum().isElasticSearch(),
+              "8.10.0");
+
+      // when - the running application is one minor version ahead of the stored schema
+      final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+      // then - the real mismatch between what's stored and what's running is reported as-is,
+      // leaving the upgrade-readiness mapping (MIGRATED vs MIGRATION_IN_PROGRESS) to the caller
+      assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.AVAILABLE);
+      assertThat(currentSchemaVersion.schemaVersion()).contains("8.9.0");
+      assertThat(currentSchemaVersion.stableApplicationVersion()).contains("8.10.0");
+    }
+  }
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaVersionStoreTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaVersionStoreTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static io.camunda.search.schema.ElasticsearchSchemaVersionStore.CurrentSchemaVersion.Kind;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchSchemaVersionStoreTest {
+
+  @Test
+  void shouldReportAvailableForExistingSchemaVersion() {
+    // given - metadata index exists with a stored schema version
+    final var store = store(fakeClient("8.10.0"), "8.10.0");
+
+    // when
+    final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.AVAILABLE);
+    assertThat(currentSchemaVersion.schemaVersion()).contains("8.10.0");
+    assertThat(currentSchemaVersion.stableApplicationVersion()).contains("8.10.0");
+  }
+
+  @Test
+  void shouldNormalizeSnapshotSuffixOnStoredSchemaVersion() {
+    // given - SchemaManager stores VersionUtil.getVersion() as-is (unlike RdbmsSchemaVersionStore,
+    // which normalizes before every write), so a non-release build's stored schema version may
+    // still carry a "-SNAPSHOT" suffix
+    final var store = store(fakeClient("8.10.0-SNAPSHOT"), "8.10.0-SNAPSHOT");
+
+    // when
+    final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+    // then - both sides are normalized before comparison, so a matching non-release build still
+    // reports AVAILABLE with a stable (unsuffixed) schema version
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.AVAILABLE);
+    assertThat(currentSchemaVersion.schemaVersion()).contains("8.10.0");
+    assertThat(currentSchemaVersion.stableApplicationVersion()).contains("8.10.0");
+  }
+
+  @Test
+  void shouldReportFreshDatabaseWhenMetadataIndexDoesNotExist() {
+    // given - metadata index does not exist yet
+    final var searchEngineClient = mock(SearchEngineClient.class);
+    when(searchEngineClient.indexExists(anyString())).thenReturn(false);
+    final var store = store(searchEngineClient, "8.10.0");
+
+    // when
+    final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.FRESH_DATABASE);
+  }
+
+  @Test
+  void shouldReportFreshDatabaseWhenNoVersionDocumentStored() {
+    // given - metadata index exists, but no schema-version document was ever written
+    final var searchEngineClient = mock(SearchEngineClient.class);
+    when(searchEngineClient.indexExists(anyString())).thenReturn(true);
+    when(searchEngineClient.getDocument(anyString(), anyString())).thenReturn(null);
+    final var store = store(searchEngineClient, "8.10.0");
+
+    // when
+    final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.FRESH_DATABASE);
+  }
+
+  @Test
+  void shouldReportReadFailureWhenApplicationVersionIsMissing() {
+    // given - applicationVersion not configured
+    final var store = store(fakeClient("8.10.0"), null);
+
+    // when
+    final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.READ_FAILURE);
+    assertThat(currentSchemaVersion.detail()).isPresent();
+  }
+
+  @Test
+  void shouldReportReadFailureWhenApplicationVersionIsUnparseable() {
+    // given - applicationVersion is not a valid semantic version
+    final var store = store(fakeClient("8.10.0"), "development");
+
+    // when
+    final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.READ_FAILURE);
+    assertThat(currentSchemaVersion.detail())
+        .hasValueSatisfying(d -> assertThat(d).contains("development"));
+  }
+
+  @Test
+  void shouldReportReadFailureWhenSearchEngineClientThrows() {
+    // given - the search engine call itself fails (e.g. connection refused)
+    final var searchEngineClient = mock(SearchEngineClient.class);
+    when(searchEngineClient.indexExists(anyString()))
+        .thenThrow(new RuntimeException("connection refused"));
+    final var store = store(searchEngineClient, "8.10.0");
+
+    // when
+    final var currentSchemaVersion = store.getCurrentSchemaVersion();
+
+    // then
+    assertThat(currentSchemaVersion.kind()).isEqualTo(Kind.READ_FAILURE);
+    assertThat(currentSchemaVersion.detail())
+        .hasValueSatisfying(d -> assertThat(d).contains("connection refused"));
+  }
+
+  private static ElasticsearchSchemaVersionStore store(
+      final SearchEngineClient searchEngineClient, final String applicationVersion) {
+    return new ElasticsearchSchemaVersionStore(searchEngineClient, "", true, applicationVersion);
+  }
+
+  /** A {@link SearchEngineClient} stub reporting {@code schemaVersion} as already stored. */
+  private static SearchEngineClient fakeClient(final String schemaVersion) {
+    final var searchEngineClient = mock(SearchEngineClient.class);
+    when(searchEngineClient.indexExists(anyString())).thenReturn(true);
+    when(searchEngineClient.getDocument(anyString(), anyString()))
+        .thenReturn(Map.of(MetadataIndex.VALUE, schemaVersion));
+    return searchEngineClient;
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ElasticsearchSchemaMigrationStatusProviderIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ElasticsearchSchemaMigrationStatusProviderIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.management;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.zeebe.qa.util.actuator.UpgradeReadinessActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * End-to-end happy-path coverage for {@code GET /actuator/upgradeReadiness}
+ * (camunda/product-hub#3067) with Elasticsearch as the secondary storage: a normally-booted broker
+ * initializes its own schema at startup (via the existing search-engine schema initializer), which
+ * records the current application version — so the {@code elasticsearchSchemaMigrated} condition
+ * must settle on {@code MIGRATED} for the default physical tenant without any exporter, chained
+ * upgrade, or migration scenario involved.
+ *
+ * <p>Sibling of {@link UpgradeReadinessEndpointIT} (RDBMS): the two secondary storage types are
+ * mutually exclusive per broker, so this is a separate broker/test rather than an extension of that
+ * one.
+ */
+@Testcontainers
+@ZeebeIntegration
+final class ElasticsearchSchemaMigrationStatusProviderIT {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefaultElasticsearchContainer();
+
+  @TestZeebe(autoStart = false)
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker().withSecondaryStorageType(SecondaryStorageType.elasticsearch);
+
+  @BeforeEach
+  void beforeEach() {
+    broker
+        // TestStandaloneBroker disables schema creation by default (ES/OS containers may not be
+        // used in a given test); this IT needs the real schema (and its schema-version metadata
+        // document) actually created at startup.
+        .withCreateSchema(true)
+        .withUnifiedConfig(
+            cfg ->
+                cfg.getData()
+                    .getSecondaryStorage()
+                    .getElasticsearch()
+                    .setUrl("http://" + CONTAINER.getHttpHostAddress()));
+    broker.start();
+  }
+
+  @Test
+  void shouldReportElasticsearchSchemaMigratedForTheDefaultPhysicalTenant() {
+    Awaitility.await(
+            "until the elasticsearchSchemaMigrated condition settles on MIGRATED for the default"
+                + " tenant")
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var response = UpgradeReadinessActuator.of(broker).get();
+
+              assertThat(response.physicalTenants()).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID);
+              final var defaultTenant = response.physicalTenants().get(DEFAULT_PHYSICAL_TENANT_ID);
+              assertThat(defaultTenant).containsKey("elasticsearchSchemaMigrated");
+              assertThat(defaultTenant.get("elasticsearchSchemaMigrated").state())
+                  .isEqualTo("MIGRATED");
+              assertThat(response.upgradeable()).isTrue();
+            });
+  }
+}


### PR DESCRIPTION
- Adds `ElasticsearchSchemaMigrationStatusProvider`: whether the Elasticsearch/OpenSearch schema of every configured physical tenant has migrated to the running application version. Covers both search engines identically.
- Adds an `ElasticsearchSchemaVersionStore` as read-only version compatibility check => Note: This may be later harmonized into a single class if useful. For now I decided that a separate and dedicated reader for the migration status is more useful

## Verified before implementing

Confirmed there is genuinely only one relevant schema-version-tracking mechanism to hook
into here, not two: `CamundaExporter` and the classic `ElasticsearchExporter`/
`OpensearchExporter` do use disjoint index sets, but only `CamundaExporter`'s schema
(via `SchemaManager`/`SchemaMetadataStore`) has any version-compatibility concept

## Testing

- Unit tests for both new classes (schema-manager), covering every `MIGRATED`/
  `MIGRATION_IN_PROGRESS`/`UNKNOWN` branch.
- `ElasticsearchSchemaVersionStoreIT`: real Elasticsearch + real OpenSearch (via the existing
  `SchemaManagerITInvocationProvider` harness), including a genuine stored-vs-running version
  mismatch.
- `ElasticsearchSchemaMigrationStatusProviderConfigurationTest`: the bean factory method itself.
- `ElasticsearchSchemaMigrationStatusProviderIT`: end-to-end, a real `TestStandaloneBroker` +
  real Elasticsearch container hitting `GET /actuator/upgradeReadiness`, sibling of
  `UpgradeReadinessEndpointIT` (RDBMS and ES/OS secondary storage are mutually exclusive per
  broker, so this can't just extend that IT).

Closes #59850
