### PR TITLE
Commit and discard agent history for external agents

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAgentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAgentIT.java
@@ -43,6 +43,8 @@ public class AuditLogAgentIT {
           .withAuthenticatedAccess();
 
   private static final String AGENT_ELEMENT_ID = "test_agent_ahsp";
+  private static final String EXTERNAL_AGENT_ELEMENT_ID = "external_agent_service_task";
+  private static final String EXTERNAL_AGENT_JOB_TYPE = "external-agent-job";
   private static CamundaClient adminClient;
 
   @BeforeAll
@@ -69,6 +71,26 @@ public class AuditLogAgentIT {
         .send()
         .join();
 
+    // Deploy a process with an external agent service task, whose job type does not carry the
+    // legacy agentic job type prefix, and complete its job
+    final var externalAgentProcessModel =
+        Bpmn.createExecutableProcess("EXTERNAL_AGENT_PROCESS")
+            .startEvent()
+            .serviceTask(
+                EXTERNAL_AGENT_ELEMENT_ID,
+                t -> t.zeebeJobType(EXTERNAL_AGENT_JOB_TYPE).zeebeExternalAgentDefinition())
+            .endEvent()
+            .done();
+    final var externalAgentProcess =
+        deployProcessAndWaitForIt(client, externalAgentProcessModel, "external_agent_process.bpmn");
+    final var externalAgentProcessInstance =
+        startProcessInstance(client, externalAgentProcess.getBpmnProcessId());
+    waitForProcessInstancesToStart(client, 2);
+
+    final var externalAgentJobs =
+        waitForJobs(client, List.of(externalAgentProcessInstance.getProcessInstanceKey()));
+    client.newCompleteCommand(externalAgentJobs.getFirst().getJobKey()).send().join();
+
     // Wait for audit logs to be available
     Awaitility.await("job to be completed")
         .ignoreExceptionsInstanceOf(ProblemException.class)
@@ -85,7 +107,7 @@ public class AuditLogAgentIT {
                       .send()
                       .join();
 
-              assertThat(result.items()).hasSize(1);
+              assertThat(result.items()).hasSize(2);
             });
   }
 
@@ -151,5 +173,44 @@ public class AuditLogAgentIT {
             auditLog -> {
               assertThat(auditLog.getAgentElementId()).startsWith("test_agent");
             });
