### PR TITLE
feat: wire a dependency graph into partition-group changes

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -14,6 +14,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.state.ChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
@@ -62,7 +63,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRouti
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -113,6 +114,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.springframework.http.ResponseEntity;
 
@@ -281,19 +283,26 @@ final class ClusterApiUtils {
               configuration.globalConfiguration().pendingChanges(),
               completed,
               pending);
-      case final PartitionGroupParallelPhase parallelPhase ->
-          parallelPhase
-              .groupOperations()
-              .forEach(
-                  (groupId, operations) ->
-                      splitSubConfigOperations(
-                          groupId,
-                          operations,
-                          Optional.ofNullable(configuration.partitionGroups().get(groupId))
-                              .flatMap(PartitionGroupConfiguration::pendingChanges),
-                          completed,
-                          pending));
+      case final PartitionGroupPhase groupPhase ->
+          splitGroupOperations(configuration, groupPhase.groupOperations(), completed, pending);
     }
+  }
+
+  private static void splitGroupOperations(
+      final CurrentClusterConfiguration configuration,
+      final Map<String, ? extends List<? extends ClusterConfigurationChangeOperation>>
+          groupOperations,
+      final List<Operation> completed,
+      final List<Operation> pending) {
+    groupOperations.forEach(
+        (groupId, operations) ->
+            splitSubConfigOperations(
+                groupId,
+                operations,
+                Optional.ofNullable(configuration.partitionGroups().get(groupId))
+                    .flatMap(PartitionGroupConfiguration::pendingChanges),
+                completed,
+                pending));
   }
 
   /**
@@ -306,7 +315,7 @@ final class ClusterApiUtils {
   private static void splitSubConfigOperations(
       final String physicalTenantId,
       final List<? extends ClusterConfigurationChangeOperation> phaseOperations,
-      final Optional<ClusterChangePlan> subConfigPlan,
+      final Optional<? extends ChangePlan> subConfigPlan,
       final List<Operation> completed,
       final List<Operation> pending) {
     if (subConfigPlan.isEmpty()) {
@@ -378,6 +387,13 @@ final class ClusterApiUtils {
     return operations.stream().map(op -> mapOperation(physicalTenantId, op)).toList();
   }
 
+  private static Stream<Operation> mapGroupOperations(
+      final Map<String, ? extends List<? extends ClusterConfigurationChangeOperation>>
+          groupOperations) {
+    return groupOperations.entrySet().stream()
+        .flatMap(entry -> mapOperations(entry.getKey(), entry.getValue()).stream());
+  }
+
   private static List<Operation> mapPhaseOperations(final List<Phase> phases) {
     return phases.stream()
         .flatMap(
@@ -385,10 +401,8 @@ final class ClusterApiUtils {
                 switch (phase) {
                   case final GlobalPhase globalPhase ->
                       mapOperations(null, globalPhase.operations()).stream();
-                  case final PartitionGroupParallelPhase partitionGroupPhase ->
-                      partitionGroupPhase.groupOperations().entrySet().stream()
-                          .flatMap(
-                              entry -> mapOperations(entry.getKey(), entry.getValue()).stream());
+                  case final PartitionGroupPhase groupPhase ->
+                      mapGroupOperations(groupPhase.groupOperations());
                 })
         .toList();
   }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -17,9 +17,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
-import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
-import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
@@ -1362,57 +1360,10 @@ final class ClusterApiUtilsTest {
   }
 
   @Test
-  void shouldSplitActivePhaseOperationsUsingSubConfigProgress() {
-    // given: the active phase targets physical tenant "tenant-a" with two operations, but the
-    // tenant's own ClusterChangePlan shows the join already completed and only the leave pending
-    final var memberId1 = member(1);
-    final var joinOperation = new PartitionJoinOperation(memberId1, 3, 1);
-    final var leaveOperation = new PartitionLeaveOperation(memberId1, 3, 0);
-    final var tenantPlan =
-        new ClusterChangePlan(
-            1,
-            1,
-            Status.IN_PROGRESS,
-            Instant.now(),
-            List.of(new CompletedOperation(joinOperation, Instant.now())),
-            List.of(leaveOperation));
-    final var tenantGroup =
-        new PartitionGroupConfiguration(
-            1, 0, Map.of(), Optional.empty(), Optional.of(tenantPlan), Optional.empty());
-    final List<Phase> phases =
-        List.of(
-            PartitionGroupPhase.sequential(
-                Map.of("tenant-a", List.of(joinOperation, leaveOperation))),
-            new GlobalPhase(List.of(new MemberLeaveOperation(memberId1))));
-    final var config =
-        new CurrentClusterConfiguration(
-            CurrentClusterConfiguration.INITIAL_VERSION,
-            GlobalConfiguration.init(),
-            Map.of("tenant-a", tenantGroup),
-            new PhasedChangeState(
-                8, Map.of(7L, new PhasedChangePlan(7, 0, phases, Instant.now())), List.of()));
-
-    // when
-    final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 7);
-
-    // then
-    assertThat(response.getStatusCode().value()).isEqualTo(200);
-    final var body = (ConfigurationChange) response.getBody();
-    assertThat(body).isNotNull();
-    assertThat(body.getCompleted())
-        .extracting(Operation::getOperation, Operation::getPhysicalTenant)
-        .containsExactly(tuple(PARTITION_JOIN, "tenant-a"));
-    assertThat(body.getPending())
-        .extracting(Operation::getOperation, Operation::getPhysicalTenant)
-        .containsExactly(
-            tuple(Operation.OperationEnum.PARTITION_LEAVE, "tenant-a"), tuple(BROKER_REMOVE, null));
-  }
-
-  @Test
   void shouldSplitActiveGraphPhaseUsingSubConfigProgress() {
-    // given: the active phase is a dependency graph rather than a queue. The tenant has run the
-    // join and not the leave, which is what the API must report -- a graph tracks progress as a set
-    // of completed operations, with no queue index to read.
+    // given: the active phase targets physical tenant "tenant-a" with two operations, and the
+    // tenant has run the join and not the leave -- which is what the API must report. A group's
+    // progress is a set of completed operations, with no queue index to read.
     final var memberId1 = member(1);
     final var joinOperation = new PartitionJoinOperation(memberId1, 3, 1);
     final var leaveOperation = new PartitionLeaveOperation(memberId1, 4, 0);
@@ -1427,7 +1378,7 @@ final class ClusterApiUtilsTest {
     final List<Phase> phases =
         List.of(
             new PartitionGroupPhase(
-                Map.of("tenant-a", tenantGroup.pendingGraphChanges().orElseThrow().graph())),
+                Map.of("tenant-a", tenantGroup.pendingChanges().orElseThrow().graph())),
             new GlobalPhase(List.of(new MemberLeaveOperation(memberId1))));
     final var config =
         new CurrentClusterConfiguration(

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartiti
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.FixedConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
@@ -67,7 +68,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRouti
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -251,7 +252,7 @@ final class ClusterApiUtilsTest {
     final List<Phase> phases =
         List.of(
             new GlobalPhase(List.of(globalOperation)),
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     "tenant-a", List.of(tenantAOperation),
                     "tenant-b", List.of(tenantBOperation))));
@@ -1337,7 +1338,7 @@ final class ClusterApiUtilsTest {
     final var memberId1 = member(1);
     final List<Phase> phases =
         List.of(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of("default", List.of(new PartitionJoinOperation(memberId1, 1, 3)))),
             new GlobalPhase(List.of(new MemberLeaveOperation(memberId1))));
     final var config =
@@ -1380,8 +1381,53 @@ final class ClusterApiUtilsTest {
             1, 0, Map.of(), Optional.empty(), Optional.of(tenantPlan), Optional.empty());
     final List<Phase> phases =
         List.of(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of("tenant-a", List.of(joinOperation, leaveOperation))),
+            new GlobalPhase(List.of(new MemberLeaveOperation(memberId1))));
+    final var config =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", tenantGroup),
+            new PhasedChangeState(
+                8, Map.of(7L, new PhasedChangePlan(7, 0, phases, Instant.now())), List.of()));
+
+    // when
+    final var response = ClusterApiUtils.mapConfigurationChangeResponse(config, 7);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    final var body = (ConfigurationChange) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getCompleted())
+        .extracting(Operation::getOperation, Operation::getPhysicalTenant)
+        .containsExactly(tuple(PARTITION_JOIN, "tenant-a"));
+    assertThat(body.getPending())
+        .extracting(Operation::getOperation, Operation::getPhysicalTenant)
+        .containsExactly(
+            tuple(Operation.OperationEnum.PARTITION_LEAVE, "tenant-a"), tuple(BROKER_REMOVE, null));
+  }
+
+  @Test
+  void shouldSplitActiveGraphPhaseUsingSubConfigProgress() {
+    // given: the active phase is a dependency graph rather than a queue. The tenant has run the
+    // join and not the leave, which is what the API must report -- a graph tracks progress as a set
+    // of completed operations, with no queue index to read.
+    final var memberId1 = member(1);
+    final var joinOperation = new PartitionJoinOperation(memberId1, 3, 1);
+    final var leaveOperation = new PartitionLeaveOperation(memberId1, 4, 0);
+    final var graphBuilder = OperationGraph.builder();
+    final var joinId = graphBuilder.add(joinOperation);
+    graphBuilder.add(leaveOperation, Set.of(joinId));
+    final var tenantGroup =
+        new PartitionGroupConfiguration(
+                1, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.empty())
+            .startGraphConfigurationChange(graphBuilder.build())
+            .completeOperation(joinId, UnaryOperator.identity());
+    final List<Phase> phases =
+        List.of(
+            new PartitionGroupPhase(
+                Map.of("tenant-a", tenantGroup.pendingGraphChanges().orElseThrow().graph())),
             new GlobalPhase(List.of(new MemberLeaveOperation(memberId1))));
     final var config =
         new CurrentClusterConfiguration(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -428,8 +428,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
 
   /**
    * The single place group-scoped {@link ScopeReconciler}s and {@link GraphScopeReconciler}s are
-   * created — registering a group's appliers via {@link #registerPartitionGroupChangeAppliers}
-   * does not create either. Every live group keeps both on every broker, whether or not the broker
+   * created — registering a group's appliers via {@link #registerPartitionGroupChangeAppliers} does
+   * not create either. Every live group keeps both on every broker, whether or not the broker
    * registered that group's appliers — a broker can be named in a group operation without ever
    * hosting the group (a disabled physical tenant's forced removal executes on whichever broker
    * received the request, and no broker runs a disabled tenant). Removed groups are tombstones that
@@ -656,7 +656,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         groupId,
         localMemberId,
         persistedCurrentConfiguration::getConfiguration,
-        () -> partitionGroupChangeAppliers.get(groupId),
+        operation -> applierFor(operation, partitionGroupChangeAppliers.get(groupId)),
         this::updateLocalCurrentConfiguration,
         executor,
         topologyMetrics,
@@ -673,7 +673,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
    * A {@code RemovePhysicalTenantOperation} is dispatchable even with no {@code appliers}
    * registered for the group, since it is a pure configuration edit with no broker-side executor.
    * Every other operation still requires a registered appliers set, returning {@code
-   * Optional.empty()} — leaving it pending — otherwise.
+   * Optional.empty()} — leaving it pending — otherwise. Shared by both execution models: {@link
+   * GroupScopeOperations#nextOperation} for the queue, {@link GraphScopeReconciler} for the graph.
    */
   private static Optional<PartitionGroupConfigurationChangeApplier> applierFor(
       final PartitionGroupOperation operation,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -321,17 +321,17 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
 
   /**
    * Returns {@code true} if the current (unmutated, per-phase) plan has an operation targeting
-   * {@link #localMemberId} within {@code groupId}'s {@link PartitionGroupParallelPhase}s, whether
-   * already completed or still pending. Phases are fixed at plan creation and never mutated, so
-   * this reflects the member's original involvement in the plan regardless of how far it has since
+   * {@link #localMemberId} within {@code groupId}'s {@link PartitionGroupPhase}s, whether already
+   * completed or still pending. Phases are fixed at plan creation and never mutated, so this
+   * reflects the member's original involvement in the plan regardless of how far it has since
    * progressed.
    */
   private boolean wasTargetedByCurrentPlan(
       final CurrentClusterConfiguration configuration, final String groupId) {
     return configuration.phasedChangeState().pending().values().stream()
         .flatMap(plan -> plan.phases().stream())
-        .filter(PartitionGroupParallelPhase.class::isInstance)
-        .map(PartitionGroupParallelPhase.class::cast)
+        .filter(PartitionGroupPhase.class::isInstance)
+        .map(PartitionGroupPhase.class::cast)
         .map(phase -> phase.groupOperations().get(groupId))
         .filter(Objects::nonNull)
         .flatMap(List::stream)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -103,6 +105,10 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private final Duration minRetryDelay;
   private final Duration maxRetryDelay;
   private final Map<Scope, ScopeReconciler> scopeReconcilers = new HashMap<>();
+  // Separate from scopeReconcilers: a graph runs several of a group's operations at once, so it
+  // cannot share ScopeReconciler's single-in-flight-operation contract. Keyed by group id, since a
+  // graph change only ever belongs to a partition group.
+  private final Map<String, GraphScopeReconciler> graphReconcilers = new HashMap<>();
   // Keyed by plan id, since multiple plans can be advancing (and independently retrying) at once.
   private final Map<Long, PlanAdvancer> planAdvancers = new HashMap<>();
   private final int completedChangeHistoryLimit;
@@ -255,20 +261,40 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
                 LOG.error(errorMessage);
                 startFuture.completeExceptionally(new IllegalStateException(errorMessage));
               } else {
+                CurrentClusterConfiguration toPersist;
                 try {
                   // merge in case there was a concurrent update via gossip
-                  persistedCurrentConfiguration.update(
-                      configuration.merge(persistedCurrentConfiguration.getConfiguration()));
-                  LOG.debug(
-                      "Initialized cluster configuration '{}'",
-                      persistedCurrentConfiguration.getConfiguration());
-                  if (currentConfigurationGossiper != null) {
-                    currentConfigurationGossiper.accept(
-                        persistedCurrentConfiguration.getConfiguration());
-                  }
+                  toPersist = configuration.merge(persistedCurrentConfiguration.getConfiguration());
+                } catch (final RuntimeException e) {
+                  // The merge can throw when a concurrently-gossiped peer's write genuinely
+                  // conflicts with this member's own state at the same version (see
+                  // BrokerPartitionState#merge) -- a real disagreement between brokers, not a
+                  // transient error. Failing start over it would leave this broker down
+                  // indefinitely against a condition later, unrelated writes are what actually
+                  // resolve. Starting from this member's own freshly-initialized configuration
+                  // instead -- skipping the merge, not skipping the update -- lets normal gossip
+                  // reconciliation surface and retry against the same conflict once running,
+                  // exactly as it does for one arriving after start via {@link
+                  // #onGossipReceivedCurrent}.
+                  LOG.warn(
+                      "Failed to merge cluster configuration during startup; starting without "
+                          + "the merge",
+                      e);
+                  toPersist = configuration;
+                }
+                try {
+                  persistedCurrentConfiguration.update(toPersist);
                 } catch (final IOException e) {
                   startFuture.completeExceptionally(
                       "Failed to start update cluster configuration", e);
+                  return;
+                }
+                LOG.debug(
+                    "Initialized cluster configuration '{}'",
+                    persistedCurrentConfiguration.getConfiguration());
+                if (currentConfigurationGossiper != null) {
+                  currentConfigurationGossiper.accept(
+                      persistedCurrentConfiguration.getConfiguration());
                 }
                 setStarted();
               }
@@ -330,12 +356,27 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
       final CurrentClusterConfiguration configuration, final String groupId) {
     return configuration.phasedChangeState().pending().values().stream()
         .flatMap(plan -> plan.phases().stream())
-        .filter(PartitionGroupPhase.class::isInstance)
-        .map(PartitionGroupPhase.class::cast)
-        .map(phase -> phase.groupOperations().get(groupId))
+        .map(phase -> groupOperationsOf(phase, groupId))
         .filter(Objects::nonNull)
         .flatMap(List::stream)
         .anyMatch(operation -> operation.memberId().equals(localMemberId));
+  }
+
+  /**
+   * {@code phase}'s operations for {@code groupId}, or {@code null} if the phase targets no group
+   * at all ({@link GlobalPhase}) or not this one.
+   *
+   * <p>Switches over every phase kind rather than filtering for one — mirroring {@link
+   * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan#scopeOf}'s own javadoc warning against
+   * exactly that pattern — so a phase kind added later without a case here fails to compile instead
+   * of silently making {@link #wasTargetedByCurrentPlan} blind to it.
+   */
+  private static @Nullable List<PartitionGroupOperation> groupOperationsOf(
+      final Phase phase, final String groupId) {
+    return switch (phase) {
+      case final GlobalPhase ignored -> null;
+      case final PartitionGroupPhase groupPhase -> groupPhase.groupOperations().get(groupId);
+    };
   }
 
   void registerTopologyChangedListener(final InconsistentConfigurationListener listener) {
@@ -356,6 +397,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(
         () -> {
           scopeReconcilers.clear();
+          graphReconcilers.clear();
           planAdvancers.clear();
         });
   }
@@ -385,15 +427,15 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   }
 
   /**
-   * The single place group-scoped {@link ScopeReconciler}s are created — registering a group's
-   * appliers via {@link #registerPartitionGroupChangeAppliers} does not create one. Every live
-   * group keeps a reconciler on every broker, whether or not the broker registered that group's
-   * appliers — a broker can be named in a group operation without ever hosting the group (a
-   * disabled physical tenant's forced removal executes on whichever broker received the request,
-   * and no broker runs a disabled tenant). Removed groups are tombstones that can never have work
-   * again, and they accumulate over a cluster's lifetime, so no new reconciler is created for one —
-   * an existing one persisting is fine, since reconcilers are deliberately never removed except on
-   * {@link #close}. A reconciler with nothing pending is a no-op per pass.
+   * The single place group-scoped {@link ScopeReconciler}s and {@link GraphScopeReconciler}s are
+   * created — registering a group's appliers via {@link #registerPartitionGroupChangeAppliers}
+   * does not create either. Every live group keeps both on every broker, whether or not the broker
+   * registered that group's appliers — a broker can be named in a group operation without ever
+   * hosting the group (a disabled physical tenant's forced removal executes on whichever broker
+   * received the request, and no broker runs a disabled tenant). Removed groups are tombstones that
+   * can never have work again, and they accumulate over a cluster's lifetime, so no new reconciler
+   * is created for one — an existing one persisting is fine, since reconcilers are deliberately
+   * never removed except on {@link #close}. A reconciler with nothing pending is a no-op per pass.
    */
   private void ensurePartitionGroupScopeReconcilers(final CurrentClusterConfiguration config) {
     config
@@ -403,6 +445,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
               if (!group.isRemoved()) {
                 scopeReconcilers.computeIfAbsent(
                     new Scope.Group(groupId), ignored -> newGroupScopeReconciler(groupId));
+                graphReconcilers.computeIfAbsent(
+                    groupId, ignored -> newGraphScopeReconciler(groupId));
               }
             });
   }
@@ -411,12 +455,12 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(
         () -> {
           partitionGroupChangeAppliers.remove(groupId);
-          // Deliberately not removing this group's ScopeReconciler here: it's created solely by
-          // ensurePartitionGroupScopeReconcilers, so it survives a remove/register round-trip
-          // unmolested. PartitionManagerImpl/RecoveryPartitionManager re-register their change
-          // appliers on every recovery/processing mode transition; discarding the ScopeReconciler
-          // here would discard its in-flight retry/backoff state on every such transition, leaving
-          // a broker stuck mid-transition (see
+          // Deliberately not removing this group's ScopeReconciler or GraphScopeReconciler here:
+          // both are created solely by ensurePartitionGroupScopeReconcilers, so they survive a
+          // remove/register round-trip unmolested. PartitionManagerImpl/RecoveryPartitionManager
+          // re-register their change appliers on every recovery/processing mode transition;
+          // discarding either reconciler here would discard its in-flight retry/backoff state on
+          // every such transition, leaving a broker stuck mid-transition (see
           // ModeChangeAcceptanceIT#shouldCycleBetweenRecoveryAndProcessing).
         });
   }
@@ -463,6 +507,12 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
                               "Failed to process cluster configuration received via gossip. '{}'",
                               receivedConfiguration,
                               error));
