### PR TITLE
fix: upgrade netty to 4.1.137.Final to resolve CVE-2026-59903

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -61,7 +61,7 @@
     <quartz.version>2.3.2</quartz.version>
     <kotlin-stdlib.version>2.1.0</kotlin-stdlib.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
-    <netty.version>4.1.136.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <log4j2.version>2.25.4</log4j2.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.37</logback.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.mockito>5.13.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.8</version.msgpack>
-    <version.netty>4.1.136.Final</version.netty>
+    <version.netty>4.1.137.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
     <version.opentelemetry>1.62.0</version.opentelemetry>


### PR DESCRIPTION
## Description

Fixes [CVE-2026-59903](https://github.com/advisories/GHSA-8c42-7qj2-3j46) (CVSS 6.5, cache poisoning → information disclosure). Netty's `CorsHandler#setVaryHeader` uses `Headers.set` instead of `add`, so it silently replaces any `Vary` header the application already set — an app that sets `Vary: Authorization` to keep a CDN caching per user gets it overwritten with `Vary: origin`, letting a caching proxy serve one user's authenticated response to another.

`4.1.136.Final` → **`4.1.137.Final`** (the advisory's fix for the 4.1.x line).

### Two pins, not one

This branch pins netty in **two independent places**, and both were on `4.1.136.Final`:

| Where | Property | Governs |
|---|---|---|
| `parent/pom.xml` | `version.netty` | `netty-bom` import |
| `optimize/pom.xml` | `netty.version` | a second `netty-bom` import, plus explicit versions for `netty-codec-http`, `netty-codec-http2`, `netty-handler`, `netty-handler-proxy` |

Bumping only the parent property would leave every Optimize module resolving `4.1.136.Final` with the CVE still open — the same silent-override failure mode as #60170. Both are bumped here; there is no remaining `4.1.136` anywhere on the branch.

### Why this isn't a backport

`main`, `stable/8.9`, `stable/8.8` and `stable/8.7` are all already safe (4.1.137.Final / 4.2.17.Final), so there is no merged counterpart to cherry-pick. And the sibling bumps that reached 4.1.137.Final — #59718 and #59719 — only touch `parent/pom.xml`, because `optimize/pom.xml`'s `netty.version` property **exists on no other branch**. Backporting either would have fixed one lineage and silently missed the other.

Renovate does not track this branch either: its `baseBranchPatterns` is `/^stable\/8\.([7-9]|[1-9][0-9])/` plus `main`, which never matches `stable/optimize-8.7`.

### Worth knowing

`4.1.136.Final` was itself a CVE fix here (#58617, for CVE-2026-55831) and *is* the patched version for CVE-2026-59898 — so it looks current. This advisory covers everything up to **and including** it, which is easy to misread.

## What to scrutinise

Confirm both properties moved and nothing else did — the diff should be exactly two single-line changes. `4.1.137.Final` is a patch bump inside 4.1.x and is already running on `stable/8.7` and `stable/8.8`, so no behavioural change is expected; `version.reactor-netty` is a different artifact and is deliberately untouched.

Separately, and not a blocker for the bump: the flaw only bites an application that uses Netty's `CorsHandler`, sets its own `Vary`, and sits behind a caching proxy. Whether Optimize actually does that is an applicability question worth a second opinion if you want to judge real-world exposure.

## Related issues

relates CVE-2026-59903, #60170, #58617