### PR TITLE
feat: instrument the load-tester worker's per-job round-trip

### DIFF
--- a/load-tests/docs/dashboards/load-test-client-metrics.json
+++ b/load-tests/docs/dashboards/load-test-client-metrics.json
@@ -1,0 +1,2267 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "load-test-client-metrics"
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Crosshair",
+    "description": "Client-side metrics emitted by the load-tester worker: how long each job occupies a worker thread, how long the message publication it issues takes, how long the dispatched job completion takes to round-trip, and whether those completions are backing up. Use it to tell added per-job latency (e.g. AUTH overhead on the gateway) apart from reduced engine capacity: with a fixed job concurrency, thread occupancy per job bounds achievable throughput — but the completion is never awaited by the handler, so its latency is invisible in thread occupancy and has to be read on its own panel. The bottom row covers the worker pod's own CPU: a starved client produces healthy medians with a catastrophic tail, exactly like a slow gateway does, so clear it before attributing any latency to the server.",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (op) (label_replace((sum by (outcome) (rate(worker_publish_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) > 0), \"op\", \"publish ($1)\", \"outcome\", \"(.*)\")) or sum by (op) (label_replace((sum by (outcome) (rate(worker_complete_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) > 0), \"op\", \"complete ($1)\", \"outcome\", \"(.*)\")) or sum by (op) (label_replace(sum(rate(worker_handle_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])), \"op\", \"handle (total)\", \"\", \"\")) or sum by (op) (label_replace(sum(rate(worker_intake_delay_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])), \"op\", \"intake (delivery)\", \"\", \"\"))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (op) (label_replace((histogram_quantile(0.50, sum by (le, outcome) (rate(worker_publish_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0), \"op\", \"publish ($1)\", \"outcome\", \"(.*)\")) or sum by (op) (label_replace((histogram_quantile(0.50, sum by (le, outcome) (rate(worker_complete_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0), \"op\", \"complete ($1)\", \"outcome\", \"(.*)\")) or sum by (op) (label_replace(histogram_quantile(0.50, sum by (le) (rate(worker_handle_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))), \"op\", \"handle (total)\", \"\", \"\")) or sum by (op) (label_replace(histogram_quantile(0.50, sum by (le) (rate(worker_intake_delay_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))), \"op\", \"intake (delivery)\", \"\", \"\"))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (op) (label_replace((histogram_quantile(0.95, sum by (le, outcome) (rate(worker_publish_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0), \"op\", \"publish ($1)\", \"outcome\", \"(.*)\")) or sum by (op) (label_replace((histogram_quantile(0.95, sum by (le, outcome) (rate(worker_complete_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0), \"op\", \"complete ($1)\", \"outcome\", \"(.*)\")) or sum by (op) (label_replace(histogram_quantile(0.95, sum by (le) (rate(worker_handle_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))), \"op\", \"handle (total)\", \"\", \"\")) or sum by (op) (label_replace(histogram_quantile(0.95, sum by (le) (rate(worker_intake_delay_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))), \"op\", \"intake (delivery)\", \"\", \"\"))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (op) (label_replace((histogram_quantile(0.99, sum by (le, outcome) (rate(worker_publish_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0), \"op\", \"publish ($1)\", \"outcome\", \"(.*)\")) or sum by (op) (label_replace((histogram_quantile(0.99, sum by (le, outcome) (rate(worker_complete_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0), \"op\", \"complete ($1)\", \"outcome\", \"(.*)\")) or sum by (op) (label_replace(histogram_quantile(0.99, sum by (le) (rate(worker_handle_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))), \"op\", \"handle (total)\", \"\", \"\")) or sum by (op) (label_replace(histogram_quantile(0.99, sum by (le) (rate(worker_intake_delay_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))), \"op\", \"intake (delivery)\", \"\", \"\"))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "group": "joinByField",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "byField": "op",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "group": "organize",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true
+                      },
+                      "indexByName": {
+                        "Value #A": 1,
+                        "Value #B": 2,
+                        "Value #C": 3,
+                        "Value #D": 4,
+                        "op": 0
+                      },
+                      "renameByName": {
+                        "Value #A": "ops/s",
+                        "Value #B": "p50",
+                        "Value #C": "p95",
+                        "Value #D": "p99",
+                        "op": "Operation"
+                      }
+                    }
+                  }
+                },
+                {
+                  "group": "sortBy",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "desc": true,
+                          "field": "p95"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Per-operation rate and p50/p95/p99 latency inside the load-tester worker, sorted by p95 desc. 'publish (...)' is the synchronous message publication tagged by outcome; 'complete (...)' is the round-trip of the dispatched complete command tagged by outcome; 'handle (total)' is the whole job handler, i.e. thread occupancy per job. Note: handle duration is floored at the configured completionDelay (300ms by default), because the handler sleeps to pad up to it — it only rises above that floor once publish alone exceeds the delay. The completion is dispatched without ever being awaited, so its latency is NOT part of handle duration. Idle outcomes are filtered out, so a missing row means that outcome did not occur.",
+          "id": 1,
+          "links": [],
+          "title": "Worker Job Latency by Operation",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "p50"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "p95"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "p99"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "ops/s"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "ops"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "p95"
+                  }
+                ]
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.50, sum by (le, outcome) (rate(worker_publish_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0",
+                        "legendFormat": "p50 {{outcome}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.95, sum by (le, outcome) (rate(worker_publish_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0",
+                        "legendFormat": "p95 {{outcome}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.99, sum by (le, outcome) (rate(worker_publish_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0",
+                        "legendFormat": "p99 {{outcome}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Latency of the synchronous message publication issued while handling a job (the /v2/messages/publication call), split by outcome. This is the one call in the handler that crosses the gateway, so authentication and authorization overhead shows up here first. A rising 'timeout' series means publications are hitting the worker's 10s ceiling and the job is deliberately left to time out.",
+          "id": 2,
+          "links": [],
+          "title": "Message Publish Latency by Outcome",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "max": 0.5,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.50, sum by (le) (rate(worker_handle_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "legendFormat": "p50",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.95, sum by (le) (rate(worker_handle_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "legendFormat": "p95",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.99, sum by (le) (rate(worker_handle_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "legendFormat": "p99",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(worker_handle_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / sum(rate(worker_handle_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+                        "legendFormat": "avg",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Total time a worker thread is occupied by a single job: publication, the configured completion delay, and dispatch of the complete command. Recorded on every path, including the one where publication failed. The complete command is only dispatched here and never awaited, so its round-trip is not part of this metric — see 'Job Completion Latency by Outcome'. The dashed threshold marks the 300ms default completionDelay: the handler sleeps to pad up to it, so this metric sits flat on that floor and only rises above it once publication alone exceeds the delay. With a fixed job concurrency, achievable throughput is bounded by concurrency divided by this value.",
+          "id": 3,
+          "links": [],
+          "title": "Job Handling Duration (thread occupancy)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "max": 0.5,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.3
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.50, sum by (le, outcome) (rate(worker_complete_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0",
+                        "legendFormat": "p50 {{outcome}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.95, sum by (le, outcome) (rate(worker_complete_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0",
+                        "legendFormat": "p95 {{outcome}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.99, sum by (le, outcome) (rate(worker_complete_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) > 0",
+                        "legendFormat": "p99 {{outcome}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(worker_complete_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", outcome=\"success\"}[$__rate_interval])) / sum(rate(worker_complete_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", outcome=\"success\"}[$__rate_interval]))",
+                        "legendFormat": "avg success",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Round-trip of the complete command dispatched at the end of job handling, split by outcome. The handler sends it without awaiting it, so this latency is invisible in thread occupancy — yet it delays the broker observing the job as done, and with it the next job of the process instance. This is the panel to check when throughput drops while job handling duration stays flat. The dashed threshold at 1s marks the fixed retry interval Apache HC5 applies to a retried REST request: a plateau at ~1s or ~2s means retries, not a slow broker. 'backpressure' covers both transports (gRPC RESOURCE_EXHAUSTED, REST HTTP 429/503) and is expected under load; a non-empty 'error' series is not. Idle outcomes are filtered out.",
+          "id": 5,
+          "links": [],
+          "title": "Job Completion Latency by Outcome",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max by (pod) (worker_completion_queue_depth{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+                        "legendFormat": "{{pod}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Dispatched job completions whose response has not been checked yet, per worker pod. By Little's law this is completion latency multiplied by completion rate, so it is a coarser view of the panel to its left — prefer that one for the latency itself, and read this as the saturation signal. The queue is bounded at 10000; once full, the worker stops tracking further completions and logs a throttled warning, at which point the depth stops being informative.",
+          "id": 4,
+          "links": [],
+          "title": "Completion Queue Depth",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "max": 30,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 8000
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", container!=\"POD\"}[$__rate_interval]))",
+                        "legendFormat": "{{pod}} used",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (pod) (kube_pod_container_resource_limits{namespace=~\"$namespace\", pod=~\"$pod\", resource=\"cpu\"})",
+                        "legendFormat": "{{pod}} limit",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (pod) (kube_pod_container_resource_requests{namespace=~\"$namespace\", pod=~\"$pod\", resource=\"cpu\"})",
+                        "legendFormat": "{{pod}} request",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "CPU cores consumed by the worker container, against its request and limit. REST costs the client considerably more CPU than gRPC — HTTP/1.1 without multiplexing plus JSON serialization instead of protobuf — so a transport switch can move this line even though nothing about the cluster changed. 'used' sitting on 'limit' means the pod is the bottleneck and every latency reading on this dashboard is suspect. Unlike the worker's own metrics these come from the kubelet (cAdvisor) and kube-state-metrics, whose label sets differ, so the panel is filtered by namespace and pod only — an empty 'limit'/'request' series just means kube-state-metrics is not scraped here.",
+          "id": 6,
+          "links": [],
+          "title": "Worker CPU Usage vs Limit",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "cores",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*(limit|request)$"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.lineStyle",
+                        "value": {
+                          "dash": [
+                            10,
+                            10
+                          ],
+                          "fill": "dash"
+                        }
+                      },
+                      {
+                        "id": "custom.fillOpacity",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", container!=\"POD\"}[$__rate_interval])) / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", container!=\"POD\"}[$__rate_interval]))",
+                        "legendFormat": "{{pod}} throttled periods",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (pod) (rate(container_cpu_cfs_throttled_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", container!=\"POD\"}[$__rate_interval]))",
+                        "legendFormat": "{{pod}} stall time",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Whether the kernel is suspending the worker container at its CFS quota. 'throttled periods' is the share of 100ms scheduling periods in which a runnable thread was stopped; anything sustained above the dashed 5% line means the client, not the cluster, is producing the latency tail. 'stall time' is the wall-clock seconds of that suspension per second and can exceed 100% because it sums across threads — read it as how many cores' worth of work were held back. Throttling is the one client-side fault that mimics a slow gateway exactly: medians stay healthy because unthrottled requests are unaffected, while anything unlucky enough to span a quota exhaustion is delayed by up to a full period. A gap in the worker's own timeseries alongside throttling here means the JVM could not even serve the metrics scrape.",
+          "id": 7,
+          "links": [],
+          "title": "Worker CPU Throttling",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.05
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg by (pod) (process_cpu_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+                        "legendFormat": "{{pod}} process cpu",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg by (pod) (system_cpu_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+                        "legendFormat": "{{pod}} system cpu",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (pod) (rate(jvm_gc_pause_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+                        "legendFormat": "{{pod}} gc pause",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The worker JVM's own view of its CPU, from the same scrape as every other metric here, so it is available even where cAdvisor and kube-state-metrics are not. 'process cpu' is the fraction of its available processors this JVM is using and approaching 1 means it is out of headroom regardless of what the cgroup reports; 'system cpu' is the whole node and shows a noisy neighbour. 'gc pause' is the share of wall-clock time spent in stop-the-world collection — a competing explanation for a latency tail that CPU throttling would not account for, since it stalls the process without the kernel suspending it.",
+          "id": 8,
+          "links": [],
+          "title": "Worker JVM CPU & GC Pressure",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-9": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"created\"}[$__rate_interval]))",
+                        "legendFormat": "created",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"pushed\"}[$__rate_interval]))",
+                        "legendFormat": "pushed",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"activated\"}[$__rate_interval]))",
+                        "legendFormat": "activated",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"completed\"}[$__rate_interval]))",
+                        "legendFormat": "completed",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"timed out\"}[$__rate_interval]))",
+                        "legendFormat": "timed out",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "E"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Job lifecycle counters from the broker, the supply side of everything above. 'created' is the offered load: if it holds at target while the worker completes fewer, jobs are backing up and the worker is starved rather than saturated. 'pushed' is delivery over the gRPC job stream and 'activated' is delivery via a polled activation request — streaming and polling are separate intake paths in the client, so this pair shows which one is actually feeding the worker. 'timed out' means a job's lease expired before completion and it will be handed out again, doing the same work twice. Sourced from the broker pods, so this panel deliberately ignores the Worker pod variable; the counter carries no job-type label either, so every worker in the namespace is aggregated here.",
+          "id": 9,
+          "links": [],
+          "title": "Engine Job Event Rates",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "ops",
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"created\"}[$__rate_interval])) - sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"completed\"}[$__rate_interval]))",
+                        "legendFormat": "backlog growth",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"created\"}[$__rate_interval])) - (sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"pushed\"}[$__rate_interval])) + sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"activated\"}[$__rate_interval])))",
+                        "legendFormat": "undelivered",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Two derived balances that localize a throughput shortfall to a stage. 'backlog growth' is created minus completed: sustained above zero means the engine is producing jobs faster than they come back, so the deficit is downstream of creation. 'undelivered' is created minus everything handed to a worker (pushed plus activated): above zero means jobs exist but no intake path is delivering them, which is the signature of a stalled job stream while handler threads sit idle; below zero means delivery exceeds creation, i.e. jobs are being handed out more than once after a lease expiry. Both should sit on the dashed zero line in a healthy run — read them together with 'timed out' on the panel to the left.",
+          "id": 10,
+          "links": [],
+          "title": "Job Delivery Deficit",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": true,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.50, sum by (le) (rate(worker_intake_delay_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "legendFormat": "p50",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.95, sum by (le) (rate(worker_intake_delay_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "legendFormat": "p95",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.99, sum by (le) (rate(worker_intake_delay_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+                        "legendFormat": "p99",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(worker_intake_delay_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / sum(rate(worker_intake_delay_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+                        "legendFormat": "avg",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "How long a job waits between the broker activating it and a worker thread picking it up: broker, gateway, the client's job stream or activation response, and the client's own handler queue. The only segment of the job round-trip the other timers here do not cover, so this is what to read when the worker has idle threads and still falls short of the offered job rate.\n\nDerived from the job deadline (activation instant + job timeout), i.e. measured against the broker's clock rather than the worker's — a clock offset shifts every sample equally, so compare runs on the same pods and read the difference, not the absolute value.\n\nThe 100 ms threshold line is the default client poll interval: polled jobs spread evenly below it, whereas streamed jobs are pushed on creation and should sit far lower.",
+          "id": 11,
+          "links": [],
+          "title": "Job Intake Delay (broker activation → handler thread)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.1
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              },
+              "height": 9,
+              "width": 24,
+              "x": 0,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              },
+              "height": 8,
+              "width": 12,
+              "x": 0,
+              "y": 9
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              },
+              "height": 8,
+              "width": 12,
+              "x": 12,
+              "y": 9
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              },
+              "height": 8,
+              "width": 12,
+              "x": 0,
+              "y": 17
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              },
+              "height": 8,
+              "width": 12,
+              "x": 12,
+              "y": 17
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-11"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 25
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-6"
+              },
+              "height": 8,
+              "width": 8,
+              "x": 0,
+              "y": 33
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-7"
+              },
+              "height": 8,
+              "width": 8,
+              "x": 8,
+              "y": 33
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-8"
+              },
+              "height": 8,
+              "width": 8,
+              "x": 16,
+              "y": 33
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-9"
+              },
+              "height": 8,
+              "width": 12,
+              "x": 0,
+              "y": 41
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-10"
+              },
+              "height": 8,
+              "width": 12,
+              "x": 12,
+              "y": 41
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "load-test",
+      "camunda",
+      "client"
+    ],
+    "timeSettings": {
+      "autoRefresh": "30s",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-15m",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "Load Test Client Metrics",
+    "variables": [
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "Prometheus",
+            "value": "prometheus"
+          },
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Datasource",
+          "multi": false,
+          "name": "DS_PROMETHEUS",
+          "options": [],
+          "pluginId": "prometheus",
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "definition": "label_values(worker_handle_duration_seconds_count, cluster)",
+          "hide": "dontHide",
+          "includeAll": true,
+          "label": "Cluster",
+          "multi": true,
+          "name": "cluster",
+          "options": [],
+          "query": {
+            "datasource": {
+              "name": "${DS_PROMETHEUS}"
+            },
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(worker_handle_duration_seconds_count, cluster)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": [
+              "c8-meg-client-metrics"
+            ],
+            "value": [
+              "c8-meg-client-metrics"
+            ]
+          },
+          "definition": "label_values(worker_handle_duration_seconds_count{cluster=~\"$cluster\"}, namespace)",
+          "hide": "dontHide",
+          "includeAll": true,
+          "label": "Namespace",
+          "multi": true,
+          "name": "namespace",
+          "options": [],
+          "query": {
+            "datasource": {
+              "name": "${DS_PROMETHEUS}"
+            },
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(worker_handle_duration_seconds_count{cluster=~\"$cluster\"}, namespace)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "definition": "label_values(worker_handle_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}, pod)",
+          "hide": "dontHide",
+          "includeAll": true,
+          "label": "Worker pod",
+          "multi": true,
+          "name": "pod",
+          "options": [],
+          "query": {
+            "datasource": {
+              "name": "${DS_PROMETHEUS}"
+            },
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(worker_handle_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}, pod)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
+      }
+    ]
+  }
+}

--- a/load-tests/docs/dashboards/load-test-client-metrics.json
+++ b/load-tests/docs/dashboards/load-test-client-metrics.json
@@ -2508,6 +2508,121 @@
             "version": "13.2.0"
           }
         }
+      },
+      "panel-15": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (action) (rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\"}[$__rate_interval]))",
+                        "legendFormat": "{{action}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Every action label the engine's job counter carries, unaggregated, for the selected job type. The named panels above chart the actions we expect; this one shows the ones we do not, which is what to look at when a job is activatable and a poll still returns nothing.\n\nThe activation collector has three ways to pass over a job it was offered: 'skipped' for a leased job an unleased activation may not take, 'skipped uncached secret' for a job whose secret references are not resolved yet, and the per-job authorization check — which counts nothing. So if recovery is zero and neither skip appears here, the jobs are being dropped by the authorization predicate, silently, and the difference is the requester rather than the job.\n\nAlso the fastest way to spot an action nobody thought to chart: a label that appears here and on no other panel is a path the investigation has not accounted for.",
+          "id": 15,
+          "links": [],
+          "title": "Job Event Actions (every label)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "ops",
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
       }
     },
     "layout": {
@@ -2694,6 +2809,19 @@
               "width": 24,
               "x": 0,
               "y": 57
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-15"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 65
             }
           }
         ]

--- a/load-tests/docs/dashboards/load-test-client-metrics.json
+++ b/load-tests/docs/dashboards/load-test-client-metrics.json
@@ -2759,6 +2759,122 @@
             "version": "13.2.0"
           }
         }
+      },
+      "panel-17": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "zeebe_long_polling_queued_current{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\"}",
+                        "legendFormat": "{{type}} — {{protocol}} / {{physicalTenant}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The same parked-request gauge as the yield-recovery panel, but keeping the physicalTenant label instead of summing it away. That label is the tenant half of the key a parked request is filed under: the gateway builds the gauge with the same string it uses for the JobTypeKey, taken from the activation request's partition group.\n\nA job-available notification is looked up under the tenant its subscription was created with, so the two only meet when the strings are identical. If a protocol's series carries a physicalTenant the notifications do not use, its parked requests can never be woken: the wake-up misses the key, no activation is retried, and jobs yielded by a failed stream push are never recovered.\n\nA frozen value is itself the signal. The gauge is only updated through the state object that owns the request, so a state nobody ever looks up keeps its last reading indefinitely — a flat line here means unreachable, not busy. Compare against the tenant named in the gateway's own log line, which is emitted at TRACE by the io.camunda.zeebe.gateway.longPolling logger.",
+          "id": 17,
+          "links": [],
+          "title": "Parked Activation Requests by Notification Key",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "min": 0,
+                  "decimals": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
       }
     },
     "layout": {
@@ -2971,6 +3087,19 @@
               "width": 24,
               "x": 0,
               "y": 73
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-17"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 81
             }
           }
         ]

