### PR TITLE
feat: run restore as a dependency graph

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
@@ -64,9 +64,7 @@ public final class ClusterRestoreRequestTransformer implements ConfigurationChan
       if (result.isLeft()) {
         return Either.left(result.getLeft());
       }
-      if (!result.get().isEmpty()) {
-        graphsPerTenant.put(physicalTenantId, result.get());
-      }
+      graphsPerTenant.put(physicalTenantId, result.get());
     }
     if (graphsPerTenant.isEmpty()) {
       return Either.right(List.of());

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformer.java
@@ -8,12 +8,11 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterRestoreRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
@@ -50,7 +49,7 @@ public final class ClusterRestoreRequestTransformer implements ConfigurationChan
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
-    final Map<String, List<PartitionGroupOperation>> operationsPerTenant = new LinkedHashMap<>();
+    final Map<String, OperationGraph> graphsPerTenant = new LinkedHashMap<>();
     for (final var physicalTenantId : request.tenantArguments().keySet()) {
       final var partitionGroup = clusterConfiguration.partitionGroup(physicalTenantId);
       if (partitionGroup == null) {
@@ -61,18 +60,20 @@ public final class ClusterRestoreRequestTransformer implements ConfigurationChan
       }
       final var transformer =
           new RestoreRequestTransformer(request.toRestoreRequest(physicalTenantId), registry);
-      final var result = transformer.groupOperations(partitionGroup);
+      final var result = transformer.groupGraph(partitionGroup);
       if (result.isLeft()) {
         return Either.left(result.getLeft());
       }
       if (!result.get().isEmpty()) {
-        operationsPerTenant.put(physicalTenantId, result.get());
+        graphsPerTenant.put(physicalTenantId, result.get());
       }
     }
-    if (operationsPerTenant.isEmpty()) {
+    if (graphsPerTenant.isEmpty()) {
       return Either.right(List.of());
     }
-    return Either.right(List.of(PartitionGroupPhase.sequential(operationsPerTenant)));
+    // Each tenant keeps its own graph, so the tenants restore in parallel exactly as before while
+    // each one's brokers and partitions now also proceed concurrently within it.
+    return Either.right(List.of(new PartitionGroupPhase(graphsPerTenant)));
   }
 
   private Optional<RestoreRequestTransformer> singleTenantRestore() {
@@ -83,11 +84,5 @@ public final class ClusterRestoreRequestTransformer implements ConfigurationChan
     final var physicalTenantId = tenantArguments.keySet().iterator().next();
     return Optional.of(
         new RestoreRequestTransformer(request.toRestoreRequest(physicalTenantId), registry));
-  }
-
-  private static InvalidRequest clusterWideNotSupported() {
-    return new InvalidRequest(
-        "Restoring every physical tenant of the cluster in one request is not supported yet; "
-            + "provide a physicalTenantId to restore a single physical tenant.");
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -20,8 +20,9 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
@@ -31,10 +32,11 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhas
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.util.Either;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -74,10 +76,8 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
               "Expected to restore physical tenant '%s', but there's no such tenant"
                   .formatted(physicalTenantId)));
     }
-    return groupOperations(partitionGroup)
-        .map(
-            operations ->
-                List.of(PartitionGroupPhase.sequential(Map.of(physicalTenantId, operations))));
+    return groupGraph(partitionGroup)
+        .map(graph -> List.of(new PartitionGroupPhase(Map.of(physicalTenantId, graph))));
   }
 
   /**
@@ -85,8 +85,7 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
    * partition group alone. Shared with {@link ClusterRestoreRequestTransformer}, which combines the
    * plans of several physical tenants into one phase.
    */
