### PR TITLE
fix: let HealthCheck propagate status-request failures

### DIFF
--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -147,6 +147,10 @@
             <!-- Exclude tests that use Jackson 3.x (tools.jackson.*) which is not available in Spring Boot 3.x -->
             <exclude>io/camunda/client/impl/CamundaObjectMapperTest.java</exclude>
             <exclude>io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java</exclude>
+            <!-- Exclude test that uses org.springframework.boot.health.contributor, which is a
+                 Spring Boot 4.x-only package; Spring Boot 3.x has its own
+                 CamundaClientHealthIndicator override under org.springframework.boot.actuate.health -->
+            <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicatorTest.java</exclude>
           </testExcludes>
         </configuration>
       </plugin>

--- a/clients/camunda-spring-boot-starter/revapi.json
+++ b/clients/camunda-spring-boot-starter/revapi.json
@@ -797,6 +797,19 @@
           "old": "class io.camunda.client.spring.properties.CamundaClientPropertiesPostProcessor",
           "new": "class io.camunda.client.spring.properties.CamundaClientPropertiesPostProcessor",
           "justification": "Spring Boot moved EnvironmentPostProcessor from org.springframework.boot.env to org.springframework.boot and deprecated the old location; this class now implements the new interface, which revapi sees as no longer implementing the old one. Same method contract, no behavior change."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": "enum io.camunda.client.health.HealthCheck.CheckResult",
+          "justification": "Replaced by returning io.camunda.client.api.response.StatusResponse.Status directly from HealthCheck.health(), which already carries the same UP/DOWN information without introducing a redundant type. Compatibility impact accepted for this release."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method io.camunda.client.health.HealthCheck.CheckResult io.camunda.client.health.HealthCheck::health()",
+          "new": "method io.camunda.client.api.response.StatusResponse.Status io.camunda.client.health.HealthCheck::health()",
+          "justification": "health() now returns StatusResponse.Status directly instead of the removed CheckResult wrapper, and lets status-request failures propagate instead of catching them - the one caller, CamundaClientHealthIndicator (backed by Spring's AbstractHealthIndicator), already maps both the return value and any thrown exception to the correct health status. Compatibility impact accepted for this release."
         }
       ]
     }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/health/HealthCheck.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/health/HealthCheck.java