+            } else {
+              // The merge changed nothing locally, so reconcile() is not reached — but a graph
+              // change may still be drained and unfinished, most plausibly because an earlier
+              // attempt to finish it failed to persist. Retrying on every gossip round rides the
+              // existing sync cadence and needs no timer of its own.
+              maybeCompleteGraphChanges(merged);
             }
           } catch (final Exception e) {
             LOG.warn(
@@ -522,6 +572,49 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
       planAdvancers.keySet().retainAll(pendingIds);
     }
     scopeReconcilers.values().forEach(ScopeReconciler::reconcile);
+    graphReconcilers.values().forEach(GraphScopeReconciler::reconcile);
+    maybeCompleteGraphChanges(config);
+  }
+
+  /**
+   * Finishes any graph change whose operations have all completed.
+   *
+   * <p>Runs on every broker with no coordinator check: completion is a pure function of converged
+   * state, so several brokers computing it agree. It must also run when a gossip merge changes
+   * nothing locally (see {@link #onGossipReceivedCurrent}) — otherwise a completion whose persist
+   * failed is never retried once the cluster converges, and the change sits drained but unfinished
+   * with nothing left to perturb it.
+   */
+  private void maybeCompleteGraphChanges(final CurrentClusterConfiguration config) {
+    final var drained =
+        config.partitionGroups().values().stream()
+            .anyMatch(
+                group ->
+                    group
+                        .pendingGraphChanges()
+                        .filter(plan -> !plan.hasPendingChanges())
+                        .isPresent());
+    if (!drained) {
+      return;
+    }
+    updateMultiConfiguration(ClusterConfigurationManagerImpl::completeDrainedGraphChanges)
+        .onComplete(
+            (ignore, completionError) -> {
+              if (completionError != null) {
+                LOG.warn("Failed to complete a drained configuration change", completionError);
+              }
+            });
+  }
+
+  private static CurrentClusterConfiguration completeDrainedGraphChanges(
+      final CurrentClusterConfiguration config) {
+    var result = config;
+    for (final String groupId : List.copyOf(config.partitionGroups().keySet())) {
+      result =
+          result.updatePartitionGroupConfig(
+              groupId, PartitionGroupConfiguration::completeGraphChangeIfDrained);
+    }
+    return result;
   }
 
   private PlanAdvancer newPlanAdvancer(final long planId) {
@@ -529,7 +622,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         planId,
         executor,
         this::updateMultiConfiguration,
-        () -> persistedCurrentConfiguration.getConfiguration(),
+        persistedCurrentConfiguration::getConfiguration,
         this::isLocalMemberCoordinator,
         minRetryDelay,
         maxRetryDelay,
@@ -539,7 +632,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private ScopeReconciler newGlobalScopeReconciler() {
     return new ScopeReconciler(
         new GlobalScopeOperations(),
-        () -> persistedCurrentConfiguration.getConfiguration(),
+        persistedCurrentConfiguration::getConfiguration,
         this::updateLocalCurrentConfiguration,
         executor,
         topologyMetrics,
@@ -550,7 +643,20 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private ScopeReconciler newGroupScopeReconciler(final String groupId) {
     return new ScopeReconciler(
         new GroupScopeOperations(groupId),
-        () -> persistedCurrentConfiguration.getConfiguration(),
+        persistedCurrentConfiguration::getConfiguration,
+        this::updateLocalCurrentConfiguration,
+        executor,
+        topologyMetrics,
+        minRetryDelay,
+        maxRetryDelay);
+  }
+
+  private GraphScopeReconciler newGraphScopeReconciler(final String groupId) {
+    return new GraphScopeReconciler(
+        groupId,
+        localMemberId,
+        persistedCurrentConfiguration::getConfiguration,
+        () -> partitionGroupChangeAppliers.get(groupId),
         this::updateLocalCurrentConfiguration,
         executor,
         topologyMetrics,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -369,10 +369,10 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
    * {@code phase}'s operations for {@code groupId}, or {@code null} if the phase targets no group
    * at all ({@link GlobalPhase}) or not this one.
    *
-   * <p>Switches over every phase kind rather than filtering for one — mirroring {@link
-   * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan#scopeOf}'s own javadoc warning against
-   * exactly that pattern — so a phase kind added later without a case here fails to compile instead
-   * of silently making {@link #wasTargetedByCurrentPlan} blind to it.
+   * <p>Switches over every phase kind rather than filtering for one, for the same reason {@link
+   * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan#scopeOf} does: a phase kind added later
+   * without a case here fails to compile, instead of silently making {@link
+   * #wasTargetedByCurrentPlan} blind to it.
    */
   private static @Nullable List<PartitionGroupOperation> groupOperationsOf(
       final Phase phase, final String groupId) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -77,8 +77,11 @@ import org.slf4j.LoggerFactory;
  * key's failures cannot delay another's:
  *
  * <ul>
- *   <li>A {@link ScopeReconciler} per {@link Scope} (the global configuration, or one named
- *       partition group) applies the local member's next pending operation in that scope.
+ *   <li>One {@link ScopeReconciler} applies the local member's next pending operation on {@link
+ *       io.camunda.zeebe.dynamic.config.state.GlobalConfiguration}, whose change is a queue.
+ *   <li>A {@link GraphScopeReconciler} per partition group applies whichever of that group's
+ *       operations the local member may run right now — several at once, since a group's change is
+ *       a dependency graph.
  *   <li>A {@link PlanAdvancer} per pending plan id advances that plan to its next phase, or
  *       completes it, once its current phase has fully drained.
  * </ul>
@@ -104,10 +107,10 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
       partitionGroupChangeAppliers = new HashMap<>();
   private final Duration minRetryDelay;
   private final Duration maxRetryDelay;
-  private final Map<Scope, ScopeReconciler> scopeReconcilers = new HashMap<>();
-  // Separate from scopeReconcilers: a graph runs several of a group's operations at once, so it
-  // cannot share ScopeReconciler's single-in-flight-operation contract. Keyed by group id, since a
-  // graph change only ever belongs to a partition group.
+  private @Nullable ScopeReconciler globalScopeReconciler;
+  // Not a ScopeReconciler: a graph runs several of a group's operations at once, so it cannot share
+  // ScopeReconciler's single-in-flight-operation contract. Keyed by group id, since a graph change
+  // only ever belongs to a partition group.
   private final Map<String, GraphScopeReconciler> graphReconcilers = new HashMap<>();
   // Keyed by plan id, since multiple plans can be advancing (and independently retrying) at once.
   private final Map<Long, PlanAdvancer> planAdvancers = new HashMap<>();
@@ -391,12 +394,12 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
    * Drops every scope's and plan's reconciliation worker. Only meant to be called once, as part of
    * shutting down the whole manager (see {@link ClusterConfigurationManagerService#closeAsync} ) —
    * unlike {@link #removePartitionGroupChangeAppliers}, which must leave a group's {@link
-   * ScopeReconciler} alone so it survives that group's own register/remove churn.
+   * GraphScopeReconciler} alone so it survives that group's own register/remove churn.
    */
   void close() {
     executor.run(
         () -> {
-          scopeReconcilers.clear();
+          globalScopeReconciler = null;
           graphReconcilers.clear();
           planAdvancers.clear();
         });
@@ -411,8 +414,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(
         () -> {
           globalChangeAppliers = appliers;
-          scopeReconcilers.computeIfAbsent(
-              new Scope.Global(), ignored -> newGlobalScopeReconciler());
+          if (globalScopeReconciler == null) {
+            globalScopeReconciler = newGlobalScopeReconciler();
+          }
           reconcile(persistedCurrentConfiguration.getConfiguration());
         });
   }
@@ -427,15 +431,15 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   }
 
   /**
-   * The single place group-scoped {@link ScopeReconciler}s and {@link GraphScopeReconciler}s are
-   * created — registering a group's appliers via {@link #registerPartitionGroupChangeAppliers} does
-   * not create either. Every live group keeps both on every broker, whether or not the broker
-   * registered that group's appliers — a broker can be named in a group operation without ever
-   * hosting the group (a disabled physical tenant's forced removal executes on whichever broker
-   * received the request, and no broker runs a disabled tenant). Removed groups are tombstones that
-   * can never have work again, and they accumulate over a cluster's lifetime, so no new reconciler
-   * is created for one — an existing one persisting is fine, since reconcilers are deliberately
-   * never removed except on {@link #close}. A reconciler with nothing pending is a no-op per pass.
+   * The single place group-scoped {@link GraphScopeReconciler}s are created — registering a group's
+   * appliers via {@link #registerPartitionGroupChangeAppliers} does not create one. Every live
+   * group keeps one on every broker, whether or not the broker registered that group's appliers — a
+   * broker can be named in a group operation without ever hosting the group (a disabled physical
+   * tenant's forced removal executes on whichever broker received the request, and no broker runs a
+   * disabled tenant). Removed groups are tombstones that can never have work again, and they
+   * accumulate over a cluster's lifetime, so no new reconciler is created for one — an existing one
+   * persisting is fine, since reconcilers are deliberately never removed except on {@link #close}.
+   * A reconciler with nothing pending is a no-op per pass.
    */
   private void ensurePartitionGroupScopeReconcilers(final CurrentClusterConfiguration config) {
     config
@@ -443,8 +447,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         .forEach(
             (groupId, group) -> {
               if (!group.isRemoved()) {
-                scopeReconcilers.computeIfAbsent(
-                    new Scope.Group(groupId), ignored -> newGroupScopeReconciler(groupId));
                 graphReconcilers.computeIfAbsent(
                     groupId, ignored -> newGraphScopeReconciler(groupId));
               }
@@ -455,12 +457,12 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(
         () -> {
           partitionGroupChangeAppliers.remove(groupId);
-          // Deliberately not removing this group's ScopeReconciler or GraphScopeReconciler here:
-          // both are created solely by ensurePartitionGroupScopeReconcilers, so they survive a
-          // remove/register round-trip unmolested. PartitionManagerImpl/RecoveryPartitionManager
-          // re-register their change appliers on every recovery/processing mode transition;
-          // discarding either reconciler here would discard its in-flight retry/backoff state on
-          // every such transition, leaving a broker stuck mid-transition (see
+          // Deliberately not removing this group's GraphScopeReconciler here: it is created solely
+          // by ensurePartitionGroupScopeReconcilers, so it survives a remove/register round-trip
+          // unmolested. PartitionManagerImpl/RecoveryPartitionManager re-register their change
+          // appliers on every recovery/processing mode transition; discarding the reconciler here
+          // would discard its in-flight retry/backoff state on every such transition, leaving a
+          // broker stuck mid-transition (see
           // ModeChangeAcceptanceIT#shouldCycleBetweenRecoveryAndProcessing).
         });
   }
@@ -571,7 +573,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     if (!planAdvancers.isEmpty()) {
       planAdvancers.keySet().retainAll(pendingIds);
     }
-    scopeReconcilers.values().forEach(ScopeReconciler::reconcile);
+    if (globalScopeReconciler != null) {
+      globalScopeReconciler.reconcile();
+    }
     graphReconcilers.values().forEach(GraphScopeReconciler::reconcile);
     maybeCompleteGraphChanges(config);
   }
@@ -590,10 +594,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         config.partitionGroups().values().stream()
             .anyMatch(
                 group ->
-                    group
-                        .pendingGraphChanges()
-                        .filter(plan -> !plan.hasPendingChanges())
-                        .isPresent());
+                    group.pendingChanges().filter(plan -> !plan.hasPendingChanges()).isPresent());
     if (!drained) {
       return;
     }
@@ -640,17 +641,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         maxRetryDelay);
   }
 
-  private ScopeReconciler newGroupScopeReconciler(final String groupId) {
-    return new ScopeReconciler(
-        new GroupScopeOperations(groupId),
-        persistedCurrentConfiguration::getConfiguration,
-        this::updateLocalCurrentConfiguration,
-        executor,
-        topologyMetrics,
-        minRetryDelay,
-        maxRetryDelay);
-  }
-
   private GraphScopeReconciler newGraphScopeReconciler(final String groupId) {
     return new GraphScopeReconciler(
         groupId,
@@ -673,8 +663,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
    * A {@code RemovePhysicalTenantOperation} is dispatchable even with no {@code appliers}
    * registered for the group, since it is a pure configuration edit with no broker-side executor.
    * Every other operation still requires a registered appliers set, returning {@code
-   * Optional.empty()} — leaving it pending — otherwise. Shared by both execution models: {@link
-   * GroupScopeOperations#nextOperation} for the queue, {@link GraphScopeReconciler} for the graph.
+   * Optional.empty()} — leaving it pending — otherwise.
    */
   private static Optional<PartitionGroupConfigurationChangeApplier> applierFor(
       final PartitionGroupOperation operation,
@@ -708,47 +697,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     }
   }
 
-  private record GroupOperation(
-      String groupId,
-      PartitionGroupOperation operation,
-      PartitionGroupConfigurationChangeApplier applier)
-      implements Operation {
-
-    @Override
-    public Either<Exception, CurrentClusterConfiguration> initialize(
-        final CurrentClusterConfiguration config) {
-      final var group = config.partitionGroup(groupId);
-      return applier
-          .init(config.globalConfiguration(), group)
-          .map(transformer -> config.updatePartitionGroupConfig(groupId, transformer));
-    }
-
-    @Override
-    public ActorFuture<UnaryOperator<CurrentClusterConfiguration>> apply() {
-      return applier
-          .apply()
-          .thenApply(
-              transformer ->
-                  (UnaryOperator<CurrentClusterConfiguration>)
-                      config ->
-                          config.updatePartitionGroupConfig(
-                              groupId, g -> g.advanceConfigurationChange(transformer)));
-    }
-  }
-
-  /**
-   * Identifies exactly one reconciliation target: the global configuration, or a single named
-   * partition group. Distinct from {@code PhasedChangePlan.Scope}, which names a <em>plan's</em>
-   * footprint (possibly several groups at once, for admission conflict checks) — this key always
-   * names exactly one target, since it addresses a single {@link ScopeReconciler}.
-   */
-  private sealed interface Scope permits Scope.Global, Scope.Group {
-
-    record Global() implements Scope {}
-
-    record Group(String groupId) implements Scope {}
-  }
-
   /** {@link ScopeReconciler.Operations} for the global configuration. */
   private final class GlobalScopeOperations implements Operations {
 
@@ -773,41 +721,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     @Override
     public String describe() {
       return "global";
-    }
-  }
-
-  /** {@link ScopeReconciler.Operations} for one named partition group. */
-  private final class GroupScopeOperations implements Operations {
-
-    private final String groupId;
-
-    private GroupScopeOperations(final String groupId) {
-      this.groupId = groupId;
-    }
-
-    @Override
-    public Optional<Operation> nextOperation(final CurrentClusterConfiguration config) {
-      final var group = config.partitionGroup(groupId);
-      if (group == null) {
-        return Optional.empty();
-      }
-      return group
-          .pendingChangesFor(localMemberId)
-          .flatMap(
-              operation ->
-                  applierFor(operation, partitionGroupChangeAppliers.get(groupId))
-                      .map(applier -> new GroupOperation(groupId, operation, applier)));
-    }
-
-    @Override
-    public long versionOf(final CurrentClusterConfiguration config) {
-      final var group = config.partitionGroup(groupId);
-      return group == null ? -1 : group.version();
-    }
-
-    @Override
-    public String describe() {
-      return "partition group '%s'".formatted(groupId);
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GraphScopeReconciler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GraphScopeReconciler.java
@@ -33,18 +33,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Drives one partition group's dependency-graph change, the counterpart of {@link ScopeReconciler}
- * for the other execution model.
+ * Drives one partition group's change, the per-group counterpart of {@link ScopeReconciler} (which
+ * drives the global configuration, and only that).
  *
  * <p>The difference that makes this a separate class rather than a mode of {@link ScopeReconciler}:
- * a queue offers the local member exactly one operation at a time, so a single {@code ongoing} flag
- * is enough to keep re-entrant reconciliation idempotent. A graph offers every operation whose
- * dependencies have completed — typically several — so in-flight state and retry backoff are keyed
- * per {@link OperationId} instead. Everything else (read the config fresh, stage, apply, record,
- * persist, re-reconcile) mirrors {@link ScopeReconciler} deliberately.
- *
- * <p>A group holds one change of one model, so for any given group at most one of the two
- * reconcilers ever finds work.
+ * the global configuration's queue offers the local member exactly one operation at a time, so a
+ * single {@code ongoing} flag is enough to keep re-entrant reconciliation idempotent. A group's
+ * graph offers every operation whose dependencies have completed — typically several — so in-flight
+ * state and retry backoff are keyed per operation instead (see {@link OperationKey}). Everything
+ * else (read the config fresh, stage, apply, record, persist, re-reconcile) mirrors {@link
+ * ScopeReconciler} deliberately.
  */
 @NullMarked
 final class GraphScopeReconciler {
@@ -75,15 +73,14 @@ final class GraphScopeReconciler {
   private final Duration minRetryDelay;
   private final Duration maxRetryDelay;
 
-  private final Set<OperationId> inFlight = new HashSet<>();
-  private final Map<OperationId, ExponentialBackoffRetryDelay> backoffs = new HashMap<>();
+  private final Set<OperationKey> inFlight = new HashSet<>();
+  private final Map<OperationKey, ExponentialBackoffRetryDelay> backoffs = new HashMap<>();
 
   /**
    * @param applierFor resolves the applier for one operation, or {@link Optional#empty()} to leave
-   *     it pending — the same per-operation resolution {@code ClusterConfigurationManagerImpl}'s
-   *     {@code applierFor} gives the queue model's {@code GroupScopeOperations}, so a {@code
-   *     RemovePhysicalTenantOperation} (dispatchable with no registered appliers at all, since it
-   *     is a pure configuration edit) is not blocked by this group having none.
+   *     it pending. Resolution is per operation rather than per group so that a {@code
+   *     RemovePhysicalTenantOperation} — dispatchable with no registered appliers at all, since it
+   *     is a pure configuration edit — is not blocked by this group having none.
    */
   GraphScopeReconciler(
       final String groupId,
@@ -120,27 +117,52 @@ final class GraphScopeReconciler {
   void reconcile() {
     final var group = currentConfiguration.get().partitionGroup(groupId);
     if (group == null) {
+      forgetOperationsOutside(null);
       return;
     }
+    final var plan = group.pendingChanges().orElse(null);
+    if (plan == null) {
+      forgetOperationsOutside(null);
+      return;
+    }
+    forgetOperationsOutside(plan.id());
 
     for (final var entry : group.runnableFor(localMemberId).entrySet()) {
+      final var key = new OperationKey(plan.id(), entry.getKey());
       if (inFlight.size() >= MAX_CONCURRENT_OPERATIONS) {
         break;
       }
-      if (inFlight.contains(entry.getKey())) {
+      if (inFlight.contains(key)) {
         continue;
       }
-      start(entry.getKey(), entry.getValue());
+      start(key, entry.getValue());
     }
   }
 
   /**
-   * Leaves {@code operationId} pending — neither in-flight nor retried on a timer — if {@link
-   * #applierFor} resolves nothing for it, exactly as {@code GroupScopeOperations} does for the
-   * queue model: stalling visibly on a genuinely-unregistered operation, rather than fabricating a
-   * no-op success for it.
+   * Drops in-flight and backoff state belonging to any plan other than {@code planId} ({@code null}
+   * meaning the group has no change at all).
+   *
+   * <p>This is the only thing that reclaims that state when the plan it belongs to goes away.
+   * {@code PartitionGroupConfiguration#cancelPendingChanges()} — the operator's last resort for a
+   * stuck change — is a pure transformation of the persisted configuration and cannot reach these
+   * in-memory maps. The per-operation completion path cannot be relied on either: it only runs once
+   * the operation's {@code apply()} future completes, and a genuinely hung operation (precisely
+   * what gets a change cancelled) never gets there. Without this, that operation's entry would hold
+   * one of {@link #MAX_CONCURRENT_OPERATIONS} slots for the lifetime of the process.
    */
-  private void start(final OperationId operationId, final PartitionGroupOperation operation) {
+  private void forgetOperationsOutside(final @Nullable Long planId) {
+    inFlight.removeIf(key -> planId == null || key.planId() != planId);
+    backoffs.keySet().removeIf(key -> planId == null || key.planId() != planId);
+  }
+
+  /**
+   * Leaves the operation pending — neither in-flight nor retried on a timer — if {@link
+   * #applierFor} resolves nothing for it: stalling visibly on a genuinely-unregistered operation,
+   * rather than fabricating a no-op success for it.
+   */
+  private void start(final OperationKey key, final PartitionGroupOperation operation) {
+    final var operationId = key.operationId();
     final var resolvedApplier = applierFor.apply(operation);
     if (resolvedApplier.isEmpty()) {
       return;
@@ -154,7 +176,7 @@ final class GraphScopeReconciler {
       return;
     }
 
-    inFlight.add(operationId);
+    inFlight.add(key);
     final var observer = topologyMetrics.observeOperation(operation);
     LOG.info("Applying partition group '{}' operation {} ({})", groupId, operationId, operation);
 
@@ -166,7 +188,7 @@ final class GraphScopeReconciler {
             .flatMap(updateLocally);
     if (initialized.isLeft()) {
       observer.failed();
-      inFlight.remove(operationId);
+      inFlight.remove(key);
       LOG.error(
           "Failed to initialize partition group '{}' operation {}",
           groupId,
@@ -180,25 +202,24 @@ final class GraphScopeReconciler {
         .apply()
         .onComplete(
             (transformer, error) ->
-                onApplied(operationId, operation, transformer, error, startedVersion, observer));
+                onApplied(key, operation, transformer, error, startedVersion, observer));
   }
 
   private void onApplied(
-      final OperationId operationId,
+      final OperationKey key,
       final PartitionGroupOperation operation,
       final UnaryOperator<PartitionGroupConfiguration> transformer,
       final @Nullable Throwable error,
       final long startedVersion,
       final OperationObserver observer) {
-    inFlight.remove(operationId);
+    inFlight.remove(key);
 
     if (error != null) {
       observer.failed();
       final Duration delay =
           backoffs
               .computeIfAbsent(
-                  operationId,
-                  ignored -> new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay))
+                  key, ignored -> new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay))
               .nextDelay();
       LOG.warn(
           "Failed to apply partition group '{}' operation {}. Will be retried in {}.",
@@ -213,30 +234,19 @@ final class GraphScopeReconciler {
     }
 
     observer.applied();
-    backoffs.remove(operationId);
+    backoffs.remove(key);
 
     final var config = currentConfiguration.get();
     if (versionOf(config) != startedVersion) {
       // Recording an operation moves no version, so a version change here means the change was
-      // cancelled or already completed while this operation was running.
+      // cancelled or already completed while this operation was running. Nothing to clean up or
+      // re-check: the key carries the plan id, so whatever plan runs on this group now cannot be
+      // waiting on state this completion holds, and the update that started it already reconciled.
       LOG.debug(
           "Partition group '{}' changed while applying operation {}. Most likely the change was"
               + " cancelled.",
           groupId,
           operation);
-      // Also clears any backoff this operationId accumulated: a replacement plan on this group
-      // numbers its operations from zero, same as this one did, so its operationId can collide
-      // with this one, and without this an operation that failed a few times before this plan was
-      // cancelled would leave an inflated delay for the replacement plan's same-numbered operation
-      // to inherit -- the same reasoning ScopeReconciler's stale-version path already applies to
-      // its single shared backoff.
-      backoffs.remove(operationId);
-      // A replacement plan on this group numbers its operations from zero, same as this one did,
-      // so its own operationId may collide with the one just removed from inFlight above. If that
-      // collision was blocking it, this is the only place left to notice: nothing else about this
-      // stale completion touches the replacement plan, so without this call the collision clears
-      // but nothing ever re-checks what it was blocking.
-      reconcile();
       return;
     }
 
@@ -244,7 +254,9 @@ final class GraphScopeReconciler {
         config.updatePartitionGroupConfig(
             groupId,
             group ->
-                group.completeOperation(operationId, transformer).completeGraphChangeIfDrained());
+                group
+                    .completeOperation(key.operationId(), transformer)
+                    .completeGraphChangeIfDrained());
     // Persisting re-triggers reconciliation across every scope and plan, which is what picks up the
     // operations this completion just made runnable — no explicit "run the loop again" is needed.
     final var persisted = updateLocally.apply(advanced);
@@ -254,8 +266,7 @@ final class GraphScopeReconciler {
       final Duration delay =
           backoffs
               .computeIfAbsent(
-                  operationId,
-                  ignored -> new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay))
+                  key, ignored -> new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay))
               .nextDelay();
       LOG.warn(
           "Applied partition group '{}' operation {} but failed to record it. Will be retried in"
@@ -274,4 +285,12 @@ final class GraphScopeReconciler {
     final var group = config.partitionGroup(groupId);
     return group == null ? -1 : group.version();
   }
+
+  /**
+   * Identifies one operation of one plan. The plan id is part of the key because {@code
+   * OperationGraph.Builder} numbers every plan's operations from zero: keyed by {@link OperationId}
+   * alone, an entry left behind by a cancelled plan would be indistinguishable from — and would
+   * block — the same-numbered operation of whatever plan replaces it on this group.
+   */
+  private record OperationKey(long planId, OperationId operationId) {}
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GraphScopeReconciler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GraphScopeReconciler.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.dynamic.config;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliers;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics.OperationObserver;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -63,7 +64,9 @@ final class GraphScopeReconciler {
   private final String groupId;
   private final MemberId localMemberId;
   private final Supplier<CurrentClusterConfiguration> currentConfiguration;
-  private final Supplier<@Nullable PartitionGroupConfigurationChangeAppliers> appliers;
+  private final Function<
+          PartitionGroupOperation, Optional<PartitionGroupConfigurationChangeApplier>>
+      applierFor;
   private final Function<
           CurrentClusterConfiguration, Either<Exception, CurrentClusterConfiguration>>
       updateLocally;
@@ -75,11 +78,19 @@ final class GraphScopeReconciler {
   private final Set<OperationId> inFlight = new HashSet<>();
   private final Map<OperationId, ExponentialBackoffRetryDelay> backoffs = new HashMap<>();
 
+  /**
+   * @param applierFor resolves the applier for one operation, or {@link Optional#empty()} to leave
+   *     it pending — the same per-operation resolution {@code ClusterConfigurationManagerImpl}'s
+   *     {@code applierFor} gives the queue model's {@code GroupScopeOperations}, so a {@code
+   *     RemovePhysicalTenantOperation} (dispatchable with no registered appliers at all, since it
+   *     is a pure configuration edit) is not blocked by this group having none.
+   */
   GraphScopeReconciler(
       final String groupId,
       final MemberId localMemberId,
       final Supplier<CurrentClusterConfiguration> currentConfiguration,
-      final Supplier<@Nullable PartitionGroupConfigurationChangeAppliers> appliers,
+      final Function<PartitionGroupOperation, Optional<PartitionGroupConfigurationChangeApplier>>
+          applierFor,
       final Function<CurrentClusterConfiguration, Either<Exception, CurrentClusterConfiguration>>
           updateLocally,
       final ConcurrencyControl executor,
@@ -89,7 +100,7 @@ final class GraphScopeReconciler {
     this.groupId = groupId;
     this.localMemberId = localMemberId;
     this.currentConfiguration = currentConfiguration;
-    this.appliers = appliers;
+    this.applierFor = applierFor;
     this.updateLocally = updateLocally;
     this.executor = executor;
     this.topologyMetrics = topologyMetrics;
@@ -108,8 +119,7 @@ final class GraphScopeReconciler {
    */
   void reconcile() {
     final var group = currentConfiguration.get().partitionGroup(groupId);
-    final var groupAppliers = appliers.get();
-    if (group == null || groupAppliers == null) {
+    if (group == null) {
       return;
     }
 
@@ -120,14 +130,21 @@ final class GraphScopeReconciler {
       if (inFlight.contains(entry.getKey())) {
         continue;
       }
-      start(entry.getKey(), entry.getValue(), groupAppliers);
+      start(entry.getKey(), entry.getValue());
     }
   }
 
-  private void start(
-      final OperationId operationId,
-      final PartitionGroupOperation operation,
-      final PartitionGroupConfigurationChangeAppliers groupAppliers) {
+  /**
+   * Leaves {@code operationId} pending — neither in-flight nor retried on a timer — if {@link
+   * #applierFor} resolves nothing for it, exactly as {@code GroupScopeOperations} does for the
+   * queue model: stalling visibly on a genuinely-unregistered operation, rather than fabricating a
+   * no-op success for it.
+   */
+  private void start(final OperationId operationId, final PartitionGroupOperation operation) {
+    final var resolvedApplier = applierFor.apply(operation);
+    if (resolvedApplier.isEmpty()) {
+      return;
+    }
     // Read the configuration fresh for each operation rather than once for the loop above: staging
     // persists within this turn, so a hoisted read would make the second operation of a batch
     // overwrite the first one's staged state.
@@ -141,7 +158,7 @@ final class GraphScopeReconciler {
     final var observer = topologyMetrics.observeOperation(operation);
     LOG.info("Applying partition group '{}' operation {} ({})", groupId, operationId, operation);
 
-    final var applier = groupAppliers.getApplier(operation);
+    final var applier = resolvedApplier.get();
     final var initialized =
         applier
             .init(config.globalConfiguration(), group)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GraphScopeReconciler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GraphScopeReconciler.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliers;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics.OperationObserver;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drives one partition group's dependency-graph change, the counterpart of {@link ScopeReconciler}
+ * for the other execution model.
+ *
+ * <p>The difference that makes this a separate class rather than a mode of {@link ScopeReconciler}:
+ * a queue offers the local member exactly one operation at a time, so a single {@code ongoing} flag
+ * is enough to keep re-entrant reconciliation idempotent. A graph offers every operation whose
+ * dependencies have completed — typically several — so in-flight state and retry backoff are keyed
+ * per {@link OperationId} instead. Everything else (read the config fresh, stage, apply, record,
+ * persist, re-reconcile) mirrors {@link ScopeReconciler} deliberately.
+ *
+ * <p>A group holds one change of one model, so for any given group at most one of the two
+ * reconcilers ever finds work.
+ */
+@NullMarked
+final class GraphScopeReconciler {
+
+  /**
+   * How many of a group's runnable operations one broker starts at once.
+   *
+   * <p>A runtime policy knob, not a correctness bound: the graph already says what <em>may</em> run
+   * together, and this caps what this broker chooses to. Restore is I/O bound, so whether running
+   * several partition restores at once on one broker actually helps is a question to settle by
+   * measurement.
+   */
+  private static final int MAX_CONCURRENT_OPERATIONS = 4;
+
+  private static final Logger LOG = LoggerFactory.getLogger(GraphScopeReconciler.class);
+
+  private final String groupId;
+  private final MemberId localMemberId;
+  private final Supplier<CurrentClusterConfiguration> currentConfiguration;
+  private final Supplier<@Nullable PartitionGroupConfigurationChangeAppliers> appliers;
+  private final Function<
+          CurrentClusterConfiguration, Either<Exception, CurrentClusterConfiguration>>
+      updateLocally;
+  private final ConcurrencyControl executor;
+  private final TopologyManagerMetrics topologyMetrics;
+  private final Duration minRetryDelay;
+  private final Duration maxRetryDelay;
+
+  private final Set<OperationId> inFlight = new HashSet<>();
+  private final Map<OperationId, ExponentialBackoffRetryDelay> backoffs = new HashMap<>();
+
+  GraphScopeReconciler(
+      final String groupId,
+      final MemberId localMemberId,
+      final Supplier<CurrentClusterConfiguration> currentConfiguration,
+      final Supplier<@Nullable PartitionGroupConfigurationChangeAppliers> appliers,
+      final Function<CurrentClusterConfiguration, Either<Exception, CurrentClusterConfiguration>>
+          updateLocally,
+      final ConcurrencyControl executor,
+      final TopologyManagerMetrics topologyMetrics,
+      final Duration minRetryDelay,
+      final Duration maxRetryDelay) {
+    this.groupId = groupId;
+    this.localMemberId = localMemberId;
+    this.currentConfiguration = currentConfiguration;
+    this.appliers = appliers;
+    this.updateLocally = updateLocally;
+    this.executor = executor;
+    this.topologyMetrics = topologyMetrics;
+    this.minRetryDelay = minRetryDelay;
+    this.maxRetryDelay = maxRetryDelay;
+  }
+
+  /**
+   * Starts every operation of this group the local member may run right now and has not started.
+   *
+   * <p>Caps on {@code inFlight.size()}, not on a count local to this call. Staging an operation (in
+   * {@link #start}) persists synchronously, which re-enters this method before {@link #start}
+   * returns — a local counter would reset to zero on each nested call and the cap would only ever
+   * bound one nesting level, not the group as a whole. {@code inFlight} is the one piece of state
+   * every nesting level shares, so it is what the cap has to read.
+   */
+  void reconcile() {
+    final var group = currentConfiguration.get().partitionGroup(groupId);
+    final var groupAppliers = appliers.get();
+    if (group == null || groupAppliers == null) {
+      return;
+    }
+
+    for (final var entry : group.runnableFor(localMemberId).entrySet()) {
+      if (inFlight.size() >= MAX_CONCURRENT_OPERATIONS) {
+        break;
+      }
+      if (inFlight.contains(entry.getKey())) {
+        continue;
+      }
+      start(entry.getKey(), entry.getValue(), groupAppliers);
+    }
+  }
+
+  private void start(
+      final OperationId operationId,
+      final PartitionGroupOperation operation,
+      final PartitionGroupConfigurationChangeAppliers groupAppliers) {
+    // Read the configuration fresh for each operation rather than once for the loop above: staging
+    // persists within this turn, so a hoisted read would make the second operation of a batch
+    // overwrite the first one's staged state.
+    final var config = currentConfiguration.get();
+    final var group = config.partitionGroup(groupId);
+    if (group == null) {
+      return;
+    }
+
+    inFlight.add(operationId);
+    final var observer = topologyMetrics.observeOperation(operation);
+    LOG.info("Applying partition group '{}' operation {} ({})", groupId, operationId, operation);
+
+    final var applier = groupAppliers.getApplier(operation);
+    final var initialized =
+        applier
+            .init(config.globalConfiguration(), group)
+            .map(transformer -> config.updatePartitionGroupConfig(groupId, transformer))
+            .flatMap(updateLocally);
+    if (initialized.isLeft()) {
+      observer.failed();
+      inFlight.remove(operationId);
+      LOG.error(
+          "Failed to initialize partition group '{}' operation {}",
+          groupId,
+          operation,
+          initialized.getLeft());
+      return;
+    }
+
+    final var startedVersion = versionOf(initialized.get());
+    applier
+        .apply()
+        .onComplete(
+            (transformer, error) ->
+                onApplied(operationId, operation, transformer, error, startedVersion, observer));
+  }
+
+  private void onApplied(
+      final OperationId operationId,
+      final PartitionGroupOperation operation,
+      final UnaryOperator<PartitionGroupConfiguration> transformer,
+      final @Nullable Throwable error,
+      final long startedVersion,
+      final OperationObserver observer) {
+    inFlight.remove(operationId);
+
+    if (error != null) {
+      observer.failed();
+      final Duration delay =
+          backoffs
+              .computeIfAbsent(
+                  operationId,
+                  ignored -> new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay))
+              .nextDelay();
+      LOG.warn(
+          "Failed to apply partition group '{}' operation {}. Will be retried in {}.",
+          groupId,
+          operation,
+          delay,
+          error);
+      // Only this operation waits; the group's other runnable operations are unaffected, which is
+      // the point of keying in-flight state per operation.
+      executor.schedule(delay, this::reconcile);
+      return;
+    }
+
+    observer.applied();
+    backoffs.remove(operationId);
+
+    final var config = currentConfiguration.get();
+    if (versionOf(config) != startedVersion) {
+      // Recording an operation moves no version, so a version change here means the change was
+      // cancelled or already completed while this operation was running.
+      LOG.debug(
+          "Partition group '{}' changed while applying operation {}. Most likely the change was"
+              + " cancelled.",
+          groupId,
+          operation);
+      // Also clears any backoff this operationId accumulated: a replacement plan on this group
+      // numbers its operations from zero, same as this one did, so its operationId can collide
+      // with this one, and without this an operation that failed a few times before this plan was
+      // cancelled would leave an inflated delay for the replacement plan's same-numbered operation
+      // to inherit -- the same reasoning ScopeReconciler's stale-version path already applies to
+      // its single shared backoff.
+      backoffs.remove(operationId);
+      // A replacement plan on this group numbers its operations from zero, same as this one did,
+      // so its own operationId may collide with the one just removed from inFlight above. If that
+      // collision was blocking it, this is the only place left to notice: nothing else about this
+      // stale completion touches the replacement plan, so without this call the collision clears
+      // but nothing ever re-checks what it was blocking.
+      reconcile();
+      return;
+    }
+
+    final var advanced =
+        config.updatePartitionGroupConfig(
+            groupId,
+            group ->
+                group.completeOperation(operationId, transformer).completeGraphChangeIfDrained());
+    // Persisting re-triggers reconciliation across every scope and plan, which is what picks up the
+    // operations this completion just made runnable — no explicit "run the loop again" is needed.
+    final var persisted = updateLocally.apply(advanced);
+    if (persisted.isLeft()) {
+      // The operation itself succeeded; only recording it locally failed. Retrying re-derives it
+      // from the graph, which is safe because operations are idempotent.
+      final Duration delay =
+          backoffs
+              .computeIfAbsent(
+                  operationId,
+                  ignored -> new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay))
+              .nextDelay();
+      LOG.warn(
+          "Applied partition group '{}' operation {} but failed to record it. Will be retried in"
+              + " {}.",
+          groupId,
+          operation,
+          delay,
+          persisted.getLeft());
+      executor.schedule(delay, this::reconcile);
+      return;
+    }
+    LOG.info("Partition group '{}' operation {} applied.", groupId, operation);
+  }
+
+  private long versionOf(final CurrentClusterConfiguration config) {
+    final var group = config.partitionGroup(groupId);
+    return group == null ? -1 : group.version();
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PhysicalTenantProvisioningInitializer.java
@@ -10,8 +10,8 @@ package io.camunda.zeebe.dynamic.config;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
@@ -39,10 +39,10 @@ import org.slf4j.LoggerFactory;
  * PartitionReassignmentOperationsGenerator} to turn that placement into operations.
  *
  * <p>The change is started directly on the new group via {@link
- * PartitionGroupConfiguration#startConfigurationChange(List)}, bypassing the top-level {@link
- * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan} entirely: a phased change may already be
- * in progress for other groups when this runs, and this group is guaranteed to have no pending
- * change of its own yet since it doesn't exist before this modifier creates it.
+ * PartitionGroupConfiguration#startGraphConfigurationChange(OperationGraph)}, bypassing the
+ * top-level {@link io.camunda.zeebe.dynamic.config.state.PhasedChangePlan} entirely: a phased
+ * change may already be in progress for other groups when this runs, and this group is guaranteed
+ * to have no pending change of its own yet since it doesn't exist before this modifier creates it.
  *
  * <p>A physical tenant whose group already exists is left completely untouched, even if it's since
  * been removed from the static configuration — this modifier only ever adds a group, never removes
@@ -198,8 +198,11 @@ public class PhysicalTenantProvisioningInitializer
             updatedGroups,
             configuration.phasedChangeState());
 
-    final List<ClusterConfigurationChangeOperation> operations = List.copyOf(tenantOperations);
+    // Sequential, not the free graph a phase could express: these operations place a brand-new
+    // tenant's partitions, and provisioning has never claimed the independence between them that
+    // would let two run at once.
+    final var graph = OperationGraph.sequential(tenantOperations);
     return withEmptyGroup.updatePartitionGroupConfig(
-        newTenantId, group -> group.startConfigurationChange(operations));
+        newTenantId, group -> group.startGraphConfigurationChange(graph));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ScopeReconciler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ScopeReconciler.java
@@ -26,25 +26,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Drives ongoing/retry/backoff for the local member's next pending operation within a single
- * reconciliation scope (the global configuration, or one named partition group). One instance per
- * scope, each with its own {@link ExponentialBackoffRetryDelay}, so a repeated failure applying one
- * scope's operation cannot push another scope's retry delay toward the max the way a single shared
- * backoff instance would (see {@link ClusterConfigurationManagerImpl}, which used to keep three
- * parallel {@code Map}s for this per group, plus two more scalar fields for the global case).
+ * Drives ongoing/retry/backoff for the local member's next pending operation on the global
+ * configuration, whose change is a one-at-a-time queue. Partition groups are driven by {@link
+ * GraphScopeReconciler} instead: their change is a dependency graph, which offers several
+ * operations at once and so cannot share the single-in-flight-operation contract below.
  *
- * <p>{@link Operations} supplies the scope-specific pieces (finding the local member's pending
- * operation, and staging/applying it) so this class only implements the orchestration that is
- * otherwise identical between the global and per-group cases.
+ * <p>{@link Operations} supplies the pieces that are not orchestration (finding the local member's
+ * pending operation, and staging/applying it). It remains an interface, rather than being folded
+ * into this class, because it is the seam that keeps the orchestration below — which is subtle, and
+ * was arrived at by fixing real re-entrancy and backoff bugs — testable and reusable if a second
+ * queue-shaped scope ever appears.
  *
  * <p>Staging an operation ({@code initialize().flatMap(updateLocally)}) persists/gossips the staged
  * config synchronously, which re-enters {@link ClusterConfigurationManagerImpl#reconcile} — and
- * therefore every registered {@code ScopeReconciler}'s {@link #reconcile()}, including this one —
- * before that call returns. The {@code ongoing} flag (set before staging, not after) turns that
- * re-entrant call into a no-op rather than a recursive one, so this doesn't deepen with the number
- * of operations processed; it's bounded only by the number of scopes that simultaneously have a
- * ready operation, which is fine at the scope counts (global plus one per physical tenant) this
- * module deals with today.
+ * therefore this {@link #reconcile()} again — before that call returns. The {@code ongoing} flag
+ * (set before staging, not after) turns that re-entrant call into a no-op rather than a recursive
+ * one, so this doesn't deepen with the number of operations processed.
  */
 @NullMarked
 final class ScopeReconciler {
@@ -192,9 +189,7 @@ final class ScopeReconciler {
     /** The sub-configuration's own version, used to detect a concurrent cancel/change. */
     long versionOf(CurrentClusterConfiguration config);
 
-    /**
-     * Human-readable scope name for logs, e.g. {@code "global"} or {@code "partition group 'x'"}.
-     */
+    /** Human-readable scope name for logs, e.g. {@code "global"}. */
     String describe();
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.Co
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.util.Either;
@@ -29,9 +29,9 @@ import java.util.Optional;
  * <p>{@link #phases(CurrentClusterConfiguration)} is the entry point the new-model coordinator
  * actually drives: each named physical tenant is restored from its own {@link
  * PartitionGroupConfiguration}, exactly like the same restore submitted through that tenant's own
- * API, and the resulting plans are combined into one {@link PartitionGroupParallelPhase} so every
- * named tenant restores in parallel. A cluster-wide request — one naming every physical tenant of
- * the cluster — restores them all this way in a single change.
+ * API, and the resulting plans are combined into one {@link PartitionGroupPhase} so every named
+ * tenant restores in parallel. A cluster-wide request — one naming every physical tenant of the
+ * cluster — restores them all this way in a single change.
  *
  * <p>A request naming no physical tenant at all plans nothing, rather than being rejected: there is
  * no tenant whose partitions it could restore.
@@ -72,7 +72,7 @@ public final class ClusterRestoreRequestTransformer implements ConfigurationChan
     if (operationsPerTenant.isEmpty()) {
       return Either.right(List.of());
     }
-    return Either.right(List.of(new PartitionGroupParallelPhase(operationsPerTenant)));
+    return Either.right(List.of(PartitionGroupPhase.sequential(operationsPerTenant)));
   }
 
   private Optional<RestoreRequestTransformer> singleTenantRestore() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformer.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -84,7 +84,7 @@ public final class ExporterDeleteRequestTransformer implements ConfigurationChan
               "Expected to delete exporter '%s' for physical tenant '%s', but no matching exporters were found"
                   .formatted(exporterId, physicalTenantId.orElse("all tenants"))));
     }
-    return Either.right(List.of(new PartitionGroupParallelPhase(groupOperations)));
+    return Either.right(List.of(PartitionGroupPhase.sequential(groupOperations)));
   }
 
   private List<PartitionGroupOperation> deleteOperationsFor(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformer.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -76,7 +76,7 @@ public final class ExporterDisableRequestTransformer implements ConfigurationCha
               "Expected to disable exporter '%s' for physical tenant '%s', but no matching exporters were found"
                   .formatted(exporterId, physicalTenantId.orElse("all tenants"))));
     }
-    return Either.right(List.of(new PartitionGroupParallelPhase(groupOperations)));
+    return Either.right(List.of(PartitionGroupPhase.sequential(groupOperations)));
   }
 
   private List<PartitionGroupOperation> disableOperationsFor(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformer.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -72,7 +72,7 @@ final class ExporterEnableRequestTransformer implements ConfigurationChangeReque
         groupOperations.put(groupId, operations);
       }
     }
-    return Either.right(List.of(new PartitionGroupParallelPhase(groupOperations)));
+    return Either.right(List.of(PartitionGroupPhase.sequential(groupOperations)));
   }
 
   private List<PartitionGroupOperation> enableOperationsFor(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExportingStateChangeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExportingStateChangeRequestTransformer.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ExportingStateChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.LinkedHashMap;
@@ -69,7 +69,7 @@ public final class ExportingStateChangeRequestTransformer implements Configurati
     if (operationsPerGroup.isEmpty()) {
       return Either.right(List.of());
     }
-    return Either.right(List.of(new PartitionGroupParallelPhase(operationsPerGroup)));
+    return Either.right(List.of(PartitionGroupPhase.sequential(operationsPerGroup)));
   }
 
   private List<PartitionGroupOperation> exportingStateChangeOperations(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformer.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -115,7 +115,7 @@ public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequ
 
     final List<Phase> phases = new ArrayList<>();
     if (!reconfigureByTenant.isEmpty()) {
-      phases.add(new PartitionGroupParallelPhase(reconfigureByTenant));
+      phases.add(PartitionGroupPhase.sequential(reconfigureByTenant));
     }
     if (!removeMembers.isEmpty()) {
       phases.add(new GlobalPhase(removeMembers));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/JoinPartitionRequestTransformer.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.Co
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
@@ -55,6 +55,6 @@ public final class JoinPartitionRequestTransformer implements ConfigurationChang
 
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionJoinOperation(memberId, partitionId, priority));
-    return Either.right(List.of(new PartitionGroupParallelPhase(Map.of(groupId, operations))));
+    return Either.right(List.of(PartitionGroupPhase.sequential(Map.of(groupId, operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/LeavePartitionRequestTransformer.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.Co
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
@@ -56,6 +56,6 @@ public final class LeavePartitionRequestTransformer implements ConfigurationChan
 
     final List<PartitionGroupOperation> operations =
         List.of(new PartitionLeaveOperation(memberId, partitionId, MINIMUM_ALLOWED_REPLICAS));
-    return Either.right(List.of(new PartitionGroupParallelPhase(Map.of(groupId, operations))));
+    return Either.right(List.of(PartitionGroupPhase.sequential(Map.of(groupId, operations))));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -65,7 +65,7 @@ public final class ModeChangeRequestTransformer implements ConfigurationChangeRe
     if (operationsPerGroup.isEmpty()) {
       return Either.right(List.of());
     }
-    return Either.right(List.of(new PartitionGroupParallelPhase(operationsPerGroup)));
+    return Either.right(List.of(PartitionGroupPhase.sequential(operationsPerGroup)));
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.PartitionReassignmentOperationsGenerator;
@@ -82,8 +82,8 @@ final class PartitionGroupScalingPhases {
    *     leave every group's partition count as it is
    * @param newReplicationFactor the replication factor every partition of every group should reach,
    *     or empty to keep the one currently in use
-   * @return a single {@link PartitionGroupParallelPhase} covering every group whose partitions have
-   *     to change, or no phase at all when the cluster already has the requested placement. Left if
+   * @return a single {@link PartitionGroupPhase} covering every group whose partitions have to
+   *     change, or no phase at all when the cluster already has the requested placement. Left if
    *     the target count is below the group's current one — partitions can only be scaled up — if
    *     the live brokers cannot satisfy the replication factor, or if no valid distribution exists.
    */
@@ -214,7 +214,7 @@ final class PartitionGroupScalingPhases {
       // Every partition already sits where the requested distribution puts it.
       return Either.right(List.of());
     }
-    return Either.right(List.of(new PartitionGroupParallelPhase(operationsByGroup)));
+    return Either.right(List.of(PartitionGroupPhase.sequential(operationsByGroup)));
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -84,7 +84,7 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
     if (groupOperations.isEmpty()) {
       return Either.right(List.of());
     }
-    return Either.right(List.of(new PartitionGroupParallelPhase(groupOperations)));
+    return Either.right(List.of(PartitionGroupPhase.sequential(groupOperations)));
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemovePhysicalTenantRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemovePhysicalTenantRequestTransformer.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysicalTenantOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
@@ -70,7 +70,7 @@ public class RemovePhysicalTenantRequestTransformer implements ConfigurationChan
     }
     return Either.right(
         List.of(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     physicalTenantId, List.of(new RemovePhysicalTenantOperation(coordinator))))));
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -27,7 +27,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeO
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.util.Either;
@@ -77,7 +77,7 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
     return groupOperations(partitionGroup)
         .map(
             operations ->
-                List.of(new PartitionGroupParallelPhase(Map.of(physicalTenantId, operations))));
+                List.of(PartitionGroupPhase.sequential(Map.of(physicalTenantId, operations))));
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformer.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.Co
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.util.Either;
@@ -66,7 +66,7 @@ public class UpdateRoutingStateTransformer implements ConfigurationChangeRequest
         .map(
             memberId ->
                 List.<Phase>of(
-                    new PartitionGroupParallelPhase(
+                    PartitionGroupPhase.sequential(
                         Map.of(groupId, List.of(new UpdateRoutingState(memberId, routingState))))));
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
@@ -83,9 +83,9 @@ public interface ConfigurationChangeCoordinator {
      * Returns the phases to execute for this request. A phase is applied to the sub-configurations
      * it targets — {@link io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase} to
      * the cluster-wide broker lifecycle, {@link
-     * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase} to each
-     * named physical tenant's partition group at once — and one phase is fully drained before the
-     * next begins.
+     * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase} to each named
+     * physical tenant's partition group at once — and one phase is fully drained before the next
+     * begins.
      *
      * <p>A request that plans partition work has to decide which physical tenants it applies to.
      * There is no cluster-wide default to fall back on: partition ids restart at 1 in every tenant,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -510,32 +510,7 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
       onGroupDrained.accept(config);
       return;
     }
-    if (group.pendingGraphChanges().isPresent()) {
-      simulateGraphOperations(config, groupId, groupSimulator, onGroupDrained, simulationCompleted);
-      return;
-    }
-    final var operation = group.nextPendingOperation();
-    final var applier = groupSimulator.getApplier(operation);
-    final var result = applier.init(config.globalConfiguration(), group);
-    if (result.isLeft()) {
-      failFuture(simulationCompleted, new InvalidRequest(result.getLeft()));
-      return;
-    }
-    final var configWithInit = config.updatePartitionGroupConfig(groupId, result.get());
-    applier
-        .apply()
-        .onComplete(
-            (transformer, error) -> {
-              if (error != null) {
-                failFuture(simulationCompleted, new InvalidRequest(error));
-                return;
-              }
-              final var advanced =
-                  configWithInit.updatePartitionGroupConfig(
-                      groupId, g -> g.advanceConfigurationChange(transformer));
-              simulatePartitionGroupOperations(
-                  advanced, groupId, groupSimulator, onGroupDrained, simulationCompleted);
-            });
+    simulateGraphOperations(config, groupId, groupSimulator, onGroupDrained, simulationCompleted);
   }
 
   /**
@@ -561,7 +536,7 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
       final Consumer<CurrentClusterConfiguration> onGroupDrained,
       final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
     final var group = Objects.requireNonNull(config.partitionGroup(groupId));
-    final var plan = group.pendingGraphChanges().orElse(null);
+    final var plan = group.pendingChanges().orElse(null);
     if (plan == null || !plan.hasPendingChanges()) {
       onGroupDrained.accept(config);
       return;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -21,9 +21,10 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -32,6 +33,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import org.agrona.collections.MutableLong;
 import org.slf4j.Logger;
@@ -325,18 +327,25 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                 "Cannot apply configuration change. The global configuration has changed since the request was generated.");
           }
         }
-        case final PartitionGroupParallelPhase parallelPhase -> {
-          for (final var groupId : parallelPhase.groupOperations().keySet()) {
-            final var latestGroupConfig = latestConfig.partitionGroup(groupId);
-            final var usedGroupConfig = configUsedForGeneratingOperations.partitionGroup(groupId);
-            if (!Objects.equals(latestGroupConfig, usedGroupConfig)) {
-              throw new ConcurrentModificationException(
-                  String.format(
-                      "Cannot apply configuration change. The partition group '%s' configuration has changed since the request was generated.",
-                      groupId));
-            }
-          }
-        }
+        case final PartitionGroupPhase groupPhase ->
+            checkGroupsUnchanged(
+                groupPhase.groupGraphs().keySet(), latestConfig, configUsedForGeneratingOperations);
+      }
+    }
+  }
+
+  private void checkGroupsUnchanged(
+      final Set<String> groupIds,
+      final CurrentClusterConfiguration latestConfig,
+      final CurrentClusterConfiguration configUsedForGeneratingOperations) {
+    for (final var groupId : groupIds) {
+      final var latestGroupConfig = latestConfig.partitionGroup(groupId);
+      final var usedGroupConfig = configUsedForGeneratingOperations.partitionGroup(groupId);
+      if (!Objects.equals(latestGroupConfig, usedGroupConfig)) {
+        throw new ConcurrentModificationException(
+            String.format(
+                "Cannot apply configuration change. The partition group '%s' configuration has changed since the request was generated.",
+                groupId));
       }
     }
   }
@@ -412,11 +421,11 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
     switch (plan.currentPhase()) {
       case final GlobalPhase ignored ->
           simulateGlobalPhase(config, planId, globalSimulator, groupSimulator, simulationCompleted);
-      case final PartitionGroupParallelPhase parallelPhase ->
+      case final PartitionGroupPhase groupPhase ->
           simulatePartitionGroupPhase(
               config,
               planId,
-              new ArrayList<>(parallelPhase.groupOperations().keySet()),
+              new ArrayList<>(groupPhase.groupGraphs().keySet()),
               0,
               globalSimulator,
               groupSimulator,
@@ -501,6 +510,10 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
       onGroupDrained.accept(config);
       return;
     }
+    if (group.pendingGraphChanges().isPresent()) {
+      simulateGraphOperations(config, groupId, groupSimulator, onGroupDrained, simulationCompleted);
+      return;
+    }
     final var operation = group.nextPendingOperation();
     final var applier = groupSimulator.getApplier(operation);
     final var result = applier.init(config.globalConfiguration(), group);
@@ -525,6 +538,74 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
             });
   }
 
+  /**
+   * Walks a dependency-graph change one runnable operation at a time.
+   *
+   * <p>The real cluster runs several of these at once on different brokers; the simulator takes
+   * them in ascending operation-id order instead. Nothing validates that this is sound — the
+   * disjoint-write-set check that would have guaranteed every legal execution order reaches the
+   * same configuration was built, then removed (see {@link
+   * io.camunda.zeebe.dynamic.config.state.OperationGraph}'s class javadoc). This one arbitrary
+   * serialization is sound only to the extent the graph's author declared every edge that ordering
+   * actually requires; if an edge is missing, the simulation can silently disagree with what the
+   * real, concurrent execution does.
+   *
+   * <p>It deliberately drives the same {@code completeOperation} the manager uses rather than
+   * modelling progress a second way: a divergence between what is simulated and what is applied
+   * would be silent and very hard to find.
+   */
+  private void simulateGraphOperations(
+      final CurrentClusterConfiguration config,
+      final String groupId,
+      final PartitionGroupConfigurationChangeAppliers groupSimulator,
+      final Consumer<CurrentClusterConfiguration> onGroupDrained,
+      final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
+    final var group = Objects.requireNonNull(config.partitionGroup(groupId));
+    final var plan = group.pendingGraphChanges().orElse(null);
+    if (plan == null || !plan.hasPendingChanges()) {
+      onGroupDrained.accept(config);
+      return;
+    }
+
+    final var next =
+        plan.operations().keySet().stream().filter(plan::isRunnable).findFirst().orElse(null);
+    if (next == null) {
+      // Every remaining operation is blocked, yet none has completed — only reachable if the graph
+      // has a cycle, which construction rejects. Fail loudly rather than spin.
+      failFuture(
+          simulationCompleted,
+          new InvalidRequest(
+              new IllegalStateException(
+                  "Change for group '%s' cannot make progress; outstanding operations are blocked on %s"
+                      .formatted(groupId, plan.blockedBy()))));
+      return;
+    }
+
+    final var operation = (PartitionGroupOperation) plan.operation(next);
+    final var applier = groupSimulator.getApplier(operation);
+    final var result = applier.init(config.globalConfiguration(), group);
+    if (result.isLeft()) {
+      failFuture(simulationCompleted, new InvalidRequest(result.getLeft()));
+      return;
+    }
+    final var configWithInit = config.updatePartitionGroupConfig(groupId, result.get());
+    applier
+        .apply()
+        .onComplete(
+            (transformer, error) -> {
+              if (error != null) {
+                failFuture(simulationCompleted, new InvalidRequest(error));
+                return;
+              }
+              final var advanced =
+                  configWithInit.updatePartitionGroupConfig(
+                      groupId,
+                      g -> g.completeOperation(next, transformer).completeGraphChangeIfDrained());
+              simulateGraphOperations(
+                  advanced, groupId, groupSimulator, onGroupDrained, simulationCompleted);
+            });
+  }
+
   private void advancePhaseAndContinueSimulation(
       final CurrentClusterConfiguration config,
       final long planId,
@@ -541,17 +622,17 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
 
   /**
    * Flattens a phase list back into the flat operation list the management API answers a request
-   * with, preserving phase order. Within a {@link PartitionGroupParallelPhase} the operations of
-   * each group are concatenated; the order between groups is unspecified (they apply concurrently),
-   * but is irrelevant while only the default group is used.
+   * with, preserving phase order. Within a {@link PartitionGroupPhase} the operations of each group
+   * are concatenated; the order between groups is unspecified (they apply concurrently), but is
+   * irrelevant while only the default group is used.
    */
   private static List<ClusterConfigurationChangeOperation> flattenPhases(final List<Phase> phases) {
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
     for (final var phase : phases) {
       switch (phase) {
         case final GlobalPhase globalPhase -> operations.addAll(globalPhase.operations());
-        case final PartitionGroupParallelPhase parallelPhase ->
-            parallelPhase.groupOperations().values().forEach(operations::addAll);
+        case final PartitionGroupPhase groupPhase ->
+            groupPhase.groupOperations().values().forEach(operations::addAll);
       }
     }
     return operations;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -49,7 +49,6 @@ import io.camunda.zeebe.dynamic.config.protocol.Topology.CompletedChange;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.PartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -2005,20 +2004,9 @@ public class ProtoBufSerializer
     configuration
         .routingState()
         .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
-    // A switch over ChangePlan's sealed permits, not an if/else-if: a third implementation would
-    // fail to compile here instead of silently vanishing off the wire the way it would with an
-    // if/else-if that falls through to neither branch.
     configuration
         .pendingChanges()
-        .ifPresent(
-            changePlan -> {
-              switch (changePlan) {
-                case final ClusterChangePlan queue ->
-                    builder.setPendingChanges(encodeChangePlan(queue));
-                case final DependencyChangePlan graph ->
-                    builder.setPendingGraphChanges(encodeDependencyChangePlan(graph));
-              }
-            });
+        .ifPresent(plan -> builder.setPendingChanges(encodeDependencyChangePlan(plan)));
     configuration
         .lastChange()
         .ifPresent(lastChange -> builder.setLastChange(encodeCompletedChange(lastChange)));
@@ -2111,15 +2099,10 @@ public class ProtoBufSerializer
                     e -> MemberId.from(e.getKey()), e -> decodeBrokerPartitionState(e.getValue())));
     final Optional<RoutingState> routingState =
         proto.hasRoutingState() ? decodeRoutingState(proto.getRoutingState()) : Optional.empty();
-    // A oneof, not a hasX()/hasY() preference chain: exactly one of the two can be set on the
-    // wire, so this switches on which rather than inferring it by checking one field first.
-    final Optional<ChangePlan> pendingChanges =
-        switch (proto.getPendingChangeCase()) {
-          case PENDINGCHANGES -> Optional.of(decodeChangePlan(proto.getPendingChanges()));
-          case PENDINGGRAPHCHANGES ->
-              Optional.of(decodeDependencyChangePlan(proto.getPendingGraphChanges()));
-          case PENDINGCHANGE_NOT_SET -> Optional.empty();
-        };
+    final Optional<DependencyChangePlan> pendingChanges =
+        proto.hasPendingChanges()
+            ? Optional.of(decodeDependencyChangePlan(proto.getPendingChanges()))
+            : Optional.empty();
     final Optional<io.camunda.zeebe.dynamic.config.state.CompletedChange> lastChange =
         proto.hasLastChange()
             ? Optional.of(decodeCompletedChange(proto.getLastChange()))

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -49,12 +49,14 @@ import io.camunda.zeebe.dynamic.config.protocol.Topology.CompletedChange;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.PartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.ChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
@@ -69,6 +71,8 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartiti
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
@@ -94,7 +98,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRouti
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -110,6 +114,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
@@ -1999,13 +2005,101 @@ public class ProtoBufSerializer
     configuration
         .routingState()
         .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
+    // A switch over ChangePlan's sealed permits, not an if/else-if: a third implementation would
+    // fail to compile here instead of silently vanishing off the wire the way it would with an
+    // if/else-if that falls through to neither branch.
     configuration
         .pendingChanges()
-        .ifPresent(changePlan -> builder.setPendingChanges(encodeChangePlan(changePlan)));
+        .ifPresent(
+            changePlan -> {
+              switch (changePlan) {
+                case final ClusterChangePlan queue ->
+                    builder.setPendingChanges(encodeChangePlan(queue));
+                case final DependencyChangePlan graph ->
+                    builder.setPendingGraphChanges(encodeDependencyChangePlan(graph));
+              }
+            });
     configuration
         .lastChange()
         .ifPresent(lastChange -> builder.setLastChange(encodeCompletedChange(lastChange)));
     return builder.build();
+  }
+
+  private Topology.OperationGraph encodeOperationGraph(final OperationGraph graph) {
+    final var builder = Topology.OperationGraph.newBuilder();
+    graph
+        .operations()
+        .forEach(
+            (operationId, planned) -> {
+              final var operation =
+                  Topology.PlannedOperation.newBuilder()
+                      .setId(operationId.value())
+                      .setOperation(
+                          encodePartitionGroupChangeOperation(
+                              (PartitionGroupOperation) planned.operation()));
+              planned.dependsOn().forEach(dependency -> operation.addDependsOn(dependency.value()));
+              builder.addOperations(operation.build());
+            });
+    return builder.build();
+  }
+
+  private OperationGraph decodeOperationGraph(final Topology.OperationGraph proto) {
+    final SortedMap<OperationId, OperationGraph.PlannedOperation> operations = new TreeMap<>();
+    proto
+        .getOperationsList()
+        .forEach(
+            planned -> {
+              final var dependsOn = new TreeSet<OperationId>();
+              planned.getDependsOnList().forEach(id -> dependsOn.add(OperationId.of(id)));
+              operations.put(
+                  OperationId.of(planned.getId()),
+                  new OperationGraph.PlannedOperation(
+                      decodePartitionGroupChangeOperation(planned.getOperation()), dependsOn));
+            });
+    // OperationGraph.of, not the bare constructor: acyclicity is not an invariant of the
+    // constructor, only of this factory, and this graph came off the wire -- corruption or a
+    // future encoding bug is exactly the source a decode path has to distrust.
+    return OperationGraph.of(operations);
+  }
+
+  private Topology.DependencyChangePlan encodeDependencyChangePlan(
+      final DependencyChangePlan plan) {
+    final var builder =
+        Topology.DependencyChangePlan.newBuilder()
+            .setId(plan.id())
+            .setStatus(fromTopologyChangeStatus(plan.status()))
+            .setStartedAt(toTimestamp(plan.startedAt()))
+            .setGraph(encodeOperationGraph(plan.graph()));
+    plan.completed()
+        .forEach(
+            (operationId, at) ->
+                builder.addCompleted(
+                    Topology.OperationCompletion.newBuilder()
+                        .setOperationId(operationId.value())
+                        .setCompletedAt(toTimestamp(at))
+                        .build()));
+    return builder.build();
+  }
+
+  private DependencyChangePlan decodeDependencyChangePlan(
+      final Topology.DependencyChangePlan proto) {
+    final SortedMap<OperationId, Instant> completed = new TreeMap<>();
+    proto
+        .getCompletedList()
+        .forEach(
+            completion ->
+                completed.put(
+                    OperationId.of(completion.getOperationId()),
+                    Instant.ofEpochSecond(
+                        completion.getCompletedAt().getSeconds(),
+                        completion.getCompletedAt().getNanos())));
+
+    return new DependencyChangePlan(
+        proto.getId(),
+        toChangeStatus(proto.getStatus()),
+        Instant.ofEpochSecond(proto.getStartedAt().getSeconds(), proto.getStartedAt().getNanos()),
+        decodeOperationGraph(proto.getGraph()),
+        completed);
   }
 
   public PartitionGroupConfiguration decodePartitionGroupConfiguration(
@@ -2017,10 +2111,15 @@ public class ProtoBufSerializer
                     e -> MemberId.from(e.getKey()), e -> decodeBrokerPartitionState(e.getValue())));
     final Optional<RoutingState> routingState =
         proto.hasRoutingState() ? decodeRoutingState(proto.getRoutingState()) : Optional.empty();
-    final Optional<ClusterChangePlan> pendingChanges =
-        proto.hasPendingChanges()
-            ? Optional.of(decodeChangePlan(proto.getPendingChanges()))
-            : Optional.empty();
+    // A oneof, not a hasX()/hasY() preference chain: exactly one of the two can be set on the
+    // wire, so this switches on which rather than inferring it by checking one field first.
+    final Optional<ChangePlan> pendingChanges =
+        switch (proto.getPendingChangeCase()) {
+          case PENDINGCHANGES -> Optional.of(decodeChangePlan(proto.getPendingChanges()));
+          case PENDINGGRAPHCHANGES ->
+              Optional.of(decodeDependencyChangePlan(proto.getPendingGraphChanges()));
+          case PENDINGCHANGE_NOT_SET -> Optional.empty();
+        };
     final Optional<io.camunda.zeebe.dynamic.config.state.CompletedChange> lastChange =
         proto.hasLastChange()
             ? Optional.of(decodeCompletedChange(proto.getLastChange()))
@@ -2168,21 +2267,13 @@ public class ProtoBufSerializer
                           .map(this::encodeGlobalChangeOperation)
                           .toList())
                   .build());
-      case final PartitionGroupParallelPhase parallelPhase -> {
-        final var parallelBuilder = Topology.PartitionGroupParallelPhase.newBuilder();
-        parallelPhase
-            .groupOperations()
+      case final PartitionGroupPhase groupPhase -> {
+        final var graphBuilder = Topology.PartitionGroupGraphPhase.newBuilder();
+        groupPhase
+            .groupGraphs()
             .forEach(
-                (group, operations) ->
-                    parallelBuilder.putGroupOperations(
-                        group,
-                        Topology.PartitionGroupOperationList.newBuilder()
-                            .addAllOperations(
-                                operations.stream()
-                                    .map(this::encodePartitionGroupChangeOperation)
-                                    .toList())
-                            .build()));
-        builder.setPartitionGroupParallelPhase(parallelBuilder.build());
+                (group, graph) -> graphBuilder.putGroupGraphs(group, encodeOperationGraph(graph)));
+        builder.setPartitionGroupGraphPhase(graphBuilder.build());
       }
     }
     return builder.build();
@@ -2195,8 +2286,16 @@ public class ProtoBufSerializer
               proto.getGlobalPhase().getOperationsList().stream()
                   .map(this::decodeGlobalChangeOperation)
                   .toList());
+      case PARTITIONGROUPGRAPHPHASE ->
+          new PartitionGroupPhase(
+              proto.getPartitionGroupGraphPhase().getGroupGraphsMap().entrySet().stream()
+                  .collect(
+                      Collectors.toMap(Entry::getKey, e -> decodeOperationGraph(e.getValue()))));
+      // Decode-only: nothing writes this variant since the queue phase and the graph phase became
+      // one type, but a configuration persisted or gossiped before that still carries it. A flat
+      // operation list is exactly a sequential graph, so it decodes without loss.
       case PARTITIONGROUPPARALLELPHASE ->
-          new PartitionGroupParallelPhase(
+          PartitionGroupPhase.sequential(
               proto.getPartitionGroupParallelPhase().getGroupOperationsMap().entrySet().stream()
                   .collect(
                       Collectors.toMap(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -347,11 +347,16 @@ public record CurrentClusterConfiguration(
             (memberId, brokerState) ->
                 members.put(memberId, toLegacyMemberState(brokerState, group.getMember(memberId))));
 
+    // The single-group projection carries whichever model the group is running; both expose the
+    // same read API, and a dependency-graph change flattens into the sequential ordering it
+    // degrades to for a reader that predates it.
     final Optional<ClusterChangePlan> pendingChanges =
         globalConfiguration
             .pendingChanges()
-            .filter(ClusterChangePlan::hasPendingChanges)
-            .or(() -> group.pendingChanges().filter(ClusterChangePlan::hasPendingChanges));
+            .<ChangePlan>map(plan -> plan)
+            .filter(ChangePlan::hasPendingChanges)
+            .or(() -> group.pendingChanges().filter(ChangePlan::hasPendingChanges))
+            .map(CurrentClusterConfiguration::toQueueProjection);
 
     final Optional<CompletedChange> lastChange =
         phasedChangeState.lastChange().map(CurrentClusterConfiguration::toLegacyCompletedChange);
@@ -604,7 +609,19 @@ public record CurrentClusterConfiguration(
   /**
    * Returns {@code true} if plan {@code planId}'s current phase has fully drained: every
    * sub-configuration it targets (the global configuration for a {@link GlobalPhase}, or each named
-   * partition group for a {@link PartitionGroupParallelPhase}) has no pending changes left.
+   * partition group for a {@link PartitionGroupPhase}) has no pending changes left.
+   *
+   * <p>For a {@link PartitionGroupGraphPhase}, "no pending changes left" means the group's {@code
+   * pendingGraphChanges} is gone entirely, not merely that every operation in it has completed.
+   * Those two are different moments: {@link PartitionGroupConfiguration#hasPendingChanges()} reads
+   * the plan's own content and goes {@code false} the instant the last operation completes, while
+   * clearing the plan itself is a separate, later step ({@link
+   * PartitionGroupConfiguration#completeGraphChangeIfDrained()}), run by whichever broker's
+   * reconcile or gossip round gets there first. Treating "drained" as "complete" here would let
+   * this plan be archived into history while the group still carries a (fully drained but not yet
+   * cleared) graph plan — which is exactly the state a decoder without this phase to consult can no
+   * longer tell apart from an actually-still-running one. The queue model has no such gap: {@link
+   * PartitionGroupConfiguration#advance()} clears its plan in the same call that drains it.
    *
    * @throws IllegalStateException if no plan {@code planId} is pending
    */
@@ -616,10 +633,10 @@ public record CurrentClusterConfiguration(
     }
     return switch (plan.currentPhase()) {
       case final GlobalPhase ignored -> !globalConfiguration.hasPendingChanges();
-      case final PartitionGroupParallelPhase parallelPhase ->
-          parallelPhase.groupOperations().keySet().stream()
+      case final PartitionGroupPhase groupPhase ->
+          groupPhase.groupGraphs().keySet().stream()
               .map(this::partitionGroup)
-              .allMatch(group -> group != null && !group.hasPendingChanges());
+              .allMatch(group -> group != null && group.pendingGraphChanges().isEmpty());
     };
   }
 
@@ -652,9 +669,9 @@ public record CurrentClusterConfiguration(
         switch (plan.currentPhase()) {
           case final GlobalPhase ignored ->
               updateGlobalConfiguration(GlobalConfiguration::cancelPendingChanges);
-          case final PartitionGroupParallelPhase parallelPhase -> {
+          case final PartitionGroupPhase groupPhase -> {
             var r = this;
-            for (final var groupId : parallelPhase.groupOperations().keySet()) {
+            for (final var groupId : groupPhase.groupGraphs().keySet()) {
               r =
                   r.updatePartitionGroupConfig(
                       groupId, PartitionGroupConfiguration::cancelPendingChanges);
@@ -682,7 +699,7 @@ public record CurrentClusterConfiguration(
   /**
    * Activates the plan's current phase by copying its operations into the affected sub-config(s): a
    * {@link GlobalPhase} starts a configuration change on {@link GlobalConfiguration} only; a {@link
-   * PartitionGroupParallelPhase} starts one on each named partition group only.
+   * PartitionGroupPhase} starts one on each named partition group only.
    */
   private CurrentClusterConfiguration applyPhase(final PhasedChangePlan plan) {
     return switch (plan.currentPhase()) {
@@ -696,11 +713,11 @@ public record CurrentClusterConfiguration(
                 return global.startConfigurationChange(
                     List.<ClusterConfigurationChangeOperation>copyOf(globalPhase.operations()));
               });
-      case final PartitionGroupParallelPhase parallelPhase -> {
+      case final PartitionGroupPhase groupPhase -> {
         var result = this;
-        for (final var entry : parallelPhase.groupOperations().entrySet()) {
+        for (final var entry : groupPhase.groupGraphs().entrySet()) {
           final var groupId = entry.getKey();
-          final var operations = List.<ClusterConfigurationChangeOperation>copyOf(entry.getValue());
+          final var graph = entry.getValue();
           result =
               result.updatePartitionGroupConfig(
                   groupId,
@@ -710,7 +727,7 @@ public record CurrentClusterConfiguration(
                           "Cannot activate partition-group phase for %s: group already has pending changes"
                               .formatted(groupId));
                     }
-                    return group.startConfigurationChange(operations);
+                    return group.startGraphConfigurationChange(graph);
                   });
         }
         yield result;
@@ -741,9 +758,9 @@ public record CurrentClusterConfiguration(
   private boolean isRestorePlan(final PhasedChangePlan plan) {
     return plan.hasRestorePlanId()
         && plan.phases().size() == 1
-        && plan.phases().get(0) instanceof final PartitionGroupParallelPhase parallelPhase
-        && parallelPhase.groupOperations().size() == 1
-        && parallelPhase.groupOperations().values().stream()
+        && plan.phases().get(0) instanceof final PartitionGroupPhase groupPhase
+        && groupPhase.groupGraphs().size() == 1
+        && groupPhase.groupOperations().values().stream()
             .allMatch(
                 operations ->
                     operations.size() == 1 && operations.get(0) instanceof UpdateRoutingState);
@@ -791,6 +808,44 @@ public record CurrentClusterConfiguration(
   public Map<String, SortedMap<Integer, MemberId>> desiredLeaders() {
     return partitionGroups.entrySet().stream()
         .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().desiredLeaders()));
+  }
+
+  /**
+   * Projects whichever execution model a change uses onto the queue shape the single-group {@link
+   * ClusterConfiguration} exposes.
+   *
+   * <p>A queue projects as itself. A dependency graph flattens into its pending and completed
+   * operations in plan order — a valid, merely slower, sequential reading of the same change — with
+   * the version taken as one per completed operation, which is the contract that field has always
+   * had.
+   *
+   * <p>The projection is necessarily lossy: it cannot express that several operations are running
+   * at once, and a reader that merges by this version alone would keep only one of two concurrent
+   * completions. That is a property of the queue model, not something the projection can repair, so
+   * nothing here tries to.
+   *
+   * <p><b>This is not only a reporting view.</b> {@link #toLegacyDefault()} — which calls this — is
+   * dual-written by {@code ClusterConfigurationGossiper} into the legacy gossip field a broker
+   * without the new model reads, and a receiver on that path merges it with {@code
+   * ClusterChangePlan#merge}, using the synthetic version minted here. During a graph change that
+   * synthetic version differs per broker by completed-operation count, so on a mixed-version
+   * cluster it is a live input to that merge, not just something rendered for an operator to read.
+   * An old broker on that path would also try to execute the flattened queue sequentially. Believed
+   * out of scope for today's two graph adopters, but callers should not read "for reporting" as
+   * "never on the wire."
+   */
+  private static ClusterChangePlan toQueueProjection(final ChangePlan plan) {
+    if (plan instanceof final ClusterChangePlan queue) {
+      return queue;
+    }
+    final var completed = plan.completedOperations();
+    return new ClusterChangePlan(
+        plan.id(),
+        1 + completed.size(),
+        plan.status(),
+        plan.startedAt(),
+        completed,
+        plan.pendingOperations());
   }
 
   private static PhasedChangeState toPhasedChangeState(final ClusterConfiguration legacy) {
@@ -854,9 +909,9 @@ public record CurrentClusterConfiguration(
    * Splits a flat legacy operation list into phases, preserving order: each maximal run of
    * consecutive operations of the same kind becomes one phase — a run of {@link
    * GlobalChangeOperation} becomes a {@link GlobalPhase}, a run of {@link PartitionGroupOperation}
-   * becomes a {@link PartitionGroupParallelPhase} targeting the default group. For example {@code
-   * [MemberJoin, PartitionJoin, PartitionLeave, MemberLeave]} yields three phases: a global phase,
-   * a default-group phase with the two partition operations, and another global phase.
+   * becomes a sequential {@link PartitionGroupPhase} targeting the default group. For example
+   * {@code [MemberJoin, PartitionJoin, PartitionLeave, MemberLeave]} yields three phases: a global
+   * phase, a default-group phase with the two partition operations, and another global phase.
    *
    * <p>Also used by the coordinator to turn a freshly generated flat operation list (from the
    * unchanged request transformers) into a {@link PhasedChangePlan} for the default group.
@@ -893,7 +948,7 @@ public record CurrentClusterConfiguration(
   private static void flushPartitionRun(
       final List<Phase> phases, final List<PartitionGroupOperation> run) {
     if (!run.isEmpty()) {
-      phases.add(new PartitionGroupParallelPhase(Map.of(DEFAULT_GROUP, List.copyOf(run))));
+      phases.add(PartitionGroupPhase.sequential(DEFAULT_GROUP, List.copyOf(run)));
       run.clear();
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -611,17 +611,26 @@ public record CurrentClusterConfiguration(
    * sub-configuration it targets (the global configuration for a {@link GlobalPhase}, or each named
    * partition group for a {@link PartitionGroupPhase}) has no pending changes left.
    *
-   * <p>For a {@link PartitionGroupGraphPhase}, "no pending changes left" means the group's {@code
-   * pendingGraphChanges} is gone entirely, not merely that every operation in it has completed.
-   * Those two are different moments: {@link PartitionGroupConfiguration#hasPendingChanges()} reads
-   * the plan's own content and goes {@code false} the instant the last operation completes, while
-   * clearing the plan itself is a separate, later step ({@link
-   * PartitionGroupConfiguration#completeGraphChangeIfDrained()}), run by whichever broker's
-   * reconcile or gossip round gets there first. Treating "drained" as "complete" here would let
-   * this plan be archived into history while the group still carries a (fully drained but not yet
-   * cleared) graph plan — which is exactly the state a decoder without this phase to consult can no
-   * longer tell apart from an actually-still-running one. The queue model has no such gap: {@link
-   * PartitionGroupConfiguration#advance()} clears its plan in the same call that drains it.
+   * <p>For a {@link PartitionGroupPhase}, "no pending changes left" means the group's {@code
+   * pendingChanges} is gone entirely, not merely that every operation in it has completed. Those
+   * two are different moments under the dependency-graph model: {@link
+   * PartitionGroupConfiguration#hasPendingChanges()} reads the plan's own content and goes {@code
+   * false} the instant the last operation completes, while clearing the plan itself is a separate,
+   * later step ({@link PartitionGroupConfiguration#completeGraphChangeIfDrained()}), run by
+   * whichever broker's reconcile or gossip round gets there first. Treating "drained" as "complete"
+   * here would let this plan be archived into history while the group still carries a (fully
+   * drained but not yet cleared) graph plan — which is exactly the state a decoder without this
+   * phase to consult can no longer tell apart from an actually-still-running one. The queue model
+   * has no such gap: {@link PartitionGroupConfiguration#advance()} clears its plan in the same call
+   * that drains it.
+   *
+   * <p>The check reads {@code pendingChanges}, not {@code pendingGraphChanges}: a group whose plan
+   * is a queue would otherwise read as complete simply because it is not a graph, letting the phase
+   * advance over a change still in progress. No caller can produce that state today — {@link
+   * #applyPhase} refuses to activate onto a group that has a change, and the one path that starts a
+   * queue change on a group ({@code PhysicalTenantProvisioningInitializer}) only ever creates
+   * groups that do not exist yet — but the narrower read buys nothing for the model this phase does
+   * run, and a stuck plan is the better failure than an archived one.
    *
    * @throws IllegalStateException if no plan {@code planId} is pending
    */
@@ -636,7 +645,7 @@ public record CurrentClusterConfiguration(
       case final PartitionGroupPhase groupPhase ->
           groupPhase.groupGraphs().keySet().stream()
               .map(this::partitionGroup)
-              .allMatch(group -> group != null && group.pendingGraphChanges().isEmpty());
+              .allMatch(group -> group != null && group.pendingChanges().isEmpty());
     };
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -613,24 +613,14 @@ public record CurrentClusterConfiguration(
    *
    * <p>For a {@link PartitionGroupPhase}, "no pending changes left" means the group's {@code
    * pendingChanges} is gone entirely, not merely that every operation in it has completed. Those
-   * two are different moments under the dependency-graph model: {@link
-   * PartitionGroupConfiguration#hasPendingChanges()} reads the plan's own content and goes {@code
-   * false} the instant the last operation completes, while clearing the plan itself is a separate,
-   * later step ({@link PartitionGroupConfiguration#completeGraphChangeIfDrained()}), run by
-   * whichever broker's reconcile or gossip round gets there first. Treating "drained" as "complete"
-   * here would let this plan be archived into history while the group still carries a (fully
-   * drained but not yet cleared) graph plan — which is exactly the state a decoder without this
-   * phase to consult can no longer tell apart from an actually-still-running one. The queue model
-   * has no such gap: {@link PartitionGroupConfiguration#advance()} clears its plan in the same call
-   * that drains it.
-   *
-   * <p>The check reads {@code pendingChanges}, not {@code pendingGraphChanges}: a group whose plan
-   * is a queue would otherwise read as complete simply because it is not a graph, letting the phase
-   * advance over a change still in progress. No caller can produce that state today — {@link
-   * #applyPhase} refuses to activate onto a group that has a change, and the one path that starts a
-   * queue change on a group ({@code PhysicalTenantProvisioningInitializer}) only ever creates
-   * groups that do not exist yet — but the narrower read buys nothing for the model this phase does
-   * run, and a stuck plan is the better failure than an archived one.
+   * two are different moments: {@link PartitionGroupConfiguration#hasPendingChanges()} reads the
+   * plan's own content and goes {@code false} the instant the last operation completes, while
+   * clearing the plan itself is a separate, later step ({@link
+   * PartitionGroupConfiguration#completeGraphChangeIfDrained()}), run by whichever broker's
+   * reconcile or gossip round gets there first. Treating "drained" as "complete" here would let
+   * this plan be archived into history while the group still carries a fully drained but not yet
+   * cleared plan — which is exactly the state a decoder without this phase to consult can no longer
+   * tell apart from an actually-still-running one.
    *
    * @throws IllegalStateException if no plan {@code planId} is pending
    */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -11,10 +11,8 @@ import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
@@ -37,9 +35,9 @@ import org.jspecify.annotations.Nullable;
  * to a broker within a single group.
  *
  * <p>{@code version} is incremented only at plan boundaries (see {@link
- * #startConfigurationChange(List)} and {@link #advance()}). Merge uses a two-level scheme: if two
- * copies have different versions, the higher version wins wholesale; if equal, members are merged
- * field-by-field using their per-member versions.
+ * #startGraphConfigurationChange(OperationGraph)} and {@link #completeGraphChangeIfDrained()}).
+ * Merge uses a two-level scheme: if two copies have different versions, the higher version wins
+ * wholesale; if equal, members are merged field-by-field using their per-member versions.
  *
  * <p>This class is immutable; every mutating method returns a new instance.
  *
@@ -47,7 +45,11 @@ import org.jspecify.annotations.Nullable;
  * @param incarnationNumber incarnation number of this group, incremented after the data is purged.
  * @param members per-broker partition state within this group
  * @param routingState routing state scoped to this group, if any
- * @param pendingChanges the ongoing change plan for this group, if any
+ * @param pendingChanges the ongoing change plan for this group, if any. Always a {@link
+ *     DependencyChangePlan}: a group's operations carry their own dependencies, and the
+ *     one-at-a-time queue ({@link ClusterChangePlan}) that groups used before it is gone. The queue
+ *     survives only where there is nothing to depend on — {@link GlobalConfiguration}, whose
+ *     operations are broker lifecycle steps taken cluster-wide, one at a time by construction.
  * @param lastChange the last completed change plan for this group, if any
  * @param availability whether this tenant is currently disabled; carries its own version,
  *     independent of {@code version} — see {@link TenantAvailability}
@@ -58,7 +60,7 @@ public record PartitionGroupConfiguration(
     long incarnationNumber,
     SortedMap<MemberId, BrokerPartitionState> members,
     Optional<RoutingState> routingState,
-    Optional<ChangePlan> pendingChanges,
+    Optional<DependencyChangePlan> pendingChanges,
     Optional<CompletedChange> lastChange,
     TenantAvailability availability) {
 
@@ -83,7 +85,7 @@ public record PartitionGroupConfiguration(
       final long incarnationNumber,
       final Map<MemberId, BrokerPartitionState> members,
       final Optional<RoutingState> routingState,
-      final Optional<ChangePlan> pendingChanges,
+      final Optional<DependencyChangePlan> pendingChanges,
       final Optional<CompletedChange> lastChange) {
     this(
         version,
@@ -101,7 +103,7 @@ public record PartitionGroupConfiguration(
       final long incarnationNumber,
       final Map<MemberId, BrokerPartitionState> members,
       final Optional<RoutingState> routingState,
-      final Optional<ChangePlan> pendingChanges,
+      final Optional<DependencyChangePlan> pendingChanges,
       final Optional<CompletedChange> lastChange,
       final TenantAvailability availability) {
     this(
@@ -123,95 +125,6 @@ public record PartitionGroupConfiguration(
         Optional.empty(),
         Optional.empty(),
         Optional.empty());
-  }
-
-  /**
-   * Starts a new configuration change for this group by setting {@code pendingChanges} to a new
-   * {@link ClusterChangePlan} and bumping the group version.
-   *
-   * @param operations the operations to execute, must be non-empty
-   * @return the updated group configuration
-   * @throws IllegalArgumentException if a change is already in progress, or {@code operations} is
-   *     empty
-   */
-  public PartitionGroupConfiguration startConfigurationChange(
-      final List<ClusterConfigurationChangeOperation> operations) {
-    if (hasPendingChanges()) {
-      throw new IllegalArgumentException(
-          "Expected to start new configuration change, but there is a configuration change in progress "
-              + pendingChanges);
-    }
-    if (operations.isEmpty()) {
-      throw new IllegalArgumentException(
-          "Expected to start new configuration change, but there is no operation");
-    }
-    final long newVersion = version + 1;
-    return new PartitionGroupConfiguration(
-        newVersion,
-        incarnationNumber,
-        members,
-        routingState,
-        Optional.of(ClusterChangePlan.init(newVersion, operations)),
-        lastChange,
-        availability);
-  }
-
-  /**
-   * Advances the ongoing change plan by removing its first pending operation, following the same
-   * semantics as {@code ClusterConfiguration#advance()}.
-   *
-   * <p>While operations remain, the plan is simply stepped forward and the group version is
-   * unchanged. When the last operation is removed, the change is completed: {@code pendingChanges}
-   * is cleared, {@code lastChange} is set to the completed change, members whose {@code partitions}
-   * map is empty are removed (the structural equivalent of {@code State.LEFT} in the legacy model —
-   * a broker no longer replicating any partition of this group is no longer part of it), and the
-   * group version is bumped so peers overwrite their local copy on merge.
-   *
-   * @return the updated group configuration
-   * @throws IllegalStateException if there is no pending change to advance
-   */
-  public PartitionGroupConfiguration advance() {
-    if (!hasPendingChanges()) {
-      throw new IllegalStateException(
-          "Expected to advance the configuration change, but there is no pending change");
-    }
-
-    if (!(pendingChanges.orElseThrow() instanceof final ClusterChangePlan queue)) {
-      throw new IllegalStateException(
-          "advance() steps a queue one operation at a time and is only valid for a "
-              + "ClusterChangePlan; a DependencyChangePlan is progressed per operation via "
-              + "completeOperation(OperationId, ...)");
-    }
-    final var result =
-        new PartitionGroupConfiguration(
-            version,
-            incarnationNumber,
-            members,
-            routingState,
-            Optional.of(queue.advance()),
-            lastChange,
-            availability);
-
-    if (result.hasPendingChanges()) {
-      return result;
-    }
-
-    // The last operation has been applied. Complete the change: clean up members that no longer
-    // replicate any partition of this group and bump the version so other members merge by
-    // overwriting their local copy.
-    final var remainingMembers =
-        result.members().entrySet().stream()
-            .filter(entry -> !entry.getValue().partitions().isEmpty())
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    final var completedChange = queue.completed();
-    return new PartitionGroupConfiguration(
-        result.version() + 1,
-        incarnationNumber,
-        remainingMembers,
-        routingState,
-        Optional.empty(),
-        Optional.of(completedChange),
-        availability);
   }
 
   /**
@@ -267,10 +180,10 @@ public record PartitionGroupConfiguration(
             .flatMap(Optional::stream)
             .reduce(RoutingState::merge);
 
-    final Optional<ChangePlan> mergedChanges =
+    final Optional<DependencyChangePlan> mergedChanges =
         Stream.of(pendingChanges, other.pendingChanges)
             .flatMap(Optional::stream)
-            .reduce(PartitionGroupConfiguration::mergePlans);
+            .reduce(DependencyChangePlan::merge);
 
     return new PartitionGroupConfiguration(
         version,
@@ -456,38 +369,6 @@ public record PartitionGroupConfiguration(
   }
 
   /**
-   * Returns the next pending operation for the given memberId, or empty if the next pending
-   * operation (if any) is not applicable to that member. Mirrors {@code
-   * ClusterConfiguration#pendingChangesFor(MemberId)}.
-   */
-  public Optional<PartitionGroupOperation> pendingChangesFor(final MemberId memberId) {
-    if (!(pendingChanges.orElse(null) instanceof final ClusterChangePlan queue)
-        || !queue.hasPendingChangesFor(memberId)) {
-      return Optional.empty();
-    }
-    return Optional.of((PartitionGroupOperation) queue.nextPendingOperation());
-  }
-
-  public PartitionGroupOperation nextPendingOperation() {
-    if (!(pendingChanges.orElse(null) instanceof final ClusterChangePlan queue)
-        || !queue.hasPendingChanges()) {
-      throw new NoSuchElementException();
-    }
-    return (PartitionGroupOperation) queue.nextPendingOperation();
-  }
-
-  /**
-   * When the operation returned by {@link #pendingChangesFor(MemberId)} completes, the result is
-   * reflected here by applying {@code configurationUpdater} and then advancing past the completed
-   * operation (see {@link #advance()}). Mirrors {@code
-   * ClusterConfiguration#advanceConfigurationChange}.
-   */
-  public PartitionGroupConfiguration advanceConfigurationChange(
-      final UnaryOperator<PartitionGroupConfiguration> configurationUpdater) {
-    return configurationUpdater.apply(this).advance();
-  }
-
-  /**
    * Cancels any pending changes, returning a new configuration with the already-applied changes and
    * no pending changes. This is a dangerous operation that can leave the configuration
    * inconsistent; it should only be used as a last resort when a change is stuck. Mirrors {@code
@@ -507,30 +388,6 @@ public record PartitionGroupConfiguration(
         Optional.empty(),
         Optional.of(cancelledChange),
         availability);
-  }
-
-  /**
-   * Merges two plans of the same execution model. The two models never meet in practice — a group
-   * runs one change at a time and a change is built by one transformer — so a mismatch means the
-   * two copies disagree about which model the change uses, which merging cannot repair. Keeping the
-   * receiver is the safe answer; the version-based branch above resolves it once either side moves.
-   */
-  private static ChangePlan mergePlans(final ChangePlan mine, final ChangePlan theirs) {
-    if (mine instanceof final ClusterChangePlan a && theirs instanceof final ClusterChangePlan b) {
-      return a.merge(b);
-    }
-    if (mine instanceof final DependencyChangePlan a
-        && theirs instanceof final DependencyChangePlan b) {
-      return a.merge(b);
-    }
-    return mine;
-  }
-
-  /** The ongoing change if it uses the dependency-graph model, otherwise empty. */
-  public Optional<DependencyChangePlan> pendingGraphChanges() {
-    return pendingChanges
-        .filter(DependencyChangePlan.class::isInstance)
-        .map(DependencyChangePlan.class::cast);
   }
 
   /**
@@ -567,16 +424,15 @@ public record PartitionGroupConfiguration(
         availability);
   }
 
-  /** Everything the given member may start right now. Empty unless a graph change is running. */
+  /** Everything the given member may start right now. Empty unless a change is running. */
   public SortedMap<OperationId, PartitionGroupOperation> runnableFor(final MemberId memberId) {
     final SortedMap<OperationId, PartitionGroupOperation> runnable = new TreeMap<>();
-    pendingGraphChanges()
-        .ifPresent(
-            plan ->
-                plan.runnableFor(memberId)
-                    .forEach(
-                        (operationId, operation) ->
-                            runnable.put(operationId, (PartitionGroupOperation) operation)));
+    pendingChanges.ifPresent(
+        plan ->
+            plan.runnableFor(memberId)
+                .forEach(
+                    (operationId, operation) ->
+                        runnable.put(operationId, (PartitionGroupOperation) operation)));
     return runnable;
   }
 
@@ -593,11 +449,11 @@ public record PartitionGroupConfiguration(
     final var updated = updater.apply(this);
     final var plan =
         updated
-            .pendingGraphChanges()
+            .pendingChanges()
             .orElseThrow(
                 () ->
                     new IllegalStateException(
-                        "Expected to record %s, but no dependency-graph change is in progress"
+                        "Expected to record %s, but no change is in progress"
                             .formatted(operationId)));
     return new PartitionGroupConfiguration(
         updated.version(),
@@ -610,12 +466,13 @@ public record PartitionGroupConfiguration(
   }
 
   /**
-   * Finishes a graph change once every operation has completed, doing the same end-of-plan work
-   * {@link #advance()} does for a queue. Returns {@code this} unchanged otherwise, so every broker
+   * Finishes the change once every operation has completed: records {@code lastChange}, prunes
+   * members left replicating no partition of this group, and bumps the group version so peers
+   * overwrite their local copy on merge. Returns {@code this} unchanged otherwise, so every broker
    * may call it on every merge — which is how the change completes without a coordinator.
    */
   public PartitionGroupConfiguration completeGraphChangeIfDrained() {
-    final var plan = pendingGraphChanges().orElse(null);
+    final var plan = pendingChanges.orElse(null);
     if (plan == null || plan.hasPendingChanges()) {
       return this;
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -537,10 +537,17 @@ public record PartitionGroupConfiguration(
    * Starts a change whose operations carry their own dependencies, bumping the group version as any
    * plan start does.
    *
-   * @throws IllegalArgumentException if a change is already in progress, or the graph is empty
+   * <p>Rejects on {@code pendingChanges.isPresent()} rather than on {@link #hasPendingChanges()}: a
+   * graph plan whose last operation has completed but which has not yet been cleared by {@link
+   * #completeGraphChangeIfDrained()} still has content this call would destroy — its {@code
+   * lastChange} would never be recorded and the members it emptied never pruned — while {@link
+   * #hasPendingChanges()}, which reads the plan's content, already reports {@code false} for it.
+   *
+   * @throws IllegalArgumentException if the group still carries a change plan, drained or not, or
+   *     the graph is empty
    */
   public PartitionGroupConfiguration startGraphConfigurationChange(final OperationGraph graph) {
-    if (hasPendingChanges()) {
+    if (pendingChanges.isPresent()) {
       throw new IllegalArgumentException(
           "Expected to start new configuration change, but there is a configuration change in progress "
               + pendingChanges);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -58,7 +58,7 @@ public record PartitionGroupConfiguration(
     long incarnationNumber,
     SortedMap<MemberId, BrokerPartitionState> members,
     Optional<RoutingState> routingState,
-    Optional<ClusterChangePlan> pendingChanges,
+    Optional<ChangePlan> pendingChanges,
     Optional<CompletedChange> lastChange,
     TenantAvailability availability) {
 
@@ -83,7 +83,7 @@ public record PartitionGroupConfiguration(
       final long incarnationNumber,
       final Map<MemberId, BrokerPartitionState> members,
       final Optional<RoutingState> routingState,
-      final Optional<ClusterChangePlan> pendingChanges,
+      final Optional<ChangePlan> pendingChanges,
       final Optional<CompletedChange> lastChange) {
     this(
         version,
@@ -101,7 +101,7 @@ public record PartitionGroupConfiguration(
       final long incarnationNumber,
       final Map<MemberId, BrokerPartitionState> members,
       final Optional<RoutingState> routingState,
-      final Optional<ClusterChangePlan> pendingChanges,
+      final Optional<ChangePlan> pendingChanges,
       final Optional<CompletedChange> lastChange,
       final TenantAvailability availability) {
     this(
@@ -176,13 +176,19 @@ public record PartitionGroupConfiguration(
           "Expected to advance the configuration change, but there is no pending change");
     }
 
+    if (!(pendingChanges.orElseThrow() instanceof final ClusterChangePlan queue)) {
+      throw new IllegalStateException(
+          "advance() steps a queue one operation at a time and is only valid for a "
+              + "ClusterChangePlan; a DependencyChangePlan is progressed per operation via "
+              + "completeOperation(OperationId, ...)");
+    }
     final var result =
         new PartitionGroupConfiguration(
             version,
             incarnationNumber,
             members,
             routingState,
-            Optional.of(pendingChanges.orElseThrow().advance()),
+            Optional.of(queue.advance()),
             lastChange,
             availability);
 
@@ -197,7 +203,7 @@ public record PartitionGroupConfiguration(
         result.members().entrySet().stream()
             .filter(entry -> !entry.getValue().partitions().isEmpty())
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    final var completedChange = pendingChanges.orElseThrow().completed();
+    final var completedChange = queue.completed();
     return new PartitionGroupConfiguration(
         result.version() + 1,
         incarnationNumber,
@@ -229,7 +235,7 @@ public record PartitionGroupConfiguration(
     final var mergedAvailability = availability.merge(other.availability);
 
     if (version > other.version) {
-      return this.availability.equals(mergedAvailability)
+      return availability.equals(mergedAvailability)
           ? this
           : new PartitionGroupConfiguration(
               version,
@@ -261,10 +267,10 @@ public record PartitionGroupConfiguration(
             .flatMap(Optional::stream)
             .reduce(RoutingState::merge);
 
-    final Optional<ClusterChangePlan> mergedChanges =
+    final Optional<ChangePlan> mergedChanges =
         Stream.of(pendingChanges, other.pendingChanges)
             .flatMap(Optional::stream)
-            .reduce(ClusterChangePlan::merge);
+            .reduce(PartitionGroupConfiguration::mergePlans);
 
     return new PartitionGroupConfiguration(
         version,
@@ -272,8 +278,42 @@ public record PartitionGroupConfiguration(
         mergedMembers,
         mergedRoutingState,
         mergedChanges,
-        lastChange,
+        mergeLastChange(lastChange, other.lastChange),
         mergedAvailability);
+  }
+
+  /**
+   * Merges two {@code lastChange} records seen by different brokers, both stamped for the same
+   * completed change.
+   *
+   * <p>Every other equal-version field above is resolved by keeping the receiver's copy, safe
+   * because it either only ever has one writer or is itself independently mergeable (members,
+   * pendingChanges). {@code lastChange} for a graph change is neither: {@link
+   * #completeGraphChangeIfDrained()} runs on every broker with no coordinator gate, and each mints
+   * its own {@link CompletedChange} from its own view of when the last operation completed. Two
+   * brokers minting a moment apart can disagree on {@code completedAt} for the very same change, at
+   * the very same group version, and keeping "the receiver's own" would leave that disagreement
+   * standing forever — see {@code DependencyChangePlan#toCompletedChange}'s own javadoc for why.
+   *
+   * <p>Resolved the same way {@link DependencyChangePlan#merge} already resolves the analogous case
+   * for individual operation completions: same change id, earliest {@code completedAt} wins;
+   * different change id (a genuinely later, unrelated completion on this group), the higher id
+   * wins, since ids are monotonic and a higher one is always the newer change.
+   */
+  private static Optional<CompletedChange> mergeLastChange(
+      final Optional<CompletedChange> mine, final Optional<CompletedChange> theirs) {
+    if (mine.isEmpty()) {
+      return theirs;
+    }
+    if (theirs.isEmpty()) {
+      return mine;
+    }
+    final var mineChange = mine.orElseThrow();
+    final var theirsChange = theirs.orElseThrow();
+    if (mineChange.id() != theirsChange.id()) {
+      return mineChange.id() > theirsChange.id() ? mine : theirs;
+    }
+    return mineChange.completedAt().isBefore(theirsChange.completedAt()) ? mine : theirs;
   }
 
   /**
@@ -421,18 +461,19 @@ public record PartitionGroupConfiguration(
    * ClusterConfiguration#pendingChangesFor(MemberId)}.
    */
   public Optional<PartitionGroupOperation> pendingChangesFor(final MemberId memberId) {
-    if (pendingChanges.isEmpty() || !pendingChanges.get().hasPendingChangesFor(memberId)) {
+    if (!(pendingChanges.orElse(null) instanceof final ClusterChangePlan queue)
+        || !queue.hasPendingChangesFor(memberId)) {
       return Optional.empty();
     }
-    return Optional.of(
-        (PartitionGroupOperation) pendingChanges.orElseThrow().nextPendingOperation());
+    return Optional.of((PartitionGroupOperation) queue.nextPendingOperation());
   }
 
   public PartitionGroupOperation nextPendingOperation() {
-    if (!hasPendingChanges()) {
+    if (!(pendingChanges.orElse(null) instanceof final ClusterChangePlan queue)
+        || !queue.hasPendingChanges()) {
       throw new NoSuchElementException();
     }
-    return (PartitionGroupOperation) pendingChanges.orElseThrow().nextPendingOperation();
+    return (PartitionGroupOperation) queue.nextPendingOperation();
   }
 
   /**
@@ -465,6 +506,123 @@ public record PartitionGroupConfiguration(
         routingState,
         Optional.empty(),
         Optional.of(cancelledChange),
+        availability);
+  }
+
+  /**
+   * Merges two plans of the same execution model. The two models never meet in practice — a group
+   * runs one change at a time and a change is built by one transformer — so a mismatch means the
+   * two copies disagree about which model the change uses, which merging cannot repair. Keeping the
+   * receiver is the safe answer; the version-based branch above resolves it once either side moves.
+   */
+  private static ChangePlan mergePlans(final ChangePlan mine, final ChangePlan theirs) {
+    if (mine instanceof final ClusterChangePlan a && theirs instanceof final ClusterChangePlan b) {
+      return a.merge(b);
+    }
+    if (mine instanceof final DependencyChangePlan a
+        && theirs instanceof final DependencyChangePlan b) {
+      return a.merge(b);
+    }
+    return mine;
+  }
+
+  /** The ongoing change if it uses the dependency-graph model, otherwise empty. */
+  public Optional<DependencyChangePlan> pendingGraphChanges() {
+    return pendingChanges
+        .filter(DependencyChangePlan.class::isInstance)
+        .map(DependencyChangePlan.class::cast);
+  }
+
+  /**
+   * Starts a change whose operations carry their own dependencies, bumping the group version as any
+   * plan start does.
+   *
+   * @throws IllegalArgumentException if a change is already in progress, or the graph is empty
+   */
+  public PartitionGroupConfiguration startGraphConfigurationChange(final OperationGraph graph) {
+    if (hasPendingChanges()) {
+      throw new IllegalArgumentException(
+          "Expected to start new configuration change, but there is a configuration change in progress "
+              + pendingChanges);
+    }
+    if (graph.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected to start new configuration change, but there is no operation");
+    }
+    final long newVersion = version + 1;
+    return new PartitionGroupConfiguration(
+        newVersion,
+        incarnationNumber,
+        members,
+        routingState,
+        Optional.of(DependencyChangePlan.init(newVersion, graph)),
+        lastChange,
+        availability);
+  }
+
+  /** Everything the given member may start right now. Empty unless a graph change is running. */
+  public SortedMap<OperationId, PartitionGroupOperation> runnableFor(final MemberId memberId) {
+    final SortedMap<OperationId, PartitionGroupOperation> runnable = new TreeMap<>();
+    pendingGraphChanges()
+        .ifPresent(
+            plan ->
+                plan.runnableFor(memberId)
+                    .forEach(
+                        (operationId, operation) ->
+                            runnable.put(operationId, (PartitionGroupOperation) operation)));
+    return runnable;
+  }
+
+  /**
+   * Applies a completed operation's effect and records it against the plan, in one transition.
+   *
+   * <p>Deliberately does not move the group version. Under a graph change several brokers progress
+   * at once, and a version bump here would take the group merge off its structural branch and
+   * discard the others' progress. Finishing the change is separate — see {@link
+   * #completeGraphChangeIfDrained()}.
+   */
+  public PartitionGroupConfiguration completeOperation(
+      final OperationId operationId, final UnaryOperator<PartitionGroupConfiguration> updater) {
+    final var updated = updater.apply(this);
+    final var plan =
+        updated
+            .pendingGraphChanges()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Expected to record %s, but no dependency-graph change is in progress"
+                            .formatted(operationId)));
+    return new PartitionGroupConfiguration(
+        updated.version(),
+        updated.incarnationNumber(),
+        updated.members(),
+        updated.routingState(),
+        Optional.of(plan.completeOperation(operationId)),
+        updated.lastChange(),
+        updated.availability());
+  }
+
+  /**
+   * Finishes a graph change once every operation has completed, doing the same end-of-plan work
+   * {@link #advance()} does for a queue. Returns {@code this} unchanged otherwise, so every broker
+   * may call it on every merge — which is how the change completes without a coordinator.
+   */
+  public PartitionGroupConfiguration completeGraphChangeIfDrained() {
+    final var plan = pendingGraphChanges().orElse(null);
+    if (plan == null || plan.hasPendingChanges()) {
+      return this;
+    }
+    final var remainingMembers =
+        members.entrySet().stream()
+            .filter(entry -> !entry.getValue().partitions().isEmpty())
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    return new PartitionGroupConfiguration(
+        version + 1,
+        incarnationNumber,
+        remainingMembers,
+        routingState,
+        Optional.empty(),
+        Optional.of(plan.toCompletedChange()),
         availability);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.state;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,8 +32,8 @@ import org.jspecify.annotations.NullMarked;
  * <p>{@link #scope()} identifies which sub-configuration(s) this plan touches, derived from its
  * phases: a plan with any {@link GlobalPhase} has {@link Global} scope (cluster-wide, conflicts
  * with everything); otherwise it has {@link Groups} scope, the union of every partition group named
- * across its {@link PartitionGroupParallelPhase}s. Multiple plans with disjoint {@link Groups}
- * scopes may be pending concurrently; see {@link PhasedChangeState}.
+ * across its {@link PartitionGroupPhase}s. Multiple plans with disjoint {@link Groups} scopes may
+ * be pending concurrently; see {@link PhasedChangeState}.
  */
 @NullMarked
 public record PhasedChangePlan(
@@ -116,8 +117,8 @@ public record PhasedChangePlan(
   /**
    * Returns the scope of this plan: {@link Global} if any phase is a {@link GlobalPhase} (the plan
    * touches cluster-wide broker lifecycle, and therefore conflicts with every other plan);
-   * otherwise {@link Groups}, the union of every partition group id named across the plan's {@link
-   * PartitionGroupParallelPhase}s.
+   * otherwise {@link Groups}, the union of every partition group id named across the plan's
+   * partition-group phases.
    */
   public Scope scope() {
     return scopeOf(phases);
@@ -128,12 +129,12 @@ public record PhasedChangePlan(
     if (phases.stream().anyMatch(GlobalPhase.class::isInstance)) {
       return new Global();
     }
-    final Set<String> groupIds =
-        phases.stream()
-            .filter(PartitionGroupParallelPhase.class::isInstance)
-            .map(PartitionGroupParallelPhase.class::cast)
-            .flatMap(phase -> phase.groupOperations().keySet().stream())
-            .collect(Collectors.toUnmodifiableSet());
+    final Set<String> groupIds = new HashSet<>();
+    for (final var phase : phases) {
+      if (phase instanceof final PartitionGroupPhase groupPhase) {
+        groupIds.addAll(groupPhase.groupGraphs().keySet());
+      }
+    }
     return new Groups(groupIds);
   }
 
@@ -150,9 +151,6 @@ public record PhasedChangePlan(
     final var groupsB = ((Groups) b).groupIds();
     return !Collections.disjoint(groupsA, groupsB);
   }
-
-  /** The sub-configuration(s) a {@link PhasedChangePlan} touches. See {@link #scope()}. */
-  public sealed interface Scope permits Global, Groups {}
 
   /** Cluster-wide scope: touches {@link GlobalConfiguration}, conflicts with every other plan. */
   public record Global() implements Scope {}
@@ -175,22 +173,51 @@ public record PhasedChangePlan(
   }
 
   /**
-   * A phase whose operations are activated atomically into the {@code pendingChanges} of each named
-   * partition group.
+   * A phase whose named partition groups each run an {@link OperationGraph}, activated atomically
+   * into the {@code pendingChanges} of every named group.
+   *
+   * <p>The graph is the only execution model a phase has: an operation runs once everything it
+   * depends on has completed, so concurrency is the <em>absence of an edge</em>. A transformer that
+   * has no parallelism to express builds its phase with {@link #sequential(Map)}, which chains
+   * every operation behind its predecessor and therefore behaves exactly like the one-at-a-time
+   * queue that preceded it.
    */
-  public record PartitionGroupParallelPhase(
-      Map<String, List<PartitionGroupOperation>> groupOperations) implements Phase {
-    public PartitionGroupParallelPhase {
-      groupOperations =
+  public record PartitionGroupPhase(Map<String, OperationGraph> groupGraphs) implements Phase {
+    public PartitionGroupPhase {
+      groupGraphs = Map.copyOf(groupGraphs);
+    }
+
+    /** A phase in which each group runs its operations strictly one after another. */
+    public static PartitionGroupPhase sequential(
+        final Map<String, List<PartitionGroupOperation>> groupOperations) {
+      return new PartitionGroupPhase(
           groupOperations.entrySet().stream()
               .collect(
-                  Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> List.copyOf(e.getValue())));
+                  Collectors.toUnmodifiableMap(
+                      Map.Entry::getKey, e -> OperationGraph.sequential(e.getValue()))));
+    }
+
+    /** {@link #sequential(Map)} for the common single-group case. */
+    public static PartitionGroupPhase sequential(
+        final String groupId, final List<PartitionGroupOperation> operations) {
+      return sequential(Map.of(groupId, operations));
+    }
+
+    /** Every operation of this phase per group, flattening the dependencies away for reporting. */
+    public Map<String, List<PartitionGroupOperation>> groupOperations() {
+      return groupGraphs.entrySet().stream()
+          .collect(
+              Collectors.toUnmodifiableMap(
+                  Map.Entry::getKey,
+                  e ->
+                      e.getValue().inOrder().stream()
+                          .map(PartitionGroupOperation.class::cast)
+                          .toList()));
     }
   }
 
-  /**
-   * A single phase in a {@link PhasedChangePlan}. Exactly one of the two permitted subtypes is
-   * active.
-   */
-  public sealed interface Phase permits GlobalPhase, PartitionGroupParallelPhase {}
+  /** The sub-configuration(s) a {@link PhasedChangePlan} touches. See {@link #scope()}. */
+  public sealed interface Scope permits Global, Groups {}
+
+  public sealed interface Phase permits GlobalPhase, PartitionGroupPhase {}
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlan.java
@@ -124,15 +124,26 @@ public record PhasedChangePlan(
     return scopeOf(phases);
   }
 
-  /** Same as {@link #scope()}, computable before a plan (and its id) exists. */
+  /**
+   * Same as {@link #scope()}, computable before a plan (and its id) exists.
+   *
+   * <p>Switches over every phase kind rather than filtering for the one it cares about. The result
+   * feeds {@link #conflicts(Scope, Scope)}, which decides whether two plans may be pending
+   * concurrently — a phase kind added later and silently contributing no group ids would make its
+   * plan look like it touches nothing, admitting a second plan onto the very groups it is changing.
+   * That failure is invisible at runtime (a rejection that should happen, doesn't), so it has to be
+   * a compile error instead.
+   */
   public static Scope scopeOf(final List<Phase> phases) {
-    if (phases.stream().anyMatch(GlobalPhase.class::isInstance)) {
-      return new Global();
-    }
     final Set<String> groupIds = new HashSet<>();
     for (final var phase : phases) {
-      if (phase instanceof final PartitionGroupPhase groupPhase) {
-        groupIds.addAll(groupPhase.groupGraphs().keySet());
+      switch (phase) {
+        case final GlobalPhase ignored -> {
+          // Cluster-wide: conflicts with everything, so no group set can narrow it.
+          return new Global();
+        }
+        case final PartitionGroupPhase groupPhase ->
+            groupIds.addAll(groupPhase.groupGraphs().keySet());
       }
     }
     return new Groups(groupIds);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/PartitionReassignmentOperationsGenerator.java
@@ -33,8 +33,8 @@ import java.util.stream.Collectors;
  * PartitionReassignRequestTransformer} does inline for the legacy single-group model: it does not
  * itself decide *what* the target distribution should be (that's the reassigner's job) or *how* the
  * resulting operations get applied (that's up to the caller — e.g. wrapping the result in a {@link
- * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase} and starting
- * a pending change, whether from a bootstrap-time initializer or a runtime management-API request).
+ * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase} and starting a
+ * pending change, whether from a bootstrap-time initializer or a runtime management-API request).
  *
  * <p>{@code targetDistribution} may span several groups; the current distribution for each group it
  * touches is read from {@code currentConfiguration}. A group with no entry in {@code

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -41,9 +41,43 @@ message PartitionGroupConfiguration {
   int64 incarnationNumber = 2;
   map<string, BrokerPartitionState> members = 3;
   RoutingState routingState = 4;
-  ClusterChangePlan pendingChanges = 5;
+  // A group runs one change at a time, and a change uses one model, chosen by
+  // the transformer that built it: the queue (pendingChanges) or the
+  // dependency graph (pendingGraphChanges). A oneof rather than two independent
+  // optional fields, so "at most one is set" is enforced by the wire format
+  // instead of by a comment a future encoder change could silently violate.
+  oneof pending_change {
+    ClusterChangePlan pendingChanges = 5;
+    DependencyChangePlan pendingGraphChanges = 8;
+  }
   CompletedChange lastChange = 6;
   TenantAvailability availability = 7;
+}
+
+// A change whose operations carry their own dependencies. An operation runs once
+// everything it depends on has completed, so concurrency is the absence of an edge.
+message DependencyChangePlan {
+  int64 id = 1;
+  ChangeStatus status = 2;
+  google.protobuf.Timestamp startedAt = 3;
+  OperationGraph graph = 4;
+  repeated OperationCompletion completed = 5;
+}
+
+// The immutable operations of a change and the order constraints between them.
+message OperationGraph {
+  repeated PlannedOperation operations = 1;
+}
+
+message PlannedOperation {
+  int32 id = 1;
+  PartitionGroupChangeOperation operation = 2;
+  repeated int32 dependsOn = 3;
+}
+
+message OperationCompletion {
+  int32 operationId = 1;
+  google.protobuf.Timestamp completedAt = 2;
 }
 
 // Whether a physical tenant is running, and if not why. Carries its own version, independent of the
@@ -104,7 +138,13 @@ message PhasedChangePlanPhase {
   oneof phase {
     GlobalPhase globalPhase = 1;
     PartitionGroupParallelPhase partitionGroupParallelPhase = 2;
+    PartitionGroupGraphPhase partitionGroupGraphPhase = 3;
   }
+}
+
+// Graphs written to the named groups' pendingGraphChanges when this phase is activated.
+message PartitionGroupGraphPhase {
+  map<string, OperationGraph> groupGraphs = 1;
 }
 
 // Operations written to GlobalConfiguration.pendingChanges when this phase
@@ -113,8 +153,10 @@ message GlobalPhase {
   repeated GlobalChangeOperation operations = 1;
 }
 
-// Operations written atomically to named groups' pendingChanges when this
-// phase is activated.
+// Decode-only. Superseded by PartitionGroupGraphPhase, which represents the
+// same thing as a graph whose operations are chained one behind the other.
+// Retained so a configuration persisted or gossiped before the two phase kinds
+// became one still decodes.
 message PartitionGroupParallelPhase {
   map<string, PartitionGroupOperationList> groupOperations = 1;
 }

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -41,15 +41,7 @@ message PartitionGroupConfiguration {
   int64 incarnationNumber = 2;
   map<string, BrokerPartitionState> members = 3;
   RoutingState routingState = 4;
-  // A group runs one change at a time, and a change uses one model, chosen by
-  // the transformer that built it: the queue (pendingChanges) or the
-  // dependency graph (pendingGraphChanges). A oneof rather than two independent
-  // optional fields, so "at most one is set" is enforced by the wire format
-  // instead of by a comment a future encoder change could silently violate.
-  oneof pending_change {
-    ClusterChangePlan pendingChanges = 5;
-    DependencyChangePlan pendingGraphChanges = 8;
-  }
+  DependencyChangePlan pendingChanges = 5;
   CompletedChange lastChange = 6;
   TenantAvailability availability = 7;
 }
@@ -142,7 +134,7 @@ message PhasedChangePlanPhase {
   }
 }
 
-// Graphs written to the named groups' pendingGraphChanges when this phase is activated.
+// Graphs written to the named groups' pendingChanges when this phase is activated.
 message PartitionGroupGraphPhase {
   map<string, OperationGraph> groupGraphs = 1;
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementApiTestBase.java
@@ -94,7 +94,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
@@ -1346,7 +1346,7 @@ abstract class ClusterConfigurationManagementApiTestBase {
     final var phases = changeStatus.response().phases();
     assertThat(phases).hasSize(3);
     assertThat(phases.get(1))
-        .asInstanceOf(type(PartitionGroupParallelPhase.class))
+        .asInstanceOf(type(PartitionGroupPhase.class))
         .satisfies(
             phase -> {
               assertThat(phase.groupOperations()).containsKey(TENANT_B);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
@@ -31,9 +31,9 @@ import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
-import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
@@ -340,7 +340,7 @@ final class ClusterConfigurationManagerImplTest {
     // then — both ran and the graph drained, without any peer having to move
     final var defaultGroup =
         configuration(manager).partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
-    assertThat(defaultGroup.pendingGraphChanges()).isEmpty();
+    assertThat(defaultGroup.pendingChanges()).isEmpty();
     assertThat(defaultGroup.hasMember(MEMBER_0)).isFalse();
   }
 
@@ -368,7 +368,7 @@ final class ClusterConfigurationManagerImplTest {
     // then — nothing was applied and both operations are still outstanding
     final var defaultGroup =
         configuration(manager).partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
-    assertThat(defaultGroup.pendingGraphChanges().orElseThrow().completed()).isEmpty();
+    assertThat(defaultGroup.pendingChanges().orElseThrow().completed()).isEmpty();
     assertThat(defaultGroup.getMember(MEMBER_0).partitions()).containsOnlyKeys(1, 2);
   }
 
@@ -967,7 +967,7 @@ final class ClusterConfigurationManagerImplTest {
             // changes, matching what applyPhase does. Without this, maybeAdvancePhase would see the
             // group as trivially drained (no pending changes) and immediately complete the whole
             // plan before the gossip-receive below even runs.
-            Optional.of(ClusterChangePlan.init(1, List.of(leaveOperation))),
+            Optional.of(DependencyChangePlan.sequential(1, List.of(leaveOperation))),
             Optional.empty());
     final var global =
         new GlobalConfiguration(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
@@ -81,6 +81,7 @@ final class ClusterConfigurationManagerImplTest {
 
   private static final MemberId MEMBER_0 = MemberId.from("0");
   private static final MemberId MEMBER_1 = MemberId.from("1");
+  private static final MemberId MEMBER_2 = MemberId.from("2");
   private final TestConcurrencyControl executor = new TestConcurrencyControl();
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
@@ -1520,6 +1521,151 @@ final class ClusterConfigurationManagerImplTest {
               assertThat(defaultGroup.hasMember(MEMBER_0)).isFalse();
               assertThat(defaultGroup.hasMember(MEMBER_1)).isTrue();
             });
+  }
+
+  @Test
+  void shouldFinishADrainedChangeWithNoLocalOperationLeftToRun() {
+    // given — a change whose every operation was applied by *peers*, merged into one drained plan
+    // that nobody has cleared yet. This is the mechanic the queue model never had: finishing a
+    // change used to be a side effect of whichever broker applied its last operation, so the broker
+    // that finishes it was always one with work of its own. Here the local member has none, so
+    // nothing about applying an operation can be what triggers the completion.
+    final var persisted =
+        PersistedCurrentClusterConfiguration.ofFile(
+            tmp.resolve("config-drained-no-local-work.meta"), new ProtoBufSerializer());
+    final var manager =
+        new ClusterConfigurationManagerImpl(
+            executor,
+            MEMBER_0,
+            persisted,
+            new TopologyManagerMetrics(new SimpleMeterRegistry()),
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+    manager.setCurrentConfigurationGossiper(ignored -> {});
+    manager.registerGlobalChangeAppliers(
+        new GlobalConfigurationChangeAppliersImpl(
+            new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
+
+    // Two independent operations, one per peer, and no operation for MEMBER_0 at all.
+    final var graph = OperationGraph.builder();
+    final var first = graph.add(new PartitionLeaveOperation(MEMBER_1, 1, 1));
+    final var second = graph.add(new PartitionLeaveOperation(MEMBER_2, 2, 1));
+    final var started =
+        threeMemberCluster()
+            .initPlan(
+                List.of(
+                    new PartitionGroupPhase(
+                        Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, graph.build()))));
+    // Each peer recorded its own operation and gossiped that; the merge of the two is what the
+    // local member holds. Neither peer saw the plan drain, so neither cleared it.
+    final var peerOne =
+        started.updatePartitionGroupConfig(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            g -> g.completeOperation(first, UnaryOperator.identity()));
+    final var peerTwo =
+        started.updatePartitionGroupConfig(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            g -> g.completeOperation(second, UnaryOperator.identity()));
+    final var drained = peerOne.merge(peerTwo);
+    final var drainedGroup = drained.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(drainedGroup.hasPendingChanges()).isFalse();
+    assertThat(drainedGroup.pendingChanges()).isPresent();
+
+    // when — the manager starts from that state and the group's appliers are registered, exactly as
+    // production does once local partitions are up. There is nothing for the local member to apply.
+    manager.start(() -> CompletableActorFuture.completed(drained)).join();
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+
+    // then — the plan is cleared, its completion recorded, and the phased plan archived
+    Awaitility.await("Drained change is finished without any local operation")
+        .untilAsserted(
+            () -> {
+              final var config = configuration(manager);
+              final var group = config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+              assertThat(group.pendingChanges()).isEmpty();
+              assertThat(group.lastChange()).isPresent();
+              assertThat(config.phasedChangeState().pending()).isEmpty();
+            });
+  }
+
+  @Test
+  void shouldFinishADrainedChangeOnAGossipRoundThatChangesNothing() {
+    // given — the same drained-but-uncleared state, but reached while the manager is already
+    // running and with the completion never having been attempted -- start() does not reconcile, so
+    // a broker that comes up in this state is waiting for something else to notice. A gossip round
+    // that merges to exactly what is already held takes the "merge changed nothing" branch, which
+    // skips reconcile() entirely; that branch is the only thing standing between a completion whose
+    // persist failed and a change that sits drained forever, since gossip is all that is left to
+    // perturb a converged cluster.
+    final var manager = newManager(MEMBER_0);
+    final var graph = OperationGraph.builder();
+    final var peerOperation = graph.add(new PartitionLeaveOperation(MEMBER_1, 1, 1));
+    final var drained =
+        threeMemberCluster()
+            .initPlan(
+                List.of(
+                    new PartitionGroupPhase(
+                        Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, graph.build()))))
+            .updatePartitionGroupConfig(
+                CurrentClusterConfiguration.DEFAULT_GROUP,
+                g -> g.completeOperation(peerOperation, UnaryOperator.identity()));
+    manager.start(() -> CompletableActorFuture.completed(drained)).join();
+    assertThat(
+            configuration(manager)
+                .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                .pendingChanges())
+        .describedAs("start() alone does not finish the drained change")
+        .isPresent();
+
+    // when — a peer gossips the very same state back, so the merge changes nothing locally
+    manager.onGossipReceivedCurrent(drained);
+
+    // then
+    Awaitility.await("Drained change is finished on a gossip round")
+        .untilAsserted(
+            () -> {
+              final var group =
+                  configuration(manager).partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+              assertThat(group.pendingChanges()).isEmpty();
+              assertThat(group.lastChange()).isPresent();
+            });
+  }
+
+  /** Three active members, all replicating partitions 1 and 2 of the default group. */
+  private CurrentClusterConfiguration threeMemberCluster() {
+    final var replicated =
+        BrokerPartitionState.initialize(
+            Map.of(
+                1, PartitionState.active(1, partitionConfig),
+                2, PartitionState.active(1, partitionConfig)));
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_2, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
+        Map.of(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            new PartitionGroupConfiguration(
+                1,
+                0,
+                Map.of(MEMBER_0, replicated, MEMBER_1, replicated, MEMBER_2, replicated),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty())),
+        PhasedChangeState.empty());
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
@@ -44,7 +44,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -165,7 +165,7 @@ final class ClusterConfigurationManagerImplTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)))))))
@@ -220,7 +220,7 @@ final class ClusterConfigurationManagerImplTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(
@@ -290,7 +290,7 @@ final class ClusterConfigurationManagerImplTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)),
@@ -427,7 +427,7 @@ final class ClusterConfigurationManagerImplTest {
                 c.initPlan(
                     List.of(
                         new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0))),
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))))))
@@ -502,9 +502,9 @@ final class ClusterConfigurationManagerImplTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of("a", List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))),
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of("b", List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))))))
         .join();
 
@@ -684,7 +684,7 @@ final class ClusterConfigurationManagerImplTest {
         PhasedChangePlan.init(
             1,
             List.of(
-                new PartitionGroupParallelPhase(
+                PartitionGroupPhase.sequential(
                     Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, List.of(leaveOperation)))),
             Instant.EPOCH);
     final var seeded =
@@ -857,7 +857,7 @@ final class ClusterConfigurationManagerImplTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))))))
@@ -934,7 +934,7 @@ final class ClusterConfigurationManagerImplTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))))))
@@ -1194,7 +1194,7 @@ final class ClusterConfigurationManagerImplTest {
                 PhasedChangeState.empty())
             .initPlan(
                 List.of(
-                    new PartitionGroupParallelPhase(
+                    PartitionGroupPhase.sequential(
                         Map.of(
                             CurrentClusterConfiguration.DEFAULT_GROUP,
                             List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1))))));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChange
 import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
@@ -38,6 +39,7 @@ import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -51,17 +53,21 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.util.Either;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -308,6 +314,299 @@ final class ClusterConfigurationManagerImplTest {
           .describedAs("member 0 left group '%s'", groupId)
           .isFalse();
     }
+  }
+
+  @Test
+  void shouldApplyEveryRunnableGraphOperationOfTheLocalMember() {
+    // given — a graph phase whose two operations have no edge between them, so both are runnable
+    // from the start. Under the queue the local member would have applied one, gossiped, and only
+    // then been offered the second.
+    final var manager = newManager(MEMBER_0);
+    manager.updateMultiConfiguration(ignored -> twoPartitionCluster()).join();
+    final var graph = OperationGraph.builder();
+    graph.add(new PartitionLeaveOperation(MEMBER_0, 1, 1));
+    graph.add(new PartitionLeaveOperation(MEMBER_0, 2, 1));
+
+    // when
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupPhase(
+                            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, graph.build())))))
+        .join();
+
+    // then — both ran and the graph drained, without any peer having to move
+    final var defaultGroup =
+        configuration(manager).partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.pendingGraphChanges()).isEmpty();
+    assertThat(defaultGroup.hasMember(MEMBER_0)).isFalse();
+  }
+
+  @Test
+  void shouldNotApplyAGraphOperationWhoseDependencyHasNotCompleted() {
+    // given — the local member's operation waits on a peer's, which nothing here will run. This is
+    // what keeps a declared edge meaningful: without it the local member would apply its own
+    // operation as soon as it saw the plan.
+    final var manager = newManager(MEMBER_0);
+    manager.updateMultiConfiguration(ignored -> twoPartitionCluster()).join();
+    final var graph = OperationGraph.builder();
+    final var peerOperation = graph.add(new PartitionLeaveOperation(MEMBER_1, 1, 1));
+    graph.add(new PartitionLeaveOperation(MEMBER_0, 2, 1), Set.of(peerOperation));
+
+    // when
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupPhase(
+                            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, graph.build())))))
+        .join();
+
+    // then — nothing was applied and both operations are still outstanding
+    final var defaultGroup =
+        configuration(manager).partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.pendingGraphChanges().orElseThrow().completed()).isEmpty();
+    assertThat(defaultGroup.getMember(MEMBER_0).partitions()).containsOnlyKeys(1, 2);
+  }
+
+  @Test
+  void shouldNotExceedTheConcurrencyCapAcrossReentrantReconciliation() {
+    // given — 6 independent operations on one broker, well above the concurrency cap (4), each
+    // held open (never resolving) so the count of simultaneously-applying operations can be
+    // observed. Staging an operation persists synchronously, which re-enters reconcile() before
+    // the operation that triggered it has itself been counted — a cap tracked as a count local to
+    // one reconcile() call resets to zero on every such nesting and never actually bounds
+    // anything, which is exactly the shape this pins.
+    final var member1 = MemberId.from("1");
+    final var startedCount = new AtomicInteger();
+    final var peakConcurrent = new AtomicInteger();
+    final var manager = newManager(MEMBER_0);
+    final var real =
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor());
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        operation -> {
+          final var delegate = real.getApplier(operation);
+          return new PartitionGroupConfigurationChangeApplier() {
+            @Override
+            public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+                final GlobalConfiguration global, final PartitionGroupConfiguration group) {
+              return delegate.init(global, group);
+            }
+
+            @Override
+            public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+              peakConcurrent.updateAndGet(ignored -> startedCount.incrementAndGet());
+              // Never completes: a real (I/O-bound) applier stays in flight for a while too, and
+              // that is the window the cap is meant to hold.
+              return new CompletableActorFuture<>();
+            }
+          };
+        });
+
+    final Map<Integer, PartitionState> partitions = new HashMap<>();
+    for (int p = 1; p <= 6; p++) {
+      partitions.put(p, PartitionState.active(1, partitionConfig));
+    }
+    manager
+        .updateMultiConfiguration(
+            ignored ->
+                new CurrentClusterConfiguration(
+                    CurrentClusterConfiguration.INITIAL_VERSION,
+                    new GlobalConfiguration(
+                        1,
+                        Optional.empty(),
+                        Map.of(
+                            MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                            member1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                    Map.of(
+                        CurrentClusterConfiguration.DEFAULT_GROUP,
+                        new PartitionGroupConfiguration(
+                            1,
+                            0,
+                            Map.of(
+                                MEMBER_0, BrokerPartitionState.initialize(partitions),
+                                member1, BrokerPartitionState.initialize(partitions)),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty())),
+                    PhasedChangeState.empty()))
+        .join();
+
+    // when — member 0 leaves all 6 of its own replicas; each partition keeps member 1's replica,
+    // so every leave is independently valid and none depends on another
+    final var graph = OperationGraph.builder();
+    for (int p = 1; p <= 6; p++) {
+      graph.add(new PartitionLeaveOperation(MEMBER_0, p, 1));
+    }
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupPhase(
+                            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, graph.build())))))
+        .join();
+
+    // then — never more than the cap were simultaneously applying, however deep the reentrant
+    // cascade of staging one operation into the next went
+    assertThat(peakConcurrent).hasValueLessThanOrEqualTo(4);
+  }
+
+  @Test
+  void shouldStartAReplacementOperationBlockedByAStaleInFlightId() {
+    // given — operation ids restart at 0 for every fresh graph, and in-flight tracking is keyed by
+    // that bare id, per group. Cancelling a plan while one of its operations is still applying
+    // (async, real work, not instantly resolving), then starting a replacement on the same group,
+    // reproduces the case: the replacement's own id-0 operation is runnable but looks like it is
+    // already in flight, because id 0 still is -- from the plan that no longer exists.
+    final var member1 = MemberId.from("1");
+    final var pendingApplies =
+        new HashMap<Integer, CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>>();
+    final var applied = new java.util.ArrayList<Integer>();
+    final var manager = newManager(MEMBER_0);
+    final var real =
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor());
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        operation -> {
+          final var partitionOperation = (PartitionLeaveOperation) operation;
+          final var delegate = real.getApplier(operation);
+          return new PartitionGroupConfigurationChangeApplier() {
+            @Override
+            public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+                final GlobalConfiguration global, final PartitionGroupConfiguration group) {
+              return delegate.init(global, group);
+            }
+
+            @Override
+            public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+              applied.add(partitionOperation.partitionId());
+              final var future =
+                  new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
+              pendingApplies.put(partitionOperation.partitionId(), future);
+              return future;
+            }
+          };
+        });
+
+    final var replicated =
+        BrokerPartitionState.initialize(
+            Map.of(
+                1, PartitionState.active(1, partitionConfig),
+                2, PartitionState.active(1, partitionConfig)));
+    manager
+        .updateMultiConfiguration(
+            ignored ->
+                new CurrentClusterConfiguration(
+                    CurrentClusterConfiguration.INITIAL_VERSION,
+                    new GlobalConfiguration(
+                        1,
+                        Optional.empty(),
+                        Map.of(
+                            MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                            member1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                    Map.of(
+                        CurrentClusterConfiguration.DEFAULT_GROUP,
+                        new PartitionGroupConfiguration(
+                            1,
+                            0,
+                            Map.of(MEMBER_0, replicated, member1, replicated),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty())),
+                    PhasedChangeState.empty()))
+        .join();
+
+    // when — plan A leaves partition 1; its single operation gets id 0 and is still applying
+    // (its future is deliberately left unresolved) when the plan is cancelled
+    final var planAGraph = OperationGraph.builder();
+    planAGraph.add(new PartitionLeaveOperation(MEMBER_0, 1, 1));
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP, planAGraph.build())))))
+        .join();
+    assertThat(applied).containsExactly(1);
+    final var planAId =
+        configuration(manager).phasedChangeState().pending().keySet().iterator().next();
+    manager.updateMultiConfiguration(c -> c.cancelPendingChanges(planAId)).join();
+
+    // and — plan B leaves partition 2 instead; its single operation is also id 0 (a fresh graph
+    // numbers from zero), and is runnable, but is skipped: id 0 is still in flight, from plan A
+    final var planBGraph = OperationGraph.builder();
+    planBGraph.add(new PartitionLeaveOperation(MEMBER_0, 2, 1));
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP, planBGraph.build())))))
+        .join();
+    assertThat(applied).describedAs("plan B blocked behind plan A's stale id").containsExactly(1);
+
+    // and — plan A's operation finally resolves. Its own plan is long gone (the version check
+    // inside onApplied sees that and returns early), but this must not also strand plan B's
+    // operation that only looked blocked because of the id it reused
+    pendingApplies.get(1).complete(UnaryOperator.identity());
+
+    // then — plan B's operation starts once the stale id clears
+    assertThat(applied)
+        .describedAs("plan B's operation runs once the stale in-flight id is gone")
+        .containsExactly(1, 2);
+  }
+
+  /** Both members replicate partitions 1 and 2, so either may leave either partition. */
+  private CurrentClusterConfiguration twoPartitionCluster() {
+    final var replicated =
+        BrokerPartitionState.initialize(
+            Map.of(
+                1, PartitionState.active(1, partitionConfig),
+                2, PartitionState.active(1, partitionConfig)));
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
+        Map.of(
+            CurrentClusterConfiguration.DEFAULT_GROUP,
+            new PartitionGroupConfiguration(
+                1,
+                0,
+                Map.of(MEMBER_0, replicated, MEMBER_1, replicated),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty())),
+        PhasedChangeState.empty());
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
@@ -464,12 +464,12 @@ final class ClusterConfigurationManagerImplTest {
   }
 
   @Test
-  void shouldStartAReplacementOperationBlockedByAStaleInFlightId() {
-    // given — operation ids restart at 0 for every fresh graph, and in-flight tracking is keyed by
-    // that bare id, per group. Cancelling a plan while one of its operations is still applying
-    // (async, real work, not instantly resolving), then starting a replacement on the same group,
-    // reproduces the case: the replacement's own id-0 operation is runnable but looks like it is
-    // already in flight, because id 0 still is -- from the plan that no longer exists.
+  void shouldNotLetACancelledPlansInFlightOperationBlockItsReplacement() {
+    // given — operation ids restart at 0 for every fresh graph. Cancelling a plan while one of its
+    // operations is still applying (async, real work, never resolving here -- the "stuck change"
+    // that gets a plan cancelled in the first place), then starting a replacement on the same
+    // group, is the case: the replacement's own id-0 operation is runnable, and must not be taken
+    // for the cancelled plan's id-0 operation that is still in flight and may never finish.
     final var member1 = MemberId.from("1");
     final var pendingApplies =
         new HashMap<Integer, CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>>();
@@ -553,8 +553,8 @@ final class ClusterConfigurationManagerImplTest {
         configuration(manager).phasedChangeState().pending().keySet().iterator().next();
     manager.updateMultiConfiguration(c -> c.cancelPendingChanges(planAId)).join();
 
-    // and — plan B leaves partition 2 instead; its single operation is also id 0 (a fresh graph
-    // numbers from zero), and is runnable, but is skipped: id 0 is still in flight, from plan A
+    // when — plan B leaves partition 2 instead; its single operation is also id 0 (a fresh graph
+    // numbers from zero)
     final var planBGraph = OperationGraph.builder();
     planBGraph.add(new PartitionLeaveOperation(MEMBER_0, 2, 1));
     manager
@@ -566,17 +566,17 @@ final class ClusterConfigurationManagerImplTest {
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP, planBGraph.build())))))
         .join();
-    assertThat(applied).describedAs("plan B blocked behind plan A's stale id").containsExactly(1);
 
-    // and — plan A's operation finally resolves. Its own plan is long gone (the version check
-    // inside onApplied sees that and returns early), but this must not also strand plan B's
-    // operation that only looked blocked because of the id it reused
-    pendingApplies.get(1).complete(UnaryOperator.identity());
-
-    // then — plan B's operation starts once the stale id clears
+    // then — it starts immediately, without waiting on plan A's operation. In-flight state is keyed
+    // by (plan id, operation id), so the shared id 0 is not a collision; keyed by the bare id it
+    // would be, and plan B would be stuck for as long as plan A's operation stayed unresolved --
+    // forever, if it is genuinely hung, since nothing else reclaims that entry.
     assertThat(applied)
-        .describedAs("plan B's operation runs once the stale in-flight id is gone")
+        .describedAs("plan B's operation is not blocked by plan A's stale in-flight id")
         .containsExactly(1, 2);
+    assertThat(pendingApplies.get(1).isDone())
+        .describedAs("plan A's operation is still unresolved")
+        .isFalse();
   }
 
   /** Both members replicate partitions 1 and 2, so either may leave either partition. */

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -36,7 +36,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -397,7 +397,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionLeaveOperation(MEMBER_1, 1, 1)))))))
@@ -459,7 +459,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionLeaveOperation(MEMBER_1, 1, 1)))))))
@@ -472,7 +472,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 "tenanta", List.of(new PartitionLeaveOperation(MEMBER_0, 2, 1)))))))
         .join();
