### PR TITLE
refactor: prepare components for global listeners migration

### DIFF
--- a/identity/client/src/components/formV2/TextField.tsx
+++ b/identity/client/src/components/formV2/TextField.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { ChangeEvent, FC, ReactNode, useId } from "react";
+import { PasswordInput, TextArea, TextInput } from "@carbon/react";
+import useTranslate from "src/utility/localization";
+
+type TextInputProps = {
+  type?: "text" | "email";
+  cols?: never;
+  counterMode?: never;
+  enableCounter?: never;
+  maxCount?: never;
+};
+
+type TextAreaProps = {
+  type?: never;
+  cols: number;
+  counterMode?: "character" | "word";
+  enableCounter?: boolean;
+  maxCount?: number;
+};
+
+type PasswordInputProps = {
+  type: "password";
+  cols?: never;
+  counterMode?: never;
+  enableCounter?: never;
+  maxCount?: never;
+};
+
+export type TextFieldProps = {
+  label: string;
+  value: string;
+  errors?: string[] | string;
+  helperText?: ReactNode;
+  placeholder?: string;
+  cols?: number;
+  autoFocus?: boolean;
+  onBlur?: (newValue: string) => void;
+  readOnly?: boolean;
+  onChange?: (newValue: string) => void;
+  validate?: (newValue: string) => boolean;
+} & (TextInputProps | TextAreaProps | PasswordInputProps);
+
+const TextField: FC<TextFieldProps> = ({
+  onChange,
+  onBlur,
+  validate,
+  errors = [],
+  value,
+  helperText,
+  placeholder,
+  label,
+  cols,
+  autoFocus = false,
+  type = "text",
+  readOnly,
+  maxCount = 255,
+  enableCounter = false,
+  counterMode = "character",
+}) => {
+  const { t } = useTranslate();
+  const fieldId = useId();
+
+  const commonProps = {
+    labelText: label,
+    title: label,
+    id: fieldId,
+    helperText: helperText,
+    value: value,
+    placeholder: placeholder,
+    onChange: (
+      e: ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      onChange?.(e.currentTarget.value);
+      validate?.(e.currentTarget.value);
+    },
+    invalid: typeof errors === "string" ? Boolean(errors) : errors?.length > 0,
+    invalidText:
+      typeof errors === "string" ? errors : errors?.map((e) => t(e)).join(" "),
+    onBlur: (
+      e: ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      onBlur?.(e.currentTarget.value);
+      validate?.(e.currentTarget.value);
+    },
+    readOnly: readOnly,
+    ...(autoFocus && { "data-modal-primary-focus": true }),
+  };
+
+  if (type === "password") {
+    return <PasswordInput {...commonProps} />;
+  } else if (cols && cols > 1) {
+    return (
+      <TextArea
+        {...commonProps}
+        enableCounter={enableCounter}
+        counterMode={counterMode}
+        maxCount={maxCount}
+      />
+    );
+  } else {
+    return <TextInput {...commonProps} type={type} />;
+  }
+};
+
+export default TextField;

--- a/identity/client/src/components/modalV2/FormModal.tsx
+++ b/identity/client/src/components/modalV2/FormModal.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, FormEvent, useState } from "react";
+import { Form, Stack, Loading, InlineNotification } from "@carbon/react";
+import styled from "styled-components";
+import {
+  ApiError,
+  ErrorResponse,
+  isDetailedError,
+} from "src/utility/api/request";
+import Modal, { ModalProps } from "./Modal";
+
+// carbon element z-indexes can only be imported using scss modules
+import styles from "./styles.module.scss";
+
+const HiddenSubmitButton = styled.input`
+  display: none;
+`;
+
+const LoadingLabel = styled.div`
+  position: fixed;
+  color: var(--cds-text-on-color);
+  z-index: ${styles.overlayZIndex + 1};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  block-size: 100%;
+  inline-size: 100%;
+  inset-inline-start: 0;
+`;
+
+type FormModalProps = {
+  error?: ApiError | Error | ErrorResponse<"detailed"> | null;
+} & ModalProps;
+
+const FormModal: FC<FormModalProps> = ({
+  children,
+  onSubmit,
+  error,
+  ...modalProps
+}) => {
+  const [showError, setShowError] = useState(true);
+
+  const formSubmitHandler = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit?.();
+  };
+
+  const apiErrorBody = (() => {
+    if (!error) return null;
+    if (error instanceof ApiError) {
+      return error.body && isDetailedError(error.body) ? error.body : null;
+    }
+    if (error instanceof Error) return null;
+    return isDetailedError(error) ? error : null;
+  })();
+
+  return (
+    <Modal
+      {...modalProps}
+      onSubmit={async (...args) => {
+        setShowError(true);
+        await onSubmit?.(...args);
+      }}
+    >
+      {modalProps.loading && (
+        <>
+          <Loading />
+          <LoadingLabel>{modalProps.loadingDescription}</LoadingLabel>
+        </>
+      )}
+      <Form onSubmit={formSubmitHandler}>
+        <Stack gap="6">
+          <>{children}</>
+          {apiErrorBody && showError && (
+            <InlineNotification
+              kind="error"
+              role="alert"
+              lowContrast
+              title={apiErrorBody.title}
+              subtitle={apiErrorBody.detail}
+              onClose={() => {
+                setShowError(false);
+              }}
+            />
+          )}
+        </Stack>
+        <HiddenSubmitButton type="submit" />
+      </Form>
+    </Modal>
+  );
+};
+
+export default FormModal;