-  Either<Exception, List<PartitionGroupOperation>> groupOperations(
-      final PartitionGroupConfiguration partitionGroup) {
+  Either<Exception, OperationGraph> groupGraph(final PartitionGroupConfiguration partitionGroup) {
     if (!isGroupRecovering(partitionGroup)) {
       return Either.left(
           new ConcurrentModificationException(
@@ -102,7 +101,7 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
    * brokers. A validator rejection, and anything the plan builder throws over a partition the
    * validator did not resolve a selection for, is mapped to a request failure.
    */
-  private Either<Exception, List<PartitionGroupOperation>> restorePlan(
+  private Either<Exception, OperationGraph> restorePlan(
       final SortedMap<MemberId, Set<Integer>> partitionsPerMember) {
     final var validator = registry.getValidator(request.physicalTenantId(), RestoreRequest.class);
     if (validator.isEmpty()) {
@@ -114,7 +113,7 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
     }
     try {
       return Either.right(
-          restoreOperations(partitionsPerMember, (RestoreResolvedRequest) resolved.get()));
+          restoreGraph(partitionsPerMember, (RestoreResolvedRequest) resolved.get()));
     } catch (final Exception e) {
       return Either.left(mapFailure(e));
     }
@@ -162,34 +161,105 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
   }
 
   /**
-   * The plan is phase-major: every partition of every broker is pre-restored, then every partition
-   * is restored, then every broker leaves recovery, and finally, the incarnation number is bumped
-   * once so the restored data is not mistaken for the purged generation.
+   * The restore expressed as dependencies rather than list order, scoped to the partition each
+   * operation actually concerns.
+   *
+   * <p>The unit of ordering is one broker's copy of one partition, not the plan. Wiping and
+   * reloading a copy touches nothing else, so every {@code (broker, partition)} pair is an
+   * independent chain: {@code m0} can be reloading partition 1 while {@code m2} is still wiping its
+   * own copy of it.
+   *
+   * <p>The edges, per partition {@code k} and broker {@code m}:
+   *
+   * <ul>
+   *   <li>{@code preRestore(m,k)} — nothing; every pre-restore of every partition starts at once.
+   *   <li>{@code restore(m,k)} — only {@code preRestore(m,k)}. Wiping and reloading a broker's copy
+   *       of a partition is local to that broker, so one broker may reload {@code k} while a peer
+   *       is still wiping its own copy of {@code k}.
+   *   <li>{@code modeChange(m)} — the restores of the partitions {@code m} holds. Partitions {@code
+   *       m} does not hold cannot block it leaving recovery.
+   *   <li>{@code awaitModeChange(m)} — every mode change and <em>every</em> restore. This one is
+   *       deliberately a cluster-wide barrier: awaiting the transition observes the group as a
+   *       whole, so no broker may start observing while any partition anywhere is still reloading.
+   *   <li>{@code updateIncarnationNumber} — every await. It writes the group's own state, so it is
+   *       ordered after everything by construction.
+   * </ul>
+   *
+   * <p>So there is one cluster-wide barrier, at the awaits. Everything before it is scoped: the
+   * {@code N·P} wipes and reloads become {@code N·P} independent chains rather than two
+   * cluster-wide barriers, and a broker leaves recovery as soon as the partitions it holds are back
+   * rather than waiting on partitions it does not hold. On a tenant where every broker replicates
+   * every partition the mode-change edges collapse to cluster-wide anyway, since there every broker
+   * holds everything; the wipe/reload chains do not, and that is where the I/O is.
    */
-  private static List<PartitionGroupOperation> restoreOperations(
+  private static OperationGraph restoreGraph(
       final SortedMap<MemberId, Set<Integer>> partitionsPerMember,
       final RestoreResolvedRequest resolved) {
-    final var operations = new ArrayList<PartitionGroupOperation>();
-    for (final var member : partitionsPerMember.entrySet()) {
-      for (final var partitionId : member.getValue()) {
-        operations.add(new PartitionPreRestoreOperation(member.getKey(), partitionId));
-      }
-    }
-    for (final var member : partitionsPerMember.entrySet()) {
-      for (final var partitionId : member.getValue()) {
-        final var backupIds = resolved.backups().get(partitionId);
-        operations.add(
-            new PartitionRestoreOperation(member.getKey(), partitionId, toSortedSet(backupIds)));
-      }
-    }
-    for (final var memberId : partitionsPerMember.keySet()) {
-      operations.add(new ModeChangeOperation(memberId, Mode.PROCESSING));
-    }
-    for (final var memberId : partitionsPerMember.keySet()) {
-      operations.add(new AwaitModeChangeOperation(memberId, Mode.PROCESSING));
-    }
-    operations.add(new UpdateIncarnationNumberOperation(partitionsPerMember.firstKey()));
-    return operations;
+    final var builder = OperationGraph.builder();
+
+    final Map<MemberId, Map<Integer, OperationId>> preRestoreOf = new TreeMap<>();
+    partitionsPerMember.forEach(
+        (memberId, partitions) ->
+            partitions.forEach(
+                partitionId ->
+                    preRestoreOf
+                        .computeIfAbsent(memberId, ignored -> new TreeMap<>())
+                        .put(
+                            partitionId,
+                            builder.add(new PartitionPreRestoreOperation(memberId, partitionId)))));
+
+    final Map<Integer, Set<OperationId>> restoresOf = new TreeMap<>();
+    partitionsPerMember.forEach(
+        (memberId, partitions) ->
+            partitions.forEach(
+                partitionId ->
+                    restoresOf
+                        .computeIfAbsent(partitionId, ignored -> new HashSet<>())
+                        .add(
+                            builder.add(
+                                new PartitionRestoreOperation(
+                                    memberId,
+                                    partitionId,
+                                    toSortedSet(resolved.backups().get(partitionId))),
+                                Set.of(
+                                    Objects.requireNonNull(
+                                        preRestoreOf.get(memberId).get(partitionId)))))));
+
+    final SortedMap<MemberId, OperationId> modeChanges = new TreeMap<>();
+    partitionsPerMember.forEach(
+        (memberId, partitions) ->
+            modeChanges.put(
+                memberId,
+                builder.add(
+                    new ModeChangeOperation(memberId, Mode.PROCESSING),
+                    operationsFor(partitions, restoresOf))));
+
+    // Every await waits for every restore, cluster-wide, not only for the ones on its own broker or
+    // its own partitions' replicas. Awaiting the transition observes the group as a whole, so a
+    // broker must not start observing while any partition anywhere is still being reloaded.
+    final Set<OperationId> beforeAwaits = new HashSet<>(modeChanges.values());
+    restoresOf.values().forEach(beforeAwaits::addAll);
+
+    final Set<OperationId> awaits = new HashSet<>();
+    partitionsPerMember
+        .keySet()
+        .forEach(
+            memberId ->
+                awaits.add(
+                    builder.add(
+                        new AwaitModeChangeOperation(memberId, Mode.PROCESSING), beforeAwaits)));
+
+    builder.add(new UpdateIncarnationNumberOperation(partitionsPerMember.firstKey()), awaits);
+    return builder.build();
+  }
+
+  /** The union of the operations recorded for each of {@code partitions}. */
+  private static Set<OperationId> operationsFor(
+      final Set<Integer> partitions, final Map<Integer, Set<OperationId>> operationsPerPartition) {
+    final Set<OperationId> union = new HashSet<>();
+    partitions.forEach(
+        partitionId -> union.addAll(operationsPerPartition.getOrDefault(partitionId, Set.of())));
+    return union;
   }
 
   /** Whether every initialized broker of the cluster is in recovery. */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -16,9 +16,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidState;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.OperationGraph;
 import io.camunda.zeebe.dynamic.config.state.OperationId;
@@ -117,26 +115,6 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
     } catch (final Exception e) {
       return Either.left(mapFailure(e));
     }
-  }
-
-  /**
-   * The brokers to restore, each mapped to the partitions it holds, ordered by broker id. On the
-   * legacy model recovery is a broker-wide state, so every recovering broker takes part — including
-   * one holding no partition, which contributes no partition operation but still has to exit
-   * recovery, since entering it transitioned that broker too.
-   */
-  private static SortedMap<MemberId, Set<Integer>> recoveringMembers(
-      final ClusterConfiguration clusterConfiguration) {
-    final SortedMap<MemberId, Set<Integer>> partitionsPerMember = new TreeMap<>();
-    clusterConfiguration
-        .members()
-        .forEach(
-            (memberId, member) -> {
-              if (member.state() == State.RECOVERING) {
-                partitionsPerMember.put(memberId, member.partitions().keySet());
-              }
-            });
-    return partitionsPerMember;
   }
 
   /**
@@ -269,16 +247,6 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
     partitions.forEach(
         partitionId -> union.addAll(operationsPerPartition.getOrDefault(partitionId, Set.of())));
     return union;
-  }
-
-  /** Whether every initialized broker of the cluster is in recovery. */
-  private static boolean isClusterRecovering(final ClusterConfiguration clusterConfiguration) {
-    final var initializedMembers =
-        clusterConfiguration.members().values().stream()
-            .filter(member -> member.state() != State.UNINITIALIZED && member.state() != State.LEFT)
-            .toList();
-    return !initializedMembers.isEmpty()
-        && initializedMembers.stream().allMatch(member -> member.state() == State.RECOVERING);
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -175,7 +175,9 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
    *   <li>{@code preRestore(m,k)} — nothing; every pre-restore of every partition starts at once.
    *   <li>{@code restore(m,k)} — only {@code preRestore(m,k)}. Wiping and reloading a broker's copy
    *       of a partition is local to that broker, so one broker may reload {@code k} while a peer
-   *       is still wiping its own copy of {@code k}.
+   *       is still wiping its own copy of {@code k}. What makes leaving these unordered safe is
+   *       that neither step writes the group configuration — see {@code PartitionPreRestoreApplier}
+   *       and {@code PartitionRestoreApplier}, which both apply {@code UnaryOperator.identity()}.
    *   <li>{@code modeChange(m)} — the restores of the partitions {@code m} holds. Partitions {@code
    *       m} does not hold cannot block it leaving recovery.
    *   <li>{@code awaitModeChange(m)} — every mode change and <em>every</em> restore. This one is
@@ -184,6 +186,13 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
    *   <li>{@code updateIncarnationNumber} — every await. It writes the group's own state, so it is
    *       ordered after everything by construction.
    * </ul>
+   *
+   * <p>Scoping the edges is only safe because no two operations that may run concurrently write the
+   * same part of the group configuration: the wipes and reloads write nothing at all, a mode change
+   * and its await write only broker {@code m}'s own mode and partition states, and the one
+   * whole-group write, the incarnation number, is ordered after every await. An applier that starts
+   * writing something wider has to be paired with edges here that order it against the operations
+   * it now shares a field with.
    *
    * <p>So there is one cluster-wide barrier, at the awaits. Everything before it is scoped: the
    * {@code N·P} wipes and reloads become {@code N·P} independent chains rather than two

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/ExitRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/ExitRecoveryApplier.java
@@ -24,6 +24,14 @@ import java.util.function.UnaryOperator;
  * Mode#PROCESSING}, operating on a single named {@link PartitionGroupConfiguration}. Mirrors the
  * legacy {@code ExitRecoveryApplier} in {@code changes/}, which this does not replace or modify.
  * See {@link EnterRecoveryApplier} for the cluster-lifecycle vs. per-group-mode split rationale.
+ *
+ * <p>Writes one field of one member: {@link #init} returns {@link UnaryOperator#identity()}, and
+ * {@link #apply()} sets only {@code memberId}'s own mode to {@link Mode#PROCESSING}. {@code
+ * RestoreRequestTransformer} relies on that scoping to give every broker its own mode change,
+ * ordered after the restores of the partitions that broker holds and nothing else, so brokers leave
+ * recovery concurrently rather than at a cluster-wide barrier. A write added here that reached
+ * another member, or the group as a whole, would need dependency edges there ordering it against
+ * the other brokers' mode changes.
  */
 public final class ExitRecoveryApplier implements PartitionGroupConfigurationChangeApplier {
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionPreRestoreApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionPreRestoreApplier.java
@@ -21,6 +21,13 @@ import java.util.function.UnaryOperator;
  * PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation}. Mirrors the
  * legacy {@code PartitionPreRestoreApplier} in {@code changes/}, which this does not replace or
  * modify.
+ *
+ * <p>Writes nothing to the {@link PartitionGroupConfiguration}: wiping a partition's data touches
+ * only that broker's local disk, so both {@link #init} and {@link #apply()} return {@link
+ * UnaryOperator#identity()}. {@code RestoreRequestTransformer} relies on this to leave every
+ * pre-restore free of dependencies, so all of them run at once across brokers and partitions. A
+ * configuration write added here would need dependency edges there to order it against the other
+ * operations writing the same field.
  */
 public final class PartitionPreRestoreApplier implements PartitionGroupConfigurationChangeApplier {
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionRestoreApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionRestoreApplier.java
@@ -21,6 +21,13 @@ import java.util.function.UnaryOperator;
  * New-model applier for {@code
  * PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation}. Mirrors the legacy
  * {@code PartitionRestoreApplier} in {@code changes/}, which this does not replace or modify.
+ *
+ * <p>Writes nothing to the {@link PartitionGroupConfiguration}: reloading a partition from backup
+ * touches only that broker's local disk, so both {@link #init} and {@link #apply()} return {@link
+ * UnaryOperator#identity()}. {@code RestoreRequestTransformer} relies on this to make each {@code
+ * (broker, partition)} pair an independent chain, so one broker may reload a partition while a peer
+ * is still wiping its own copy of it. A configuration write added here would need dependency edges
+ * there to order it against the other operations writing the same field.
  */
 public final class PartitionRestoreApplier implements PartitionGroupConfigurationChangeApplier {
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/RestoreAppliers.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/RestoreAppliers.java
@@ -20,6 +20,13 @@ final class RestoreAppliers {
 
   private RestoreAppliers() {}
 
+  /**
+   * Rejects the operation unless the member is an active broker of the cluster, part of the group,
+   * in recovery for it, and a replica of the partition. Validation only: on success it returns
+   * {@link UnaryOperator#identity()}, since no restore step writes the {@link
+   * PartitionGroupConfiguration} — see {@link PartitionPreRestoreApplier} and {@link
+   * PartitionRestoreApplier} for why the restore graph depends on that.
+   */
   static Either<Exception, UnaryOperator<PartitionGroupConfiguration>> requireRecoveringMember(
       final GlobalConfiguration currentGlobalConfiguration,
       final PartitionGroupConfiguration currentPartitionGroupConfiguration,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateIncarnationNumberApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateIncarnationNumberApplier.java
@@ -20,6 +20,12 @@ import java.util.function.UnaryOperator;
  * on a single named {@link PartitionGroupConfiguration} as a whole. Mirrors the legacy {@code
  * UpdateIncarnationNumberApplier} in {@code changes/}, which this does not replace or modify.
  * Increments the group's incarnation number by 1.
+ *
+ * <p>That increment is the group record's own field rather than any one member's, so this is the
+ * only whole-group write in a restore. {@code RestoreRequestTransformer} therefore orders it after
+ * every await, leaving it concurrent with nothing: every other restore step writes either nothing
+ * at all or a single member's own mode and partition states. {@link #init} adds no write of its
+ * own.
  */
 public final class UpdateIncarnationNumberApplier
     implements PartitionGroupConfigurationChangeApplier {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -64,10 +65,8 @@ final class ClusterRestoreRequestTransformerTest {
 
     // then — one phase, scoped to tenant-b's own partition; the other two tenants are untouched
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(TENANT_B, tenantBRestoreOperations(List.of(55L)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(Map.of(TENANT_B, tenantBRestoreOperations(List.of(55L))));
   }
 
   @Test
@@ -84,13 +83,12 @@ final class ClusterRestoreRequestTransformerTest {
 
     // then — all three physical tenants restore in the same phase, each from its own backup
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(
-                    DEFAULT_GROUP, defaultRestoreOperations(List.of(100L)),
-                    TENANT_B, tenantBRestoreOperations(List.of(55L)),
-                    TENANT_C, tenantCRestoreOperations(List.of(77L)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(
+            Map.of(
+                DEFAULT_GROUP, defaultRestoreOperations(List.of(100L)),
+                TENANT_B, tenantBRestoreOperations(List.of(55L)),
+                TENANT_C, tenantCRestoreOperations(List.of(77L))));
   }
 
   @Test
@@ -107,10 +105,8 @@ final class ClusterRestoreRequestTransformerTest {
 
     // then — the restore is planned rather than refused as a cluster that is not recovering
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(TENANT_B, tenantBRestoreOperations(List.of(55L)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(Map.of(TENANT_B, tenantBRestoreOperations(List.of(55L))));
   }
 
   @Test
@@ -274,5 +270,15 @@ final class ClusterRestoreRequestTransformerTest {
           }
         });
     return registry;
+  }
+
+  /**
+   * The operations each group's graph holds, in plan order. The graph's dependency structure is
+   * covered separately; these assertions are about which operations a request produces.
+   */
+  private static Map<String, List<PartitionGroupOperation>> groupOperationsOf(
+      final List<Phase> phases) {
+    assertThat(phases).singleElement().isInstanceOf(PartitionGroupPhase.class);
+    return ((PartitionGroupPhase) phases.getFirst()).groupOperations();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
@@ -61,6 +61,7 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 final class RestoreRequestTransformerTest {
@@ -575,7 +576,7 @@ final class RestoreRequestTransformerTest {
     }
 
     final var released =
-        group.pendingGraphChanges().orElseThrow().runnableFor(memberOne).values().stream()
+        group.pendingChanges().orElseThrow().runnableFor(memberOne).values().stream()
             .filter(PartitionRestoreOperation.class::isInstance)
             .map(PartitionRestoreOperation.class::cast)
             .toList();
@@ -583,10 +584,62 @@ final class RestoreRequestTransformerTest {
   }
 
   @Test
+  void shouldOrderAModeChangeBehindTheRestoresOfOnlyItsOwnPartitions() {
+    // given - an asymmetric group: member 0 holds partition 1 alone, member 1 holds both. A broker
+    // leaves recovery as soon as the partitions it holds are back, so partition 2 must not block
+    // member 0, which does not host it. This edge is what keeps the mode changes broker-scoped
+    // instead of turning them into a second cluster-wide barrier - the whole point of the graph.
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(
+                validatorReturning(
+                    Either.right(
+                        new RestoreResolvedRequest(
+                            Map.of(1, new long[] {1L}, 2, new long[] {2L}), false)))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    memberOne, recovering(1),
+                    memberTwo, recovering(1, 2))));
+
+    // then - each mode change waits for the restores of its own partitions on every broker, and for
+    // nothing else. Partition 1 is replicated by both brokers, partition 2 only by member 1.
+    EitherAssert.assertThat(result).isRight();
+    final var graph = graphOf(result.get());
+    final var restoresOfPartitionOne = restoresOfPartition(graph, 1);
+    final var restoresOfPartitionTwo = restoresOfPartition(graph, 2);
+    assertThat(restoresOfPartitionOne).hasSize(2);
+    assertThat(restoresOfPartitionTwo).hasSize(1);
+
+    final var modeChangeOf = modeChangesByMember(graph);
+    assertThat(graph.operations().get(modeChangeOf.get(memberOne)).dependsOn())
+        .describedAs("dependencies of the mode change on the broker holding partition 1 only")
+        .containsExactlyInAnyOrderElementsOf(restoresOfPartitionOne);
+    assertThat(graph.operations().get(modeChangeOf.get(memberTwo)).dependsOn())
+        .describedAs("dependencies of the mode change on the broker holding both partitions")
+        .containsExactlyInAnyOrderElementsOf(
+            Stream.concat(restoresOfPartitionOne.stream(), restoresOfPartitionTwo.stream())
+                .toList());
+  }
+
+  @Test
   void shouldAwaitTheModeChangeOnlyAfterEveryRestoreEverywhere() {
     // given - two brokers, two partitions. Restores are narrowed per partition, but awaiting the
     // transition observes the group as a whole, so this stage is a cluster-wide barrier: no broker
     // may start awaiting while any partition anywhere is still reloading.
+    //
+    // The barrier also covers every mode change, including the awaiting broker's own. An earlier
+    // version of the edge rules derived an await's dependencies from the brokers it shares a
+    // partition with, leaving a broker that shares none unordered against its own mode change. Both
+    // write that broker's member entry, so the sub-configuration merge would keep one by version
+    // and
+    // silently drop the other. Nothing rejects that shape any more, so it is pinned here.
     final var memberOne = MemberId.from("0");
     final var memberTwo = MemberId.from("1");
     final var transformer =
@@ -606,7 +659,8 @@ final class RestoreRequestTransformerTest {
                     memberOne, recovering(1, 2),
                     memberTwo, recovering(1, 2))));
 
-    // then - every await waits for all four restores and for both mode changes
+    // then - every await waits for all four restores and for both mode changes, and for nothing
+    // else: the pre-restores are already covered transitively by the restores
     EitherAssert.assertThat(result).isRight();
     final var graph = graphOf(result.get());
     final var restores = idsOf(graph, PartitionRestoreOperation.class);
@@ -618,8 +672,48 @@ final class RestoreRequestTransformerTest {
         .allSatisfy(
             await ->
                 assertThat(graph.operations().get(await).dependsOn())
-                    .containsAll(restores)
-                    .containsAll(modeChanges));
+                    .describedAs("dependencies of the await on %s", memberOf(graph, await))
+                    .containsExactlyInAnyOrderElementsOf(
+                        Stream.concat(restores.stream(), modeChanges.stream()).toList()));
+  }
+
+  @Test
+  void shouldOrderTheIncarnationBumpAfterEveryAwait() {
+    // given - two brokers, two partitions. The incarnation number is the group's own state, written
+    // once the restore is done. Bumping it while any broker is still observing its transition would
+    // advertise a recovery that has not finished, so it is ordered behind every await - not just
+    // behind one of them, and not behind the restores alone.
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(
+                validatorReturning(
+                    Either.right(
+                        new RestoreResolvedRequest(
+                            Map.of(1, new long[] {1L}, 2, new long[] {2L}), false)))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    memberOne, recovering(1, 2),
+                    memberTwo, recovering(1, 2))));
+
+    // then - one bump, waiting for every await and for nothing else
+    EitherAssert.assertThat(result).isRight();
+    final var graph = graphOf(result.get());
+    final var awaits = idsOf(graph, AwaitModeChangeOperation.class);
+    assertThat(awaits).hasSize(2);
+    assertThat(idsOf(graph, UpdateIncarnationNumberOperation.class))
+        .singleElement()
+        .satisfies(
+            bump ->
+                assertThat(graph.operations().get(bump).dependsOn())
+                    .describedAs("dependencies of the incarnation bump")
+                    .containsExactlyInAnyOrderElementsOf(awaits));
   }
 
   private static MemberId memberOf(final OperationGraph graph, final OperationId operationId) {
@@ -631,42 +725,19 @@ final class RestoreRequestTransformerTest {
         .partitionId();
   }
 
-  @Test
-  void shouldOrderEveryBrokersAwaitAfterItsOwnModeChange() {
-    // given — a broker holding no partition of the group still has to leave recovery, so it gets a
-    // mode change and an await with no partition work between them. An earlier version of the edge
-    // rules derived the await's dependencies from the brokers it shares a partition with, which for
-    // this broker is nobody — leaving its own mode change unordered against its own await. Both
-    // write that broker's member entry, so the sub-configuration merge would keep one by version
-    // and silently drop the other. Nothing rejects that shape any more, so it is pinned here.
-    final var withPartitions = MemberId.from("0");
-    final var withoutPartitions = MemberId.from("1");
-    final var transformer =
-        new RestoreRequestTransformer(
-            restoreRequest(),
-            registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
+  /** The restores of the given partition, one per broker replicating it. */
+  private static List<OperationId> restoresOfPartition(
+      final OperationGraph graph, final int partitionId) {
+    return idsOf(graph, PartitionRestoreOperation.class).stream()
+        .filter(restore -> partitionOf(graph, restore) == partitionId)
+        .toList();
+  }
 
-    // when
-    final var result =
-        transformer.phases(
-            clusterWithDefaultGroup(
-                Map.of(
-                    withPartitions, recovering(1),
-                    withoutPartitions, BrokerPartitionState.initialize(Map.of()))));
-
-    // then — every await depends on its own broker's mode change
-    EitherAssert.assertThat(result).isRight();
-    final var graph = graphOf(result.get());
+  private static Map<MemberId, OperationId> modeChangesByMember(final OperationGraph graph) {
     final var modeChangeOf = new HashMap<MemberId, OperationId>();
     idsOf(graph, ModeChangeOperation.class)
         .forEach(id -> modeChangeOf.put(memberOf(graph, id), id));
-    assertThat(idsOf(graph, AwaitModeChangeOperation.class))
-        .isNotEmpty()
-        .allSatisfy(
-            await ->
-                assertThat(graph.operations().get(await).dependsOn())
-                    .describedAs("dependencies of the await on %s", memberOf(graph, await))
-                    .contains(modeChangeOf.get(memberOf(graph, await))));
+    return modeChangeOf;
   }
 
   private static OperationGraph graphOf(final List<Phase> phases) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
@@ -24,31 +24,42 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.Either;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
@@ -313,21 +324,20 @@ final class RestoreRequestTransformerTest {
 
     // then - one phase scoped to the tenant's own group, phase-major within it
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(
-                    DEFAULT_PHYSICAL_TENANT_ID,
-                    List.of(
-                        new PartitionPreRestoreOperation(memberOne, 1),
-                        new PartitionPreRestoreOperation(memberTwo, 1),
-                        new PartitionRestoreOperation(memberOne, 1, new TreeSet<>(List.of(1L, 2L))),
-                        new PartitionRestoreOperation(memberTwo, 1, new TreeSet<>(List.of(1L, 2L))),
-                        new ModeChangeOperation(memberOne, Mode.PROCESSING),
-                        new ModeChangeOperation(memberTwo, Mode.PROCESSING),
-                        new AwaitModeChangeOperation(memberOne, Mode.PROCESSING),
-                        new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
-                        new UpdateIncarnationNumberOperation(memberOne)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(
+            Map.of(
+                DEFAULT_PHYSICAL_TENANT_ID,
+                List.of(
+                    new PartitionPreRestoreOperation(memberOne, 1),
+                    new PartitionPreRestoreOperation(memberTwo, 1),
+                    new PartitionRestoreOperation(memberOne, 1, new TreeSet<>(List.of(1L, 2L))),
+                    new PartitionRestoreOperation(memberTwo, 1, new TreeSet<>(List.of(1L, 2L))),
+                    new ModeChangeOperation(memberOne, Mode.PROCESSING),
+                    new ModeChangeOperation(memberTwo, Mode.PROCESSING),
+                    new AwaitModeChangeOperation(memberOne, Mode.PROCESSING),
+                    new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
+                    new UpdateIncarnationNumberOperation(memberOne))));
   }
 
   @Test
@@ -352,17 +362,16 @@ final class RestoreRequestTransformerTest {
 
     // then - the restore is planned for the recovering broker alone
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get())
-        .containsExactly(
-            PartitionGroupPhase.sequential(
-                Map.of(
-                    DEFAULT_PHYSICAL_TENANT_ID,
-                    List.of(
-                        new PartitionPreRestoreOperation(memberTwo, 1),
-                        new PartitionRestoreOperation(memberTwo, 1, new TreeSet<>(List.of(1L))),
-                        new ModeChangeOperation(memberTwo, Mode.PROCESSING),
-                        new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
-                        new UpdateIncarnationNumberOperation(memberTwo)))));
+    assertThat(groupOperationsOf(result.get()))
+        .isEqualTo(
+            Map.of(
+                DEFAULT_PHYSICAL_TENANT_ID,
+                List.of(
+                    new PartitionPreRestoreOperation(memberTwo, 1),
+                    new PartitionRestoreOperation(memberTwo, 1, new TreeSet<>(List.of(1L))),
+                    new ModeChangeOperation(memberTwo, Mode.PROCESSING),
+                    new AwaitModeChangeOperation(memberTwo, Mode.PROCESSING),
+                    new UpdateIncarnationNumberOperation(memberTwo))));
   }
 
   @Test
@@ -407,9 +416,14 @@ final class RestoreRequestTransformerTest {
         .hasMessageContaining(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
-  private static BrokerPartitionState recovering(final int partitionId) {
+  private static BrokerPartitionState recovering(final int... partitionIds) {
     return BrokerPartitionState.initialize(
-            Map.of(partitionId, PartitionState.active(1, DynamicPartitionConfig.init())))
+            Arrays.stream(partitionIds)
+                .boxed()
+                .collect(
+                    Collectors.toMap(
+                        Function.identity(),
+                        ignored -> PartitionState.active(1, DynamicPartitionConfig.init()))))
         .setMode(Mode.RECOVERING);
   }
 
@@ -445,5 +459,236 @@ final class RestoreRequestTransformerTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty());
+  }
+
+  /**
+   * The point of the dependency-graph model is which operations may run at the same time. The
+   * assertions above pin <em>which</em> operations a restore produces; these two pin the
+   * concurrency, which is the part that changed.
+   */
+  @Test
+  void shouldOfferEveryBrokerAndPartitionAtOnce() {
+    // given - two brokers, each recovering the same two partitions
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(
+                validatorReturning(
+                    Either.right(
+                        new RestoreResolvedRequest(
+                            Map.of(1, new long[] {1L}, 2, new long[] {2L}), false)))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    memberOne, recovering(1, 2),
+                    memberTwo, recovering(1, 2))));
+
+    // then - a plan started from this graph offers all four pre-restores at once: both brokers,
+    // both partitions. Under the queue those were four serialised round trips.
+    EitherAssert.assertThat(result).isRight();
+    final var plan = DependencyChangePlan.init(1L, graphOf(result.get()));
+    assertThat(plan.runnableFor(memberOne)).hasSize(2);
+    assertThat(plan.runnableFor(memberTwo)).hasSize(2);
+    assertThat(plan.runnableFor(memberOne).values())
+        .allSatisfy(
+            operation -> assertThat(operation).isInstanceOf(PartitionPreRestoreOperation.class));
+  }
+
+  @Test
+  void shouldWaitOnlyForItsOwnBrokersPreRestoreOfThatPartition() {
+    // given - two brokers replicating partition 1. Wiping and reloading a broker's own copy is
+    // local to that broker, so a restore is ordered behind exactly one pre-restore: its own.
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    memberOne, recovering(1),
+                    memberTwo, recovering(1))));
+
+    // then - each restore depends on the single pre-restore of the same broker and partition, so
+    // neither broker is held up by the other's wipe
+    EitherAssert.assertThat(result).isRight();
+    final var graph = graphOf(result.get());
+    assertThat(idsOf(graph, PartitionRestoreOperation.class))
+        .hasSize(2)
+        .allSatisfy(
+            restore -> {
+              final var dependsOn = graph.operations().get(restore).dependsOn();
+              assertThat(dependsOn).hasSize(1);
+              final var preRestore = dependsOn.first();
+              assertThat(graph.operations().get(preRestore).operation())
+                  .isInstanceOf(PartitionPreRestoreOperation.class);
+              assertThat(memberOf(graph, preRestore)).isEqualTo(memberOf(graph, restore));
+              assertThat(partitionOf(graph, preRestore)).isEqualTo(partitionOf(graph, restore));
+            });
+  }
+
+  @Test
+  void shouldNotOrderOnePartitionBehindAnother() {
+    // given - two partitions on two brokers. Partition 2 shares nothing with partition 1, so
+    // holding its restore behind partition 1's wipe would serialise work that cannot interfere.
+    // This is the difference from a plan-wide barrier, and where the restore's I/O actually is.
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(
+                validatorReturning(
+                    Either.right(
+                        new RestoreResolvedRequest(
+                            Map.of(1, new long[] {1L}, 2, new long[] {2L}), false)))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    memberOne, recovering(1, 2),
+                    memberTwo, recovering(1, 2))));
+
+    // then - completing only partition 1's two pre-restores releases partition 1's restores, while
+    // partition 2 is still waiting on its own
+    EitherAssert.assertThat(result).isRight();
+    final var graph = graphOf(result.get());
+    var group =
+        new PartitionGroupConfiguration(
+                1, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.empty())
+            .startGraphConfigurationChange(graph);
+    for (final var preRestore : idsOf(graph, PartitionPreRestoreOperation.class)) {
+      if (partitionOf(graph, preRestore) == 1 && memberOf(graph, preRestore).equals(memberOne)) {
+        group = group.completeOperation(preRestore, UnaryOperator.identity());
+      }
+    }
+
+    final var released =
+        group.pendingGraphChanges().orElseThrow().runnableFor(memberOne).values().stream()
+            .filter(PartitionRestoreOperation.class::isInstance)
+            .map(PartitionRestoreOperation.class::cast)
+            .toList();
+    assertThat(released).singleElement().returns(1, PartitionRestoreOperation::partitionId);
+  }
+
+  @Test
+  void shouldAwaitTheModeChangeOnlyAfterEveryRestoreEverywhere() {
+    // given - two brokers, two partitions. Restores are narrowed per partition, but awaiting the
+    // transition observes the group as a whole, so this stage is a cluster-wide barrier: no broker
+    // may start awaiting while any partition anywhere is still reloading.
+    final var memberOne = MemberId.from("0");
+    final var memberTwo = MemberId.from("1");
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(
+                validatorReturning(
+                    Either.right(
+                        new RestoreResolvedRequest(
+                            Map.of(1, new long[] {1L}, 2, new long[] {2L}), false)))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    memberOne, recovering(1, 2),
+                    memberTwo, recovering(1, 2))));
+
+    // then - every await waits for all four restores and for both mode changes
+    EitherAssert.assertThat(result).isRight();
+    final var graph = graphOf(result.get());
+    final var restores = idsOf(graph, PartitionRestoreOperation.class);
+    final var modeChanges = idsOf(graph, ModeChangeOperation.class);
+    assertThat(restores).hasSize(4);
+    assertThat(modeChanges).hasSize(2);
+    assertThat(idsOf(graph, AwaitModeChangeOperation.class))
+        .hasSize(2)
+        .allSatisfy(
+            await ->
+                assertThat(graph.operations().get(await).dependsOn())
+                    .containsAll(restores)
+                    .containsAll(modeChanges));
+  }
+
+  private static MemberId memberOf(final OperationGraph graph, final OperationId operationId) {
+    return graph.operations().get(operationId).operation().memberId();
+  }
+
+  private static int partitionOf(final OperationGraph graph, final OperationId operationId) {
+    return ((PartitionChangeOperation) graph.operations().get(operationId).operation())
+        .partitionId();
+  }
+
+  @Test
+  void shouldOrderEveryBrokersAwaitAfterItsOwnModeChange() {
+    // given — a broker holding no partition of the group still has to leave recovery, so it gets a
+    // mode change and an await with no partition work between them. An earlier version of the edge
+    // rules derived the await's dependencies from the brokers it shares a partition with, which for
+    // this broker is nobody — leaving its own mode change unordered against its own await. Both
+    // write that broker's member entry, so the sub-configuration merge would keep one by version
+    // and silently drop the other. Nothing rejects that shape any more, so it is pinned here.
+    final var withPartitions = MemberId.from("0");
+    final var withoutPartitions = MemberId.from("1");
+    final var transformer =
+        new RestoreRequestTransformer(
+            restoreRequest(),
+            registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
+
+    // when
+    final var result =
+        transformer.phases(
+            clusterWithDefaultGroup(
+                Map.of(
+                    withPartitions, recovering(1),
+                    withoutPartitions, BrokerPartitionState.initialize(Map.of()))));
+
+    // then — every await depends on its own broker's mode change
+    EitherAssert.assertThat(result).isRight();
+    final var graph = graphOf(result.get());
+    final var modeChangeOf = new HashMap<MemberId, OperationId>();
+    idsOf(graph, ModeChangeOperation.class)
+        .forEach(id -> modeChangeOf.put(memberOf(graph, id), id));
+    assertThat(idsOf(graph, AwaitModeChangeOperation.class))
+        .isNotEmpty()
+        .allSatisfy(
+            await ->
+                assertThat(graph.operations().get(await).dependsOn())
+                    .describedAs("dependencies of the await on %s", memberOf(graph, await))
+                    .contains(modeChangeOf.get(memberOf(graph, await))));
+  }
+
+  private static OperationGraph graphOf(final List<Phase> phases) {
+    assertThat(phases).singleElement().isInstanceOf(PartitionGroupPhase.class);
+    return ((PartitionGroupPhase) phases.getFirst()).groupGraphs().get(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  private static List<OperationId> idsOf(
+      final OperationGraph graph, final Class<? extends ClusterConfigurationChangeOperation> type) {
+    return graph.operations().entrySet().stream()
+        .filter(entry -> type.isInstance(entry.getValue().operation()))
+        .map(Entry::getKey)
+        .toList();
+  }
+
+  /**
+   * The operations each group's graph holds, in plan order. The graph's dependency structure is
+   * covered separately; these assertions are about which operations a request produces.
+   */
+  private static Map<String, List<PartitionGroupOperation>> groupOperationsOf(
+      final List<Phase> phases) {
+    assertThat(phases).singleElement().isInstanceOf(PartitionGroupPhase.class);
+    return ((PartitionGroupPhase) phases.getFirst()).groupOperations();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionPreRestoreApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionPreRestoreApplierTest.java
@@ -119,6 +119,35 @@ final class PartitionPreRestoreApplierTest {
         .hasMessageContaining("does not replicate that partition");
   }
 
+  /**
+   * The restore graph leaves every pre-restore free of dependencies, which is only safe as long as
+   * this applier writes nothing to the group configuration. Pinned here so that a write added to
+   * either half of the applier fails instead of silently racing with concurrent restore steps.
+   */
+  @Test
+  void shouldLeaveGroupConfigurationUnchangedOnInit() {
+    // given
+    final var applier =
+        new PartitionPreRestoreApplier(
+            MEMBER_ID, PARTITION_ID, new SucceedingRestoreChangeExecutor());
+    final var globalConfig =
+        GlobalConfiguration.init().addMember(MEMBER_ID, BrokerState.initializeAsActive());
+    final var partitionState =
+        Map.of(PARTITION_ID, PartitionState.active(1, DynamicPartitionConfig.init()));
+    final var groupConfig =
+        PartitionGroupConfiguration.empty(1)
+            .addMember(
+                MEMBER_ID,
+                new BrokerPartitionState(0, Instant.MIN, partitionState, Mode.RECOVERING));
+
+    // when
+    final var result = applier.init(globalConfig, groupConfig);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get().apply(groupConfig)).isSameAs(groupConfig);
+  }
+
   @Test
   void shouldDelegateToExecutorAndLeaveGroupConfigurationUnchanged() {
     // given
@@ -131,6 +160,9 @@ final class PartitionPreRestoreApplierTest {
     // then
     assertThat(result).succeedsWithin(Duration.ofMillis(100));
     assertThat(executor.invokedPartitionIds).containsExactly(PARTITION_ID);
+
+    final var groupConfiguration = PartitionGroupConfiguration.empty(1);
+    assertThat(result.join().apply(groupConfiguration)).isSameAs(groupConfiguration);
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionRestoreApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionRestoreApplierTest.java
@@ -121,6 +121,36 @@ final class PartitionRestoreApplierTest {
         .hasMessageContaining("does not replicate that partition");
   }
 
+  /**
+   * The restore graph orders each restore only after the pre-restore of the same broker and
+   * partition, which is only safe as long as this applier writes nothing to the group
+   * configuration. Pinned here so that a write added to either half of the applier fails instead of
+   * silently racing with concurrent restore steps.
+   */
+  @Test
+  void shouldLeaveGroupConfigurationUnchangedOnInit() {
+    // given
+    final var applier =
+        new PartitionRestoreApplier(
+            MEMBER_ID, PARTITION_ID, BACKUP_IDS, new SucceedingRestoreChangeExecutor());
+    final var globalConfig =
+        GlobalConfiguration.init().addMember(MEMBER_ID, BrokerState.initializeAsActive());
+    final var partitionState =
+        Map.of(PARTITION_ID, PartitionState.active(1, DynamicPartitionConfig.init()));
+    final var groupConfig =
+        PartitionGroupConfiguration.empty(1)
+            .addMember(
+                MEMBER_ID,
+                new BrokerPartitionState(0, Instant.MIN, partitionState, Mode.RECOVERING));
+
+    // when
+    final var result = applier.init(globalConfig, groupConfig);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get().apply(groupConfig)).isSameAs(groupConfig);
+  }
+
   @Test
   void shouldDelegateToExecutorAndLeaveGroupConfigurationUnchanged() {
     // given

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -33,7 +33,9 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
@@ -45,6 +47,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,6 +97,64 @@ public class RecoveryControllerTest extends RestControllerTest {
             CurrentClusterConfiguration.uninitialized(),
             CurrentClusterConfiguration.uninitialized(),
             phases));
+  }
+
+  @Test
+  void shouldReturnPlannedChangesOfAGraphPhase() {
+    // given — this is the shape a mode change actually plans now: a graph whose awaits wait for
+    // every broker's mode change. The response lists the operations; the edges between them are
+    // execution detail the API does not report.
+    final var memberId = MemberId.from("0");
+    final var graph = OperationGraph.builder();
+    final var modeChange = graph.add(new ModeChangeOperation(memberId, Mode.RECOVERING));
+    graph.add(new AwaitModeChangeOperation(memberId, Mode.RECOVERING), Set.of(modeChange));
+    final var changeResponse =
+        new ClusterConfigurationChangeResponse(
+            7L,
+            new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                Map.of(), Map.of(), List.of()),
+            new ClusterConfigurationChangeResponse.CurrentConfigurationChangeResponse(
+                CurrentClusterConfiguration.uninitialized(),
+                CurrentClusterConfiguration.uninitialized(),
+                List.of(
+                    new PartitionGroupPhase(
+                        Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, graph.build())))));
+    Mockito.when(
+            recoveryServices.changeMode(
+                Mockito.eq(Mode.RECOVERING), Mockito.eq(false), Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
+
+    final var expectedResponse =
+        """
+        {
+          "changeId": "7",
+          "plannedChanges": [
+            {
+              "physicalTenantId": "default",
+              "operations": [
+                {
+                  "operation": "ModeChangeOperation",
+                  "mode": "RECOVERING"
+                },
+                {
+                  "operation": "AwaitModeChangeOperation",
+                  "mode": "RECOVERING"
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    // when / then
+    webClient
+        .patch()
+        .uri("/v2/mode?mode=RECOVERING&dryRun=false")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
@@ -10,8 +10,11 @@ package io.camunda.zeebe.it.cluster.backup;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.protocol.rest.ClusterRestoreRequest;
+import io.camunda.client.protocol.rest.RestoreRequest;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Data;
 import io.camunda.configuration.PrimaryStorageBackup;
@@ -21,6 +24,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
@@ -34,11 +38,14 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
-import org.awaitility.core.ThrowingRunnable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,11 +55,15 @@ import org.junit.jupiter.api.io.TempDir;
  * cluster/v2/restore}), as opposed to {@link InProcessRestoreAcceptance} which restores over the
  * per-physical-tenant API ({@code POST v2/restore}).
  *
- * <p>One broker serves three physical tenants — {@code default}, {@code tenantb} and {@code
- * tenantc} — each its own partition group with its own primary storage backup store. No secondary
- * storage is needed: backup/restore acts on primary storage only, independently of it (see {@code
- * ClusterRecoveryServicesTest} in the {@code service} module for coverage of the per-tenant
- * secondary-storage environment that {@code overrides} coexists with).
+ * <p>Runs on a three-broker cluster serving three physical tenants — {@code default}, {@code
+ * tenantb} and {@code tenantc} — each its own partition group of three partitions replicated across
+ * every broker, and each with its own primary storage backup store. That shape is deliberate: it is
+ * the smallest cluster in which all three parallel axes of a restore are non-trivial at once, so a
+ * cluster-wide restore plans 3 tenants × 3 brokers × 3 partitions of partition work rather than
+ * collapsing one of them to a single element. No secondary storage is needed: backup/restore acts
+ * on primary storage only, independently of it (see {@code ClusterRecoveryServicesTest} in the
+ * {@code service} module for coverage of the per-tenant secondary-storage environment that {@code
+ * overrides} coexists with).
  *
  * <p>Covers the three shapes {@link
  * io.camunda.zeebe.dynamic.config.api.ClusterRestoreRequestTransformer} supports: a request naming
@@ -62,14 +73,31 @@ import org.junit.jupiter.api.io.TempDir;
  * all from the same backup in one change; and that same cluster-wide shape with one tenant's backup
  * selection overridden to a different, additional backup, proving the override reaches exactly the
  * tenant it names and nowhere else.
+ *
+ * <h4>What the parallelism assertions here do and do not establish</h4>
+ *
+ * <p>Each scenario asserts that the accepted plan covers every broker and every partition of every
+ * tenant it targets, in a single configuration change — see {@link #assertPlanCovers(HttpResponse,
+ * Set)}. That is what proves the restore is planned across all three axes rather than, say, per
+ * broker in sequence.
+ *
+ * <p>It does not prove the operations then <em>overlap</em> in time. The cluster-admin API carries
+ * no per-operation timestamps, so overlap cannot be asserted through it. Overlap is covered where
+ * it is observable: {@code RestoreRequestTransformerTest} pins the dependency edges that permit it,
+ * and {@code ClusterConfigurationManagerImplNewConfigTest} pins that a broker starts every runnable
+ * operation rather than one per round.
  */
-@Timeout(240)
+@Timeout(600)
 @ZeebeIntegration
 final class ClusterAdminRestoreAcceptanceIT {
 
   private static final String DEFAULT_TENANT = PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
   private static final String TENANT_B = "tenantb";
   private static final String TENANT_C = "tenantc";
+  private static final Set<String> ALL_TENANTS = Set.of(DEFAULT_TENANT, TENANT_B, TENANT_C);
+
+  private static final int BROKERS_COUNT = 3;
+  private static final int PARTITIONS_COUNT = 3;
 
   private static final HttpClient HTTP = HttpClient.newHttpClient();
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -86,25 +114,33 @@ final class ClusterAdminRestoreAcceptanceIT {
           .build();
 
   @TestZeebe
-  private final TestStandaloneBroker broker =
-      configureBackupStores(
-          TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess()));
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(BROKERS_COUNT)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(BROKERS_COUNT)
+          .withEmbeddedGateway(true)
+          .withBrokerConfig(
+              broker ->
+                  configureBackupStores(TENANTS.configure(broker.withUnauthenticatedAccess())))
+          .build();
 
   @Test
   void shouldRestoreOnlyTheForcedPhysicalTenant() {
-    try (final var defaultClient = TENANTS.newClientBuilder(broker, DEFAULT_TENANT).build();
-        final var tenantBClient = TENANTS.newClientBuilder(broker, TENANT_B).build()) {
+    try (final var defaultClient = newClient(DEFAULT_TENANT);
+        final var tenantBClient = newClient(TENANT_B)) {
       final var processId = "forced-restore-process";
       final var jobType = "forced-restore-job";
       final var probeProcessId = "forced-restore-probe";
+      final long backupId = 41;
 
       // given — the default tenant keeps processing throughout; only tenant-b gets a backup
       deployProbeProcess(defaultClient, probeProcessId);
       deployProbeProcess(tenantBClient, probeProcessId);
-      deployAndCreateInstance(defaultClient, processId, jobType);
-      deployAndCreateInstance(tenantBClient, processId, jobType);
+      createInstancesOnEveryPartition(defaultClient, processId, jobType);
+      createInstancesOnEveryPartition(tenantBClient, processId, jobType);
       takeSnapshot(TENANT_B);
-      takeBackup(TENANT_B, 41);
+      takeBackup(TENANT_B, backupId);
 
       // when — only tenant-b is put into RECOVERING, scoped by physicalTenantId
       InProcessRestoreTestUtil.changeClusterMode(defaultClient, TENANT_B, "RECOVERING", false);
@@ -113,17 +149,22 @@ final class ClusterAdminRestoreAcceptanceIT {
       // and — the default tenant is left untouched by the scoped mode change
       assertThat(createInstance(defaultClient, probeProcessId)).isPositive();
 
-      // and — the restore is forced onto tenant-b alone. The mode change above may not have fully
-      // settled yet even though tenant-b's commands are already rejected (rejection can start
-      // before the configuration change that caused it is marked complete), so a transient 409
-      // while it clears is retried rather than failing outright.
-      awaitRestoreTriggered(
-          () -> InProcessRestoreTestUtil.triggerClusterRestore(defaultClient, TENANT_B, 41));
+      // and — the restore is forced onto tenant-b alone
+      final var response =
+          awaitRestoreAccepted(
+              () ->
+                  InProcessRestoreTestUtil.sendClusterRestoreRequest(
+                      defaultClient, TENANT_B, restoreBody(backupId)));
 
-      // then — tenant-b processes commands again once its restore completes, and its baseline job
-      // is still there to complete, proving partition data (not just topology/mode) was restored
+      // then — the plan targets tenant-b alone, but within it every broker and every partition, so
+      // the scoping narrows the tenant axis without serialising the other two
+      assertPlanCovers(response, Set.of(TENANT_B));
+
+      // and — tenant-b processes commands again once its restore completes, and the baseline jobs
+      // of
+      // every partition are still there, proving partition data (not just topology/mode) came back
       awaitCommandsAccepted(tenantBClient, probeProcessId);
-      activateAndComplete(tenantBClient, jobType);
+      completeJobsFromEveryPartition(tenantBClient, jobType);
 
       // and — the default tenant was never affected by the other tenant's restore
       assertThat(createInstance(defaultClient, probeProcessId)).isPositive();
@@ -132,27 +173,22 @@ final class ClusterAdminRestoreAcceptanceIT {
 
   @Test
   void shouldRestoreEveryPhysicalTenantOfTheClusterWhenNoneIsNamed() {
-    try (final var defaultClient = TENANTS.newClientBuilder(broker, DEFAULT_TENANT).build();
-        final var tenantBClient = TENANTS.newClientBuilder(broker, TENANT_B).build();
-        final var tenantCClient = TENANTS.newClientBuilder(broker, TENANT_C).build()) {
+    try (final var defaultClient = newClient(DEFAULT_TENANT);
+        final var tenantBClient = newClient(TENANT_B);
+        final var tenantCClient = newClient(TENANT_C)) {
       final var processId = "cluster-wide-restore-process";
       final var jobType = "cluster-wide-restore-job";
       final var probeProcessId = "cluster-wide-restore-probe";
-      final var backupId = 42;
+      final long backupId = 42;
 
-      // given — every physical tenant has a pending job, backed up from the same selection
-      deployProbeProcess(defaultClient, probeProcessId);
-      deployProbeProcess(tenantBClient, probeProcessId);
-      deployProbeProcess(tenantCClient, probeProcessId);
-      deployAndCreateInstance(defaultClient, processId, jobType);
-      deployAndCreateInstance(tenantBClient, processId, jobType);
-      deployAndCreateInstance(tenantCClient, processId, jobType);
-      takeSnapshot(DEFAULT_TENANT);
-      takeSnapshot(TENANT_B);
-      takeSnapshot(TENANT_C);
-      takeBackup(DEFAULT_TENANT, backupId);
-      takeBackup(TENANT_B, backupId);
-      takeBackup(TENANT_C, backupId);
+      // given — every physical tenant has a pending job on every partition, backed up from the same
+      // selection
+      for (final var client : List.of(defaultClient, tenantBClient, tenantCClient)) {
+        deployProbeProcess(client, probeProcessId);
+        createInstancesOnEveryPartition(client, processId, jobType);
+      }
+      ALL_TENANTS.forEach(this::takeSnapshot);
+      ALL_TENANTS.forEach(tenant -> takeBackup(tenant, backupId));
 
       // when — the whole cluster is put into RECOVERING, no physicalTenantId naming every tenant
       InProcessRestoreTestUtil.changeClusterMode(defaultClient, null, "RECOVERING", false);
@@ -161,27 +197,36 @@ final class ClusterAdminRestoreAcceptanceIT {
       awaitCommandsRejected(tenantCClient, probeProcessId);
 
       // and — a cluster-wide restore is triggered, no overrides: every tenant shares the selection
-      awaitRestoreTriggered(
-          () -> InProcessRestoreTestUtil.triggerClusterRestore(defaultClient, backupId, Map.of()));
+      final var response =
+          awaitRestoreAccepted(
+              () ->
+                  InProcessRestoreTestUtil.sendClusterRestoreRequest(
+                      defaultClient, null, restoreBody(backupId)));
 
-      // then — every tenant processes commands again once its restore completes
+      // then — one change plans the restore of all three tenants, each across every broker and
+      // every
+      // partition: 3 × 3 × 3 of partition work in a single change
+      assertPlanCovers(response, ALL_TENANTS);
+
+      // and — every tenant processes commands again once its restore completes
       awaitCommandsAccepted(defaultClient, probeProcessId);
       awaitCommandsAccepted(tenantBClient, probeProcessId);
       awaitCommandsAccepted(tenantCClient, probeProcessId);
 
-      // and — every tenant's baseline job is still there to complete, proving partition data (not
-      // just topology/mode) was restored on all three
-      activateAndComplete(defaultClient, jobType);
-      activateAndComplete(tenantBClient, jobType);
-      activateAndComplete(tenantCClient, jobType);
+      // and — every partition of every tenant has its baseline job back, proving partition data
+      // (not
+      // just topology/mode) was restored on all nine partitions
+      completeJobsFromEveryPartition(defaultClient, jobType);
+      completeJobsFromEveryPartition(tenantBClient, jobType);
+      completeJobsFromEveryPartition(tenantCClient, jobType);
     }
   }
 
   @Test
   void shouldRestoreTheOverriddenTenantFromItsOwnBackupWhileOthersShareTheDefault() {
-    try (final var defaultClient = TENANTS.newClientBuilder(broker, DEFAULT_TENANT).build();
-        final var tenantBClient = TENANTS.newClientBuilder(broker, TENANT_B).build();
-        final var tenantCClient = TENANTS.newClientBuilder(broker, TENANT_C).build()) {
+    try (final var defaultClient = newClient(DEFAULT_TENANT);
+        final var tenantBClient = newClient(TENANT_B);
+        final var tenantCClient = newClient(TENANT_C)) {
       final var baselineProcessId = "override-it-baseline-process";
       final var baselineJobType = "override-it-baseline-job";
       final var overrideProcessId = "override-it-override-process";
@@ -190,26 +235,20 @@ final class ClusterAdminRestoreAcceptanceIT {
       final long baselineBackupId = 100;
       final long overrideBackupId = 200;
 
-      // given — every physical tenant has a pending job from the baseline process
-      deployProbeProcess(defaultClient, probeProcessId);
-      deployProbeProcess(tenantBClient, probeProcessId);
-      deployProbeProcess(tenantCClient, probeProcessId);
-      deployAndCreateInstance(defaultClient, baselineProcessId, baselineJobType);
-      deployAndCreateInstance(tenantBClient, baselineProcessId, baselineJobType);
-      deployAndCreateInstance(tenantCClient, baselineProcessId, baselineJobType);
+      // given — every physical tenant has a pending baseline job on every partition
+      for (final var client : List.of(defaultClient, tenantBClient, tenantCClient)) {
+        deployProbeProcess(client, probeProcessId);
+        createInstancesOnEveryPartition(client, baselineProcessId, baselineJobType);
+      }
 
       // and — a completed baseline backup on all three tenants
-      takeSnapshot(DEFAULT_TENANT);
-      takeSnapshot(TENANT_B);
-      takeSnapshot(TENANT_C);
-      takeBackup(DEFAULT_TENANT, baselineBackupId);
-      takeBackup(TENANT_B, baselineBackupId);
-      takeBackup(TENANT_C, baselineBackupId);
+      ALL_TENANTS.forEach(this::takeSnapshot);
+      ALL_TENANTS.forEach(tenant -> takeBackup(tenant, baselineBackupId));
 
-      // and — tenant-c alone completes its baseline job and moves on to different work, then takes
+      // and — tenant-c alone completes its baseline jobs and moves on to different work, then takes
       // an additional backup capturing that later state
-      activateAndComplete(tenantCClient, baselineJobType);
-      deployAndCreateInstance(tenantCClient, overrideProcessId, overrideJobType);
+      completeJobsFromEveryPartition(tenantCClient, baselineJobType);
+      createInstancesOnEveryPartition(tenantCClient, overrideProcessId, overrideJobType);
       takeSnapshot(TENANT_C);
       takeBackup(TENANT_C, overrideBackupId);
 
@@ -221,27 +260,125 @@ final class ClusterAdminRestoreAcceptanceIT {
 
       // ... and a cluster-wide restore is triggered: tenant-c overridden to its own, additional
       // backup, default and tenant-b left on the top-level (baseline) selection
-      awaitRestoreTriggered(
-          () ->
-              InProcessRestoreTestUtil.triggerClusterRestore(
-                  defaultClient, baselineBackupId, Map.of(TENANT_C, overrideBackupId)));
+      final var response =
+          awaitRestoreAccepted(
+              () ->
+                  InProcessRestoreTestUtil.sendClusterRestoreRequest(
+                      defaultClient,
+                      null,
+                      restoreBody(baselineBackupId, Map.of(TENANT_C, overrideBackupId))));
 
-      // then — every tenant processes commands again once its restore completes
+      // then — the override changes which backup a tenant reads, not the shape of the plan: all
+      // three tenants are still planned across every broker and every partition
+      assertPlanCovers(response, ALL_TENANTS);
+
+      // and — every tenant processes commands again once its restore completes
       awaitCommandsAccepted(defaultClient, probeProcessId);
       awaitCommandsAccepted(tenantBClient, probeProcessId);
       awaitCommandsAccepted(tenantCClient, probeProcessId);
 
-      // and — default and tenant-b restored from the baseline backup: the baseline job is still
-      // there to complete
-      activateAndComplete(defaultClient, baselineJobType);
-      activateAndComplete(tenantBClient, baselineJobType);
+      // and — default and tenant-b restored from the baseline backup: their baseline jobs are still
+      // there to complete, on every partition
+      completeJobsFromEveryPartition(defaultClient, baselineJobType);
+      completeJobsFromEveryPartition(tenantBClient, baselineJobType);
 
-      // and — tenant-c restored from its own overridden backup, not the baseline: the baseline job
-      // it had already completed before that backup was taken never reappears, but the job the
-      // override backup captured does
+      // and — tenant-c restored from its own overridden backup, not the baseline: the baseline jobs
+      // it had already completed before that backup was taken never reappear, but the jobs the
+      // override backup captured do
       assertThat(activatedJobTypes(tenantCClient, baselineJobType)).isEmpty();
-      activateAndComplete(tenantCClient, overrideJobType);
+      completeJobsFromEveryPartition(tenantCClient, overrideJobType);
     }
+  }
+
+  /**
+   * Asserts the accepted plan covers every parallel axis the restore has: one planned group per
+   * expected physical tenant, and within each group the pre-restore and restore of every partition
+   * on every broker, plus a mode change and an await per broker.
+   *
+   * <p>This is coverage, not overlap — see the class javadoc. A plan that covered only one broker,
+   * or only one partition per broker, or only one tenant of a cluster-wide request, would still
+   * complete successfully and pass every other assertion in this test; only this one rejects it.
+   */
+  private static void assertPlanCovers(
+      final HttpResponse<String> response, final Set<String> expectedTenants) {
+    final JsonNode plannedChanges = readJson(response.body()).path("plannedChanges");
+    final var plannedTenants = new ArrayList<String>();
+    plannedChanges.forEach(group -> plannedTenants.add(group.path("physicalTenantId").asText()));
+    assertThat(plannedTenants)
+        .describedAs("physical tenants planned by the restore: %s", response.body())
+        .containsExactlyInAnyOrderElementsOf(expectedTenants);
+
+    final var expectedPartitionWork =
+        IntStream.rangeClosed(1, BROKERS_COUNT)
+            .boxed()
+            .flatMap(
+                broker ->
+                    IntStream.rangeClosed(1, PARTITIONS_COUNT)
+                        .mapToObj(partition -> brokerId(broker) + "/p" + partition))
+            .toList();
+    final var expectedBrokers =
+        IntStream.rangeClosed(1, BROKERS_COUNT)
+            .mapToObj(ClusterAdminRestoreAcceptanceIT::brokerId)
+            .toList();
+
+    plannedChanges.forEach(
+        group -> {
+          final var tenant = group.path("physicalTenantId").asText();
+          assertThat(partitionWork(group, "PartitionPreRestoreOperation"))
+              .describedAs("pre-restored partitions per broker for tenant '%s'", tenant)
+              .containsExactlyInAnyOrderElementsOf(expectedPartitionWork);
+          assertThat(partitionWork(group, "PartitionRestoreOperation"))
+              .describedAs("restored partitions per broker for tenant '%s'", tenant)
+              .containsExactlyInAnyOrderElementsOf(expectedPartitionWork);
+          assertThat(brokerWork(group, "ModeChangeOperation"))
+              .describedAs("mode changes per broker for tenant '%s'", tenant)
+              .containsExactlyInAnyOrderElementsOf(expectedBrokers);
+          assertThat(brokerWork(group, "AwaitModeChangeOperation"))
+              .describedAs("awaited mode changes per broker for tenant '%s'", tenant)
+              .containsExactlyInAnyOrderElementsOf(expectedBrokers);
+        });
+  }
+
+  /** The {@code <broker>/p<partition>} pairs a group plans for the given operation type. */
+  private static List<String> partitionWork(final JsonNode group, final String operationType) {
+    final var work = new ArrayList<String>();
+    group
+        .path("operations")
+        .forEach(
+            operation -> {
+              if (operationType.equals(operation.path("operation").asText())) {
+                work.add(
+                    operation.path("brokerId").asText()
+                        + "/p"
+                        + operation.path("partitionId").asInt());
+              }
+            });
+    return work;
+  }
+
+  /** The brokers a group plans the given broker-scoped operation type for. */
+  private static List<String> brokerWork(final JsonNode group, final String operationType) {
+    final var work = new ArrayList<String>();
+    group
+        .path("operations")
+        .forEach(
+            operation -> {
+              if (operationType.equals(operation.path("operation").asText())) {
+                work.add(operation.path("brokerId").asText());
+              }
+            });
+    return work;
+  }
+
+  /**
+   * Broker ids are zero-based; the loops above are one-based for readability alongside partitions.
+   */
+  private static String brokerId(final int oneBasedIndex) {
+    return String.valueOf(oneBasedIndex - 1);
+  }
+
+  private CamundaClient newClient(final String tenantId) {
+    return TENANTS.newClientBuilder(cluster.availableGateway(), tenantId).build();
   }
 
   /**
@@ -259,23 +396,21 @@ final class ClusterAdminRestoreAcceptanceIT {
   }
 
   /**
-   * Deploys a single-service-task process and creates one instance, leaving one job of the given
-   * type pending.
+   * Leaves one pending job of the given type on every partition of the client's tenant, so the
+   * post-restore assertions can tell a restore that brought back one partition from one that
+   * brought back all of them.
    */
-  private static void deployAndCreateInstance(
+  private static void createInstancesOnEveryPartition(
       final CamundaClient client, final String processId, final String jobType) {
-    deploy(
-        client,
-        processId,
-        Bpmn.createExecutableProcess(processId)
-            .startEvent()
-            .serviceTask("task", t -> t.zeebeJobType(jobType))
-            .endEvent()
-            .done());
-    Awaitility.await("instance of " + processId + " is created")
-        .atMost(Duration.ofSeconds(30))
-        .ignoreExceptions()
-        .untilAsserted(() -> assertThat(createInstance(client, processId)).isPositive());
+    InProcessRestoreTestUtil.deployAndCreateInstancesOnEveryPartition(
+        client, processId, jobType, PARTITIONS_COUNT);
+  }
+
+  /** Completes the pending jobs, asserting one came from every partition. */
+  private static void completeJobsFromEveryPartition(
+      final CamundaClient client, final String jobType) {
+    InProcessRestoreTestUtil.activateAndCompleteJobsFromEveryPartition(
+        client, jobType, PARTITIONS_COUNT);
   }
 
   /** Deploys a process, idempotent under retry so a transient rejection is simply retried. */
@@ -296,31 +431,15 @@ final class ClusterAdminRestoreAcceptanceIT {
                     .isNotEmpty());
   }
 
-  /** Activates at least one job of the given type and completes every job it finds. */
-  private static void activateAndComplete(final CamundaClient client, final String jobType) {
-    Awaitility.await("a job of type " + jobType + " is activated and completed")
-        .atMost(Duration.ofSeconds(30))
-        .untilAsserted(
-            () -> {
-              final var jobs =
-                  client
-                      .newActivateJobsCommand()
-                      .jobType(jobType)
-                      .maxJobsToActivate(1)
-                      .send()
-                      .join()
-                      .getJobs();
-              assertThat(jobs).isNotEmpty();
-              jobs.forEach(job -> client.newCompleteCommand(job.getKey()).send().join());
-            });
-  }
-
-  /** Activates up to one job of the given type, for a negative "it isn't there" assertion. */
+  /**
+   * Activates up to a partition's worth of jobs of the given type, for a negative "it isn't there"
+   * assertion. Sized above the partition count so a single poll can see any partition's job.
+   */
   private static List<String> activatedJobTypes(final CamundaClient client, final String jobType) {
     return client
         .newActivateJobsCommand()
         .jobType(jobType)
-        .maxJobsToActivate(1)
+        .maxJobsToActivate(2 * PARTITIONS_COUNT)
         .send()
         .join()
         .getJobs()
@@ -350,48 +469,84 @@ final class ClusterAdminRestoreAcceptanceIT {
 
   private static void awaitCommandsAccepted(final CamundaClient client, final String processId) {
     Awaitility.await("restored tenant accepts commands again")
-        .atMost(Duration.ofMinutes(2))
+        .atMost(Duration.ofMinutes(3))
         .ignoreExceptions()
         .untilAsserted(() -> assertThat(createInstance(client, processId)).isPositive());
   }
 
   /**
-   * Retries the given restore trigger until it is accepted. The mode change preceding it may not
-   * have fully settled yet even though the affected tenant's commands are already rejected —
-   * rejection can start before the configuration change that caused it is marked complete — so a
-   * transient 409 (another configuration change still in progress) is retried rather than failing
-   * outright. Safe to retry: nothing has started until the trigger is actually accepted.
+   * Retries the given restore trigger until it is accepted, and returns the accepting response so
+   * the plan it carries can be asserted. The mode change preceding it may not have fully settled
+   * yet even though the affected tenant's commands are already rejected — rejection can start
+   * before the configuration change that caused it is marked complete — so a transient 409 (another
+   * configuration change still in progress) is retried rather than failing outright. Safe to retry:
+   * nothing has started until the trigger is actually accepted.
    */
-  private static void awaitRestoreTriggered(final ThrowingRunnable trigger) {
+  private static HttpResponse<String> awaitRestoreAccepted(
+      final Supplier<HttpResponse<String>> trigger) {
+    final var accepted = new ArrayList<HttpResponse<String>>();
     Awaitility.await("cluster-admin restore is accepted once the prior change clears")
-        .atMost(Duration.ofSeconds(30))
-        .untilAsserted(trigger);
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              final var response = trigger.get();
+              assertThat(response.statusCode())
+                  .describedAs("cluster restore REST response: %s", response.body())
+                  .isEqualTo(202);
+              accepted.add(response);
+            });
+    return accepted.getLast();
+  }
+
+  private static ClusterRestoreRequest restoreBody(final long backupId) {
+    return restoreBody(backupId, Map.of());
+  }
+
+  private static ClusterRestoreRequest restoreBody(
+      final long backupId, final Map<String, Long> overrideBackupIdByTenant) {
+    final var body = new ClusterRestoreRequest().backupIds(List.of(backupId));
+    overrideBackupIdByTenant.forEach(
+        (tenantId, overrideBackupId) ->
+            body.putOverridesItem(
+                tenantId, new RestoreRequest().backupIds(List.of(overrideBackupId))));
+    return body;
   }
 
   /**
-   * Takes a snapshot on every partition of the tenant and waits for it to be persisted.
-   * Snapshotting is asynchronous, and a tenant may already carry a snapshot from an earlier call
+   * Takes a snapshot on every partition of the tenant, on every broker, and waits for it to be
+   * persisted. A restore reads each broker's own backup of its own replica, so a snapshot taken on
+   * one broker alone would leave the others' backups behind the work being captured.
+   *
+   * <p>Snapshotting is asynchronous, and a tenant may already carry a snapshot from an earlier call
    * here, so the wait is for each partition's snapshot ID to <em>change</em>: merely waiting for a
    * non-null ID would return immediately on the second call and let the backup be taken before the
    * work it is meant to capture is snapshotted.
    */
   private void takeSnapshot(final String tenantId) {
-    final var partitions = PartitionsActuator.of(broker);
-    final var previousSnapshotIds = new HashMap<Integer, String>();
-    partitions
-        .query(tenantId)
-        .forEach((id, status) -> previousSnapshotIds.put(id, status.snapshotId()));
-    partitions.takeSnapshot(tenantId);
-    Awaitility.await("a new snapshot is taken for tenant " + tenantId)
-        .atMost(Duration.ofSeconds(60))
-        .untilAsserted(
-            () ->
-                assertThat(partitions.query(tenantId))
-                    .allSatisfy(
-                        (partitionId, status) ->
-                            assertThat(status.snapshotId())
-                                .isNotNull()
-                                .isNotEqualTo(previousSnapshotIds.get(partitionId))));
+    cluster
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              final var partitions = PartitionsActuator.of(broker);
+              final var previousSnapshotIds = new HashMap<Integer, String>();
+              partitions
+                  .query(tenantId)
+                  .forEach((id, status) -> previousSnapshotIds.put(id, status.snapshotId()));
+              partitions.takeSnapshot(tenantId);
+              Awaitility.await(
+                      "a new snapshot is taken for tenant %s on broker %s"
+                          .formatted(tenantId, broker.nodeId()))
+                  .atMost(Duration.ofSeconds(60))
+                  .untilAsserted(
+                      () ->
+                          assertThat(partitions.query(tenantId))
+                              .allSatisfy(
+                                  (partitionId, status) ->
+                                      assertThat(status.snapshotId())
+                                          .isNotNull()
+                                          .isNotEqualTo(previousSnapshotIds.get(partitionId))));
+            });
   }
 
   private void takeBackup(final String tenantId, final long backupId) {
@@ -407,24 +562,31 @@ final class ClusterAdminRestoreAcceptanceIT {
         .isEqualTo(202);
 
     Awaitility.await("backup %d for tenant %s completes".formatted(backupId, tenantId))
-        .atMost(Duration.ofSeconds(60))
+        .atMost(Duration.ofSeconds(120))
         .ignoreExceptions() // 404 NOT_FOUND until the backup is registered
         .untilAsserted(
             () -> {
               final var status =
                   send(HttpRequest.newBuilder(URI.create(uri + "/" + backupId)).GET().build());
               assertThat(status.statusCode()).isEqualTo(200);
-              assertThat(OBJECT_MAPPER.readTree(status.body()).path("state").asText())
-                  .isEqualTo("COMPLETED");
+              assertThat(readJson(status.body()).path("state").asText()).isEqualTo("COMPLETED");
             });
   }
 
   private URI backupsUri(final String tenantId) {
-    final var base = broker.restAddress().toString().replaceAll("/+$", "");
+    final var base = cluster.availableGateway().restAddress().toString().replaceAll("/+$", "");
     return URI.create(
         DEFAULT_TENANT.equals(tenantId)
             ? base + "/v2/backups/runtime"
             : base + "/physical-tenants/" + tenantId + "/v2/backups/runtime");
+  }
+
+  private static JsonNode readJson(final String body) {
+    try {
+      return OBJECT_MAPPER.readTree(body);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to parse REST response: " + body, e);
+    }
   }
 
   private static HttpResponse<String> send(final HttpRequest request) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
@@ -246,8 +246,10 @@ final class ClusterAdminRestoreAcceptanceIT {
       ALL_TENANTS.forEach(tenant -> takeBackup(tenant, baselineBackupId));
 
       // and — tenant-c alone completes its baseline jobs and moves on to different work, then takes
-      // an additional backup capturing that later state
-      completeJobsFromEveryPartition(tenantCClient, baselineJobType);
+      // an additional backup capturing that later state. Every baseline job has to be drained, not
+      // just one per partition: any left pending would be captured by the override backup below and
+      // come back with it, breaking the "the baseline jobs never reappear" assertion at the end.
+      completeEveryJob(tenantCClient, baselineJobType);
       createInstancesOnEveryPartition(tenantCClient, overrideProcessId, overrideJobType);
       takeSnapshot(TENANT_C);
       takeBackup(TENANT_C, overrideBackupId);
@@ -411,6 +413,11 @@ final class ClusterAdminRestoreAcceptanceIT {
       final CamundaClient client, final String jobType) {
     InProcessRestoreTestUtil.activateAndCompleteJobsFromEveryPartition(
         client, jobType, PARTITIONS_COUNT);
+  }
+
+  /** Completes every pending job of the type, leaving none behind for a later backup to capture. */
+  private static void completeEveryJob(final CamundaClient client, final String jobType) {
+    InProcessRestoreTestUtil.completeEveryJob(client, jobType, PARTITIONS_COUNT);
   }
 
   /** Deploys a process, idempotent under retry so a transient rejection is simply retried. */

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusterAdminRestoreAcceptanceIT.java
@@ -84,7 +84,7 @@ import org.junit.jupiter.api.io.TempDir;
  * <p>It does not prove the operations then <em>overlap</em> in time. The cluster-admin API carries
  * no per-operation timestamps, so overlap cannot be asserted through it. Overlap is covered where
  * it is observable: {@code RestoreRequestTransformerTest} pins the dependency edges that permit it,
- * and {@code ClusterConfigurationManagerImplNewConfigTest} pins that a broker starts every runnable
+ * and {@code ClusterConfigurationManagerImplTest} pins that a broker starts every runnable
  * operation rather than one per round.
  */
 @Timeout(600)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.protocol.rest.ClusterModeChangeResponse;
 import io.camunda.client.protocol.rest.ClusterRestoreRequest;
 import io.camunda.client.protocol.rest.ClusterRestoreResponse;
@@ -332,31 +333,71 @@ public final class InProcessRestoreTestUtil {
         .timeout(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
-              final var jobs =
-                  client
-                      .newActivateJobsCommand()
-                      .jobType(jobType)
-                      .maxJobsToActivate(2 * partitionsCount)
-                      .send()
-                      .join();
-              jobs.getJobs()
-                  .forEach(
-                      job -> {
-                        activatedJobKeys.add(job.getKey());
-                        client.newCompleteCommand(job.getKey()).send().join();
-                      });
-
-              final var partitionsWithActivatedJob =
-                  activatedJobKeys.stream()
-                      .map(Protocol::decodePartitionId)
-                      .collect(Collectors.toSet());
-              assertThat(partitionsWithActivatedJob)
-                  .describedAs(
-                      "jobs are activated from every partition, proving partition data was"
-                          + " actually restored")
-                  .containsExactlyInAnyOrderElementsOf(
-                      IntStream.rangeClosed(1, partitionsCount).boxed().toList());
+              activateAndComplete(client, jobType, partitionsCount, activatedJobKeys);
+              assertEveryPartitionActivated(activatedJobKeys, partitionsCount);
             });
+  }
+
+  /**
+   * Completes <em>every</em> pending job of the given type, asserting that one came from every
+   * partition and that an activation afterwards finds nothing left.
+   *
+   * <p>Drains to exhaustion, where {@link #activateAndCompleteJobsFromEveryPartition} drains only
+   * to partition coverage: that one stops at the first batch spanning every partition, so a job on
+   * an already-covered partition can outlive it. A caller that goes on to assert the type is gone —
+   * because a backup taken at this point must not capture it — needs exhaustion, not coverage.
+   */
+  static void completeEveryJob(
+      final CamundaClient client, final String jobType, final int partitionsCount) {
+    final Set<Long> activatedJobKeys = new HashSet<>();
+    Awaitility.await("every job of type '%s' is completed".formatted(jobType))
+        .timeout(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var activated =
+                  activateAndComplete(client, jobType, partitionsCount, activatedJobKeys);
+              assertEveryPartitionActivated(activatedJobKeys, partitionsCount);
+              assertThat(activated)
+                  .describedAs("no job of type '%s' is left pending", jobType)
+                  .isEmpty();
+            });
+  }
+
+  /**
+   * Activates up to a batch of jobs of the given type, completes each of them, and records their
+   * keys in {@code activatedJobKeys}. Returns the batch, so a caller can tell a poll that found
+   * work from one that found none.
+   */
+  private static List<ActivatedJob> activateAndComplete(
+      final CamundaClient client,
+      final String jobType,
+      final int partitionsCount,
+      final Set<Long> activatedJobKeys) {
+    final var jobs =
+        client
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(2 * partitionsCount)
+            .send()
+            .join()
+            .getJobs();
+    jobs.forEach(
+        job -> {
+          activatedJobKeys.add(job.getKey());
+          client.newCompleteCommand(job.getKey()).send().join();
+        });
+    return jobs;
+  }
+
+  private static void assertEveryPartitionActivated(
+      final Set<Long> activatedJobKeys, final int partitionsCount) {
+    final var partitionsWithActivatedJob =
+        activatedJobKeys.stream().map(Protocol::decodePartitionId).collect(Collectors.toSet());
+    assertThat(partitionsWithActivatedJob)
+        .describedAs(
+            "jobs are activated from every partition, proving partition data was actually restored")
+        .containsExactlyInAnyOrderElementsOf(
+            IntStream.rangeClosed(1, partitionsCount).boxed().toList());
   }
 
   /**


### PR DESCRIPTION
## Description

**Stacked PR 4 of 5** — second adopter, and the one that exercises every axis at once. Base: #60667 (`pg/60302-03-mode-change-migration`), not `main`.

`RestoreRequestTransformer` builds a graph over every partition `k` and broker `m` in
the physical tenant:

```
preRestore(m,k)      depends on nothing
restore(m,k)         depends on preRestore(m,k) only
modeChange(m)        depends on the restores of the partitions m holds
awaitModeChange(m)   depends on every modeChange and every restore
updateIncarnation    depends on every awaitModeChange
```

Wiping and reloading one broker's copy of a partition is local to that broker, so
`preRestore`/`restore` become `N*P` independent chains instead of two cluster-wide
barriers, and a broker leaves recovery as soon as the partitions it actually holds are
back rather than waiting on ones it does not. Awaiting the transition stays a single
cluster-wide barrier: it observes the group as a whole, so no broker may start
observing while any partition anywhere is still reloading.

`ClusterRestoreRequestTransformer` builds the same graph per named physical tenant and
combines them into one phase, so tenants restore in parallel exactly as before while
each one's brokers and partitions now also proceed concurrently within it.

**Stack:**
1. #60665 — data model
2. #60666 — wire the graph into the plan model + execution
3. #60667 — migrate mode change
4. **This PR** — migrate restore
5. #60669 — ADR

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Part of #60302
