### PR TITLE
Fail requests with an unset physical tenant instead of routing them to the default tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceService.java
@@ -22,10 +22,6 @@ public final class BanInstanceService {
     this.client = client;
   }
 
-  public void banInstance(final long key) {
-    client.sendRequest(new BrokerAdminRequest().banInstance(key));
-  }
-
   public void banInstance(final long key, final String physicalTenantId) {
     final var request = new BrokerAdminRequest().banInstance(key);
     request.setPartitionGroup(physicalTenantId);

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.broker.client.api.dto;
 
 import io.atomix.cluster.BrokerMemberId;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.UnsupportedBrokerResponseException;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
@@ -36,7 +35,7 @@ public abstract class BrokerRequest<T> implements ClientRequest {
   protected final int schemaId;
   protected final int templateId;
 
-  private String partitionGroup = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+  private String partitionGroup;
 
   public BrokerRequest(final int schemaId, final int templateId) {
     this.schemaId = schemaId;
@@ -48,6 +47,15 @@ public abstract class BrokerRequest<T> implements ClientRequest {
     return partitionGroup;
   }
 
+  public boolean hasPartitionGroup() {
+    return partitionGroup != null;
+  }
+
+  /**
+   * Sets the partition group (physical tenant) this request is routed to. There is no implicit
+   * fallback: every request must have its partition group set before it is sent, even if it targets
+   * {@link io.camunda.cluster.PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID}.
+   */
   public void setPartitionGroup(final String partitionGroup) {
     Objects.requireNonNull(partitionGroup, "partitionGroup must not be null");
     if (partitionGroup.isBlank()) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -101,6 +101,11 @@ final class BrokerRequestManager extends Actor {
       final BrokerRequest<T> request,
       final TransportRequestSender sender,
       final Duration requestTimeout) {
+    if (!request.hasPartitionGroup()) {
+      throw new IllegalStateException(
+          "Cannot send request '%s': no partition group (physical tenant) was set. Requests are not implicitly routed to the default tenant; call setPartitionGroup explicitly, even when targeting the default tenant."
+              .formatted(request.getType()));
+    }
     final CompletableFuture<BrokerResponse<T>> responseFuture = new CompletableFuture<>();
     request.serializeValue();
     actor.run(() -> sendRequestInternal(request, responseFuture, sender, requestTimeout));

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.client.api;
 import static io.camunda.zeebe.broker.client.BrokerMemberIds.ONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import io.atomix.cluster.AtomixCluster;
@@ -18,6 +19,7 @@ import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.utils.net.Address;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -372,6 +374,19 @@ public final class BrokerClientTest {
   }
 
   @Test
+  void shouldRejectRequestWithoutPartitionGroup() {
+    // given - a request whose partition group (physical tenant) was never set
+    final var request = TestCommand.withUnsetPartitionGroup();
+
+    // when / then - the request fails instead of being routed to the default tenant
+    assertThatThrownBy(() -> client.sendRequest(request))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("no partition group (physical tenant) was set")
+        .hasMessageContaining(request.getType());
+    assertThat(broker.getReceivedCommandRequests()).isEmpty();
+  }
+
+  @Test
   void shouldFailRequestAddressingPartitionOfUnknownGroup() {
     // given - a request addressing a partition that only exists in the default group
     final var request = new TestCommand();
@@ -577,10 +592,26 @@ public final class BrokerClientTest {
         final UnifiedRecordValue record,
         final long key,
         final RequestDispatchStrategy dispatchStrategy) {
+      this(record, key, dispatchStrategy, true);
+    }
+
+    private TestCommand(
+        final UnifiedRecordValue record,
+        final long key,
+        final RequestDispatchStrategy dispatchStrategy,
+        final boolean stampDefaultPartitionGroup) {
       super(VALUE_TYPE, INTENT);
       this.record = record;
       this.key = key;
       this.dispatchStrategy = dispatchStrategy;
+      if (stampDefaultPartitionGroup) {
+        setPartitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+      }
+    }
+
+    private static TestCommand withUnsetPartitionGroup() {
+      return new TestCommand(
+          new UnifiedRecordValue(10), Protocol.encodePartitionId(1, 1), null, false);
     }
 
     @Override

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequestTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequestTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.client.api.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
@@ -20,12 +19,13 @@ import org.junit.jupiter.api.Test;
 class BrokerRequestTest {
 
   @Test
-  void shouldReturnDefaultPartitionGroup() {
+  void shouldHaveNoPartitionGroupByDefault() {
     // given
     final var request = new TestBrokerRequest();
 
     // then
-    assertThat(request.getPartitionGroup()).isEqualTo(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(request.hasPartitionGroup()).isFalse();
+    assertThat(request.getPartitionGroup()).isNull();
   }
 
   @Test
@@ -37,6 +37,7 @@ class BrokerRequestTest {
     request.setPartitionGroup("tenant1");
 
     // then
+    assertThat(request.hasPartitionGroup()).isTrue();
     assertThat(request.getPartitionGroup()).isEqualTo("tenant1");
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotTransferServiceClient.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotTransferServiceClient.java
@@ -25,9 +25,11 @@ import org.jspecify.annotations.Nullable;
 public class SnapshotTransferServiceClient implements SnapshotTransferService {
 
   private final BrokerClient client;
+  private final String partitionGroup;
 
-  public SnapshotTransferServiceClient(final BrokerClient client) {
+  public SnapshotTransferServiceClient(final BrokerClient client, final String partitionGroup) {
     this.client = client;
+    this.partitionGroup = partitionGroup;
   }
 
   @Override
@@ -53,6 +55,7 @@ public class SnapshotTransferServiceClient implements SnapshotTransferService {
       final UUID transferId) {
     final var request = new GetSnapshotChunk(partition, transferId, snapshotId, previousChunkName);
     final var brokerRequest = new SnapshotBrokerRequest(request);
+    brokerRequest.setPartitionGroup(partitionGroup);
     final var future = new CompletableActorFuture<@Nullable SnapshotChunk>();
     client
         .sendRequestWithRetry(brokerRequest, Duration.ofSeconds(30))

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -56,7 +56,10 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
                     final var snapshotTransfer =
                         new SnapshotTransferImpl(
                             context.partitionMetadata().id(),
-                            actor -> new SnapshotTransferServiceClient(context.brokerClient()),
+                            actor ->
+                                new SnapshotTransferServiceClient(
+                                    context.brokerClient(),
+                                    context.partitionMetadata().id().group()),
                             snapshotStore.getSnapshotMetrics(),
                             snapshotStore);
                     return context

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -79,7 +79,12 @@ public class SnapshotApiRequestHandler
       final var request = requestReader.getRequest();
       return switch (request) {
         case final GetSnapshotChunk snapshotChunkRequest ->
-            handleGet(snapshotChunkRequest, partitionId, responseWriter, errorWriter, service);
+            handleGet(
+                snapshotChunkRequest,
+                registration.partitionId(),
+                responseWriter,
+                errorWriter,
+                service);
         case final DeleteSnapshotForBootstrapRequest deleteRequest ->
             handleDelete(partitionId, responseWriter, errorWriter, service);
       };
@@ -110,10 +115,11 @@ public class SnapshotApiRequestHandler
 
   private ActorFuture<Either<ErrorResponseWriter, SnapshotApiResponseWriter>> handleGet(
       final GetSnapshotChunk request,
-      final int partitionId,
+      final PartitionId fullPartitionId,
       final SnapshotApiResponseWriter responseWriter,
       final ErrorResponseWriter errorWriter,
       final SnapshotTransferService service) {
+    final int partitionId = fullPartitionId.number();
     if (request.lastChunkName().isPresent() && request.snapshotId().isPresent()) {
       return service
           .getNextChunk(
@@ -131,7 +137,7 @@ public class SnapshotApiRequestHandler
       LOG.atLevel(Level.DEBUG)
           .addKeyValue("transferId", request.transferId())
           .log("Received request to get the latest snapshot for partition {}", partitionId);
-      return getLastProcessedPositionRequired(request.transferId())
+      return getLastProcessedPositionRequired(request.transferId(), fullPartitionId.group())
           .andThen(
               lastProcessedPosition -> {
                 LOG.atLevel(Level.DEBUG)
@@ -170,10 +176,13 @@ public class SnapshotApiRequestHandler
     super.close();
   }
 
-  private ActorFuture<Long> getLastProcessedPositionRequired(final UUID transferId) {
+  private ActorFuture<Long> getLastProcessedPositionRequired(
+      final UUID transferId, final String partitionGroup) {
     final ActorFuture<Long> lastProcessedPosition = actor.createFuture();
+    final var request = new GetScaleUpProgress();
+    request.setPartitionGroup(partitionGroup);
     brokerClient
-        .sendRequestWithRetry(new GetScaleUpProgress())
+        .sendRequestWithRetry(request)
         .thenApplyAsync(
             r -> {
               final var response = r.getResponseOrThrow();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -158,7 +158,9 @@ public class SnapshotApiRequestHandlerTest {
                 snapshotPath -> SnapshotFilesInfo.none(),
                 new SimpleMeterRegistry()));
 
-    client = new SnapshotTransferServiceClient(brokerClient);
+    client =
+        new SnapshotTransferServiceClient(
+            brokerClient, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
 
     scheduler.workUntilDone();
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/QueryApiImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/QueryApiImpl.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.zeebe.gateway.query.impl;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.camunda.zeebe.gateway.query.QueryApi;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.grpc.Context;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -56,13 +60,18 @@ public final class QueryApiImpl implements QueryApi {
       final long key,
       final ValueType valueType,
       final Duration timeout,
-      final CompletableFuture<String> result) {
+      final CompletableFuture<String> result)
+      throws Exception {
     final var request = new BrokerExecuteQuery();
     final var partitionId = Protocol.decodePartitionId(key);
 
     request.setKey(key);
     request.setPartitionId(partitionId);
     request.setValueType(valueType);
+    request.setPartitionGroup(
+        Objects.requireNonNullElse(
+            Context.current().call(InterceptorUtil.getPhysicalTenantIdKey()::get),
+            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID));
 
     client
         .sendRequestWithRetry(request, timeout)

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPriorityTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPriorityTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.gateway.Gateway;
 import io.camunda.zeebe.gateway.RequestMapper;
 import io.camunda.zeebe.gateway.ResponseMapper;
@@ -123,7 +124,10 @@ final class LongPollingActivateJobsPriorityTest {
             .setMaxJobsToActivate(maxJobs)
             .setRequestTimeout(LONG_POLLING_TIMEOUT)
             .build();
-    return RequestMapper.toActivateJobsRequest(grpcRequest);
+    // requests must always carry a partition group before they are sent to the broker
+    final var brokerRequest = RequestMapper.toActivateJobsRequest(grpcRequest);
+    brokerRequest.setPartitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    return brokerRequest;
   }
 
   private ResponseObserver<ActivateJobsResponse> buildObserver(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -972,10 +972,13 @@ public final class LongPollingActivateJobsTest {
             .setMaxJobsToActivate(MAX_JOBS_TO_ACTIVATE)
             .setRequestTimeout(500)
             .build();
+    // requests must always carry a partition group before they are sent to the broker
+    final var brokerRequest = RequestMapper.toActivateJobsRequest(grpcRequest);
+    brokerRequest.setPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
     final var request =
         new InflightActivateJobsRequest<ActivateJobsResponse>(
             getNextRequestId(),
-            RequestMapper.toActivateJobsRequest(grpcRequest),
+            brokerRequest,
             spy(ServerStreamObserver.class),
             grpcRequest.getRequestTimeout()) {
 
@@ -1012,6 +1015,9 @@ public final class LongPollingActivateJobsTest {
     assertThat(brokerRequestValue.getRetries()).isEqualTo(activatedJob.getRetries());
     assertThat(brokerRequestValue.getRetryBackoff()).isEqualTo(0);
     assertThat(brokerRequestValue.getErrorMessageBuffer()).isNotNull();
+    assertThat(failRequest.getPartitionGroup())
+        .describedAs("fail request should inherit the activate request's partition group")
+        .isEqualTo(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   @Test
@@ -1126,9 +1132,12 @@ public final class LongPollingActivateJobsTest {
 
   private InflightActivateJobsRequest<ActivateJobsResponse> toInflightActivateJobsRequest(
       final ActivateJobsRequest grpcRequest) {
+    // requests must always carry a partition group before they are sent to the broker
+    final var brokerRequest = RequestMapper.toActivateJobsRequest(grpcRequest);
+    brokerRequest.setPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
     return new InflightActivateJobsRequest<ActivateJobsResponse>(
         getNextRequestId(),
-        RequestMapper.toActivateJobsRequest(grpcRequest),
+        brokerRequest,
         spy(ServerStreamObserver.class),
         grpcRequest.getRequestTimeout());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl.job;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -1048,6 +1049,8 @@ public class LongPollingActivateJobsRestTest {
             .setTenantIds(activateJobsRequest.tenantIds())
             .setVariables(activateJobsRequest.fetchVariable())
             .setWorker(activateJobsRequest.worker());
+    // requests must always carry a partition group before they are sent to the broker
+    brokerRequest.setPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
     final var request =
         new InflightActivateJobsRequest<>(
             getNextRequestId(),
@@ -1088,6 +1091,9 @@ public class LongPollingActivateJobsRestTest {
     assertThat(brokerRequestValue.getRetries()).isEqualTo(activatedJob.getRetries());
     assertThat(brokerRequestValue.getRetryBackoff()).isEqualTo(0);
     assertThat(brokerRequestValue.getErrorMessageBuffer()).isNotNull();
+    assertThat(failRequest.getPartitionGroup())
+        .describedAs("fail request should inherit the activate request's partition group")
+        .isEqualTo(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   private List<InflightActivateJobsRequest<JobActivationResult>> activateJobsAndWaitUntilBlocked(
@@ -1134,6 +1140,8 @@ public class LongPollingActivateJobsRestTest {
             .setTenantIds(activateJobsRequest.tenantIds())
             .setVariables(activateJobsRequest.fetchVariable())
             .setWorker(activateJobsRequest.worker());
+    // requests must always carry a partition group before they are sent to the broker
+    brokerRequest.setPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
     return new InflightActivateJobsRequest<>(
         getNextRequestId(),
         brokerRequest,

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -174,6 +174,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
                       maxMessageSize,
                       request.getRequest().getPartitionGroup()));
 
+          final var partitionGroup = request.getRequest().getPartitionGroup();
           final List<ActivatedJob> jobsToDefer = jobActivationResult.getJobsToDefer();
           if (!jobsToDefer.isEmpty()) {
             final var jobKeys = jobsToDefer.stream().map(ActivatedJob::key).toList();
@@ -181,7 +182,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
             final var reason = String.format(MAX_MESSAGE_SIZE_EXCEEDED_MSG, maxMessageSize);
 
             logResponseNotSent(jobType, jobKeys, reason);
-            reactivateJobs(jobsToDefer, reason);
+            reactivateJobs(jobsToDefer, reason, partitionGroup);
           }
 
           final T activateJobsResponse = jobActivationResult.getActivateJobsResponse();
@@ -198,7 +199,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
               final var reason = createReasonMessage(result);
 
               logResponseNotSent(jobType, jobKeys, reason);
-              reactivateJobs(activatedJobsToReactivate, reason);
+              reactivateJobs(activatedJobsToReactivate, reason, partitionGroup);
               cancelActivateJobsRequest(reason, delegate);
               return;
             }
@@ -224,14 +225,16 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
     return errorMessage;
   }
 
-  private void reactivateJobs(final List<ActivatedJob> activateJobs, final String message) {
+  private void reactivateJobs(
+      final List<ActivatedJob> activateJobs, final String message, final String partitionGroup) {
     if (activateJobs != null) {
-      activateJobs.forEach(j -> tryToReactivateJob(j, message));
+      activateJobs.forEach(j -> tryToReactivateJob(j, message, partitionGroup));
     }
   }
 
-  private void tryToReactivateJob(final ActivatedJob job, final String message) {
-    final var request = toFailJobRequest(job, message);
+  private void tryToReactivateJob(
+      final ActivatedJob job, final String message, final String partitionGroup) {
+    final var request = toFailJobRequest(job, message, partitionGroup);
     brokerClient
         .sendRequestWithRetry(request)
         .whenCompleteAsync(
@@ -247,10 +250,12 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
             actor);
   }
 
-  private BrokerFailJobRequest toFailJobRequest(final ActivatedJob job, final String errorMessage) {
+  private BrokerFailJobRequest toFailJobRequest(
+      final ActivatedJob job, final String errorMessage, final String partitionGroup) {
     final BrokerFailJobRequest brokerFailJobRequest =
         new BrokerFailJobRequest(job.key(), job.retries(), 0).setErrorMessage(errorMessage);
     brokerFailJobRequest.setAuthorization(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
+    brokerFailJobRequest.setPartitionGroup(partitionGroup);
     return brokerFailJobRequest;
   }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -60,6 +60,7 @@ public final class StubbedBrokerClient implements BrokerClient {
   @Override
   public <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
       final BrokerRequest<T> request) {
+    ensurePartitionGroupSet(request);
     final CompletableFuture<BrokerResponse<T>> future = new CompletableFuture<>();
     brokerRequests.add(request);
 
@@ -87,6 +88,7 @@ public final class StubbedBrokerClient implements BrokerClient {
       final BrokerRequest<T> request,
       final BrokerResponseConsumer<T> responseConsumer,
       final Consumer<Throwable> throwableConsumer) {
+    ensurePartitionGroupSet(request);
     brokerRequests.add(request);
     try {
       final RequestHandler requestHandler = requestHandlers.get(request.getClass());
@@ -105,6 +107,18 @@ public final class StubbedBrokerClient implements BrokerClient {
       throwableConsumer.accept(e);
     } catch (final Exception e) {
       throwableConsumer.accept(new BrokerResponseException(e));
+    }
+  }
+
+  /**
+   * Mirrors the guard in the production {@code BrokerRequestManager}, so tests using this stub
+   * catch senders that forget to set the physical tenant instead of silently passing.
+   */
+  private static void ensurePartitionGroupSet(final BrokerRequest<?> request) {
+    if (!request.hasPartitionGroup()) {
+      throw new IllegalStateException(
+          "Cannot send request '%s': no partition group (physical tenant) was set. Requests are not implicitly routed to the default tenant; call setPartitionGroup explicitly, even when targeting the default tenant."
+              .formatted(request.getType()));
     }
   }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl.broker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
@@ -322,6 +323,9 @@ final class RequestRetryHandlerTest {
     TestBrokerRequest(final Optional<RequestDispatchStrategy> strategy) {
       super(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATE);
       this.strategy = strategy;
+      // requests must always carry a partition group; tests that verify multi-tenant routing
+      // override this with their own tenant id
+      setPartitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     }
 
     @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -441,6 +441,7 @@ class BackupMultiPartitionTest {
     backupRequest.setBackupId(backupId);
     backupRequest.setPartitionId(partitionId);
     backupRequest.setCheckpointType(CheckpointType.MANUAL_BACKUP);
+    backupRequest.setPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
     final BrokerClient brokerClient = cluster.anyGateway().bean(BrokerClient.class);
     brokerClient.sendRequest(backupRequest).orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -451,6 +452,7 @@ class BackupMultiPartitionTest {
     final BackupStatusRequest backupStatusRequest = new BackupStatusRequest();
     backupStatusRequest.setPartitionId(partitionId);
     backupStatusRequest.setBackupId(backupId);
+    backupStatusRequest.setPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
     final BrokerClient brokerClient = cluster.anyGateway().bean(BrokerClient.class);
     Awaitility.await()
         .ignoreExceptions()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -784,6 +784,7 @@ public class ClusteringRule extends ExternalResource {
             .setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variables)));
 
     request.setPartitionId(partitionId);
+    request.setPartitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
 
     final BrokerResponse<ProcessInstanceCreationRecord> response =
         gatewayResource.gateway.getBrokerClient().sendRequestWithRetry(request).join();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/system/BrokerAdminServiceTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.cluster.system;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
@@ -264,6 +265,7 @@ public class BrokerAdminServiceTest {
     final var expectedInstant = Instant.now().minusMillis(3600).truncatedTo(ChronoUnit.MILLIS);
     final var request =
         new TestClockRequest(new ClockRecord().pinAt(expectedInstant.toEpochMilli()));
+    request.setPartitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     brokerClient.sendRequest(request, Duration.ofSeconds(30)).join();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayIntegrationTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.it.shared.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -38,10 +39,12 @@ final class GatewayIntegrationTest {
     final var latch = new CountDownLatch(1);
     final AtomicReference<Throwable> errorResponse = new AtomicReference<>();
     final var client = gateway.bean(BrokerClient.class);
+    final var request = new BrokerCreateProcessInstanceRequest();
+    request.setPartitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     client.sendRequestWithRetry(
-        new BrokerCreateProcessInstanceRequest(),
+        request,
         (k, r) -> {},
         error -> {
           errorResponse.set(error);


### PR DESCRIPTION
## Description

`BrokerRequest` initialised its partition group to the default physical tenant, so any sender that forgot to call `setPartitionGroup` was silently routed to the default tenant's engine — no error, no log line, nothing in the response (see #59994 for the defect this hid).

This PR, in commit order:

1. **Fixes the four senders that relied on the silent default** (found by auditing every `BrokerClient` send path): job reactivation in `RoundRobinActivateJobsHandler` (now inherits the activation request's group), `SnapshotApiRequestHandler`'s `GetScaleUpProgress` (now uses the served partition's group), `SnapshotTransferServiceClient` (group injected at construction), and `QueryApiImpl` (tenant resolved from the gRPC context with an explicit default fallback).
2. **Removes the dead, tenant-unaware `BanInstanceService#banInstance(long)` overload.**
3. **Removes the default and enforces the invariant at runtime**: the group starts unset and `BrokerRequestManager` rejects a tenant-less request at send time with an `IllegalStateException` naming the request type. `StubbedBrokerClient` mirrors the guard so gateway tests catch regressions. Targeting the default tenant stays legitimate but must be explicit.

A runtime guard was chosen over a constructor parameter on all 86 `BrokerRequest` subclasses: requests are constructed in mappers that don't know the tenant and stamped at send-side chokepoints that do (service-layer mutators, `EndpointManager`, `BackupRequestHandler`); the guard turns silent misrouting into a loud error at a fraction of the churn. Rationale recorded on the issue.

Verified with the new `shouldRejectRequestWithoutPartitionGroup` test, full unit suites of all touched modules, and `QueryApiIT`, `PhysicalTenantPartitionScalingIT`, `PhysicalTenantRoutingStateIT`.

Closes #60103