--- a/identity/client/src/components/modalV2/Modal.tsx
+++ b/identity/client/src/components/modalV2/Modal.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, ReactNode, useEffect, useRef } from "react";
+import {
+  ButtonSet,
+  ComposedModal,
+  InlineLoading,
+  Modal as CarbonModal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from "@carbon/react";
+import styled from "styled-components";
+import useTranslate from "src/utility/localization";
+
+const ModalWrapper = styled.div<{ $overflowVisible: boolean }>`
+  ${({ $overflowVisible }) =>
+    $overflowVisible
+      ? `
+  & .cds--modal-content,
+  & .cds--modal-container {
+    overflow: visible;
+    max-height: none;
+  }
+  &.cds--modal, & .cds--modal {
+    overflow: auto;
+  }
+  & .cds--modal-content {
+    margin-bottom: 0;
+    padding-bottom: 3rem;
+  }
+  /*
+   * Carbon's cds--modal-scroll-content adds border-block-end and a
+   * last-child margin that change the content's height. With max-height
+   * removed above, that toggles isScrollable on every render and produces
+   * a flicker when the content sits near the scroll threshold (e.g. a
+   * single dropdown entry). Neutralize those height contributions so the
+   * measurement stays stable.
+   */
+  & .cds--modal-content.cds--modal-scroll-content {
+    border-block-end-width: 0;
+  }
+  & .cds--modal-content.cds--modal-scroll-content > *:last-child {
+    margin-block-end: 0;
+  }
+  `
+      : ""}
+`;
+
+const FooterButtonSet = styled(ButtonSet)`
+  width: 100%;
+`;
+
+type BaseModalProps = {
+  open: boolean;
+  headline: string;
+  onClose: () => void;
+  children?: ReactNode;
+  danger?: boolean;
+  overflowVisible?: boolean;
+  onSubmit?: () => unknown;
+  submitDisabled?: boolean;
+  loading?: boolean;
+  loadingDescription?: string | null;
+  buttons?: ReactNode[];
+  size?: "xs" | "sm" | "md" | "lg";
+  preventCloseOnClickOutside?: boolean;
+};
+
+// Confirm label is optional here since it will be ignored
+type PassiveModalProps = BaseModalProps & {
+  passiveModal: true;
+  confirmLabel?: string;
+};
+
+// Confirm label is required for an active modal
+type ActiveModalProps = BaseModalProps & {
+  passiveModal?: false;
+  confirmLabel: string;
+};
+
+export type ModalProps = PassiveModalProps | ActiveModalProps;
+
+const Modal: FC<ModalProps> = ({
+  children,
+  open,
+  onClose,
+  headline,
+  confirmLabel,
+  danger = false,
+  overflowVisible = false,
+  onSubmit = () => undefined,
+  submitDisabled = false,
+  loading = false,
+  loadingDescription,
+  buttons,
+  size,
+  passiveModal = false,
+  preventCloseOnClickOutside = false,
+}) => {
+  const { t } = useTranslate("components");
+  const submitLoading = (
+    <InlineLoading description={loadingDescription || t("loading")} />
+  );
+
+  const modalRef = useRef<HTMLDivElement>(null);
+  const findFocusableCandidate = (
+    container: HTMLDivElement,
+  ): HTMLInputElement | undefined => {
+    return container.querySelector(
+      "button:not([disabled])",
+    ) as HTMLInputElement;
+  };
+
+  useEffect(() => {
+    if (
+      modalRef.current &&
+      !modalRef.current.contains(document.activeElement)
+    ) {
+      const focusableInput = findFocusableCandidate(modalRef.current);
+      focusableInput?.focus();
+    }
+  }, []);
+  const modal =
+    buttons === undefined ? (
+      <CarbonModal
+        size={size}
+        modalHeading={headline}
+        aria-label={headline}
+        open={open}
+        passiveModal={passiveModal}
+        preventCloseOnClickOutside={preventCloseOnClickOutside}
+        primaryButtonText={loading ? submitLoading : confirmLabel}
+        primaryButtonDisabled={submitDisabled || loading}
+        closeButtonLabel={t("close")}
+        secondaryButtonText={t("cancel")}
+        onRequestSubmit={onSubmit}
+        onRequestClose={onClose}
+        onSecondarySubmit={onClose}
+        danger={danger}
+        ref={modalRef}
+      >
+        {children}
+      </CarbonModal>
+    ) : (
+      <ComposedModal
+        aria-label={headline}
+        open={open}
+        onClose={onClose}
+        ref={modalRef}
+      >
+        <ModalHeader title={headline} />
+        <ModalBody hasForm>{children}</ModalBody>
+        <ModalFooter>
+          <FooterButtonSet>{buttons}</FooterButtonSet>
+        </ModalFooter>
+      </ComposedModal>
+    );
+
+  return (
+    <ModalWrapper $overflowVisible={overflowVisible}>{modal}</ModalWrapper>
+  );
+};
+
+export const DeleteModal: FC<
+  Omit<ModalProps, "confirmLabel" | "buttons" | "size"> &
+    Partial<Pick<ModalProps, "confirmLabel">>
+> = ({ children, ...modalProps }) => {
+  const { t } = useTranslate("components");
+
+  return (
+    <Modal confirmLabel={t("delete")} {...modalProps} danger size="sm">
+      {children}
+    </Modal>
+  );
+};
+
+export default Modal;

--- a/identity/client/src/components/modalV2/index.tsx
+++ b/identity/client/src/components/modalV2/index.tsx
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export { default } from "./Modal";
+export * from "./Modal";
+export { default as FormModal } from "./FormModal";
+export * from "./FormModal";
+export * from "./useModal";

--- a/identity/client/src/components/modalV2/styles.module.scss
+++ b/identity/client/src/components/modalV2/styles.module.scss
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+@use "@carbon/react/scss/utilities/z-index" as *;
+
+:export {
+  overlayZIndex: z("overlay");
+}

--- a/identity/client/src/components/modalV2/useModal.tsx
+++ b/identity/client/src/components/modalV2/useModal.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { ComponentType, ReactNode, useCallback, useState } from "react";
+import useDebounce from "react-debounced";
+import { modalFadeDurationMs } from "src/utility/style";
+
+export type UseModalProps = {
+  open: boolean;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+const useModalState = () => {
+  const debounce = useDebounce(modalFadeDurationMs);
+  const [isOpen, setOpen] = useState(false);
+  const [isVisible, setVisible] = useState(false);
+
+  const openModal = useCallback(() => {
+    setOpen(true);
+    setVisible(true);
+    debounce(() => null);
+  }, [debounce]);
+
+  const closeModal = useCallback(() => {
+    setOpen(false);
+    debounce(() => setVisible(false));
+  }, [debounce]);
+
+  return { isOpen, isVisible, openModal, closeModal };
+};
+
+const useModal = <P,>(
+  ...params:
+    | [ComponentType<UseModalProps>, () => unknown]
+    | [ComponentType<UseModalProps & P>, () => unknown, P]
+): [() => void, ReactNode] => {
+  const [ModalComponent, onSuccess, props = {}] = params;
+  const { isOpen, isVisible, openModal, closeModal } = useModalState();
+
+  const modal = isVisible ? (
+    <ModalComponent
+      open={isOpen}
+      onClose={closeModal}
+      onSuccess={() => {
+        closeModal();
+        onSuccess();
+      }}
+      {...(props as P)}
+    />
+  ) : null;
+
+  return [openModal, modal];
+};
+
+export type UseEntityModalProps<E> = UseModalProps & {
+  entity: E;
+};
+
+export type UseEntityModalCustomProps<E, P> = P & UseEntityModalProps<E>;
+
+type UseEntityModalParams<E> = [
+  Component: ComponentType<UseEntityModalProps<E>>,
+  onSuccess: () => void,
+];
+
+type UseEntityModalWithPropsParams<E, P> = [
+  Component: ComponentType<UseEntityModalCustomProps<E, P>>,
+  onSuccess: () => void,
+  customProps: P,
+];
+
+export const useEntityModal = <E, P extends { [key: string]: unknown }>(
+  ...params: UseEntityModalParams<E> | UseEntityModalWithPropsParams<E, P>
+): [(selectEntity: E) => void, ReactNode] => {
+  const [Component, onSuccess, customProps] = params;
+
+  const { isOpen, isVisible, openModal, closeModal } = useModalState();
+  const [entity, setEntity] = useState<E | null>(null);
+
+  const showModal = useCallback(
+    (selectEntity: E) => {
+      setEntity(selectEntity);
+      openModal();
+    },
+    [openModal],
+  );
+
+  const modal =
+    isVisible && entity ? (
+      <Component
+        open={isOpen}
+        entity={entity}
+        onClose={closeModal}
+        onSuccess={() => {
+          closeModal();
+          onSuccess();
+        }}
+        {...(customProps as P)}
+      />
+    ) : null;
+
+  return [showModal, modal];
+};
+
+export default useModal;

--- a/identity/client/src/pages/global-task-listeners/ListV2.tsx
+++ b/identity/client/src/pages/global-task-listeners/ListV2.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { Edit, TrashCan } from "@carbon/react/icons";
+import useTranslate from "src/utility/localization";
+import { usePagination } from "src/utility/api";
+import { useQuery } from "@tanstack/react-query";
+import { globalTaskListenerQueries } from "src/utility/api/global-task-listeners/queries";
+import Page, { PageHeader } from "src/components/layoutV2/Page";
+import EntityList from "src/components/entityListV2";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+import useModal, { useEntityModal } from "src/components/modalV2/useModal";
+import AddModal from "src/pages/global-task-listeners/modalsV2/AddModal";
+import EditModal from "src/pages/global-task-listeners/modalsV2/EditModal";
+import DeleteModal from "src/pages/global-task-listeners/modalsV2/DeleteModal";
+import PageEmptyState from "src/components/layoutV2/PageEmptyState";
+import { getEventTypeLabels } from "src/pages/global-task-listeners/utility";
+
+const List: FC = () => {
+  const { t } = useTranslate("globalTaskListeners");
+  const noop = () => {};
+
+  const { pageParams, page, search, ...paginationCallbacks } = usePagination();
+  const {
+    data: globalTaskListeners,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery(globalTaskListenerQueries.search(pageParams));
+
+  const [addGlobalTaskListener, addGlobalTaskListenerModal] = useModal(
+    AddModal,
+    noop,
+  );
+  const [editGlobalTaskListener, editGlobalTaskListenerModal] = useEntityModal(
+    EditModal,
+    noop,
+  );
+  const [deleteGlobalTaskListener, deleteGlobalTaskListenerModal] =
+    useEntityModal(DeleteModal, noop);
+
+  const shouldShowEmptyState =
+    success && !search && !globalTaskListeners?.items.length;
+
+  const pageHeader = (
+    <PageHeader
+      title={t("globalTaskListeners")}
+      linkText={t("globalTaskListeners").toLowerCase()}
+      docsLinkPath="/components/concepts/global-user-task-listeners/"
+      shouldShowDocumentationLink={!shouldShowEmptyState}
+    />
+  );
+
+  if (shouldShowEmptyState) {
+    return (
+      <Page>
+        {pageHeader}
+        <PageEmptyState
+          resourceTypeTranslationKey={"globalTaskListener"}
+          docsLinkPath="/components/concepts/global-user-task-listeners/"
+          handleClick={addGlobalTaskListener}
+        />
+        {addGlobalTaskListenerModal}
+      </Page>
+    );
+  }
+
+  const transformedData = globalTaskListeners?.items.map((listener) => ({
+    ...listener,
+    afterNonGlobal: listener.afterNonGlobal
+      ? t("executionOrderAfter")
+      : t("executionOrderBefore"),
+    eventTypes: getEventTypeLabels(listener.eventTypes, t),
+    originalListener: listener,
+  }));
+
+  return (
+    <Page>
+      {pageHeader}
+      <EntityList
+        data={transformedData ?? []}
+        headers={[
+          {
+            header: t("globalTaskListenerId"),
+            key: "id",
+            isSortable: true,
+          },
+          { header: t("listenerType"), key: "type", isSortable: true },
+          {
+            header: t("eventType"),
+            key: "eventTypes",
+            isSortable: false,
+          },
+          { header: t("retries"), key: "retries", isSortable: false },
+          {
+            header: t("executionOrder"),
+            key: "afterNonGlobal",
+            isSortable: true,
+          },
+          { header: t("priority"), key: "priority", isSortable: true },
+        ]}
+        addEntityLabel={t("createListener")}
+        onAddEntity={addGlobalTaskListener}
+        loading={loading}
+        menuItems={[
+          {
+            label: t("editGlobalTaskListener"),
+            icon: Edit,
+            onClick: (entity) =>
+              editGlobalTaskListener(entity.originalListener),
+          },
+          {
+            label: t("delete"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: (entity) =>
+              deleteGlobalTaskListener(entity.originalListener),
+          },
+        ]}
+        searchPlaceholder={t("searchById")}
+        searchKey="id"
+        page={{ ...page, ...globalTaskListeners?.page }}
+        {...paginationCallbacks}
+      />
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title={t("globalTaskListenersCouldNotLoad")}
+          actionButton={{
+            label: t("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+      {addGlobalTaskListenerModal}
+      {editGlobalTaskListenerModal}
+      {deleteGlobalTaskListenerModal}
+    </Page>
+  );
+};
+
+export default List;

--- a/identity/client/src/pages/global-task-listeners/index.tsx
+++ b/identity/client/src/pages/global-task-listeners/index.tsx
@@ -8,14 +8,26 @@
 
 import { FC, lazy, Suspense } from "react";
 import { ListPageFallback } from "src/components/fallbacks";
+import { ListPageFallback as ListPageFallbackV2 } from "src/components/fallbacksV2";
 import PageRoutes from "src/components/router/PageRoutes";
+import { IS_NEW_DESIGN_SYSTEM_ENABLED } from "src/feature-flags";
 
-const List = lazy(() => import("./List"));
+const List = lazy(() =>
+  IS_NEW_DESIGN_SYSTEM_ENABLED ? import("./ListV2") : import("./List"),
+);
 
 const GlobalTaskListeners: FC = () => (
   <PageRoutes
     indexElement={
-      <Suspense fallback={<ListPageFallback />}>
+      <Suspense
+        fallback={
+          IS_NEW_DESIGN_SYSTEM_ENABLED ? (
+            <ListPageFallbackV2 />
+          ) : (
+            <ListPageFallback />
+          )
+        }
+      >
         <List />
       </Suspense>
     }

--- a/identity/client/src/pages/global-task-listeners/modalsV2/AddModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modalsV2/AddModal.tsx
@@ -1,0 +1,294 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { Dropdown, MultiSelect, NumberInput } from "@carbon/react";
+import { FormModal, UseModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { globalTaskListenerMutations } from "src/utility/api/global-task-listeners/mutations";
+import TextField from "src/components/formV2/TextField";
+import { LISTENER_EVENT_TYPES } from "src/utility/api/global-task-listeners";
+import { useNotifications } from "src/components/notifications";
+import {
+  getEventTypeLabel,
+  getEventTypeLabels,
+  LISTENER_TYPE_PATTERN,
+} from "src/pages/global-task-listeners/utility";
+import type {
+  CreateGlobalTaskListenerRequestBody,
+  GlobalTaskListenerEventType,
+} from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
+  const { t } = useTranslate("globalTaskListeners");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const {
+    mutate,
+    isPending: loading,
+    error,
+  } = useMutation(globalTaskListenerMutations.create(qc));
+
+  const { control, handleSubmit, watch, setValue } =
+    useForm<CreateGlobalTaskListenerRequestBody>({
+      defaultValues: {
+        id: "",
+        type: "",
+        eventTypes: [],
+        retries: 3,
+        afterNonGlobal: false,
+        priority: 50,
+      },
+      mode: "all",
+    });
+
+  const eventTypes = watch("eventTypes");
+
+  const handleEventTypeChange = (
+    selectedItems: GlobalTaskListenerEventType[],
+  ) => {
+    const individualTypes = LISTENER_EVENT_TYPES.filter((opt) => opt !== "all");
+
+    // If "all" was just checked, select all individual types too
+    if (selectedItems.includes("all") && !eventTypes.includes("all")) {
+      setValue("eventTypes", [...LISTENER_EVENT_TYPES]); // includes "all" and all individuals
+      return;
+    }
+
+    // If "all" was just unchecked, uncheck all individual types too
+    if (!selectedItems.includes("all") && eventTypes.includes("all")) {
+      setValue("eventTypes", []);
+      return;
+    }
+
+    // If an individual type was unchecked while "all" is checked, uncheck "all" too
+    if (
+      eventTypes.includes("all") &&
+      selectedItems.length < LISTENER_EVENT_TYPES.length
+    ) {
+      setValue(
+        "eventTypes",
+        selectedItems.filter((item) => item !== "all"),
+      );
+      return;
+    }
+
+    // If all individual types are now selected, also select "all"
+    const allIndividualSelected = individualTypes.every((type) =>
+      selectedItems.includes(type),
+    );
+    if (allIndividualSelected && !selectedItems.includes("all")) {
+      setValue("eventTypes", [...LISTENER_EVENT_TYPES]); // includes "all" and all individuals
+      return;
+    }
+
+    setValue("eventTypes", selectedItems);
+  };
+
+  const onSubmit = (data: CreateGlobalTaskListenerRequestBody) => {
+    const eventTypes = data.eventTypes.includes("all")
+      ? ["all" as const]
+      : data.eventTypes.filter((type) => type !== "all");
+
+    mutate(
+      {
+        id: data.id,
+        type: data.type,
+        eventTypes: eventTypes,
+        retries: data.retries,
+        afterNonGlobal: data.afterNonGlobal,
+        priority: data.priority,
+      },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("globalTaskListenerCreated"),
+            subtitle: data.type,
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  const afterNonGlobalOptions = [
+    { id: "false", label: t("executionOrderBefore"), value: false },
+    { id: "true", label: t("executionOrderAfter"), value: true },
+  ];
+
+  return (
+    <FormModal
+      open={open}
+      headline={t("createGlobalTaskListener")}
+      loading={loading}
+      error={error}
+      loadingDescription={t("creatingGlobalTaskListener")}
+      confirmLabel={t("create")}
+      onClose={onClose}
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Controller
+        name="id"
+        control={control}
+        rules={{
+          required: t("globalTaskListenerIdRequired"),
+        }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("globalTaskListenerId")}
+            placeholder={t("globalTaskListenerIdPlaceholder")}
+            errors={fieldState.error?.message}
+            helperText={t("globalTaskListenerIdHelperText")}
+            autoFocus
+          />
+        )}
+      />
+      <Controller
+        name="type"
+        control={control}
+        rules={{
+          required: t("listenerTypeRequired"),
+          maxLength: {
+            value: 50,
+            message: t("pleaseEnterValidListenerType"),
+          },
+          pattern: {
+            value: LISTENER_TYPE_PATTERN,
+            message: t("pleaseEnterValidListenerType"),
+          },
+        }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("listenerType")}
+            placeholder={t("listenerTypePlaceholder")}
+            errors={fieldState.error?.message}
+            helperText={t("listenerTypeHelperText")}
+          />
+        )}
+      />
+      <Controller
+        name="eventTypes"
+        control={control}
+        rules={{
+          validate: (value) => value.length > 0 || t("eventTypeRequired"),
+        }}
+        render={({ field, fieldState }) => (
+          <MultiSelect
+            id="event-type-multiselect"
+            titleText={t("eventType")}
+            label={
+              field.value.length > 0
+                ? getEventTypeLabels(field.value, t)
+                : t("selectEventTypes")
+            }
+            items={[...LISTENER_EVENT_TYPES]}
+            selectedItems={field.value}
+            onChange={({
+              selectedItems,
+            }: {
+              selectedItems: GlobalTaskListenerEventType[];
+            }) => {
+              handleEventTypeChange(selectedItems);
+            }}
+            itemToString={(item: GlobalTaskListenerEventType) =>
+              getEventTypeLabel(item, t)
+            }
+            invalid={!!fieldState.error}
+            invalidText={fieldState.error?.message}
+          />
+        )}
+      />
+      <Controller
+        name="retries"
+        control={control}
+        render={({ field, fieldState }) => (
+          <NumberInput
+            id="retries-input"
+            label={t("retries")}
+            min={1}
+            step={1}
+            value={field.value}
+            onChange={(_, { value }) => {
+              const numValue =
+                typeof value === "string" ? parseInt(value, 10) : value;
+              if (!isNaN(numValue)) {
+                field.onChange(numValue);
+              }
+            }}
+            invalid={!!fieldState.error}
+            invalidText={fieldState.error?.message}
+          />
+        )}
+      />
+      <Controller
+        name="afterNonGlobal"
+        control={control}
+        render={({ field }) => (
+          <Dropdown
+            id="execution-order-dropdown"
+            titleText={t("executionOrder")}
+            label={t("executionOrder")}
+            items={afterNonGlobalOptions}
+            selectedItem={afterNonGlobalOptions.find(
+              (opt) => opt.value === field.value,
+            )}
+            onChange={({
+              selectedItem,
+            }: {
+              selectedItem: {
+                id: string;
+                label: string;
+                value: boolean;
+              } | null;
+            }) => {
+              if (selectedItem) {
+                field.onChange(selectedItem.value);
+              }
+            }}
+            itemToString={(item: { id: string; label: string } | null) =>
+              item?.label ?? ""
+            }
+          />
+        )}
+      />
+      <Controller
+        name="priority"
+        control={control}
+        render={({ field, fieldState }) => (
+          <NumberInput
+            id="priority-input"
+            label={t("priority")}
+            helperText={t("priorityHelperText")}
+            min={0}
+            step={1}
+            value={field.value}
+            onChange={(
+              _,
+              { value }: { value: string | number; direction: string },
+            ) => {
+              const numValue =
+                typeof value === "string" ? parseInt(value, 10) : value;
+              if (!isNaN(numValue)) {
+                field.onChange(numValue);
+              }
+            }}
+            invalid={!!fieldState.error}
+            invalidText={fieldState.error?.message}
+          />
+        )}
+      />
+    </FormModal>
+  );
+};
+
+export default AddModal;

--- a/identity/client/src/pages/global-task-listeners/modalsV2/DeleteModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modalsV2/DeleteModal.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalProps,
+} from "src/components/modalV2";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { globalTaskListenerMutations } from "src/utility/api/global-task-listeners/mutations";
+import { useNotifications } from "src/components/notifications";
+import type { GlobalTaskListener } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const DeleteModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
+  open,
+  onClose,
+  onSuccess,
+  entity: { id, type },
+}) => {
+  const { t } = useTranslate("globalTaskListeners");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    globalTaskListenerMutations.delete(qc),
+  );
+
+  const handleSubmit = () => {
+    mutate(
+      { id },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("globalTaskListenerDeleted"),
+            subtitle: type,
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("deleteGlobalTaskListener")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("deletingGlobalTaskListener")}
+      onClose={onClose}
+      confirmLabel={t("delete")}
+    >
+      <p>{t("deleteGlobalTaskListenerConfirmation")}</p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/global-task-listeners/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/global-task-listeners/modalsV2/EditModal.tsx
@@ -1,0 +1,306 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { Dropdown, MultiSelect, NumberInput } from "@carbon/react";
+import { FormModal, UseEntityModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { globalTaskListenerMutations } from "src/utility/api/global-task-listeners/mutations";
+import TextField from "src/components/formV2/TextField";
+import { LISTENER_EVENT_TYPES } from "src/utility/api/global-task-listeners";
+import { useNotifications } from "src/components/notifications";
+import {
+  getEventTypeLabel,
+  getEventTypeLabels,
+  LISTENER_TYPE_PATTERN,
+} from "src/pages/global-task-listeners/utility";
+import type {
+  CreateGlobalTaskListenerRequestBody,
+  GlobalTaskListener,
+  GlobalTaskListenerEventType,
+} from "@camunda/camunda-api-zod-schemas/8.10";
+
+const EditModal: FC<UseEntityModalProps<GlobalTaskListener>> = ({
+  open,
+  onClose,
+  onSuccess,
+  entity,
+}) => {
+  const { t } = useTranslate("globalTaskListeners");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const {
+    mutate,
+    isPending: loading,
+    error,
+  } = useMutation(globalTaskListenerMutations.update(qc));
+
+  const { control, handleSubmit, watch, setValue, reset } =
+    useForm<CreateGlobalTaskListenerRequestBody>({
+      defaultValues: {
+        id: entity.id,
+        type: entity.type,
+        eventTypes: entity.eventTypes,
+        retries: entity.retries ?? undefined,
+        afterNonGlobal: entity.afterNonGlobal ?? undefined,
+        priority: entity.priority ?? undefined,
+      },
+      mode: "all",
+    });
+
+  // Reset form when entity changes
+  useEffect(() => {
+    reset({
+      id: entity.id,
+      type: entity.type,
+      eventTypes: entity.eventTypes,
+      retries: entity.retries ?? undefined,
+      afterNonGlobal: entity.afterNonGlobal ?? undefined,
+      priority: entity.priority ?? undefined,
+    });
+  }, [entity, reset]);
+
+  const eventTypes = watch("eventTypes");
+
+  const handleEventTypeChange = (
+    selectedItems: GlobalTaskListenerEventType[],
+  ) => {
+    const individualTypes = LISTENER_EVENT_TYPES.filter((opt) => opt !== "all");
+
+    // If "all" was just checked, select all individual types too
+    if (selectedItems.includes("all") && !eventTypes.includes("all")) {
+      setValue("eventTypes", [...LISTENER_EVENT_TYPES]); // includes "all" and all individuals
+      return;
+    }
+
+    // If "all" was just unchecked, uncheck all individual types too
+    if (!selectedItems.includes("all") && eventTypes.includes("all")) {
+      setValue("eventTypes", []);
+      return;
+    }
+
+    // If an individual type was unchecked while "all" is checked, uncheck "all" too
+    if (
+      eventTypes.includes("all") &&
+      selectedItems.length < LISTENER_EVENT_TYPES.length
+    ) {
+      setValue(
+        "eventTypes",
+        selectedItems.filter((item) => item !== "all"),
+      );
+      return;
+    }
+
+    // If all individual types are now selected, also select "all"
+    const allIndividualSelected = individualTypes.every((type) =>
+      selectedItems.includes(type),
+    );
+    if (allIndividualSelected && !selectedItems.includes("all")) {
+      setValue("eventTypes", [...LISTENER_EVENT_TYPES]); // includes "all" and all individuals
+      return;
+    }
+
+    setValue("eventTypes", selectedItems);
+  };
+
+  const onSubmit = (data: CreateGlobalTaskListenerRequestBody) => {
+    const eventTypes = data.eventTypes.includes("all")
+      ? ["all" as const]
+      : data.eventTypes.filter((type) => type !== "all");
+
+    mutate(
+      {
+        id: entity.id,
+        type: data.type,
+        eventTypes: eventTypes,
+        retries: data.retries,
+        afterNonGlobal: data.afterNonGlobal,
+        priority: data.priority,
+      },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("globalTaskListenerUpdated"),
+            subtitle: data.type,
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  const afterNonGlobalOptions = [
+    { id: "false", label: t("executionOrderBefore"), value: false },
+    { id: "true", label: t("executionOrderAfter"), value: true },
+  ];
+
+  return (
+    <FormModal
+      open={open}
+      headline={t("editGlobalTaskListener")}
+      loading={loading}
+      error={error}
+      loadingDescription={t("editingGlobalTaskListener")}
+      confirmLabel={t("update")}
+      onClose={onClose}
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Controller
+        name="id"
+        control={control}
+        render={({ field }) => (
+          <TextField {...field} label={t("globalTaskListenerId")} readOnly />
+        )}
+      />
+      <Controller
+        name="type"
+        control={control}
+        rules={{
+          required: t("listenerTypeRequired"),
+          maxLength: {
+            value: 50,
+            message: t("pleaseEnterValidListenerType"),
+          },
+          pattern: {
+            value: LISTENER_TYPE_PATTERN,
+            message: t("pleaseEnterValidListenerType"),
+          },
+        }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("listenerType")}
+            placeholder={t("listenerTypePlaceholder")}
+            errors={fieldState.error?.message}
+            helperText={t("listenerTypeHelperText")}
+            autoFocus
+          />
+        )}
+      />
+      <Controller
+        name="eventTypes"
+        control={control}
+        rules={{
+          validate: (value) => value.length > 0 || t("eventTypeRequired"),
+        }}
+        render={({ field, fieldState }) => (
+          <MultiSelect
+            id="event-type-multiselect-edit"
+            titleText={t("eventType")}
+            label={
+              field.value.length > 0
+                ? getEventTypeLabels(field.value, t)
+                : t("selectEventTypes")
+            }
+            items={[...LISTENER_EVENT_TYPES]}
+            selectedItems={field.value}
+            onChange={({
+              selectedItems,
+            }: {
+              selectedItems: GlobalTaskListenerEventType[];
+            }) => {
+              handleEventTypeChange(selectedItems);
+            }}
+            itemToString={(item: GlobalTaskListenerEventType) =>
+              getEventTypeLabel(item, t)
+            }
+            invalid={!!fieldState.error}
+            invalidText={fieldState.error?.message}
+          />
+        )}
+      />
+      <Controller
+        name="retries"
+        control={control}
+        render={({ field, fieldState }) => (
+          <NumberInput
+            id="retries-input-edit"
+            label={t("retries")}
+            min={1}
+            step={1}
+            value={field.value}
+            onChange={(
+              _,
+              { value }: { value: string | number; direction: string },
+            ) => {
+              const numValue =
+                typeof value === "string" ? parseInt(value, 10) : value;
+              if (!isNaN(numValue)) {
+                field.onChange(numValue);
+              }
+            }}
+            invalid={!!fieldState.error}
+            invalidText={fieldState.error?.message}
+          />
+        )}
+      />
+      <Controller
+        name="afterNonGlobal"
+        control={control}
+        render={({ field }) => (
+          <Dropdown
+            id="execution-order-dropdown-edit"
+            titleText={t("executionOrder")}
+            label={t("executionOrder")}
+            items={afterNonGlobalOptions}
+            selectedItem={afterNonGlobalOptions.find(
+              (opt) => opt.value === field.value,
+            )}
+            onChange={({
+              selectedItem,
+            }: {
+              selectedItem: {
+                id: string;
+                label: string;
+                value: boolean;
+              } | null;
+            }) => {
+              if (selectedItem) {
+                field.onChange(selectedItem.value);
+              }
+            }}
+            itemToString={(item: { id: string; label: string } | null) =>
+              item?.label ?? ""
+            }
+          />
+        )}
+      />
+      <Controller
+        name="priority"
+        control={control}
+        render={({ field, fieldState }) => (
+          <NumberInput
+            id="priority-input-edit"
+            label={t("priority")}
+            helperText={t("priorityHelperText")}
+            min={0}
+            step={1}
+            value={field.value}
+            onChange={(
+              _,
+              { value }: { value: string | number; direction: string },
+            ) => {
+              const numValue =
+                typeof value === "string" ? parseInt(value, 10) : value;
+              if (!isNaN(numValue)) {
+                field.onChange(numValue);
+              }
+            }}
+            invalid={!!fieldState.error}
+            invalidText={fieldState.error?.message}
+          />
+        )}
+      />
+    </FormModal>
+  );
+};
+
+export default EditModal;


### PR DESCRIPTION
## Description

This PR prepares the components required for the "Global task listeners" page migration, by duplicating them into V2 version. When the new design is enabled, they are used.

Outside of import paths in the V2 versions, no code was changed.

## Related issues

relates #60630
