### PR TITLE
fix: deprecate key sort field on Tenant search endpoint

### DIFF
--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -149,7 +149,16 @@ rules:
   valid-deprecated-enum-members:
     description: "`x-deprecated-enum-members` must be a valid array of {name, deprecatedInVersion} referencing existing enum values."
     severity: error
-    given: "$.components.schemas[*]"
+    # Matches named schemas and inline (property-level) enums alike. resolved:
+    # false reports at the schema's source location instead of at every $ref
+    # consumer (mirrors properties-added-in-version-shape below). The parent
+    # operator (^) is required over a [?(@['x-deprecated-enum-members'])]
+    # filter: Spectral crashes walking into a `x-deprecated-enum-members:`
+    # with no value (e.g. a YAML indentation mistake), since the filter
+    # dereferences the property on every visited node, including once it is
+    # null.
+    resolved: false
+    given: "$..x-deprecated-enum-members^"
     message: "{{error}}"
     then:
       function: verifyDeprecatedEnumMembers

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/enums.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/enums.yaml
@@ -61,6 +61,25 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidMultipleDeprecatedResult'
 
+  /valid-inline-enum/{id}:
+    get:
+      operationId: getValidInlineEnum
+      summary: Property-level inline enum (not a named schema) with a valid deprecated member
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidInlineEnumResult'
+
   # ── Invalid cases ───────────────────────────────────────────
 
   /invalid-not-array/{id}:
@@ -233,6 +252,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InvalidNoEnumResult'
+
+  /invalid-null-value/{id}:
+    get:
+      operationId: getInvalidNullValue
+      summary: Extension key present with no value (null)
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidNullValueResult'
+
+  /invalid-inline-enum/{id}:
+    get:
+      operationId: getInvalidInlineEnum
+      summary: Property-level inline enum with a malformed deprecated member
+      tags: [Test]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidInlineEnumResult'
 
 components:
   schemas:
@@ -465,3 +522,58 @@ components:
         value:
           description: The value.
           $ref: '#/components/schemas/InvalidNoEnumEnum'
+
+    InvalidNullValueEnum:
+      description: Extension key present with no value (e.g. a YAML indentation mistake).
+      type: string
+      enum:
+        - A
+        - B
+      x-deprecated-enum-members:
+
+    InvalidNullValueResult:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          description: The value.
+          $ref: '#/components/schemas/InvalidNullValueEnum'
+
+    # ── Inline (non-named) enum cases ─────────────────────────
+    # The enum lives directly on the property, with no separate named
+    # schema for the extension to attach to via $ref.
+
+    ValidInlineEnumResult:
+      description: An inline property enum with a properly deprecated member.
+      type: object
+      required:
+        - sortField
+      properties:
+        sortField:
+          description: The field to sort by.
+          type: string
+          enum:
+            - ACTIVE
+            - INACTIVE
+            - LEGACY_MODE
+          x-deprecated-enum-members:
+            - name: LEGACY_MODE
+              deprecatedInVersion: "8.9.0"
+
+    InvalidInlineEnumResult:
+      description: An inline property enum with a malformed deprecated member.
+      type: object
+      required:
+        - sortField
+      properties:
+        sortField:
+          description: The field to sort by.
+          type: string
+          enum:
+            - ACTIVE
+            - INACTIVE
+            - LEGACY_MODE
+          x-deprecated-enum-members:
+            - name: LEGACY_MODE
+              deprecatedInVersion: "8.9"

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/deprecated-enum-members/rest-api.yaml
@@ -18,6 +18,9 @@ paths:
   /valid-multiple-deprecated/{id}:
     $ref: 'enums.yaml#/paths/~1valid-multiple-deprecated~1{id}'
 
+  /valid-inline-enum/{id}:
+    $ref: 'enums.yaml#/paths/~1valid-inline-enum~1{id}'
+
   # ── Invalid cases ───────────────────────────────────────────
   /invalid-not-array/{id}:
     $ref: 'enums.yaml#/paths/~1invalid-not-array~1{id}'
@@ -45,3 +48,9 @@ paths:
 
   /invalid-no-enum/{id}:
     $ref: 'enums.yaml#/paths/~1invalid-no-enum~1{id}'
+
+  /invalid-null-value/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-null-value~1{id}'
+
+  /invalid-inline-enum/{id}:
+    $ref: 'enums.yaml#/paths/~1invalid-inline-enum~1{id}'

