### PR TITLE
feat: add process definition deletion job handler

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/JobDispatcherIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/JobDispatcherIT.java
@@ -49,11 +49,8 @@ public class JobDispatcherIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
-  void shouldMarkQueuedJobAsFailedWhenNoHandlerIsRegistered() {
+  void shouldMarkQueuedJobAsCompletedWhenTargetEntityNoLongerExists() {
     // given
-    // No JobHandler bean exists yet for (DELETE, PROCESS_DEFINITION) in this test context -- the
-    // concrete handler is separate follow-up work, so this exercises the dispatcher's "unhandled
-    // job type" path against the real index.
     final JobRegistryEntryDto queued =
         jobRegistryWriter.createJobEntry(
             JobType.DELETE, EntityType.PROCESS_DEFINITION, "2251799813685251");
@@ -68,7 +65,7 @@ public class JobDispatcherIT extends AbstractBrokerlessZeebeCCSMIT {
             JobType.DELETE, EntityType.PROCESS_DEFINITION, "2251799813685251");
     assertThat(found).isPresent();
     assertThat(found.get().getId()).isEqualTo(queued.getId());
-    assertThat(found.get().getStatus()).isEqualTo(JobStatus.FAILED);
+    assertThat(found.get().getStatus()).isEqualTo(JobStatus.COMPLETED);
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.job;
+
+import static io.camunda.optimize.service.util.InstanceIndexUtil.getProcessInstanceIndexAliasName;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.reader.ProcessOverviewReader;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.db.writer.ProcessOverviewWriter;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private ProcessDefinitionDeletionJobHandler handler;
+  private ProcessDefinitionReader processDefinitionReader;
+  private ProcessOverviewReader processOverviewReader;
+  private ProcessOverviewWriter processOverviewWriter;
+  private JobRegistryWriter jobRegistryWriter;
+  private JobDispatcher jobDispatcher;
+
+  @BeforeEach
+  void setup() {
+    handler = embeddedOptimizeExtension.getBean(ProcessDefinitionDeletionJobHandler.class);
+    processDefinitionReader = embeddedOptimizeExtension.getBean(ProcessDefinitionReader.class);
+    processOverviewReader = embeddedOptimizeExtension.getBean(ProcessOverviewReader.class);
+    processOverviewWriter = embeddedOptimizeExtension.getBean(ProcessOverviewWriter.class);
+    jobRegistryWriter = embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+    jobDispatcher = embeddedOptimizeExtension.getBean(JobDispatcher.class);
+  }
+
+  @Test
+  void shouldDeleteAllInstancesOfTargetedVersionAndLeaveOtherVersionsUntouched() {
+    // given
+    final String bpmnProcessId = "definition-deletion-test-" + UUID.randomUUID();
+    final String definitionIdV1 = bpmnProcessId + ":1:" + UUID.randomUUID();
+    final String definitionIdV2 = bpmnProcessId + ":2:" + UUID.randomUUID();
+
+    // multiple instances per version, so deletion is verified as a genuine delete-by-query over
+    // all matching docs rather than a single-document coincidence
+    final List<ProcessInstanceDto> instancesV1 =
+        List.of(
+            instanceFor(bpmnProcessId, definitionIdV1, "1"),
+            instanceFor(bpmnProcessId, definitionIdV1, "1"),
+            instanceFor(bpmnProcessId, definitionIdV1, "1"));
+    final List<ProcessInstanceDto> instancesV2 =
+        List.of(
+            instanceFor(bpmnProcessId, definitionIdV2, "2"),
+            instanceFor(bpmnProcessId, definitionIdV2, "2"));
+    persistProcessInstances(Stream.concat(instancesV1.stream(), instancesV2.stream()).toList());
+
+    processOverviewWriter.updateProcessOwnerIfNotSet(bpmnProcessId, "owner-1");
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // when
+    handler.handle(job(definitionIdV1));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertThat(processDefinitionReader.getProcessDefinition(definitionIdV1)).isEmpty();
+    assertThat(processDefinitionReader.getProcessDefinition(definitionIdV2)).isPresent();
+
+    final List<ProcessInstanceDto> remainingInstances =
+        databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
+            getProcessInstanceIndexAliasName(bpmnProcessId), ProcessInstanceDto.class);
+    assertThat(remainingInstances)
+        .extracting(ProcessInstanceDto::getProcessInstanceId)
+        .containsExactlyInAnyOrderElementsOf(
+            instancesV2.stream().map(ProcessInstanceDto::getProcessInstanceId).toList());
+
+    // ProcessOverview for the bpmnProcessId is untouched even though this was one of its versions
+    assertThat(processOverviewReader.getProcessOverviewByKey(bpmnProcessId)).isPresent();
+  }
+
+  @Test
+  void shouldLeaveOverviewUntouchedWhenDeletingTheOnlyRemainingVersion() {
+    // given -- a single version of bpmnProcessId, so this deletion removes its last version
+    final String bpmnProcessId = "definition-deletion-last-version-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
+    processOverviewWriter.updateProcessOwnerIfNotSet(bpmnProcessId, "owner-1");
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // when
+    handler.handle(job(definitionId));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertThat(processDefinitionReader.getProcessDefinition(definitionId)).isEmpty();
+    assertThat(processOverviewReader.getProcessOverviewByKey(bpmnProcessId)).isPresent();
+  }
+
+  @Test
+  void shouldNotThrowWhenNoInstancesWereEverImportedForTheDefinition() {
+    // given -- the process-instance index for this bpmnProcessId was never created, since no
+    // instance was ever persisted for it; exercises the "index doesn't exist" branch distinct
+    // from "index exists but is now empty"
+    final String bpmnProcessId = "definition-deletion-no-instances-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessDefinitions(List.of(definitionFor(bpmnProcessId, definitionId, "1")));
+
+    // when / then
+    assertThatCode(() -> handler.handle(job(definitionId))).doesNotThrowAnyException();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    assertThat(processDefinitionReader.getProcessDefinition(definitionId)).isEmpty();
+  }
+
+  @Test
+  void shouldBeIdempotentWhenReInvokedAgainstAlreadyDeletedData() {
+    // given
+    final String bpmnProcessId = "definition-deletion-idempotency-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    handler.handle(job(definitionId));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    assertThat(processDefinitionReader.getProcessDefinition(definitionId)).isEmpty();
+
+    // when / then -- re-invoking against already-deleted data is a no-op, not an exception
+    assertThatCode(() -> handler.handle(job(definitionId))).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldCompleteJobViaDispatcher() {
+    // given
+    final String bpmnProcessId = "definition-deletion-dispatch-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    final JobRegistryEntryDto queued =
+        jobRegistryWriter.createJobEntry(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, definitionId);
+
+    // when
+    jobDispatcher.dispatchNextBatch();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertThat(processDefinitionReader.getProcessDefinition(definitionId)).isEmpty();
+    final JobRegistryReader jobRegistryReader =
+        embeddedOptimizeExtension.getBean(JobRegistryReader.class);
+    final var found =
+        jobRegistryReader.findLastByJobTypeAndEntityId(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, definitionId);
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(queued.getId());
+    assertThat(found.get().getStatus()).isEqualTo(JobStatus.COMPLETED);
+  }
+
+  private JobRegistryEntryDto job(final String definitionId) {
+    return new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, definitionId);
+  }
+
+  private ProcessInstanceDto instanceFor(
+      final String bpmnProcessId, final String definitionId, final String version) {
+    return completedInstance(bpmnProcessId)
+        .processInstanceId(UUID.randomUUID().toString())
+        .processDefinitionId(definitionId)
+        .processDefinitionVersion(version)
+        .build();
+  }
+
+  private ProcessDefinitionOptimizeDto definitionFor(
+      final String bpmnProcessId, final String definitionId, final String version) {
+    return ProcessDefinitionOptimizeDto.builder()
+        .id(definitionId)
+        .key(bpmnProcessId)
+        .version(version)
+        .name(bpmnProcessId)
+        .dataSource(new ZeebeDataSourceDto("test-source", 1))
+        .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+        .bpmn20Xml("<definitions/>")
+        .build();
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
@@ -26,6 +26,7 @@ import io.camunda.optimize.service.db.reader.ProcessOverviewReader;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.db.writer.ProcessOverviewWriter;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,8 +79,8 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
     // then
-    assertThat(processDefinitionReader.getProcessDefinition(definitionIdV1)).isEmpty();
-    assertThat(processDefinitionReader.getProcessDefinition(definitionIdV2)).isPresent();
+    assertThat(getProcessDefinition(definitionIdV1)).isEmpty();
+    assertThat(getProcessDefinition(definitionIdV2)).isPresent();
 
     final List<ProcessInstanceDto> remainingInstances =
         databaseIntegrationTestExtension.getAllDocumentsOfIndexAs(
@@ -107,7 +108,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
     // then
-    assertThat(processDefinitionReader.getProcessDefinition(definitionId)).isEmpty();
+    assertThat(getProcessDefinition(definitionId)).isEmpty();
     assertThat(processOverviewReader.getProcessOverviewByKey(bpmnProcessId)).isPresent();
   }
 
@@ -123,7 +124,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     // when / then
     assertThatCode(() -> handler.handle(job(definitionId))).doesNotThrowAnyException();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
-    assertThat(processDefinitionReader.getProcessDefinition(definitionId)).isEmpty();
+    assertThat(getProcessDefinition(definitionId)).isEmpty();
   }
 
   @Test
@@ -136,7 +137,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
     handler.handle(job(definitionId));
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
-    assertThat(processDefinitionReader.getProcessDefinition(definitionId)).isEmpty();
+    assertThat(getProcessDefinition(definitionId)).isEmpty();
 
     // when / then -- re-invoking against already-deleted data is a no-op, not an exception
     assertThatCode(() -> handler.handle(job(definitionId))).doesNotThrowAnyException();
@@ -159,7 +160,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
     // then
-    assertThat(processDefinitionReader.getProcessDefinition(definitionId)).isEmpty();
+    assertThat(getProcessDefinition(definitionId)).isEmpty();
     final JobRegistryReader jobRegistryReader =
         embeddedOptimizeExtension.getBean(JobRegistryReader.class);
     final var found =
@@ -168,6 +169,10 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     assertThat(found).isPresent();
     assertThat(found.get().getId()).isEqualTo(queued.getId());
     assertThat(found.get().getStatus()).isEqualTo(JobStatus.COMPLETED);
+  }
+
+  private Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(final String definitionId) {
+    return processDefinitionReader.getProcessDefinition(definitionId, false);
   }
 
   private JobRegistryEntryDto job(final String definitionId) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
