### PR TITLE
fix: keep the Optimize cloud E2E backend booting under CSL

### DIFF
--- a/.github/workflows/optimize-e2e-tests-cloud-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-cloud-nightly.yml
@@ -22,6 +22,7 @@ on:
       - ".github/workflows/optimize-e2e-tests-cloud-nightly.yml"
       - "optimize/client/e2e/cloud-tests/**"
       - "optimize/client/e2e/config.js"
+      - "optimize/client/scripts/start-backend.js"
 
 # One bucket for the whole workflow: every run authenticates the same user against the same Auth0
 # tenant, and concurrent logins are what trip its per-IP throttling. In-flight runs are left to

--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -51,17 +51,33 @@ const commonEnv = {
 const cloudEnv = {
   SPRING_PROFILES_ACTIVE: 'cloud',
   ZEEBE_IMPORT_ENABLED: 'true',
-  CAMUNDA_OPTIMIZE_AUTH0_BACKENDDOMAIN: 'camunda-excitingdev.eu.auth0.com',
-  CAMUNDA_OPTIMIZE_AUTH0_CLIENTID: '4ySAuc47zUsrQVHzQGTTPSDCiecSoqnp',
-  CAMUNDA_OPTIMIZE_AUTH0_CLIENTSECRET: process.env.AUTH0_CLIENTSECRET,
-  CAMUNDA_OPTIMIZE_AUTH0_DOMAIN: 'weblogin.cloud.dev.ultrawombat.com',
+
+  // Not auth config. Optimize's own SaaS access control reads these and fails startup on a
+  // blank value, and the M2M Accounts client needs the token url and audience.
+  CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID: 'optimize-e2e-cloud',
   CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION: 'f4e522a8-f642-4293-b5cb-1d14e1730534',
   CAMUNDA_OPTIMIZE_AUTH0_TOKEN_URL: 'https://login.cloud.dev.ultrawombat.com/oauth/token',
-  SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI:
-    'https://camunda-excitingdev.eu.auth0.com/.well-known/jwks.json',
-  CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE: 'optimize.dev.ultrawombat.com',
   CAMUNDA_OPTIMIZE_M2M_ACCOUNTS_URL: 'https://accounts.cloud.dev.ultrawombat.com',
   CAMUNDA_OPTIMIZE_M2M_ACCOUNTS_AUTH0_AUDIENCE: 'cloud.dev.ultrawombat.com',
+
+  CAMUNDA_SECURITY_AUTHENTICATION_METHOD: 'OIDC',
+  CAMUNDA_SECURITY_SAAS_CLUSTERID: 'optimize-e2e-cloud',
+  CAMUNDA_SECURITY_SAAS_ORGANIZATIONID: 'f4e522a8-f642-4293-b5cb-1d14e1730534',
+  CAMUNDA_SECURITY_AUTHENTICATION_OIDC_CLIENTID: '4ySAuc47zUsrQVHzQGTTPSDCiecSoqnp',
+  CAMUNDA_SECURITY_AUTHENTICATION_OIDC_CLIENTSECRET: process.env.AUTH0_CLIENTSECRET,
+  CAMUNDA_SECURITY_AUTHENTICATION_OIDC_ISSUERURI: 'https://weblogin.cloud.dev.ultrawombat.com/',
+  CAMUNDA_SECURITY_AUTHENTICATION_OIDC_JWKSETURI:
+    'https://camunda-excitingdev.eu.auth0.com/.well-known/jwks.json',
+  CAMUNDA_SECURITY_AUTHENTICATION_OIDC_ORGANIZATIONID: 'f4e522a8-f642-4293-b5cb-1d14e1730534',
+  // Placeholder form on purpose, this is byte for byte what the bridge derives today.
+  CAMUNDA_SECURITY_AUTHENTICATION_OIDC_REDIRECTURI:
+    '{baseScheme}://{baseHost}{basePort}/sso-callback?uuid=optimize-e2e-cloud',
+  // Login id_token carries the client id as its only aud, bearer tokens carry the resource one.
+  CAMUNDA_SECURITY_AUTHENTICATION_OIDC_AUDIENCES:
+    'optimize.dev.ultrawombat.com,4ySAuc47zUsrQVHzQGTTPSDCiecSoqnp',
+  CAMUNDA_SECURITY_AUTHENTICATION_OIDC_AUTHORIZEREQUEST_ADDITIONALPARAMETERS_AUDIENCE:
+    'cloud.dev.ultrawombat.com',
+
   CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN: 'true',
   CAMUNDA_OPTIMIZE_NOTIFICATIONS_URL: 'https://notifications.cloud.dev.ultrawombat.com',
 };


### PR DESCRIPTION
## Description

The nightly [Optimize E2E Cloud](https://github.com/camunda/camunda/actions/workflows/optimize-e2e-tests-cloud-nightly.yml) smoke job [went red on main](https://github.com/camunda/camunda/actions/runs/32327739251/job/96302297276) the night after #60190 made `optimize.security.csl.enabled` default to `true`. The backend never started, so the job died waiting for `/api/readyz`:

```
Caused by: java.lang.IllegalStateException: CCSaaS CSL mode requires a non-blank clusterId:
SaaS organization and cluster access control cannot be enforced without it.
```

CSL's CCSaaS wiring refuses to start without a cluster id, and the cloud stack `start-backend.js` brings up never set `CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID` — the legacy stack it replaced only used the cluster id to derive a request path prefix and was happy without it.

This sets a cluster id, and pins the context path to the root alongside it. A cluster id otherwise moves the app under `/<clusterId>`, which the dev server in front of it does not know about: it proxies to the backend at the root, so every proxied request would 404. Pinning the context path keeps the cluster id a pure security-configuration value here, which is all this stack needs it for — no cluster backs it.

The alternative, disabling CSL for this job, was rejected: it would leave the only Auth0 login coverage we have exercising a stack that no longer ships.

The second commit adds `optimize/client/scripts/start-backend.js` to the workflow's `pull_request` paths, on the same grounds the cloud test itself is already listed there — a mistake in its cloud environment block fails the run outright, as this one did. Without it this fix would only be verifiable after merge, on the next night's run.

## Checklist

- [x] No backport needed: `stable/8.8` and `stable/8.9` still default CSL to off, so their copies of this stack start fine without a cluster id.

## Related issues

Follow-up to #60190.