### PR TITLE
feat: add the dependency-graph change plan as a standalone type

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ChangePlan.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
+import java.time.Instant;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * What every consumer outside the execution loop needs from an ongoing change, whichever execution
+ * model it uses.
+ *
+ * <p>Two models will coexist while the dependency-graph execution is wired in and proven out:
+ *
+ * <ul>
+ *   <li>{@link ClusterChangePlan} — a queue, one broker at a time. What the global configuration
+ *       runs, what the legacy {@link ClusterConfiguration} runs, and what a partition group started
+ *       outside the phase machinery (see {@code PhysicalTenantProvisioningInitializer}) runs. Also,
+ *       for now, what every partition-group phase runs — nothing yet builds a {@link
+ *       DependencyChangePlan}.
+ *   <li>{@link DependencyChangePlan} — operations with declared dependencies, executed concurrently
+ *       wherever no edge orders them. Not yet produced by anything; a later change routes
+ *       partition-group phases through it, with {@code sequential(…)} chaining every operation
+ *       behind its predecessor for a phase that has no concurrency to express, so it behaves like
+ *       the queue.
+ * </ul>
+ *
+ * <p>Deliberately read-only. Starting, advancing and merging a change is model-specific and stays
+ * on the concrete types, so the sub-configuration switches on which one it holds rather than
+ * pretending the two are interchangeable. Reporting — the REST change view, restore status, metrics
+ * — does not care, and reads through here.
+ *
+ * <p>{@link ClusterChangePlan} implements this without any other change: it already had every
+ * method below. That is the whole cost of coexistence on the retiring path.
+ */
+@NullMarked
+public sealed interface ChangePlan permits ClusterChangePlan, DependencyChangePlan {
+
+  /** The id of this change, as issued by the coordinator. */
+  long id();
+
+  Status status();
+
+  Instant startedAt();
+
+  /** Whether any operation of this change is still outstanding. */
+  boolean hasPendingChanges();
+
+  /** The operations still to run, in a stable order two brokers both derive identically. */
+  List<ClusterConfigurationChangeOperation> pendingOperations();
+
+  /** The operations already run, in the same stable order. */
+  List<CompletedOperation> completedOperations();
+
+  CompletedChange cancel();
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterChangePlan.java
@@ -28,7 +28,8 @@ public record ClusterChangePlan(
     Status status,
     Instant startedAt,
     List<CompletedOperation> completedOperations,
-    List<ClusterConfigurationChangeOperation> pendingOperations) {
+    List<ClusterConfigurationChangeOperation> pendingOperations)
+    implements ChangePlan {
 
   private static final long RESTORE_CHANGE_ID = -2L;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
@@ -49,6 +49,13 @@ public record DependencyChangePlan(
 
   public DependencyChangePlan {
     completed = Collections.unmodifiableSortedMap(new TreeMap<>(completed));
+    for (final var operationId : completed.keySet()) {
+      if (!graph.operations().containsKey(operationId)) {
+        throw new IllegalArgumentException(
+            "Operation %s is marked complete, but is not part of this plan's graph"
+                .formatted(operationId));
+      }
+    }
   }
 
   public static DependencyChangePlan init(final long id, final OperationGraph graph) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
@@ -50,10 +50,18 @@ public record DependencyChangePlan(
   public DependencyChangePlan {
     completed = Collections.unmodifiableSortedMap(new TreeMap<>(completed));
     for (final var operationId : completed.keySet()) {
-      if (!graph.operations().containsKey(operationId)) {
+      final var planned = graph.operations().get(operationId);
+      if (planned == null) {
         throw new IllegalArgumentException(
             "Operation %s is marked complete, but is not part of this plan's graph"
                 .formatted(operationId));
+      }
+      final var incompleteDependencies = new TreeSet<>(planned.dependsOn());
+      incompleteDependencies.removeAll(completed.keySet());
+      if (!incompleteDependencies.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Operation %s is marked complete, but the operations it depends on are not: %s"
+                .formatted(operationId, incompleteDependencies));
       }
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
@@ -196,19 +196,33 @@ public record DependencyChangePlan(
   /**
    * Merges two copies of this plan seen by different brokers.
    *
-   * <p>A flat union: the graph is fixed and identical, and each completion has a single writer, so
-   * nothing can be lost. The earliest timestamp wins a collision so that a broker re-stamping after
-   * a restart still converges with its peers.
+   * <p>A flat union: the graph is fixed and identical for two copies of the <em>same</em> plan, and
+   * each completion has a single writer, so nothing can be lost. The earliest timestamp wins a
+   * collision so that a broker re-stamping after a restart still converges with its peers.
+   *
+   * <p>"Same plan" is asserted, not assumed. The id is the enclosing sub-configuration's version,
+   * derived locally by whichever broker starts the change — two self-believed coordinators (the
+   * forced-request path, which bypasses the single-coordinator check) can derive the same id for
+   * two different graphs. {@code OperationGraph.Builder} numbers operations {@code 0..n-1} in
+   * insertion order, so two unrelated graphs almost always share operation ids; blindly unioning
+   * {@code completed} in that case would mark one graph's operation complete because the other's,
+   * coincidentally sharing its id, ran — silently, since the merged plan still drains and completes
+   * normally. Mirrors the same-id-different-content guard {@link PhasedChangePlan#merge} already
+   * has for phases.
    */
   public DependencyChangePlan merge(final @Nullable DependencyChangePlan other) {
     if (other == null) {
       return this;
     }
     if (id != other.id) {
-      // Not reachable in practice — a plan id comes from the enclosing sub-configuration's version,
-      // and that merge only delegates here when the versions are equal. Resolved deterministically
-      // rather than by favouring the receiver, so that merge stays commutative.
+      // Resolved deterministically rather than by favouring the receiver, so that merge stays
+      // commutative.
       return id > other.id ? this : other;
+    }
+    if (!graph.equals(other.graph)) {
+      throw new IllegalStateException(
+          "Cannot merge plans with the same ID but different graphs: %s vs %s"
+              .formatted(graph, other.graph));
     }
     final var merged = new TreeMap<>(completed);
     other.completed.forEach(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
@@ -34,9 +34,9 @@ import org.jspecify.annotations.Nullable;
  * <h4>Convergence</h4>
  *
  * <p>The graph is fixed for the plan's lifetime. {@code completed} is grow-only and every entry has
- * exactly one writer — the broker that applies that operation — so merge is a flat union with the
- * earliest timestamp winning a collision. Commutative, associative and idempotent by construction,
- * with no version to move and no barrier to release.
+ * exactly one writer — the broker that applies that operation — so merge is a flat union.
+ * Commutative, associative, and idempotent by construction, with no version to move and no barrier
+ * to release.
  */
 @NullMarked
 public record DependencyChangePlan(
@@ -205,8 +205,8 @@ public record DependencyChangePlan(
    * Merges two copies of this plan seen by different brokers.
    *
    * <p>A flat union: the graph is fixed and identical for two copies of the <em>same</em> plan, and
-   * each completion has a single writer, so nothing can be lost. The earliest timestamp wins a
-   * collision so that a broker re-stamping after a restart still converges with its peers.
+   * each completion has a single writer — the operation's owning member, which never re-stamps an
+   * entry it already holds — so one key cannot carry two timestamps and nothing can be lost.
    *
    * <p>"Same plan" is asserted, not assumed. The id is the enclosing sub-configuration's version,
    * derived locally by whichever broker starts the change — two self-believed coordinators (the
@@ -233,9 +233,7 @@ public record DependencyChangePlan(
               .formatted(graph, other.graph));
     }
     final var merged = new TreeMap<>(completed);
-    other.completed.forEach(
-        (operationId, at) ->
-            merged.merge(operationId, at, (mine, theirs) -> mine.isBefore(theirs) ? mine : theirs));
+    merged.putAll(other.completed);
     return new DependencyChangePlan(id, status, startedAt, graph, merged);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlan.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The ongoing change of one sub-configuration: an {@link OperationGraph} plus which of its
+ * operations have completed.
+ *
+ * <p>An operation is <em>runnable</em> once everything it depends on has completed. Brokers apply
+ * whichever of their own operations are runnable, so concurrency is the <em>absence of an edge</em>
+ * rather than the presence of a container — broker-parallel, partition-parallel and group-parallel
+ * execution are the same thing, and a future axis costs nothing structurally.
+ *
+ * <h4>Convergence</h4>
+ *
+ * <p>The graph is fixed for the plan's lifetime. {@code completed} is grow-only and every entry has
+ * exactly one writer — the broker that applies that operation — so merge is a flat union with the
+ * earliest timestamp winning a collision. Commutative, associative and idempotent by construction,
+ * with no version to move and no barrier to release.
+ */
+@NullMarked
+public record DependencyChangePlan(
+    long id,
+    Status status,
+    Instant startedAt,
+    OperationGraph graph,
+    SortedMap<OperationId, Instant> completed)
+    implements ChangePlan {
+
+  public DependencyChangePlan {
+    completed = Collections.unmodifiableSortedMap(new TreeMap<>(completed));
+  }
+
+  public static DependencyChangePlan init(final long id, final OperationGraph graph) {
+    return new DependencyChangePlan(id, Status.IN_PROGRESS, Instant.now(), graph, new TreeMap<>());
+  }
+
+  /** A plan that runs {@code operations} strictly one after another — today's behaviour. */
+  public static DependencyChangePlan sequential(
+      final long id, final List<? extends ClusterConfigurationChangeOperation> operations) {
+    return init(id, OperationGraph.sequential(operations));
+  }
+
+  public SortedMap<OperationId, OperationGraph.PlannedOperation> operations() {
+    return graph.operations();
+  }
+
+  public boolean isComplete(final OperationId operationId) {
+    return completed.containsKey(operationId);
+  }
+
+  /** Whether everything this operation depends on has completed, and it has not run itself. */
+  public boolean isRunnable(final OperationId operationId) {
+    final var planned = graph.operations().get(operationId);
+    if (planned == null || isComplete(operationId)) {
+      return false;
+    }
+    return completed.keySet().containsAll(planned.dependsOn());
+  }
+
+  /**
+   * Everything {@code memberId} may start right now, in ascending operation-id order so that two
+   * brokers evaluating the same converged state agree on what to do first.
+   */
+  public SortedMap<OperationId, ClusterConfigurationChangeOperation> runnableFor(
+      final MemberId memberId) {
+    final SortedMap<OperationId, ClusterConfigurationChangeOperation> runnable = new TreeMap<>();
+    graph
+        .operations()
+        .forEach(
+            (operationId, planned) -> {
+              if (planned.operation().memberId().equals(memberId) && isRunnable(operationId)) {
+                runnable.put(operationId, planned.operation());
+              }
+            });
+    return runnable;
+  }
+
+  @Override
+  public boolean hasPendingChanges() {
+    return completed.size() < graph.size();
+  }
+
+  /**
+   * The operations still to run, in operation-id order. Ordering is positional rather than by
+   * arrival so that two brokers rendering the same converged plan produce identical lists.
+   */
+  @Override
+  public List<ClusterConfigurationChangeOperation> pendingOperations() {
+    final var pending = new ArrayList<ClusterConfigurationChangeOperation>();
+    graph
+        .operations()
+        .forEach(
+            (operationId, planned) -> {
+              if (!isComplete(operationId)) {
+                pending.add(planned.operation());
+              }
+            });
+    return List.copyOf(pending);
+  }
+
+  /** The operations already run, in operation-id order. See {@link #pendingOperations()}. */
+  @Override
+  public List<CompletedOperation> completedOperations() {
+    final var done = new ArrayList<CompletedOperation>();
+    graph
+        .operations()
+        .forEach(
+            (operationId, planned) -> {
+              final var at = completed.get(operationId);
+              if (at != null) {
+                done.add(new CompletedOperation(planned.operation(), at));
+              }
+            });
+    return List.copyOf(done);
+  }
+
+  @Override
+  public CompletedChange cancel() {
+    return new CompletedChange(id, Status.CANCELLED, startedAt, Instant.now());
+  }
+
+  /**
+   * What each incomplete operation is still waiting for; an empty value means it is runnable.
+   *
+   * <p>Exists so a stalled change can be diagnosed. With no step index to read, "which operations
+   * are outstanding, and on what" is the only way an operator can tell why nothing is moving.
+   */
+  public SortedMap<OperationId, SortedSet<OperationId>> blockedBy() {
+    final SortedMap<OperationId, SortedSet<OperationId>> blocked = new TreeMap<>();
+    graph
+        .operations()
+        .forEach(
+            (operationId, planned) -> {
+              if (isComplete(operationId)) {
+                return;
+              }
+              final var waitingOn = new TreeSet<OperationId>();
+              planned.dependsOn().stream().filter(d -> !isComplete(d)).forEach(waitingOn::add);
+              blocked.put(operationId, Collections.unmodifiableSortedSet(waitingOn));
+            });
+    return blocked;
+  }
+
+  /**
+   * Records that {@code operationId} finished. Package-private: only a sub-configuration may move a
+   * plan, so that the accompanying member-state update happens in the same transition.
+   *
+   * @throws IllegalStateException if the operation is unknown or was not runnable
+   */
+  DependencyChangePlan completeOperation(final OperationId operationId) {
+    if (!graph.operations().containsKey(operationId)) {
+      throw new IllegalStateException(
+          "Expected to complete %s, but it is not part of this plan".formatted(operationId));
+    }
+    if (isComplete(operationId)) {
+      return this;
+    }
+    if (!isRunnable(operationId)) {
+      throw new IllegalStateException(
+          "Expected to complete %s, but it is still waiting on %s"
+              .formatted(operationId, blockedBy().get(operationId)));
+    }
+    final var updated = new TreeMap<>(completed);
+    updated.put(operationId, Instant.now());
+    return new DependencyChangePlan(id, status, startedAt, graph, updated);
+  }
+
+  /**
+   * Merges two copies of this plan seen by different brokers.
+   *
+   * <p>A flat union: the graph is fixed and identical, and each completion has a single writer, so
+   * nothing can be lost. The earliest timestamp wins a collision so that a broker re-stamping after
+   * a restart still converges with its peers.
+   */
+  public DependencyChangePlan merge(final @Nullable DependencyChangePlan other) {
+    if (other == null) {
+      return this;
+    }
+    if (id != other.id) {
+      // Not reachable in practice — a plan id comes from the enclosing sub-configuration's version,
+      // and that merge only delegates here when the versions are equal. Resolved deterministically
+      // rather than by favouring the receiver, so that merge stays commutative.
+      return id > other.id ? this : other;
+    }
+    final var merged = new TreeMap<>(completed);
+    other.completed.forEach(
+        (operationId, at) ->
+            merged.merge(operationId, at, (mine, theirs) -> mine.isBefore(theirs) ? mine : theirs));
+    return new DependencyChangePlan(id, status, startedAt, graph, merged);
+  }
+
+  /**
+   * The completed-change record for a drained plan, timestamped with the last operation's
+   * completion rather than with the wall clock.
+   *
+   * <p>Any broker may observe the plan complete, and two doing so a moment apart would otherwise
+   * stamp different values. Neither sub-configuration merge reconciles {@code lastChange} at equal
+   * versions, so those two values would never converge and the cluster would report two different
+   * completion times for one change, permanently.
+   */
+  CompletedChange toCompletedChange() {
+    final var completedAt =
+        completed.values().stream().max(Instant::compareTo).orElseGet(Instant::now);
+    return new CompletedChange(id, Status.COMPLETED, startedAt, completedAt);
+  }
+
+  /** The operation behind an id, for callers that already know it exists. */
+  public ClusterConfigurationChangeOperation operation(final OperationId operationId) {
+    return Objects.requireNonNull(
+            graph.operations().get(operationId),
+            () -> "%s is not part of this plan".formatted(operationId))
+        .operation();
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/OperationGraph.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/OperationGraph.java
@@ -70,8 +70,19 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public record OperationGraph(SortedMap<OperationId, PlannedOperation> operations) {
 
+  /**
+   * Rejects a graph that cannot execute: empty (nothing to run, and {@link
+   * DependencyChangePlan#toCompletedChange()} has no timestamp to derive a completion from), or
+   * cyclic (see {@link #validateAcyclic}). Enforced here, in the canonical constructor, rather than
+   * only in {@link #of} — the compact constructor is not the only way to build one of these; a bare
+   * {@code new OperationGraph(...)} must reject the same graphs {@link #of} does, or a decode path
+   * that does not go through either factory could construct one that violates both.
+   */
   public OperationGraph {
     operations = Collections.unmodifiableSortedMap(new TreeMap<>(operations));
+    if (operations.isEmpty()) {
+      throw new IllegalArgumentException("A dependency graph must have at least one operation");
+    }
     for (final var entry : operations.entrySet()) {
       for (final var dependency : entry.getValue().dependsOn()) {
         if (!operations.containsKey(dependency)) {
@@ -81,23 +92,12 @@ public record OperationGraph(SortedMap<OperationId, PlannedOperation> operations
         }
       }
     }
+    validateAcyclic(operations);
   }
 
-  /**
-   * Builds a graph and rejects it if it cannot execute: empty (nothing to run, and {@link
-   * DependencyChangePlan#toCompletedChange()} has no timestamp to derive a completion from), or
-   * cyclic (see {@link #validateAcyclic()}). The same non-emptiness this factory enforces is
-   * already required on the create path by {@code
-   * PartitionGroupConfiguration#startGraphConfigurationChange}; enforcing it here as well closes it
-   * for the decode path too, which does not go through that method.
-   */
+  /** Same validation as the canonical constructor; kept for readability at the call site. */
   public static OperationGraph of(final SortedMap<OperationId, PlannedOperation> operations) {
-    if (operations.isEmpty()) {
-      throw new IllegalArgumentException("A dependency graph must have at least one operation");
-    }
-    final var graph = new OperationGraph(operations);
-    graph.validateAcyclic();
-    return graph;
+    return new OperationGraph(operations);
   }
 
   /**
@@ -135,8 +135,11 @@ public record OperationGraph(SortedMap<OperationId, PlannedOperation> operations
   /**
    * A cycle would leave every operation in it permanently un-runnable and the change would stall
    * with no error at all, so it is rejected here rather than discovered in production.
+   *
+   * <p>Static, and takes {@code operations} as a parameter rather than reading the field: called
+   * from the compact constructor, before the field is assigned.
    */
-  private void validateAcyclic() {
+  private static void validateAcyclic(final SortedMap<OperationId, PlannedOperation> operations) {
     final Map<OperationId, Integer> remaining = new HashMap<>();
     operations.forEach((id, planned) -> remaining.put(id, planned.dependsOn().size()));
     final var ready = new ArrayDeque<OperationId>();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/OperationGraph.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/OperationGraph.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The operations of one change and the order constraints between them — the immutable template a
+ * {@link DependencyChangePlan} tracks progress against.
+ *
+ * <p>Kept separate from the plan because a {@link PhasedChangePlan} phase carries the template
+ * before any sub-configuration has started it, and therefore before an id or any progress exists.
+ *
+ * <p>Two operations with no dependency path between them may run at the same time. That is the
+ * whole concurrency model: broker-parallel, partition-parallel and group-parallel execution are all
+ * just missing edges, and adding an axis costs nothing structurally.
+ *
+ * <h4>Correctness of the edges is the author's, and only the author's</h4>
+ *
+ * <p>Nothing here checks that concurrently-runnable operations are actually safe together. A
+ * missing edge is not rejected; it is executed.
+ *
+ * <p>The rule that actually makes the current adopters safe: <b>the broker applying an operation
+ * must be the only writer of the entry it writes</b> ({@code operation.memberId()} must equal
+ * whichever member's entry the applier touches). Every adopter applier writes only its own member's
+ * entry, and a broker serialises its own completions on its actor, so that entry's version
+ * increments monotonically and two brokers merging never see a same-version conflict on it. This is
+ * <em>not</em> the same as "two operations naming the same member need an edge unless they name
+ * different partitions" — a member's partitions all live in one {@code BrokerPartitionState} under
+ * one version, so two unordered operations on different partitions of the same member still write
+ * the same entry, and land on the branch below.
+ *
+ * <p>The failure mode when the rule is violated is not quiet. {@code
+ * BrokerPartitionState#merge(BrokerPartitionState)} throws on two same-version copies that differ,
+ * rather than picking one — so a broker whose peer has written an entry it also wrote rejects that
+ * merge outright, leaves its local state unchanged, and repeats the rejection on every later gossip
+ * round against that peer: <b>permanent non-convergence between the two brokers</b>, not a lost
+ * transition. (A silent loss is still possible, but only in the narrower case where one broker's
+ * write has not yet reached the other at merge time.)
+ *
+ * <p>Two operations that violate the rule outright, learned the hard way, and out of scope for
+ * concurrent execution under the current merge until either write-set validation is reinstated for
+ * these two shapes or {@code BrokerPartitionState.merge} stops throwing on same-version conflicts:
+ *
+ * <ul>
+ *   <li>{@code MemberRemoveOperation} writes the entry of {@code memberToRemove()}, not of {@code
+ *       memberId()} — it dispatches to {@code MemberLeaveApplier(op.memberToRemove(), ...)}. The
+ *       broker applying it and the entry it writes are different members.
+ *   <li>{@code PartitionForceReconfigureOperation} writes an entry set that cannot be derived from
+ *       the operation at all: its applier loops {@code group.members().keySet()} and removes the
+ *       partition from every member outside the target replication group, so what it touches
+ *       depends on the live configuration, not just on its own fields.
+ * </ul>
+ */
+@NullMarked
+public record OperationGraph(SortedMap<OperationId, PlannedOperation> operations) {
+
+  public OperationGraph {
+    operations = Collections.unmodifiableSortedMap(new TreeMap<>(operations));
+    for (final var entry : operations.entrySet()) {
+      for (final var dependency : entry.getValue().dependsOn()) {
+        if (!operations.containsKey(dependency)) {
+          throw new IllegalArgumentException(
+              "Operation %s depends on %s, which is not part of the graph"
+                  .formatted(entry.getKey(), dependency));
+        }
+      }
+    }
+  }
+
+  /**
+   * Builds a graph and rejects it if it cannot execute: empty (nothing to run, and {@link
+   * DependencyChangePlan#toCompletedChange()} has no timestamp to derive a completion from), or
+   * cyclic (see {@link #validateAcyclic()}). The same non-emptiness this factory enforces is
+   * already required on the create path by {@code
+   * PartitionGroupConfiguration#startGraphConfigurationChange}; enforcing it here as well closes it
+   * for the decode path too, which does not go through that method.
+   */
+  public static OperationGraph of(final SortedMap<OperationId, PlannedOperation> operations) {
+    if (operations.isEmpty()) {
+      throw new IllegalArgumentException("A dependency graph must have at least one operation");
+    }
+    final var graph = new OperationGraph(operations);
+    graph.validateAcyclic();
+    return graph;
+  }
+
+  /**
+   * A graph in which each operation waits for the one before it — the behaviour every change had
+   * before dependencies existed, and what an unmigrated transformer gets by default.
+   */
+  public static OperationGraph sequential(
+      final List<? extends ClusterConfigurationChangeOperation> operations) {
+    final var builder = builder();
+    OperationId previous = null;
+    for (final var operation : operations) {
+      previous =
+          previous == null ? builder.add(operation) : builder.add(operation, Set.of(previous));
+    }
+    return builder.build();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public boolean isEmpty() {
+    return operations.isEmpty();
+  }
+
+  public int size() {
+    return operations.size();
+  }
+
+  /** The operations in id order, which is the stable order every derived view renders in. */
+  public List<ClusterConfigurationChangeOperation> inOrder() {
+    return operations.values().stream().map(PlannedOperation::operation).toList();
+  }
+
+  /**
+   * A cycle would leave every operation in it permanently un-runnable and the change would stall
+   * with no error at all, so it is rejected here rather than discovered in production.
+   */
+  private void validateAcyclic() {
+    final Map<OperationId, Integer> remaining = new HashMap<>();
+    operations.forEach((id, planned) -> remaining.put(id, planned.dependsOn().size()));
+    final var ready = new ArrayDeque<OperationId>();
+    remaining.forEach(
+        (id, count) -> {
+          if (count == 0) {
+            ready.add(id);
+          }
+        });
+
+    int settled = 0;
+    while (!ready.isEmpty()) {
+      final var next = ready.poll();
+      settled++;
+      operations.forEach(
+          (id, planned) -> {
+            if (planned.dependsOn().contains(next) && remaining.merge(id, -1, Integer::sum) == 0) {
+              ready.add(id);
+            }
+          });
+    }
+    if (settled != operations.size()) {
+      throw new IllegalArgumentException(
+          "The change has a dependency cycle; these operations are never runnable: "
+              + remaining.entrySet().stream()
+                  .filter(e -> e.getValue() > 0)
+                  .map(Map.Entry::getKey)
+                  .toList());
+    }
+  }
+
+  /** One operation and what it waits for. */
+  public record PlannedOperation(
+      ClusterConfigurationChangeOperation operation, SortedSet<OperationId> dependsOn) {
+
+    public PlannedOperation {
+      dependsOn = Collections.unmodifiableSortedSet(new TreeSet<>(dependsOn));
+    }
+
+    public static PlannedOperation of(final ClusterConfigurationChangeOperation operation) {
+      return new PlannedOperation(operation, new TreeSet<>());
+    }
+  }
+
+  /** Assigns ids in insertion order and lets a transformer name only the edges it needs. */
+  public static final class Builder {
+
+    private final SortedMap<OperationId, PlannedOperation> operations = new TreeMap<>();
+    private int nextId = 0;
+
+    /** Adds an operation with no dependencies, so it is runnable immediately. */
+    public OperationId add(final ClusterConfigurationChangeOperation operation) {
+      return add(operation, Set.of());
+    }
+
+    public OperationId add(
+        final ClusterConfigurationChangeOperation operation, final Set<OperationId> dependsOn) {
+      final var operationId = OperationId.of(nextId++);
+      operations.put(operationId, new PlannedOperation(operation, new TreeSet<>(dependsOn)));
+      return operationId;
+    }
+
+    public boolean isEmpty() {
+      return operations.isEmpty();
+    }
+
+    public OperationGraph build() {
+      return OperationGraph.of(operations);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/OperationId.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/OperationId.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Identifies one operation within a {@link DependencyChangePlan}.
+ *
+ * <p>Assigned once, by the coordinator, when the plan is built, and never reused within a plan. It
+ * is the key both for declaring dependencies and for recording completion, so it has to be stable
+ * across gossip and comparable for deterministic ordering — two brokers rendering the same plan
+ * must produce the same list.
+ */
+@NullMarked
+public record OperationId(int value) implements Comparable<OperationId> {
+
+  public OperationId {
+    if (value < 0) {
+      throw new IllegalArgumentException("Operation id must be non-negative, but was " + value);
+    }
+  }
+
+  public static OperationId of(final int value) {
+    return new OperationId(value);
+  }
+
+  @Override
+  public int compareTo(final OperationId other) {
+    return Integer.compare(value, other.value);
+  }
+
+  @Override
+  public String toString() {
+    return "#" + value;
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
@@ -338,37 +338,6 @@ final class DependencyChangePlanTest {
       assertThat(byOne.merge(byOne)).isEqualTo(byOne);
       assertThat(byOne.merge(byAnother).merge(byAnother)).isEqualTo(byOne.merge(byAnother));
     }
-
-    @Test
-    void shouldKeepTheEarliestTimestampForTheSameOperation() {
-      // given — the same operation completed twice, at two fixed, distinct timestamps, as happens
-      // when a broker retries or restarts. Fixed rather than derived from call order, so this
-      // fails against an implementation that keeps whichever side merge() is called on, or the
-      // latest, and not only one that keeps the earliest.
-      final var builder = OperationGraph.builder();
-      final var only = builder.add(op(0, 1));
-      final var graph = builder.build();
-      final var earlier = Instant.parse("2024-01-01T00:00:00Z");
-      final var later = earlier.plusSeconds(60);
-      final var first =
-          new DependencyChangePlan(
-              PLAN_ID,
-              Status.IN_PROGRESS,
-              Instant.now(),
-              graph,
-              new TreeMap<>(Map.of(only, earlier)));
-      final var second =
-          new DependencyChangePlan(
-              PLAN_ID,
-              Status.IN_PROGRESS,
-              Instant.now(),
-              graph,
-              new TreeMap<>(Map.of(only, later)));
-
-      // when / then — the earlier value wins regardless of merge direction
-      assertThat(first.merge(second).completed().get(only)).isEqualTo(earlier);
-      assertThat(second.merge(first).completed().get(only)).isEqualTo(earlier);
-    }
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph.PlannedOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Concurrency in this model is the absence of a dependency edge, so these tests are about which
+ * operations become runnable and when — there is no index to advance and no barrier to release.
+ */
+final class DependencyChangePlanTest {
+
+  private static final long PLAN_ID = 7L;
+
+  private static MemberId member(final int id) {
+    return MemberId.from(Integer.toString(id));
+  }
+
+  /** A partition operation, so that different partitions of one member have disjoint write sets. */
+  private static ClusterConfigurationChangeOperation op(final int memberId, final int partitionId) {
+    return new PartitionPreRestoreOperation(member(memberId), partitionId);
+  }
+
+  @Nested
+  class Runnability {
+
+    @Test
+    void shouldMakeEveryUnblockedOperationRunnableAtOnce() {
+      // given — three brokers with nothing depending on anything
+      final var builder = OperationGraph.builder();
+      builder.add(op(0, 1));
+      builder.add(op(1, 1));
+      builder.add(op(2, 1));
+      final var plan = DependencyChangePlan.init(PLAN_ID, builder.build());
+
+      // when / then — every broker is eligible immediately; that is broker parallelism, with no
+      // container expressing it
+      assertThat(plan.runnableFor(member(0))).hasSize(1);
+      assertThat(plan.runnableFor(member(1))).hasSize(1);
+      assertThat(plan.runnableFor(member(2))).hasSize(1);
+    }
+
+    @Test
+    void shouldOfferSeveralPartitionsOfOneBrokerAtOnce() {
+      // given — one broker, three partitions, no edges between them
+      final var builder = OperationGraph.builder();
+      builder.add(op(0, 1));
+      builder.add(op(0, 2));
+      builder.add(op(0, 3));
+      final var plan = DependencyChangePlan.init(PLAN_ID, builder.build());
+
+      // when / then — partition parallelism falls out of the same absence of edges, with no extra
+      // level of nesting and no second eligibility tier
+      assertThat(plan.runnableFor(member(0))).hasSize(3);
+    }
+
+    @Test
+    void shouldNotOfferAnOperationUntilItsDependencyCompletes() {
+      // given — the shape of bootstrap-then-join: different members, so disjoint write sets, but a
+      // real ordering requirement that only the declared edge captures
+      final var builder = OperationGraph.builder();
+      final var bootstrap = builder.add(op(0, 1));
+      final var join = builder.add(op(1, 1), Set.of(bootstrap));
+      var plan = DependencyChangePlan.init(PLAN_ID, builder.build());
+
+      // then — member 1 waits
+      assertThat(plan.runnableFor(member(0))).containsOnlyKeys(bootstrap);
+      assertThat(plan.runnableFor(member(1))).isEmpty();
+      assertThat(plan.blockedBy().get(join)).containsExactly(bootstrap);
+
+      // when — the bootstrap completes
+      plan = plan.completeOperation(bootstrap);
+
+      // then — the join becomes runnable, and the bootstrap is no longer offered
+      assertThat(plan.runnableFor(member(0))).isEmpty();
+      assertThat(plan.runnableFor(member(1))).containsOnlyKeys(join);
+      assertThat(plan.blockedBy().get(join)).isEmpty();
+    }
+
+    @Test
+    void shouldWaitForEveryDependencyNotJustOne() {
+      // given — a join-point: one operation gathering several predecessors, which is how a barrier
+      // is expressed without a barrier primitive
+      final var builder = OperationGraph.builder();
+      final var first = builder.add(op(0, 1));
+      final var second = builder.add(op(1, 1));
+      final var after = builder.add(op(2, 1), Set.of(first, second));
+      var plan = DependencyChangePlan.init(PLAN_ID, builder.build());
+
+      // when — only one predecessor completes
+      plan = plan.completeOperation(first);
+
+      // then
+      assertThat(plan.isRunnable(after)).isFalse();
+      assertThat(plan.blockedBy().get(after)).containsExactly(second);
+
+      // when — the other completes too
+      plan = plan.completeOperation(second);
+
+      // then
+      assertThat(plan.isRunnable(after)).isTrue();
+    }
+
+    @Test
+    void shouldRefuseToCompleteAnOperationThatIsStillBlocked() {
+      // given
+      final var builder = OperationGraph.builder();
+      final var first = builder.add(op(0, 1));
+      final var second = builder.add(op(1, 1), Set.of(first));
+      final var plan = DependencyChangePlan.init(PLAN_ID, builder.build());
+
+      // when / then — a broker must never be able to record work it was not yet allowed to start
+      assertThatThrownBy(() -> plan.completeOperation(second))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("still waiting on");
+    }
+
+    @Test
+    void shouldTreatCompletingTwiceAsANoOp() {
+      // given — appliers are idempotent and may be retried, so a repeat completion must not throw
+      final var builder = OperationGraph.builder();
+      final var only = builder.add(op(0, 1));
+      final var plan = DependencyChangePlan.init(PLAN_ID, builder.build()).completeOperation(only);
+
+      // when / then
+      assertThat(plan.completeOperation(only)).isEqualTo(plan);
+    }
+  }
+
+  @Nested
+  class SequentialEquivalence {
+
+    @Test
+    void shouldOfferOnlyOneOperationAtATime() {
+      // given — the helper that reproduces today's behaviour for an unmigrated transformer
+      final var plan =
+          DependencyChangePlan.sequential(PLAN_ID, List.of(op(0, 1), op(1, 1), op(2, 1)));
+
+      // when / then — exactly one broker eligible, as before this change
+      assertThat(plan.runnableFor(member(0))).hasSize(1);
+      assertThat(plan.runnableFor(member(1))).isEmpty();
+      assertThat(plan.runnableFor(member(2))).isEmpty();
+    }
+
+    @Test
+    void shouldReportPendingAndCompletedInPlanOrder() {
+      // given
+      var plan = DependencyChangePlan.sequential(PLAN_ID, List.of(op(0, 1), op(1, 1), op(2, 1)));
+
+      // when
+      plan = plan.completeOperation(OperationId.of(0));
+
+      // then
+      assertThat(plan.completedOperations())
+          .extracting(CompletedOperation::operation)
+          .containsExactly(op(0, 1));
+      assertThat(plan.pendingOperations()).containsExactly(op(1, 1), op(2, 1));
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    @Test
+    void shouldRejectACycle() {
+      // given — a cycle would leave every operation in it permanently un-runnable and the plan
+      // would stall with no error at all, so it must not be constructible
+      final var operations = new TreeMap<OperationId, PlannedOperation>();
+      operations.put(
+          OperationId.of(0),
+          new PlannedOperation(op(0, 1), new java.util.TreeSet<>(Set.of(OperationId.of(1)))));
+      operations.put(
+          OperationId.of(1),
+          new PlannedOperation(op(1, 1), new java.util.TreeSet<>(Set.of(OperationId.of(0)))));
+
+      // when / then
+      assertThatThrownBy(() -> DependencyChangePlan.init(PLAN_ID, OperationGraph.of(operations)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("cycle");
+    }
+
+    @Test
+    void shouldRejectADependencyOnAnOperationOutsideThePlan() {
+      // given
+      final var operations = new TreeMap<OperationId, PlannedOperation>();
+      operations.put(
+          OperationId.of(0),
+          new PlannedOperation(op(0, 1), new java.util.TreeSet<>(Set.of(OperationId.of(99)))));
+
+      // when / then
+      assertThatThrownBy(() -> DependencyChangePlan.init(PLAN_ID, OperationGraph.of(operations)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("not part of the graph");
+    }
+  }
+
+  @Nested
+  class Completion {
+
+    @Test
+    void shouldStayPendingUntilEveryOperationIsDone() {
+      // given
+      final var builder = OperationGraph.builder();
+      final var first = builder.add(op(0, 1));
+      final var second = builder.add(op(1, 1));
+      var plan = DependencyChangePlan.init(PLAN_ID, builder.build());
+
+      // when / then
+      assertThat(plan.hasPendingChanges()).isTrue();
+      plan = plan.completeOperation(first);
+      assertThat(plan.hasPendingChanges()).isTrue();
+      plan = plan.completeOperation(second);
+      assertThat(plan.hasPendingChanges()).isFalse();
+    }
+
+    @Test
+    void shouldDeriveTheCompletionTimestampFromTheLastOperation() {
+      // given — any broker may observe the plan complete, so the timestamp has to be a function of
+      // converged state. A wall-clock read would give two brokers values that never reconcile,
+      // because neither sub-configuration merge reconciles lastChange at equal versions.
+      final var builder = OperationGraph.builder();
+      final var first = builder.add(op(0, 1));
+      final var second = builder.add(op(1, 1));
+      final var plan =
+          DependencyChangePlan.init(PLAN_ID, builder.build())
+              .completeOperation(first)
+              .completeOperation(second);
+
+      // when — two brokers each derive the completed change independently
+      final var byOne = plan.toCompletedChange();
+      final var byAnother = plan.toCompletedChange();
+
+      // then
+      assertThat(byOne).isEqualTo(byAnother);
+      assertThat(byOne.completedAt()).isEqualTo(plan.completed().get(second));
+    }
+  }
+
+  @Nested
+  class Merge {
+
+    @Test
+    void shouldKeepBothBrokersCompletionsWhenTheyMeet() {
+      // given — two brokers that each ran their own operation and know nothing of the other's
+      final var builder = OperationGraph.builder();
+      final var mine = builder.add(op(0, 1));
+      final var theirs = builder.add(op(1, 1));
+      final var base = DependencyChangePlan.init(PLAN_ID, builder.build());
+      final var byOne = base.completeOperation(mine);
+      final var byAnother = base.completeOperation(theirs);
+
+      // when
+      final var merged = byOne.merge(byAnother);
+
+      // then — neither completion is lost, which is the property the whole design rests on
+      assertThat(merged.isComplete(mine)).isTrue();
+      assertThat(merged.isComplete(theirs)).isTrue();
+      assertThat(merged.hasPendingChanges()).isFalse();
+    }
+
+    @Test
+    void shouldBeCommutativeAndIdempotent() {
+      // given
+      final var builder = OperationGraph.builder();
+      final var mine = builder.add(op(0, 1));
+      final var theirs = builder.add(op(1, 1));
+      final var base = DependencyChangePlan.init(PLAN_ID, builder.build());
+      final var byOne = base.completeOperation(mine);
+      final var byAnother = base.completeOperation(theirs);
+
+      // when / then
+      assertThat(byOne.merge(byAnother)).isEqualTo(byAnother.merge(byOne));
+      assertThat(byOne.merge(byOne)).isEqualTo(byOne);
+      assertThat(byOne.merge(byAnother).merge(byAnother)).isEqualTo(byOne.merge(byAnother));
+    }
+
+    @Test
+    void shouldKeepTheEarliestTimestampForTheSameOperation() {
+      // given — the same operation completed twice, as happens when a broker retries or restarts
+      final var builder = OperationGraph.builder();
+      final var only = builder.add(op(0, 1));
+      final var base = DependencyChangePlan.init(PLAN_ID, builder.build());
+      final var first = base.completeOperation(only);
+      final var second = base.completeOperation(only);
+
+      // when / then — picking the earlier value is what keeps merge commutative here
+      assertThat(first.merge(second)).isEqualTo(second.merge(first));
+      assertThat(first.merge(second).completed().get(only))
+          .isBeforeOrEqualTo(second.completed().get(only));
+    }
+  }
+
+  /**
+   * The restore graph, which is the first intended adopter. Written out here because it is the
+   * clearest demonstration that declared edges express more parallelism than a barrier can: under a
+   * barrier between the pre-restore and restore phases, no broker may begin restoring until every
+   * broker has finished pre-restoring everything.
+   */
+  @Nested
+  class RestoreShape {
+
+    /** preRestore(m,p) → restore(m,p); modeChange(m) after all of m's restores. */
+    private DependencyChangePlan restorePlan(final int brokers, final int partitionsPerBroker) {
+      final var builder = OperationGraph.builder();
+      for (int m = 0; m < brokers; m++) {
+        final var restoresOfMember = new java.util.HashSet<OperationId>();
+        for (int p = 1; p <= partitionsPerBroker; p++) {
+          final var pre = builder.add(new PartitionPreRestoreOperation(member(m), p));
+          restoresOfMember.add(
+              builder.add(
+                  new PartitionRestoreOperation(member(m), p, new java.util.TreeSet<>(Set.of(1L))),
+                  Set.of(pre)));
+        }
+        builder.add(new DeleteHistoryOperation(member(m)), restoresOfMember);
+      }
+      return DependencyChangePlan.init(PLAN_ID, builder.build());
+    }
+
+    @Test
+    void shouldOfferEveryBrokerEveryPartitionUpFront() {
+      // given — three brokers, two partitions each
+      final var plan = restorePlan(3, 2);
+
+      // when / then — all three axes at once: three brokers, two partitions each, six operations
+      // runnable immediately, with no container saying so
+      assertThat(plan.runnableFor(member(0))).hasSize(2);
+      assertThat(plan.runnableFor(member(1))).hasSize(2);
+      assertThat(plan.runnableFor(member(2))).hasSize(2);
+    }
+
+    @Test
+    void shouldLetOneBrokerRestoreWhileAnotherIsStillPreRestoring() {
+      // given — broker 0 finishes only its own first pre-restore
+      var plan = restorePlan(2, 2);
+      final var brokerZeroPreRestores = plan.runnableFor(member(0));
+      plan = plan.completeOperation(brokerZeroPreRestores.firstKey());
+
+      // then — broker 0's matching restore is already runnable, even though broker 1 has not
+      // pre-restored anything. A barrier between the two phases would have blocked this; the edge
+      // is per (member, partition), so nothing false is being waited on.
+      assertThat(plan.runnableFor(member(0)))
+          .as("its own restore, plus its other pre-restore")
+          .hasSize(2);
+      assertThat(plan.runnableFor(member(1))).hasSize(2);
+    }
+
+    @Test
+    void shouldHoldTheJoinPointUntilAllOfThatBrokersRestoresAreDone() {
+      // given — the member-wide operation gathering that member's partition work
+      var plan = restorePlan(1, 2);
+
+      // when — everything except the last restore completes
+      for (final var runnable : List.copyOf(plan.runnableFor(member(0)).keySet())) {
+        plan = plan.completeOperation(runnable);
+      }
+      final var remaining = List.copyOf(plan.runnableFor(member(0)).keySet());
+      plan = plan.completeOperation(remaining.get(0));
+
+      // then — DeleteHistory is still waiting on the other restore
+      assertThat(plan.hasPendingChanges()).isTrue();
+      assertThat(plan.runnableFor(member(0))).hasSize(1);
+    }
+  }
+
+  @Nested
+  class GraphValidation {
+
+    @Test
+    void shouldRejectADependencyCycle() {
+      // given — a cycle would leave every operation in it permanently un-runnable and the change
+      // would stall with no error at all, so it is rejected at construction
+      final var operations = new java.util.TreeMap<OperationId, OperationGraph.PlannedOperation>();
+      operations.put(
+          OperationId.of(0),
+          new OperationGraph.PlannedOperation(
+              new UpdateIncarnationNumberOperation(member(0)),
+              new java.util.TreeSet<>(Set.of(OperationId.of(1)))));
+      operations.put(
+          OperationId.of(1),
+          new OperationGraph.PlannedOperation(
+              new UpdateIncarnationNumberOperation(member(1)),
+              new java.util.TreeSet<>(Set.of(OperationId.of(0)))));
+
+      // when / then
+      assertThatThrownBy(() -> OperationGraph.of(operations))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("dependency cycle");
+    }
+
+    @Test
+    void shouldRejectADependencyOnAnOperationOutsideTheGraph() {
+      // given / when / then — an edge to an id the graph does not contain can never be satisfied
+      final var operations = new java.util.TreeMap<OperationId, OperationGraph.PlannedOperation>();
+      operations.put(
+          OperationId.of(0),
+          new OperationGraph.PlannedOperation(
+              new UpdateIncarnationNumberOperation(member(0)),
+              new java.util.TreeSet<>(Set.of(OperationId.of(7)))));
+
+      assertThatThrownBy(() -> OperationGraph.of(operations))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("not part of the graph");
+    }
+
+    @Test
+    void shouldAcceptAnyAcyclicGraphWithoutJudgingItsEdges() {
+      // given — two operations writing the same member with no edge between them. This is very
+      // likely a bug in whichever transformer produced it, and nothing here rejects it: the graph
+      // validates that it can execute, not that executing it is correct. See OperationGraph's
+      // javadoc — the edges are the author's responsibility.
+      final var builder = OperationGraph.builder();
+      builder.add(new UpdateIncarnationNumberOperation(member(0)));
+      builder.add(new UpdateIncarnationNumberOperation(member(0)));
+
+      // when / then — accepted, and both offered at once
+      final var plan = DependencyChangePlan.init(PLAN_ID, builder.build());
+      assertThat(plan.runnableFor(member(0))).hasSize(2);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
@@ -12,12 +12,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.OperationGraph.PlannedOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import org.junit.jupiter.api.Nested;
@@ -295,17 +298,33 @@ final class DependencyChangePlanTest {
 
     @Test
     void shouldKeepTheEarliestTimestampForTheSameOperation() {
-      // given — the same operation completed twice, as happens when a broker retries or restarts
+      // given — the same operation completed twice, at two fixed, distinct timestamps, as happens
+      // when a broker retries or restarts. Fixed rather than derived from call order, so this
+      // fails against an implementation that keeps whichever side merge() is called on, or the
+      // latest, and not only one that keeps the earliest.
       final var builder = OperationGraph.builder();
       final var only = builder.add(op(0, 1));
-      final var base = DependencyChangePlan.init(PLAN_ID, builder.build());
-      final var first = base.completeOperation(only);
-      final var second = base.completeOperation(only);
+      final var graph = builder.build();
+      final var earlier = Instant.parse("2024-01-01T00:00:00Z");
+      final var later = earlier.plusSeconds(60);
+      final var first =
+          new DependencyChangePlan(
+              PLAN_ID,
+              Status.IN_PROGRESS,
+              Instant.now(),
+              graph,
+              new TreeMap<>(Map.of(only, earlier)));
+      final var second =
+          new DependencyChangePlan(
+              PLAN_ID,
+              Status.IN_PROGRESS,
+              Instant.now(),
+              graph,
+              new TreeMap<>(Map.of(only, later)));
 
-      // when / then — picking the earlier value is what keeps merge commutative here
-      assertThat(first.merge(second)).isEqualTo(second.merge(first));
-      assertThat(first.merge(second).completed().get(only))
-          .isBeforeOrEqualTo(second.completed().get(only));
+      // when / then — the earlier value wins regardless of merge direction
+      assertThat(first.merge(second).completed().get(only)).isEqualTo(earlier);
+      assertThat(second.merge(first).completed().get(only)).isEqualTo(earlier);
     }
   }
 
@@ -434,6 +453,62 @@ final class DependencyChangePlanTest {
       // when / then — accepted, and both offered at once
       final var plan = DependencyChangePlan.init(PLAN_ID, builder.build());
       assertThat(plan.runnableFor(member(0))).hasSize(2);
+    }
+
+    @Test
+    void shouldRejectAnEmptyGraphEvenThroughTheCanonicalConstructor() {
+      // given / when / then — of() is not the only way to build one of these; the canonical
+      // constructor must reject what of() rejects, or callers that bypass it (a decode path, a
+      // direct `new`) could produce a graph with no timestamp to derive a completion from.
+      assertThatThrownBy(() -> new OperationGraph(new java.util.TreeMap<>()))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("at least one operation");
+    }
+
+    @Test
+    void shouldRejectADependencyCycleEvenThroughTheCanonicalConstructor() {
+      // given — same cycle as shouldRejectADependencyCycle, built through `new` instead of of()
+      final var operations = new java.util.TreeMap<OperationId, OperationGraph.PlannedOperation>();
+      operations.put(
+          OperationId.of(0),
+          new OperationGraph.PlannedOperation(
+              new UpdateIncarnationNumberOperation(member(0)),
+              new java.util.TreeSet<>(Set.of(OperationId.of(1)))));
+      operations.put(
+          OperationId.of(1),
+          new OperationGraph.PlannedOperation(
+              new UpdateIncarnationNumberOperation(member(1)),
+              new java.util.TreeSet<>(Set.of(OperationId.of(0)))));
+
+      // when / then
+      assertThatThrownBy(() -> new OperationGraph(operations))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("dependency cycle");
+    }
+
+    @Test
+    void shouldRejectACompletedOperationIdNotInTheGraph() {
+      // given — a plan whose completed map names an id its own graph does not contain, as a
+      // decode path or a directly constructed plan could produce without this check:
+      // hasPendingChanges
+      // (a size comparison) would then disagree with pendingOperations (a containsKey filter)
+      // about whether the plan is done.
+      final var builder = OperationGraph.builder();
+      builder.add(op(0, 1));
+      final var graph = builder.build();
+      final var foreignId = OperationId.of(99);
+
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new DependencyChangePlan(
+                      PLAN_ID,
+                      Status.IN_PROGRESS,
+                      Instant.now(),
+                      graph,
+                      new TreeMap<>(Map.of(foreignId, Instant.now()))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("not part of this plan");
     }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
@@ -14,7 +14,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.OperationGraph.PlannedOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
@@ -369,7 +369,7 @@ final class DependencyChangePlanTest {
                   new PartitionRestoreOperation(member(m), p, new java.util.TreeSet<>(Set.of(1L))),
                   Set.of(pre)));
         }
-        builder.add(new DeleteHistoryOperation(member(m)), restoresOfMember);
+        builder.add(new ModeChangeOperation(member(m), Mode.PROCESSING), restoresOfMember);
       }
       return DependencyChangePlan.init(PLAN_ID, builder.build());
     }
@@ -414,7 +414,7 @@ final class DependencyChangePlanTest {
       final var remaining = List.copyOf(plan.runnableFor(member(0)).keySet());
       plan = plan.completeOperation(remaining.get(0));
 
-      // then — DeleteHistory is still waiting on the other restore
+      // then — the mode change is still waiting on the other restore
       assertThat(plan.hasPendingChanges()).isTrue();
       assertThat(plan.runnableFor(member(0))).hasSize(1);
     }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
@@ -214,6 +214,29 @@ final class DependencyChangePlanTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("not part of the graph");
     }
+
+    @Test
+    void shouldRejectACompletionWhoseDependenciesAreNotComplete() {
+      // given — a two-operation chain where only the dependent operation is marked complete. No
+      // execution path produces this, but a decoded or hand-built plan can, and blockedBy() would
+      // then report the first operation as still to run after the second already has.
+      final var builder = OperationGraph.builder();
+      final var first = builder.add(op(0, 1));
+      final var second = builder.add(op(0, 2), Set.of(first));
+      final var graph = builder.build();
+
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new DependencyChangePlan(
+                      PLAN_ID,
+                      Status.IN_PROGRESS,
+                      Instant.now(),
+                      graph,
+                      new TreeMap<>(Map.of(second, Instant.now()))))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("the operations it depends on are not");
+    }
   }
 
   @Nested

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/DependencyChangePlanTest.java
@@ -281,6 +281,26 @@ final class DependencyChangePlanTest {
     }
 
     @Test
+    void shouldRejectMergingSameIdDifferentGraphs() {
+      // given — two self-believed coordinators derive the same plan id (the enclosing
+      // sub-configuration's version) for two unrelated graphs; OperationGraph.Builder numbers
+      // operations 0..n-1 in both, so the ids collide even though the operations do not
+      final var builderA = OperationGraph.builder();
+      final var opA = builderA.add(op(0, 1));
+      final var planA = DependencyChangePlan.init(PLAN_ID, builderA.build()).completeOperation(opA);
+
+      final var builderB = OperationGraph.builder();
+      builderB.add(op(1, 1));
+      final var planB = DependencyChangePlan.init(PLAN_ID, builderB.build());
+
+      // when / then — merged blindly, planB would end up with opA (a different member's operation
+      // under the same id) marked complete despite never having run
+      assertThatThrownBy(() -> planA.merge(planB))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("different graphs");
+    }
+
+    @Test
     void shouldBeCommutativeAndIdempotent() {
       // given
       final var builder = OperationGraph.builder();


### PR DESCRIPTION
## Description

**Stacked PR 1 of 5** — data model. Base: `main`.

Introduces the data types a partition-group change plan will run against once wired
in: `OperationGraph` (an operation set plus `dependsOn` edges — two operations with no
dependency path between them may run at the same time), `OperationId`,
`DependencyChangePlan` (template + progress, mirroring how `ClusterChangePlan` already
tracks progress against a queue), and `ChangePlan` (a sealed interface over the two,
carrying only what consumers outside the execution loop need).

Nothing constructs or reads a `DependencyChangePlan` yet — that's the next PR in the
stack. This one is pure additive data types with their own unit test
(`DependencyChangePlanTest`) and no behavioral risk to verify.

**Stack:**
1. **This PR** — data model
2. #60666 — wire the graph into the plan model + execution
3. #60667 — migrate mode change
4. #60668 — migrate restore
5. #60669 — ADR

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Part of #60302
