### PR TITLE
fix: derive the OIDC endpoints from the Identity backend URL when no issuer is set

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -219,13 +219,10 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   // Last resort when no issuer-uri could be derived, so CSL can still build a registration: the
   // endpoints carry no issuer check, unlike issuer-uri, so the backend URL is usable for them.
   //
-  // The paths assume Keycloak's realm layout, which is what camunda.identity.issuerBackendUrl
-  // points
-  // at in the official Helm chart. Behind another provider they are wrong, but only jwk-set-uri can
-  // ever be dialed from here: this is reached only when no issuer is configured, so there is no
-  // browser login to use authorization-uri/token-uri, and the public API's own JWK set URI wins
-  // over
-  // the derived one whenever it is set. Anything else has to configure the endpoints explicitly.
+  // The paths assume Keycloak's realm layout, which is what the chart's issuerBackendUrl points
+  // at. Elsewhere they are wrong, but only jwk-set-uri can be dialed from here: no issuer means
+  // no browser login for authorization-uri/token-uri, and the public API's own JWK set URI wins
+  // when it is set. Any other provider has to configure the endpoints explicitly.
   private void deriveOidcEndpointsFromIssuerBackendUrl(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
     if (!isBlank(effectiveOidcProperty(env, derived, "issuer-uri"))) {
@@ -247,13 +244,11 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         OIDC_PREFIX + "jwk-set-uri",
         isBlank(publicApiJwks) ? base + "/protocol/openid-connect/certs" : publicApiJwks);
     LOG.info(
-        "Optimize derived the CSL OIDC endpoints from 'camunda.identity.issuerBackendUrl' (assuming"
-            + " Keycloak's realm paths) because no OIDC issuer is configured. Browser login cannot"
-            + " work against an internal URL; set 'camunda.identity.issuer' (or"
-            + " 'camunda.security.authentication.oidc.issuer-uri') if this deployment serves the"
-            + " Optimize UI, or set the"
-            + " 'camunda.security.authentication.oidc.{authorization,token,jwk-set}-uri' explicitly"
-            + " for a non-Keycloak provider.");
+        "Optimize derived the CSL OIDC endpoints from 'camunda.identity.issuerBackendUrl', assuming"
+            + " Keycloak's realm paths, because no OIDC issuer is configured. Browser login cannot"
+            + " work against an internal URL: set 'camunda.identity.issuer' if this deployment"
+            + " serves the Optimize UI, or set the OIDC endpoints explicitly for a non-Keycloak"
+            + " provider.");
   }
 
   // Bridges a legacy issuer source into issuer-uri, but only when the host left the OIDC endpoints

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -217,15 +217,8 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     bridgeAuth0SaasOrgAndCluster(env, derived, clusterId);
   }
 
