### PR TITLE
Expose authorization enablement in self search

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -122,6 +122,7 @@ import io.camunda.gateway.protocol.model.MessageSubscriptionSearchQueryResult;
 import io.camunda.gateway.protocol.model.MessageSubscriptionStateEnum;
 import io.camunda.gateway.protocol.model.MessageSubscriptionTypeEnum;
 import io.camunda.gateway.protocol.model.MessageWaitStateDetails;
+import io.camunda.gateway.protocol.model.OwnAuthorizationSearchResult;
 import io.camunda.gateway.protocol.model.OwnerTypeEnum;
 import io.camunda.gateway.protocol.model.PermissionTypeEnum;
 import io.camunda.gateway.protocol.model.ProcessDefinitionElementStatisticsQueryResult;
@@ -1758,6 +1759,16 @@ public final class SearchQueryResponseMapper {
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toAuthorizations)
                 .orElseGet(Collections::emptyList))
+        .build();
+  }
+
+  public static OwnAuthorizationSearchResult toOwnAuthorizationSearchQueryResponse(
+      final SearchQueryResult<AuthorizationEntity> result, final boolean authorizationsEnabled) {
+    final var authorizationSearchResult = toAuthorizationSearchQueryResponse(result);
+    return OwnAuthorizationSearchResult.Builder.create()
+        .page(authorizationSearchResult.getPage())
+        .items(authorizationSearchResult.getItems())
+        .authorizationsEnabled(authorizationsEnabled)
         .build();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsDisabledIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsDisabledIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class MeAuthorizationsDisabledIT {
+
+  private static final String USERNAME = "meAuthorizationsDisabledUser";
+  private static final String PASSWORD = "password";
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsDisabled()
+          .withAuthenticatedAccess();
+
+  @UserDefinition private static final TestUser USER = new TestUser(USERNAME, PASSWORD, List.of());
+
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @Test
+  void shouldIndicateWhenAuthorizationsAreDisabled(
+      @Authenticated(USERNAME) final CamundaClient client) throws Exception {
+    // when
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(createUri(client, "v2/authentication/me/authorizations/search"))
+            .header("Authorization", basicAuthentication())
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+    final var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    final var responseBody = JSON.readTree(response.body());
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+    assertThat(responseBody.path("authorizationsEnabled").asBoolean()).isFalse();
+    assertThat(responseBody.path("items").size()).isZero();
+  }
+
+  private static String basicAuthentication() {
+    return "Basic " + Base64.getEncoder().encodeToString((USERNAME + ":" + PASSWORD).getBytes());
+  }
+
+  private static URI createUri(final CamundaClient client, final String path)
+      throws URISyntaxException {
+    final String base = client.getConfiguration().getRestAddress().toString();
+    final String separator = base.endsWith("/") ? "" : "/";
+    return new URI(base + separator + path);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsDisabledIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsDisabledIT.java
@@ -64,7 +64,16 @@ class MeAuthorizationsDisabledIT {
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
     assertThat(responseBody.path("authorizationsEnabled").asBoolean()).isFalse();
-    assertThat(responseBody.path("items").size()).isZero();
+    // user creation always grants a self USER authorization, so items is not empty even when
+    // authorization checks are disabled
+    assertThat(responseBody.path("items"))
+        .allSatisfy(
+            item -> {
+              assertThat(item.path("ownerId").asText()).isEqualTo(USERNAME);
+              assertThat(item.path("ownerType").asText()).isEqualTo("USER");
+              assertThat(item.path("resourceType").asText()).isEqualTo("USER");
+              assertThat(item.path("resourceId").asText()).isEqualTo(USERNAME);
+            });
   }
 
   private static String basicAuthentication() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsIT.java
@@ -17,6 +17,7 @@ import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static io.camunda.client.api.search.enums.ResourceType.USER_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.Authorization;
 import io.camunda.client.api.search.response.SearchResponse;
@@ -41,6 +42,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
@@ -70,6 +72,7 @@ class MeAuthorizationsIT {
   private static final String STRANGER = "meAuthorizationsStranger";
   private static final String DIRECT_PROCESS_ID = "meAuthorizationsDirectProcess";
   private static final String STRANGER_DECISION_ID = "meAuthorizationsStrangerDecision";
+  private static final ObjectMapper JSON = new ObjectMapper();
 
   @UserDefinition
   private static final TestUser ME_USER =
@@ -109,7 +112,7 @@ class MeAuthorizationsIT {
 
   @Test
   void shouldReturnAuthorizationsGrantedDirectlyViaGroupAndViaRole(
-      @Authenticated(ME) final CamundaClient meClient) {
+      @Authenticated(ME) final CamundaClient meClient) throws Exception {
     Awaitility.await()
         .untilAsserted(
             () -> {
@@ -149,11 +152,12 @@ class MeAuthorizationsIT {
                   .extracting(item -> item.getResourceType().name())
                   .doesNotContain("DECISION_DEFINITION");
             });
+    assertAuthorizationsAreEnabled(meClient);
   }
 
   @Test
-  void shouldFilterOwnAuthorizationsByResourceType(
-      @Authenticated(ME) final CamundaClient meClient) {
+  void shouldFilterOwnAuthorizationsByResourceType(@Authenticated(ME) final CamundaClient meClient)
+      throws Exception {
     Awaitility.await()
         .untilAsserted(
             () -> {
@@ -175,6 +179,23 @@ class MeAuthorizationsIT {
                         assertThat(item.getResourceId()).isEqualTo(DIRECT_PROCESS_ID);
                       });
             });
+    assertAuthorizationsAreEnabled(meClient);
+  }
+
+  private void assertAuthorizationsAreEnabled(final CamundaClient client) throws Exception {
+    // when
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(createUri(client, "v2/authentication/me/authorizations/search"))
+            .header("Authorization", basicAuthentication())
+            .POST(BodyPublishers.noBody())
+            .build();
+    final HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+    final var responseBody = JSON.readTree(response.body());
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+    assertThat(responseBody.path("authorizationsEnabled").asBoolean()).isTrue();
   }
 
   @Test
@@ -191,6 +212,10 @@ class MeAuthorizationsIT {
 
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  private static String basicAuthentication() {
+    return "Basic " + Base64.getEncoder().encodeToString((ME + ":" + PASSWORD).getBytes());
   }
 
   private static URI createUri(final CamundaClient client, final String path)

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -51,7 +51,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'authorizations.yaml#/components/schemas/AuthorizationSearchResult'
+                $ref: '#/components/schemas/OwnAuthorizationSearchResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -64,6 +64,20 @@ paths:
 
 components:
   schemas:
+    OwnAuthorizationSearchResult:
+      type: object
+      allOf:
+        - $ref: 'authorizations.yaml#/components/schemas/AuthorizationSearchResult'
+      required:
+        - authorizationsEnabled
+      properties:
+        authorizationsEnabled:
+          description: Indicates whether authorization checks are enabled for the cluster.
+          type: boolean
+      x-properties-added-in-version:
+        - propertyName: authorizationsEnabled
+          addedInVersion: "8.10"
+
     CamundaUserResult:
       type: object
       required:

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -74,9 +74,6 @@ components:
         authorizationsEnabled:
           description: Indicates whether authorization checks are enabled for the cluster.
           type: boolean
-      x-properties-added-in-version:
-        - propertyName: authorizationsEnabled
-          addedInVersion: "8.10"
 
     CamundaUserResult:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationController.java
@@ -14,14 +14,15 @@ import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.protocol.model.AuthorizationSearchQuery;
-import io.camunda.gateway.protocol.model.AuthorizationSearchResult;
 import io.camunda.gateway.protocol.model.CamundaUserResult;
+import io.camunda.gateway.protocol.model.OwnAuthorizationSearchResult;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.core.port.in.CamundaUserPort;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
@@ -44,14 +45,17 @@ public class AuthenticationController {
   private final CamundaUserPort camundaUserPort;
   private final ServiceRegistry serviceRegistry;
   private final CamundaAuthenticationProvider authenticationProvider;
+  private final CamundaSecurityLibraryProperties securityProperties;
 
   public AuthenticationController(
       final CamundaUserPort camundaUserPort,
       final ServiceRegistry serviceRegistry,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final CamundaSecurityLibraryProperties securityProperties) {
     this.camundaUserPort = camundaUserPort;
     this.serviceRegistry = serviceRegistry;
     this.authenticationProvider = authenticationProvider;
+    this.securityProperties = securityProperties;
   }
 
   @CamundaGetMapping(path = "/me")
@@ -75,7 +79,7 @@ public class AuthenticationController {
    * #getCurrentUser()}.
    */
   @CamundaPostMapping(path = "/me/authorizations/search")
-  public ResponseEntity<AuthorizationSearchResult> searchOwnAuthorizations(
+  public ResponseEntity<OwnAuthorizationSearchResult> searchOwnAuthorizations(
       @PhysicalTenantId final String physicalTenantId,
       @RequestBody(required = false) final AuthorizationSearchQuery query) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
@@ -88,7 +92,7 @@ public class AuthenticationController {
             q -> searchOwn(physicalTenantId, q, authentication));
   }
 
-  private ResponseEntity<AuthorizationSearchResult> searchOwn(
+  private ResponseEntity<OwnAuthorizationSearchResult> searchOwn(
       final String physicalTenantId,
       final AuthorizationQuery query,
       final CamundaAuthentication authentication) {
@@ -98,7 +102,8 @@ public class AuthenticationController {
               .authorizationServices(physicalTenantId)
               .searchOwnAuthorizations(query, authentication);
       return ResponseEntity.ok(
-          SearchQueryResponseMapper.toAuthorizationSearchQueryResponse(result));
+          SearchQueryResponseMapper.toOwnAuthorizationSearchQueryResponse(
+              result, securityProperties.getAuthorizations().isEnabled()));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationControllerTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -59,10 +60,12 @@ public class AuthenticationControllerTest extends RestControllerTest {
   @MockitoBean private ServiceRegistry serviceRegistry;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean private AuthorizationServices authorizationServices;
+  @Autowired private CamundaSecurityLibraryProperties securityProperties;
 
   @BeforeEach
   void setUpAuthorizationServices() {
     when(serviceRegistry.authorizationServices(any())).thenReturn(authorizationServices);
+    securityProperties.getAuthorizations().setEnabled(true);
   }
 
   @Test
@@ -172,6 +175,7 @@ public class AuthenticationControllerTest extends RestControllerTest {
         .json(
             """
                 {
+                  "authorizationsEnabled": true,
                   "items": [
                     {
                       "authorizationKey": "1",
@@ -207,6 +211,33 @@ public class AuthenticationControllerTest extends RestControllerTest {
     verify(authorizationServices)
         .searchOwnAuthorizations(
             any(AuthorizationQuery.class), eq(AUTHENTICATION_WITH_DEFAULT_TENANT));
+  }
+
+  @Test
+  void searchOwnAuthorizationsShouldIndicateWhenAuthorizationsAreDisabled() {
+    // given
+    securityProperties.getAuthorizations().setEnabled(false);
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+    when(authorizationServices.searchOwnAuthorizations(any(AuthorizationQuery.class), any()))
+        .thenReturn(SearchQueryResult.empty());
+
+    // when / then
+    webClient
+        .post()
+        .uri(ME_AUTHORIZATIONS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+                {
+                  "authorizationsEnabled": false,
+                  "items": []
+                }""",
+            JsonCompareMode.LENIENT);
   }
 
   @Test


### PR DESCRIPTION
Closes #60604, #60605

## Summary

Add `authorizationsEnabled` to `POST /v2/authentication/me/authorizations/search` so consumers can distinguish disabled authorization checks from an enabled cluster with no grants.

The general authorization search response remains unchanged. The change includes controller and acceptance coverage for enabled and disabled authorization configurations.