### PR TITLE
ci: load-test: use the top-level `.tool-versions` file

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -552,12 +552,8 @@ jobs:
           ref: ${{ inputs.ref }}
           persist-credentials: false
 
-      # camunda-platform-8.10 requires Helm CLI v4; runners ship v3.x.
       - name: Set up Helm
         uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
-        with:
-          tool_versions: |
-            helm 4.2.0
 
       # Authenticate with Teleport
       - name: Set up Teleport

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,3 @@
+# GitHub runners "ubuntu-latest"/"ubuntu-24.04" ship with Helm v3, which is not
+# supported by Camunda Platform Helm Chart starting from 8.10.
 helm 4.2.4


### PR DESCRIPTION
## Description

Added in 0da65023e35995d479ddd2800ce02b9fd8f85fe8 and automatically updated by Renovate since then. No need for a custom, non-updated one here.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
