### PR TITLE
ci: migrate preview environment and load tests off removed camunda-platform global datastore values

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/elasticsearch.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/elasticsearch.yml
@@ -7,7 +7,8 @@
 # namespaces, so this CR is created in the preview namespace itself).
 #
 # ECK names the Service `<metadata.name>-es-http`, i.e. `elasticsearch-es-http`; the
-# camunda-platform values point `global.elasticsearch.url.host` at that name.
+# camunda-platform values point `optimize.database.elasticsearch.url.host` and
+# `orchestration.data.secondaryStorage.elasticsearch.url` at that name.
 #
 # Anonymous=superuser + TLS disabled mirrors the load-test setup
 # (load-tests/setup/charts/load-test-setup/templates/elasticsearch.yaml): fine for a

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -52,17 +52,6 @@ global:
     secrets:
       name: camunda-credentials
 
-  # Camunda 8 Self-Managed global configurations
-  elasticsearch:
-    # Required so the orchestration chart renders the `camunda.data.secondary-storage.elasticsearch`
-    # block (url, credentials, etc.). Without this, embedded Operate/Tasklist may fall back
-    # to their defaults (e.g. `http://localhost:9200`).
-    enabled: true
-    url:
-      # Secondary storage is an ECK-managed Elasticsearch CR (templates/elasticsearch.yml);
-      # the ECK operator names the Service <cr-name>-es-http.
-      host: elasticsearch-es-http
-
   identity:
     auth:
       # Enable Camunda Identity-based authentication
@@ -312,6 +301,16 @@ camunda-platform:
     fullnameOverride: optimize
     contextPath: /optimize
     partitionCount: "1"
+    database:
+      elasticsearch:
+        # Optimize's datastore and the legacy Zeebe exporter resolve from this
+        # component-scoped block (global.elasticsearch was removed in
+        # camunda-platform 15.x). Secondary storage is an ECK-managed
+        # Elasticsearch CR (templates/elasticsearch.yml); the ECK operator
+        # names the Service <cr-name>-es-http.
+        enabled: true
+        url:
+          host: elasticsearch-es-http
     image:
       registry: registry.camunda.cloud
       repository: team-camunda/optimize

--- a/load-tests/setup/main/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-elasticsearch.yaml
@@ -11,18 +11,6 @@
 # the other file in sync (minus the secondary storage-only options).
 
 ########################################################################################
-################################################### Global cluster configuration
-########################################################################################
-global:
-  elasticsearch:
-    enabled: true
-    url:
-      # The Elasticsearch host value is derived from the ECK Elasticsearch custom resource name.
-      # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
-      # See resources/elasticsearch.yaml for the resource definition.
-      host: elasticsearch-es-http
-
-########################################################################################
 ################################################### Orchestration cluster configuration
 ########################################################################################
 orchestration:
@@ -31,3 +19,20 @@ orchestration:
   data:
     secondaryStorage:
       type: elasticsearch
+      elasticsearch:
+        # The Elasticsearch host value is derived from the ECK Elasticsearch custom resource name.
+        # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
+        # See resources/elasticsearch.yaml for the resource definition.
+        url: http://elasticsearch-es-http:9200
+
+########################################################################################
+################################################### Optimize datastore configuration
+########################################################################################
+# Optimize and the legacy Zeebe exporter resolve the Elasticsearch connection from
+# this component-scoped block (global.elasticsearch was removed in camunda-platform 15.x).
+optimize:
+  database:
+    elasticsearch:
+      enabled: true
+      url:
+        host: elasticsearch-es-http

--- a/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
@@ -1,15 +1,4 @@
 ########################################################################################
-################################################### Global cluster configuration
-########################################################################################
-global:
-  opensearch:
-    enabled: true
-    url:
-      protocol: http
-      host: "opensearch"
-      port: 9200
-
-########################################################################################
 ################################################### Orchestration cluster configuration
 ########################################################################################
 orchestration:
@@ -18,3 +7,19 @@ orchestration:
   data:
     secondaryStorage:
       type: opensearch
+      opensearch:
+        url: http://opensearch:9200
+
+########################################################################################
+################################################### Optimize datastore configuration
+########################################################################################
+# Optimize and the legacy Zeebe exporter resolve the OpenSearch connection from
+# this component-scoped block (global.opensearch was removed in camunda-platform 15.x).
+optimize:
+  database:
+    opensearch:
+      enabled: true
+      url:
+        protocol: http
+        host: "opensearch"
+        port: 9200

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/common/configmap-warnings.yaml
@@ -17,24 +17,6 @@ metadata:
     {}
 data:
   warnings: |-