@@ -517,7 +517,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 "tenanta", List.of(new PartitionLeaveOperation(MEMBER_0, 2, 1)))))))
         .join();
@@ -551,7 +551,7 @@ final class NewModelConfigurationChangeCoordinatorTest {
             c ->
                 c.initPlan(
                     List.of(
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 CurrentClusterConfiguration.DEFAULT_GROUP,
                                 List.of(new PartitionLeaveOperation(MEMBER_1, 1, 1)))))))

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionGroupExporterStateInitializerTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import java.time.Instant;
 import java.util.List;
@@ -457,7 +457,7 @@ final class PartitionGroupExporterStateInitializerTest {
     final var plan =
         PhasedChangePlan.initForRestore(
             List.of(
-                new PartitionGroupParallelPhase(
+                PartitionGroupPhase.sequential(
                     Map.of(
                         CurrentClusterConfiguration.DEFAULT_GROUP,
                         List.of(new UpdateRoutingState(LOCAL_MEMBER_ID, Optional.empty()))))),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeAwaiterTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeAwaiterTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ExportingStateChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.util.Either;
@@ -242,12 +242,11 @@ final class ClusterConfigurationChangeAwaiterTest {
                     CurrentClusterConfiguration.init(),
                     CurrentClusterConfiguration.init(),
                     List.of(
-                        new PartitionGroupParallelPhase(
-                            Map.of(
-                                "default",
-                                List.of(
-                                    new ExportingStateChangeOperation(
-                                        MemberId.from("0"), ExportingState.PAUSED)))))))));
+                        PartitionGroupPhase.sequential(
+                            "default",
+                            List.of(
+                                new ExportingStateChangeOperation(
+                                    MemberId.from("0"), ExportingState.PAUSED))))))));
   }
 
   private CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> topology(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -35,7 +35,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
@@ -353,15 +353,14 @@ final class ClusterPatchRequestTransformerTest {
         Optional.empty());
   }
 