--- a/load-tests/docs/dashboards/load-test-client-metrics.json
+++ b/load-tests/docs/dashboards/load-test-client-metrics.json
@@ -1451,7 +1451,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"created\"}[$__rate_interval]))",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"created\"}[$__rate_interval]))",
                         "legendFormat": "created",
                         "range": true
                       },
@@ -1472,7 +1472,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"pushed\"}[$__rate_interval]))",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"pushed\"}[$__rate_interval]))",
                         "legendFormat": "pushed",
                         "range": true
                       },
@@ -1493,7 +1493,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"activated\"}[$__rate_interval]))",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"activated\"}[$__rate_interval]))",
                         "legendFormat": "activated",
                         "range": true
                       },
@@ -1514,7 +1514,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"completed\"}[$__rate_interval]))",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"completed\"}[$__rate_interval]))",
                         "legendFormat": "completed",
                         "range": true
                       },
@@ -1535,7 +1535,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"timed out\"}[$__rate_interval]))",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"timed out\"}[$__rate_interval]))",
                         "legendFormat": "timed out",
                         "range": true
                       },
@@ -1549,7 +1549,7 @@
               "transformations": []
             }
           },
-          "description": "Job lifecycle counters from the broker, the supply side of everything above. 'created' is the offered load: if it holds at target while the worker completes fewer, jobs are backing up and the worker is starved rather than saturated. 'pushed' is delivery over the gRPC job stream and 'activated' is delivery via a polled activation request — streaming and polling are separate intake paths in the client, so this pair shows which one is actually feeding the worker. 'timed out' means a job's lease expired before completion and it will be handed out again, doing the same work twice. Sourced from the broker pods, so this panel deliberately ignores the Worker pod variable; the counter carries no job-type label either, so every worker in the namespace is aggregated here.",
+          "description": "Job lifecycle counters from the broker, the supply side of everything above. 'created' is the offered load: if it holds at target while the worker completes fewer, jobs are backing up and the worker is starved rather than saturated. 'pushed' is delivery over the gRPC job stream and 'activated' is delivery via a polled activation request — streaming and polling are separate intake paths in the client, so this pair shows which one is actually feeding the worker. 'timed out' means a job's lease expired before completion and it will be handed out again, doing the same work twice. Sourced from the broker pods, so this panel deliberately ignores the Worker pod variable; the counter carries no job-type label either, so every worker in the namespace is aggregated here.\n\nScoped to the Job type variable. Leaving it on All aggregates every worker in the namespace, which for a load test means several job types at once.",
           "id": 9,
           "links": [],
           "title": "Engine Job Event Rates",
