### PR TITLE
feat: support content blocks in agent instances system-prompt

### DIFF
--- a/operate/client/e2e-playwright/mocks/processInstance/aiAgentProcessInstance.mock.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/aiAgentProcessInstance.mock.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {AgentInstanceDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
 import type {InstanceMock} from '.';
 
 const PROCESS_INSTANCE_KEY = '2251799813700001';
@@ -88,11 +89,15 @@ const xml = `<?xml version="1.0" encoding="UTF-8"?>
     </bpmndi:BPMNDiagram>
   </bpmn:definitions>`;
 
-const agentDefinition = {
+const agentDefinition: AgentInstanceDefinition = {
   model: 'gpt-4o',
   provider: 'openai',
-  systemPrompt:
-    'You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.',
+  systemPrompt: [
+    {
+      contentType: 'TEXT',
+      text: 'You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.',
+    },
+  ],
 };
 
 const agentLimits = {

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.13.0",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.89",
+        "@camunda/camunda-api-zod-schemas": "0.0.90",
         "@camunda/camunda-composite-components": "0.25.2",
         "@camunda/design-system": "0.45.0",
         "@camunda/session-heartbeat": "0.0.1",
@@ -500,9 +500,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.89",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.89.tgz",
-      "integrity": "sha512-cOub5mgT33xcv5xSKgRohkWPEzGTzhLcmHFfBOgiclbFMrPhFpUh2JLM+9knNa/Sgt0Z5+88o3Yxnfwy2zlc1A==",
+      "version": "0.0.90",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.90.tgz",
+      "integrity": "sha512-5aD3Hy0Gb30jP6WJkz+TNQcvFAc9fSp8IiPf78JGA2EcX86c9pODR9xKqlgvCXSD9/6SOQ77bpBwLv2JtCpzbg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.13.0",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.89",
+    "@camunda/camunda-api-zod-schemas": "0.0.90",
     "@camunda/camunda-composite-components": "0.25.2",
     "@camunda/design-system": "0.45.0",
     "@camunda/session-heartbeat": "0.0.1",

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -327,6 +327,56 @@ describe('<AgentDetails />', () => {
     ).toBeInTheDocument();
   });
 
+  it('should render document references in the system prompt', () => {
+    render(
+      <AgentDetails
+        agentInstances={[
+          mockAgentInstance({
+            definition: {
+              model: 'gpt-4',
+              provider: 'openai',
+              systemPrompt: [
+                {contentType: 'TEXT', text: 'You are a helpful assistant.'},
+                {
+                  contentType: 'DOCUMENT',
+                  documentReference: {
+                    'camunda.document.type': 'camunda',
+                    contentHash: 'abc123',
+                    documentId: 'doc-1',
+                    storeId: 'default',
+                    metadata: {
+                      contentType: 'text/plain',
+                      fileName: 'guidelines.txt',
+                      size: 1234,
+                      expiresAt: null,
+                      processDefinitionId: null,
+                      processInstanceKey: null,
+                      customProperties: {},
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+        ]}
+        totalAgentsCount={1}
+        hasMoreTotalItems={false}
+        isError={false}
+        selectedElementInstanceKey={null}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    const section = screen.getByTestId('agent-system-prompt-section');
+
+    expect(
+      within(section).getByText('You are a helpful assistant.'),
+    ).toBeInTheDocument();
+    expect(
+      within(section).getByRole('listitem', {name: 'guidelines.txt'}),
+    ).toBeInTheDocument();
+  });
+
   it('should not fetch the conversation history until its accordion item is opened', async () => {
     const historySpy = vi.fn();
     mockSearchAgentInstanceHistory(agentInstance.agentInstanceKey).withSuccess(

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -235,7 +235,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
         >
           <ConversationMessage
             actor="SYSTEM"
-            content={[{contentType: 'TEXT', text: definition.systemPrompt}]}
+            content={definition.systemPrompt}
           />
         </AccordionItem>
         <AccordionItem

--- a/operate/client/src/modules/mocks/mockAgentInstance.ts
+++ b/operate/client/src/modules/mocks/mockAgentInstance.ts
@@ -18,7 +18,12 @@ function mockAgentInstance(
     definition: {
       model: 'gpt-4',
       provider: 'openai',
-      systemPrompt: 'You are a helpful assistant.',
+      systemPrompt: [
+        {
+          contentType: 'TEXT',
+          text: 'You are a helpful assistant.',
+        },
+      ],
     },
     metrics: {
       inputTokens: 100,


### PR DESCRIPTION
## Description

This PR bumps the Zod API schemas version in Operate. It fixes existing test-data to support the new `systemPrompt` typing. Additionally, it adds a test that verifies that document references are indeed rendered by the system prompt.

## Related issues

closes #60624
