### PR TITLE
ci: reduce optimize-e2e-smoke job timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -420,7 +420,7 @@ jobs:
     name: "E2E / Self-Managed (Smoke)"
     if: inputs.runFeTests
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 45
+    timeout-minutes: 30
     permissions: { }
     env:
       TEST_TYPE: E2E


### PR DESCRIPTION
## Summary
- `optimize-e2e-smoke` had a 45-minute job timeout, exceeding the company-wide 30-minute CI job timeout limit
- Reduced `timeout-minutes` from 45 to 30 for this job in `.github/workflows/ci-optimize.yml`

## Test plan
- [ ] CI run for `optimize-e2e-smoke` completes within the new 30-minute timeout without being cut off