@@ -1650,7 +1650,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"created\"}[$__rate_interval])) - sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"completed\"}[$__rate_interval]))",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"created\"}[$__rate_interval])) - sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"completed\"}[$__rate_interval]))",
                         "legendFormat": "backlog growth",
                         "range": true
                       },
@@ -1671,7 +1671,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"created\"}[$__rate_interval])) - (sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"pushed\"}[$__rate_interval])) + sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", action=\"activated\"}[$__rate_interval])))",
+                        "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"created\"}[$__rate_interval])) - (sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"pushed\"}[$__rate_interval])) + sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"activated\"}[$__rate_interval])))",
                         "legendFormat": "undelivered",
                         "range": true
                       },
@@ -1685,7 +1685,7 @@
               "transformations": []
             }
           },
-          "description": "Two derived balances that localize a throughput shortfall to a stage. 'backlog growth' is created minus completed: sustained above zero means the engine is producing jobs faster than they come back, so the deficit is downstream of creation. 'undelivered' is created minus everything handed to a worker (pushed plus activated): above zero means jobs exist but no intake path is delivering them, which is the signature of a stalled job stream while handler threads sit idle; below zero means delivery exceeds creation, i.e. jobs are being handed out more than once after a lease expiry. Both should sit on the dashed zero line in a healthy run — read them together with 'timed out' on the panel to the left.",
+          "description": "Two derived balances that localize a throughput shortfall to a stage. 'backlog growth' is created minus completed: sustained above zero means the engine is producing jobs faster than they come back, so the deficit is downstream of creation. 'undelivered' is created minus everything handed to a worker (pushed plus activated): above zero means jobs exist but no intake path is delivering them, which is the signature of a stalled job stream while handler threads sit idle; below zero means delivery exceeds creation, i.e. jobs are being handed out more than once after a lease expiry. Both should sit on the dashed zero line in a healthy run — read them together with 'timed out' on the panel to the left.\n\nScoped to the Job type variable. Leaving it on All aggregates every worker in the namespace, which for a load test means several job types at once.",
           "id": 10,
           "links": [],
           "title": "Job Delivery Deficit",
@@ -2308,6 +2308,143 @@
             "version": "13.2.0"
           }
         }
+      },
+      "panel-14": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (type, protocol) (zeebe_long_polling_queued_current{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\"})",
+                        "legendFormat": "{{type}} ({{protocol}})",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (type) (rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"activated\"}[$__rate_interval]))",
+                        "legendFormat": "{{type}} poll recovery (ops/s)",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Activation requests currently parked at the gateway waiting for a job to appear. A worker whose poll is long-polling correctly keeps a request parked essentially all the time, so this sits at or above 1 for its job type; the poll then returns the instant a job becomes available, which is how jobs yielded by a failed stream push get recovered within milliseconds.\n\nZero for a job type whose worker is actively polling means long polling is not engaging: the activation returns an empty response immediately, and the client's poll interval then backs off — with a job stream open, up to a one-minute cap — so yielded jobs accumulate unrecovered until a poll happens to coincide with one.\n\nThe protocol tag separates REST from gRPC activations, so a transport-specific failure is visible directly on this panel.",
+          "id": 14,
+          "links": [],
+          "title": "Long-Polling Requests Parked (by job type)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "min": 0,
+                  "decimals": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
       }
     },
     "layout": {
@@ -2482,6 +2619,19 @@
               "x": 12,
               "y": 49
             }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-14"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 57
+            }
           }
         ]
       }
@@ -2634,6 +2784,41 @@
             "spec": {
               "qryType": 1,
               "query": "label_values(worker_handle_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}, pod)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "definition": "label_values(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}, type)",
+          "hide": "dontHide",
+          "includeAll": true,
+          "label": "Job type",
+          "multi": true,
+          "name": "jobType",
+          "options": [],
+          "query": {
+            "datasource": {
+              "name": "${DS_PROMETHEUS}"
+            },
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}, type)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "version": "v0"

--- a/load-tests/docs/dashboards/load-test-client-metrics.json
+++ b/load-tests/docs/dashboards/load-test-client-metrics.json
@@ -2623,6 +2623,142 @@
             "version": "13.2.0"
           }
         }
+      },
+      "panel-16": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (requestType) (rate(zeebe_gateway_total_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+                        "legendFormat": "{{requestType}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (requestType, error) (rate(zeebe_gateway_failed_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+                        "legendFormat": "{{requestType}} failed ({{error}})",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Requests the gateway sends to the brokers, by type, and the ones that come back as failures. Every activation — polled or long-polled — is one JOB_BATCH request here, and an activation that never reaches a broker can never activate anything.\n\nThis is what separates 'the poll asked and the engine had nothing for it' from 'the poll never asked'. Read the JOB_BATCH rate against poll recovery on the yield panel: a healthy request rate with zero recovery puts the fault in the engine's collector, and a near-zero request rate puts it in the client or the gateway, before the engine is ever consulted.\n\nGateway-wide: these counters carry no job type and no protocol, so they cannot be scoped to the Job type variable and they aggregate REST and gRPC together.",
+          "id": 16,
+          "links": [],
+          "title": "Gateway → Broker Requests",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "ops",
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
       }
     },
     "layout": {
@@ -2822,6 +2958,19 @@
               "width": 24,
               "x": 0,
               "y": 65
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-16"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 73
             }
           }
         ]

--- a/load-tests/docs/dashboards/load-test-client-metrics.json
+++ b/load-tests/docs/dashboards/load-test-client-metrics.json
@@ -1951,6 +1951,363 @@
             "version": "13.2.0"
           }
         }
+      },
+      "panel-12": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (status) (rate(zeebe_gateway_job_stream_push_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+                        "legendFormat": "gateway push ({{status}})",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_broker_jobs_push_fail_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+                        "legendFormat": "broker push failed (job yielded)",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (code) (rate(zeebe_gateway_job_stream_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+                        "legendFormat": "gateway attempt failed ({{code}})",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (code) (rate(zeebe_broker_jobs_fail_try_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+                        "legendFormat": "broker attempt failed ({{code}})",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Whether the broker's push of an activated job actually reached a client. The engine's 'pushed' counter increments when the job is handed to the stream, not when it is delivered, so a push that fails is invisible there.\n\nA gateway failure means the gRPC send buffer to the worker was not ready (BLOCKED) — the client is not draining the stream fast enough. When every client fails, the broker yields the job back to the queue: it becomes available again with no lease and therefore no 'timed out' event, and only a poll can retrieve it. That is what a growing backlog with zero timeouts looks like.\n\nThe per-code series comes from a counter registered under a truncated name (`zeebe.gateway.job.stream.`), which is why the stock Zeebe dashboard's panel for it is empty.",
+          "id": 12,
+          "links": [],
+          "title": "Job Stream Push Outcome",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "ops",
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
+      },
+      "panel-13": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(zeebe_broker_open_job_stream_count{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+                        "legendFormat": "broker open streams",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(zeebe_gateway_job_stream_clients{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+                        "legendFormat": "gateway clients",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(zeebe_gateway_job_stream_streams{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+                        "legendFormat": "gateway streams",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(zeebe_gateway_job_stream_aggregated_stream_clients{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+                        "legendFormat": "aggregated stream clients",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Open job streams as seen by the broker and the gateway. A flapping count means the worker's stream is being torn down and re-registered, during which pushes have nowhere to go; a stable count moves the cause to the push itself (see 'Job Stream Push Outcome'). Aggregated streams collapse identical job-type/tenant registrations, so it stays flat while client count tracks worker replicas.",
+          "id": 13,
+          "links": [],
+          "title": "Job Stream Registration",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "min": 0,
+                  "decimals": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.2.0"
+          }
+        }
       }
     },
     "layout": {
@@ -2098,6 +2455,32 @@
               "width": 12,
               "x": 12,
               "y": 41
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-12"
+              },
+              "height": 8,
+              "width": 12,
+              "x": 0,
+              "y": 49
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-13"
+              },
+              "height": 8,
+              "width": 12,
+              "x": 12,
+              "y": 49
             }
           }
         ]

--- a/load-tests/docs/dashboards/load-test-client-metrics.json
+++ b/load-tests/docs/dashboards/load-test-client-metrics.json
@@ -2378,16 +2378,58 @@
                     },
                     "refId": "C"
                   }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (type) (rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"timed out\"}[$__rate_interval]))",
+                        "legendFormat": "{{type}} timed out (ops/s)",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(zeebe_broker_jobs_push_fail_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+                        "legendFormat": "yields attempted, all job types (ops/s)",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "E"
+                  }
                 }
               ],
               "queryOptions": {},
               "transformations": []
             }
           },
