### PR TITLE
feat: run mode change as a dependency graph

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
@@ -13,18 +13,20 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.util.Either;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 /**
  * Transitions partitions between {@link Mode#PROCESSING} and {@link Mode#RECOVERING}, either for
@@ -50,22 +52,22 @@ public final class ModeChangeRequestTransformer implements ConfigurationChangeRe
                   .formatted(physicalTenantId.get())));
     }
 
-    final Map<String, List<PartitionGroupOperation>> operationsPerGroup = new LinkedHashMap<>();
+    final Map<String, OperationGraph> graphsPerGroup = new LinkedHashMap<>();
     clusterConfiguration.partitionGroups().entrySet().stream()
         .filter(
             group -> physicalTenantId.isEmpty() || physicalTenantId.get().equals(group.getKey()))
         .forEach(
             group -> {
-              final var operations = modeChangeOperations(membersToTransition(group.getValue()));
-              if (!operations.isEmpty()) {
-                operationsPerGroup.put(group.getKey(), operations);
+              final var members = membersToTransition(group.getValue());
+              if (!members.isEmpty()) {
+                graphsPerGroup.put(group.getKey(), modeChangeGraph(members));
               }
             });
 
-    if (operationsPerGroup.isEmpty()) {
+    if (graphsPerGroup.isEmpty()) {
       return Either.right(List.of());
     }
-    return Either.right(List.of(PartitionGroupPhase.sequential(operationsPerGroup)));
+    return Either.right(List.of(new PartitionGroupPhase(graphsPerGroup)));
   }
 
   /**
@@ -82,14 +84,27 @@ public final class ModeChangeRequestTransformer implements ConfigurationChangeRe
   }
 
   /**
-   * All members first start the change operation and complete it async. Following up with a
-   * verification step that the operation completed successfully.
+   * Every member starts the transition, then every member's completion is verified.
+   *
+   * <p>The two stages stay ordered against each other exactly as they were when this was a flat
+   * list: each verification waits for <em>all</em> the mode changes, not only its own broker's. The
+   * transition is a cluster-wide one and nothing here establishes that a broker may be confirmed
+   * while a peer has not yet started, so the conservative ordering is kept until someone who knows
+   * the recovery semantics says otherwise. Narrowing each verification to its own broker is a
+   * one-line change to the dependency below.
+   *
+   * <p>What does change is that the members no longer take turns: all the mode changes run at once,
+   * then all the verifications do. Round trips drop from {@code 2N} to two.
    */