-    [camunda][warning] DEPRECATION: values.yaml is using legacy option 'global.elasticsearch.enabled'. This option is deprecated and will be removed in a future version. Please migrate to the new option: 'orchestration.data.secondaryStorage.(elasticsearch|opensearch).enabled'. or for optimize: 'optimize.database.(elasticsearch|opensearch).enabled'.
-    
-      
-    
-      
-    
-      
-    
-      
-        
-        
-        
-        
-        
-        
-        
-        
-        
     [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
     [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/common/configmap-warnings.yaml
@@ -17,24 +17,6 @@ metadata:
     {}
 data:
   warnings: |-
-    [camunda][warning] DEPRECATION: values.yaml is using legacy option 'global.elasticsearch.enabled'. This option is deprecated and will be removed in a future version. Please migrate to the new option: 'orchestration.data.secondaryStorage.(elasticsearch|opensearch).enabled'. or for optimize: 'optimize.database.(elasticsearch|opensearch).enabled'.
-    
-      
-    
-      
-    
-      
-    
-      
-        
-        
-        
-        
-        
-        
-        
-        
-        
     [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
     [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -94,7 +94,6 @@ data:
     
       # Database configuration - Separated syntax.
       database:
-        awsEnabled: false
     
       data:
         snapshot-period: "5m"
@@ -191,11 +190,6 @@ data:
           enabled: false
         identity:
           redirectRootUrl: "http://localhost:8080/operate"
-        # OpenSearch
-        opensearch:
-          awsEnabled: false
-        zeebeOpensearch:
-          awsEnabled: false
         # Zeebe instance
         zeebe:
           # Gateway address
@@ -212,13 +206,6 @@ data:
           enabled: false
         identity:
           redirectRootUrl: "http://localhost:8080/tasklist"
-        # OpenSearch
-        opensearch:
-          awsEnabled: false
-        zeebeOpensearch:
-          awsEnabled: false
-          username: ""
-          password: "${VALUES_OPENSEARCH_PASSWORD:}"
         # Zeebe instance
         zeebe:
           # Gateway address

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/common/configmap-warnings.yaml
@@ -17,24 +17,6 @@ metadata:
     {}
 data:
   warnings: |-
-    [camunda][warning] DEPRECATION: values.yaml is using legacy option 'global.opensearch.enabled'. This option is deprecated and will be removed in a future version. Please migrate to the new option: 'orchestration.data.secondaryStorage.(elasticsearch|opensearch).enabled'. or for optimize: 'optimize.database.(elasticsearch|opensearch).enabled'.
-    
-      
-    
-      
-    
-      
-    
-      
-        
-        
-        
-        
-        
-        
-        
-        
-        
     [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
     [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -94,7 +94,6 @@ data:
     
       # Database configuration - Separated syntax.
       database:
-        awsEnabled: false
     
       data:
         snapshot-period: "5m"
@@ -191,11 +190,6 @@ data:
           enabled: false
         identity:
           redirectRootUrl: "http://localhost:8080/operate"
-        # OpenSearch
-        opensearch:
-          awsEnabled: false
-        zeebeOpensearch:
-          awsEnabled: false
         # Zeebe instance
         zeebe:
           # Gateway address
@@ -212,13 +206,6 @@ data:
           enabled: false
         identity:
           redirectRootUrl: "http://localhost:8080/tasklist"
-        # OpenSearch
-        opensearch:
-          awsEnabled: false
-        zeebeOpensearch:
-          awsEnabled: false
-          username: ""
-          password: "${VALUES_OPENSEARCH_PASSWORD:}"
         # Zeebe instance
         zeebe:
           # Gateway address

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/common/configmap-warnings.yaml
@@ -17,24 +17,6 @@ metadata:
     {}
 data:
   warnings: |-
-    [camunda][warning] DEPRECATION: values.yaml is using legacy option 'global.opensearch.enabled'. This option is deprecated and will be removed in a future version. Please migrate to the new option: 'orchestration.data.secondaryStorage.(elasticsearch|opensearch).enabled'. or for optimize: 'optimize.database.(elasticsearch|opensearch).enabled'.
-    
-      
-    
-      
-    
-      
-    
-      
-        
-        
-        
-        
-        
-        
-        
-        
-        
     [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
     [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
@@ -94,7 +94,6 @@ data:
     
       # Database configuration - Separated syntax.
       database:
-        awsEnabled: false
     
       data:
         snapshot-period: "5m"
@@ -191,11 +190,6 @@ data:
           enabled: false
         identity:
           redirectRootUrl: "http://localhost:8080/operate"
-        # OpenSearch
-        opensearch:
-          awsEnabled: false
-        zeebeOpensearch:
-          awsEnabled: false
         # Zeebe instance
         zeebe:
           # Gateway address
@@ -212,13 +206,6 @@ data:
           enabled: false
         identity:
           redirectRootUrl: "http://localhost:8080/tasklist"
-        # OpenSearch
-        opensearch:
-          awsEnabled: false
-        zeebeOpensearch:
-          awsEnabled: false
-          username: ""
-          password: "${VALUES_OPENSEARCH_PASSWORD:}"
         # Zeebe instance
         zeebe:
           # Gateway address


### PR DESCRIPTION
## Description

camunda-platform chart 15.x (Camunda 8.10) removes the deprecated `global.elasticsearch.*` and `global.opensearch.*` value trees (camunda/camunda-platform-helm#6766, removal in camunda/camunda-platform-helm#6914). Once the chart dependency moves past `15.0.0-alpha4`, any values file still carrying those keys fails `helm install`/`helm upgrade` with a `keyRemoved` error.

This PR migrates the two consumers in this repository to the component-scoped replacement keys ahead of the chart bump. The values are valid both before and after the removal, so this is safe to merge independently:

- `.ci/preview-environments/charts/c8sm`: `global.elasticsearch.{enabled,url.host}` moves to `camunda-platform.optimize.database.elasticsearch.{enabled,url.host}` (Optimize's datastore and the legacy Zeebe exporter resolve from that block; the Orchestration Cluster already uses `orchestration.data.secondaryStorage`). Also retargets a stale comment in `templates/elasticsearch.yml`.
- `load-tests/setup/main/values`: `camunda-platform-values-elasticsearch.yaml` and `camunda-platform-values-opensearch.yaml` move to `orchestration.data.secondaryStorage.<engine>.url` plus `optimize.database.<engine>.*`. The `-optimize-*` variants already use component-scoped keys.
- Load-test golden files regenerated (`make warm-chart-cache update-golden PATTERN='GoldenFiles/c8-golden-main'`, 16/16 pass). The diff is strictly removals: the chart's deprecation warnings for the legacy keys, and legacy Operate/Tasklist OpenSearch config blocks that only rendered when `global.opensearch.enabled` was set (ignored by the unified 8.10 application configuration).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes camunda/camunda-platform-helm#6917