-          "description": "Activation requests currently parked at the gateway waiting for a job to appear. A worker whose poll is long-polling correctly keeps a request parked essentially all the time, so this sits at or above 1 for its job type; the poll then returns the instant a job becomes available, which is how jobs yielded by a failed stream push get recovered within milliseconds.\n\nZero for a job type whose worker is actively polling means long polling is not engaging: the activation returns an empty response immediately, and the client's poll interval then backs off — with a job stream open, up to a one-minute cap — so yielded jobs accumulate unrecovered until a poll happens to coincide with one.\n\nThe protocol tag separates REST from gRPC activations, so a transport-specific failure is visible directly on this panel.\n\nThe notification rate is the wake-up signal itself: a yielded job broadcasts one (JobYieldProcessor), and it is what releases a parked request. Notifications without matching poll recovery means the signal is emitted but never reaches the parked request, so the request sits until its long-poll timeout returns an empty response.",
+          "description": "The full path a job takes after its stream push failed, on one axis. A failed push has the broker append a YIELD command (RemoteStreamPusher increments the push-failure counter and calls the yield error handler in the same breath, so 'yields attempted' is that rate); the yield makes the job activatable again and broadcasts a notification; the notification releases a parked activation request, which recovers the job.\n\nRead it as a chain, each step against the one before:\n\n- notified far below yields attempted: the yield itself is not completing. A rejected YIELD notifies nothing, and an unwritten one logs 'job will remain activated until it times out'. The job stays ACTIVATED, which is not activatable, so no poll can ever recover it.\n- timed out rising to meet yields attempted, lagged by one job timeout: confirms exactly that. Job expiry is then the only recovery path, and the throughput deficit is the yield rate.\n- notified matching yields attempted but recovery near zero: the wake-up is emitted and never reaches the parked request.\n\nParked is the gauge of activation requests waiting at the gateway, tagged by protocol so a transport-specific failure is visible directly. With a continuous supply of jobs it sits near zero because the poll gets jobs on its first attempt; it only climbs when polls have to wait.\n\nEverything except 'yields attempted' is scoped to the Job type variable — the broker's push-failure counter carries no job type, so it aggregates the namespace and is only comparable when the variable is on All.",
           "id": 14,
           "links": [],
-          "title": "Long-Polling Requests Parked (by job type)",
+          "title": "Yield Recovery Path (parked polls, notification, recovery)",
           "vizConfig": {
             "group": "timeseries",
             "kind": "VizConfig",

--- a/load-tests/docs/dashboards/load-test-client-metrics.json
+++ b/load-tests/docs/dashboards/load-test-client-metrics.json
@@ -2357,13 +2357,34 @@
                     },
                     "refId": "B"
                   }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "${DS_PROMETHEUS}"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (type) (rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=~\"$jobType\", action=\"workers notified\"}[$__rate_interval]))",
+                        "legendFormat": "{{type}} workers notified (ops/s)",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
                 }
               ],
               "queryOptions": {},
               "transformations": []
             }
           },
-          "description": "Activation requests currently parked at the gateway waiting for a job to appear. A worker whose poll is long-polling correctly keeps a request parked essentially all the time, so this sits at or above 1 for its job type; the poll then returns the instant a job becomes available, which is how jobs yielded by a failed stream push get recovered within milliseconds.\n\nZero for a job type whose worker is actively polling means long polling is not engaging: the activation returns an empty response immediately, and the client's poll interval then backs off — with a job stream open, up to a one-minute cap — so yielded jobs accumulate unrecovered until a poll happens to coincide with one.\n\nThe protocol tag separates REST from gRPC activations, so a transport-specific failure is visible directly on this panel.",
+          "description": "Activation requests currently parked at the gateway waiting for a job to appear. A worker whose poll is long-polling correctly keeps a request parked essentially all the time, so this sits at or above 1 for its job type; the poll then returns the instant a job becomes available, which is how jobs yielded by a failed stream push get recovered within milliseconds.\n\nZero for a job type whose worker is actively polling means long polling is not engaging: the activation returns an empty response immediately, and the client's poll interval then backs off — with a job stream open, up to a one-minute cap — so yielded jobs accumulate unrecovered until a poll happens to coincide with one.\n\nThe protocol tag separates REST from gRPC activations, so a transport-specific failure is visible directly on this panel.\n\nThe notification rate is the wake-up signal itself: a yielded job broadcasts one (JobYieldProcessor), and it is what releases a parked request. Notifications without matching poll recovery means the signal is emitted but never reaches the parked request, so the request sits until its long-poll timeout returns an empty response.",
           "id": 14,
           "links": [],
           "title": "Long-Polling Requests Parked (by job type)",