-  private List<PartitionGroupOperation> modeChangeOperations(final List<MemberId> members) {
-    final List<PartitionGroupOperation> operations = new ArrayList<>();
-    members.forEach(memberId -> operations.add(new ModeChangeOperation(memberId, request.mode())));
+  private OperationGraph modeChangeGraph(final List<MemberId> members) {
+    final var builder = OperationGraph.builder();
+    final Set<OperationId> modeChanges = new HashSet<>();
     members.forEach(
-        memberId -> operations.add(new AwaitModeChangeOperation(memberId, request.mode())));
-    return operations;
+        memberId ->
+            modeChanges.add(builder.add(new ModeChangeOperation(memberId, request.mode()))));
+    members.forEach(
+        memberId ->
+            builder.add(new AwaitModeChangeOperation(memberId, request.mode()), modeChanges));
+    return builder.build();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
@@ -16,19 +16,25 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -62,14 +68,13 @@ final class ModeChangeRequestTransformerTest {
     // then — id1 is left out: it has no partition to transition, and awaiting a mode change from it
     // would never complete and would stall the whole plan
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(
-                    DEFAULT_GROUP,
-                    List.of(
-                        new ModeChangeOperation(id0, Mode.RECOVERING),
-                        new AwaitModeChangeOperation(id0, Mode.RECOVERING)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(
+            Map.of(
+                DEFAULT_GROUP,
+                List.of(
+                    new ModeChangeOperation(id0, Mode.RECOVERING),
+                    new AwaitModeChangeOperation(id0, Mode.RECOVERING))));
   }
 
   @Test
@@ -97,14 +102,13 @@ final class ModeChangeRequestTransformerTest {
 
     // then — the default group keeps processing
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(
-                    TENANT_B,
-                    List.of(
-                        new ModeChangeOperation(id1, Mode.RECOVERING),
-                        new AwaitModeChangeOperation(id1, Mode.RECOVERING)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(
+            Map.of(
+                TENANT_B,
+                List.of(
+                    new ModeChangeOperation(id1, Mode.RECOVERING),
+                    new AwaitModeChangeOperation(id1, Mode.RECOVERING))));
   }
 
   @Test
@@ -117,18 +121,17 @@ final class ModeChangeRequestTransformerTest {
 
     // then — one phase carrying both groups, so their partitions transition concurrently
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(
-                    DEFAULT_GROUP,
-                    List.of(
-                        new ModeChangeOperation(id0, Mode.RECOVERING),
-                        new AwaitModeChangeOperation(id0, Mode.RECOVERING)),
-                    TENANT_B,
-                    List.of(
-                        new ModeChangeOperation(id1, Mode.RECOVERING),
-                        new AwaitModeChangeOperation(id1, Mode.RECOVERING)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(
+            Map.of(
+                DEFAULT_GROUP,
+                List.of(
+                    new ModeChangeOperation(id0, Mode.RECOVERING),
+                    new AwaitModeChangeOperation(id0, Mode.RECOVERING)),
+                TENANT_B,
+                List.of(
+                    new ModeChangeOperation(id1, Mode.RECOVERING),
+                    new AwaitModeChangeOperation(id1, Mode.RECOVERING))));
   }
 
   @Test
@@ -141,14 +144,13 @@ final class ModeChangeRequestTransformerTest {
 
     // then — the group that has nothing to do is left out of the phase entirely
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(
-                    DEFAULT_GROUP,
-                    List.of(
-                        new ModeChangeOperation(id0, Mode.RECOVERING),
-                        new AwaitModeChangeOperation(id0, Mode.RECOVERING)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(
+            Map.of(
+                DEFAULT_GROUP,
+                List.of(
+                    new ModeChangeOperation(id0, Mode.RECOVERING),
+                    new AwaitModeChangeOperation(id0, Mode.RECOVERING))));
   }
 
   @Test
@@ -221,5 +223,67 @@ final class ModeChangeRequestTransformerTest {
 
   private BrokerPartitionState hostingNothing(final Mode mode) {
     return BrokerPartitionState.initialize(Map.of()).setMode(mode);
+  }
+
+  /**
+   * The concurrency, as distinct from the operation list the assertions above pin: every broker's
+   * mode change is offered at once, and every await waits for all of them.
+   */
+  @Test
+  void shouldChangeModeOnEveryBrokerAtOnceAndAwaitThemTogether() {
+    // given — two brokers of the group, both still processing
+    final var transformer = recoveringTransformer(Optional.empty());
+    final var clusterConfiguration =
+        cluster(
+            Map.of(
+                DEFAULT_GROUP,
+                group(
+                    Map.of(
+                        id0, hostingAPartition(Mode.PROCESSING),
+                        id1, hostingAPartition(Mode.PROCESSING)))));
+
+    // when
+    final var result = transformer.phases(clusterConfiguration);
+
+    // then — both mode changes are runnable immediately, one per broker
+    EitherAssert.assertThat(result).isRight();
+    final var graph =
+        ((PartitionGroupPhase) result.get().getFirst()).groupGraphs().get(DEFAULT_GROUP);
+    final var plan = DependencyChangePlan.init(1L, graph);
+    assertThat(plan.runnableFor(id0).values())
+        .singleElement()
+        .isInstanceOf(ModeChangeOperation.class);
+    assertThat(plan.runnableFor(id1).values())
+        .singleElement()
+        .isInstanceOf(ModeChangeOperation.class);
+
+    // and — each await waits for both mode changes, so no broker is declared recovering before the
+    // group as a whole has stopped processing
+    final var modeChanges = idsOf(graph, ModeChangeOperation.class);
+    assertThat(modeChanges).hasSize(2);
+    assertThat(idsOf(graph, AwaitModeChangeOperation.class))
+        .hasSize(2)
+        .allSatisfy(
+            await ->
+                assertThat(graph.operations().get(await).dependsOn())
+                    .containsExactlyElementsOf(modeChanges));
+  }
+
+  private static List<OperationId> idsOf(
+      final OperationGraph graph, final Class<? extends PartitionGroupOperation> type) {
+    return graph.operations().entrySet().stream()
+        .filter(entry -> type.isInstance(entry.getValue().operation()))
+        .map(Entry::getKey)
+        .toList();
+  }
+
+  /**
+   * The operations each group's graph holds, in plan order. The graph's dependency structure is
+   * covered separately; these assertions are about which operations a request produces.
+   */
+  private static Map<String, List<PartitionGroupOperation>> groupOperationsOf(
+      final List<Phase> phases) {
+    assertThat(phases).singleElement().isInstanceOf(PartitionGroupPhase.class);
+    return ((PartitionGroupPhase) phases.getFirst()).groupOperations();
   }
 }


### PR DESCRIPTION
## Description

**Stacked PR 3 of 5** — first real adopter. Base: #60666 (`pg/60302-02-graph-model-and-integration`), not `main`.

`ModeChangeRequestTransformer` now builds an `OperationGraph` instead of a flat
operation list:

```
modeChange(m)        depends on nothing
awaitModeChange(m)   depends on every modeChange
```

Members no longer take turns — every mode change runs at once, then every
verification does. Round trips drop from `2N` to two. The await edge is deliberately
cluster-wide (every `awaitModeChange` depends on every `modeChange`, not just its own
member's) rather than narrowed to each broker's own transition, since a broker
verifying a group-wide transition should not start observing while a peer has not yet
started; narrowing it later is a one-edge change.

**Stack:**
1. #60665 — data model
2. #60666 — wire the graph into the plan model + execution
3. **This PR** — migrate mode change
4. #60668 — migrate restore
5. #60669 — ADR

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Part of #60302