+  }
+
+  @Test
+  void shouldAttributeExternalAgentJobInAuditLog(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // when - search for the external agent job's audit log entry
+    final var result =
+        client
+            .newAuditLogSearchRequest()
+            .filter(f -> f.entityType(AuditLogEntityTypeEnum.JOB))
+            .send()
+            .join();
+
+    // then - the entry for the external agent job carries the agent element id
+    assertThat(result.items())
+        .filteredOn(auditLog -> auditLog.getEntityDescription().equals(EXTERNAL_AGENT_JOB_TYPE))
+        .describedAs("audit log entry for the external agent job")
+        .hasSize(1)
+        .allSatisfy(
+            auditLog ->
+                assertThat(auditLog.getAgentElementId())
+                    .describedAs("agent element id of the external agent job's audit log entry")
+                    .isEqualTo(EXTERNAL_AGENT_ELEMENT_ID));
+
+    // when - filter audit logs by the external agent's element id
+    final var filteredResult =
+        client
+            .newAuditLogSearchRequest()
+            .filter(f -> f.agentElementId(EXTERNAL_AGENT_ELEMENT_ID))
+            .send()
+            .join();
+
+    // then - the filter finds the external agent's audit log entry
+    assertThat(filteredResult.items())
+        .describedAs("audit logs filtered by the external agent's element id")
+        .isNotEmpty()
+        .allSatisfy(
+            auditLog ->
+                assertThat(auditLog.getAgentElementId()).isEqualTo(EXTERNAL_AGENT_ELEMENT_ID));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentDefinitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentDefinitionBehavior.java
@@ -28,9 +28,13 @@ public final class AgentDefinitionBehavior {
    *
    * <p>A job's element id does not always refer to a real BPMN element: for example, {@link
    * io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor} overwrites it with a synthetic
-   * marker when an error is thrown but not caught, and a deployment can be deleted while one of its
-   * jobs is still in flight. Neither case can have an agent definition, so both resolve to {@code
-   * false} rather than raising.
+   * marker when an error is thrown but not caught. That case can't have an agent definition, so it
+   * resolves to {@code false} rather than raising.
+   *
+   * <p>The process lookup is defensive rather than a known reachable case: process deletion drains
+   * until every active instance finishes, so a job on a running instance always finds its process
+   * in state. Resolving to {@code false} here guards against that invariant changing, rather than
+   * documenting a gap that exists today.
    */
   public boolean belongsToAgent(final JobRecord job) {
     final var process =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentDefinitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentDefinitionBehavior.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public final class AgentDefinitionBehavior {
+
+  private final ProcessState processState;
+
+  public AgentDefinitionBehavior(final ProcessState processState) {
+    this.processState = processState;
+  }
+
+  /**
+   * Answers whether the given job belongs to an agent, i.e. whether the job's element was marked as
+   * an agent definition at deployment time. It is cheap enough to call on every job cancellation,
+   * completion, and thrown error.
+   */
+  public boolean belongsToAgent(final JobRecord job) {
+    final var process =
+        processState.getProcessByKeyAndTenant(job.getProcessDefinitionKey(), job.getTenantId());
+
+    final ExecutableFlowElement element =
+        process.getProcess().getElementById(job.getElementIdBuffer());
+    if (element == null) {
+      throw new IllegalStateException(
+          "Expected element with id '%s' to exist in process with key '%d', but it did not"
+              .formatted(
+                  BufferUtil.bufferAsString(job.getElementIdBuffer()),
+                  job.getProcessDefinitionKey()));
+    }
+
+    // A multi-instance body and its inner activity share the same element id, but only the inner
+    // activity can carry the agent-definition marker. Resolve to it here, or a job on a
+    // multi-instance agent element would look like it doesn't belong to an agent.
+    final ExecutableFlowElement agentDefinitionElement =
+        element instanceof final ExecutableMultiInstanceBody multiInstanceBody
+            ? multiInstanceBody.getInnerActivity()
+            : element;
+
+    return agentDefinitionElement instanceof final ExecutableJobWorkerElement jobWorkerElement
+        && jobWorkerElement.isAgentDefinition();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentDefinitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentDefinitionBehavior.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJob
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public final class AgentDefinitionBehavior {
 
@@ -26,19 +25,24 @@ public final class AgentDefinitionBehavior {
    * Answers whether the given job belongs to an agent, i.e. whether the job's element was marked as
    * an agent definition at deployment time. It is cheap enough to call on every job cancellation,
    * completion, and thrown error.
+   *
+   * <p>A job's element id does not always refer to a real BPMN element: for example, {@link
+   * io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor} overwrites it with a synthetic
+   * marker when an error is thrown but not caught, and a deployment can be deleted while one of its
+   * jobs is still in flight. Neither case can have an agent definition, so both resolve to {@code
+   * false} rather than raising.
    */
   public boolean belongsToAgent(final JobRecord job) {
     final var process =
         processState.getProcessByKeyAndTenant(job.getProcessDefinitionKey(), job.getTenantId());
+    if (process == null) {
+      return false;
+    }
 
     final ExecutableFlowElement element =
         process.getProcess().getElementById(job.getElementIdBuffer());
     if (element == null) {
-      throw new IllegalStateException(
-          "Expected element with id '%s' to exist in process with key '%d', but it did not"
-              .formatted(
-                  BufferUtil.bufferAsString(job.getElementIdBuffer()),
-                  job.getProcessDefinitionKey()));
+      return false;
     }
 
     // A multi-instance body and its inner activity share the same element id, but only the inner

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -65,5 +65,7 @@ public interface BpmnBehaviors {
 
   AgentInstanceBehavior agentInstanceBehavior();
 
+  AgentDefinitionBehavior agentDefinitionBehavior();
+
   BpmnProcessDeletionBehavior processDeletionBehavior();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -75,6 +75,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final ExpressionBehavior expressionBehavior;
   private final ExpressionLanguage expressionLanguage;
   private final AgentInstanceBehavior agentInstanceBehavior;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
 
   public BpmnBehaviorsImpl(
       final MutableProcessingState processingState,
@@ -264,6 +265,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             config.isCandidateGroupNameResolution(),
             clock);
 
+    agentDefinitionBehavior = new AgentDefinitionBehavior(processingState.getProcessState());
+
     jobBehavior =
         new BpmnJobBehavior(
             processingState.getKeyGenerator(),
@@ -274,6 +277,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getResourceState(),
             processingState.getFormState(),
             processingState.getAgentDefinitionState(),
+            agentDefinitionBehavior,
             incidentBehavior,
             jobActivationBehavior,
             jobMetrics,
@@ -469,6 +473,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public AgentInstanceBehavior agentInstanceBehavior() {
     return agentInstanceBehavior;
+  }
+
+  @Override
+  public AgentDefinitionBehavior agentDefinitionBehavior() {
+    return agentDefinitionBehavior;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -134,6 +134,7 @@ public final class BpmnJobBehavior {
   private final ResourceState resourceState;
   private final FormState formState;
   private final AgentDefinitionState agentDefinitionState;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
   private final JobProcessingMetrics jobMetrics;
   private final BpmnJobActivationBehavior jobActivationBehavior;
@@ -150,6 +151,7 @@ public final class BpmnJobBehavior {
       final ResourceState resourceState,
       final FormState formState,
       final AgentDefinitionState agentDefinitionState,
+      final AgentDefinitionBehavior agentDefinitionBehavior,
       final BpmnIncidentBehavior incidentBehavior,
       final BpmnJobActivationBehavior jobActivationBehavior,
       final JobProcessingMetrics jobMetrics,
@@ -165,6 +167,7 @@ public final class BpmnJobBehavior {
     this.resourceState = resourceState;
     this.formState = formState;
     this.agentDefinitionState = agentDefinitionState;
+    this.agentDefinitionBehavior = agentDefinitionBehavior;
     this.incidentBehavior = incidentBehavior;
     this.jobMetrics = jobMetrics;
     this.jobActivationBehavior = jobActivationBehavior;
@@ -822,7 +825,7 @@ public final class BpmnJobBehavior {
       // it there as well.
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
       jobMetrics.countJobEvent(JobAction.CANCELED, job.getJobKind(), job.getType());
-      if (job.isAgentic()) {
+      if (agentDefinitionBehavior.belongsToAgent(job)) {
         // The job is destroyed without completing — discard all its pending history items. The
         // lease is left empty on purpose: the whole job is gone, so every activation's items must
         // be discarded regardless of the lease they were created with.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -34,6 +35,7 @@ public final class JobCancelProcessor
   public static final String NO_JOB_FOUND_MESSAGE =
       "Expected to cancel job with key '%d', but no such job was found";
   private final JobState jobState;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
   private final JobProcessingMetrics jobMetrics;
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
@@ -41,8 +43,12 @@ public final class JobCancelProcessor
   private final TypedRejectionWriter rejectionWriter;
 
   public JobCancelProcessor(
-      final ProcessingState state, final JobProcessingMetrics jobMetrics, final Writers writers) {
+      final ProcessingState state,
+      final AgentDefinitionBehavior agentDefinitionBehavior,
+      final JobProcessingMetrics jobMetrics,
+      final Writers writers) {
     jobState = state.getJobState();
+    this.agentDefinitionBehavior = agentDefinitionBehavior;
     this.jobMetrics = jobMetrics;
     stateWriter = writers.state();
     commandWriter = writers.command();
@@ -59,7 +65,7 @@ public final class JobCancelProcessor
       // it there as well.
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
       jobMetrics.countJobEvent(JobAction.CANCELED, job.getJobKind(), job.getType());
-      if (job.isAgentic()) {
+      if (agentDefinitionBehavior.belongsToAgent(job)) {
         // The job is destroyed without completing — discard all its pending history items. The
         // lease is left empty on purpose: the whole job is gone, so every activation's items must
         // be discarded regardless of the lease they were created with.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -219,7 +219,7 @@ public final class JobCompleteProcessor
       final TypedRecord<JobRecord> command, final JobRecord job, final ProcessingSession session) {
 
     final boolean jobBelongsToAgent = agentDefinitionBehavior.belongsToAgent(job);
-    if (job.isAgentic() || jobBelongsToAgent) {
+    if (job.hasAgenticPrefix() || jobBelongsToAgent) {
       session.appendAgentInfoToFollowUps(new AgentInfo().setElementId(job.getElementId()));
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -300,7 +300,8 @@ public final class JobCompleteProcessor
   }
 
   private void preCompleteActions(final JobRecord job, final ProcessingSession session) {
-    if (job.isAgentic()) {
+    final boolean belongsToAgent = agentDefinitionBehavior.belongsToAgent(job);
+    if (job.isAgentic() || belongsToAgent) {
       session.appendAgentInfoToFollowUps(new AgentInfo().setElementId(job.getElementId()));
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -218,7 +218,10 @@ public final class JobCompleteProcessor
   private void completeJob(
       final TypedRecord<JobRecord> command, final JobRecord job, final ProcessingSession session) {
 
-    preCompleteActions(job, session);
+    final boolean jobBelongsToAgent = agentDefinitionBehavior.belongsToAgent(job);
+    if (job.isAgentic() || jobBelongsToAgent) {
+      session.appendAgentInfoToFollowUps(new AgentInfo().setElementId(job.getElementId()));
+    }
 
     // If job completed variables are disabled, emit the COMPLETED event without variables to avoid
     // ExceededBatchRecordSizeException. Variables are not needed in the COMPLETED event; exporters
@@ -232,7 +235,7 @@ public final class JobCompleteProcessor
     responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), JobIntent.COMPLETED, job, command);
 
-    if (agentDefinitionBehavior.belongsToAgent(job)) {
+    if (jobBelongsToAgent) {
       commandWriter.appendFollowUpCommand(
           command.getKey(),
           AgentHistoryIntent.COMMIT,
@@ -297,13 +300,6 @@ public final class JobCompleteProcessor
     }
 
     return businessIdAssignmentBehavior.validate(processInstance, businessIdToAssign).map(d -> job);
-  }
-
-  private void preCompleteActions(final JobRecord job, final ProcessingSession session) {
-    final boolean belongsToAgent = agentDefinitionBehavior.belongsToAgent(job);
-    if (job.isAgentic() || belongsToAgent) {
-      session.appendAgentInfoToFollowUps(new AgentInfo().setElementId(job.getElementId()));
-    }
   }
 
   private void postCompleteActions(final JobRecord value) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessUtils;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.ValidationException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
@@ -137,6 +138,7 @@ public final class JobCompleteProcessor
   private final JobProcessingMetrics jobMetrics;
   private final EventHandle eventHandle;
   private final ProcessingState processState;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
   private final VariableBehavior variableBehavior;
   private final ProcessInstanceBusinessIdAssignmentBehavior businessIdAssignmentBehavior;
 
@@ -154,10 +156,12 @@ public final class JobCompleteProcessor
       final EventHandle eventHandle,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
+      final AgentDefinitionBehavior agentDefinitionBehavior,
       final VariableBehavior variableBehavior,
       final boolean includeVariablesInJobCompletedEvent,
       final boolean businessIdUniquenessEnabled) {
     processState = state;
+    this.agentDefinitionBehavior = agentDefinitionBehavior;
     userTaskState = state.getUserTaskState();
     elementInstanceState = state.getElementInstanceState();
     commandWriter = writers.command();
@@ -228,7 +232,7 @@ public final class JobCompleteProcessor
     responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), JobIntent.COMPLETED, job, command);
 
-    if (job.isAgentic()) {
+    if (agentDefinitionBehavior.belongsToAgent(job)) {
       commandWriter.appendFollowUpCommand(
           command.getKey(),
           AgentHistoryIntent.COMMIT,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -65,6 +65,7 @@ public final class JobEventProcessors {
                 eventHandle,
                 cslCheck,
                 tenantCheck,
+                bpmnBehaviors.agentDefinitionBehavior(),
                 bpmnBehaviors.variableBehavior(),
                 config.isIncludeVariablesInJobCompletedEvent(),
                 config.isBusinessIdUniquenessEnabled()))
@@ -97,6 +98,7 @@ public final class JobEventProcessors {
                 tenantCheck,
                 writers,
                 incidentMetrics,
+                bpmnBehaviors.agentDefinitionBehavior(),
                 bpmnBehaviors.variableBehavior()))
         .onCommand(
             ValueType.JOB,
@@ -118,7 +120,8 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.CANCEL,
-            new JobCancelProcessor(processingState, jobMetrics, writers))
+            new JobCancelProcessor(
+                processingState, bpmnBehaviors.agentDefinitionBehavior(), jobMetrics, writers))
         .onCommand(
             ValueType.JOB,
             JobIntent.RECUR_AFTER_BACKOFF,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -91,6 +92,7 @@ public class JobThrowErrorProcessor
   private final TypedCommandWriter commandWriter;
   private final IncidentMetrics incidentMetrics;
   private final VariableBehavior variableBehavior;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
 
   public JobThrowErrorProcessor(
       final ProcessingState state,
@@ -101,12 +103,14 @@ public class JobThrowErrorProcessor
       final CslTenantCheck tenantCheck,
       final Writers writers,
       final IncidentMetrics incidentMetrics,
+      final AgentDefinitionBehavior agentDefinitionBehavior,
       final VariableBehavior variableBehavior) {
     this.keyGenerator = keyGenerator;
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
     processState = state.getProcessState();
     eventScopeInstanceState = state.getEventScopeInstanceState();
+    this.agentDefinitionBehavior = agentDefinitionBehavior;
     this.cslCheck = cslCheck;
 
     preconditionChecker =
@@ -207,7 +211,7 @@ public class JobThrowErrorProcessor
     } else {
       writeThrowErrorEvent(jobKey, job, command);
       eventPublicationBehavior.throwErrorEvent(foundCatchEvent.get(), job.getVariablesBuffer());
-      if (job.isAgentic()) {
+      if (agentDefinitionBehavior.belongsToAgent(job)) {
         // The error was caught, so the job is deleted without completing — discard all its pending
         // history items. The lease is left empty on purpose: the whole job is gone, so every
         // activation's items must be discarded regardless of the lease they were created with.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior.UserTaskProperties;
@@ -78,6 +79,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
   private final BpmnUserTaskBehavior userTaskBehavior;
   private final JobState jobState;
   private final UserTaskState userTaskState;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
 
   public ProcessInstanceMigrationUserTaskBehavior(
       final StateWriter stateWriter,
@@ -89,6 +91,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
     this.commandWriter = commandWriter;
     this.jobState = jobState;
     this.userTaskState = userTaskState;
+    agentDefinitionBehavior = bpmnBehaviors.agentDefinitionBehavior();
     userTaskBehavior = bpmnBehaviors.userTaskBehavior();
   }
 
@@ -160,7 +163,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
     job.setIsJobToUserTaskMigration(true);
     // Cancel previous job worker job
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
-    if (job.isAgentic()) {
+    if (agentDefinitionBehavior.belongsToAgent(job)) {
       // The job is destroyed without completing — discard all its pending history items. The lease
       // is left empty on purpose: the whole job is gone, so every activation's items must be
       // discarded regardless of the lease they were created with. Today the cancelled job is a

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -41,6 +41,12 @@ public class AgentHistoryCommitTest {
   private static final String EXTERNAL_AD_HOC_SUB_PROCESS_ID = "external-agent-ad-hoc-sub-process";
   private static final String EXTERNAL_AD_HOC_INNER_TASK_ID = "external-agent-ad-hoc-inner-task";
   private static final String EXTERNAL_AD_HOC_JOB_TYPE = "external-agent-ad-hoc-job";
+  private static final String EXTERNAL_MULTI_INSTANCE_PROCESS_ID =
+      "external-agent-multi-instance-service-task";
+  private static final String EXTERNAL_MULTI_INSTANCE_TASK_ID =
+      "external-agent-multi-instance-task";
+  private static final String EXTERNAL_MULTI_INSTANCE_JOB_TYPE =
+      "external-agent-multi-instance-job";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
@@ -148,6 +154,75 @@ public class AgentHistoryCommitTest {
             "a history item for an external agent's ad-hoc sub-process job must reach COMMITTED"
                 + " when its job completes, even though the job type does not carry the legacy"
                 + " agentic prefix")
+        .isEqualTo(jobKey);
+  }
+
+  /**
+   * A multi-instance body and its inner activity share the same BPMN element id, but only the inner
+   * activity can carry the {@code zeebe:agentDefinition} marker. {@link
+   * io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior#belongsToAgent}
+   * therefore resolves through the multi-instance body to the inner activity before checking for an
+   * agent definition.
+   *
+   * <p>This test proves the runtime half of that resolution — that a completed job on such an
+   * element commits its agent history. {@link
+   * io.camunda.zeebe.engine.processing.deployment.AgentDefinitionMultiInstanceDeploymentTest}
+   * proves the deploy-time half: that the {@code AgentDefinition} is minted for the inner activity,
+   * not the wrapping body.
+   */
+  @Test
+  public void shouldCommitAgentHistoryWhenExternalAgentMultiInstanceServiceTaskJobCompletes() {
+    // given — a service task with an external agent marker that is also configured as a
+    // multi-instance activity; the wrapping multi-instance body and the inner service task
+    // share the same BPMN element id, EXTERNAL_MULTI_INSTANCE_TASK_ID
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(EXTERNAL_MULTI_INSTANCE_PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    EXTERNAL_MULTI_INSTANCE_TASK_ID,
+                    t ->
+                        t.zeebeJobType(EXTERNAL_MULTI_INSTANCE_JOB_TYPE)
+                            .zeebeExternalAgentDefinition()
+                            .multiInstance(m -> m.zeebeInputCollectionExpression("[1]")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(EXTERNAL_MULTI_INSTANCE_PROCESS_ID).create();
+    // withElementType(SERVICE_TASK) picks the inner activity's ELEMENT_ACTIVATED record, not the
+    // wrapping MULTI_INSTANCE_BODY's — both share EXTERNAL_MULTI_INSTANCE_TASK_ID as element id.
+    final var serviceTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(EXTERNAL_MULTI_INSTANCE_TASK_ID)
+            .getFirst();
+    final long elementInstanceKey = serviceTaskInstance.getKey();
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+
+    ENGINE.jobs().withType(EXTERNAL_MULTI_INSTANCE_JOB_TYPE).activate();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(EXTERNAL_MULTI_INSTANCE_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+
+    // when
+    ENGINE.job().withKey(jobKey).complete();
+
+    // then
+    final var committed =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withRecordKey(itemKey)
+            .getFirst();
+    assertThat(committed.getValue().getJobKey())
+        .describedAs(
+            "a history item for a multi-instance-wrapped agent's job must reach COMMITTED when"
+                + " its job completes")
         .isEqualTo(jobKey);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -37,6 +37,10 @@ public class AgentHistoryCommitTest {
   private static final String EXTERNAL_SERVICE_TASK_PROCESS_ID = "external-agent-service-task";
   private static final String EXTERNAL_SERVICE_TASK_ID = "external-agent-task";
   private static final String EXTERNAL_SERVICE_TASK_JOB_TYPE = "external-agent-job";
+  private static final String EXTERNAL_AD_HOC_PROCESS_ID = "external-agent-ad-hoc-process";
+  private static final String EXTERNAL_AD_HOC_SUB_PROCESS_ID = "external-agent-ad-hoc-sub-process";
+  private static final String EXTERNAL_AD_HOC_INNER_TASK_ID = "external-agent-ad-hoc-inner-task";
+  private static final String EXTERNAL_AD_HOC_JOB_TYPE = "external-agent-ad-hoc-job";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
@@ -89,6 +93,61 @@ public class AgentHistoryCommitTest {
         .describedAs(
             "a history item for an external agent's job must reach COMMITTED when its job"
                 + " completes, even though the job type does not carry the legacy agentic prefix")
+        .isEqualTo(jobKey);
+  }
+
+  @Test
+  public void shouldCommitAgentHistoryWhenExternalAgentAdHocSubProcessJobCompletes() {
+    // given — external agent marker on an ad-hoc sub-process, job type does not carry the legacy
+    // agentic prefix
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(EXTERNAL_AD_HOC_PROCESS_ID)
+                .startEvent()
+                .adHocSubProcess(
+                    EXTERNAL_AD_HOC_SUB_PROCESS_ID,
+                    ahsp -> {
+                      ahsp.zeebeExternalAgentDefinition();
+                      ahsp.task(EXTERNAL_AD_HOC_INNER_TASK_ID);
+                      ahsp.zeebeJobType(EXTERNAL_AD_HOC_JOB_TYPE);
+                    })
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(EXTERNAL_AD_HOC_PROCESS_ID).create();
+    final var adHocSubProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .withElementId(EXTERNAL_AD_HOC_SUB_PROCESS_ID)
+            .getFirst();
+    final long elementInstanceKey = adHocSubProcessInstance.getKey();
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+
+    ENGINE.jobs().withType(EXTERNAL_AD_HOC_JOB_TYPE).activate();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(EXTERNAL_AD_HOC_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+
+    // when
+    ENGINE.job().withKey(jobKey).complete();
+
+    // then
+    final var committed =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withRecordKey(itemKey)
+            .getFirst();
+    assertThat(committed.getValue().getJobKey())
+        .describedAs(
+            "a history item for an external agent's ad-hoc sub-process job must reach COMMITTED"
+                + " when its job completes, even though the job type does not carry the legacy"
+                + " agentic prefix")
         .isEqualTo(jobKey);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -34,8 +34,63 @@ public class AgentHistoryCommitTest {
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_ID = "agent-task";
   private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String EXTERNAL_SERVICE_TASK_PROCESS_ID = "external-agent-service-task";
+  private static final String EXTERNAL_SERVICE_TASK_ID = "external-agent-task";
+  private static final String EXTERNAL_SERVICE_TASK_JOB_TYPE = "external-agent-job";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCommitAgentHistoryWhenExternalAgentServiceTaskJobCompletes() {
+    // given — external agent marker on a service task, job type does not carry the legacy
+    // agentic prefix
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(EXTERNAL_SERVICE_TASK_PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    EXTERNAL_SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType(EXTERNAL_SERVICE_TASK_JOB_TYPE)
+                            .zeebeExternalAgentDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(EXTERNAL_SERVICE_TASK_PROCESS_ID).create();
+    final var serviceTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(EXTERNAL_SERVICE_TASK_ID)
+            .getFirst();
+    final long elementInstanceKey = serviceTaskInstance.getKey();
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+
+    ENGINE.jobs().withType(EXTERNAL_SERVICE_TASK_JOB_TYPE).activate();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(EXTERNAL_SERVICE_TASK_JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+
+    // when
+    ENGINE.job().withKey(jobKey).complete();
+
+    // then
+    final var committed =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withRecordKey(itemKey)
+            .getFirst();
+    assertThat(committed.getValue().getJobKey())
+        .describedAs(
+            "a history item for an external agent's job must reach COMMITTED when its job"
+                + " completes, even though the job type does not carry the legacy agentic prefix")
+        .isEqualTo(jobKey);
+  }
 
   @Test
   public void shouldEmitCommittedEventOnCommitCommand() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -172,22 +172,41 @@ public class AgentHistoryDiscardOnJobDestructionTest {
 
   @Test
   public void shouldNotDiscardWhenNonAgenticJobIsCanceled() {
-    // given
-    final var fixture = deployActivateAndCreatePendingItem(process(PLAIN_JOB_TYPE), PLAIN_JOB_TYPE);
+    // given — a plain service task with no agent definition anywhere, so it cannot carry a
+    // pending history item in the first place
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(PLAIN_JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    ENGINE.jobs().withType(PLAIN_JOB_TYPE).activate();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(PLAIN_JOB_TYPE)
+            .getFirst()
+            .getKey();
 
     // when
-    ENGINE.processInstance().withInstanceKey(fixture.processInstanceKey).cancel();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
     final long clockResetKey = ENGINE.clock().reset().getKey();
 
-    // then — the job is canceled but no discard is emitted for this non-agentic job. Scope by
-    // jobKey so residual async records from other tests on the shared engine cannot interfere.
+    // then — scope by jobKey so residual async records from other tests on the shared engine
+    // cannot interfere.
     assertThat(
             RecordingExporter.records()
                 .limit(r -> r.getKey() == clockResetKey)
                 .withValueType(ValueType.AGENT_HISTORY)
                 .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARD)
-                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == fixture.jobKey)
+                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == jobKey)
                 .exists())
+        .describedAs(
+            "no discard command is emitted for a job whose element has no agent definition")
         .isFalse();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -150,6 +150,27 @@ public class AgentHistoryDiscardOnJobDestructionTest {
   }
 
   @Test
+  public void shouldDiscardPendingItemsWhenExternalAgentJobCanceledByProcessInstanceCancellation() {
+    // given — external agent marker, job type does not carry the legacy agentic prefix
+    final var fixture =
+        deployActivateAndCreatePendingItem(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(EXTERNAL_AGENT_JOB_TYPE).zeebeExternalAgentDefinition())
+                .endEvent()
+                .done(),
+            EXTERNAL_AGENT_JOB_TYPE);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(fixture.processInstanceKey).cancel();
+
+    // then
+    assertItemDiscarded(fixture.jobKey, fixture.itemKey);
+  }
+
+  @Test
   public void shouldNotDiscardWhenNonAgenticJobIsCanceled() {
     // given
     final var fixture = deployActivateAndCreatePendingItem(process(PLAIN_JOB_TYPE), PLAIN_JOB_TYPE);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -121,6 +121,35 @@ public class AgentHistoryDiscardOnJobDestructionTest {
   }
 
   @Test
+  public void shouldDiscardPendingItemsWhenExternalAgentJobThrowsCaughtError() {
+    // given — external agent marker, job type does not carry the legacy agentic prefix
+    final var fixture =
+        deployActivateAndCreatePendingItem(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(EXTERNAL_AGENT_JOB_TYPE).zeebeExternalAgentDefinition())
+                .boundaryEvent(BOUNDARY_ID, b -> b.error(ERROR_CODE))
+                .endEvent()
+                .moveToActivity(SERVICE_TASK_ID)
+                .endEvent()
+                .done(),
+            EXTERNAL_AGENT_JOB_TYPE);
+
+    // when — error is caught by the boundary event, so the job is deleted without completing
+    ENGINE
+        .job()
+        .ofInstance(fixture.processInstanceKey)
+        .withType(EXTERNAL_AGENT_JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertItemDiscarded(fixture.jobKey, fixture.itemKey);
+  }
+
+  @Test
   public void shouldNotDiscardWhenNonAgenticJobIsCanceled() {
     // given
     final var fixture = deployActivateAndCreatePendingItem(process(PLAIN_JOB_TYPE), PLAIN_JOB_TYPE);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -44,6 +44,7 @@ public class AgentHistoryDiscardOnJobDestructionTest {
   private static final String AGENTIC_JOB_TYPE =
       JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
   private static final String PLAIN_JOB_TYPE = "plain-service-task";
+  private static final String EXTERNAL_AGENT_JOB_TYPE = "external-agent-task";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
@@ -90,6 +91,30 @@ public class AgentHistoryDiscardOnJobDestructionTest {
         .withType(AGENTIC_JOB_TYPE)
         .withErrorCode(ERROR_CODE)
         .throwError();
+
+    // then
+    assertItemDiscarded(fixture.jobKey, fixture.itemKey);
+  }
+
+  @Test
+  public void shouldDiscardPendingItemsWhenExternalAgentJobCanceledByCancelCommand() {
+    // given — external agent marker, job type does not carry the legacy agentic prefix
+    final var fixture =
+        deployActivateAndCreatePendingItem(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(EXTERNAL_AGENT_JOB_TYPE).zeebeExternalAgentDefinition())
+                .endEvent()
+                .done(),
+            EXTERNAL_AGENT_JOB_TYPE);
+
+    // when — explicit JOB:CANCEL command (JobCancelProcessor path)
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .key(fixture.jobKey)
+            .job(JobIntent.CANCEL, new JobRecord().setType(EXTERNAL_AGENT_JOB_TYPE)));
 
     // then
     assertItemDiscarded(fixture.jobKey, fixture.itemKey);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
@@ -144,6 +145,46 @@ public final class CompleteJobTest {
                             && r.getKey() == recordValue.getProcessInstanceKey()))
         .isNotEmpty()
         .allMatch(r -> "task".equals(r.getAgent().getElementId()));
+  }
+
+  @Test
+  public void shouldCompleteExternalAgentJobWithFollowupMetadata() {
+    // given
+    final var externalAgentJobType = jobType;
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    t -> t.zeebeJobType(externalAgentJobType).zeebeExternalAgentDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(externalAgentJobType).activate(username);
+
+    // when
+    final Record<JobRecordValue> jobCompletedRecord =
+        ENGINE.job().withKey(batchRecord.getValue().getJobKeys().get(0)).complete();
+
+    // then
+    final JobRecordValue recordValue = jobCompletedRecord.getValue();
+    assertThat(
+            RecordingExporter.records()
+                .withSourceRecordPosition(jobCompletedRecord.getSourceRecordPosition())
+                .between(
+                    l -> l.getIntent().equals(JobIntent.COMPLETED),
+                    r ->
+                        r.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                            && r.getKey() == recordValue.getProcessInstanceKey()))
+        .describedAs(
+            "a job type not matching the legacy agentic prefix must still carry the agent "
+                + "element id when its element has a resolved external agent definition")
+        .isNotEmpty()
+        .allMatch(r -> r.getAgent() != null && "task".equals(r.getAgent().getElementId()));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -188,6 +188,34 @@ public final class CompleteJobTest {
   }
 
   @Test
+  public void shouldNotCarryAgentElementIdForNonAgenticJob() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).activate(username);
+
+    // when
+    final Record<JobRecordValue> jobCompletedRecord =
+        ENGINE.job().withKey(batchRecord.getValue().getJobKeys().get(0)).complete();
+
+    // then
+    final JobRecordValue recordValue = jobCompletedRecord.getValue();
+    assertThat(
+            RecordingExporter.records()
+                .withSourceRecordPosition(jobCompletedRecord.getSourceRecordPosition())
+                .between(
+                    l -> l.getIntent().equals(JobIntent.COMPLETED),
+                    r ->
+                        r.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                            && r.getKey() == recordValue.getProcessInstanceKey()))
+        .describedAs(
+            "a plain job with no agent definition and a job type not matching the legacy "
+                + "agentic prefix must not have an agent element id on any follow-up record")
+        .isNotEmpty()
+        .allMatch(r -> r.getAgent() == null || r.getAgent().getElementId().isEmpty());
+  }
+
+  @Test
   public void shouldRejectCompletionIfJobNotFound() {
     // given
     final int key = 123;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -719,6 +719,14 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
+  /**
+   * @deprecated This job-type-prefix check now only backs the 8.9 compatibility half of audit
+   *     attribution (jobs deployed on 8.9 with this job type and no resolved agent definition still
+   *     need attribution). Every other agentic decision uses whether the job's element has a
+   *     resolved agent definition instead. Remove once no supported version relies on this prefix
+   *     rule anymore, and affected processes have been redeployed with changed content.
+   */
+  @Deprecated
   @JsonIgnore
   public boolean isAgentic() {
     return getType().startsWith(IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -728,7 +728,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
    */
   @Deprecated
   @JsonIgnore
-  public boolean isAgentic() {
+  public boolean hasAgenticPrefix() {
     return getType().startsWith(IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX);
   }
 }


### PR DESCRIPTION
## Description

An external agent's job never reached `COMMITTED` or `DISCARDED` in agent history. Commit and discard both gated on a job-type prefix check (`io.camunda.agenticai:aiagent`), but external agents mark their element with `zeebe:agentDefinition agentType="external"` and can use any job type, so the prefix never matched. The follow-up `AGENT_HISTORY` command was never appended and pending items stayed `PENDING` forever.

This widens the check from the job-type prefix to whether the job's element has a resolved agent definition, which is the real signal for "is this job agentic" (an agent instance, and therefore agent history, cannot exist without one). Widening is non-breaking: a legacy-prefix job with no definition still no-ops in the commit/discard processors, exactly as it does today for non-agentic jobs.

**Also touches the audit log.** `JOB.COMPLETED` and its follow-up records get an agent element id stamped for the audit log and Operations Log UI. That reuses the same "is this job agentic" question, so the same disagreement applied there too. This PR widens audit attribution to an OR: attribute the job if its type carries the legacy prefix (kept, since some processes deployed on 8.9 rely on it and have no way to get an agent definition retroactively), or if it belongs to an agent. External agents now get the same attribution native and legacy agents already have.

The legacy prefix rule now survives in exactly one place, audit attribution, and is deprecated there. A follow-up issue tracks its removal (#60860), once no supported version relies on it and affected processes have been redeployed with changed content.

**Out of scope:**
- No upgrade or backfill path for pre-fix jobs. Agent history never shipped before this fix, so no customer cluster has a pre-fix job outliving it.
- The job-to-user-task migration discard call site is updated for consistency but stays untested: its own comment says the cancelled job is never agentic today, so the branch is unreachable.
- Removing the legacy prefix rule itself. Follow-up issue only.

No backport label: none of this exists on any `stable/*` branch (agent history is unreleased).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60554