--- a/load-tests/docs/metrics.md
+++ b/load-tests/docs/metrics.md
@@ -278,6 +278,43 @@ histogram_quantile(0.99, sum by (le) (rate(worker_handle_duration_seconds_bucket
 
 ---
 
+### Worker job-completion latency
+
+Round-trip time of the complete command the worker dispatches at the end of job handling. Tagged by
+`outcome` (`success`, `backpressure`, `error`), where `backpressure` covers both transports —
+`RESOURCE_EXHAUSTED` over gRPC and HTTP 429/503 over REST.
+
+The completion is sent without being awaited, so this latency is invisible in the job-handling
+duration above — but it still delays the broker observing the job as done, and with it the next job
+of the process instance. That makes it the metric to check when throughput drops while the
+job-handling duration stays flat.
+
+- **Unit:** seconds (quantiles)
+- **Measurement:** p50, p90, p99
+
+```promql
+histogram_quantile(0.99, sum by (le) (rate(worker_complete_duration_seconds_bucket{namespace=~"$namespace", outcome="success"}[$__rate_interval])))
+```
+
+---
+
+### Worker completion-queue depth
+
+Number of dispatched completions whose response has not been checked yet. By Little's law this is
+the completion latency multiplied by the completion rate, so it rises whenever completions are sent
+faster than the broker answers them. It is a coarser view of the metric above and predates it;
+prefer the latency histogram, and read the depth as the saturation signal — once it reaches the
+queue capacity (10 000), response tracking is dropped for further completions.
+
+- **Unit:** count
+- **Measurement:** current value
+
+```promql
+max by (pod) (worker_completion_queue_depth{namespace=~"$namespace"})
+```
+
+---
+
 ## Resources
 
 The following metrics apply to all running applications (Camunda and secondary storage). Replace

--- a/load-tests/docs/metrics.md
+++ b/load-tests/docs/metrics.md
@@ -243,6 +243,41 @@ histogram_quantile(0.99, sum by (le) (rate(starter_response_latency_seconds_buck
 
 ---
 
+### Worker message-publish latency
+
+Time the worker spends on the synchronous message publication it issues while handling a job, from
+sending the command until the response arrives. Tagged by `outcome` (`success`, `timeout`, `error`).
+Measured in the Worker, so it includes authentication and authorization overhead on the gateway.
+
+- **Unit:** seconds (quantiles)
+- **Measurement:** p50, p90, p99
+
+```promql
+histogram_quantile(0.99, sum by (le) (rate(worker_publish_duration_seconds_bucket{namespace=~"$namespace", outcome="success"}[$__rate_interval])))
+```
+
+---
+
+### Worker job-handling duration
+
+Total time a worker thread is occupied by a single job: the message publication, the configured
+completion delay and the dispatch of the complete command. Recorded on every path, including the
+one where the publication failed and the job is left to time out.
+
+Since a worker can only handle `capacity` jobs concurrently, this bounds achievable throughput at
+`capacity / p50`. Compare it against the configured completion delay (300 ms by default): the excess
+above that floor is added per-job latency, and it is what turns into lost PI/s when the worker
+concurrency is low.
+
+- **Unit:** seconds (quantiles)
+- **Measurement:** p50, p90, p99
+
+```promql
+histogram_quantile(0.99, sum by (le) (rate(worker_handle_duration_seconds_bucket{namespace=~"$namespace"}[$__rate_interval])))
+```
+
+---
+
 ## Resources
 
 The following metrics apply to all running applications (Camunda and secondary storage). Replace

--- a/load-tests/docs/metrics.md
+++ b/load-tests/docs/metrics.md
@@ -243,6 +243,31 @@ histogram_quantile(0.99, sum by (le) (rate(starter_response_latency_seconds_buck
 
 ---
 
+### Worker job-intake delay
+
+Time a job spends between the broker activating it and a worker thread picking it up: the whole
+delivery path — broker, gateway, the client's job stream or activation response, and the client's
+own handler queue. It is the only segment of the job round-trip none of the timers below cover,
+which makes it the one to read when the worker has idle threads and still falls short of the offered
+job rate.
+
+Derived from the job deadline, which the broker sets to the activation instant plus the configured
+job timeout, so it is measured against the broker's clock rather than the worker's. A clock offset
+between the two shifts every sample by the same amount: compare runs on the same pods and read the
+difference, not the absolute value. Samples that skew negative are dropped.
+
+The bucket at 100 ms is the default client poll interval — polled jobs spread evenly below it,
+whereas streamed jobs are pushed on creation and should sit far lower.
+
+- **Unit:** seconds (quantiles)
+- **Measurement:** p50, p90, p99
+
+```promql
+histogram_quantile(0.99, sum by (le) (rate(worker_intake_delay_seconds_bucket{namespace=~"$namespace"}[$__rate_interval])))
+```
+
+---
+
 ### Worker message-publish latency
 
 Time the worker spends on the synchronous message publication it issues while handling a job, from

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/WorkerMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/WorkerMetricsDoc.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+/** Metrics recorded by the Worker while handling jobs. */
+public enum WorkerMetricsDoc implements ExtendedMeterDocumentation {
+
+  /**
+   * The duration of the synchronous message publication issued while handling a job, from sending
+   * the command until the response arrives (or the wait times out). Isolates the latency of the
+   * publish call from the rest of the job handling, so its contribution to thread occupancy — e.g.
+   * authentication and authorization overhead on the gateway — can be attributed.
+   */
+  PUBLISH_DURATION {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {WorkerMetricKeyNames.OUTCOME};
+
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(5),
+      Duration.ofMillis(10),
+      Duration.ofMillis(25),
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10)
+    };
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The duration of the message publication issued while handling a job, tagged by outcome.";
+    }
+
+    @Override
+    public String getName() {
+      return "worker.publish.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /**
+   * The total time a worker thread is occupied by a single job, covering the message publication,
+   * the configured completion delay and the dispatch of the complete command. With a fixed job
+   * concurrency this bounds the achievable throughput, so it is the metric that explains throughput
+   * loss caused by added per-job latency. Recorded on every path, including the one where the
+   * message publication failed and the job is left to time out.
+   */
+  HANDLE_DURATION {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(300),
+      Duration.ofMillis(350),
+      Duration.ofMillis(400),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(30)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The total time a worker thread is occupied by a single job.";
+    }
+
+    @Override
+    public String getName() {
+      return "worker.handle.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /**
+   * The number of dispatched job completions whose response has not been checked yet. A growing
+   * value means completions are being sent faster than the broker answers them; once it reaches the
+   * queue capacity, tracking is dropped for further completions.
+   */
+  COMPLETION_QUEUE_DEPTH {
+    @Override
+    public String getDescription() {
+      return "The number of dispatched job completions whose response has not been checked yet.";
+    }
+
+    @Override
+    public String getName() {
+      return "worker.completion.queue.depth";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  };
+
+  public enum WorkerMetricKeyNames implements KeyName {
+
+    /** The outcome of the timed operation */
+    OUTCOME {
+      @Override
+      public String asString() {
+        return "outcome";
+      }
+    },
+  }
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/WorkerMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/WorkerMetricsDoc.java
@@ -112,6 +112,64 @@ public enum WorkerMetricsDoc implements ExtendedMeterDocumentation {
   },
 
   /**
+   * The round-trip duration of the job completion dispatched at the end of job handling, from
+   * sending the command until the response arrives. The completion is sent without being awaited,
+   * so its latency never shows up in {@link #HANDLE_DURATION} — yet it delays the broker observing
+   * the job as done, and with it the creation of the next job in the process instance. That makes
+   * it the signal that explains throughput loss which the per-thread occupancy metrics cannot see.
+   *
+   * <p>Buckets are dense around one second because that is the fixed retry interval Apache HC5
+   * applies to a retried REST request (HTTP 429/503 or a stale connection), so a single retry is
+   * distinguishable from a genuinely slow broker.
+   */
+  COMPLETE_DURATION {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {WorkerMetricKeyNames.OUTCOME};
+
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(5),
+      Duration.ofMillis(10),
+      Duration.ofMillis(25),
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(1250),
+      Duration.ofMillis(1500),
+      Duration.ofSeconds(2),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10)
+    };
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The round-trip duration of the dispatched job completion, tagged by outcome.";
+    }
+
+    @Override
+    public String getName() {
+      return "worker.complete.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /**
    * The number of dispatched job completions whose response has not been checked yet. A growing
    * value means completions are being sent faster than the broker answers them; once it reaches the
    * queue capacity, tracking is dropped for further completions.

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/WorkerMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/WorkerMetricsDoc.java
@@ -16,6 +16,60 @@ import java.time.Duration;
 public enum WorkerMetricsDoc implements ExtendedMeterDocumentation {
 
   /**
+   * How long a job waited between the broker activating it and a handler thread picking it up: the
+   * delivery path, covering broker, gateway, the client's job stream or activation response, and
+   * the client's own handler queue. It is the only segment of the job round-trip that none of the
+   * other timers here cover, which makes it the one to read when the worker has idle threads and
+   * still falls short of the offered job rate.
+   *
+   * <p>Derived from the job's deadline, which the broker sets to the activation instant plus the
+   * configured job timeout, so it measures against the broker's clock rather than the worker's: a
+   * clock offset between the two shifts every sample by the same amount. Compare runs on the same
+   * pods and read the difference, not the absolute value. Samples that skew negative are dropped by
+   * the timer.
+   *
+   * <p>The bucket at 100ms is the default client poll interval: polled jobs spread evenly below it,
+   * whereas streamed jobs are pushed on creation and should sit far lower.
+   */
+  INTAKE_DELAY {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(1),
+      Duration.ofMillis(5),
+      Duration.ofMillis(10),
+      Duration.ofMillis(25),
+      Duration.ofMillis(50),
+      Duration.ofMillis(100),
+      Duration.ofMillis(150),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(1500),
+      Duration.ofSeconds(2)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The delay between the broker activating a job and a handler thread picking it up.";
+    }
+
+    @Override
+    public String getName() {
+      return "worker.intake.delay";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /**
    * The duration of the synchronous message publication issued while handling a job, from sending
    * the command until the response arrives (or the wait times out). Isolates the latency of the
    * publish call from the rest of the job handling, so its contribution to thread occupancy — e.g.

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/ResponseChecker.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/ResponseChecker.java
@@ -7,43 +7,66 @@
  */
 package io.camunda.zeebe.worker;
 
+import io.camunda.client.api.command.ClientHttpException;
+import io.camunda.zeebe.metrics.WorkerMetricsDoc;
+import io.camunda.zeebe.metrics.WorkerMetricsDoc.WorkerMetricKeyNames;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ResponseChecker extends Thread {
   private static final Logger THROTTLED_LOGGER =
       new ThrottledLogger(LoggerFactory.getLogger(Worker.class), Duration.ofSeconds(5));
+  private static final int SC_TOO_MANY_REQUESTS = 429;
+  private static final int SC_SERVICE_UNAVAILABLE = 503;
 
-  private final BlockingQueue<Future<?>> futures;
+  private final BlockingQueue<PendingRequest> requests;
+  private final Map<CompleteOutcome, Timer> completeDurationTimers =
+      new EnumMap<>(CompleteOutcome.class);
   private volatile boolean shuttingDown = false;
 
-  public ResponseChecker(final BlockingQueue<Future<?>> futures) {
-    this.futures = futures;
+  public ResponseChecker(
+      final BlockingQueue<PendingRequest> requests, final MeterRegistry registry) {
+    this.requests = requests;
+    for (final var outcome : CompleteOutcome.values()) {
+      completeDurationTimers.put(
+          outcome,
+          MicrometerUtil.buildTimer(WorkerMetricsDoc.COMPLETE_DURATION)
+              .tag(WorkerMetricKeyNames.OUTCOME.asString(), outcome.tagValue)
+              .register(registry));
+    }
   }
 
   @Override
   public void run() {
     while (!shuttingDown) {
       try {
-        futures.take().get();
-      } catch (final InterruptedException e) {
-        // ignore and retry
-      } catch (final ExecutionException e) {
-        final Throwable cause = e.getCause();
-        if (cause instanceof StatusRuntimeException) {
-          final StatusRuntimeException statusRuntimeException = (StatusRuntimeException) cause;
-          if (statusRuntimeException.getStatus().getCode() != Code.RESOURCE_EXHAUSTED) {
+        final var request = requests.take();
+        try {
+          request.future().get();
+          recordDuration(CompleteOutcome.SUCCESS, request);
+        } catch (final ExecutionException e) {
+          final var outcome = classifyFailure(e.getCause());
+          recordDuration(outcome, request);
+          if (outcome != CompleteOutcome.BACKPRESSURE) {
             // we don't want to flood the log
             THROTTLED_LOGGER.warn("Request failed", e);
           }
         }
+      } catch (final InterruptedException e) {
+        // ignore and retry
       }
     }
   }
@@ -51,5 +74,50 @@ public class ResponseChecker extends Thread {
   public void close() {
     shuttingDown = true;
     interrupt();
+  }
+
+  private void recordDuration(final CompleteOutcome outcome, final PendingRequest request) {
+    completeDurationTimers
+        .get(outcome)
+        .record(System.nanoTime() - request.startNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Backpressure is the expected steady-state rejection under load and is reported separately
+   * rather than logged. It reaches the client differently per transport — as {@code
+   * RESOURCE_EXHAUSTED} over gRPC and as HTTP 429/503 over REST — and only the gRPC form used to be
+   * recognised here, so every REST failure went entirely unreported.
+   */
+  private static CompleteOutcome classifyFailure(final Throwable cause) {
+    if (cause instanceof StatusRuntimeException) {
+      return ((StatusRuntimeException) cause).getStatus().getCode() == Code.RESOURCE_EXHAUSTED
+          ? CompleteOutcome.BACKPRESSURE
+          : CompleteOutcome.ERROR;
+    }
+    if (cause instanceof ClientHttpException) {
+      final int code = ((ClientHttpException) cause).code();
+      return code == SC_TOO_MANY_REQUESTS || code == SC_SERVICE_UNAVAILABLE
+          ? CompleteOutcome.BACKPRESSURE
+          : CompleteOutcome.ERROR;
+    }
+    return CompleteOutcome.ERROR;
+  }
+
+  /**
+   * A dispatched job completion together with the {@link System#nanoTime()} reading taken just
+   * before it was sent, so its round-trip can be timed once the response is checked here.
+   */
+  public record PendingRequest(Future<?> future, long startNanos) {}
+
+  private enum CompleteOutcome {
+    SUCCESS("success"),
+    BACKPRESSURE("backpressure"),
+    ERROR("error");
+
+    private final String tagValue;
+
+    CompleteOutcome(final String tagValue) {
+      this.tagValue = tagValue;
+    }
   }
 }

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
@@ -14,15 +14,23 @@ import io.camunda.client.api.worker.JobClient;
 import io.camunda.zeebe.config.LoadTesterProperties;
 import io.camunda.zeebe.config.WorkerProperties;
 import io.camunda.zeebe.metrics.ConnectionMonitor;
+import io.camunda.zeebe.metrics.WorkerMetricsDoc;
+import io.camunda.zeebe.metrics.WorkerMetricsDoc.WorkerMetricKeyNames;
 import io.camunda.zeebe.util.PayloadReader;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -43,17 +51,33 @@ public class Worker {
       new ArrayBlockingQueue<>(REQUEST_FUTURES_CAPACITY);
   private final ResponseChecker responseChecker;
   private final ConnectionMonitor connectionMonitor;
+  private final Timer handleDurationTimer;
+  private final Map<PublishOutcome, Timer> publishDurationTimers =
+      new EnumMap<>(PublishOutcome.class);
 
   public Worker(
       final CamundaClient client,
       final LoadTesterProperties properties,
       final PayloadReader payloadReader,
-      final ConnectionMonitor connectionMonitor) {
+      final ConnectionMonitor connectionMonitor,
+      final MeterRegistry registry) {
     this.client = client;
     workerCfg = properties.getWorker();
     variables = payloadReader.readPayload(workerCfg.getPayloadPath());
     responseChecker = new ResponseChecker(requestFutures);
     this.connectionMonitor = connectionMonitor;
+
+    handleDurationTimer =
+        MicrometerUtil.buildTimer(WorkerMetricsDoc.HANDLE_DURATION).register(registry);
+    for (final var outcome : PublishOutcome.values()) {
+      publishDurationTimers.put(
+          outcome,
+          MicrometerUtil.buildTimer(WorkerMetricsDoc.PUBLISH_DURATION)
+              .tag(WorkerMetricKeyNames.OUTCOME.asString(), outcome.tagValue)
+              .register(registry));
+    }
+    MicrometerUtil.buildGauge(WorkerMetricsDoc.COMPLETION_QUEUE_DEPTH, requestFutures::size)
+        .register(registry);
   }
 
   @PostConstruct
@@ -86,7 +110,16 @@ public class Worker {
   @JobWorker(autoComplete = false)
   public void handleJob(final JobClient jobClient, final ActivatedJob job) {
     final long startHandlingTime = System.currentTimeMillis();
+    final long startHandlingNanos = System.nanoTime();
+    try {
+      handleJobInternal(jobClient, job, startHandlingTime);
+    } finally {
+      handleDurationTimer.record(System.nanoTime() - startHandlingNanos, TimeUnit.NANOSECONDS);
+    }
+  }
 
+  private void handleJobInternal(
+      final JobClient jobClient, final ActivatedJob job, final long startHandlingTime) {
     if (workerCfg.isSendMessage()) {
       final var correlationKey =
           job.getVariable(workerCfg.getCorrelationKeyVariableName()).toString();
@@ -132,6 +165,7 @@ public class Worker {
     final var messageName = workerCfg.getMessageName();
 
     LOGGER.debug("Publish message '{}' with correlation key '{}'", messageName, correlationKey);
+    final long publishStartNanos = System.nanoTime();
     final var messageSendFuture =
         client
             .newPublishMessageCommand()
@@ -141,8 +175,12 @@ public class Worker {
 
     try {
       messageSendFuture.get(10, TimeUnit.SECONDS);
+      recordPublishDuration(PublishOutcome.SUCCESS, publishStartNanos);
       return true;
     } catch (final Exception ex) {
+      recordPublishDuration(
+          ex instanceof TimeoutException ? PublishOutcome.TIMEOUT : PublishOutcome.ERROR,
+          publishStartNanos);
       THROTTLED_LOGGER.error(
           "Exception on publishing a message with name {} and correlationKey {}",
           messageName,
@@ -150,6 +188,10 @@ public class Worker {
           ex);
       return false;
     }
+  }
+
+  private void recordPublishDuration(final PublishOutcome outcome, final long startNanos) {
+    publishDurationTimers.get(outcome).record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
   }
 
   private static void addDelayToCompletion(
@@ -172,6 +214,18 @@ public class Worker {
           "Interrupted during completion delay sleep of {} ms", completionDelay, e);
     } catch (final Exception e) {
       THROTTLED_LOGGER.error("Exception on sleep with completion delay {}", completionDelay, e);
+    }
+  }
+
+  private enum PublishOutcome {
+    SUCCESS("success"),
+    TIMEOUT("timeout"),
+    ERROR("error");
+
+    private final String tagValue;
+
+    PublishOutcome(final String tagValue) {
+      this.tagValue = tagValue;
     }
   }
 }

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
@@ -11,6 +11,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.zeebe.config.LoadTesterProperties;
 import io.camunda.zeebe.config.WorkerProperties;
 import io.camunda.zeebe.metrics.ConnectionMonitor;
@@ -52,12 +53,17 @@ public class Worker {
   private final ResponseChecker responseChecker;
   private final ConnectionMonitor connectionMonitor;
   private final Timer handleDurationTimer;
+  private final Timer intakeDelayTimer;
+  // Null when no job timeout is configured, in which case the job deadline cannot be resolved back
+  // to an activation instant and the intake delay is not recorded at all.
+  private final Duration jobTimeout;
   private final Map<PublishOutcome, Timer> publishDurationTimers =
       new EnumMap<>(PublishOutcome.class);
 
   public Worker(
       final CamundaClient client,
       final LoadTesterProperties properties,
+      final CamundaClientProperties clientProperties,
       final PayloadReader payloadReader,
       final ConnectionMonitor connectionMonitor,
       final MeterRegistry registry) {
@@ -66,9 +72,11 @@ public class Worker {
     variables = payloadReader.readPayload(workerCfg.getPayloadPath());
     responseChecker = new ResponseChecker(requestFutures, registry);
     this.connectionMonitor = connectionMonitor;
+    jobTimeout = clientProperties.getWorker().getDefaults().getTimeout();
 
     handleDurationTimer =
         MicrometerUtil.buildTimer(WorkerMetricsDoc.HANDLE_DURATION).register(registry);
+    intakeDelayTimer = MicrometerUtil.buildTimer(WorkerMetricsDoc.INTAKE_DELAY).register(registry);
     for (final var outcome : PublishOutcome.values()) {
       publishDurationTimers.put(
           outcome,
@@ -111,11 +119,25 @@ public class Worker {
   public void handleJob(final JobClient jobClient, final ActivatedJob job) {
     final long startHandlingTime = System.currentTimeMillis();
     final long startHandlingNanos = System.nanoTime();
+    recordIntakeDelay(job, startHandlingTime);
     try {
       handleJobInternal(jobClient, job, startHandlingTime);
     } finally {
       handleDurationTimer.record(System.nanoTime() - startHandlingNanos, TimeUnit.NANOSECONDS);
     }
+  }
+
+  /**
+   * The broker sets the job deadline to the instant it activated the job plus the configured job
+   * timeout, so the time already spent on delivery is what the timeout minus the remaining lease
+   * leaves.
+   */
+  private void recordIntakeDelay(final ActivatedJob job, final long startHandlingTime) {
+    if (jobTimeout == null) {
+      return;
+    }
+    final long remainingLease = job.getDeadline() - startHandlingTime;
+    intakeDelayTimer.record(jobTimeout.toMillis() - remainingLease, TimeUnit.MILLISECONDS);
   }
 
   private void handleJobInternal(

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.metrics.WorkerMetricsDoc.WorkerMetricKeyNames;
 import io.camunda.zeebe.util.PayloadReader;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.worker.ResponseChecker.PendingRequest;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
@@ -28,7 +29,6 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
@@ -47,7 +47,7 @@ public class Worker {
   private final CamundaClient client;
   private final WorkerProperties workerCfg;
   private final String variables;
-  private final BlockingQueue<Future<?>> requestFutures =
+  private final BlockingQueue<PendingRequest> requestFutures =
       new ArrayBlockingQueue<>(REQUEST_FUTURES_CAPACITY);
   private final ResponseChecker responseChecker;
   private final ConnectionMonitor connectionMonitor;
@@ -64,7 +64,7 @@ public class Worker {
     this.client = client;
     workerCfg = properties.getWorker();
     variables = payloadReader.readPayload(workerCfg.getPayloadPath());
-    responseChecker = new ResponseChecker(requestFutures);
+    responseChecker = new ResponseChecker(requestFutures, registry);
     this.connectionMonitor = connectionMonitor;
 
     handleDurationTimer =
@@ -150,7 +150,8 @@ public class Worker {
 
     final var command = jobClient.newCompleteCommand(job.getKey()).variables(variables);
     addDelayToCompletion(workerCfg.getCompletionDelay().toMillis(), startHandlingTime);
-    if (!requestFutures.offer(command.send())) {
+    final long completeStartNanos = System.nanoTime();
+    if (!requestFutures.offer(new PendingRequest(command.send(), completeStartNanos))) {
       // Non-blocking: if the response-check queue is saturated, drop tracking for this
       // completion rather than stalling the job handler thread (which would cascade into
       // broker timeouts). We lose visibility into its eventual result — log throttled so

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/worker/ResponseCheckerTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/worker/ResponseCheckerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.api.command.ClientHttpException;
+import io.camunda.zeebe.worker.ResponseChecker.PendingRequest;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ResponseCheckerTest {
+
+  private final MeterRegistry registry = new SimpleMeterRegistry();
+  private final LinkedBlockingQueue<PendingRequest> requests = new LinkedBlockingQueue<>();
+  private final ResponseChecker responseChecker = new ResponseChecker(requests, registry);
+
+  @AfterEach
+  void tearDown() {
+    responseChecker.close();
+  }
+
+  @Test
+  void shouldRecordCompleteDurationOfSuccessfulCompletion() {
+    // given
+    responseChecker.start();
+    final long startNanos = System.nanoTime() - Duration.ofMillis(20).toNanos();
+
+    // when
+    requests.add(new PendingRequest(CompletableFuture.completedFuture("ok"), startNanos));
+
+    // then — the round-trip is measured from the timestamp taken before the command was sent
+    awaitCount("success", 1);
+    assertThat(timer("success").totalTime(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(20);
+  }
+
+  @Test
+  void shouldTagBackpressureSeparatelyPerTransport() {
+    // given — backpressure surfaces as RESOURCE_EXHAUSTED over gRPC and as HTTP 429/503 over REST
+    responseChecker.start();
+
+    // when
+    requests.add(failedRequest(new StatusRuntimeException(Status.RESOURCE_EXHAUSTED)));
+    requests.add(failedRequest(new ClientHttpException(429, "Too Many Requests")));
+    requests.add(failedRequest(new ClientHttpException(503, "Service Unavailable")));
+
+    // then
+    awaitCount("backpressure", 3);
+    assertThat(timer("error").count()).isZero();
+  }
+
+  @Test
+  void shouldTagOtherFailuresAsError() {
+    // given
+    responseChecker.start();
+
+    // when — a non-backpressure status on either transport, and a failure with neither
+    requests.add(failedRequest(new StatusRuntimeException(Status.UNAVAILABLE)));
+    requests.add(failedRequest(new ClientHttpException(500, "Internal Server Error")));
+    requests.add(failedRequest(new RuntimeException("boom")));
+
+    // then
+    awaitCount("error", 3);
+    assertThat(timer("backpressure").count()).isZero();
+  }
+
+  private static PendingRequest failedRequest(final Throwable cause) {
+    return new PendingRequest(CompletableFuture.failedFuture(cause), System.nanoTime());
+  }
+
+  private void awaitCount(final String outcome, final long expected) {
+    await().untilAsserted(() -> assertThat(timer(outcome).count()).isEqualTo(expected));
+  }
+
+  private Timer timer(final String outcome) {
+    return registry.get("worker.complete.duration").tag("outcome", outcome).timer();
+  }
+}

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/worker/WorkerTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/worker/WorkerTest.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.command.PublishMessageCommandStep1.PublishMessageCo
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.PublishMessageResponse;
 import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.zeebe.config.LoadTesterProperties;
 import io.camunda.zeebe.config.WorkerProperties;
 import io.camunda.zeebe.metrics.ConnectionMonitor;
@@ -42,6 +43,7 @@ class WorkerTest {
   private static final String CORRELATION_KEY_VALUE = "abc";
   private static final String MESSAGE_NAME = "messageName";
   private static final Duration COMPLETION_DELAY = Duration.ofMillis(250);
+  private static final Duration JOB_TIMEOUT = Duration.ofSeconds(30);
 
   private final MeterRegistry registry = new SimpleMeterRegistry();
 
@@ -156,6 +158,37 @@ class WorkerTest {
     assertThat(gauge.value()).isEqualTo(1);
   }
 
+  @Test
+  void shouldRecordIntakeDelayFromTheLeaseAlreadySpentOnDelivery() {
+    // given — a job the broker activated 400ms ago, so 400ms of its lease went on delivery
+    final var worker = newWorker(mock(CamundaClient.class), new WorkerProperties());
+    final var job = mockJob(Duration.ofMillis(400));
+
+    // when
+    final var jobClient = mock(JobClient.class);
+    mockCompleteJob(jobClient);
+    worker.handleJob(jobClient, job);
+
+    // then
+    final var timer = registry.get("worker.intake.delay").timer();
+    assertThat(timer.count()).isOne();
+    assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isBetween(350d, 450d);
+  }
+
+  @Test
+  void shouldSkipIntakeDelayWhenNoJobTimeoutIsConfigured() {
+    // given — without a configured timeout the deadline cannot be resolved to an activation instant
+    final var worker = newWorker(mock(CamundaClient.class), new WorkerProperties(), null);
+
+    // when
+    final var jobClient = mock(JobClient.class);
+    mockCompleteJob(jobClient);
+    worker.handleJob(jobClient, mockJob());
+
+    // then — no sample rather than a wrong one
+    assertThat(registry.find("worker.intake.delay").timer().count()).isZero();
+  }
+
   private static long timeHandleJob(
       final Worker worker, final JobClient jobClient, final ActivatedJob job) {
     final long start = System.currentTimeMillis();
@@ -164,9 +197,16 @@ class WorkerTest {
   }
 
   private static ActivatedJob mockJob() {
+    return mockJob(Duration.ZERO);
+  }
+
+  /** A job the broker activated {@code intakeDelay} ago, i.e. with that much of its lease spent. */
+  private static ActivatedJob mockJob(final Duration intakeDelay) {
     final var job = mock(ActivatedJob.class);
     when(job.getKey()).thenReturn(42L);
     when(job.getVariable(CORRELATION_KEY_VAR)).thenReturn(CORRELATION_KEY_VALUE);
+    when(job.getDeadline())
+        .thenReturn(System.currentTimeMillis() + JOB_TIMEOUT.toMillis() - intakeDelay.toMillis());
     return job;
   }
 
@@ -180,12 +220,20 @@ class WorkerTest {
   }
 
   private Worker newWorker(final CamundaClient client, final WorkerProperties workerProps) {
+    return newWorker(client, workerProps, JOB_TIMEOUT);
+  }
+
+  private Worker newWorker(
+      final CamundaClient client, final WorkerProperties workerProps, final Duration jobTimeout) {
     final var properties = new LoadTesterProperties();
     properties.setWorker(workerProps);
+    final var clientProperties = new CamundaClientProperties();
+    clientProperties.getWorker().getDefaults().setTimeout(jobTimeout);
     final var payloadReader = mock(PayloadReader.class);
     when(payloadReader.readPayload(anyString())).thenReturn("{}");
     final var connectionMonitor = mock(ConnectionMonitor.class);
-    return new Worker(client, properties, payloadReader, connectionMonitor, registry);
+    return new Worker(
+        client, properties, clientProperties, payloadReader, connectionMonitor, registry);
   }
 
   private static void mockFailingPublish(final CamundaClient client) throws Exception {

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/worker/WorkerTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/worker/WorkerTest.java
@@ -28,9 +28,12 @@ import io.camunda.zeebe.config.LoadTesterProperties;
 import io.camunda.zeebe.config.WorkerProperties;
 import io.camunda.zeebe.metrics.ConnectionMonitor;
 import io.camunda.zeebe.util.PayloadReader;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
 
 class WorkerTest {
@@ -39,6 +42,8 @@ class WorkerTest {
   private static final String CORRELATION_KEY_VALUE = "abc";
   private static final String MESSAGE_NAME = "messageName";
   private static final Duration COMPLETION_DELAY = Duration.ofMillis(250);
+
+  private final MeterRegistry registry = new SimpleMeterRegistry();
 
   @Test
   void shouldApplyCompletionDelayWhenPublishMessageFails() throws Exception {
@@ -84,6 +89,73 @@ class WorkerTest {
     verify(completeStep).send();
   }
 
+  @Test
+  void shouldRecordHandleDurationOnBothPublishOutcomes() throws Exception {
+    // given — one worker whose publish succeeds and one whose publish fails
+    final var successClient = mock(CamundaClient.class);
+    mockSuccessfulPublish(successClient);
+    final var failingClient = mock(CamundaClient.class);
+    mockFailingPublish(failingClient);
+    final var jobClient = mock(JobClient.class);
+    mockCompleteJob(jobClient);
+
+    // when — a job is handled on the success path and one on the early-return failure path
+    newWorker(successClient, sendMessageProperties()).handleJob(jobClient, mockJob());
+    newWorker(failingClient, sendMessageProperties()).handleJob(mock(JobClient.class), mockJob());
+
+    // then — both paths are timed, each taking at least the completion delay
+    final var timer = registry.get("worker.handle.duration").timer();
+    assertThat(timer.count()).isEqualTo(2);
+    assertThat(timer.totalTime(TimeUnit.MILLISECONDS))
+        .describedAs("both the success and the early-return path record the handling duration")
+        .isGreaterThanOrEqualTo(2 * COMPLETION_DELAY.toMillis());
+  }
+
+  @Test
+  void shouldRecordPublishDurationTaggedWithOutcome() throws Exception {
+    // given — three workers whose publish succeeds, times out and errors respectively
+    final var successClient = mock(CamundaClient.class);
+    mockSuccessfulPublish(successClient);
+    final var timingOutClient = mock(CamundaClient.class);
+    mockPublishFailingWith(timingOutClient, new TimeoutException("simulated timeout"));
+    final var erroringClient = mock(CamundaClient.class);
+    mockPublishFailingWith(
+        erroringClient, new ExecutionException("simulated failure", new RuntimeException()));
+    final var jobClient = mock(JobClient.class);
+    mockCompleteJob(jobClient);
+
+    // when
+    newWorker(successClient, sendMessageProperties()).handleJob(jobClient, mockJob());
+    newWorker(timingOutClient, sendMessageProperties()).handleJob(jobClient, mockJob());
+    newWorker(erroringClient, sendMessageProperties()).handleJob(jobClient, mockJob());
+
+    // then — each publish is timed under its own outcome
+    assertThat(registry.get("worker.publish.duration").tag("outcome", "success").timer().count())
+        .isEqualTo(1);
+    assertThat(registry.get("worker.publish.duration").tag("outcome", "timeout").timer().count())
+        .isEqualTo(1);
+    assertThat(registry.get("worker.publish.duration").tag("outcome", "error").timer().count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldReportCompletionQueueDepth() throws Exception {
+    // given
+    final var client = mock(CamundaClient.class);
+    mockSuccessfulPublish(client);
+    final var jobClient = mock(JobClient.class);
+    mockCompleteJob(jobClient);
+    final var worker = newWorker(client, sendMessageProperties());
+    final var gauge = registry.get("worker.completion.queue.depth").gauge();
+
+    // when — a job is completed but its response is not checked yet
+    assertThat(gauge.value()).isZero();
+    worker.handleJob(jobClient, mockJob());
+
+    // then — the untracked completion future shows up as queue depth
+    assertThat(gauge.value()).isEqualTo(1);
+  }
+
   private static long timeHandleJob(
       final Worker worker, final JobClient jobClient, final ActivatedJob job) {
     final long start = System.currentTimeMillis();
@@ -107,17 +179,23 @@ class WorkerTest {
     return props;
   }
 
-  private static Worker newWorker(final CamundaClient client, final WorkerProperties workerProps) {
+  private Worker newWorker(final CamundaClient client, final WorkerProperties workerProps) {
     final var properties = new LoadTesterProperties();
     properties.setWorker(workerProps);
     final var payloadReader = mock(PayloadReader.class);
     when(payloadReader.readPayload(anyString())).thenReturn("{}");
     final var connectionMonitor = mock(ConnectionMonitor.class);
-    return new Worker(client, properties, payloadReader, connectionMonitor);
+    return new Worker(client, properties, payloadReader, connectionMonitor, registry);
+  }
+
+  private static void mockFailingPublish(final CamundaClient client) throws Exception {
+    mockPublishFailingWith(
+        client, new ExecutionException("simulated publish failure", new RuntimeException()));
   }
 
   @SuppressWarnings("unchecked")
-  private static void mockFailingPublish(final CamundaClient client) throws Exception {
+  private static void mockPublishFailingWith(final CamundaClient client, final Exception failure)
+      throws Exception {
     final var step1 = mock(PublishMessageCommandStep1.class);
     final var step2 = mock(PublishMessageCommandStep2.class);
     final var step3 = mock(PublishMessageCommandStep3.class);
@@ -127,7 +205,7 @@ class WorkerTest {
     when(step2.correlationKey(CORRELATION_KEY_VALUE)).thenReturn(step3);
     when(step3.send()).thenReturn(future);
     when(future.get(anyLong(), org.mockito.ArgumentMatchers.any(TimeUnit.class)))
-        .thenThrow(new ExecutionException("simulated publish failure", new RuntimeException()));
+        .thenThrow(failure);
   }
 
   @SuppressWarnings("unchecked")

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -378,6 +378,15 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
     // get to avoid the creation of a state instance.
     final var state = jobTypeState.get(key);
 
+    // A notification only wakes a request when it is delivered to the same handler instance that
+    // parked it, under an equal key. Logging both identities makes a mismatch of either directly
+    // visible instead of showing up as a silent absence of "Handle jobs available notification".
+    LOG.trace(
+        "Notification on handler {} looked up {}; known keys are {}.",
+        System.identityHashCode(this),
+        key,
+        jobTypeState.keySet());
+
     if (state != null) {
       LOG.trace("Handle jobs available notification for type {}.", jobType);
       actor.run(
@@ -410,6 +419,9 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
         request.getType(),
         request.getLongPollingTimeout(longPollingTimeout));
     state.enqueueRequest(request);
+    // Counterpart to the identity logged on the notification path: the two must agree for the
+    // request to ever be woken.
+    LOG.trace("Parked on handler {} under {}.", System.identityHashCode(this), keyOf(request));
   }
 
   private void scheduleLongPollingTimeout(


### PR DESCRIPTION
## Why

A benchmark run with AUTH enabled on the REST endpoints showed process instance throughput dropping sharply with a **single** worker, while the same configuration with **two** workers stayed within ~5% of the unauthenticated baseline. That shape looks like added *per-job latency* rather than reduced engine capacity, but we could not tell with the metrics we had: the Camunda client only exposes `camunda.client.worker.job.activated` and `camunda.client.worker.job.handled`, which count how many jobs went through, not how long each one occupied a worker thread, and nothing reported the backlog of dispatched completions.

So this PR adds the missing instrumentation. **The AUTH hypothesis it was built for turned out to be wrong**, and the same metrics then located the real problem, which is not latency at all: the worker had stopped polling altogether and so never recovered the jobs the broker yields after a failed job push. That is #59633, already fixed in #61195 — the load test is the first field observation of it, and the evidence is in a comment there.

The measurements are worth keeping in the PR because they are what ruled each candidate out:

- `worker.publish.duration` and `worker.handle.duration` are **flat** between the REST and the gRPC run, so the worker thread is not the bottleneck and AUTH overhead is not visible in the handler.
- `worker.completion.queue.depth` grows under REST, which pointed at the completion round-trip; `worker.complete.duration` then measured it directly and showed it is too small to explain the gap.
- `worker.intake.delay` covers the last unmeasured segment, from the broker activating a job to a handler thread receiving it. It is also flat (p50 95 vs 112 ms).

With every segment of the round-trip flat and throughput still down, the gap had to be jobs that never arrive at all — which is what the engine and gateway panels then confirmed.

## What

**Five Micrometer meters in the load-tester worker**, registered the way `ConnectionMonitor` and `Starter` do it (constructor-injected `MeterRegistry`, declared in an `ExtendedMeterDocumentation` enum, built via `MicrometerUtil`):

| Metric | Type | What it tells us |
|---|---|---|
| `worker.intake.delay` | Timer | Time from the broker activating a job to a handler thread picking it up — broker, gateway, job stream or activation response, and the client's own handler queue. |
| `worker.publish.duration` | Timer, tag `outcome`=`success`\|`timeout`\|`error` | Latency of the synchronous message publication the handler does. It crosses the gateway, so gateway-side overhead shows up here first. |
| `worker.handle.duration` | Timer | Total thread occupancy per job. This figure bounds throughput at `concurrency / duration`. |
| `worker.complete.duration` | Timer, tag `outcome`=`success`\|`backpressure`\|`error` | Round-trip of the dispatched complete command. Invisible in `handle.duration` because it is never awaited, yet it delays the broker observing the job as done. |
| `worker.completion.queue.depth` | Gauge | Depth of the bounded (10k) `requestFutures` queue of in-flight completion futures. Coarser than the timer above, but cheap enough for a dashboard. |

Implementation notes:

- To keep `worker.handle.duration` from biasing quantiles downwards without duplicating the record call, the handler body moved into a private `handleJobInternal` and the timer wraps it in `try/finally`.
- `worker.complete.duration` is recorded in `ResponseChecker`, which already awaits every completion future; it only needed the timestamp taken just before the command was sent, so the queue now carries a `PendingRequest` record (future + start nanos) instead of a bare `Future`.
- `worker.intake.delay` is derived from `ActivatedJob.getDeadline()`, which the broker sets to the activation instant plus the configured job timeout; subtracting the remaining lease yields the delivery time with no extra call and no protocol change. The cost is that it mixes two clocks — the deadline is the broker's, the handler timestamp the worker's. A clock offset shifts every sample by the same amount, so the metric is read as a difference between runs on the same pods rather than as an absolute. Negative samples are dropped by the timer rather than clamped, so an offset large enough to matter shows up as a missing count instead of a plausible-looking zero. When no job timeout is configured the activation instant cannot be recovered, and no sample is recorded at all rather than one derived from a guessed timeout.
- Timers carry explicit buckets rather than the default Prometheus set, mirroring `StarterLatencyMetricsDoc`.

**A Grafana dashboard**, `load-tests/docs/dashboards/load-test-client-metrics.json` (schema V2, import-ready): a per-operation summary table, one panel per meter, worker CPU/throttling/GC, and the engine- and gateway-side panels that carried the investigation — job event rates by action, job stream push outcome, the full yield recovery path on one panel, and gateway-to-broker request rates so a missing activation attempt is visible.

**Two TRACE lines in `LongPollingActivateJobsHandler`**, on the `jobs available` path: one logs the looked-up key and the keys actually present in `jobTypeState`, one logs the key a request is parked under. Those two lines are what showed that every notification for the affected job type found an empty map — proving no activation request was in flight at all, rather than one being in flight and not woken. That distinction is what pointed the investigation at the client instead of the gateway. They are on `Loggers.LONG_POLLING` (`io.camunda.zeebe.gateway.longPolling`), so they cost nothing unless that logger is raised.

### Drive-by fix: REST completion failures were reported nowhere

`ResponseChecker` recognised backpressure only as the gRPC `RESOURCE_EXHAUSTED` status and logged everything else. Over REST, backpressure arrives as HTTP 429/503 inside a `ClientHttpException`, which matched neither branch — so REST completion failures were silently discarded. Failures are now classified per transport: backpressure goes to its own timer series instead of the log (it is expected in steady state under load), anything else is logged as before.

## How to verify

The load-tester exposes its Prometheus registry on port 9600 at **`/metrics`** (not `/actuator/prometheus` — `application.yaml` remaps it so the Helm-managed ServiceMonitor keeps working). Against a worker pod:

```bash
kubectl port-forward <worker-pod> 9600:9600
curl -s localhost:9600/metrics | grep -E 'worker_(publish|handle|complete)_duration|worker_intake_delay|worker_completion_queue_depth'
```

Then in Prometheus/Grafana:

```promql
# p99 job-intake delay (activation -> handler thread)
histogram_quantile(0.99, sum by (le) (rate(worker_intake_delay_seconds_bucket{namespace=~"$namespace"}[$__rate_interval])))
# p99 publish latency, successful publications only
histogram_quantile(0.99, sum by (le) (rate(worker_publish_duration_seconds_bucket{namespace=~"$namespace", outcome="success"}[$__rate_interval])))
# p99 thread occupancy per job
histogram_quantile(0.99, sum by (le) (rate(worker_handle_duration_seconds_bucket{namespace=~"$namespace"}[$__rate_interval])))
# p99 completion round-trip
histogram_quantile(0.99, sum by (le) (rate(worker_complete_duration_seconds_bucket{namespace=~"$namespace", outcome="success"}[$__rate_interval])))
# completion backlog
max(worker_completion_queue_depth{namespace=~"$namespace"})
```

All five metrics are documented in `load-tests/docs/metrics.md` alongside the existing catalogue.

For the gateway TRACE lines, raise the logger at runtime — an env var cannot set it, because Spring's relaxed binding lowercases the camelCase `longPolling`:

```bash
curl -X POST localhost:9600/actuator/loggers/io.camunda.zeebe.gateway.longPolling \
  -H 'Content-Type: application/json' -d '{"configuredLevel":"TRACE"}'
```

## Testing

`WorkerTest` is extended with five cases against a `SimpleMeterRegistry`: handle duration recorded on both the success and the early-return path, publish duration tagged per outcome, the queue-depth gauge tracking a dispatched completion, a job whose lease is already partly spent recording the elapsed intake delay, and a worker without a configured job timeout recording no intake sample at all. A new `ResponseCheckerTest` covers the completion timer: the round-trip is measured from the pre-send timestamp, and the outcome is classified for gRPC `RESOURCE_EXHAUSTED`, HTTP 429, HTTP 503 and everything else.

Module suite green. The full-repo `install -Dquickly` fails on `zeebe-cluster-config` with a NullAway error in `ProtoBufSerializer` — pre-existing on `main` and untouched by this branch.

## Note

No issue linked for the instrumentation itself; it came out of an ad-hoc load-test investigation. The bug it found is tracked in #59633 and fixed in #61195. Tell me if the `worker.` prefix should be something else — the load-tester's own meters use a component prefix with no vendor prefix (`app.connected`, `client.info`, `starter.response.latency`), and `camunda.client.worker.job.*` belongs to the client library rather than this module, but I am happy to rename.