-  private static PartitionGroupParallelPhase singlePhase(
-      final Either<Exception, List<Phase>> result) {
+  private static PartitionGroupPhase singlePhase(final Either<Exception, List<Phase>> result) {
     assertThat(result).isRight();
     Assertions.assertThat(result.get()).hasSize(1);
-    return (PartitionGroupParallelPhase) result.get().get(0);
+    return (PartitionGroupPhase) result.get().get(0);
   }
 
   private static List<PartitionBootstrapOperation> bootstraps(
-      final PartitionGroupParallelPhase phase, final String groupId) {
+      final PartitionGroupPhase phase, final String groupId) {
     return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
         .filter(PartitionBootstrapOperation.class::isInstance)
         .map(PartitionBootstrapOperation.class::cast)
@@ -369,7 +368,7 @@ final class ClusterPatchRequestTransformerTest {
   }
 
   private static List<PartitionJoinOperation> joins(
-      final PartitionGroupParallelPhase phase, final String groupId) {
+      final PartitionGroupPhase phase, final String groupId) {
     return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
         .filter(PartitionJoinOperation.class::isInstance)
         .map(PartitionJoinOperation.class::cast)
@@ -642,7 +641,7 @@ final class ClusterPatchRequestTransformerTest {
     // then
     assertThat(result).isRight();
     Assertions.assertThat(result.get()).hasSize(3);
-    final var partitionPhase = (PartitionGroupParallelPhase) result.get().get(1);
+    final var partitionPhase = (PartitionGroupPhase) result.get().get(1);
     Assertions.assertThat(partitionPhase.groupOperations()).containsOnlyKeys(TENANT_B);
     Assertions.assertThat(partitionPhase.groupOperations().get(TENANT_B))
         .describedAs("tenant-b gives up the partition on the departing broker")

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -27,7 +27,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -126,7 +126,7 @@ final class ClusterPurgeRequestTransformerTest {
 
     // then — both tenants are purged, each within its own group
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A, TENANT_B);
     assertThat(phase.groupOperations().get(TENANT_A))
         .containsExactly(
@@ -157,7 +157,7 @@ final class ClusterPurgeRequestTransformerTest {
 
     // then — tenant B keeps its partitions and its history
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
   }
 
@@ -262,7 +262,7 @@ final class ClusterPurgeRequestTransformerTest {
   private List<PartitionGroupOperation> operationsOf(
       final Either<Exception, List<Phase>> result, final String groupId) {
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     return phase.groupOperations().get(groupId);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
@@ -33,7 +33,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -66,7 +66,7 @@ final class ClusterRestoreRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(TENANT_B, tenantBRestoreOperations(List.of(55L)))));
   }
 
@@ -86,7 +86,7 @@ final class ClusterRestoreRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     DEFAULT_GROUP, defaultRestoreOperations(List.of(100L)),
                     TENANT_B, tenantBRestoreOperations(List.of(55L)),
@@ -109,7 +109,7 @@ final class ClusterRestoreRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(TENANT_B, tenantBRestoreOperations(List.of(55L)))));
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -36,7 +36,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
@@ -461,15 +461,14 @@ final class ClusterScaleRequestTransformerTest {
         Optional.empty(), newPartitionCount, Optional.empty(), Optional.empty(), physicalTenantId);
   }
 
-  private static PartitionGroupParallelPhase singlePhase(
-      final Either<Exception, List<Phase>> result) {
+  private static PartitionGroupPhase singlePhase(final Either<Exception, List<Phase>> result) {
     assertThat(result).isRight();
     Assertions.assertThat(result.get()).hasSize(1);
-    return (PartitionGroupParallelPhase) result.get().get(0);
+    return (PartitionGroupPhase) result.get().get(0);
   }
 
   private static List<PartitionBootstrapOperation> bootstraps(
-      final PartitionGroupParallelPhase phase, final String groupId) {
+      final PartitionGroupPhase phase, final String groupId) {
     return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
         .filter(PartitionBootstrapOperation.class::isInstance)
         .map(PartitionBootstrapOperation.class::cast)
@@ -477,7 +476,7 @@ final class ClusterScaleRequestTransformerTest {
   }
 
   private static List<PartitionJoinOperation> joins(
-      final PartitionGroupParallelPhase phase, final String groupId) {
+      final PartitionGroupPhase phase, final String groupId) {
     return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
         .filter(PartitionJoinOperation.class::isInstance)
         .map(PartitionJoinOperation.class::cast)
@@ -706,7 +705,7 @@ final class ClusterScaleRequestTransformerTest {
     // then
     assertThat(result).isRight();
     Assertions.assertThat(result.get()).hasSize(3);
-    final var partitionPhase = (PartitionGroupParallelPhase) result.get().get(1);
+    final var partitionPhase = (PartitionGroupPhase) result.get().get(1);
     Assertions.assertThat(partitionPhase.groupOperations()).containsOnlyKeys(TENANT_B);
     Assertions.assertThat(joins(partitionPhase, TENANT_B))
         .describedAs("tenant-b's partition is placed on a retained broker")

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
@@ -69,7 +69,7 @@ final class ExporterDeleteRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations())
         .containsOnlyKeys(TENANT_A, TENANT_B)
         .allSatisfy(
@@ -95,7 +95,7 @@ final class ExporterDeleteRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
   }
 
@@ -130,7 +130,7 @@ final class ExporterDeleteRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations())
         .containsOnlyKeys(TENANT_A)
         .hasEntrySatisfying(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
@@ -62,7 +62,7 @@ final class ExporterDisableRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations())
         .containsOnlyKeys(TENANT_A, TENANT_B)
         .allSatisfy(
@@ -88,7 +88,7 @@ final class ExporterDisableRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
   }
 
@@ -108,7 +108,7 @@ final class ExporterDisableRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations())
         .containsOnlyKeys(TENANT_A)
         .hasEntrySatisfying(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
@@ -68,7 +68,7 @@ final class ExporterEnableRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations())
         .containsOnlyKeys(TENANT_A, TENANT_B)
         .allSatisfy(
@@ -92,7 +92,7 @@ final class ExporterEnableRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
   }
 
@@ -112,7 +112,7 @@ final class ExporterEnableRequestTransformerTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations())
         .containsOnlyKeys(TENANT_A)
         .hasEntrySatisfying(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExportingStateChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExportingStateChangeRequestTransformerTest.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ExportingStateChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
@@ -55,7 +55,7 @@ final class ExportingStateChangeRequestTransformerTest {
 
     // then — one phase carrying both groups, so their partitions change concurrently
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations())
         .containsOnlyKeys(TENANT_A, TENANT_B)
         .allSatisfy(
@@ -81,7 +81,7 @@ final class ExportingStateChangeRequestTransformerTest {
 
     // then — the group that has nothing to do is left out of the phase entirely
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations()).containsOnlyKeys(TENANT_A);
   }
 
@@ -105,7 +105,7 @@ final class ExportingStateChangeRequestTransformerTest {
 
     // then — only the member not yet in the target state gets an operation
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations().get(TENANT_A))
         .containsExactly(new ExportingStateChangeOperation(id0, ExportingState.PAUSED));
   }
@@ -129,7 +129,7 @@ final class ExportingStateChangeRequestTransformerTest {
 
     // then — one operation for the member, not one per partition
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations().get(TENANT_A))
         .containsExactly(new ExportingStateChangeOperation(id0, ExportingState.PAUSED));
   }
