### PR TITLE
ci: load-test: harden checkout credential handling

### DIFF
--- a/.github/workflows/load-test-golden-update.yml
+++ b/.github/workflows/load-test-golden-update.yml
@@ -63,6 +63,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           token: ${{ steps.github-token.outputs.token }}
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -80,6 +81,7 @@ jobs:
         uses: camunda/action-git-commit@v1
         with:
           commit-message: "test: update load-test golden files"
+          token: ${{ steps.github-token.outputs.token }}
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION


## Description

Don't persist git credentials locally.

Same as https://github.com/camunda/camunda/pull/59630/, without inlining the original upstream GitHub Action (using https://github.com/camunda/action-git-commit/pull/18)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* [INC-7027](https://app.incident.io/camunda/incidents/7027)