### PR TITLE
fix: query FOSSA with the release tag commit on monorepo releases

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -89,6 +89,7 @@ jobs:
     runs-on: gcp-core-32-release
     outputs:
       releaseTagRevision: ${{ steps.maven-perform-release.outputs.tagRevision }}
+      releaseTagCommitSha: ${{ steps.maven-perform-release.outputs.tagCommitSha }}
       releaseBranch: ${{ env.RELEASE_BRANCH }}
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
@@ -263,8 +264,11 @@ jobs:
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
           pushd target/checkout
           TAG_REVISION=$(git log -n 1 --pretty=format:'%h')
+          TAG_COMMIT_SHA=$(git rev-parse HEAD)
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
+          echo "Release tag ${RELEASE_TAG} points to commit ${TAG_COMMIT_SHA}"
+          echo "tagCommitSha=${TAG_COMMIT_SHA}" >> "$GITHUB_OUTPUT"
           popd
 
       - name: Validate flattened POM metadata
@@ -862,7 +866,7 @@ jobs:
           api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}
           project-id: "custom+50756/camunda/camunda@single-app"
-          revision-id: ${{ steps.fossa-context.outputs.head-revision }}
+          revision-id: ${{ needs.release.outputs.releaseTagCommitSha }}
           dry-run: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       - name: Create FOSSA releases and generate reports
         uses: camunda/infra-global-github-actions/fossa/release@fc4fa13813cbc1835129967f10a12f24aa7a393c
@@ -873,7 +877,7 @@ jobs:
           attribution-release-group-id: "4904" # https://app.fossa.com/projects/group/4904
           sbom-release-group-id: "4905"        # https://app.fossa.com/projects/group/4905
           release-number: ${{ env.RELEASE_VERSION }}
-          revision-id: ${{ steps.fossa-context.outputs.head-revision }}
+          revision-id: ${{ needs.release.outputs.releaseTagCommitSha }}
           attribution-format: "TXT"
           sbom-format: "CYCLONEDX_JSON"
           dry-run: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}


### PR DESCRIPTION
## Description

The `fossa-release` job of the monorepo release workflow sourced FOSSA's `revision-id` from `fossa/info`'s `head-revision`, which resolves to `github.sha` — the commit the release workflow was **dispatched** against.

During a release, `mvn release:prepare` mints the release commit and tag plus a development-version bump commit **after** `github.sha` is already frozen. `check-licenses.yml` scans the **tag commit** on tag push, so `wait-for-scan` queried a revision FOSSA never scanned and failed with HTTP 404. This blocked releases whenever the dispatch commit diverged from the tag commit (e.g. 8.8.21), and was previously unblocked only via a manual fake-PR workaround that minted a revision for the wrong SHA.

## Fix

- Resolve the release tag's full commit SHA from Maven's `target/checkout` release checkout in the `release` job and expose it as a new job output `releaseTagCommitSha`.
- The `fossa-release` job now uses that SHA as `revision-id` for both `wait-for-scan` and the FOSSA `release` step, so the FOSSA gate always targets the exact commit `check-licenses` scanned.

## Notes

- The existing short `releaseTagRevision` output is retained — it still feeds Docker image metadata consumers.
- The FOSSA `branch:` label is intentionally left unchanged: `wait-for-scan` matches only on the revision locator (`PROJECT_ID$REVISION_ID`) and ignores `branch`.

Related to #50175