@@ -150,7 +150,7 @@ final class ExportingStateChangeRequestTransformerTest {
 
     // then — tenant-b keeps exporting
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations())
         .containsOnlyKeys(TENANT_A)
         .hasEntrySatisfying(
@@ -233,7 +233,7 @@ final class ExportingStateChangeRequestTransformerTest {
 
     // then — id1 owns no partition, so there is nothing on it to change
     EitherAssert.assertThat(result).isRight();
-    final var phase = (PartitionGroupParallelPhase) result.get().getFirst();
+    final var phase = (PartitionGroupPhase) result.get().getFirst();
     assertThat(phase.groupOperations().get(TENANT_A))
         .containsExactly(new ExportingStateChangeOperation(id0, ExportingState.PAUSED));
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.time.Instant;
@@ -64,7 +64,7 @@ final class ModeChangeRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     DEFAULT_GROUP,
                     List.of(
@@ -99,7 +99,7 @@ final class ModeChangeRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     TENANT_B,
                     List.of(
@@ -119,7 +119,7 @@ final class ModeChangeRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     DEFAULT_GROUP,
                     List.of(
@@ -143,7 +143,7 @@ final class ModeChangeRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     DEFAULT_GROUP,
                     List.of(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
@@ -36,7 +36,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -315,7 +315,7 @@ final class RestoreRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     DEFAULT_PHYSICAL_TENANT_ID,
                     List.of(
@@ -354,7 +354,7 @@ final class RestoreRequestTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     DEFAULT_PHYSICAL_TENANT_ID,
                     List.of(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -36,7 +36,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
@@ -455,7 +455,7 @@ class ScaleRequestTransformerTest {
                 assertThat(((GlobalPhase) list.get(0)).operations())
                     .contains(new MemberJoinOperation(MemberId.from("3")))
                     .doesNotContain(new MemberLeaveOperation(MemberId.from("2")));
-                assertThat(list.get(1)).isInstanceOf(PartitionGroupParallelPhase.class);
+                assertThat(list.get(1)).isInstanceOf(PartitionGroupPhase.class);
                 assertThat(((GlobalPhase) list.get(2)).operations())
                     .contains(new MemberLeaveOperation(MemberId.from("2")))
                     .doesNotContain(new MemberJoinOperation(MemberId.from("3")));
@@ -559,18 +559,17 @@ class ScaleRequestTransformerTest {
           .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
     }
 
-    private PartitionGroupParallelPhase partitionPhase(
-        final Either<Exception, List<Phase>> phases) {
+    private PartitionGroupPhase partitionPhase(final Either<Exception, List<Phase>> phases) {
       EitherAssert.assertThat(phases).isRight();
-      return (PartitionGroupParallelPhase)
+      return (PartitionGroupPhase)
           phases.get().stream()
-              .filter(PartitionGroupParallelPhase.class::isInstance)
+              .filter(PartitionGroupPhase.class::isInstance)
               .findFirst()
               .orElseThrow(() -> new AssertionError("no partition group phase in " + phases.get()));
     }
 
     private List<PartitionJoinOperation> joinedPartitions(
-        final PartitionGroupParallelPhase phase, final String groupId) {
+        final PartitionGroupPhase phase, final String groupId) {
       return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
           .filter(PartitionJoinOperation.class::isInstance)
           .map(PartitionJoinOperation.class::cast)
@@ -578,7 +577,7 @@ class ScaleRequestTransformerTest {
     }
 
     private List<PartitionLeaveOperation> leftPartitions(
-        final PartitionGroupParallelPhase phase, final String groupId) {
+        final PartitionGroupPhase phase, final String groupId) {
       return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
           .filter(PartitionLeaveOperation.class::isInstance)
           .map(PartitionLeaveOperation.class::cast)
@@ -674,8 +673,8 @@ class ScaleRequestTransformerTest {
       EitherAssert.assertThat(phases).isRight();
       final var partitionPhase =
           phases.get().stream()
-              .filter(PartitionGroupParallelPhase.class::isInstance)
-              .map(PartitionGroupParallelPhase.class::cast)
+              .filter(PartitionGroupPhase.class::isInstance)
+              .map(PartitionGroupPhase.class::cast)
               .findFirst()
               .orElseThrow();
       assertThat(partitionPhase.groupOperations())

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestChangePlan.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestChangePlan.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -50,8 +50,10 @@ final class TestChangePlan {
     for (final var phase : phases) {
       switch (phase) {
         case final GlobalPhase globalPhase -> operations.addAll(globalPhase.operations());
-        case final PartitionGroupParallelPhase parallelPhase ->
-            parallelPhase.groupOperations().values().forEach(operations::addAll);
+        // A graph's operations flatten in plan order; the edges between them are execution detail
+        // this view does not carry.
+        case final PartitionGroupPhase groupPhase ->
+            groupPhase.groupGraphs().values().forEach(graph -> operations.addAll(graph.inOrder()));
       }
     }
     return operations;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
@@ -23,10 +23,13 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import java.util.List;
+import java.util.TreeMap;
 
 /**
  * Drains a change plan against the same appliers the broker uses, so a transformer test can assert
@@ -77,8 +80,8 @@ final class TestTopologyChangeSimulator {
       current =
           switch (plan.currentPhase()) {
             case final GlobalPhase ignored -> drainGlobalPhase(current, globalAppliers);
-            case final PartitionGroupParallelPhase parallelPhase ->
-                drainPartitionGroupPhase(current, parallelPhase, groupAppliers);
+            case final PartitionGroupPhase groupPhase ->
+                drainPartitionGroupPhase(current, groupPhase, groupAppliers);
           };
       current =
           current.phasedChangeState().pending().get(planId).hasNextPhase()
@@ -108,26 +111,55 @@ final class TestTopologyChangeSimulator {
     return current;
   }
 
+  /**
+   * Drains a partition-group phase by repeatedly running whatever each group's graph currently
+   * declares runnable, in operation-id order. A graph can offer several operations at once and
+   * offers none while an unfinished dependency blocks them — so a round that finds nothing runnable
+   * while operations remain is a stalled graph, not a finished one, and is failed loudly rather
+   * than looping forever.
+   */
   private static CurrentClusterConfiguration drainPartitionGroupPhase(
       final CurrentClusterConfiguration configuration,
-      final PartitionGroupParallelPhase phase,
+      final PartitionGroupPhase phase,
       final PartitionGroupConfigurationChangeAppliers appliers) {
     var current = configuration;
-    for (final var groupId : phase.groupOperations().keySet()) {
+    for (final var groupId : phase.groupGraphs().keySet()) {
       while (current.partitionGroup(groupId).hasPendingChanges()) {
         final var group = current.partitionGroup(groupId);
-        final var operation = group.nextPendingOperation();
-        final var applier = appliers.getApplier(operation);
-        final var init = applier.init(current.globalConfiguration(), group);
-        if (init.isLeft()) {
-          fail("Failed to init operation '%s' : '%s'", operation, init.getLeft());
+        final var plan = group.pendingGraphChanges().orElseThrow();
+        final var runnable = new TreeMap<OperationId, PartitionGroupOperation>();
+        plan.graph()
+            .operations()
+            .forEach(
+                (operationId, planned) -> {
+                  if (plan.isRunnable(operationId)) {
+                    runnable.put(operationId, (PartitionGroupOperation) planned.operation());
+                  }
+                });
+        if (runnable.isEmpty()) {
+          fail(
+              "Graph change of group '%s' has %d operation(s) left but none is runnable; blocked by %s",
+              groupId, plan.pendingOperations().size(), plan.blockedBy());
         }
-        final var transformer = applier.apply().join();
-        current =
-            current
-                .updatePartitionGroupConfig(groupId, init.get())
-                .updatePartitionGroupConfig(
-                    groupId, updated -> updated.advanceConfigurationChange(transformer));
+        for (final var entry : runnable.entrySet()) {
+          final var operation = entry.getValue();
+          final var applier = appliers.getApplier(operation);
+          final var staged = current.partitionGroup(groupId);
+          final var init = applier.init(current.globalConfiguration(), staged);
+          if (init.isLeft()) {
+            fail("Failed to init operation '%s' : '%s'", operation, init.getLeft());
+          }
+          final var transformer = applier.apply().join();
+          current =
+              current
+                  .updatePartitionGroupConfig(groupId, init.get())
+                  .updatePartitionGroupConfig(
+                      groupId,
+                      updated ->
+                          updated
+                              .completeOperation(entry.getKey(), transformer)
+                              .completeGraphChangeIfDrained());
+        }
       }
     }
     return current;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
@@ -126,7 +126,7 @@ final class TestTopologyChangeSimulator {
     for (final var groupId : phase.groupGraphs().keySet()) {
       while (current.partitionGroup(groupId).hasPendingChanges()) {
         final var group = current.partitionGroup(groupId);
-        final var plan = group.pendingGraphChanges().orElseThrow();
+        final var plan = group.pendingChanges().orElseThrow();
         final var runnable = new TreeMap<OperationId, PartitionGroupOperation>();
         plan.graph()
             .operations()

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -114,7 +114,7 @@ class UpdateRoutingStateTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(TENANT_B, List.of(new UpdateRoutingState(id1, routingState)))));
   }
 
@@ -132,7 +132,7 @@ class UpdateRoutingStateTransformerTest {
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get())
         .containsExactly(
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(DEFAULT_GROUP, List.of(new UpdateRoutingState(id0, routingState)))));
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -30,7 +30,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.HashMap;
@@ -499,10 +499,10 @@ final class ZoneMigrationRequestTransformerTest {
                           "Zone migration requires a persisted zone-aware partition distribution config, but was not set."));
     }
 
-    private PartitionGroupParallelPhase partitionPhase(final List<Phase> phases) {
+    private PartitionGroupPhase partitionPhase(final List<Phase> phases) {
       return phases.stream()
-          .filter(PartitionGroupParallelPhase.class::isInstance)
-          .map(PartitionGroupParallelPhase.class::cast)
+          .filter(PartitionGroupPhase.class::isInstance)
+          .map(PartitionGroupPhase.class::cast)
           .findFirst()
           .orElseThrow(
               () -> new AssertionError("expected the plan to contain partition work: " + phases));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
@@ -14,10 +14,23 @@ import com.google.protobuf.Timestamp;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Topology;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -25,11 +38,14 @@ import org.junit.jupiter.params.provider.EnumSource;
 /**
  * Edge cases for the {@code CurrentClusterConfiguration} serialization that the property test
  * ({@code ProtoBufSerializerPropertyTest#shouldEncodeAndDecodeCurrentClusterConfiguration}) cannot
- * exercise: decoding invalid bytes and decoding a proto that carries a broker lifecycle state which
- * the domain model cannot represent. The happy-path round-trips are all covered by the property
- * test.
+ * exercise: decoding invalid bytes, decoding a proto that carries a broker lifecycle state which
+ * the domain model cannot represent, and a group whose pending change is a dependency graph. The
+ * remaining happy-path round-trips are covered by the property test.
  */
 final class CurrentClusterConfigurationSerializerTest {
+
+  private static final MemberId MEMBER = MemberId.from("0");
+  private static final MemberId OTHER_MEMBER = MemberId.from("1");
 
   private final ProtoBufSerializer serializer = new ProtoBufSerializer();
 
@@ -102,5 +118,148 @@ final class CurrentClusterConfigurationSerializerTest {
     // then
     assertThat(decoded.getClusterConfiguration()).isEqualTo(legacy);
     assertThat(decoded.getCurrentClusterConfiguration()).isNull();
+  }
+
+  @Test
+  void shouldRejectADecodedGraphWithADependencyCycle() {
+    // given — a proto whose two operations depend on each other. Nothing produces this from the
+    // domain model (OperationGraph.of rejects the cycle before it could ever be encoded), so the
+    // only way it reaches decode is corruption or a future encoding bug -- exactly what a decode
+    // path has to distrust rather than assume.
+    final var operationA =
+        Topology.PartitionGroupChangeOperation.newBuilder()
+            .setMemberId(MEMBER.id())
+            .setModeChange(
+                Topology.ModeChangeOperation.newBuilder().setMode(Topology.Mode.MODE_PROCESSING))
+            .build();
+    final var plannedA =
+        Topology.PlannedOperation.newBuilder().setId(0).setOperation(operationA).addDependsOn(1);
+    final var plannedB =
+        Topology.PlannedOperation.newBuilder().setId(1).setOperation(operationA).addDependsOn(0);
+    final var graph =
+        Topology.OperationGraph.newBuilder()
+            .addOperations(plannedA)
+            .addOperations(plannedB)
+            .build();
+    final var plan =
+        Topology.DependencyChangePlan.newBuilder()
+            .setId(1)
+            .setStatus(Topology.ChangeStatus.IN_PROGRESS)
+            .setStartedAt(Timestamp.newBuilder().build())
+            .setGraph(graph)
+            .build();
+    final var group =
+        Topology.PartitionGroupConfiguration.newBuilder()
+            .setVersion(1)
+            .setIncarnationNumber(0)
+            .setPendingGraphChanges(plan)
+            .build();
+    final var proto =
+        Topology.CurrentClusterConfiguration.newBuilder()
+            .setVersion(0)
+            .setGlobalConfiguration(Topology.GlobalConfiguration.newBuilder().setVersion(1).build())
+            .putPartitionGroups("tenant", group)
+            .build();
+
+    // when / then
+    assertThatThrownBy(() -> serializer.decodeCurrentClusterConfiguration(proto.toByteArray()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("dependency cycle");
+  }
+
+  @Test
+  void shouldRoundTripAGroupCarryingADependencyGraphChange() {
+    // given — a group whose pending change is a graph rather than a queue. The property test only
+    // generates queue plans, because the two models share one field and a generator cannot produce
+    // a graph whose edges and write sets are consistent.
+    final var graph = restoreGraph();
+    final var configuration = configurationWithGraph(graph);
+
+    // when
+    final var decoded =
+        serializer.decodeCurrentClusterConfiguration(
+            serializer.encodeCurrentClusterConfiguration(configuration));
+
+    // then — the operations and the edges between them both survive; an edge lost in transit would
+    // let a peer start an operation whose dependency has not run
+    assertThat(decoded).isEqualTo(configuration);
+    assertThat(decoded.partitionGroups().values())
+        .singleElement()
+        .satisfies(
+            group ->
+                assertThat(group.pendingGraphChanges().orElseThrow().graph()).isEqualTo(graph));
+  }
+
+  @Test
+  void shouldRoundTripPartialProgressThroughAGraph() {
+    // given — one operation of the graph has completed, which is the state a broker gossips while a
+    // graph change is in flight and the state a peer must be able to read to know what is runnable
+    final var started = groupWithGraph(restoreGraph());
+    final var firstOperation =
+        started.pendingGraphChanges().orElseThrow().graph().operations().firstKey();
+    final var inFlight =
+        configurationWith(started.completeOperation(firstOperation, UnaryOperator.identity()));
+
+    // when
+    final var decoded =
+        serializer.decodeCurrentClusterConfiguration(
+            serializer.encodeCurrentClusterConfiguration(inFlight));
+
+    // then
+    assertThat(decoded).isEqualTo(inFlight);
+    assertThat(decoded.partitionGroups().values())
+        .singleElement()
+        .satisfies(
+            group ->
+                assertThat(group.pendingGraphChanges().orElseThrow().completed())
+                    .containsKey(firstOperation));
+  }
+
+  /** A two-stage graph: both pre-restores may run at once, both restores wait for both of them. */
+  private static OperationGraph restoreGraph() {
+    final var builder = OperationGraph.builder();
+    final var preRestores =
+        Set.of(
+            builder.add(new PartitionPreRestoreOperation(MEMBER, 1)),
+            builder.add(new PartitionPreRestoreOperation(OTHER_MEMBER, 1)));
+    builder.add(new PartitionRestoreOperation(MEMBER, 1, new TreeSet<>(Set.of(1L))), preRestores);
+    builder.add(
+        new PartitionRestoreOperation(OTHER_MEMBER, 1, new TreeSet<>(Set.of(1L))), preRestores);
+    return builder.build();
+  }
+
+  private static CurrentClusterConfiguration configurationWithGraph(final OperationGraph graph) {
+    return configurationWith(groupWithGraph(graph));
+  }
+
+  private static PartitionGroupConfiguration groupWithGraph(final OperationGraph graph) {
+    final var members =
+        Map.of(
+            MEMBER, BrokerPartitionState.initialize(Map.of()),
+            OTHER_MEMBER, BrokerPartitionState.initialize(Map.of()));
+    return new PartitionGroupConfiguration(
+            1, 0, members, Optional.empty(), Optional.empty(), Optional.empty())
+        .startGraphConfigurationChange(graph);
+  }
+
+  private static CurrentClusterConfiguration configurationWith(
+      final PartitionGroupConfiguration group) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration(),
+        Map.of("tenant", group),
+        PhasedChangeState.empty());
+  }
+
+  private static GlobalConfiguration globalConfiguration() {
+    return new GlobalConfiguration(
+        1,
+        Optional.empty(),
+        Map.of(
+            MEMBER, new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE),
+            OTHER_MEMBER, new BrokerState(0, Instant.EPOCH, BrokerState.State.ACTIVE)),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
@@ -152,7 +152,7 @@ final class CurrentClusterConfigurationSerializerTest {
         Topology.PartitionGroupConfiguration.newBuilder()
             .setVersion(1)
             .setIncarnationNumber(0)
-            .setPendingGraphChanges(plan)
+            .setPendingChanges(plan)
             .build();
     final var proto =
         Topology.CurrentClusterConfiguration.newBuilder()
@@ -169,9 +169,9 @@ final class CurrentClusterConfigurationSerializerTest {
 
   @Test
   void shouldRoundTripAGroupCarryingADependencyGraphChange() {
-    // given — a group whose pending change is a graph rather than a queue. The property test only
-    // generates queue plans, because the two models share one field and a generator cannot produce
-    // a graph whose edges and write sets are consistent.
+    // given — a group carrying a graph with real edges. The property test generates graphs too, but
+    // only ones whose shape its generator happens to build; this pins a two-stage fan-in/fan-out
+    // explicitly, since a lost edge is invisible in anything that only compares operation lists.
     final var graph = restoreGraph();
     final var configuration = configurationWithGraph(graph);
 
@@ -186,8 +186,7 @@ final class CurrentClusterConfigurationSerializerTest {
     assertThat(decoded.partitionGroups().values())
         .singleElement()
         .satisfies(
-            group ->
-                assertThat(group.pendingGraphChanges().orElseThrow().graph()).isEqualTo(graph));
+            group -> assertThat(group.pendingChanges().orElseThrow().graph()).isEqualTo(graph));
   }
 
   @Test
@@ -196,7 +195,7 @@ final class CurrentClusterConfigurationSerializerTest {
     // graph change is in flight and the state a peer must be able to read to know what is runnable
     final var started = groupWithGraph(restoreGraph());
     final var firstOperation =
-        started.pendingGraphChanges().orElseThrow().graph().operations().firstKey();
+        started.pendingChanges().orElseThrow().graph().operations().firstKey();
     final var inFlight =
         configurationWith(started.completeOperation(firstOperation, UnaryOperator.identity()));
 
@@ -211,7 +210,7 @@ final class CurrentClusterConfigurationSerializerTest {
         .singleElement()
         .satisfies(
             group ->
-                assertThat(group.pendingGraphChanges().orElseThrow().completed())
+                assertThat(group.pendingChanges().orElseThrow().completed())
                     .containsKey(firstOperation));
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
@@ -20,10 +20,14 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import java.time.Instant;
 import java.util.Map;
@@ -39,8 +43,9 @@ import org.junit.jupiter.params.provider.EnumSource;
  * Edge cases for the {@code CurrentClusterConfiguration} serialization that the property test
  * ({@code ProtoBufSerializerPropertyTest#shouldEncodeAndDecodeCurrentClusterConfiguration}) cannot
  * exercise: decoding invalid bytes, decoding a proto that carries a broker lifecycle state which
- * the domain model cannot represent, and a group whose pending change is a dependency graph. The
- * remaining happy-path round-trips are covered by the property test.
+ * the domain model cannot represent, a graph whose edges must survive exactly, and the decode-only
+ * legacy phase shape that only a pre-upgrade peer can put on the wire. The remaining happy-path
+ * round-trips are covered by the property test.
  */
 final class CurrentClusterConfigurationSerializerTest {
 
@@ -212,6 +217,65 @@ final class CurrentClusterConfigurationSerializerTest {
             group ->
                 assertThat(group.pendingChanges().orElseThrow().completed())
                     .containsKey(firstOperation));
+  }
+
+  @Test
+  void shouldDecodeALegacyParallelPhaseAsASequentialGraph() {
+    // given — a phase in the shape written before the queue phase and the graph phase became one
+    // type. Nothing encodes this any more; it reaches decode only from a configuration persisted or
+    // gossiped by a broker that predates the merge, which is the rolling-upgrade path.
+    final var first = modeChange(MEMBER);
+    final var second = modeChange(OTHER_MEMBER);
+    final var legacyPhase =
+        Topology.PhasedChangePlanPhase.newBuilder()
+            .setPartitionGroupParallelPhase(
+                Topology.PartitionGroupParallelPhase.newBuilder()
+                    .putGroupOperations(
+                        "tenant",
+                        Topology.PartitionGroupOperationList.newBuilder()
+                            .addOperations(first)
+                            .addOperations(second)
+                            .build()))
+            .build();
+    final var proto =
+        Topology.CurrentClusterConfiguration.newBuilder()
+            .setVersion(0)
+            .setGlobalConfiguration(Topology.GlobalConfiguration.newBuilder().setVersion(1).build())
+            .setPhasedChangeState(
+                Topology.PhasedChangeState.newBuilder()
+                    .setNextId(2)
+                    .addPending(
+                        Topology.PhasedChangePlan.newBuilder()
+                            .setId(1)
+                            .setCurrentPhaseIndex(0)
+                            .addPhases(legacyPhase)
+                            .setStartedAt(Timestamp.newBuilder().build())))
+            .build();
+
+    // when
+    final var decoded = serializer.decodeCurrentClusterConfiguration(proto.toByteArray());
+
+    // then — the flat list becomes a *chain*, not a free graph. Asserting only on the operations
+    // would pass just as well for a fully-parallel decode, which would let both operations start at
+    // once on a plan whose author never claimed they were independent.
+    final var phase =
+        (PartitionGroupPhase) decoded.phasedChangeState().pending().get(1L).phases().getFirst();
+    final var graph = phase.groupGraphs().get("tenant");
+    assertThat(graph.operations().get(OperationId.of(0)).dependsOn()).isEmpty();
+    assertThat(graph.operations().get(OperationId.of(1)).dependsOn())
+        .containsExactly(OperationId.of(0));
+    assertThat(graph.inOrder())
+        .containsExactly(
+            new ModeChangeOperation(MEMBER, Mode.PROCESSING),
+            new ModeChangeOperation(OTHER_MEMBER, Mode.PROCESSING));
+  }
+
+  private static Topology.PartitionGroupChangeOperation modeChange(final MemberId memberId) {
+    return Topology.PartitionGroupChangeOperation.newBuilder()
+        .setMemberId(memberId.id())
+        .setModeChange(
+            Topology.ModeChangeOperation.newBuilder().setMode(Topology.Mode.MODE_PROCESSING))
+        .build();
   }
 
   /** A two-stage graph: both pre-restores may run at once, both restores wait for both of them. */

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -59,7 +59,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.RemovePhysi
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
@@ -557,7 +557,7 @@ final class ProtoBufSerializerTest {
     final List<Phase> phases =
         List.of(
             new GlobalPhase(List.of(new MemberLeaveOperation(MemberId.from("1")))),
-            new PartitionGroupParallelPhase(
+            PartitionGroupPhase.sequential(
                 Map.of(
                     "default",
                     List.of(
@@ -646,7 +646,7 @@ final class ProtoBufSerializerTest {
             1,
             0,
             List.of(
-                new PartitionGroupParallelPhase(
+                PartitionGroupPhase.sequential(
                     Map.of(
                         groupId,
                         List.of(new PartitionPreRestoreOperation(MemberId.from("1"), 1))))),
@@ -675,7 +675,7 @@ final class ProtoBufSerializerTest {
             1,
             0,
             List.of(
-                new PartitionGroupParallelPhase(
+                PartitionGroupPhase.sequential(
                     Map.of(
                         groupId,
                         List.of(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -745,7 +745,7 @@ final class ProtoBufSerializerTest {
             1,
             0,
             List.of(
-                new PartitionGroupParallelPhase(
+                PartitionGroupPhase.sequential(
                     Map.of(
                         groupId, List.of(new RemovePhysicalTenantOperation(MemberId.from("1")))))),
             Instant.now());

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -89,7 +89,7 @@ class CurrentClusterConfigurationTest {
       final CurrentClusterConfiguration config, final String groupId) {
     var current = config;
     while (current.partitionGroup(groupId).hasPendingChanges()) {
-      final var plan = current.partitionGroup(groupId).pendingGraphChanges().orElseThrow();
+      final var plan = current.partitionGroup(groupId).pendingChanges().orElseThrow();
       final var next =
           plan.operations().keySet().stream().filter(plan::isRunnable).findFirst().orElseThrow();
       current =
@@ -763,7 +763,10 @@ class CurrentClusterConfigurationTest {
       // when — start a change on group "a"
       final var updated =
           config.updatePartitionGroupConfig(
-              "a", g -> g.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0))));
+              "a",
+              g ->
+                  g.startGraphConfigurationChange(
+                      OperationGraph.sequential(List.of(new DeleteHistoryOperation(MEMBER_0)))));
 
       // then
       assertThat(updated.partitionGroup("a").hasPendingChanges()).isTrue();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHisto
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import java.time.Instant;
 import java.util.List;
@@ -78,6 +78,29 @@ class CurrentClusterConfigurationTest {
       final PhasedChangeState phasedChangeState) {
     return new CurrentClusterConfiguration(
         CurrentClusterConfiguration.INITIAL_VERSION, global, groups, phasedChangeState);
+  }
+
+  /**
+   * Completes every operation of {@code groupId}'s pending change, one runnable operation at a
+   * time, and finishes the change — what the broker applying the operations would leave behind,
+   * without any of their effects on member state.
+   */
+  private static CurrentClusterConfiguration drainGroup(
+      final CurrentClusterConfiguration config, final String groupId) {
+    var current = config;
+    while (current.partitionGroup(groupId).hasPendingChanges()) {
+      final var plan = current.partitionGroup(groupId).pendingGraphChanges().orElseThrow();
+      final var next =
+          plan.operations().keySet().stream().filter(plan::isRunnable).findFirst().orElseThrow();
+      current =
+          current.updatePartitionGroupConfig(
+              groupId,
+              group ->
+                  group
+                      .completeOperation(next, UnaryOperator.identity())
+                      .completeGraphChangeIfDrained());
+    }
+    return current;
   }
 
   @Nested
@@ -170,7 +193,7 @@ class CurrentClusterConfigurationTest {
       assertThat(plan.phases())
           .containsExactly(
               new GlobalPhase(List.of(memberJoin)),
-              new PartitionGroupParallelPhase(
+              PartitionGroupPhase.sequential(
                   Map.of(
                       CurrentClusterConfiguration.DEFAULT_GROUP,
                       List.of(partitionJoin, partitionLeave))),
@@ -499,7 +522,7 @@ class CurrentClusterConfigurationTest {
       // then — a single default-group phase holds both, in order
       assertThat(migrated.phasedChangeState().onlyPending().phases())
           .containsExactly(
-              new PartitionGroupParallelPhase(
+              PartitionGroupPhase.sequential(
                   Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, List.of(join, leave))));
     }
 
@@ -846,8 +869,8 @@ class CurrentClusterConfigurationTest {
       return new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)));
     }
 
-    private static PartitionGroupParallelPhase parallelPhase(final String groupId) {
-      return new PartitionGroupParallelPhase(
+    private static PartitionGroupPhase groupPhase(final String groupId) {
+      return PartitionGroupPhase.sequential(
           Map.of(groupId, List.of(new DeleteHistoryOperation(MEMBER_0))));
     }
 
@@ -881,7 +904,7 @@ class CurrentClusterConfigurationTest {
       // given — plan: phase 0 global, phase 1 targets group "a"
       final var config =
           config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty())
-              .initPlan(List.of(globalPhase(), parallelPhase("a")));
+              .initPlan(List.of(globalPhase(), groupPhase("a")));
 
       // when
       final var updated = config.activateNextPhase(config.phasedChangeState().onlyPending().id());
@@ -896,7 +919,7 @@ class CurrentClusterConfigurationTest {
       // given — plan: phase 0 global, phase 1 targets group "a"
       final var config =
           config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty())
-              .initPlan(List.of(globalPhase(), parallelPhase("a")));
+              .initPlan(List.of(globalPhase(), groupPhase("a")));
       final var planId = config.phasedChangeState().onlyPending().id();
 
       // when — expectedPhaseIndex (0) matches the plan's actual current phase index
@@ -912,7 +935,7 @@ class CurrentClusterConfigurationTest {
       // given — a plan already advanced to phase 1 by an earlier trigger
       final var config =
           config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty())
-              .initPlan(List.of(globalPhase(), parallelPhase("a")));
+              .initPlan(List.of(globalPhase(), groupPhase("a")));
       final var planId = config.phasedChangeState().onlyPending().id();
       final var advanced = config.activateNextPhase(planId);
 
@@ -995,7 +1018,7 @@ class CurrentClusterConfigurationTest {
       // given — a two-phase plan already advanced to phase 1 by an earlier trigger
       final var config =
           config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty())
-              .initPlan(List.of(globalPhase(), parallelPhase("a")));
+              .initPlan(List.of(globalPhase(), groupPhase("a")));
       final var planId = config.phasedChangeState().onlyPending().id();
       final var advanced = config.activateNextPhase(planId);
 
@@ -1064,7 +1087,7 @@ class CurrentClusterConfigurationTest {
               PhasedChangeState.empty());
 
       // when
-      final var updated = config.initPlan(List.of(parallelPhase("a")));
+      final var updated = config.initPlan(List.of(groupPhase("a")));
 
       // then — only group "a" is changed; group "b" and the global config are untouched
       assertThat(updated.partitionGroup("a").hasPendingChanges()).isTrue();
@@ -1114,10 +1137,10 @@ class CurrentClusterConfigurationTest {
     }
 
     @Test
-    void shouldBeIncompleteForParallelPhaseUntilEveryNamedGroupDrains() {
-      // given — a parallel phase targeting groups "a" and "b"; only "a" has drained
+    void shouldBeIncompleteForGroupPhaseUntilEveryNamedGroupDrains() {
+      // given — a phase targeting groups "a" and "b"; only "a" has drained
       final var phase =
-          new PartitionGroupParallelPhase(
+          PartitionGroupPhase.sequential(
               Map.of(
                   "a", List.of(new DeleteHistoryOperation(MEMBER_0)),
                   "b", List.of(new DeleteHistoryOperation(MEMBER_0))));
@@ -1130,17 +1153,13 @@ class CurrentClusterConfigurationTest {
       final var planId = config.phasedChangeState().onlyPending().id();
 
       // when — group "a" drains its side of the phase, "b" is still pending
-      final var partiallyDrained =
-          config.updatePartitionGroupConfig(
-              "a", g -> g.advanceConfigurationChange(UnaryOperator.identity()));
+      final var partiallyDrained = drainGroup(config, "a");
 
       // then
       assertThat(partiallyDrained.isCurrentPhaseComplete(planId)).isFalse();
 
       // when — group "b" drains too
-      final var fullyDrained =
-          partiallyDrained.updatePartitionGroupConfig(
-              "b", g -> g.advanceConfigurationChange(UnaryOperator.identity()));
+      final var fullyDrained = drainGroup(partiallyDrained, "b");
 
       // then
       assertThat(fullyDrained.isCurrentPhaseComplete(planId)).isTrue();
@@ -1192,7 +1211,7 @@ class CurrentClusterConfigurationTest {
                   PhasedChangeState.empty())
               .initPlan(
                   List.of(
-                      new PartitionGroupParallelPhase(
+                      PartitionGroupPhase.sequential(
                           Map.of(
                               "a",
                               List.of(new DeleteHistoryOperation(MEMBER_0)),
@@ -1222,9 +1241,9 @@ class CurrentClusterConfigurationTest {
                   PhasedChangeState.empty())
               .initPlan(
                   List.of(
-                      new PartitionGroupParallelPhase(
+                      PartitionGroupPhase.sequential(
                           Map.of("a", List.of(new DeleteHistoryOperation(MEMBER_0)))),
-                      new PartitionGroupParallelPhase(
+                      PartitionGroupPhase.sequential(
                           Map.of("b", List.of(new DeleteHistoryOperation(MEMBER_0))))));
       final var changeId = config.phasedChangeState().onlyPending().id();
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -212,10 +212,15 @@ class PartitionGroupConfigurationTest {
       // given — same config version, but the two sides disagree on which change last completed on
       // this group: a genuinely later, unrelated completion on one side, not a re-stamp of the
       // same one
+      // The higher id also carries the *earlier* completedAt, so a merge that compared timestamps
+      // first and only broke ties on id would pick `older` here and fail. With both stamped at the
+      // same instant the two rules are indistinguishable.
       final var older =
-          new CompletedChange(3, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH);
+          new CompletedChange(
+              3, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH.plusSeconds(9));
       final var newer =
-          new CompletedChange(4, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH);
+          new CompletedChange(
+              4, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH.plusSeconds(2));
       final var left =
           new PartitionGroupConfiguration(
               3, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.of(older));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -124,6 +124,67 @@ class PartitionGroupConfigurationTest {
     }
 
     @Test
+    void shouldThrowWhenMembersConflictAtEqualVersion() {
+      // given — same config version, MEMBER_0 at the same per-member version on both sides but
+      // with genuinely different content: the shape two brokers applying concurrent, same-member
+      // writes under a graph change can produce (see OperationGraph's class javadoc on why the
+      // graph model does not protect against this)
+      final var left = group(3, Map.of(MEMBER_0, broker(5, 1)));
+      final var right = group(3, Map.of(MEMBER_0, broker(5, 2)));
+
+      // when / then — rejected outright by BrokerPartitionState#merge, not silently resolved by
+      // picking one; this is the throw the change-view/reporting fixes assume when they describe
+      // this as a permanent-non-convergence failure mode rather than a silent one
+      assertThatThrownBy(() -> left.merge(right)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> right.merge(left)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldConvergeLastChangeDeterministicallyWhenBrokersMintDifferentTimestamps() {
+      // given — same config version, both brokers minted a lastChange for the same completed
+      // change (id 7) a moment apart: exactly what two brokers independently running
+      // completeGraphChangeIfDrained can produce, since neither is gated by a coordinator
+      final var earlier =
+          new CompletedChange(
+              7, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH.plusSeconds(1));
+      final var later =
+          new CompletedChange(
+              7, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH.plusSeconds(5));
+      final var left =
+          new PartitionGroupConfiguration(
+              3, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.of(earlier));
+      final var right =
+          new PartitionGroupConfiguration(
+              3, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.of(later));
+
+      // when / then — the earlier timestamp wins regardless of which side is the receiver, so two
+      // brokers merging in either order converge on the same value instead of each keeping its own
+      assertThat(left.merge(right).lastChange()).contains(earlier);
+      assertThat(right.merge(left).lastChange()).contains(earlier);
+    }
+
+    @Test
+    void shouldPreferHigherChangeIdForLastChangeWhenIdsDiffer() {
+      // given — same config version, but the two sides disagree on which change last completed on
+      // this group: a genuinely later, unrelated completion on one side, not a re-stamp of the
+      // same one
+      final var older =
+          new CompletedChange(3, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH);
+      final var newer =
+          new CompletedChange(4, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH);
+      final var left =
+          new PartitionGroupConfiguration(
+              3, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.of(older));
+      final var right =
+          new PartitionGroupConfiguration(
+              3, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.of(newer));
+
+      // when / then — ids are monotonic, so the higher one is always the newer change
+      assertThat(left.merge(right).lastChange()).contains(newer);
+      assertThat(right.merge(left).lastChange()).contains(newer);
+    }
+
+    @Test
     void shouldTakeMaxIncarnationNumber() {
       // given
       final var left =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
@@ -57,6 +58,17 @@ class PartitionGroupConfigurationTest {
         Optional.empty());
   }
 
+  /**
+   * Two operations with no edge between them, so both are runnable from the start and either broker
+   * can complete its own without waiting — the divergence the merge tests need.
+   */
+  private static OperationGraph twoIndependentOps() {
+    final var builder = OperationGraph.builder();
+    builder.add(new DeleteHistoryOperation(MEMBER_0));
+    builder.add(new DeleteHistoryOperation(MEMBER_1));
+    return builder.build();
+  }
+
   @Nested
   class Merge {
 
@@ -102,25 +114,6 @@ class PartitionGroupConfigurationTest {
 
       // then
       assertThat(merged.routingState()).contains(higherRouting);
-    }
-
-    @Test
-    void shouldMergePendingChangesByPlanVersion() {
-      // given — same config version, two versions of the same plan
-      final var plan = ClusterChangePlan.init(1, List.of(new DeleteHistoryOperation(MEMBER_0)));
-      final var advancedPlan = plan.advance();
-      final var left =
-          new PartitionGroupConfiguration(
-              1, 0, Map.of(), Optional.empty(), Optional.of(plan), Optional.empty());
-      final var right =
-          new PartitionGroupConfiguration(
-              1, 0, Map.of(), Optional.empty(), Optional.of(advancedPlan), Optional.empty());
-
-      // when
-      final var merged = left.merge(right);
-
-      // then — the higher plan version wins
-      assertThat(merged.pendingChanges()).contains(advancedPlan);
     }
 
     @Test
@@ -335,14 +328,16 @@ class PartitionGroupConfigurationTest {
   @Nested
   class StartConfigurationChange {
 
+    private static final OperationGraph ONE_OP =
+        OperationGraph.sequential(List.of(new DeleteHistoryOperation(MEMBER_0)));
+
     @Test
     void shouldSetPendingChangesAndIncrementVersion() {
       // given
       final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
 
       // when
-      final var updated =
-          config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+      final var updated = config.startGraphConfigurationChange(ONE_OP);
 
       // then
       assertThat(updated.version()).isEqualTo(5);
@@ -358,8 +353,7 @@ class PartitionGroupConfigurationTest {
       final var config = group(4, Map.of());
 
       // when
-      final var updated =
-          config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+      final var updated = config.startGraphConfigurationChange(ONE_OP);
 
       // then
       assertThat(updated.pendingChanges().get().id()).isEqualTo(5);
@@ -368,13 +362,26 @@ class PartitionGroupConfigurationTest {
     @Test
     void shouldThrowWhenChangeAlreadyInProgress() {
       // given
-      final var config =
-          group(4, Map.of())
-              .startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+      final var config = group(4, Map.of()).startGraphConfigurationChange(ONE_OP);
 
       // when / then
-      assertThatThrownBy(
-              () -> config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0))))
+      assertThatThrownBy(() -> config.startGraphConfigurationChange(ONE_OP))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenPreviousChangeIsDrainedButNotYetCleared() {
+      // given — every operation has completed, but completeGraphChangeIfDrained has not run yet, so
+      // the plan is still there with a lastChange to record and members to prune
+      final var drained =
+          group(4, Map.of())
+              .startGraphConfigurationChange(ONE_OP)
+              .completeOperation(OperationId.of(0), UnaryOperator.identity());
+      assertThat(drained.hasPendingChanges()).isFalse();
+
+      // when / then — refused on the plan's presence, not its content: starting here would discard
+      // that unfinished bookkeeping
+      assertThatThrownBy(() -> drained.startGraphConfigurationChange(ONE_OP))
           .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -384,58 +391,67 @@ class PartitionGroupConfigurationTest {
       final var config = group(4, Map.of());
 
       // when / then
-      assertThatThrownBy(() -> config.startConfigurationChange(List.of()))
+      assertThatThrownBy(
+              () -> config.startGraphConfigurationChange(OperationGraph.sequential(List.of())))
           .isInstanceOf(IllegalArgumentException.class);
     }
   }
 
   @Nested
-  class Advance {
+  class CompleteChange {
 
     private static final DeleteHistoryOperation OP_1 = new DeleteHistoryOperation(MEMBER_0);
     private static final DeleteHistoryOperation OP_2 = new DeleteHistoryOperation(MEMBER_1);
+    private static final OperationId ID_1 = OperationId.of(0);
+    private static final OperationId ID_2 = OperationId.of(1);
 
     @Test
-    void shouldThrowWhenNoPendingChange() {
+    void shouldReturnSameConfigWhenNoPendingChange() {
       // given
       final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
 
-      // when / then
-      assertThatThrownBy(config::advance).isInstanceOf(IllegalStateException.class);
+      // when / then — unguarded on purpose: every broker calls this on every merge, so a group with
+      // nothing running has to be a no-op rather than a throw
+      assertThat(config.completeGraphChangeIfDrained()).isSameAs(config);
     }
 
     @Test
-    void shouldRemoveFirstPendingOperationWhenMoreRemain() {
-      // given — a plan with two operations
+    void shouldRecordCompletionWithoutMovingVersionWhileOperationsRemain() {
+      // given — a plan with two operations, the second behind the first
       final var config =
-          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_1, OP_2));
+          group(4, Map.of(MEMBER_0, broker(1, 1)))
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_1, OP_2)));
       final var versionAfterStart = config.version();
 
       // when
-      final var advanced = config.advance();
+      final var advanced =
+          config.completeOperation(ID_1, UnaryOperator.identity()).completeGraphChangeIfDrained();
 
-      // then — the first operation is removed, the change is still pending, version is unchanged
+      // then — the change is still pending and the version has not moved, so a peer's concurrent
+      // progress still merges structurally instead of being overwritten wholesale
       assertThat(advanced.hasPendingChanges()).isTrue();
-      assertThat(advanced.pendingChanges().get().pendingOperations()).containsExactly(OP_2);
+      assertThat(advanced.pendingChanges().orElseThrow().pendingOperations()).containsExactly(OP_2);
       assertThat(advanced.version()).isEqualTo(versionAfterStart);
     }
 
     @Test
-    void shouldCompleteChangeWhenLastOperationIsRemoved() {
+    void shouldCompleteChangeWhenLastOperationIsRecorded() {
       // given — a plan with a single operation
       final var config =
-          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_1));
-      final var planId = config.pendingChanges().get().id();
+          group(4, Map.of(MEMBER_0, broker(1, 1)))
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_1)));
+      final var planId = config.pendingChanges().orElseThrow().id();
       final var versionAfterStart = config.version();
 
       // when
-      final var advanced = config.advance();
+      final var advanced =
+          config.completeOperation(ID_1, UnaryOperator.identity()).completeGraphChangeIfDrained();
 
       // then — pending changes are cleared, the completed change is recorded, version is bumped
       assertThat(advanced.hasPendingChanges()).isFalse();
       assertThat(advanced.pendingChanges()).isEmpty();
       assertThat(advanced.lastChange()).isPresent();
-      assertThat(advanced.lastChange().get().id()).isEqualTo(planId);
+      assertThat(advanced.lastChange().orElseThrow().id()).isEqualTo(planId);
       assertThat(advanced.version()).isEqualTo(versionAfterStart + 1);
     }
 
@@ -444,10 +460,11 @@ class PartitionGroupConfigurationTest {
       // given — MEMBER_0 still hosts partition 1, MEMBER_1 hosts none; a single-op plan
       final var config =
           group(4, Map.of(MEMBER_0, broker(1, 1), MEMBER_1, broker(1)))
-              .startConfigurationChange(List.of(OP_1));
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_1)));
 
       // when
-      final var advanced = config.advance();
+      final var advanced =
+          config.completeOperation(ID_1, UnaryOperator.identity()).completeGraphChangeIfDrained();
 
       // then — on completion the member with no partitions is removed, the other is kept
       assertThat(advanced.members()).containsOnlyKeys(MEMBER_0);
@@ -459,13 +476,44 @@ class PartitionGroupConfigurationTest {
       // given — MEMBER_1 hosts no partitions, but the plan still has a pending operation
       final var config =
           group(4, Map.of(MEMBER_0, broker(1, 1), MEMBER_1, broker(1)))
-              .startConfigurationChange(List.of(OP_1, OP_2));
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_1, OP_2)));
 
       // when
-      final var advanced = config.advance();
+      final var advanced =
+          config.completeOperation(ID_1, UnaryOperator.identity()).completeGraphChangeIfDrained();
 
-      // then — members are untouched during an intermediate advance
+      // then — members are untouched until the whole change is done
       assertThat(advanced.members()).containsOnlyKeys(MEMBER_0, MEMBER_1);
+    }
+
+    @Test
+    void shouldStampCompletionWithTheLastOperationRatherThanTheWallClock() {
+      // given — a drained two-operation plan
+      final var drained =
+          group(4, Map.of())
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_1, OP_2)))
+              .completeOperation(ID_1, UnaryOperator.identity())
+              .completeOperation(ID_2, UnaryOperator.identity());
+      final var lastCompletion = drained.pendingChanges().orElseThrow().completed().get(ID_2);
+
+      // when
+      final var completed = drained.completeGraphChangeIfDrained();
+
+      // then — two brokers observing the drain a moment apart both derive this same value from the
+      // plan, instead of each stamping its own "now" and never converging
+      assertThat(completed.lastChange().orElseThrow().completedAt()).isEqualTo(lastCompletion);
+    }
+
+    @Test
+    void shouldThrowWhenRecordingAnOperationStillWaitingOnItsDependency() {
+      // given — OP_2 sits behind OP_1 in a sequential graph
+      final var config =
+          group(4, Map.of())
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_1, OP_2)));
+
+      // when / then
+      assertThatThrownBy(() -> config.completeOperation(ID_2, UnaryOperator.identity()))
+          .isInstanceOf(IllegalStateException.class);
     }
   }
 
@@ -661,38 +709,55 @@ class PartitionGroupConfigurationTest {
     private static final DeleteHistoryOperation OP_1 = new DeleteHistoryOperation(MEMBER_1);
 
     @Test
-    void shouldReturnPendingChangeForTargetMemberOnly() {
-      // given
+    void shouldOfferOnlyTheOperationsTargetingTheGivenMember() {
+      // given — two independent operations, one per member, so neither is blocked by the other
       final var config =
           group(4, Map.of(MEMBER_0, broker(1, 1), MEMBER_1, broker(1, 2)))
-              .startConfigurationChange(List.of(OP_1));
+              .startGraphConfigurationChange(twoIndependentOps());
 
-      // when / then
-      assertThat(config.pendingChangesFor(MEMBER_1)).contains(OP_1);
-      assertThat(config.pendingChangesFor(MEMBER_0)).isEmpty();
-      assertThat(config.nextPendingOperation()).isEqualTo(OP_1);
+      // when / then — each member sees its own operation and nothing else; the graph offers both at
+      // once precisely because there is no edge between them
+      assertThat(config.runnableFor(MEMBER_0)).containsExactly(entry(OperationId.of(0), OP_0));
+      assertThat(config.runnableFor(MEMBER_1)).containsExactly(entry(OperationId.of(1), OP_1));
+      assertThat(config.runnableFor(MEMBER_2)).isEmpty();
     }
 
     @Test
-    void shouldReturnEmptyPendingChangeWhenNoChangeInProgress() {
+    void shouldOfferNothingRunnableWhenNoChangeInProgress() {
       // given
       final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
 
       // when / then
-      assertThat(config.pendingChangesFor(MEMBER_0)).isEmpty();
+      assertThat(config.runnableFor(MEMBER_0)).isEmpty();
+    }
+
+    @Test
+    void shouldNotOfferAnOperationWhoseDependencyHasNotCompleted() {
+      // given — OP_1 sits behind OP_0, and both target their own member
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1), MEMBER_1, broker(1, 2)))
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_0, OP_1)));
+
+      // when / then — MEMBER_1's operation stays hidden until MEMBER_0's has been recorded
+      assertThat(config.runnableFor(MEMBER_1)).isEmpty();
+      final var afterFirst = config.completeOperation(OperationId.of(0), UnaryOperator.identity());
+      assertThat(afterFirst.runnableFor(MEMBER_1)).containsExactly(entry(OperationId.of(1), OP_1));
     }
 
     @Test
     void shouldApplyUpdaterAndCompleteChangeOnLastOperation() {
       // given — a single pending operation
       final var config =
-          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_0));
+          group(4, Map.of(MEMBER_0, broker(1, 1)))
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_0)));
       final long versionAfterStart = config.version();
 
       // when — the operation completes with an updater that flips the broker mode
       final var advanced =
-          config.advanceConfigurationChange(
-              c -> c.updateMember(MEMBER_0, b -> b.setMode(Mode.RECOVERING)));
+          config
+              .completeOperation(
+                  OperationId.of(0), c -> c.updateMember(MEMBER_0, b -> b.setMode(Mode.RECOVERING)))
+              .completeGraphChangeIfDrained();
 
       // then — the updater's effect is visible, the change is completed and the version is bumped
       assertThat(advanced.getMember(MEMBER_0).mode()).isEqualTo(Mode.RECOVERING);
@@ -702,26 +767,11 @@ class PartitionGroupConfigurationTest {
     }
 
     @Test
-    void shouldStepPlanWithoutBumpingVersionWhileOperationsRemain() {
-      // given — two operations pending
-      final var config =
-          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_0, OP_1));
-      final long versionAfterStart = config.version();
-
-      // when
-      final var advanced = config.advanceConfigurationChange(UnaryOperator.identity());
-
-      // then
-      assertThat(advanced.hasPendingChanges()).isTrue();
-      assertThat(advanced.pendingChanges().get().pendingOperations()).containsExactly(OP_1);
-      assertThat(advanced.version()).isEqualTo(versionAfterStart);
-    }
-
-    @Test
     void shouldCancelPendingChangesBumpingVersionByTwo() {
       // given
       final var config =
-          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_0));
+          group(4, Map.of(MEMBER_0, broker(1, 1)))
+              .startGraphConfigurationChange(OperationGraph.sequential(List.of(OP_0)));
       final long versionAfterStart = config.version();
 
       // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -117,6 +117,57 @@ class PartitionGroupConfigurationTest {
     }
 
     @Test
+    void shouldUnionCompletionsOfTheSamePendingChange() {
+      // given — same config version, and two brokers that each completed a *different* operation of
+      // the same plan: the shape a graph change produces, since several brokers progress it at once
+      // and completeOperation deliberately does not move the group version
+      final var started = group(1, Map.of()).startGraphConfigurationChange(twoIndependentOps());
+      final var leftDid = started.completeOperation(OperationId.of(0), UnaryOperator.identity());
+      final var rightDid = started.completeOperation(OperationId.of(1), UnaryOperator.identity());
+
+      // when
+      final var merged = leftDid.merge(rightDid);
+
+      // then — both completions survive; neither side's progress is dropped in favour of the
+      // receiver's own copy
+      assertThat(merged.pendingChanges().orElseThrow().completed())
+          .containsOnlyKeys(OperationId.of(0), OperationId.of(1));
+      assertThat(merged.hasPendingChanges()).isFalse();
+    }
+
+    @Test
+    void shouldUnionCompletionsRegardlessOfMergeDirection() {
+      // given — the same divergence as above
+      final var started = group(1, Map.of()).startGraphConfigurationChange(twoIndependentOps());
+      final var leftDid = started.completeOperation(OperationId.of(0), UnaryOperator.identity());
+      final var rightDid = started.completeOperation(OperationId.of(1), UnaryOperator.identity());
+
+      // when / then — merge is commutative on completions, so gossip converges whichever broker
+      // receives whose state first
+      assertThat(leftDid.merge(rightDid).pendingChanges())
+          .isEqualTo(rightDid.merge(leftDid).pendingChanges());
+    }
+
+    @Test
+    void shouldThrowWhenMergingSameChangeIdWithDifferentGraphs() {
+      // given — two brokers that each derived plan id 2 (the group version they started from) for a
+      // genuinely different graph, which the forced-request path can produce by bypassing the
+      // single-coordinator check
+      final var left =
+          group(1, Map.of())
+              .startGraphConfigurationChange(
+                  OperationGraph.sequential(List.of(new DeleteHistoryOperation(MEMBER_0))));
+      final var right =
+          group(1, Map.of())
+              .startGraphConfigurationChange(
+                  OperationGraph.sequential(List.of(new DeleteHistoryOperation(MEMBER_1))));
+
+      // when / then — refused rather than unioned: operation ids restart at 0 per graph, so a blind
+      // union would mark one graph's operation complete because the other's ran
+      assertThatThrownBy(() -> left.merge(right)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
     void shouldThrowWhenMembersConflictAtEqualVersion() {
       // given — same config version, MEMBER_0 at the same per-member version on both sides but
       // with genuinely different content: the shape two brokers applying concurrent, same-member

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlanScopeTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlanScopeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Groups;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A plan's scope is the only thing that stops two plans being admitted onto the same
+ * sub-configuration, so a phase kind missing from it is a silent hole: the plan reports no group,
+ * conflicts with nothing, and a second plan is let through to fail later inside the
+ * sub-configuration rather than being rejected as a concurrent modification.
+ */
+final class PhasedChangePlanScopeTest {
+
+  private static final MemberId MEMBER = MemberId.from("0");
+
+  @Test
+  void shouldScopeAGraphPhaseToItsGroups() {
+    // given — a plan whose only phase carries a dependency graph per group
+    final List<Phase> phases =
+        List.of(
+            new PartitionGroupPhase(
+                Map.of(
+                    "tenant-a", graphFor(MEMBER),
+                    "tenant-b", graphFor(MEMBER))));
+
+    // when / then — both groups are in scope, exactly as they would be for a queue phase
+    assertThat(PhasedChangePlan.scopeOf(phases))
+        .isEqualTo(new Groups(Set.of("tenant-a", "tenant-b")));
+  }
+
+  @Test
+  void shouldConflictWithAnotherPlanOnTheSameGroup() {
+    // given — two plans whose graph phases share a group
+    final var first =
+        PhasedChangePlan.scopeOf(
+            List.of(new PartitionGroupPhase(Map.of("tenant-a", graphFor(MEMBER)))));
+    final var second =
+        PhasedChangePlan.scopeOf(
+            List.of(
+                new PartitionGroupPhase(
+                    Map.of(
+                        "tenant-a", graphFor(MEMBER),
+                        "tenant-c", graphFor(MEMBER)))));
+    final var unrelated =
+        PhasedChangePlan.scopeOf(
+            List.of(new PartitionGroupPhase(Map.of("tenant-c", graphFor(MEMBER)))));
+
+    // when / then — sharing tenant-a conflicts; a plan on tenant-c alone does not
+    assertThat(PhasedChangePlan.conflicts(first, second)).isTrue();
+    assertThat(PhasedChangePlan.conflicts(first, unrelated)).isFalse();
+  }
+
+  @Test
+  void shouldScopeAMixOfPhaseKindsToTheUnionOfTheirGroups() {
+    // given — a plan mixing both partition-group execution models across different groups
+    final List<Phase> phases =
+        List.of(
+            PartitionGroupPhase.sequential(
+                Map.of("tenant-a", List.of(new ModeChangeOperation(MEMBER, Mode.RECOVERING)))),
+            new PartitionGroupPhase(Map.of("tenant-b", graphFor(MEMBER))));
+
+    // when / then
+    assertThat(PhasedChangePlan.scopeOf(phases))
+        .isEqualTo(new Groups(Set.of("tenant-a", "tenant-b")));
+  }
+
+  @Test
+  void shouldScopeAPlanWithAnyGlobalPhaseAsClusterWide() {
+    // given — a global phase makes the plan cluster-wide regardless of what else it carries
+    final List<Phase> phases =
+        List.of(
+            new PartitionGroupPhase(Map.of("tenant-a", graphFor(MEMBER))),
+            new GlobalPhase(List.of(new MemberJoinOperation(MEMBER))));
+
+    // when / then
+    assertThat(PhasedChangePlan.scopeOf(phases)).isEqualTo(new PhasedChangePlan.Global());
+  }
+
+  private static OperationGraph graphFor(final MemberId memberId) {
+    final var builder = OperationGraph.builder();
+    builder.add(new ModeChangeOperation(memberId, Mode.RECOVERING));
+    return builder.build();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlanTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangePlanTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOpe
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -29,8 +29,8 @@ class PhasedChangePlanTest {
 
   private final GlobalPhase globalPhase0 =
       new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_1)));
-  private final PartitionGroupParallelPhase groupPhase1 =
-      new PartitionGroupParallelPhase(
+  private final PartitionGroupPhase groupPhase1 =
+      PartitionGroupPhase.sequential(
           Map.of("groupA", List.of(new UpdateIncarnationNumberOperation(MEMBER_2))));
   private final GlobalPhase globalPhase2 =
       new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_1)));
@@ -197,12 +197,12 @@ class PhasedChangePlanTest {
     }
 
     @Test
-    void shouldDefensivelyCopyPartitionGroupParallelPhaseOperations() {
+    void shouldDefensivelyCopyPartitionGroupPhaseOperations() {
       // given
       final var mutableOps =
           new java.util.ArrayList<PartitionGroupOperation>(
               List.of(new UpdateIncarnationNumberOperation(MEMBER_1)));
-      final var phase = new PartitionGroupParallelPhase(Map.of("g1", mutableOps));
+      final var phase = PartitionGroupPhase.sequential(Map.of("g1", mutableOps));
 
       // when
       mutableOps.add(new UpdateIncarnationNumberOperation(MEMBER_2));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeStateTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PhasedChangeStateTest.java
@@ -14,7 +14,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +32,7 @@ class PhasedChangeStateTest {
 
   private List<PhasedChangePlan.Phase> groupPhase(final String groupId) {
     return List.of(
-        new PartitionGroupParallelPhase(
+        PartitionGroupPhase.sequential(
             Map.of(groupId, List.of(new UpdateIncarnationNumberOperation(MEMBER_1)))));
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -413,17 +413,27 @@ public final class ClusterTopologyDomain extends DomainContextBase {
         .set()
         .ofMaxSize(ids.size())
         .map(
-            completedIds -> {
+            pickedIds -> {
+              // An operation counts as complete only once everything it depends on is: no
+              // execution can produce any other combination, and DependencyChangePlan rejects
+              // one outright. Ids ascend with dependency order (see operationGraphs()), so a
+              // single ascending pass suffices -- a picked operation whose dependencies were not
+              // themselves picked is simply not reached yet, and is dropped.
+              //
               // Each completion gets its own instant, derived from the operation id so it stays
               // reproducible. Reusing startedAt for all of them would make every generated plan
               // share the shape an encoder bug produces -- writing startedAt in place of each
               // operation's real completion instant -- and the round-trip property could then
               // never tell the bug from the fixture.
               final SortedMap<OperationId, Instant> completed = new TreeMap<>();
-              completedIds.forEach(
-                  operationId ->
-                      completed.put(
-                          operationId, partial.startedAt().plusMillis(1L + operationId.value())));
+              for (final var operationId : ids) {
+                final var planned = partial.graph().operations().get(operationId);
+                if (pickedIds.contains(operationId)
+                    && completed.keySet().containsAll(planned.dependsOn())) {
+                  completed.put(
+                      operationId, partial.startedAt().plusMillis(1L + operationId.value()));
+                }
+              }
               return new DependencyChangePlan(
                   partial.id(), partial.status(), partial.startedAt(), partial.graph(), completed);
             });

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.dynamic.config.util;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -248,18 +247,9 @@ public final class ClusterTopologyDomain extends DomainContextBase {
     final var incarnationNumber = Arbitraries.longs().greaterOrEqual(0);
     final var members = Arbitraries.maps(memberIds(), brokerPartitionStates()).ofMaxSize(6);
     final var routingState = routingStates().optional();
-    // Typed as ChangePlan so the generated value fits the group's field, which carries either
-    // execution model: both are generated here (roughly evenly, via oneOf) so that anything built
-    // from an arbitrary PartitionGroupConfiguration -- decode round-trips, merge, the change view
-    // -- gets exercised against a graph plan as often as a queue one, not only in the dedicated
-    // DependencyChangePlanTest.
-    final Arbitrary<Optional<ChangePlan>> pendingChanges =
-        Arbitraries.oneOf(
-                Arbitraries.forType(ClusterChangePlan.class)
-                    .enableRecursion()
-                    .<ChangePlan>map(plan -> plan),
-                dependencyChangePlans().<ChangePlan>map(plan -> plan))
-            .optional();
+    // A group's change is always a dependency graph, so this is the only plan shape generated here.
+    final Arbitrary<Optional<DependencyChangePlan>> pendingChanges =
+        dependencyChangePlans().optional();
     final var lastChange = Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
     final var availability = tenantAvailabilities();
     return Combinators.combine(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -414,13 +414,16 @@ public final class ClusterTopologyDomain extends DomainContextBase {
         .ofMaxSize(ids.size())
         .map(
             completedIds -> {
-              // Real completions are stamped by whichever broker applied the operation, at
-              // whatever moment it happened -- an exact value here does not matter to the
-              // consumers this domain feeds (decode round-trip, merge, the change view), only
-              // that completed is a valid subset of the graph's own ids, so reusing one instant
-              // for all of them keeps the generator simple without weakening that coverage.
+              // Each completion gets its own instant, derived from the operation id so it stays
+              // reproducible. Reusing startedAt for all of them would make every generated plan
+              // share the shape an encoder bug produces -- writing startedAt in place of each
+              // operation's real completion instant -- and the round-trip property could then
+              // never tell the bug from the fixture.
               final SortedMap<OperationId, Instant> completed = new TreeMap<>();
-              completedIds.forEach(operationId -> completed.put(operationId, partial.startedAt()));
+              completedIds.forEach(
+                  operationId ->
+                      completed.put(
+                          operationId, partial.startedAt().plusMillis(1L + operationId.value())));
               return new DependencyChangePlan(
                   partial.id(), partial.status(), partial.startedAt(), partial.graph(), completed);
             });

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -10,25 +10,29 @@ package io.camunda.zeebe.dynamic.config.util;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.ChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -244,8 +248,18 @@ public final class ClusterTopologyDomain extends DomainContextBase {
     final var incarnationNumber = Arbitraries.longs().greaterOrEqual(0);
     final var members = Arbitraries.maps(memberIds(), brokerPartitionStates()).ofMaxSize(6);
     final var routingState = routingStates().optional();
-    final var pendingChanges =
-        Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
+    // Typed as ChangePlan so the generated value fits the group's field, which carries either
+    // execution model: both are generated here (roughly evenly, via oneOf) so that anything built
+    // from an arbitrary PartitionGroupConfiguration -- decode round-trips, merge, the change view
+    // -- gets exercised against a graph plan as often as a queue one, not only in the dedicated
+    // DependencyChangePlanTest.
+    final Arbitrary<Optional<ChangePlan>> pendingChanges =
+        Arbitraries.oneOf(
+                Arbitraries.forType(ClusterChangePlan.class)
+                    .enableRecursion()
+                    .<ChangePlan>map(plan -> plan),
+                dependencyChangePlans().<ChangePlan>map(plan -> plan))
+            .optional();
     final var lastChange = Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
     final var availability = tenantAvailabilities();
     return Combinators.combine(
@@ -328,11 +342,98 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   Arbitrary<Phase> phases() {
     final Arbitrary<Phase> globalPhases =
         globalChangeOperations().list().ofMaxSize(3).<Phase>map(GlobalPhase::new);
-    final Arbitrary<Phase> parallelPhases =
-        Arbitraries.maps(partitionGroupIds(), partitionGroupChangeOperations().list().ofMaxSize(3))
+    // Each group's own operation list must be non-empty: PartitionGroupPhase.sequential builds an
+    // OperationGraph per group, and OperationGraph.of rejects an empty one -- the same invariant
+    // operationGraphs() below already respects.
+    final Arbitrary<Phase> sequentialGroupPhases =
+        Arbitraries.maps(
+                partitionGroupIds(),
+                partitionGroupChangeOperations().list().ofMinSize(1).ofMaxSize(3))
             .ofMaxSize(3)
-            .<Phase>map(PartitionGroupParallelPhase::new);
-    return Arbitraries.oneOf(globalPhases, parallelPhases);
+            .<Phase>map(PartitionGroupPhase::sequential);
+    final Arbitrary<Phase> graphGroupPhases =
+        Arbitraries.maps(partitionGroupIds(), operationGraphs())
+            .ofMaxSize(3)
+            .<Phase>map(PartitionGroupPhase::new);
+    return Arbitraries.oneOf(globalPhases, sequentialGroupPhases, graphGroupPhases);
+  }
+
+  /**
+   * A graph over 1–4 operations, each depending on an arbitrary subset of the operations before it
+   * in generation order. Ids are assigned by that same order ({@link OperationId#of(int)} matching
+   * list index), so a dependency can only ever point to an earlier id — the result is acyclic by
+   * construction, with no rejection sampling needed to keep {@link OperationGraph#of} from
+   * throwing.
+   */
+  @Provide
+  Arbitrary<OperationGraph> operationGraphs() {
+    return partitionGroupChangeOperations()
+        .list()
+        .ofMinSize(1)
+        .ofMaxSize(4)
+        .flatMap(ClusterTopologyDomain::operationGraphOf);
+  }
+
+  private static Arbitrary<OperationGraph> operationGraphOf(
+      final List<PartitionGroupOperation> operations) {
+    final List<Arbitrary<Set<Integer>>> dependsOnPerIndex = new ArrayList<>();
+    for (int i = 0; i < operations.size(); i++) {
+      dependsOnPerIndex.add(
+          i == 0
+              ? Arbitraries.just(Set.of())
+              : Arbitraries.integers().between(0, i - 1).set().ofMaxSize(i));
+    }
+    return Combinators.combine(dependsOnPerIndex)
+        .as(
+            dependsOnByIndex -> {
+              final SortedMap<OperationId, OperationGraph.PlannedOperation> planned =
+                  new TreeMap<>();
+              for (int i = 0; i < operations.size(); i++) {
+                final SortedSet<OperationId> dependsOn = new TreeSet<>();
+                for (final var index : dependsOnByIndex.get(i)) {
+                  dependsOn.add(OperationId.of(index));
+                }
+                planned.put(
+                    OperationId.of(i),
+                    new OperationGraph.PlannedOperation(operations.get(i), dependsOn));
+              }
+              return OperationGraph.of(planned);
+            });
+  }
+
+  /**
+   * A {@link DependencyChangePlan} over an arbitrary {@link #operationGraphs()} graph, with an
+   * arbitrary subset of that graph's own operation ids marked completed — never an id outside the
+   * graph, which is the shape every real plan has and the one round-trip/merge/decode tests need to
+   * see exercised.
+   */
+  @Provide
+  Arbitrary<DependencyChangePlan> dependencyChangePlans() {
+    final var id = Arbitraries.longs().between(0, 500);
+    final var status = Arbitraries.of(ClusterChangePlan.Status.values());
+    return Combinators.combine(id, status, nanoPrecisionInstants(), operationGraphs())
+        .as(PartialDependencyChangePlan::new)
+        .flatMap(ClusterTopologyDomain::withCompletedOperations);
+  }
+
+  private static Arbitrary<DependencyChangePlan> withCompletedOperations(
+      final PartialDependencyChangePlan partial) {
+    final var ids = new ArrayList<>(partial.graph().operations().keySet());
+    return Arbitraries.of(ids)
+        .set()
+        .ofMaxSize(ids.size())
+        .map(
+            completedIds -> {
+              // Real completions are stamped by whichever broker applied the operation, at
+              // whatever moment it happened -- an exact value here does not matter to the
+              // consumers this domain feeds (decode round-trip, merge, the change view), only
+              // that completed is a valid subset of the graph's own ids, so reusing one instant
+              // for all of them keeps the generator simple without weakening that coverage.
+              final SortedMap<OperationId, Instant> completed = new TreeMap<>();
+              completedIds.forEach(operationId -> completed.put(operationId, partial.startedAt()));
+              return new DependencyChangePlan(
+                  partial.id(), partial.status(), partial.startedAt(), partial.graph(), completed);
+            });
   }
 
   @Provide
@@ -414,4 +515,7 @@ public final class ClusterTopologyDomain extends DomainContextBase {
           .collect(CollectorsSupport.toLinkedHashSet());
     }
   }
+
+  private record PartialDependencyChangePlan(
+      long id, ClusterChangePlan.Status status, Instant startedAt, OperationGraph graph) {}
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PhysicalTenantFixtures.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PhysicalTenantFixtures.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.dynamic.config.util;
 
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import java.util.List;
 import java.util.Map;
@@ -48,10 +48,10 @@ public final class PhysicalTenantFixtures {
    * The phase of a plan that carries the per-tenant work, which is where a plan that only ever saw
    * the default partition group differs from one that saw every tenant's.
    */
-  public static PartitionGroupParallelPhase partitionGroupPhase(final List<Phase> phases) {
+  public static PartitionGroupPhase partitionGroupPhase(final List<Phase> phases) {
     return phases.stream()
-        .filter(PartitionGroupParallelPhase.class::isInstance)
-        .map(PartitionGroupParallelPhase.class::cast)
+        .filter(PartitionGroupPhase.class::isInstance)
+        .map(PartitionGroupPhase.class::cast)
         .findFirst()
         .orElseThrow(
             () -> new AssertionError("expected the plan to contain partition work: " + phases));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterModeChangeMapper.java
@@ -30,7 +30,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeO
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -109,14 +109,10 @@ final class ClusterModeChangeMapper {
     final List<ClusterConfigurationChangeOperation> clusterWideOperations = new ArrayList<>();
     for (final Phase phase : requireNonNull(response.response()).phases()) {
       switch (phase) {
-        case final PartitionGroupParallelPhase parallelPhase ->
-            parallelPhase
-                .groupOperations()
-                .forEach(
-                    (physicalTenantId, operations) ->
-                        operationsPerTenant
-                            .computeIfAbsent(physicalTenantId, tenant -> new ArrayList<>())
-                            .addAll(operations));
+        // A phase carries its operations plus the edges between them. The edges say what may run
+        // when, which this view does not report, so it reads the operations alone.
+        case final PartitionGroupPhase groupPhase ->
+            collectPerTenant(groupPhase.groupOperations(), operationsPerTenant);
         // Broker lifecycle operations belong to the cluster, not to any single physical tenant.
         case final GlobalPhase globalPhase ->
             clusterWideOperations.addAll(globalPhase.operations());
@@ -131,6 +127,17 @@ final class ClusterModeChangeMapper {
       groups.add(new PlannedGroup(null, clusterWideOperations));
     }
     return groups;
+  }
+
+  private static void collectPerTenant(
+      final Map<String, ? extends List<? extends ClusterConfigurationChangeOperation>>
+          groupOperations,
+      final Map<String, List<ClusterConfigurationChangeOperation>> operationsPerTenant) {
+    groupOperations.forEach(
+        (physicalTenantId, operations) ->
+            operationsPerTenant
+                .computeIfAbsent(physicalTenantId, tenant -> new ArrayList<>())
+                .addAll(operations));
   }
 
   private static Status mapErrorStatus(final ErrorResponse.ErrorCode code) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRecoveryControllerTest.java
@@ -27,7 +27,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeO
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
 import java.util.HashMap;
@@ -339,7 +339,7 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
                 Either.right(
                     plannedChange(
                         9L,
-                        new PartitionGroupParallelPhase(
+                        PartitionGroupPhase.sequential(
                             Map.of(
                                 "default",
                                 List.of(
@@ -466,11 +466,11 @@ class ClusterRecoveryControllerTest extends RestControllerTest {
       groupOperations.put(
           physicalTenantId, List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING)));
     }
-    return plannedChange(changeId, new PartitionGroupParallelPhase(groupOperations));
+    return plannedChange(changeId, PartitionGroupPhase.sequential(groupOperations));
   }
 
   private ClusterConfigurationChangeResponse plannedChange(
-      final long changeId, final PartitionGroupParallelPhase phase) {
+      final long changeId, final PartitionGroupPhase phase) {
     final var flatOperations =
         phase.groupOperations().values().stream()
             .flatMap(List::stream)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -37,7 +37,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
-import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
@@ -84,7 +84,7 @@ public class RecoveryControllerTest extends RestControllerTest {
         plannedChanges.isEmpty()
             ? List.<Phase>of()
             : List.<Phase>of(
-                new PartitionGroupParallelPhase(
+                PartitionGroupPhase.sequential(
                     Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, plannedChanges)));
     return new ClusterConfigurationChangeResponse(
         changeId,


### PR DESCRIPTION
## Description

**Stacked PR 2 of 5** — wire the graph into the plan model and execution. Base: #60665 (`pg/60302-01-graph-data-types`), not `main`.

Two commits, landed together deliberately:

1. **Wire the model in.** Renames `PartitionGroupParallelPhase` to `PartitionGroupPhase`
   and has it always carry one `OperationGraph` per group (`sequential(...)` builds the
   old chain-of-edges shape for every current adopter, which hasn't migrated yet).
   `PartitionGroupConfiguration` and `CurrentClusterConfiguration` now dispatch
   phase-completion and scope-reconciliation on whether a group holds a
   `ClusterChangePlan` (queue) or a `DependencyChangePlan` (graph). The wire format
   gains a `oneof` between the old flat list and the new graph so existing messages
   still decode; the previous message name is kept decode-only for the same reason.

   Renaming forces every referencer to update in the same commit or fail to compile —
   that's why this also touches files otherwise unrelated to graph execution: every
   exhaustive switch over the sealed `Phase` interface (dry-run simulator, cluster
   management API reporting, REST mode-change mapper), and every other adopter's
   construction call site (a mechanical, semantics-preserving swap to
   `PartitionGroupPhase.sequential(...)`).

2. **Drive it.** Adds `GraphScopeReconciler`, the graph-model counterpart of
   `ScopeReconciler`: starts every operation the local member may run right now for a
   group's graph change, up to a concurrency cap, with in-flight state and retry
   backoff keyed per operation id rather than per group. `ClusterConfigurationManagerImpl`
   registers one per group alongside the existing `ScopeReconciler`.

   This has to land with the rename, not as a separate PR: once every partition-group
   phase is graph-shaped, a group change has nothing driving it without a graph-aware
   reconciler — verified by testing the rename alone first, which left pending changes
   that never drain.

BREAKING CHANGE: Removal of `ClusterChangePlan` from the `PartitionGroupConfiguration` is accepted since it's not released yet.

**Stack:**
1. #60665 — data model
2. **This PR** — wire the graph into the plan model + execution
3. #60667 — migrate mode change
4. #60668 — migrate restore
5. #60669 — ADR

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Part of #60302
