### PR TITLE
Require one ES/OS snapshot repository per physical tenant

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -69,7 +69,8 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
           new GenericExporterIsolationValidation(),
           new SecondaryStorageTypeHomogeneityValidation(),
           new DocumentStoreIsolationValidation(),
-          new PrimaryStorageBackupIsolationValidation());
+          new PrimaryStorageBackupIsolationValidation(),
+          new SnapshotRepositoryIsolationValidation());
 
   private final Map<String, Camunda> resolved;
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/SnapshotRepositoryIdentity.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/SnapshotRepositoryIdentity.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The identity of the Elasticsearch/OpenSearch snapshot repository a document-based physical tenant
+ * writes its history backups into: {@code (type, connection, repositoryName)}.
+ *
+ * <p>Like {@link RetentionPolicyIdentity}, and unlike {@link StorageIdentity}, the index prefix is
+ * deliberately <em>absent</em>: a snapshot repository is a cluster-global named object ({@code
+ * _snapshot/<name>}), not scoped to any index prefix. Two tenants that share a cluster but use
+ * distinct index prefixes — the explicitly-allowed "shared cluster, distinct prefix" setup under
+ * {@link SecondaryStorageIsolationValidation} — nevertheless write into the same repository if they
+ * resolve to the same {@code (type, connection, repositoryName)}.
+ *
+ * <p>The {@code connection} is normalized by {@link StorageIdentity#connectionOf} so every rule
+ * agrees on what "the same cluster" means. The {@code repositoryName} is only trimmed —
+ * <em>not</em> lowercased — because Elasticsearch and OpenSearch repository names are
+ * case-sensitive. {@code type} discriminates Elasticsearch from OpenSearch, mirroring {@link
+ * StorageIdentity}.
+ *
+ * @param type the document-based secondary-storage type (elasticsearch or opensearch)
+ * @param connection the normalized, sorted connection url(s)
+ * @param repositoryName the trimmed snapshot-repository name
+ */
+@NullMarked
+record SnapshotRepositoryIdentity(
+    SecondaryStorageType type, List<String> connection, String repositoryName) {
+
+  /**
+   * Extracts the snapshot-repository identity of a document-based tenant, or {@code null} when no
+   * repository is configured — such a tenant takes no snapshots at all (its backup endpoints reject
+   * every request at runtime) and therefore cannot collide with anything.
+   */
+  static @Nullable SnapshotRepositoryIdentity of(
+      final SecondaryStorageType type, final DocumentBasedSecondaryStorageDatabase database) {
+    final String repositoryName = database.getBackup().getRepositoryName();
+    if (repositoryName == null || repositoryName.isBlank()) {
+      return null;
+    }
+    return new SnapshotRepositoryIdentity(
+        type, StorageIdentity.connectionOf(database), repositoryName.trim());
+  }
+
+  /** A human-readable rendering of this identity for error messages. */
+  String describe() {
+    final String connectionText =
+        connection.size() == 1 ? connection.get(0) : connection.toString();
+    return String.format(
+        "type=%s, connection=%s, repositoryName='%s'", type, connectionText, repositoryName);
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/SnapshotRepositoryIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/SnapshotRepositoryIsolationValidation.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Cross-tenant rule: no two physical tenants may resolve to the same {@link
+ * SnapshotRepositoryIdentity} — the same Elasticsearch/OpenSearch snapshot repository on the same
+ * cluster.
+ *
+ * <p>History snapshots carry no tenant id in their names, so the repository <em>is</em> the
+ * boundary between two tenants' backups. Sharing one puts every tenant's snapshots within reach of
+ * an {@code _all} listing, a {@code DELETE _snapshot/<repo>/*}, a repository delete, or an operator
+ * restoring the wrong repository. This mirrors {@link PrimaryStorageBackupIsolationValidation},
+ * which hard-fails on a shared primary-storage backup location for the same reason.
+ *
+ * <p>Comparing <em>fully resolved</em> configuration means tenants that merely inherit a root
+ * {@code repository-name} collide too — the case this rule mainly exists for, since inheriting is
+ * the default.
+ *
+ * <p>A tenant with no {@code repository-name} takes no snapshots and is skipped, not rejected: that
+ * deployment is already surfaced by a startup warning and its backup endpoints reject every request
+ * at runtime. RDBMS and {@code none} tenants have no snapshot repository and are skipped as well.
+ *
+ * <p>The synthesized {@code default} tenant participates like any other. Single-tenant deployments
+ * resolve to a one-entry map and are a no-op. Colliding tenants are reported as a single grouped
+ * error, not O(n²) pairwise messages.
+ */
+@NullMarked
+class SnapshotRepositoryIsolationValidation implements CrossTenantValidation {
+
+  @Override
+  public void validate(final Map<String, Camunda> resolvedByTenant) {
+    if (resolvedByTenant.size() <= 1) {
+      // a single tenant cannot collide with anything
+      return;
+    }
+
+    final Map<SnapshotRepositoryIdentity, List<String>> tenantsByRepository = new LinkedHashMap<>();
+    resolvedByTenant.forEach(
+        (tenantId, camunda) -> {
+          final var secondaryStorage = camunda.getData().getSecondaryStorage();
+          // rdbms/none take no ES/OS snapshots; elasticsearchOrOpensearch() is empty for them
+          secondaryStorage
+              .elasticsearchOrOpensearch()
+              .map(database -> SnapshotRepositoryIdentity.of(secondaryStorage.getType(), database))
+              .ifPresent(
+                  identity ->
+                      tenantsByRepository
+                          .computeIfAbsent(identity, k -> new ArrayList<>())
+                          .add(tenantId));
+        });
+
+    final List<String> collisions = new ArrayList<>();
+    tenantsByRepository.forEach(
+        (identity, tenantIds) -> {
+          if (tenantIds.size() > 1) {
+            collisions.add(
+                String.format(
+                    "tenants %s share the same snapshot repository [%s]",
+                    tenantIds, identity.describe()));
+          }
+        });
+
+    if (!collisions.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Physical tenants must not share a secondary-storage snapshot repository: history "
+              + "snapshots carry no tenant id, so one tenant's listing, delete or restore would "
+              + "reach another tenant's backups. Register one repository per tenant and set a "
+              + "distinct data.secondary-storage.<database>.backup.repository-name for each. "
+              + "Conflicts: "
+              + String.join("; ", collisions));
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/SnapshotRepositoryIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/SnapshotRepositoryIsolationValidation.java
@@ -76,9 +76,8 @@ class SnapshotRepositoryIsolationValidation implements CrossTenantValidation {
 
     if (!collisions.isEmpty()) {
       throw new UnifiedConfigurationException(
-          "Physical tenants must not share a secondary-storage snapshot repository: history "
-              + "snapshots carry no tenant id, so one tenant's listing, delete or restore would "
-              + "reach another tenant's backups. Register one repository per tenant and set a "
+          "Physical tenants must not share a secondary-storage snapshot repository."
+             + "Register one repository per tenant and set a "
               + "distinct data.secondary-storage.<database>.backup.repository-name for each. "
               + "Conflicts: "
               + String.join("; ", collisions));

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
@@ -401,6 +401,50 @@ class PhysicalTenantResolverTest {
         .containsOnlyKeys("tenanta", "tenantb", PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }
 
+  @Test
+  void shouldRejectTenantsInheritingOneRootSnapshotRepository() {
+    // given a root repository-name and two tenants that override only their index prefix (so the
+    // isolation rule passes) — both inherit the one repository, which is the default outcome and
+    // only visible once the root and tenant configurations are resolved together
+    setProperties(
+        Map.of(
+            "camunda.data.secondary-storage.elasticsearch.backup.repository-name", "camunda-backup",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                "tenantb"),
+        "tenanta",
+        "tenantb");
+
+    // when / then resolution fails fast at boot on the shared snapshot repository
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(this::newResolver)
+        .withMessageContaining("snapshot repository");
+  }
+
+  @Test
+  void shouldResolveWhenSharedClusterButDistinctSnapshotRepositories() {
+    // given two tenants on the same cluster that each override the inherited root repository-name
+    setProperties(
+        Map.of(
+            "camunda.data.secondary-storage.elasticsearch.backup.repository-name", "camunda-backup",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.backup.repository-name",
+                "camunda-backup-tenanta",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                "tenantb",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.backup.repository-name",
+                "camunda-backup-tenantb"),
+        "tenanta",
+        "tenantb");
+
+    // when / then distinct repositories isolate the tenants — resolution succeeds
+    final PhysicalTenantResolver resolver = newResolver();
+    assertThat(resolver.getAll())
+        .containsOnlyKeys("tenanta", "tenantb", PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
   // --- exporter assignment wiring (ADR-0008 D1/D2/D5) --------------------------------------------
   // PhysicalTenantExporterAssignedValidation, PhysicalTenantExporterConfigurations#narrowToAssigned
   // and GenericExporterIsolationValidation are unit-tested standalone elsewhere; these tests

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/SnapshotRepositoryIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/SnapshotRepositoryIsolationValidationTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Unit tests for the {@link SnapshotRepositoryIsolationValidation} cross-tenant rule: no two
+ * physical tenants may resolve to the same {@link SnapshotRepositoryIdentity} (their history
+ * snapshots would share one repository, which is the only thing separating them).
+ */
+class SnapshotRepositoryIsolationValidationTest {
+
+  private static final String SHARED_REPOSITORY = "camunda-backup";
+
+  private final SnapshotRepositoryIsolationValidation validation =
+      new SnapshotRepositoryIsolationValidation();
+
+  @BeforeEach
+  void setUp() {
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldRejectTenantsSharingClusterAndRepositoryName() {
+    // given two tenants on the same cluster pointed at the same repository — the headline footgun:
+    // distinct index prefixes pass the isolation rule, yet the repository is cluster-global
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", SHARED_REPOSITORY),
+            "tenantb", es("http://es:9200", SHARED_REPOSITORY));
+
+    // when / then the shared repository is rejected, naming both tenants and the repository
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("http://es:9200")
+        .withMessageContaining(SHARED_REPOSITORY);
+  }
+
+  @Test
+  void shouldPassWhenSharedClusterButDistinctRepositoryNames() {
+    // given two tenants on the same cluster with a repository each
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", "tenant-a-backup"),
+            "tenantb", es("http://es:9200", "tenant-b-backup"));
+
+    // when / then distinct repositories isolate the tenants' snapshots — no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenSameRepositoryNameButDistinctClusters() {
+    // given two tenants using the same repository name on distinct clusters
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es-a:9200", SHARED_REPOSITORY),
+            "tenantb", es("http://es-b:9200", SHARED_REPOSITORY));
+
+    // when / then a repository is scoped to its cluster, so the two never overlap — no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldIgnoreTenantsWithoutAConfiguredRepository() {
+    // given two tenants on the same cluster that configure no repository at all
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", null),
+            "tenantb", es("http://es:9200", "   "));
+
+    // when / then a tenant with no repository takes no snapshots — it is skipped, not rejected
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldOnlyConsiderTenantsWithAConfiguredRepository() {
+    // given two tenants on one cluster, only one of which configures a repository
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", SHARED_REPOSITORY),
+            "tenantb", es("http://es:9200", null));
+
+    // when / then a single participant cannot collide
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassForSingleTenantMap() {
+    // given a single-tenant deployment
+    final Map<String, Camunda> resolved =
+        tenants("default", es("http://es:9200", SHARED_REPOSITORY));
+
+    // when / then uniqueness over one entry is a no-op
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectWhenDefaultTenantSharesRepositoryWithExplicitTenant() {
+    // given the synthesized 'default' tenant and an explicit tenant resolve to the same repository
+    // — what inheriting a root repository-name produces
+    final Map<String, Camunda> resolved =
+        tenants(
+            "default", es("http://es:9200", SHARED_REPOSITORY),
+            "tenanta", es("http://es:9200", SHARED_REPOSITORY));
+
+    // when / then 'default' participates like any other tenant
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("default")
+        .withMessageContaining("tenanta");
+  }
+
+  @Test
+  void shouldReportOneGroupedErrorWhenThreeTenantsShareOneRepository() {
+    // given three tenants all sharing the same cluster + repository name
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", SHARED_REPOSITORY),
+            "tenantb", es("http://es:9200", SHARED_REPOSITORY),
+            "tenantc", es("http://es:9200", SHARED_REPOSITORY));
+
+    // when / then one grouped error lists all three (not three pairwise errors)
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("tenantc")
+        // a single grouped message mentions the shared repository exactly once
+        .satisfies(
+            e -> assertThat(countOccurrences(e.getMessage(), SHARED_REPOSITORY)).isEqualTo(1));
+  }
+
+  @Test
+  void shouldRejectOpensearchTenantsSharingClusterAndRepositoryName() {
+    // given two OpenSearch tenants on the same cluster pointed at the same repository
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", os("http://os:9200", SHARED_REPOSITORY),
+            "tenantb", os("http://os:9200", SHARED_REPOSITORY));
+
+    // when / then the OpenSearch collision is rejected too
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("opensearch");
+  }
+
+  @Test
+  void shouldTreatElasticsearchAndOpensearchAsDistinctLocations() {
+    // given one ES and one OS tenant whose urls and repository names happen to match
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://same:9200", SHARED_REPOSITORY),
+            "tenantb", os("http://same:9200", SHARED_REPOSITORY));
+
+    // when / then the engine type discriminates — no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldIgnoreRdbmsAndNoneTenants() {
+    // given rdbms/none tenants — they take no ES/OS snapshots
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", rdbms(),
+            "tenantb", rdbms(),
+            "tenantc", none());
+
+    // when / then non-document stores have no snapshot repository → no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldTrimRepositoryNameWhitespace() {
+    // given two tenants whose repository names differ only by surrounding whitespace — a config
+    // typo, not isolation
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", "backup"),
+            "tenantb", es("http://es:9200", "  backup  "));
+
+    // when / then trimming folds them together → the collision is surfaced
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldNotFoldRepositoryNamesThatDifferOnlyByCase() {
+    // given two tenants whose repository names differ only by case
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", "Backup"),
+            "tenantb", es("http://es:9200", "backup"));
+
+    // when / then ES/OS repository names are case-sensitive, so these are two repositories
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  // --- helpers -----------------------------------------------------------------------------------
+
+  private static Camunda es(final String url, final String repositoryName) {
+    return documentBased(SecondaryStorageType.elasticsearch, url, repositoryName);
+  }
+
+  private static Camunda os(final String url, final String repositoryName) {
+    return documentBased(SecondaryStorageType.opensearch, url, repositoryName);
+  }
+
+  private static Camunda documentBased(
+      final SecondaryStorageType type, final String url, final String repositoryName) {
+    final Camunda camunda = new Camunda();
+    final var ss = camunda.getData().getSecondaryStorage();
+    ss.setType(type);
+    final var database =
+        type == SecondaryStorageType.elasticsearch ? ss.getElasticsearch() : ss.getOpensearch();
+    database.setUrl(url);
+    database.getBackup().setRepositoryName(repositoryName);
+    return camunda;
+  }
+
+  private static Camunda rdbms() {
+    final Camunda camunda = new Camunda();
+    final var ss = camunda.getData().getSecondaryStorage();
+    ss.setType(SecondaryStorageType.rdbms);
+    ss.getRdbms().setUrl("jdbc:postgresql://db:5432/camunda");
+    return camunda;
+  }
+
+  private static Camunda none() {
+    final Camunda camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
+    return camunda;
+  }
+
+  private static Map<String, Camunda> tenants(final Object... idThenCamunda) {
+    final Map<String, Camunda> map = new LinkedHashMap<>();
+    for (int i = 0; i < idThenCamunda.length; i += 2) {
+      map.put((String) idThenCamunda[i], (Camunda) idThenCamunda[i + 1]);
+    }
+    return map;
+  }
+
+  private static int countOccurrences(final String haystack, final String needle) {
+    int count = 0;
+    int from = 0;
+    while ((from = haystack.indexOf(needle, from)) >= 0) {
+      count++;
+      from += needle.length();
+    }
+    return count;
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupServiceRegistryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupServiceRegistryConfiguration.java
@@ -11,7 +11,6 @@ import static io.camunda.configuration.SecondaryStorage.SecondaryStorageType.ela
 import static io.camunda.configuration.SecondaryStorage.SecondaryStorageType.opensearch;
 
 import io.camunda.application.commons.backup.BackupServiceRegistry.PhysicalTenantBackup;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.DocumentBasedSecondaryStorageBackup;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
@@ -161,7 +160,7 @@ public class BackupServiceRegistryConfiguration {
       final SearchClients searchClients,
       final BackupRepositoryProps props,
       final ThreadPoolTaskExecutor threadPoolTaskExecutor) {
-    final var snapshotNameProvider = snapshotNameProvider(physicalTenantId);
+    final var snapshotNameProvider = new WebappsSnapshotNameProvider();
     final var esClient = searchClients.esClients().get(physicalTenantId);
     if (esClient != null) {
       return new ElasticsearchBackupRepository(
@@ -184,12 +183,6 @@ public class BackupServiceRegistryConfiguration {
           secondaryStorage.getType(),
           secondaryStorage.getType());
     }
-  }
-
-  static WebappsSnapshotNameProvider snapshotNameProvider(final String physicalTenantId) {
-    return PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)
-        ? new WebappsSnapshotNameProvider()
-        : new WebappsSnapshotNameProvider(physicalTenantId);
   }
 
   static BackupRepositoryProps props(

--- a/docs/monorepo-docs/architecture/components/secondary-storage/backup-and-restore.md
+++ b/docs/monorepo-docs/architecture/components/secondary-storage/backup-and-restore.md
@@ -142,6 +142,9 @@ The `{total}` can vary across backups (e.g. from 5 to 7) depending on which opti
 active at backup time. Always use the `scheduledSnapshots` list returned by the take-backup response
 to determine how many parts were created for a specific backup.
 
+The name carries no physical-tenant id: tenants are separated by their snapshot repository, not by
+their snapshot names (see [§1.6](#16-physical-tenants)).
+
 ### 1.4 Backup States
 
 `BackupStateDto` represents the aggregate state of a backup:
@@ -172,7 +175,53 @@ returns an error if it is not found.
 
 The backup executor uses a single-core thread pool with a queue capacity of 4096.
 
-### 1.6 API / Actuator Endpoints
+### 1.6 Physical Tenants
+
+**Each physical tenant requires its own snapshot repository.** Snapshot names are identical across
+tenants, so the repository is the only boundary between one tenant's backups and another's. Sharing
+one would put every tenant's snapshots within reach of an `_all` listing, a
+`DELETE _snapshot/<repo>/*`, a repository delete, or an operator restoring the wrong repository.
+
+Set a distinct repository per tenant — the property already resolves per tenant, so no separate
+configuration surface exists:
+
+```yaml
+camunda:
+  data:
+    secondary-storage:
+      elasticsearch:
+        backup:
+          repository-name: camunda-backup-default
+  physical-tenants:
+    tenanta:
+      data:
+        secondary-storage:
+          elasticsearch:
+            backup:
+              repository-name: camunda-backup-tenanta
+```
+
+As in the single-tenant case, Camunda never creates a repository — the operator registers each one
+with ES/OS beforehand.
+
+`SnapshotRepositoryIsolationValidation` (in `configuration`, registered in
+`PhysicalTenantResolver.CROSS_TENANT_VALIDATIONS`) enforces this at boot: startup fails when two
+tenants resolve to the same `(type, connection, repository-name)`, with the colliding tenants named
+in one grouped error. Note what the identity leaves out — the index prefix. A repository is a
+cluster-global object (`_snapshot/<name>`), so the "shared cluster, distinct index prefix" setup
+that `SecondaryStorageIsolationValidation` allows for indices still collides here.
+
+The rule compares fully resolved configuration, so tenants that merely inherit a root
+`repository-name` without overriding it collide too — the case it mainly exists for. A tenant that
+configures no repository takes no snapshots and is skipped rather than rejected (its backup
+endpoints reject every request at runtime, and startup logs a warning). The `default` tenant
+participates like any other, and single-tenant deployments are a no-op.
+
+A repository may still hold foreign snapshots: Optimize writes its `camunda_optimize_` snapshots
+into the same repository (see [§3.2](#32-snapshot-naming-optimize)). That is a deployment decision
+this rule does not govern — it constrains the Orchestration Cluster's tenants only.
+
+### 1.7 API / Actuator Endpoints
 
 Backups are triggered, monitored, and deleted via Spring Boot actuator endpoints:
 
@@ -349,33 +398,34 @@ the secondary storage state (the exporter will simply re-process any gap after r
 
 ## 5. Key Classes and Locations
 
-|        Class / Interface        |      Module      |                                            Role                                            |
-|---------------------------------|------------------|--------------------------------------------------------------------------------------------|
-| `BackupPriority`                | `webapps-schema` | Marker interface for ES/OS index backup ordering                                           |
-| `Prio1Backup` – `Prio4Backup`   | `webapps-schema` | Priority marker sub-interfaces                                                             |
-| `BackupPriorities`              | `webapps-schema` | Record holding all 4 priority lists; produces ordered `SnapshotIndexCollection` list       |
-| `SnapshotIndexCollection`       | `webapps-schema` | Required + skippable index names for one snapshot part                                     |
-| `BackupPriorityConfiguration`   | `dist`           | Assembles `BackupPriorities` from descriptors; ES/OS only                                  |
-| `BackupService` (webapps)       | `webapps-backup` | Interface: `takeBackup`, `deleteBackup`, `getBackupState`, `getBackups`                    |
-| `BackupServiceImpl`             | `webapps-backup` | Single-threaded sequential snapshot executor                                               |
-| `BackupRepository`              | `webapps-backup` | Interface to ES/OS snapshot API                                                            |
-| `ElasticsearchBackupRepository` | `webapps-backup` | ES implementation                                                                          |
-| `OpensearchBackupRepository`    | `webapps-backup` | OS implementation                                                                          |
-| `WebappsSnapshotNameProvider`   | `webapps-backup` | `camunda_webapps_{id}_{ver}_part_{n}_of_{total}`                                           |
-| `Metadata`                      | `webapps-backup` | Record: `backupId`, `version`, `partNo`, `partCount`                                       |
-| `BackupStateDto`                | `webapps-backup` | `IN_PROGRESS`, `INCOMPLETE`, `COMPLETED`, `FAILED`, `INCOMPATIBLE`                         |
-| `BackupController`              | `dist`           | `@WebEndpoint(id = "backupHistory")` - combined deployment actuator                        |
-| `BackupControllerStandalone`    | `dist`           | `@WebEndpoint(id = "backups")` - standalone deployment actuator                            |
-| `HistoryBackupComponent`        | `dist`           | Wires `BackupServiceImpl`; conditional on ES/OS                                            |
-| `BackupConfig`                  | `dist`           | Configures repository props and executor thread pool                                       |
-| `BackupService` (Optimize)      | `optimize`       | Orchestrates Optimize's 2-snapshot backup                                                  |
-| `BackupWriter` (Optimize)       | `optimize`       | Triggers two snapshots back-to-back; sequential on ES (blocking), concurrent on OS (async) |
-| `BackupReader` (Optimize)       | `optimize`       | Interface: reads snapshot state (ES + OS impls)                                            |
-| `BackupRestService` (Optimize)  | `optimize`       | `@RestControllerEndpoint(id = "backups")` - Optimize actuator                              |
-| `SnapshotUtil` (Optimize)       | `optimize`       | `camunda_optimize_{id}_{ver}_part_{1\|2}_of_2`                                             |
-| `RestoreManager`                | `zeebe/restore`  | Restores Zeebe partition data; RDBMS-aware path included                                   |
-| `RestorePointResolver`          | `zeebe/restore`  | Selects optimal backup checkpoint per partition aligned to RDBMS position                  |
-| `ExporterPositionMapper`        | `db/rdbms`       | Reads per-partition exporter positions from RDBMS during restore                           |
+|            Class / Interface            |      Module      |                                            Role                                            |
+|-----------------------------------------|------------------|--------------------------------------------------------------------------------------------|
+| `BackupPriority`                        | `webapps-schema` | Marker interface for ES/OS index backup ordering                                           |
+| `Prio1Backup` – `Prio4Backup`           | `webapps-schema` | Priority marker sub-interfaces                                                             |
+| `BackupPriorities`                      | `webapps-schema` | Record holding all 4 priority lists; produces ordered `SnapshotIndexCollection` list       |
+| `SnapshotIndexCollection`               | `webapps-schema` | Required + skippable index names for one snapshot part                                     |
+| `BackupPriorityConfiguration`           | `dist`           | Assembles `BackupPriorities` from descriptors; ES/OS only                                  |
+| `BackupService` (webapps)               | `webapps-backup` | Interface: `takeBackup`, `deleteBackup`, `getBackupState`, `getBackups`                    |
+| `BackupServiceImpl`                     | `webapps-backup` | Single-threaded sequential snapshot executor                                               |
+| `BackupRepository`                      | `webapps-backup` | Interface to ES/OS snapshot API                                                            |
+| `ElasticsearchBackupRepository`         | `webapps-backup` | ES implementation                                                                          |
+| `OpensearchBackupRepository`            | `webapps-backup` | OS implementation                                                                          |
+| `WebappsSnapshotNameProvider`           | `webapps-backup` | `camunda_webapps_{id}_{ver}_part_{n}_of_{total}`                                           |
+| `Metadata`                              | `webapps-backup` | Record: `backupId`, `version`, `partNo`, `partCount`                                       |
+| `BackupStateDto`                        | `webapps-backup` | `IN_PROGRESS`, `INCOMPLETE`, `COMPLETED`, `FAILED`, `INCOMPATIBLE`                         |
+| `BackupController`                      | `dist`           | `@WebEndpoint(id = "backupHistory")` - combined deployment actuator                        |
+| `BackupControllerStandalone`            | `dist`           | `@WebEndpoint(id = "backups")` - standalone deployment actuator                            |
+| `HistoryBackupComponent`                | `dist`           | Wires `BackupServiceImpl`; conditional on ES/OS                                            |
+| `BackupConfig`                          | `dist`           | Configures repository props and executor thread pool                                       |
+| `SnapshotRepositoryIsolationValidation` | `configuration`  | Boot-time rule: one snapshot repository per physical tenant                                |
+| `BackupService` (Optimize)              | `optimize`       | Orchestrates Optimize's 2-snapshot backup                                                  |
+| `BackupWriter` (Optimize)               | `optimize`       | Triggers two snapshots back-to-back; sequential on ES (blocking), concurrent on OS (async) |
+| `BackupReader` (Optimize)               | `optimize`       | Interface: reads snapshot state (ES + OS impls)                                            |
+| `BackupRestService` (Optimize)          | `optimize`       | `@RestControllerEndpoint(id = "backups")` - Optimize actuator                              |
+| `SnapshotUtil` (Optimize)               | `optimize`       | `camunda_optimize_{id}_{ver}_part_{1\                                                      |
+| `RestoreManager`                        | `zeebe/restore`  | Restores Zeebe partition data; RDBMS-aware path included                                   |
+| `RestorePointResolver`                  | `zeebe/restore`  | Selects optimal backup checkpoint per partition aligned to RDBMS position                  |
+| `ExporterPositionMapper`                | `db/rdbms`       | Reads per-partition exporter positions from RDBMS during restore                           |
 
 ## 6. References
 

--- a/docs/monorepo-docs/architecture/components/secondary-storage/backup-and-restore.md
+++ b/docs/monorepo-docs/architecture/components/secondary-storage/backup-and-restore.md
@@ -422,7 +422,7 @@ the secondary storage state (the exporter will simply re-process any gap after r
 | `BackupWriter` (Optimize)               | `optimize`       | Triggers two snapshots back-to-back; sequential on ES (blocking), concurrent on OS (async) |
 | `BackupReader` (Optimize)               | `optimize`       | Interface: reads snapshot state (ES + OS impls)                                            |
 | `BackupRestService` (Optimize)          | `optimize`       | `@RestControllerEndpoint(id = "backups")` - Optimize actuator                              |
-| `SnapshotUtil` (Optimize)               | `optimize`       | `camunda_optimize_{id}_{ver}_part_{1\                                                      |
+| `SnapshotUtil` (Optimize)               | `optimize`       | `camunda_optimize_{id}_{ver}_part_{1\|2}_of_2`                                             |
 | `RestoreManager`                        | `zeebe/restore`  | Restores Zeebe partition data; RDBMS-aware path included                                   |
 | `RestorePointResolver`                  | `zeebe/restore`  | Selects optimal backup checkpoint per partition aligned to RDBMS position                  |
 | `ExporterPositionMapper`                | `db/rdbms`       | Reads per-partition exporter positions from RDBMS during restore                           |

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/PhysicalTenantHistoryBackupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/PhysicalTenantHistoryBackupIT.java
@@ -84,7 +84,8 @@ final class PhysicalTenantHistoryBackupIT {
             .build();
     tenants.configure(BROKER);
 
-    // one repository for both tenants, on purpose — see the class javadoc
+    // a repository per tenant: sharing one is rejected at boot by
+    // SnapshotRepositoryIsolationValidation
     BROKER.withUnifiedConfig(
         camunda ->
             camunda
@@ -121,19 +122,19 @@ final class PhysicalTenantHistoryBackupIT {
     final var tenantATaken = takeBackup(TENANT_A, TENANT_A_BACKUP_ID);
     assertStatus(tenantATaken, 202);
 
-    // then each tenant's snapshots carry its own name prefix
+    // then both tenants name their snapshots the same way — the repository is what separates them
     assertThat(scheduledSnapshots(defaultTaken))
         .isNotEmpty()
         .allSatisfy(name -> assertThat(name).startsWith("camunda_webapps_"));
     assertThat(scheduledSnapshots(tenantATaken))
         .isNotEmpty()
-        .allSatisfy(name -> assertThat(name).startsWith(TENANT_A + "_camunda_webapps_"));
+        .allSatisfy(name -> assertThat(name).startsWith("camunda_webapps_"));
 
     // and each backup completes on its own tenant
     awaitBackupState(DEFAULT_TENANT_ID, DEFAULT_BACKUP_ID, "COMPLETED");
     awaitBackupState(TENANT_A, TENANT_A_BACKUP_ID, "COMPLETED");
 
-    // and neither tenant sees the other's backup, although they share one repository
+    // and neither tenant sees the other's backup
     assertThat(listedBackupIds(DEFAULT_TENANT_ID))
         .contains(DEFAULT_BACKUP_ID)
         .doesNotContain(TENANT_A_BACKUP_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/PhysicalTenantStandaloneBackupManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/PhysicalTenantStandaloneBackupManagerIT.java
@@ -23,20 +23,20 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that the standalone backup manager backs up every configured physical tenant. Both
- * tenants share one search cluster and one snapshot repository, so the test also verifies that
- * snapshot name prefixing keeps the tenants' backups distinguishable in a shared repository.
+ * tenants share one search cluster but own a snapshot repository each — the isolation the boot-time
+ * {@code SnapshotRepositoryIsolationValidation} rule enforces — so the test also verifies that a
+ * tenant's snapshots land in its own repository and nowhere else.
  */
 @ZeebeIntegration
 final class PhysicalTenantStandaloneBackupManagerIT {
 
-  private static final String REPOSITORY_NAME = "backup-test";
+  private static final String DEFAULT_REPOSITORY_NAME = "backup-test";
+  private static final String TENANT_A_REPOSITORY_NAME = "backup-test-tenanta";
   private static final String TENANT_A = "tenanta";
   private static final long BACKUP_ID = 42L;
 
-  private static final String DEFAULT_SNAPSHOT_PREFIX =
+  private static final String SNAPSHOT_PREFIX =
       new WebappsSnapshotNameProvider().getSnapshotNamePrefix(BACKUP_ID);
-  private static final String TENANT_A_SNAPSHOT_PREFIX =
-      new WebappsSnapshotNameProvider(TENANT_A).getSnapshotNamePrefix(BACKUP_ID);
 
   @TestZeebe(autoStart = false)
   final TestStandaloneBackupManager backupManager = new TestStandaloneBackupManager();
@@ -48,7 +48,7 @@ final class PhysicalTenantStandaloneBackupManagerIT {
   final TestStandaloneSchemaManager tenantASchemaManager = new TestStandaloneSchemaManager();
 
   @Test
-  void shouldBackupAllPhysicalTenantsIntoSharedRepository() throws Exception {
+  void shouldBackupAllPhysicalTenantsIntoOwnRepositories() throws Exception {
     try (final SearchBackendStrategy strategy = new ElasticsearchBackendStrategy()) {
       // given
       strategy.startContainer();
@@ -67,16 +67,17 @@ final class PhysicalTenantStandaloneBackupManagerIT {
       defaultSchemaManager.start();
       tenantASchemaManager.start();
 
-      strategy.createSnapshotRepository(REPOSITORY_NAME);
+      strategy.createSnapshotRepository(DEFAULT_REPOSITORY_NAME);
+      strategy.createSnapshotRepository(TENANT_A_REPOSITORY_NAME);
 
-      strategy.configureStandaloneBackupManager(backupManager, REPOSITORY_NAME);
+      strategy.configureStandaloneBackupManager(backupManager, DEFAULT_REPOSITORY_NAME);
       backupManager
           .withProperty(tenantProperty("data.secondary-storage.elasticsearch.url"), url)
           .withProperty(
               tenantProperty("data.secondary-storage.elasticsearch.index-prefix"), TENANT_A)
           .withProperty(
               tenantProperty("data.secondary-storage.elasticsearch.backup.repository-name"),
-              REPOSITORY_NAME)
+              TENANT_A_REPOSITORY_NAME)
           .withProperty(
               tenantProperty("security.initialization.default-roles.admin.users[0]"),
               TENANT_A + "-admin");
@@ -84,20 +85,18 @@ final class PhysicalTenantStandaloneBackupManagerIT {
       // when
       backupManager.withBackupId(BACKUP_ID).withSkipSchemaCheck(true).start();
 
-      // then
+      // then each tenant's snapshots are complete in its own repository
       final List<String> defaultSnapshots =
-          waitForSuccessSnapshots(strategy, DEFAULT_SNAPSHOT_PREFIX);
+          waitForSuccessSnapshots(strategy, DEFAULT_REPOSITORY_NAME);
       final List<String> tenantASnapshots =
-          waitForSuccessSnapshots(strategy, TENANT_A_SNAPSHOT_PREFIX);
+          waitForSuccessSnapshots(strategy, TENANT_A_REPOSITORY_NAME);
 
       assertThat(defaultSnapshots).isNotEmpty().hasSameSizeAs(tenantASnapshots);
-      // the default tenant keeps the legacy unprefixed names; tenant A's are prefixed
+      // the repository, not the snapshot name, is what separates the tenants
       assertThat(defaultSnapshots)
           .allSatisfy(name -> assertThat(name).startsWith("camunda_webapps_"));
       assertThat(tenantASnapshots)
-          .allSatisfy(name -> assertThat(name).startsWith(TENANT_A + "_camunda_webapps_"));
-      // sharing one repository must not leak one tenant's snapshots into the other's listing
-      assertThat(defaultSnapshots).doesNotContainAnyElementsOf(tenantASnapshots);
+          .allSatisfy(name -> assertThat(name).startsWith("camunda_webapps_"));
     }
   }
 
@@ -106,12 +105,12 @@ final class PhysicalTenantStandaloneBackupManagerIT {
   }
 
   private List<String> waitForSuccessSnapshots(
-      final SearchBackendStrategy strategy, final String snapshotNamePrefix) {
-    return Awaitility.await("should find completed snapshots for prefix " + snapshotNamePrefix)
+      final SearchBackendStrategy strategy, final String repositoryName) {
+    return Awaitility.await("should find completed snapshots in repository " + repositoryName)
         .atMost(ofSeconds(60))
         .pollDelay(ofSeconds(2))
         .until(
-            () -> strategy.getSuccessSnapshots(REPOSITORY_NAME, snapshotNamePrefix),
+            () -> strategy.getSuccessSnapshots(repositoryName, SNAPSHOT_PREFIX),
             snapshots -> !snapshots.isEmpty());
   }
 }

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/WebappsSnapshotNameProvider.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/WebappsSnapshotNameProvider.java
@@ -12,33 +12,28 @@ import io.camunda.webapps.backup.Metadata;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Names the Orchestration Cluster's snapshots. The {@value #SNAPSHOT_NAME_PREFIX} prefix separates
+ * them from foreign snapshots a repository may legitimately hold — Optimize writes {@code
+ * camunda_optimize_} snapshots into the very same repository.
+ *
+ * <p>Physical tenants are <em>not</em> encoded in the name: each tenant owns a snapshot repository
+ * of its own, enforced at boot by {@code SnapshotRepositoryIsolationValidation}.
+ */
 public class WebappsSnapshotNameProvider implements SnapshotNameProvider {
   public static final String SNAPSHOT_NAME_PREFIX = "camunda_webapps_";
   private static final String SNAPSHOT_NAME_PATTERN = "{prefix}{version}_part_{index}_of_{count}";
-
-  private final String physicalTenantPrefix;
-  private final String snapshotNamePrefixPattern;
-  private final Pattern backupIdPattern;
-  private final Pattern metadataPattern;
-
-  public WebappsSnapshotNameProvider() {
-    this("");
-  }
-
-  public WebappsSnapshotNameProvider(final String physicalTenantId) {
-    physicalTenantPrefix = physicalTenantId.isEmpty() ? "" : physicalTenantId + "_";
-    final String prefix = physicalTenantPrefix + SNAPSHOT_NAME_PREFIX;
-    snapshotNamePrefixPattern = prefix + "{backupId}_";
-    backupIdPattern = Pattern.compile(Pattern.quote(prefix) + "(\\d*)_.*");
-    metadataPattern =
-        Pattern.compile(
-            Pattern.quote(prefix)
-                + "(?<backupId>\\d+)_(?<version>[^_]+)_part_(?<index>\\d+)_of_(?<count>\\d+)");
-  }
+  private static final String SNAPSHOT_NAME_PREFIX_PATTERN = SNAPSHOT_NAME_PREFIX + "{backupId}_";
+  private static final Pattern BACKUP_ID_PATTERN =
+      Pattern.compile(Pattern.quote(SNAPSHOT_NAME_PREFIX) + "(\\d*)_.*");
+  private static final Pattern METADATA_PATTERN =
+      Pattern.compile(
+          Pattern.quote(SNAPSHOT_NAME_PREFIX)
+              + "(?<backupId>\\d+)_(?<version>[^_]+)_part_(?<index>\\d+)_of_(?<count>\\d+)");
 
   @Override
   public String getSnapshotNamePrefix(final long backupId) {
-    return snapshotNamePrefixPattern.replace("{backupId}", String.valueOf(backupId));
+    return SNAPSHOT_NAME_PREFIX_PATTERN.replace("{backupId}", String.valueOf(backupId));
   }
 
   @Override
@@ -52,7 +47,7 @@ public class WebappsSnapshotNameProvider implements SnapshotNameProvider {
 
   @Override
   public Long extractBackupId(final String snapshotName) {
-    final Matcher matcher = backupIdPattern.matcher(snapshotName);
+    final Matcher matcher = BACKUP_ID_PATTERN.matcher(snapshotName);
     if (matcher.matches()) {
       return Long.valueOf(matcher.group(1));
     } else {
@@ -65,7 +60,7 @@ public class WebappsSnapshotNameProvider implements SnapshotNameProvider {
     if (snapshotName == null) {
       return null;
     }
-    final Matcher matcher = metadataPattern.matcher(snapshotName);
+    final Matcher matcher = METADATA_PATTERN.matcher(snapshotName);
     if (matcher.matches()) {
       final Long backupId = Long.parseLong(matcher.group("backupId"));
       final String version = matcher.group("version");
@@ -81,6 +76,6 @@ public class WebappsSnapshotNameProvider implements SnapshotNameProvider {
 
   @Override
   public String snapshotNamePrefix() {
-    return physicalTenantPrefix + SNAPSHOT_NAME_PREFIX;
+    return SNAPSHOT_NAME_PREFIX;
   }
 }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/WebappsSnapshotNameProviderTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/WebappsSnapshotNameProviderTest.java
@@ -26,30 +26,20 @@ public class WebappsSnapshotNameProviderTest {
   }
 
   @Test
-  void shouldBuildAndExtractTenantPrefixedSnapshotName() {
-    final SnapshotNameProvider physicalTenantProvider = new WebappsSnapshotNameProvider("tenant1");
-
-    final var snapshotName = physicalTenantProvider.getSnapshotName(metadata);
-
-    assertThat(snapshotName).startsWith("tenant1_camunda_webapps_");
-    assertThat(physicalTenantProvider.extractMetadataFromSnapshotName(snapshotName))
-        .isEqualTo(metadata);
-    assertThat(physicalTenantProvider.extractBackupId(snapshotName)).isEqualTo(metadata.backupId());
-  }
-
-  @Test
-  void shouldNotExtractMetadataFromAnotherTenantsSnapshotName() {
-    final SnapshotNameProvider physicalTenantProvider = new WebappsSnapshotNameProvider("tenant1");
-    final var snapshotName = physicalTenantProvider.getSnapshotName(metadata);
-
-    assertThatThrownBy(() -> snapshotNameProvider.extractMetadataFromSnapshotName(snapshotName))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void shouldKeepDefaultNamesUnprefixed() {
+  void shouldNameSnapshotsWithoutAPhysicalTenantId() {
     assertThat(snapshotNameProvider.getSnapshotName(metadata))
         .isEqualTo("camunda_webapps_12312938123_8.7.3_part_11_of_13");
     assertThat(snapshotNameProvider.snapshotNamePrefix()).isEqualTo("camunda_webapps_");
+  }
+
+  @Test
+  void shouldRejectAForeignSnapshotName() {
+    // a repository may legitimately hold snapshots of another backup system — Optimize writes its
+    // own into the same repository, and they carry no webapps metadata
+    assertThatThrownBy(
+            () ->
+                snapshotNameProvider.extractMetadataFromSnapshotName(
+                    "camunda_optimize_12312938123_8.7.3_part_1_of_2"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }


### PR DESCRIPTION
## Description

Physical tenants had two ways to keep their history backups apart: a per-tenant `repository-name`, or a `<tenantId>_` prefix on every snapshot name so they could share one repository. This drops the second one, because a naming convention is a weak boundary — an `_all` listing, a `DELETE _snapshot/<repo>/*`, a repository delete, an operator restoring the wrong repository, or a bug that drops the prefix all reach across it, and primary storage already refuses to work this way via `PrimaryStorageBackupIsolationValidation`. `WebappsSnapshotNameProvider` is stateless again with no tenant id in the snapshot name or either regex (`camunda_webapps_` stays, since a repository legitimately holds Optimize's `camunda_optimize_` snapshots), and a new `SnapshotRepositoryIsolationValidation` fails the boot when two tenants resolve to the same `(type, connection, repository-name)`, naming the colliding tenants in one grouped error; it is modelled on the retention-policy rule, leaves the index prefix out of the identity because a repository is the cluster-global `_snapshot/<name>`, and compares fully-resolved config so tenants that merely inherit a root `repository-name` collide too — the case it mainly exists for, while a tenant with no repository is skipped rather than rejected and single-tenant deployments are a no-op. Keeping the prefix as a second layer on top of per-tenant repositories would leave `extractBackupId` and `extractMetadataFromSnapshotName` parsing a tenant id back out of a name for a boundary the repository already draws, and detecting the collision at backup time rather than at boot would only surface it once a production cluster had been mixing tenants' backups since startup.

## Related issues

closes #60610 
