### PR TITLE
Stabilize Operate AI agent tool result visual test

### DIFF
--- a/operate/client/e2e-playwright/visual/processInstanceAiAgent.spec.ts
+++ b/operate/client/e2e-playwright/visual/processInstanceAiAgent.spec.ts
@@ -212,6 +212,7 @@ test.describe('AI agent details', () => {
         .getByRole('button', {name: 'Expand'});
 
     await processInstancePage.aiAgentDetails.conversationHistorySectionTrigger.click();
+    await resultExpandButton.scrollIntoViewIfNeeded();
     await resultExpandButton.focus();
     await resultExpandButton.click();
 


### PR DESCRIPTION
## Description

Stabilize the Operate `conversation tool result modal` visual regression test by waiting for its expand button to reach a stable visible position before focusing it. Carbon accordion expansion and focus-triggered scrolling otherwise race, shifting the dimmed background by 16 pixels while leaving the modal unchanged.

No baseline is regenerated and no screenshot tolerance is added.

## Verification

- Reproduced unchanged test: 15/15 failures, each with 4,954 differing pixels
- Fixed light theme: 30/30 passed
- Fixed dark theme: 30/30 passed
- Complete AI-agent visual file: 16/16 passed
- Operate lint and full-repository compile passed

## Checklist

- [x] Backports are not required because this fixes a main-only regression from #60570.

Closes #60660