@@ -29,11 +29,11 @@ public class HealthCheck {
   /**
    * Does not catch failures itself: on connectivity issues or timeouts, {@code
    * newStatusRequest().execute()} throws (e.g. {@code ClientException}/{@code
-   * ClientStatusException}), and this method lets that propagate. This relies on the caller
-   * mapping the failure to a degraded status instead of surfacing it as-is — e.g. Spring Boot's
-   * {@code AbstractHealthIndicator.health()} catches any exception from {@code doHealthCheck} and
-   * reports {@code DOWN} with the exception recorded as the {@code error} detail. Callers that do
-   * not offer that safety net must handle the exception themselves.
+   * ClientStatusException}), and this method lets that propagate. This relies on the caller mapping
+   * the failure to a degraded status instead of surfacing it as-is — e.g. Spring Boot's {@code
+   * AbstractHealthIndicator.health()} catches any exception from {@code doHealthCheck} and reports
+   * {@code DOWN} with the exception recorded as the {@code error} detail. Callers that do not offer
+   * that safety net must handle the exception themselves.
    *
    * @throws RuntimeException if the status request fails
    */

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/health/HealthCheck.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/health/HealthCheck.java
@@ -17,11 +17,8 @@ package io.camunda.client.health;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.StatusResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HealthCheck {
-  private static final Logger LOG = LoggerFactory.getLogger(HealthCheck.class);
 
   private final CamundaClient camundaClient;
 
@@ -29,20 +26,18 @@ public class HealthCheck {
     this.camundaClient = camundaClient;
   }
 
-  public CheckResult health() {
-    try {
-      final StatusResponse status = camundaClient.newStatusRequest().send().join();
-      return status.getStatus() == StatusResponse.Status.UP ? CheckResult.UP : CheckResult.DOWN;
-    } catch (final RuntimeException e) {
-      // send().join() throws ClientException/ClientStatusException on connectivity issues or
-      // timeouts; the health endpoint must report DOWN rather than surface an error response.
-      LOG.warn("Failed to determine health status", e);
-      return CheckResult.DOWN;
-    }
-  }
-
-  public enum CheckResult {
-    UP,
-    DOWN
+  /**
+   * Does not catch failures itself: on connectivity issues or timeouts, {@code
+   * newStatusRequest().execute()} throws (e.g. {@code ClientException}/{@code
+   * ClientStatusException}), and this method lets that propagate. This relies on the caller
+   * mapping the failure to a degraded status instead of surfacing it as-is — e.g. Spring Boot's
+   * {@code AbstractHealthIndicator.health()} catches any exception from {@code doHealthCheck} and
+   * reports {@code DOWN} with the exception recorded as the {@code error} detail. Callers that do
+   * not offer that safety net must handle the exception themselves.
+   *
+   * @throws RuntimeException if the status request fails
+   */
+  public StatusResponse.Status health() {
+    return camundaClient.newStatusRequest().execute().getStatus();
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/health/HealthCheck.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/health/HealthCheck.java
@@ -17,8 +17,12 @@ package io.camunda.client.health;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.StatusResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HealthCheck {
+  private static final Logger LOG = LoggerFactory.getLogger(HealthCheck.class);
+
   private final CamundaClient camundaClient;
 
   public HealthCheck(final CamundaClient camundaClient) {
@@ -26,10 +30,13 @@ public class HealthCheck {
   }
 
   public CheckResult health() {
-    final StatusResponse status = camundaClient.newStatusRequest().send().join();
-    if (status.getStatus() == StatusResponse.Status.UP) {
-      return CheckResult.UP;
-    } else {
+    try {
+      final StatusResponse status = camundaClient.newStatusRequest().send().join();
+      return status.getStatus() == StatusResponse.Status.UP ? CheckResult.UP : CheckResult.DOWN;
+    } catch (final RuntimeException e) {
+      // send().join() throws ClientException/ClientStatusException on connectivity issues or
+      // timeouts; the health endpoint must report DOWN rather than surface an error response.
+      LOG.warn("Failed to determine health status", e);
       return CheckResult.DOWN;
     }
   }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.spring.actuator;
 
+import io.camunda.client.api.response.StatusResponse;
 import io.camunda.client.health.HealthCheck;
 import org.springframework.boot.health.contributor.AbstractHealthIndicator;
 import org.springframework.boot.health.contributor.Health;
@@ -29,10 +30,11 @@ public class CamundaClientHealthIndicator extends AbstractHealthIndicator {
 
   @Override
   protected void doHealthCheck(final Health.Builder builder) {
-    switch (healthCheck.health()) {
-      case UP -> builder.up();
-      case DOWN -> builder.down();
-      default -> throw new IllegalStateException("Unexpected value: " + healthCheck.health());
+    final StatusResponse.Status status = healthCheck.health();
+    if (status == StatusResponse.Status.UP) {
+      builder.up();
+    } else {
+      builder.down();
     }
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/health/HealthCheckTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/health/HealthCheckTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.client.api.command.StatusRequestStep1;
+import io.camunda.client.api.response.StatusResponse;
+import io.camunda.client.health.HealthCheck.CheckResult;
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+final class HealthCheckTest {
+
+  @Test
+  void shouldReportUpWhenStatusRequestReportsUp() {
+    // given
+    final CamundaClient camundaClient = mock(CamundaClient.class);
+    final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
+    final CamundaFuture<StatusResponse> future = mock(CamundaFuture.class);
+    final StatusResponse statusResponse = mock(StatusResponse.class);
+    when(camundaClient.newStatusRequest()).thenReturn(statusRequestStep1);
+    when(statusRequestStep1.send()).thenReturn(future);
+    when(future.join()).thenReturn(statusResponse);
+    when(statusResponse.getStatus()).thenReturn(StatusResponse.Status.UP);
+    final HealthCheck healthCheck = new HealthCheck(camundaClient);
+
+    // when
+    final CheckResult result = healthCheck.health();
+
+    // then
+    assertThat(result).isEqualTo(CheckResult.UP);
+  }
+
+  @Test
+  void shouldReportDownWhenStatusRequestReportsDown() {
+    // given
+    final CamundaClient camundaClient = mock(CamundaClient.class);
+    final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
+    final CamundaFuture<StatusResponse> future = mock(CamundaFuture.class);
+    final StatusResponse statusResponse = mock(StatusResponse.class);
+    when(camundaClient.newStatusRequest()).thenReturn(statusRequestStep1);
+    when(statusRequestStep1.send()).thenReturn(future);
+    when(future.join()).thenReturn(statusResponse);
+    when(statusResponse.getStatus()).thenReturn(StatusResponse.Status.DOWN);
+    final HealthCheck healthCheck = new HealthCheck(camundaClient);
+
+    // when
+    final CheckResult result = healthCheck.health();
+
+    // then
+    assertThat(result).isEqualTo(CheckResult.DOWN);
+  }
+
+  @Test
+  void shouldReportDownWhenStatusRequestFailsWithConnectivityIssue() {
+    // given
+    final CamundaClient camundaClient = mock(CamundaClient.class);
+    final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
+    final CamundaFuture<StatusResponse> future = mock(CamundaFuture.class);
+    when(camundaClient.newStatusRequest()).thenReturn(statusRequestStep1);
+    when(statusRequestStep1.send()).thenReturn(future);
+    when(future.join())
+        .thenThrow(
+            new ClientStatusException(
+                Status.UNAVAILABLE.withDescription("unreachable"), new RuntimeException()));
+    final HealthCheck healthCheck = new HealthCheck(camundaClient);
+
+    // when
+    final CheckResult result = healthCheck.health();
+
+    // then
+    assertThat(result).isEqualTo(CheckResult.DOWN);
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/health/HealthCheckTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/health/HealthCheckTest.java
@@ -16,15 +16,14 @@
 package io.camunda.client.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.response.StatusResponse;
-import io.camunda.client.health.HealthCheck.CheckResult;
 import io.grpc.Status;
 import org.junit.jupiter.api.Test;
 
@@ -35,19 +34,17 @@ final class HealthCheckTest {
     // given
     final CamundaClient camundaClient = mock(CamundaClient.class);
     final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
-    final CamundaFuture<StatusResponse> future = mock(CamundaFuture.class);
     final StatusResponse statusResponse = mock(StatusResponse.class);
     when(camundaClient.newStatusRequest()).thenReturn(statusRequestStep1);
-    when(statusRequestStep1.send()).thenReturn(future);
-    when(future.join()).thenReturn(statusResponse);
+    when(statusRequestStep1.execute()).thenReturn(statusResponse);
     when(statusResponse.getStatus()).thenReturn(StatusResponse.Status.UP);
     final HealthCheck healthCheck = new HealthCheck(camundaClient);
 
     // when
-    final CheckResult result = healthCheck.health();
+    final StatusResponse.Status result = healthCheck.health();
 
     // then
-    assertThat(result).isEqualTo(CheckResult.UP);
+    assertThat(result).isEqualTo(StatusResponse.Status.UP);
   }
 
   @Test
@@ -55,39 +52,32 @@ final class HealthCheckTest {
     // given
     final CamundaClient camundaClient = mock(CamundaClient.class);
     final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
-    final CamundaFuture<StatusResponse> future = mock(CamundaFuture.class);
     final StatusResponse statusResponse = mock(StatusResponse.class);
     when(camundaClient.newStatusRequest()).thenReturn(statusRequestStep1);
-    when(statusRequestStep1.send()).thenReturn(future);
-    when(future.join()).thenReturn(statusResponse);
+    when(statusRequestStep1.execute()).thenReturn(statusResponse);
     when(statusResponse.getStatus()).thenReturn(StatusResponse.Status.DOWN);
     final HealthCheck healthCheck = new HealthCheck(camundaClient);
 
     // when
-    final CheckResult result = healthCheck.health();
+    final StatusResponse.Status result = healthCheck.health();
 
     // then
-    assertThat(result).isEqualTo(CheckResult.DOWN);
+    assertThat(result).isEqualTo(StatusResponse.Status.DOWN);
   }
 
   @Test
-  void shouldReportDownWhenStatusRequestFailsWithConnectivityIssue() {
+  void shouldPropagateExceptionWhenStatusRequestFailsWithConnectivityIssue() {
     // given
     final CamundaClient camundaClient = mock(CamundaClient.class);
     final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
-    final CamundaFuture<StatusResponse> future = mock(CamundaFuture.class);
+    final ClientStatusException failure =
+        new ClientStatusException(
+            Status.UNAVAILABLE.withDescription("unreachable"), new RuntimeException());
     when(camundaClient.newStatusRequest()).thenReturn(statusRequestStep1);
-    when(statusRequestStep1.send()).thenReturn(future);
-    when(future.join())
-        .thenThrow(
-            new ClientStatusException(
-                Status.UNAVAILABLE.withDescription("unreachable"), new RuntimeException()));
+    when(statusRequestStep1.execute()).thenThrow(failure);
     final HealthCheck healthCheck = new HealthCheck(camundaClient);
 
-    // when
-    final CheckResult result = healthCheck.health();
-
-    // then
-    assertThat(result).isEqualTo(CheckResult.DOWN);
+    // when then
+    assertThatThrownBy(healthCheck::health).isSameAs(failure);
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/health/HealthCheckTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/health/HealthCheckTest.java
@@ -17,7 +17,6 @@ package io.camunda.client.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
@@ -26,15 +25,20 @@ import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.response.StatusResponse;
 import io.grpc.Status;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 final class HealthCheckTest {
+
+  @Mock private CamundaClient camundaClient;
+  @Mock private StatusRequestStep1 statusRequestStep1;
+  @Mock private StatusResponse statusResponse;
 
   @Test
   void shouldReportUpWhenStatusRequestReportsUp() {
     // given
-    final CamundaClient camundaClient = mock(CamundaClient.class);
-    final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
-    final StatusResponse statusResponse = mock(StatusResponse.class);
     when(camundaClient.newStatusRequest()).thenReturn(statusRequestStep1);
     when(statusRequestStep1.execute()).thenReturn(statusResponse);
     when(statusResponse.getStatus()).thenReturn(StatusResponse.Status.UP);
@@ -50,9 +54,6 @@ final class HealthCheckTest {
   @Test
   void shouldReportDownWhenStatusRequestReportsDown() {
     // given
-    final CamundaClient camundaClient = mock(CamundaClient.class);
-    final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
-    final StatusResponse statusResponse = mock(StatusResponse.class);
     when(camundaClient.newStatusRequest()).thenReturn(statusRequestStep1);
     when(statusRequestStep1.execute()).thenReturn(statusResponse);
     when(statusResponse.getStatus()).thenReturn(StatusResponse.Status.DOWN);
@@ -68,8 +69,6 @@ final class HealthCheckTest {
   @Test
   void shouldPropagateExceptionWhenStatusRequestFailsWithConnectivityIssue() {
     // given
-    final CamundaClient camundaClient = mock(CamundaClient.class);
-    final StatusRequestStep1 statusRequestStep1 = mock(StatusRequestStep1.class);
     final ClientStatusException failure =
         new ClientStatusException(
             Status.UNAVAILABLE.withDescription("unreachable"), new RuntimeException());

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/CamundaClientHealthIndicatorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/CamundaClientHealthIndicatorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.actuator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.client.api.response.StatusResponse;
+import io.camunda.client.health.HealthCheck;
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.health.contributor.Health;
+
+@ExtendWith(MockitoExtension.class)
+final class CamundaClientHealthIndicatorTest {
+
+  @Mock private HealthCheck healthCheck;
+
+  @Test
+  void shouldReportUpWhenHealthCheckReportsUp() {
+    // given
+    when(healthCheck.health()).thenReturn(StatusResponse.Status.UP);
+    final CamundaClientHealthIndicator indicator = new CamundaClientHealthIndicator(healthCheck);
+
+    // when
+    final Health health = indicator.health();
+
+    // then
+    assertThat(health.getStatus().getCode()).isEqualTo("UP");
+  }
+
+  @Test
+  void shouldReportDownWhenHealthCheckReportsDown() {
+    // given
+    when(healthCheck.health()).thenReturn(StatusResponse.Status.DOWN);
+    final CamundaClientHealthIndicator indicator = new CamundaClientHealthIndicator(healthCheck);
+
+    // when
+    final Health health = indicator.health();
+
+    // then
+    assertThat(health.getStatus().getCode()).isEqualTo("DOWN");
+  }
+
+  @Test
+  void shouldReportDownWithErrorDetailWhenHealthCheckThrows() {
+    // given
+    final ClientStatusException failure =
+        new ClientStatusException(
+            Status.UNAVAILABLE.withDescription("unreachable"), new RuntimeException());
+    when(healthCheck.health()).thenThrow(failure);
+    final CamundaClientHealthIndicator indicator = new CamundaClientHealthIndicator(healthCheck);
+
+    // when
+    final Health health = indicator.health();
+
+    // then: AbstractHealthIndicator.health() catches the exception thrown by doHealthCheck and
+    // maps it to DOWN with the exception recorded as the "error" detail, which is the behaviour
+    // HealthCheck.health() relies on instead of catching failures itself.
+    assertThat(health.getStatus().getCode()).isEqualTo("DOWN");
+    assertThat(health.getDetails()).containsKey("error");
+  }
+}


### PR DESCRIPTION
## Description

The original fix wrapped `HealthCheck.health()`'s status request in a
try/catch that mapped any `RuntimeException` to `CheckResult.DOWN`,
with a comment claiming this was needed because the failure would
otherwise turn the Actuator health endpoint into an error response.
That claim was wrong: `CamundaClientHealthIndicator` extends Spring's
`AbstractHealthIndicator`, whose `health()` already catches any
exception thrown by `doHealthCheck` and reports `DOWN` - the endpoint
never surfaced an error response, before or after the catch was added.
Catching inside `HealthCheck` only meant losing the exception as the
`error` detail on `/actuator/health` when `show-details` is enabled.

This PR removes the catch and lets the failure propagate, documenting
via Javadoc that callers must map it to a degraded status themselves -
Spring's `AbstractHealthIndicator` already does this for the one
caller in this module. It also drops the custom `CheckResult` type in
favor of returning `StatusResponse.Status` directly, since it added no
value over the type `CamundaClient` already exposes.

Addresses the two outstanding Copilot review comments on PR #60499
(backport of #60295 to `stable/8.9`) that were never resolved before
merge:
- https://github.com/camunda/camunda/pull/60499#discussion_r3810483788
- https://github.com/camunda/camunda/pull/60499#discussion_r3810483818

Closes #60600

## Test plan

- [x] `HealthCheckTest` covers UP, DOWN, and that a connectivity
  failure (`ClientStatusException`) propagates out of `health()`
  instead of being swallowed.
- [x] `CamundaClientHealthIndicatorTest` verifies the assumption end to
  end: the indicator reports DOWN with the exception recorded as the
  `error` detail when `HealthCheck` throws.
- [x] `./mvnw verify -pl clients/camunda-spring-boot-starter -Dtest=HealthCheckTest,CamundaClientHealthIndicatorTest -DskipTests=false -DskipITs -Dquickly` — all tests pass.