@@ -24,12 +24,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.builders.OptimizeDeleteRequestBuilderES;
 import io.camunda.optimize.service.db.es.builders.OptimizeUpdateRequestBuilderES;
 import io.camunda.optimize.service.db.repository.es.TaskRepositoryES;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -84,6 +86,22 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
       throw new OptimizeRuntimeException(
           String.format(
               "There was a problem when trying to mark process definition with ID %s as deleted",
+              definitionId),
+          e);
+    }
+  }
+
+  @Override
+  public void deleteDefinition(final String definitionId) {
+    LOG.debug("Deleting process definition with ID {}", definitionId);
+    try {
+      esClient.delete(
+          OptimizeDeleteRequestBuilderES.of(
+              d -> d.optimizeIndex(esClient, PROCESS_DEFINITION_INDEX_NAME).id(definitionId)));
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException(
+          String.format(
+              "There was a problem when trying to delete process definition with ID %s",
               definitionId),
           e);
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
@@ -82,6 +82,12 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
   }
 
   @Override
+  public void deleteDefinition(final String definitionId) {
+    LOG.debug("Deleting process definition with ID {}", definitionId);
+    osClient.delete(PROCESS_DEFINITION_INDEX_NAME, definitionId);
+  }
+
+  @Override
   public boolean markRedeployedDefinitionsAsDeleted(
       final List<ProcessDefinitionOptimizeDto> importedDefinitions) {
     final AtomicBoolean definitionsUpdated = new AtomicBoolean(false);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/ProcessInstanceRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/ProcessInstanceRepository.java
@@ -18,6 +18,8 @@ public interface ProcessInstanceRepository {
   void deleteByIds(
       final String index, final String itemName, final List<String> processInstanceIds);
 
+  void deleteByDefinitionId(final String bpmnProcessId, final String definitionId);
+
   void bulkImport(final String bulkRequestName, final List<ImportRequestDto> importRequests);
 
   boolean processDefinitionHasStartedInstances(String processDefinitionKey);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/ProcessInstanceRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/ProcessInstanceRepositoryES.java
@@ -16,17 +16,16 @@ import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.P
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.VARIABLES;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.VARIABLE_ID;
 import static io.camunda.optimize.service.util.ExceptionUtil.isInstanceIndexNotFoundException;
+import static io.camunda.optimize.service.util.ExceptionUtil.isInstanceIndexNotFoundExceptionInCauseChain;
 import static io.camunda.optimize.service.util.InstanceIndexUtil.getProcessInstanceIndexAliasName;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 
-import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
-import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
@@ -64,16 +63,19 @@ class ProcessInstanceRepositoryES implements ProcessInstanceRepository {
   private final OptimizeElasticsearchClient esClient;
   private final ObjectMapper objectMapper;
   private final DateTimeFormatter dateTimeFormatter;
+  private final TaskRepositoryES taskRepositoryES;
 
   public ProcessInstanceRepositoryES(
       final ConfigurationService configurationService,
       final OptimizeElasticsearchClient esClient,
       final ObjectMapper objectMapper,
-      final DateTimeFormatter dateTimeFormatter) {
+      final DateTimeFormatter dateTimeFormatter,
+      final TaskRepositoryES taskRepositoryES) {
     this.configurationService = configurationService;
     this.esClient = esClient;
     this.objectMapper = objectMapper;
     this.dateTimeFormatter = dateTimeFormatter;
+    this.taskRepositoryES = taskRepositoryES;
   }
 
   @Override
@@ -113,18 +115,16 @@ class ProcessInstanceRepositoryES implements ProcessInstanceRepository {
                                         t.field(ProcessInstanceIndex.PROCESS_DEFINITION_ID)
                                             .value(definitionId)))));
     try {
-      esClient.deleteByQuery(
-          new DeleteByQueryRequest.Builder()
-              .query(query)
-              .refresh(true)
-              .conflicts(Conflicts.Proceed),
+      taskRepositoryES.tryDeleteByQueryRequest(
+          query,
+          String.format("process instances with definitionId %s", definitionId),
+          true,
           getProcessInstanceIndexAliasName(bpmnProcessId));
-    } catch (final IOException e) {
-      throw new OptimizeRuntimeException(
-          String.format("Could not delete process instances with definitionId %s.", definitionId),
-          e);
-    } catch (final ElasticsearchException e) {
-      if (isInstanceIndexNotFoundException(PROCESS, e)) {
+    } catch (final RuntimeException e) {
+      // A missing index surfaces either as a synchronous ElasticsearchException, or, via the async
+      // delete-by-query task path, as an OptimizeRuntimeException wrapping another
+      // OptimizeRuntimeException carrying the task's error status
+      if (isInstanceIndexNotFoundExceptionInCauseChain(PROCESS, e)) {
         LOG.info(
             "Was not able to delete process instances for definitionId {} because instance index {} does not exist.",
             definitionId,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/ProcessInstanceRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/ProcessInstanceRepositoryES.java
@@ -19,11 +19,14 @@ import static io.camunda.optimize.service.util.ExceptionUtil.isInstanceIndexNotF
 import static io.camunda.optimize.service.util.InstanceIndexUtil.getProcessInstanceIndexAliasName;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 
+import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
@@ -61,19 +64,16 @@ class ProcessInstanceRepositoryES implements ProcessInstanceRepository {
   private final OptimizeElasticsearchClient esClient;
   private final ObjectMapper objectMapper;
   private final DateTimeFormatter dateTimeFormatter;
-  private final TaskRepositoryES taskRepositoryES;
 
   public ProcessInstanceRepositoryES(
       final ConfigurationService configurationService,
       final OptimizeElasticsearchClient esClient,
       final ObjectMapper objectMapper,
-      final DateTimeFormatter dateTimeFormatter,
-      final TaskRepositoryES taskRepositoryES) {
+      final DateTimeFormatter dateTimeFormatter) {
     this.configurationService = configurationService;
     this.esClient = esClient;
     this.objectMapper = objectMapper;
     this.dateTimeFormatter = dateTimeFormatter;
-    this.taskRepositoryES = taskRepositoryES;
   }
 
   @Override
@@ -97,6 +97,42 @@ class ProcessInstanceRepositoryES implements ProcessInstanceRepository {
                                                             .get(0)))))
                         .toList()));
     esClient.doBulkRequest(bulkRequest, index, false);
+  }
+
+  @Override
+  public void deleteByDefinitionId(final String bpmnProcessId, final String definitionId) {
+    final Query query =
+        Query.of(
+            q ->
+                q.bool(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.term(
+                                    t ->
+                                        t.field(ProcessInstanceIndex.PROCESS_DEFINITION_ID)
+                                            .value(definitionId)))));
+    try {
+      esClient.deleteByQuery(
+          new DeleteByQueryRequest.Builder()
+              .query(query)
+              .refresh(true)
+              .conflicts(Conflicts.Proceed),
+          getProcessInstanceIndexAliasName(bpmnProcessId));
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException(
+          String.format("Could not delete process instances with definitionId %s.", definitionId),
+          e);
+    } catch (final ElasticsearchException e) {
+      if (isInstanceIndexNotFoundException(PROCESS, e)) {
+        LOG.info(
+            "Was not able to delete process instances for definitionId {} because instance index {} does not exist.",
+            definitionId,
+            getProcessInstanceIndexAliasName(bpmnProcessId));
+        return;
+      }
+      throw e;
+    }
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/TaskRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/TaskRepositoryES.java
@@ -10,10 +10,12 @@ package io.camunda.optimize.service.db.repository.es;
 import static io.camunda.optimize.service.exceptions.ExceptionHelper.safe;
 import static io.camunda.optimize.service.util.mapper.ObjectMapperFactory.OPTIMIZE_MAPPER;
 
+import co.elastic.clients.elasticsearch._types.BulkIndexByScrollFailure;
 import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import co.elastic.clients.elasticsearch.core.UpdateByQueryRequest;
 import co.elastic.clients.elasticsearch.tasks.ListRequest;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
@@ -135,8 +137,8 @@ public class TaskRepositoryES extends TaskRepository {
 
   private boolean syncUpdate(final UpdateByQueryRequest request) {
     try {
-      final Long deleted = esClient.submitUpdateTask(request).updated();
-      return deleted != null && deleted > 0L;
+      final Long updated = esClient.submitUpdateTask(request).updated();
+      return updated != null && updated > 0L;
     } catch (final IOException e) {
       throw new OptimizeRuntimeException("Error while trying to submit update task", e);
     }
@@ -174,7 +176,9 @@ public class TaskRepositoryES extends TaskRepository {
 
   private boolean syncDelete(final DeleteByQueryRequest request) {
     try {
-      final Long deleted = esClient.submitDeleteTask(request).deleted();
+      final DeleteByQueryResponse response = esClient.submitDeleteTask(request);
+      throwOnFailures(response.failures());
+      final Long deleted = response.deleted();
       return deleted != null && deleted > 0L;
     } catch (final IOException e) {
       throw new OptimizeRuntimeException("Error while trying to submit update task", e);
@@ -210,6 +214,15 @@ public class TaskRepositoryES extends TaskRepository {
           String.format(
               "Error while trying to read Elasticsearch task status with ID: [%s]", taskId),
           e);
+    }
+  }
+
+  private void throwOnFailures(final List<BulkIndexByScrollFailure> failures) {
+    if (failures != null && !failures.isEmpty()) {
+      final String message =
+          "A synchronous delete/update by query task contained failures: " + failures;
+      LOG.error(message);
+      throw new OptimizeRuntimeException(message);
     }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/ProcessInstanceRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/ProcessInstanceRepositoryOS.java
@@ -17,6 +17,7 @@ import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.json;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.lt;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.nested;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.sourceInclude;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.term;
 import static io.camunda.optimize.service.db.os.writer.OpenSearchWriterUtil.createDefaultScriptWithPrimitiveParams;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.END_DATE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_INSTANCE_ID;
@@ -100,6 +101,25 @@ class ProcessInstanceRepositoryOS implements ProcessInstanceRepository {
             .toList();
 
     osClient.doBulkRequest(BulkRequest.Builder::new, bulkOperations, itemName, false);
+  }
+
+  @Override
+  public void deleteByDefinitionId(final String bpmnProcessId, final String definitionId) {
+    try {
+      osClient.deleteByQuery(
+          term(ProcessInstanceIndex.PROCESS_DEFINITION_ID, definitionId),
+          true,
+          getProcessInstanceIndexAliasName(bpmnProcessId));
+    } catch (final OpenSearchException e) {
+      if (isInstanceIndexNotFoundException(PROCESS, e)) {
+        LOG.info(
+            "Was not able to delete process instances for definitionId {} because instance index {} does not exist.",
+            definitionId,
+            getProcessInstanceIndexAliasName(bpmnProcessId));
+        return;
+      }
+      throw e;
+    }
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/ProcessInstanceRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/ProcessInstanceRepositoryOS.java
@@ -24,6 +24,7 @@ import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.P
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.VARIABLES;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.VARIABLE_ID;
 import static io.camunda.optimize.service.util.ExceptionUtil.isInstanceIndexNotFoundException;
+import static io.camunda.optimize.service.util.ExceptionUtil.isInstanceIndexNotFoundExceptionInCauseChain;
 import static io.camunda.optimize.service.util.InstanceIndexUtil.getProcessInstanceIndexAliasName;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -106,12 +107,15 @@ class ProcessInstanceRepositoryOS implements ProcessInstanceRepository {
   @Override
   public void deleteByDefinitionId(final String bpmnProcessId, final String definitionId) {
     try {
-      osClient.deleteByQuery(
+      osClient.deleteByQueryTask(
+          String.format("process instances with definitionId %s", definitionId),
           term(ProcessInstanceIndex.PROCESS_DEFINITION_ID, definitionId),
           true,
           getProcessInstanceIndexAliasName(bpmnProcessId));
-    } catch (final OpenSearchException e) {
-      if (isInstanceIndexNotFoundException(PROCESS, e)) {
+    } catch (final RuntimeException e) {
+      // Depending on how the async delete-by-query task fails, a missing index can surface as an
+      // OpenSearchException directly or wrapped in one or more OptimizeRuntimeExceptions
+      if (isInstanceIndexNotFoundExceptionInCauseChain(PROCESS, e)) {
         LOG.info(
             "Was not able to delete process instances for definitionId {} because instance index {} does not exist.",
             definitionId,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessDefinitionWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessDefinitionWriter.java
@@ -33,6 +33,8 @@ public interface ProcessDefinitionWriter {
 
   void markDefinitionAsDeleted(final String definitionId);
 
+  void deleteDefinition(final String definitionId);
+
   boolean markRedeployedDefinitionsAsDeleted(
       final List<ProcessDefinitionOptimizeDto> importedDefinitions);
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessInstanceWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessInstanceWriter.java
@@ -63,6 +63,10 @@ public class ProcessInstanceWriter {
     this.processInstanceRepository = processInstanceRepository;
   }
 
+  public void deleteInstancesByDefinitionId(final String bpmnProcessId, final String definitionId) {
+    processInstanceRepository.deleteByDefinitionId(bpmnProcessId, definitionId);
+  }
+
   public List<ImportRequestDto> generateProcessInstanceImports(
       final List<ProcessInstanceDto> processInstances, final String sourceExportIndex) {
     final String importItemName = "zeebe process instances";

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -45,6 +46,7 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
   private final ProcessDefinitionWriter processDefinitionWriter;
   private final Sleeper sleeper;
 
+  @Autowired
   public ProcessDefinitionDeletionJobHandler(
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessInstanceWriter processInstanceWriter,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -43,14 +43,24 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
   private final ProcessDefinitionReader processDefinitionReader;
   private final ProcessInstanceWriter processInstanceWriter;
   private final ProcessDefinitionWriter processDefinitionWriter;
+  private final Sleeper sleeper;
 
   public ProcessDefinitionDeletionJobHandler(
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessInstanceWriter processInstanceWriter,
       final ProcessDefinitionWriter processDefinitionWriter) {
+    this(processDefinitionReader, processInstanceWriter, processDefinitionWriter, Thread::sleep);
+  }
+
+  ProcessDefinitionDeletionJobHandler(
+      final ProcessDefinitionReader processDefinitionReader,
+      final ProcessInstanceWriter processInstanceWriter,
+      final ProcessDefinitionWriter processDefinitionWriter,
+      final Sleeper sleeper) {
     this.processDefinitionReader = processDefinitionReader;
     this.processInstanceWriter = processInstanceWriter;
     this.processDefinitionWriter = processDefinitionWriter;
+    this.sleeper = sleeper;
   }
 
   @Override
@@ -109,7 +119,7 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
             MAX_ATTEMPTS,
             e.getMessage());
         try {
-          Thread.sleep(backoffCalculator.calculateSleepTime());
+          sleeper.sleep(backoffCalculator.calculateSleepTime());
         } catch (final InterruptedException ie) {
           Thread.currentThread().interrupt();
           throw e;
@@ -128,5 +138,10 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
       }
     }
     return false;
+  }
+
+  @FunctionalInterface
+  interface Sleeper {
+    void sleep(long millis) throws InterruptedException;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.job;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.util.BackoffCalculator;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.Optional;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProcessDefinitionDeletionJobHandler implements JobHandler {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ProcessDefinitionDeletionJobHandler.class);
+  private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS =
+      List.of(
+          IOException.class,
+          SocketTimeoutException.class,
+          ElasticsearchException.class,
+          OpenSearchException.class);
+  private static final int MAX_ATTEMPTS = 3;
+  private static final long MAX_BACKOFF_SECONDS = 5;
+  private static final long INITIAL_BACKOFF_MILLIS = 1000;
+
+  private final ProcessDefinitionReader processDefinitionReader;
+  private final ProcessInstanceWriter processInstanceWriter;
+  private final ProcessDefinitionWriter processDefinitionWriter;
+
+  public ProcessDefinitionDeletionJobHandler(
+      final ProcessDefinitionReader processDefinitionReader,
+      final ProcessInstanceWriter processInstanceWriter,
+      final ProcessDefinitionWriter processDefinitionWriter) {
+    this.processDefinitionReader = processDefinitionReader;
+    this.processInstanceWriter = processInstanceWriter;
+    this.processDefinitionWriter = processDefinitionWriter;
+  }
+
+  @Override
+  public JobType getJobType() {
+    return JobType.DELETE;
+  }
+
+  @Override
+  public EntityType getEntityType() {
+    return EntityType.PROCESS_DEFINITION;
+  }
+
+  @Override
+  public void handle(final JobRegistryEntryDto job) {
+    final String definitionId = job.getEntityId();
+    final Optional<ProcessDefinitionOptimizeDto> definition =
+        processDefinitionReader.getProcessDefinition(definitionId);
+    if (definition.isEmpty()) {
+      LOG.info("Process definition with ID {} no longer exists, nothing to delete.", definitionId);
+      return;
+    }
+    final String bpmnProcessId = definition.get().getKey();
+    deleteWithRetry(
+        "delete process instances for definition " + definitionId,
+        () -> processInstanceWriter.deleteInstancesByDefinitionId(bpmnProcessId, definitionId));
+    deleteWithRetry(
+        "delete process definition " + definitionId,
+        () -> processDefinitionWriter.deleteDefinition(definitionId));
+  }
+
+  private void deleteWithRetry(final String description, final Runnable deletion) {
+    final BackoffCalculator backoffCalculator =
+        new BackoffCalculator(MAX_BACKOFF_SECONDS, INITIAL_BACKOFF_MILLIS);
+    for (int attempt = 1; ; attempt++) {
+      try {
+        deletion.run();
+        return;
+      } catch (final Exception e) {
+        if (!isRetryable(e) || attempt >= MAX_ATTEMPTS) {
+          throw e;
+        }
+        LOG.warn(
+            "Retrying {} (attempt {}/{}) after retryable error: {}",
+            description,
+            attempt,
+            MAX_ATTEMPTS,
+            e.getMessage());
+        try {
+          Thread.sleep(backoffCalculator.calculateSleepTime());
+        } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw e;
+        }
+      }
+    }
+  }
+
+  private boolean isRetryable(final Throwable t) {
+    return RETRYABLE_EXCEPTIONS.stream()
+        .anyMatch(clazz -> clazz.isInstance(t) || clazz.isInstance(t.getCause()));
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
@@ -66,7 +67,9 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
   public void handle(final JobRegistryEntryDto job) {
     final String definitionId = job.getEntityId();
     final Optional<ProcessDefinitionOptimizeDto> definition =
-        processDefinitionReader.getProcessDefinition(definitionId, false);
+        withRetry(
+            "look up process definition " + definitionId,
+            () -> processDefinitionReader.getProcessDefinition(definitionId, false));
     if (definition.isEmpty()) {
       LOG.info("Process definition with ID {} no longer exists, nothing to delete.", definitionId);
       return;
@@ -81,12 +84,20 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
   }
 
   private void deleteWithRetry(final String description, final Runnable deletion) {
+    withRetry(
+        description,
+        () -> {
+          deletion.run();
+          return null;
+        });
+  }
+
+  private <T> T withRetry(final String description, final Supplier<T> operation) {
     final BackoffCalculator backoffCalculator =
         new BackoffCalculator(MAX_BACKOFF_SECONDS, INITIAL_BACKOFF_MILLIS);
     for (int attempt = 1; ; attempt++) {
       try {
-        deletion.run();
-        return;
+        return operation.get();
       } catch (final Exception e) {
         if (!isRetryable(e) || attempt >= MAX_ATTEMPTS) {
           throw e;

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -66,7 +66,7 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
   public void handle(final JobRegistryEntryDto job) {
     final String definitionId = job.getEntityId();
     final Optional<ProcessDefinitionOptimizeDto> definition =
-        processDefinitionReader.getProcessDefinition(definitionId);
+        processDefinitionReader.getProcessDefinition(definitionId, false);
     if (definition.isEmpty()) {
       LOG.info("Process definition with ID {} no longer exists, nothing to delete.", definitionId);
       return;
@@ -107,8 +107,15 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
     }
   }
 
-  private boolean isRetryable(final Throwable t) {
-    return RETRYABLE_EXCEPTIONS.stream()
-        .anyMatch(clazz -> clazz.isInstance(t) || clazz.isInstance(t.getCause()));
+  // The real error could be wrapped several levels deep
+  private boolean isRetryable(final Throwable throwable) {
+    for (Throwable current = throwable; current != null; current = current.getCause()) {
+      for (final Class<? extends Throwable> retryableClass : RETRYABLE_EXCEPTIONS) {
+        if (retryableClass.isInstance(current)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -109,6 +109,35 @@ class ProcessDefinitionDeletionJobHandlerTest {
   }
 
   @Test
+  void shouldRetryOnRetryableErrorDuringDefinitionLookup() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
+        .thenReturn(Optional.of(definition()));
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(processDefinitionReader, times(2)).getProcessDefinition(DEFINITION_ID, false);
+    verify(processInstanceWriter).deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
+  }
+
+  @Test
+  void shouldPropagateOnceRetryableErrorDuringDefinitionLookupExceedsMaxAttempts() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")));
+
+    // when / then
+    assertThatThrownBy(() -> handler.handle(job())).isInstanceOf(OptimizeRuntimeException.class);
+    verify(processDefinitionReader, times(3)).getProcessDefinition(DEFINITION_ID, false);
+    verify(processInstanceWriter, never()).deleteInstancesByDefinitionId(anyString(), anyString());
+    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+  }
+
+  @Test
   void shouldRetryOnRetryableErrorNestedTwoLevelsDeep() {
     // given -- the repository layer can wrap a retryable error inside another
     // OptimizeRuntimeException (e.g. an async delete-by-query task failure)

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -63,7 +63,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
   @Test
   void shouldDeleteInstancesAndDefinitionWhenDefinitionExists() {
     // given
-    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID))
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
 
     // when
@@ -77,7 +77,8 @@ class ProcessDefinitionDeletionJobHandlerTest {
   @Test
   void shouldNoOpWhenDefinitionNoLongerExists() {
     // given
-    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID)).thenReturn(Optional.empty());
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.empty());
 
     // when
     handler.handle(job());
@@ -90,7 +91,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
   @Test
   void shouldRetryOnRetryableErrorAndEventuallySucceed() {
     // given
-    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID))
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     doThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
         .doThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
@@ -108,9 +109,31 @@ class ProcessDefinitionDeletionJobHandlerTest {
   }
 
   @Test
+  void shouldRetryOnRetryableErrorNestedTwoLevelsDeep() {
+    // given -- the repository layer can wrap a retryable error inside another
+    // OptimizeRuntimeException (e.g. an async delete-by-query task failure)
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    doThrow(
+            new OptimizeRuntimeException(
+                "outer", new OptimizeRuntimeException("inner", new SocketTimeoutException("boom"))))
+        .doNothing()
+        .when(processInstanceWriter)
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(processInstanceWriter, times(2))
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
+  }
+
+  @Test
   void shouldPropagateOnceRetryableErrorExceedsMaxAttempts() {
     // given
-    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID))
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     doThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
         .when(processInstanceWriter)
@@ -124,7 +147,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
   @Test
   void shouldNotRetryNonRetryableError() {
     // given
-    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID))
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     doThrow(new IllegalStateException("not retryable"))
         .when(processInstanceWriter)

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -50,7 +50,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
     processDefinitionWriter = mock(ProcessDefinitionWriter.class);
     handler =
         new ProcessDefinitionDeletionJobHandler(
-            processDefinitionReader, processInstanceWriter, processDefinitionWriter);
+            processDefinitionReader, processInstanceWriter, processDefinitionWriter, millis -> {});
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import java.net.SocketTimeoutException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessDefinitionDeletionJobHandlerTest {
+
+  private static final String DEFINITION_ID = "definition-1";
+  private static final String BPMN_PROCESS_ID = "invoice-process";
+
+  private ProcessDefinitionReader processDefinitionReader;
+  private ProcessInstanceWriter processInstanceWriter;
+  private ProcessDefinitionWriter processDefinitionWriter;
+  private ProcessDefinitionDeletionJobHandler handler;
+
+  @BeforeEach
+  void init() {
+    processDefinitionReader = mock(ProcessDefinitionReader.class);
+    processInstanceWriter = mock(ProcessInstanceWriter.class);
+    processDefinitionWriter = mock(ProcessDefinitionWriter.class);
+    handler =
+        new ProcessDefinitionDeletionJobHandler(
+            processDefinitionReader, processInstanceWriter, processDefinitionWriter);
+  }
+
+  @Test
+  void shouldExposeJobTypeAndEntityType() {
+    // when / then
+    assertThat(handler.getJobType()).isEqualTo(JobType.DELETE);
+    assertThat(handler.getEntityType()).isEqualTo(EntityType.PROCESS_DEFINITION);
+  }
+
+  @Test
+  void shouldDeleteInstancesAndDefinitionWhenDefinitionExists() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID))
+        .thenReturn(Optional.of(definition()));
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(processInstanceWriter).deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
+  }
+
+  @Test
+  void shouldNoOpWhenDefinitionNoLongerExists() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID)).thenReturn(Optional.empty());
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(processInstanceWriter, never()).deleteInstancesByDefinitionId(anyString(), anyString());
+    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+  }
+
+  @Test
+  void shouldRetryOnRetryableErrorAndEventuallySucceed() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID))
+        .thenReturn(Optional.of(definition()));
+    doThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
+        .doThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
+        .doNothing()
+        .when(processInstanceWriter)
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(processInstanceWriter, times(3))
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
+  }
+
+  @Test
+  void shouldPropagateOnceRetryableErrorExceedsMaxAttempts() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID))
+        .thenReturn(Optional.of(definition()));
+    doThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
+        .when(processInstanceWriter)
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+
+    // when / then
+    assertThatThrownBy(() -> handler.handle(job())).isInstanceOf(OptimizeRuntimeException.class);
+    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+  }
+
+  @Test
+  void shouldNotRetryNonRetryableError() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID))
+        .thenReturn(Optional.of(definition()));
+    doThrow(new IllegalStateException("not retryable"))
+        .when(processInstanceWriter)
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+
+    // when / then
+    assertThatThrownBy(() -> handler.handle(job())).isInstanceOf(IllegalStateException.class);
+    verify(processInstanceWriter, times(1))
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+  }
+
+  private JobRegistryEntryDto job() {
+    return new JobRegistryEntryDto(JobType.DELETE, EntityType.PROCESS_DEFINITION, DEFINITION_ID);
+  }
+
+  private ProcessDefinitionOptimizeDto definition() {
+    final ProcessDefinitionOptimizeDto definition = new ProcessDefinitionOptimizeDto();
+    definition.setId(DEFINITION_ID);
+    definition.setKey(BPMN_PROCESS_ID);
+    return definition;
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -956,8 +956,8 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
     waitUntilTaskIsFinished(taskId, deleteItemIdentifier);
 
     final Status taskStatus = richOpenSearchClient.task().task(taskId).task().status();
-    LOG.debug("Deleted [{}] {}.", taskStatus.updated(), deleteItemIdentifier);
-    return taskStatus.updated() > 0L;
+    LOG.debug("Deleted [{}] {}.", taskStatus.deleted(), deleteItemIdentifier);
+    return taskStatus.deleted() > 0L;
   }
 
   public void waitUntilTaskIsFinished(final String taskId, final String taskItemIdentifier) {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -186,7 +186,8 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
   public static void validateTaskResponse(final GetTasksResponse taskResponse) {
     if (taskResponse.error() != null) {
       LOG.error("An Opensearch task failed with error: {}", taskResponse.error());
-      throw new OptimizeRuntimeException(taskResponse.error().toString());
+      // ErrorCause has no toString() override; toJsonString() serializes every field.
+      throw new OptimizeRuntimeException(taskResponse.error().toJsonString());
     }
 
     if (taskResponse.response() != null) {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/ExceptionUtil.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/ExceptionUtil.java
@@ -39,6 +39,18 @@ public class ExceptionUtil {
                 && containsInstanceIndexAliasOrPrefix(type, e.getMessage()));
   }
 
+  public static boolean isInstanceIndexNotFoundExceptionInCauseChain(
+      final DefinitionType type, final Throwable throwable) {
+    Throwable current = throwable;
+    while (current instanceof final RuntimeException runtimeException) {
+      if (isInstanceIndexNotFoundException(type, runtimeException)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
   private static boolean isDbExceptionWithMessage(
       final RuntimeException e, final Function<String, Boolean> messageFilter) {
     if (e instanceof final ElasticsearchException err) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Adds `ProcessDefinitionDeletionJobHandler`, the `JobHandler` implementation for `DELETE`/`PROCESS_DEFINITION` job registry entries: given a process definition's unique id, it resolves the definition's `bpmnProcessId`, deletes its process-instance docs (delete-by-query, scoped to that specific version only — other versions of the same `bpmnProcessId`
are untouched) and the definition record itself, then no-ops idempotently if the data is already gone.
- Retries transient DB/network errors (`IOException`, `ElasticsearchException`, `OpenSearchException`, at any depth in the exception's cause chain) with backoff before giving up, so a job only reaches `FAILED` after genuinely exhausting retries.
- Uses async delete-by-query (ES `taskRepositoryES`/OS `deleteByQueryTask`) rather than a blocking synchronous call, since a process-instance index can be large.
- Adds `ExceptionUtil.isInstanceIndexNotFoundExceptionInCauseChain`, shared by the ES and OS repository implementations, since an async delete-by-query task's index-not-found failure can surface as an exception wrapping another exception rather than a single one carrying the error directly.
- Fixes some latent bugs in shared ES/OS client code:
    - `TaskRepositoryES.syncDelete` ignored the delete-by-query response's `failures` list, so partial failures returned silently as success.
    - `OptimizeOpenSearchClient.deleteByQueryTask` read the task status's `updated` count instead of `deleted` for a delete operation, so its log line and return value never reflected the real delete count.
    - `OptimizeOpenSearchClient.validateTaskResponse` built its error message from `ErrorCause.toString()` (no override, produced an uninformative `ErrorCause@<hash>`); now uses `toJsonString()`.

Follow up issue: #59927

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59849 