--- a/zeebe/gateway-protocol/spectral-tests/verifyDeprecatedEnumMembers.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyDeprecatedEnumMembers.test.js
@@ -41,6 +41,13 @@ describe('verifyDeprecatedEnumMembers', () => {
     });
   });
 
+  describe('valid: inline (property-level) enum with a deprecated member', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'ValidInlineEnumResult');
+      assert.equal(v.length, 0);
+    });
+  });
+
   // ── Invalid cases ────────────────────────────────────────────────
 
   describe('invalid: x-deprecated-enum-members is not an array', () => {
@@ -148,6 +155,30 @@ describe('verifyDeprecatedEnumMembers', () => {
     it('reports the correct message', () => {
       const v = filterByPathSegment(violations, 'InvalidNoEnumEnum');
       assert.match(v[0].message, /requires the schema to have a non-empty `enum` array/);
+    });
+  });
+
+  describe('invalid: extension key present with no value (null)', () => {
+    it('flags one violation without crashing Spectral', () => {
+      const v = filterByPathSegment(violations, 'InvalidNullValueEnum');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidNullValueEnum');
+      assert.match(v[0].message, /must be an array/);
+    });
+  });
+
+  describe('invalid: inline (property-level) enum with a malformed deprecated member', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidInlineEnumResult');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'InvalidInlineEnumResult');
+      assert.match(v[0].message, /deprecatedInVersion.*must be a semver string/);
     });
   });
 });

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -1064,12 +1064,17 @@ components:
       type: object
       properties:
         field:
-          description: The field to sort by.
+          description: >-
+            The field to sort by. `key` is deprecated and should not be used
+            anymore.
           type: string
           enum:
             - key
             - name
             - tenantId
+          x-deprecated-enum-members:
+            - name: key
+              deprecatedInVersion: "8.10.0"
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:


### PR DESCRIPTION
## Description

Tenant search can no longer filter by the internal numeric `key`
(#51089), but it still exposes `key` as a sort option, the only
Identity entity where key-based sorting remains public; User, Group,
and MappingRule already hide it (see the ADR in #51090).

`key` sort shipped in the released 8.9 API, so removing it outright
would be a breaking change for any consumer currently sorting by it.
This marks it deprecated instead, per the deprecate-before-remove
process in `docs/rest-api-endpoint-guidelines.md` §2.7. Actual removal
is a separate, later change.

## Why not extract into a named schema

The Tenant sort field enum is inline (defined directly on the
`field` property, not as its own named schema), and the
`valid-deprecated-enum-members` Spectral rule only validated named
schemas under `components.schemas`. The obvious fix looked like
extracting the enum into its own named schema so the rule could see
it, but that renames the generated type
(`TenantSearchQuerySortRequest.FieldEnum` becomes a standalone type),
breaking the hand-written mappers in `clients/java` and
`gateways/gateway-mapping-http` that reference it by name, for no
runtime benefit.

Instead, this widens the Spectral rule itself: the validator function
never cared about named vs. inline schemas, only its `given` selector
did. Broadening `given` to match the extension anywhere in the
document (with `resolved: false`, to avoid double-counting named
schemas referenced via `$ref` from multiple places, mirroring
`properties-added-in-version-shape`) lets `x-deprecated-enum-members`
work on inline enums with zero changes to generated code.

## Changes

- `zeebe/gateway-protocol/.spectral.yaml`: broaden
  `valid-deprecated-enum-members` to validate inline enums, not just
  named schemas.
- `zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml`: mark `key`
  deprecated via `x-deprecated-enum-members` (target: 8.10.0), and
  note the deprecation in the property description.
- `zeebe/gateway-protocol/spectral-tests/`: regression coverage
  proving the rule validates inline enums (valid and malformed
  cases), not only named ones.

## Verification

- `node --test spectral-tests/*.test.js` — all 8 suites pass.
- `spectral lint` against the real spec (entry-point and file-level
  passes) — clean.
- Deliberately corrupted the new `tenants.yaml` entry to confirm the
  linter catches it at the right location, then reverted.
- Regenerated the `clients/java` and `gateway-model` OpenAPI sources:
  `TenantSearchQuerySortRequest.FieldEnum` is unchanged (same type
  name, same three values); the updated description now appears as
  Javadoc.
- `TenantQueryControllerTest`: 15/15 pass, unchanged.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Docs

Created a deprecation entry in the announcement docs: https://github.com/camunda/camunda-docs/pull/9664
## Related issues

Closes #51091