-  // Last resort when no issuer-uri could be derived: build the endpoints from
-  // camunda.identity.issuerBackendUrl, which is the in-cluster Identity URL and reachable from the
-  // pod. issuer-uri cannot be derived from it — CSL validates the discovery document's issuer
-  // against the URL it dialed, and Identity reports its externally-configured issuer either way —
-  // but the endpoints carry no such check, so a registration built from them works. Without this a
-  // deployment that configures only the public API (jwtAuthForApiEnabled plus a jwkSetUri, no
-  // browser login) has neither an issuer nor a complete endpoint set, and CSL fails to build any
-  // client registration at all. A deployment that does serve browser login configures
-  // camunda.identity.issuer and never reaches this.
+  // Last resort when no issuer-uri could be derived, so CSL can still build a registration: the
+  // endpoints carry no issuer check, unlike issuer-uri, so the backend URL is usable for them.
   private void deriveOidcEndpointsFromIssuerBackendUrl(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
     if (derived.containsKey(OIDC_PREFIX + "issuer-uri")
@@ -275,9 +268,8 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         && !isBlank(env.getProperty(OIDC_PREFIX + "token-uri"));
   }
 
-  // As hasExplicitOidcEndpoints, but also counting endpoints this bridge derived in this pass, so
-  // the credential guard below does not withhold client-id and client-secret from a registration
-  // the bridge has just made buildable.
+  // As hasExplicitOidcEndpoints, but also counting endpoints derived in this pass: a registration
+  // cannot be built without a client id, so the guard below must not withhold the credentials.
   private static boolean hasOidcEndpoints(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
     return hasExplicitOidcEndpoints(env)

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -218,6 +218,14 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
 
   // Last resort when no issuer-uri could be derived, so CSL can still build a registration: the
   // endpoints carry no issuer check, unlike issuer-uri, so the backend URL is usable for them.
+  //
+  // The paths assume Keycloak's realm layout, which is what camunda.identity.issuerBackendUrl
+  // points
+  // at in the official Helm chart. Behind another provider they are wrong, but only jwk-set-uri can
+  // ever be dialed from here: this is reached only when no issuer is configured, so there is no
+  // browser login to use authorization-uri/token-uri, and the public API's own JWK set URI wins
+  // over
+  // the derived one whenever it is set. Anything else has to configure the endpoints explicitly.
   private void deriveOidcEndpointsFromIssuerBackendUrl(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
     if (!isBlank(effectiveOidcProperty(env, derived, "issuer-uri"))) {
@@ -227,8 +235,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     if (isBlank(backendUrl)) {
       return;
     }
-    final String base =
-        backendUrl.endsWith("/") ? backendUrl.substring(0, backendUrl.length() - 1) : backendUrl;
+    final String base = backendUrl.trim().replaceAll("/+$", "");
     derived.putIfAbsent(OIDC_PREFIX + "authorization-uri", base + "/protocol/openid-connect/auth");
     derived.putIfAbsent(OIDC_PREFIX + "token-uri", base + "/protocol/openid-connect/token");
     // The public API's own JWK set URI wins: it is configured for the IdP that signs the API
@@ -240,11 +247,13 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         OIDC_PREFIX + "jwk-set-uri",
         isBlank(publicApiJwks) ? base + "/protocol/openid-connect/certs" : publicApiJwks);
     LOG.info(
-        "Optimize derived the CSL OIDC endpoints from 'camunda.identity.issuerBackendUrl' because no"
-            + " OIDC issuer is configured. Browser login cannot work against an internal URL; set"
-            + " 'camunda.identity.issuer' (or"
+        "Optimize derived the CSL OIDC endpoints from 'camunda.identity.issuerBackendUrl' (assuming"
+            + " Keycloak's realm paths) because no OIDC issuer is configured. Browser login cannot"
+            + " work against an internal URL; set 'camunda.identity.issuer' (or"
             + " 'camunda.security.authentication.oidc.issuer-uri') if this deployment serves the"
-            + " Optimize UI.");
+            + " Optimize UI, or set the"
+            + " 'camunda.security.authentication.oidc.{authorization,token,jwk-set}-uri' explicitly"
+            + " for a non-Keycloak provider.");
   }
 
   // Bridges a legacy issuer source into issuer-uri, but only when the host left the OIDC endpoints

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -174,6 +174,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     if (isBlank(env.getProperty("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL"))) {
       mapIssuerUri(env, derived, "camunda.identity.issuer");
     }
+    deriveOidcEndpointsFromIssuerBackendUrl(env, derived);
 
     // The Helm chart's Optimize ConfigMap can legitimately render clientId/CAMUNDA_IDENTITY_
     // CLIENT_SECRET while leaving camunda.identity.issuer blank. Bridging a client-id/secret with
@@ -183,7 +184,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     // for a boot failure. Mirrors bridgeAuth0SaasOrgAndCluster's all-or-nothing precedent below.
     if (!derived.containsKey(OIDC_PREFIX + "issuer-uri")
         && isBlank(env.getProperty(OIDC_PREFIX + "issuer-uri"))
-        && !hasExplicitOidcEndpoints(env)) {
+        && !hasOidcEndpoints(env, derived)) {
       final String clientId = env.getProperty("camunda.identity.clientId");
       final String clientSecret = env.getProperty("CAMUNDA_IDENTITY_CLIENT_SECRET");
       if (!isBlank(clientId) || !isBlank(clientSecret)) {
@@ -216,6 +217,38 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     bridgeAuth0SaasOrgAndCluster(env, derived, clusterId);
   }
 
+  // Last resort when no issuer-uri could be derived: build the endpoints from
+  // camunda.identity.issuerBackendUrl, which is the in-cluster Identity URL and reachable from the
+  // pod. issuer-uri cannot be derived from it — CSL validates the discovery document's issuer
+  // against the URL it dialed, and Identity reports its externally-configured issuer either way —
+  // but the endpoints carry no such check, so a registration built from them works. Without this a
+  // deployment that configures only the public API (jwtAuthForApiEnabled plus a jwkSetUri, no
+  // browser login) has neither an issuer nor a complete endpoint set, and CSL fails to build any
+  // client registration at all. A deployment that does serve browser login configures
+  // camunda.identity.issuer and never reaches this.
+  private void deriveOidcEndpointsFromIssuerBackendUrl(
+      final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    if (derived.containsKey(OIDC_PREFIX + "issuer-uri")
+        || !isBlank(env.getProperty(OIDC_PREFIX + "issuer-uri"))) {
+      return;
+    }
+    final String backendUrl = env.getProperty("camunda.identity.issuerBackendUrl");
+    if (isBlank(backendUrl)) {
+      return;
+    }
+    final String base =
+        backendUrl.endsWith("/") ? backendUrl.substring(0, backendUrl.length() - 1) : backendUrl;
+    derived.putIfAbsent(OIDC_PREFIX + "authorization-uri", base + "/protocol/openid-connect/auth");
+    derived.putIfAbsent(OIDC_PREFIX + "token-uri", base + "/protocol/openid-connect/token");
+    derived.putIfAbsent(OIDC_PREFIX + "jwk-set-uri", base + "/protocol/openid-connect/certs");
+    LOG.info(
+        "Optimize derived the CSL OIDC endpoints from 'camunda.identity.issuerBackendUrl' because no"
+            + " OIDC issuer is configured. Browser login cannot work against an internal URL; set"
+            + " 'camunda.identity.issuer' (or"
+            + " 'camunda.security.authentication.oidc.issuer-uri') if this deployment serves the"
+            + " Optimize UI.");
+  }
+
   // Bridges a legacy issuer source into issuer-uri, but only when the host left the OIDC endpoints
   // to CSL: an issuer-uri makes CSL discover them by dialing the browser-facing issuer from inside
   // the pod, which is what explicit endpoints exist to avoid. The key is deprecated either way, so
@@ -240,6 +273,17 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     return !isBlank(env.getProperty(OIDC_PREFIX + "authorization-uri"))
         && !isBlank(env.getProperty(OIDC_PREFIX + "jwk-set-uri"))
         && !isBlank(env.getProperty(OIDC_PREFIX + "token-uri"));
+  }
+
+  // As hasExplicitOidcEndpoints, but also counting endpoints this bridge derived in this pass, so
+  // the credential guard below does not withhold client-id and client-secret from a registration
+  // the bridge has just made buildable.
+  private static boolean hasOidcEndpoints(
+      final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    return hasExplicitOidcEndpoints(env)
+        || (derived.containsKey(OIDC_PREFIX + "authorization-uri")
+            && derived.containsKey(OIDC_PREFIX + "jwk-set-uri")
+            && derived.containsKey(OIDC_PREFIX + "token-uri"));
   }
 
   private static boolean isAuth0Configured(final ConfigurableEnvironment env) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -233,7 +233,14 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         backendUrl.endsWith("/") ? backendUrl.substring(0, backendUrl.length() - 1) : backendUrl;
     derived.putIfAbsent(OIDC_PREFIX + "authorization-uri", base + "/protocol/openid-connect/auth");
     derived.putIfAbsent(OIDC_PREFIX + "token-uri", base + "/protocol/openid-connect/token");
-    derived.putIfAbsent(OIDC_PREFIX + "jwk-set-uri", base + "/protocol/openid-connect/certs");
+    // The public API's own JWK set URI wins: it is configured for the IdP that signs the API
+    // tokens, which need not be the Identity instance behind issuerBackendUrl. bridgePublicApiJwt
+    // runs later and would not overwrite a value put here.
+    final String publicApiJwks =
+        env.getProperty("SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI");
+    derived.putIfAbsent(
+        OIDC_PREFIX + "jwk-set-uri",
+        isBlank(publicApiJwks) ? base + "/protocol/openid-connect/certs" : publicApiJwks);
     LOG.info(
         "Optimize derived the CSL OIDC endpoints from 'camunda.identity.issuerBackendUrl' because no"
             + " OIDC issuer is configured. Browser login cannot work against an internal URL; set"
@@ -272,10 +279,21 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   // cannot be built without a client id, so the guard below must not withhold the credentials.
   private static boolean hasOidcEndpoints(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
-    return hasExplicitOidcEndpoints(env)
-        || (derived.containsKey(OIDC_PREFIX + "authorization-uri")
-            && derived.containsKey(OIDC_PREFIX + "jwk-set-uri")
-            && derived.containsKey(OIDC_PREFIX + "token-uri"));
+    return !isBlank(effectiveOidcEndpoint(env, derived, "authorization-uri"))
+        && !isBlank(effectiveOidcEndpoint(env, derived, "jwk-set-uri"))
+        && !isBlank(effectiveOidcEndpoint(env, derived, "token-uri"));
+  }
+
+  // What CSL will actually see: the derived source is added last, so any explicitly set value wins
+  // even when blank.
+  private static String effectiveOidcEndpoint(
+      final ConfigurableEnvironment env, final Map<String, Object> derived, final String suffix) {
+    final String explicit = env.getProperty(OIDC_PREFIX + suffix);
+    if (explicit != null) {
+      return explicit;
+    }
+    final Object derivedValue = derived.get(OIDC_PREFIX + suffix);
+    return derivedValue == null ? null : derivedValue.toString();
   }
 
   private static boolean isAuth0Configured(final ConfigurableEnvironment env) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -148,13 +148,13 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   // CAMUNDA_IDENTITY_CLIENT_SECRET env var it uses for the secret. Skipped when Auth0 is
   // configured (the two modes are mutually exclusive, cloud wins) to avoid a mixed registration.
   //
-  // Deliberately NOT bridged: camunda.identity.issuerBackendUrl. CSL has a single issuer-uri, used
+  // Never bridged into issuer-uri: camunda.identity.issuerBackendUrl. CSL uses that single value
   // for OIDC discovery AND for validating each token's iss claim against the discovery document's
   // issuer field. Keycloak reports the same externally-configured issuer regardless of which URL
   // was dialed to reach it, so pointing issuer-uri at the backend-reachable URL would make
   // discovery fail (issuer mismatch) instead of fixing reachability. camunda.identity.issuer (the
-  // browser-facing one) is the correct, and only, source for issuer-uri — mirroring the existing
-  // CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL precedent, which never bridged _ISSUER_BACKEND_URL either.
+  // browser-facing one) is the correct, and only, source for issuer-uri. The backend URL does feed
+  // the OIDC endpoints, which carry no issuer check — see deriveOidcEndpointsFromIssuerBackendUrl.
   //
   // Also deliberately NOT bridged: camunda.identity.clientSecret, the config-file secret key that
   // application-ccsm.yaml also declares — the official Helm chart never renders it, only the
@@ -182,16 +182,15 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     // ScopedClientRegistrationFactory throw IllegalStateException at startup, so this bridge is
     // all-or-nothing on the issuer-uri: withhold both credentials rather than trade a login problem
     // for a boot failure. Mirrors bridgeAuth0SaasOrgAndCluster's all-or-nothing precedent below.
-    if (!derived.containsKey(OIDC_PREFIX + "issuer-uri")
-        && isBlank(env.getProperty(OIDC_PREFIX + "issuer-uri"))
+    if (isBlank(effectiveOidcProperty(env, derived, "issuer-uri"))
         && !hasOidcEndpoints(env, derived)) {
       final String clientId = env.getProperty("camunda.identity.clientId");
       final String clientSecret = env.getProperty("CAMUNDA_IDENTITY_CLIENT_SECRET");
       if (!isBlank(clientId) || !isBlank(clientSecret)) {
         LOG.warn(
             "Optimize config 'camunda.identity.clientId'/'CAMUNDA_IDENTITY_CLIENT_SECRET' cannot"
-                + " be bridged without an OIDC issuer: 'camunda.identity.issuer' is blank and no"
-                + " 'camunda.security.authentication.oidc.issuer-uri' is set explicitly."
+                + " be bridged without an OIDC issuer: neither 'camunda.identity.issuer' nor"
+                + " 'camunda.security.authentication.oidc.issuer-uri' resolves to a value."
                 + " 'camunda.identity.issuerBackendUrl' cannot substitute for it (OIDC discovery"
                 + " would fail against it, see the Javadoc above). Leaving the OIDC client"
                 + " unconfigured rather than failing Optimize startup with a missing issuer.");
@@ -221,8 +220,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   // endpoints carry no issuer check, unlike issuer-uri, so the backend URL is usable for them.
   private void deriveOidcEndpointsFromIssuerBackendUrl(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
-    if (derived.containsKey(OIDC_PREFIX + "issuer-uri")
-        || !isBlank(env.getProperty(OIDC_PREFIX + "issuer-uri"))) {
+    if (!isBlank(effectiveOidcProperty(env, derived, "issuer-uri"))) {
       return;
     }
     final String backendUrl = env.getProperty("camunda.identity.issuerBackendUrl");
@@ -279,14 +277,14 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   // cannot be built without a client id, so the guard below must not withhold the credentials.
   private static boolean hasOidcEndpoints(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
-    return !isBlank(effectiveOidcEndpoint(env, derived, "authorization-uri"))
-        && !isBlank(effectiveOidcEndpoint(env, derived, "jwk-set-uri"))
-        && !isBlank(effectiveOidcEndpoint(env, derived, "token-uri"));
+    return !isBlank(effectiveOidcProperty(env, derived, "authorization-uri"))
+        && !isBlank(effectiveOidcProperty(env, derived, "jwk-set-uri"))
+        && !isBlank(effectiveOidcProperty(env, derived, "token-uri"));
   }
 
   // What CSL will actually see: the derived source is added last, so any explicitly set value wins
   // even when blank.
-  private static String effectiveOidcEndpoint(
+  private static String effectiveOidcProperty(
       final ConfigurableEnvironment env, final Map<String, Object> derived, final String suffix) {
     final String explicit = env.getProperty(OIDC_PREFIX + suffix);
     if (explicit != null) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -190,7 +190,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "benchmark-secret");
     legacy.put(
         "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI",
-        backend + "/protocol/openid-connect/certs");
+        "https://public-api-idp.example.com/keys");
 
     final StandardEnvironment env = environmentWith(legacy);
     processor.postProcessEnvironment(env, null);
@@ -200,12 +200,48 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         .isEqualTo(backend + "/protocol/openid-connect/auth");
     assertThat(env.getProperty(OIDC + "token-uri"))
         .isEqualTo(backend + "/protocol/openid-connect/token");
+    // The public API's own JWK set URI wins over the derived one: it may belong to a different IdP.
     assertThat(env.getProperty(OIDC + "jwk-set-uri"))
-        .isEqualTo(backend + "/protocol/openid-connect/certs");
+        .isEqualTo("https://public-api-idp.example.com/keys");
     // The credentials must come with them: a registration cannot be built without a client id, so
     // the guard that withholds them when there is no issuer has to count the derived endpoints.
     assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
     assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("benchmark-secret");
+  }
+
+  @Test
+  void shouldDeriveTheJwkSetUriFromTheBackendUrlWhenThePublicApiConfiguresNone() {
+    final String backend = "http://identity.svc:18080/auth/realms/camunda-platform";
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put("camunda.identity.issuerBackendUrl", backend);
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "jwk-set-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/certs");
+  }
+
+  @Test
+  void shouldWithholdCredentialsWhenAnEndpointIsExplicitlyBlank() {
+    // An explicitly set blank value outranks the derived one, so the trio CSL sees is incomplete.
+    // Bridging the credentials into it would swap the missing-endpoint failure for a missing-client
+    // one rather than fixing anything.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put(
+        "camunda.identity.issuerBackendUrl",
+        "http://identity.svc:18080/auth/realms/camunda-platform");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "secret");
+    legacy.put(OIDC + "token-uri", "");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "client-id")).isNull();
+    assertThat(env.getProperty(OIDC + "client-secret")).isNull();
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -178,6 +178,73 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldDeriveEndpointsFromIssuerBackendUrlWhenNoIssuerIsConfigured() {
+    // A deployment that only protects the public API: a JWK set URI, no browser-facing issuer. CSL
+    // needs an issuer-uri or all three endpoints, so without this it can build no registration at
+    // all and Optimize fails to start (camunda/camunda#60617).
+    final String backend = "http://identity.svc:18080/auth/realms/camunda-platform";
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put("camunda.identity.issuerBackendUrl", backend);
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "benchmark-secret");
+    legacy.put(
+        "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI",
+        backend + "/protocol/openid-connect/certs");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "authorization-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/auth");
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/token");
+    assertThat(env.getProperty(OIDC + "jwk-set-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/certs");
+    // The credentials must come with them: a registration cannot be built without a client id, so
+    // the guard that withholds them when there is no issuer has to count the derived endpoints.
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
+    assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("benchmark-secret");
+  }
+
+  @Test
+  void shouldNotDeriveEndpointsFromIssuerBackendUrlWhenAnIssuerIsConfigured() {
+    // With an issuer, CSL resolves the endpoints through discovery against the browser-facing URL.
+    // Deriving internal endpoints on top would override that.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put(
+        "camunda.identity.issuer", "https://public.example.com/auth/realms/camunda-platform");
+    legacy.put(
+        "camunda.identity.issuerBackendUrl",
+        "http://identity.svc:18080/auth/realms/camunda-platform");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri"))
+        .isEqualTo("https://public.example.com/auth/realms/camunda-platform");
+    assertThat(env.getProperty(OIDC + "authorization-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "token-uri")).isNull();
+  }
+
+  @Test
+  void shouldNotDoubleTheSeparatorWhenIssuerBackendUrlEndsWithSlash() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put(
+        "camunda.identity.issuerBackendUrl",
+        "http://identity.svc:18080/auth/realms/camunda-platform/");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(
+            "http://identity.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token");
+  }
+
+  @Test
   void shouldNotDeriveIssuerUriWhenTheHostConfiguredTheOidcEndpoints() {
     // The camunda-platform Helm chart renders the endpoints directly for a Keycloak setup, keeping
     // the back-channel on the in-cluster URL. Deriving an issuer-uri from camunda.identity.issuer

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -224,6 +224,48 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldDeriveEndpointsWhenTheCslIssuerUriIsExplicitlyBlank() {
+    // The legacy issuer would be bridged into issuer-uri, but the explicitly blank value outranks
+    // it, so CSL still sees no issuer and needs the endpoints.
+    final String backend = "http://identity.svc:18080/auth/realms/camunda-platform";
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "https://weblogin.example.com/realm");
+    legacy.put("camunda.identity.issuerBackendUrl", backend);
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "secret");
+    legacy.put(OIDC + "issuer-uri", "");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "authorization-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/auth");
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/token");
+    assertThat(env.getProperty(OIDC + "jwk-set-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/certs");
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
+    assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("secret");
+  }
+
+  @Test
+  void shouldWithholdCredentialsWhenTheCslIssuerUriIsExplicitlyBlankAndNoEndpointsCanBeDerived() {
+    // Same shadowed legacy issuer, but nothing to derive endpoints from: CSL would get credentials
+    // and no way to build a registration.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "https://weblogin.example.com/realm");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "secret");
+    legacy.put(OIDC + "issuer-uri", "");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "client-id")).isNull();
+    assertThat(env.getProperty(OIDC + "client-secret")).isNull();
+  }
+
+  @Test
   void shouldWithholdCredentialsWhenAnEndpointIsExplicitlyBlank() {
     // An explicitly set blank value outranks the derived one, so the trio CSL sees is incomplete.
     // Bridging the credentials into it would swap the missing-endpoint failure for a missing-client

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -31,7 +31,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   @RegisterExtension
   final LogCapturer logs =
       LogCapturer.create()
-          .captureForType(OptimizeSecurityConfigCompatibilityPostProcessor.class, Level.WARN);
+          .captureForType(OptimizeSecurityConfigCompatibilityPostProcessor.class, Level.INFO);
 
   private final OptimizeSecurityConfigCompatibilityPostProcessor processor =
       new OptimizeSecurityConfigCompatibilityPostProcessor();
@@ -221,6 +221,60 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
 
     assertThat(env.getProperty(OIDC + "jwk-set-uri"))
         .isEqualTo(backend + "/protocol/openid-connect/certs");
+  }
+
+  @Test
+  void shouldKeepExplicitlyConfiguredEndpointsAndDeriveOnlyTheMissingOnes() {
+    // A host that pointed one endpoint at its own IdP keeps it: the derived values are added as the
+    // lowest-precedence source, so they only fill the gaps.
+    final String backend = "http://identity.svc:18080/auth/realms/camunda-platform";
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put("camunda.identity.issuerBackendUrl", backend);
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put(OIDC + "authorization-uri", "https://idp.example.com/authorize");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "authorization-uri"))
+        .isEqualTo("https://idp.example.com/authorize");
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/token");
+    assertThat(env.getProperty(OIDC + "jwk-set-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/certs");
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
+  }
+
+  @Test
+  void shouldTellOperatorsWhichKeysToSetWhenEndpointsAreDerived() {
+    // The only signal that Optimize started with endpoints browser login cannot use.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put(
+        "camunda.identity.issuerBackendUrl",
+        "http://identity.svc:18080/auth/realms/camunda-platform");
+
+    processor.postProcessEnvironment(environmentWith(legacy), null);
+
+    logs.assertContains("camunda.identity.issuerBackendUrl");
+    logs.assertContains("Browser login cannot work against an internal URL");
+  }
+
+  @Test
+  void shouldNormaliseAWhitespacePaddedIssuerBackendUrl() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "");
+    legacy.put(
+        "camunda.identity.issuerBackendUrl",
+        "  http://identity.svc:18080/auth/realms/camunda-platform//  ");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(
+            "http://identity.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token");
   }
 
   @Test


