### PR TITLE
fix: finalize a draining process definition when its last instance migrates away

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessDeletionBehavior.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
  *
  * <ul>
  *   <li>its last active instance completes or terminates ({@link #finalizeDeletionIfDraining})
+ *   <li>the last instance is migrated away
  *   <li>for a definition inherited by a freshly bootstrapped partition that holds none of its
  *       instances, when that partition finishes bootstrapping ({@link
  *       #finalizeDrainingDefinitionsWithoutLocalInstances})
@@ -79,9 +80,11 @@ public final class BpmnProcessDeletionBehavior {
       return;
     }
 
-    final var process =
-        processState.getProcessByKeyAndTenant(
-            context.getProcessDefinitionKey(), context.getTenantId());
+    finalizeDeletionIfDraining(context.getProcessDefinitionKey(), context.getTenantId());
+  }
+
+  public void finalizeDeletionIfDraining(final long processDefinitionKey, final String tenantId) {
+    final var process = processState.getProcessByKeyAndTenant(processDefinitionKey, tenantId);
     if (process == null || process.getState() != PersistedProcessState.DRAINING) {
       return;
     }
@@ -131,13 +134,17 @@ public final class BpmnProcessDeletionBehavior {
             .setTenantId(process.getTenantId())
             .setDeploymentKey(process.getDeploymentKey())
             .setDeleteHistory(process.isDeleteHistory());
+    finalizeDeletion(processRecord);
+    processDefinitionMetrics.processDefinitionDrainFinalized();
+  }
+
+  public void finalizeDeletion(final ProcessRecord processRecord) {
     // the locally-minted key identifies the reporting partition to ProcessDeleteCompleteProcessor
     final long key = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETING, processRecord);
-    deleteAgentDefinitions(process.getKey());
+    deleteAgentDefinitions(processRecord.getKey());
     stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETED, processRecord);
     commandWriter.appendFollowUpCommand(key, ProcessIntent.DELETE_COMPLETE, processRecord);
-    processDefinitionMetrics.processDefinitionDrainFinalized();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -16,6 +16,7 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnProcessDeletionBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
@@ -83,6 +84,7 @@ public class ProcessInstanceMigrationMigrateProcessor
   private final EventScopeInstanceState eventScopeInstanceState;
   private final MessageState messageState;
   private final CslAuthorizationCheck cslCheck;
+  private final BpmnProcessDeletionBehavior processDeletionBehavior;
   private final ProcessInstanceMigrationCatchEventBehavior migrationCatchEventBehaviour;
   private final ProcessInstanceMigrationJobBehavior migrationJobBehaviour;
   private final ProcessInstanceMigrationSequenceFlowBehavior migrationSequenceFlowBehaviour;
@@ -109,6 +111,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
     messageState = processingState.getMessageState();
     this.cslCheck = cslCheck;
+    processDeletionBehavior = bpmnBehaviors.processDeletionBehavior();
 
     migrationCatchEventBehaviour =
         new ProcessInstanceMigrationCatchEventBehavior(
@@ -221,6 +224,11 @@ public class ProcessInstanceMigrationMigrateProcessor
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value);
     responseWriter.writeAcceptedResponseOnCommand(
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value, command);
+
+    // migration can empty a draining source definition without ever emitting a completion event
+    // against it, so re-check its drain here (no-op unless the source is now fully drained).
+    processDeletionBehavior.finalizeDeletionIfDraining(
+        sourceProcessDefinition.getKey(), processInstanceRecord.getTenantId());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import io.camunda.security.core.authz.TenantAccess;
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnProcessDeletionBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -33,7 +34,6 @@ import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
-import io.camunda.zeebe.engine.state.immutable.AgentDefinitionState;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
@@ -51,7 +51,6 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.AgentDefinitionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
@@ -85,7 +84,7 @@ public class ResourceDeletionDeleteProcessor
   private final DecisionState decisionState;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final ProcessState processState;
-  private final AgentDefinitionState agentDefinitionState;
+  private final BpmnProcessDeletionBehavior processDeletionBehavior;
   private final ElementInstanceState elementInstanceState;
   private final TimerInstanceState timerInstanceState;
   private final BannedInstanceState bannedInstanceState;
@@ -119,7 +118,7 @@ public class ResourceDeletionDeleteProcessor
     decisionState = processingState.getDecisionState();
     this.commandDistributionBehavior = commandDistributionBehavior;
     processState = processingState.getProcessState();
-    agentDefinitionState = processingState.getAgentDefinitionState();
+    processDeletionBehavior = bpmnBehaviors.processDeletionBehavior();
     elementInstanceState = processingState.getElementInstanceState();
     timerInstanceState = processingState.getTimerState();
     bannedInstanceState = processingState.getBannedInstanceState();
@@ -411,34 +410,11 @@ public class ResourceDeletionDeleteProcessor
         !elementInstanceState.hasActiveProcessInstances(process.getKey(), bannedInstances);
 
     if (finalizedImmediately) {
-      finalizeDeletion(processRecord);
+      processDeletionBehavior.finalizeDeletion(processRecord);
       processDefinitionMetrics.processDefinitionDeleted(process.getKey());
     } else {
       processDefinitionMetrics.processDefinitionDraining(process.getKey());
     }
-  }
-
-  private void finalizeDeletion(final ProcessRecord processRecord) {
-    final long key = keyGenerator.nextKey();
-    stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETING, processRecord);
-    deleteAgentDefinitions(processRecord.getKey());
-    stateWriter.appendFollowUpEvent(key, ProcessIntent.DELETED, processRecord);
-    commandWriter.appendFollowUpCommand(key, ProcessIntent.DELETE_COMPLETE, processRecord);
-  }
-
-  /**
-   * Emits {@code AgentDefinition:DELETED} for each agent definition owned by {@code
-   * processDefinitionKey}, so that none is left referencing an already-deleted process, even
-   * momentarily on the record stream.
-   */
-  private void deleteAgentDefinitions(final long processDefinitionKey) {
-    agentDefinitionState.forEachAgentDefinitionKey(
-        processDefinitionKey,
-        agentDefinitionKey ->
-            stateWriter.appendFollowUpEvent(
-                agentDefinitionKey,
-                AgentDefinitionIntent.DELETED,
-                agentDefinitionState.getAgentDefinition(agentDefinitionKey)));
   }
 
   private ProcessRecord toProcessRecord(final DeployedProcess process) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -792,6 +793,113 @@ public class DrainingProcessDefinitionTest {
   }
 
   @Test
+  public void shouldFinalizeDrainingWhenLastInstanceMigratedAway() {
+    // given - a draining source definition whose only active instance is about to migrate away, and
+    // a separate target definition to receive it
+    final var sourceId = helper.getBpmnProcessId() + "-source";
+    final var targetId = helper.getBpmnProcessId() + "-target";
+    final var source = deployWithJob(sourceId);
+    final var target = deployWithJob(targetId);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(sourceId).create();
+    awaitJobCreated(processInstanceKey);
+    drainViaDeletion(source.getProcessDefinitionKey());
+
+    // when - the instance migrates to the target, emptying the draining source without ever
+    // emitting
+    // a completion or termination event against it
+    migrateToTarget(processInstanceKey, target.getProcessDefinitionKey(), "task");
+
+    // then - the source is finalized (physically deleted locally and reported drained) rather than
+    // stranded in DRAINING forever
+    assertDeletedLocally(source.getProcessDefinitionKey());
+    assertReportedDrained(source.getProcessDefinitionKey());
+  }
+
+  @Test
+  public void shouldNotFinalizeDrainingWhenOtherInstancesRemainAfterMigration() {
+    // given - a draining source definition with two active instances, and a target definition
+    final var sourceId = helper.getBpmnProcessId() + "-source";
+    final var targetId = helper.getBpmnProcessId() + "-target";
+    final var source = deployWithJob(sourceId);
+    final var target = deployWithJob(targetId);
+    final long migratingInstanceKey = engine.processInstance().ofBpmnProcessId(sourceId).create();
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(sourceId).create());
+    awaitJobCreated(migratingInstanceKey);
+    drainViaDeletion(source.getProcessDefinitionKey());
+
+    // when - only one of the two instances migrates away
+    migrateToTarget(migratingInstanceKey, target.getProcessDefinitionKey(), "task");
+
+    // then - the source is not finalized while the other instance still references it: it stays
+    // DRAINING, so a new instance is still rejected for that reason (not "not found")
+    engine.processInstance().ofBpmnProcessId(sourceId).expectRejection().create();
+    final var rejection =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING.formatted(
+                sourceId, source.getVersion(), source.getProcessDefinitionKey()));
+  }
+
+  @Test
+  public void shouldReportDrainedAcrossPartitionsAfterMigration() {
+    // given - a draining source (seeded across three partitions) with one active instance, and a
+    // target definition to migrate into
+    final var sourceId = helper.getBpmnProcessId() + "-source";
+    final var targetId = helper.getBpmnProcessId() + "-target";
+    final var source = deployWithJob(sourceId);
+    final var target = deployWithJob(targetId);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(sourceId).create();
+    awaitJobCreated(processInstanceKey);
+    drainViaDeletion(source.getProcessDefinitionKey());
+    injectDraining(source, false, 2, 3);
+
+    // when - the last active instance migrates away, finalizing partition 1 locally, and each
+    // partition then reports it has finished draining
+    migrateToTarget(processInstanceKey, target.getProcessDefinitionKey(), "task");
+    engine.writeRecords(
+        drainReport(source.getProcessDefinitionKey(), source, 1),
+        drainReport(source.getProcessDefinitionKey(), source, 2),
+        drainReport(source.getProcessDefinitionKey(), source, 3));
+
+    // then - the definition is reported fully deleted cluster-wide exactly once
+    assertThat(
+            RecordingExporter.processRecords()
+                .withIntent(ProcessIntent.FULLY_DELETED)
+                .withProcessDefinitionKey(source.getProcessDefinitionKey())
+                .limit(1)
+                .count())
+        .describedAs("the source is reported fully deleted exactly once")
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldDeleteAgentDefinitionWhenDrainingFinalizedByMigration() {
+    // given - a draining source whose only task is agent-marked, with a running instance, plus a
+    // matching target to migrate the agent element into
+    final var sourceId = helper.getBpmnProcessId() + "-source";
+    final var targetId = helper.getBpmnProcessId() + "-target";
+    final var source = deployWithAgentDefinitionAndJob(sourceId);
+    final var target = deployWithAgentDefinitionAndJob(targetId);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(sourceId).create();
+    awaitJobCreated(processInstanceKey);
+    drainViaDeletion(source.getProcessDefinitionKey());
+
+    // when - the instance migrates away, finalizing the source
+    migrateToTarget(processInstanceKey, target.getProcessDefinitionKey(), "agent-task");
+
+    // then - the source's agent definition is deleted as part of the migration-triggered finalize,
+    // mirroring the completion-triggered cascade
+    assertThat(
+            RecordingExporter.agentDefinitionRecords(AgentDefinitionIntent.DELETED)
+                .withProcessDefinitionKey(source.getProcessDefinitionKey())
+                .exists())
+        .describedAs("migration-triggered finalize must cascade AgentDefinition:DELETED too")
+        .isTrue();
+  }
+
+  @Test
   public void shouldResubscribeStartEventsToLatestActiveVersionSkippingDraining() {
     // given - three versions of the same message-start-event definition. Only the latest holds the
     // start-event subscription, so on deletion it must be handed down.
@@ -1129,6 +1237,23 @@ public class DrainingProcessDefinitionTest {
                 .exists())
         .describedAs("this partition reports drained (DELETE_COMPLETE) once its last instance ends")
         .isTrue();
+  }
+
+  private void migrateToTarget(
+      final long processInstanceKey,
+      final long targetProcessDefinitionKey,
+      final String elementId) {
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction(elementId, elementId)
+        .migrate();
+    // await MIGRATED so the source definition's active-instance state has settled before asserting
+    RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
   }
 
   private void awaitJobCreated(final long processInstanceKey) {


### PR DESCRIPTION
## Description

fix: finalize a draining process definition when its last instance migrates away
refactor: centralize draining-deletion finalization in BpmnProcessDeletionBehavior

## Related issues

closes https://github.com/camunda/camunda/issues/60439
