### PR TITLE
feat: sync Zod API schema with OpenAPI

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -21,7 +21,7 @@
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
 		"@bpmn-io/form-js-carbon-styles": "1.24.1",
 		"@bpmn-io/form-js-viewer": "1.24.1",
-		"@camunda/camunda-api-zod-schemas": "0.0.89",
+		"@camunda/camunda-api-zod-schemas": "0.0.90",
 		"@camunda/camunda-composite-components": "0.25.4",
 		"@camunda/design-system": "0.45.0",
 		"@camunda/session-heartbeat": "0.0.1",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -32,7 +32,7 @@
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
 				"@bpmn-io/form-js-carbon-styles": "1.24.1",
 				"@bpmn-io/form-js-viewer": "1.24.1",
-				"@camunda/camunda-api-zod-schemas": "0.0.89",
+				"@camunda/camunda-api-zod-schemas": "0.0.90",
 				"@camunda/camunda-composite-components": "0.25.4",
 				"@camunda/design-system": "0.45.0",
 				"@camunda/session-heartbeat": "0.0.1",
@@ -15032,7 +15032,7 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.89",
+				"@camunda/camunda-api-zod-schemas": "0.0.90",
 				"typescript": "7.0.2"
 			}
 		},
@@ -15073,7 +15073,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.89",
+			"version": "0.0.90",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "26.2.0",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.89",
+		"@camunda/camunda-api-zod-schemas": "0.0.90",
 		"typescript": "7.0.2"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.90
+
+### 🩹 Fixes
+
+- Type `AgentInstanceDefinition.systemPrompt` as a content block array instead of a plain string, matching the breaking API change from [#60602](https://github.com/camunda/camunda/pull/60602) ([#60624](https://github.com/camunda/camunda/issues/60624))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.89
 
 ### 🩹 Fixes

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -30,10 +30,35 @@ const agentInstanceStatusSchema = z.enum([
 ]);
 type AgentInstanceStatus = z.infer<typeof agentInstanceStatusSchema>;
 
+const agentInstanceTextContentSchema = z.object({
+	contentType: z.literal('TEXT'),
+	text: z.string(),
+});
+type AgentInstanceTextContent = z.infer<typeof agentInstanceTextContentSchema>;
+
+const agentInstanceDocumentContentSchema = z.object({
+	contentType: z.literal('DOCUMENT'),
+	documentReference: documentReferenceSchema,
+});
+type AgentInstanceDocumentContent = z.infer<typeof agentInstanceDocumentContentSchema>;
+
+const agentInstanceObjectContentSchema = z.object({
+	contentType: z.literal('OBJECT'),
+	object: z.unknown(),
+});
+type AgentInstanceObjectContent = z.infer<typeof agentInstanceObjectContentSchema>;
+
+const agentInstanceMessageContentSchema = z.discriminatedUnion('contentType', [
+	agentInstanceTextContentSchema,
+	agentInstanceDocumentContentSchema,
+	agentInstanceObjectContentSchema,
+]);
+type AgentInstanceMessageContent = z.infer<typeof agentInstanceMessageContentSchema>;
+
 const agentInstanceDefinitionSchema = z.object({
 	model: z.string(),
 	provider: z.string(),
-	systemPrompt: z.string(),
+	systemPrompt: z.array(agentInstanceMessageContentSchema),
 });
 type AgentInstanceDefinition = z.infer<typeof agentInstanceDefinitionSchema>;
 
@@ -132,31 +157,6 @@ type AgentInstanceHistoryRole = z.infer<typeof agentInstanceHistoryRoleSchema>;
 
 const agentInstanceHistoryCommitStatusSchema = z.enum(['COMMITTED', 'PENDING', 'DISCARDED']);
 type AgentInstanceHistoryCommitStatus = z.infer<typeof agentInstanceHistoryCommitStatusSchema>;
-
-const agentInstanceTextContentSchema = z.object({
-	contentType: z.literal('TEXT'),
-	text: z.string(),
-});
-type AgentInstanceTextContent = z.infer<typeof agentInstanceTextContentSchema>;
-
-const agentInstanceDocumentContentSchema = z.object({
-	contentType: z.literal('DOCUMENT'),
-	documentReference: documentReferenceSchema,
-});
-type AgentInstanceDocumentContent = z.infer<typeof agentInstanceDocumentContentSchema>;
-
-const agentInstanceObjectContentSchema = z.object({
-	contentType: z.literal('OBJECT'),
-	object: z.unknown(),
-});
-type AgentInstanceObjectContent = z.infer<typeof agentInstanceObjectContentSchema>;
-
-const agentInstanceMessageContentSchema = z.discriminatedUnion('contentType', [
-	agentInstanceTextContentSchema,
-	agentInstanceDocumentContentSchema,
-	agentInstanceObjectContentSchema,
-]);
-type AgentInstanceMessageContent = z.infer<typeof agentInstanceMessageContentSchema>;
 
 const agentInstanceToolCallSchema = z.object({
 	toolCallId: z.string(),

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.89",
+	"version": "0.0.90",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

This PR adjust the Zod schema of the `systemPrompt` in agent-instance definitions to accept message content. This align the schema with a breaking change in the API.

## TODO

- [x] Release package

## Related issues

related #60624