### PR DESCRIPTION
## Description

Optimize fails to start when CSL is active and no browser-facing issuer
is configured — the shape of
a deployment that only protects the public API
(`api.jwtAuthForApiEnabled` plus a `jwtSetUri`). The
bridge derives no `issuer-uri` and bridges only a `jwk-set-uri`, while
still forcing `method=oidc`;
CSL accepts an `issuer-uri` **or** all three of
`authorization-uri`/`token-uri`/`jwk-set-uri`, so it
can build no client registration. Before CSL became the default (#60190)
that config ran on the
legacy stack, which needed only the JWK set URI. Seen in the Camunda PR
Benchmark install, whose
ConfigMap has `camunda.identity.issuer: ""` and a populated
`issuerBackendUrl`.

Derive the endpoints from `camunda.identity.issuerBackendUrl`. It is
deliberately not bridged into
`issuer-uri`, because CSL validates the discovery document's issuer
against the URL it dialed — but
explicit endpoints carry no such check. Confirmed on the affected
deployment: setting the three
values by hand starts the pod, with no code change.

Four behaviours worth reviewing:

- **The paths assume Keycloak's realm layout**, which is what the chart
points `issuerBackendUrl`
at. Behind another provider they are wrong, but only `jwk-set-uri` can
ever be dialed from here
(no issuer means no browser login), and the public API's own value wins
over it whenever set. Both
  the code and the log say so.
- **Only when no `issuer-uri` is available.** A deployment serving
browser login configures
`camunda.identity.issuer` and never reaches this — which matters,
because an `authorization-uri` on
  an internal URL cannot serve a real login. The code logs that.
- **The public API's own `jwk-set-uri` wins** over the derived one; it
may belong to a different IdP
  than Identity.
- **Both guards resolve the issuer and endpoints the way CSL will**,
rather than reading the bridge's
own map. An explicitly configured but blank value outranks anything
derived, so a bridge that
trusted its map would withhold the endpoint fallback and hand CSL
credentials it cannot use.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug
fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes),
[for CI
changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes),
[for docs
changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

Closes #60617
