### PR TITLE
Cover data-plane features on asymmetric multi-tenant clusters

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantJobReactivationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantJobReactivationIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
+
+/**
+ * Verifies that jobs the gateway cannot fit into an activate-jobs response are reactivated on the
+ * physical tenant they were activated from. When a gRPC {@code ActivateJobsResponse} would exceed
+ * {@code maxMessageSize}, {@code RoundRobinActivateJobsHandler} defers the jobs that do not fit and
+ * immediately FAILs them via a gateway-internal {@code BrokerFailJobRequest}, so they become
+ * activatable again right away instead of staying locked until their activation timeout.
+ *
+ * <p>Before <a href="https://github.com/camunda/camunda/issues/60103">#60103</a> that internal
+ * request carried no partition group and was silently routed to the <em>default</em> physical
+ * tenant: the FAIL either addressed a partition id the default group does not have at all, or was
+ * rejected there because the job key is unknown to the default engine. Either way the deferred jobs
+ * stayed invisibly locked on their own tenant. Only an asymmetric multi-physical-tenant cluster
+ * observes this: on a single-tenant cluster the default group <em>is</em> the right target, and on
+ * a symmetric cluster a misrouted request often finds an identical-looking partition, so the
+ * misroute at most surfaces as a quiet rejection. Here the default tenant runs 1 partition while
+ * {@value #TENANT_A} runs {@value #TENANT_A_PARTITIONS}, so a misrouted FAIL cannot even resolve an
+ * address for most of the jobs, and the deferred jobs never come back within the await window.
+ */
+@ZeebeIntegration
+final class PhysicalTenantJobReactivationIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int TENANT_A_PARTITIONS = 3;
+
+  // Each variable value is a string of literal `"` characters. The broker stores variables as
+  // MsgPack (~7 KB per JobRecord) but the gRPC gateway re-encodes them as JSON in the
+  // ActivateJobsResponse proto, escaping each `"` to `\"` and doubling the byte count (~14 KB per
+  // ActivatedJob). With maxMessageSize = 64 KB and 15 jobs round-robined over tenanta's 3
+  // partitions (~5 per partition; by pigeonhole at least one partition holds >= 5):
+  //   - the broker fits a partition's ~5 jobs into a single JobBatchRecord
+  //     (5 * 7.5 KB + 8 KB safety buffer <= 64 KB)
+  //   - but that partition's gateway response (5 * ~14 KB) cannot fit within 64 KB, so at least
+  //     one job is deferred and FAILed through RoundRobinActivateJobsHandler.toFailJobRequest.
+  // The gRPC path is required: the REST gateway's defer check compares against the broker record
+  // size, not the REST response size, so it cannot trigger this path under unified config that
+  // ties broker and gateway maxMessageSize together.
+  private static final DataSize MAX_MESSAGE_SIZE = DataSize.ofKilobytes(64);
+  private static final int QUOTE_PAYLOAD_LENGTH = 7000;
+  private static final int JOBS_TO_CREATE = 15;
+
+  // long enough that a job activated during this test can never hit its activation timeout: a job
+  // that becomes activatable again within the await windows below can only have been FAILed back
+  // by the gateway, not released by a timeout
+  private static final Duration JOB_TIMEOUT = Duration.ofMinutes(10);
+
+  private static final String JOB_TYPE = "reactivation-task";
+  private static final String PROCESS_ID = "reactivation-process";
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+          .endEvent()
+          .done();
+
+  // the default tenant and tenant A both run broker-only (no secondary storage); the deliberately
+  // different partition counts are what make a misrouted gateway-internal request observable (see
+  // class javadoc)
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none(), TENANT_A_PARTITIONS)
+          .build();
+
+  // instance-scoped: the test writes state (deployments, instances, jobs) that must not leak into
+  // another run; maxMessageSize is a cluster-wide setting (it may not be overridden per physical
+  // tenant), so the small limit applies to tenant A's engine and the gateway alike
+  @TestZeebe(purgeAfterEach = false)
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withRecordingExporter(true)
+              .withClusterConfig(c -> c.getNetwork().setMaxMessageSize(MAX_MESSAGE_SIZE)));
+
+  @AutoClose private CamundaClient defaultClient;
+  @AutoClose private CamundaClient tenantAClient;
+
+  @BeforeEach
+  void beforeEach() {
+    // the extension resets this to 5s before each test; gateway-issued FAIL commands can take
+    // longer than that to propagate on slow CI runners
+    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(30).toMillis());
+    defaultClient =
+        TENANTS
+            .newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+            .preferRestOverGrpc(false)
+            .build();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).preferRestOverGrpc(false).build();
+  }
+
+  @Test
+  void shouldReactivateDeferredJobsOnTheirOwnPhysicalTenant() {
+    // given — jobs with large variables on tenant A, so that one partition's activate-jobs
+    // response exceeds the gateway's maxMessageSize
+    awaitTenantAPartitionsReady();
+    deployProcessToTenantA();
+    final Set<Long> createdJobKeys = createJobsOnTenantA();
+
+    // when — activating everything over gRPC: the gateway defers the jobs that do not fit into
+    // the response and FAILs them back to the broker
+    final Set<Long> activatedJobKeys =
+        activateJobs(tenantAClient).stream().map(ActivatedJob::getKey).collect(Collectors.toSet());
+
+    // then — at least one job did not fit and was FAILed back through the gateway-internal
+    // reactivation path under test
+    assertThat(activatedJobKeys)
+        .as("the first activation cannot return every job within maxMessageSize")
+        .hasSizeLessThan(JOBS_TO_CREATE);
+    assertThat(RecordingExporter.jobRecords(JobIntent.FAILED).withType(JOB_TYPE).exists())
+        .as("at least one deferred job was FAILed back by the gateway")
+        .isTrue();
+
+    // and — every deferred job becomes activatable again on tenant A well before its activation
+    // timeout: the gateway's FAIL request reached tenant A's partition group, not the default one
+    final Set<Long> reactivatableJobKeys = new HashSet<>(activatedJobKeys);
+    await("deferred jobs become activatable again on tenant A")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              activateJobs(tenantAClient).forEach(job -> reactivatableJobKeys.add(job.getKey()));
+              assertThat(reactivatableJobKeys).containsExactlyInAnyOrderElementsOf(createdJobKeys);
+            });
+
+    // and — nothing leaked to the default tenant: it has no activatable jobs, and no FAIL command
+    // was ever rejected (a FAIL misrouted to the default group would be rejected there because the
+    // job key is unknown to its engine)
+    assertThat(
+            defaultClient
+                .newActivateJobsCommand()
+                .jobType(JOB_TYPE)
+                .maxJobsToActivate(JOBS_TO_CREATE)
+                .timeout(JOB_TIMEOUT)
+                .requestTimeout(Duration.ofSeconds(2))
+                .send()
+                .join()
+                .getJobs())
+        .as("the default tenant has no activatable jobs")
+        .isEmpty();
+    final boolean failRejected =
+        RecordingExporter.expectNoMatchingRecords(
+            records ->
+                records.jobRecords().onlyCommandRejections().withIntent(JobIntent.FAIL).exists());
+    assertThat(failRejected)
+        .as("no gateway-issued FAIL command was rejected on any tenant")
+        .isFalse();
+  }
+
+  /**
+   * Waits until every partition of tenant A has a leader. Instance creation is round-robined over
+   * all of the tenant's partitions, so a single not-yet-ready partition fails the setup.
+   */
+  private void awaitTenantAPartitionsReady() {
+    await("tenant A runs %d partitions with a leader each".formatted(TENANT_A_PARTITIONS))
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(tenantAClient.newTopologyRequest().send().join())
+                    .isComplete(1, TENANT_A_PARTITIONS, 1));
+  }
+
+  private void deployProcessToTenantA() {
+    await("deployment to tenant A succeeds")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        tenantAClient
+                            .newDeployResourceCommand()
+                            .addProcessModel(PROCESS, PROCESS_ID + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+  }
+
+  /** Creates {@link #JOBS_TO_CREATE} instances and returns the keys of their created jobs. */
+  private Set<Long> createJobsOnTenantA() {
+    final var quoteHeavyPayload = "\"".repeat(QUOTE_PAYLOAD_LENGTH);
+    for (int i = 0; i < JOBS_TO_CREATE; i++) {
+      tenantAClient
+          .newCreateInstanceCommand()
+          .bpmnProcessId(PROCESS_ID)
+          .latestVersion()
+          .variables(Map.of("message_content", quoteHeavyPayload))
+          .send()
+          .join();
+    }
+    final Set<Long> createdJobKeys =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withType(JOB_TYPE)
+            .limit(JOBS_TO_CREATE)
+            .map(Record::getKey)
+            .collect(Collectors.toSet());
+    assertThat(createdJobKeys).as("all jobs are created before activation").hasSize(JOBS_TO_CREATE);
+    return createdJobKeys;
+  }
+
+  private List<ActivatedJob> activateJobs(final CamundaClient client) {
+    return client
+        .newActivateJobsCommand()
+        .jobType(JOB_TYPE)
+        .maxJobsToActivate(JOBS_TO_CREATE)
+        .timeout(JOB_TIMEOUT)
+        .requestTimeout(Duration.ofSeconds(2))
+        .send()
+        .join()
+        .getJobs();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantMessageCorrelationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantMessageCorrelationIT.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that message correlation stays inside the addressed physical tenant on a cluster with
+ * asymmetric per-tenant partition counts.
+ *
+ * <p>Messages are routed to a partition by {@code HashMod(correlationKey, partitionCount)}, and so
+ * are the message subscriptions opened by waiting catch events. With asymmetric partition counts
+ * the same correlation key deterministically resolves to <em>different</em> partitions per tenant —
+ * here, {@link #CORRELATION_KEY} hashes to partition 3 of {@link #TENANT_A}'s three partitions,
+ * while the default tenant only has partition 1. That divergence is what makes misrouting
+ * observable: if any leg of correlation (opening the subscription, distributing the publish)
+ * consulted the <em>other</em> tenant's partition count or partition group, subscription and
+ * message would land on different partitions — or in the wrong tenant entirely — and correlation
+ * would never complete. On a symmetric cluster the same bug would silently pass, because both
+ * tenants map the key to an identical-looking partition.
+ *
+ * <p>Both tenants deploy the same process (same process id, message name, and correlation key
+ * value) and each waits with one instance at the message catch event. Publishing on {@link
+ * #TENANT_A} only must complete only tenant A's instance, while the default tenant's instance keeps
+ * waiting over a window; publishing on the default tenant afterwards completes its instance too.
+ * Each publish carries a {@code source} variable naming its tenant, and the follow-up job's
+ * variables are asserted against it — so even a leaked message that is buffered (messages are
+ * published with a TTL) and correlated late is still caught, as it would complete the other
+ * tenant's instance with the wrong {@code source}.
+ */
+@ZeebeIntegration
+final class PhysicalTenantMessageCorrelationIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int TENANT_A_PARTITIONS_COUNT = 3;
+
+  private static final String PROCESS_ID = "correlation-process";
+  private static final String MESSAGE_NAME = "payment-received";
+  private static final String CORRELATION_KEY = "order-1";
+  private static final String JOB_TYPE = "after-message";
+  private static final Duration MESSAGE_TTL = Duration.ofMinutes(1);
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none(), 1)
+          .withTenant(TENANT_A, Storage.none(), TENANT_A_PARTITIONS_COUNT)
+          .build();
+
+  @TestZeebe(purgeAfterEach = false)
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  @AutoClose private CamundaClient defaultClient;
+  @AutoClose private CamundaClient tenantAClient;
+
+  @BeforeEach
+  void beforeEach() {
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+  }
+
+  @Test
+  void shouldCorrelateMessagesOnlyWithinTheAddressedPhysicalTenant() {
+    // given — the asymmetry this test relies on (see class javadoc): the correlation key resolves
+    // to different partitions in the two tenants, so a message routed with the wrong tenant's
+    // partition count could never meet its subscription
+    assertThat(
+            SubscriptionUtil.getSubscriptionPartitionId(
+                BufferUtil.wrapString(CORRELATION_KEY), TENANT_A_PARTITIONS_COUNT))
+        .isEqualTo(3);
+    assertThat(
+            SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString(CORRELATION_KEY), 1))
+        .isEqualTo(1);
+
+    // and — both tenants run the same process, each with one instance waiting for the same message
+    // name and correlation key value
+    deploy(defaultClient);
+    deploy(tenantAClient);
+    final long defaultInstanceKey = createWaitingInstance(defaultClient, "default");
+    final long tenantAInstanceKey = createWaitingInstance(tenantAClient, TENANT_A);
+
+    // when — the message is published on tenant A only
+    publish(tenantAClient, TENANT_A);
+
+    // then — tenant A's instance correlates and progresses past the catch event, carrying tenant
+    // A's own publish payload
+    final ActivatedJob tenantAJob =
+        awaitJob(tenantAClient, "tenant A's instance passed the message catch event");
+    assertThat(tenantAJob.getProcessInstanceKey()).isEqualTo(tenantAInstanceKey);
+    assertThat(tenantAJob.getVariablesAsMap()).containsEntry("source", TENANT_A);
+    tenantAClient.newCompleteCommand(tenantAJob.getKey()).send().join();
+
+    // and — the default tenant's instance stays waiting at the catch event over a window, so a
+    // late-arriving leak still fails the test
+    await("the default tenant's instance stays waiting at the message catch event")
+        .during(Duration.ofSeconds(3))
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(() -> assertThat(activateJobs(defaultClient)).isEmpty());
+
+    // when — the message is published on the default tenant
+    publish(defaultClient, PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+
+    // then — the default tenant's instance correlates with its own tenant's publish (a buffered
+    // leaked message would surface here as the wrong source)
+    final ActivatedJob defaultJob =
+        awaitJob(defaultClient, "the default tenant's instance passed the message catch event");
+    assertThat(defaultJob.getProcessInstanceKey()).isEqualTo(defaultInstanceKey);
+    assertThat(defaultJob.getVariablesAsMap())
+        .containsEntry("source", PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+    defaultClient.newCompleteCommand(defaultJob.getKey()).send().join();
+  }
+
+  private static void deploy(final CamundaClient client) {
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .intermediateCatchEvent(
+                "wait-for-message",
+                c -> c.message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKeyExpression("key")))
+            .serviceTask("after-message-task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    // the tenant's partition group may need a moment to elect a leader after startup; retry the
+    // first command until it lands
+    await("deployment succeeds")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, PROCESS_ID + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+  }
+
+  /**
+   * Creates one instance that will wait at the message catch event. Retried because instance
+   * creation is round-robined across the tenant's partitions and may hit a partition the deployment
+   * has not been distributed to yet.
+   */
+  private static long createWaitingInstance(final CamundaClient client, final String tenant) {
+    final var instanceKey = new AtomicLong();
+    await("an instance is created in tenant '%s'".formatted(tenant))
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                instanceKey.set(
+                    client
+                        .newCreateInstanceCommand()
+                        .bpmnProcessId(PROCESS_ID)
+                        .latestVersion()
+                        .variables(Map.of("key", CORRELATION_KEY))
+                        .send()
+                        .join()
+                        .getProcessInstanceKey()));
+    return instanceKey.get();
+  }
+
+  private static void publish(final CamundaClient client, final String source) {
+    // the TTL buffers the message in case the instance has not opened its subscription yet — and
+    // deliberately keeps a hypothetically leaked message correlatable, so the source assertion can
+    // catch it (see class javadoc)
+    client
+        .newPublishMessageCommand()
+        .messageName(MESSAGE_NAME)
+        .correlationKey(CORRELATION_KEY)
+        .timeToLive(MESSAGE_TTL)
+        .variables(Map.of("source", source))
+        .send()
+        .join();
+  }
+
+  private static ActivatedJob awaitJob(final CamundaClient client, final String description) {
+    final var match = new AtomicReference<ActivatedJob>();
+    await(description)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var jobs = activateJobs(client);
+              assertThat(jobs).isNotEmpty();
+              match.set(jobs.get(0));
+            });
+    return match.get();
+  }
+
+  private static List<ActivatedJob> activateJobs(final CamundaClient client) {
+    return client
+        .newActivateJobsCommand()
+        .jobType(JOB_TYPE)
+        .maxJobsToActivate(10)
+        .requestTimeout(Duration.ofMillis(500))
+        .send()
+        .join()
+        .getJobs();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionScalingIT.java
@@ -13,6 +13,8 @@ import static org.awaitility.Awaitility.await;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
@@ -21,6 +23,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import java.time.Duration;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -46,8 +49,11 @@ final class PhysicalTenantPartitionScalingIT {
 
   private static final PhysicalTenantsITHelper TENANTS =
       PhysicalTenantsITHelper.builder()
-          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
-          .withTenant(TENANT_A, Storage.none())
+          .withTenant(
+              PhysicalTenantsITHelper.DEFAULT_TENANT_ID,
+              Storage.none(),
+              DEFAULT_TENANT_PARTITIONS_COUNT)
+          .withTenant(TENANT_A, Storage.none(), TENANT_A_PARTITIONS_COUNT)
           .build();
 
   @TestZeebe(purgeAfterEach = false)
@@ -55,9 +61,17 @@ final class PhysicalTenantPartitionScalingIT {
       TENANTS.configure(
           new TestStandaloneBroker()
               .withUnauthenticatedAccess()
+              // command redistribution retries back off exponentially up to 5 minutes by default;
+              // a scaled-up partition receives pre-existing deployments through exactly that
+              // mechanism, so without a short, flat backoff the hand-off assertion below would
+              // need to out-wait the worst-case retry gap
               .withPtConfig(
                   TENANT_A,
-                  camunda -> camunda.getCluster().setPartitionCount(TENANT_A_PARTITIONS_COUNT)));
+                  camunda -> {
+                    final var distribution = camunda.getProcessing().getEngine().getDistribution();
+                    distribution.setRedistributionInterval(Duration.ofSeconds(1));
+                    distribution.setMaxBackoffDuration(Duration.ofSeconds(1));
+                  }));
 
   private final ClusterActuator actuator = ClusterActuator.of(broker);
 
@@ -101,6 +115,87 @@ final class PhysicalTenantPartitionScalingIT {
     awaitTopologyPartitionCount(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, targetPartitionCount);
     assertThat(partitionCount(TENANT_A)).isEqualTo(TENANT_A_PARTITIONS_COUNT);
     assertTopologyPartitionCount(TENANT_A, TENANT_A_PARTITIONS_COUNT);
+  }
+
+  /**
+   * Verifies that a partition added by a scale-up serves its own physical tenant's state, not the
+   * default tenant's. A new partition receives existing deployments through bootstrap and
+   * asynchronous redistribution, both of which are driven by broker requests (snapshot chunks,
+   * scale-up and redistribution progress reads) that before #60103 carried no partition group and
+   * were silently answered by the default tenant. A process deployed only to tenant A before the
+   * scale-up is instantiable on the new partition only if that hand-off really happened within
+   * tenant A — the decoy deployment on the default tenant gives a wrong-tenant hand-off concrete
+   * state to leak.
+   */
+  @Test
+  @Disabled(
+      "The hand-off really is cross-tenant today: SnapshotApiRequestHandler keys transfer"
+          + " services by bare partition number, so the new partition can bootstrap from the"
+          + " default tenant's snapshot — https://github.com/camunda/camunda/issues/60676")
+  void shouldServeTheScaledUpPartitionFromItsOwnPhysicalTenant() {
+    // given — a process deployed to tenant A, and a decoy deployed to the default tenant, before
+    // tenant A is scaled up
+    final var tenantAProcessId = "scale-up-bootstrap-tenanta";
+    deploy(TENANT_A, tenantAProcessId);
+    deploy(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, "scale-up-bootstrap-default");
+
+    // when — tenant A is scaled up by one partition
+    final var targetPartitionCount = TENANT_A_PARTITIONS_COUNT + 1;
+    awaitAccepted(
+        "tenant A accepts a scale-up scoped to it",
+        () -> scalePartitions(targetPartitionCount, TENANT_A));
+    awaitPartitionCount(TENANT_A, targetPartitionCount);
+    awaitTopologyPartitionCount(TENANT_A, targetPartitionCount);
+
+    // then — an instance of tenant A's process can be created on the new partition; round-robin
+    // request routing cycles through all of tenant A's partitions, so retrying until an instance
+    // key decodes to the new partition proves that partition knows the deployment. NOT_FOUND
+    // rejections are retried: the new partition only learns existing deployments through
+    // asynchronous redistribution after its bootstrap
+    try (final var client = TENANTS.newClientBuilder(broker, TENANT_A).build()) {
+      await("tenant A's new partition %d runs its own processes".formatted(targetPartitionCount))
+          .atMost(Duration.ofMinutes(3))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final long processInstanceKey =
+                    client
+                        .newCreateInstanceCommand()
+                        .bpmnProcessId(tenantAProcessId)
+                        .latestVersion()
+                        .send()
+                        .join()
+                        .getProcessInstanceKey();
+                assertThat(Protocol.decodePartitionId(processInstanceKey))
+                    .isEqualTo(targetPartitionCount);
+              });
+    }
+  }
+
+  private void deploy(final String physicalTenantId, final String processId) {
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(processId))
+            .endEvent()
+            .done();
+    try (final var client = TENANTS.newClientBuilder(broker, physicalTenantId).build()) {
+      // the tenant's partition group may still be electing a leader right after startup; retry
+      // the first command until it lands
+      await("deployment to physical tenant '%s' succeeds".formatted(physicalTenantId))
+          .atMost(Duration.ofSeconds(30))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          client
+                              .newDeployResourceCommand()
+                              .addProcessModel(process, processId + ".bpmn")
+                              .send()
+                              .join()
+                              .getProcesses())
+                      .isNotEmpty());
+    }
   }
 
   private void scalePartitions(final int targetPartitionCount, final String physicalTenant) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantQueryApiIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantQueryApiIT.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.configuration.Interceptor;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.grpc.CloseAwareListener;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import net.bytebuddy.ByteBuddy;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the interceptor-facing query API ({@code QueryApiImpl}, exposed to gRPC
+ * interceptors via {@code InterceptorUtil.getQueryApiKey()}) routes its broker queries to the
+ * physical tenant stamped into the gRPC context, instead of unconditionally querying the default
+ * tenant as it did before the #60103 audit (bug 4 of 4: {@code BrokerExecuteQuery} was sent without
+ * a partition group).
+ *
+ * <p>The cluster is asymmetric on purpose: the default tenant has one partition while {@link
+ * #TENANT_A} has two. An entity living on tenant A's partition 2 cannot even be addressed by a
+ * query misrouted to the default tenant — the default partition group has no partition 2 — so
+ * misrouting is observable rather than silently returning an identical-looking answer.
+ *
+ * <p>A {@link PhysicalTenantQueryServerInterceptor} is installed which gates every {@code
+ * CompleteJob} call on a query-API lookup of the job's process id (mirroring {@code QueryApiIT}'s
+ * authorization pattern):
+ *
+ * <ul>
+ *   <li>{@link #shouldResolveDefaultTenantQueryViaExplicitFallback}: a call without a physical
+ *       tenant header must fall back to the default tenant explicitly, resolve the process id
+ *       there, and let the completion through. If the query resolved nothing — or resolved against
+ *       any other tenant, whose query engine is disabled (see below) — the completion would fail.
+ *   <li>{@link #shouldRouteScopedQueryToTheScopedTenantsEngine}: a call scoped to tenant A for a
+ *       job on its partition 2 must reach <em>tenant A's own</em> engine. The strongest available
+ *       observation for this is deliberate: the deprecated query API's enable flag exists only as
+ *       the legacy {@code zeebe.broker.experimental.queryApi.enabled} property, which reaches only
+ *       the default tenant's broker configuration ({@code SystemContextLoader} builds non-default
+ *       tenant configs purely from unified configuration via {@code
+ *       BrokerBasedPropertiesOverride#convert}, and unified configuration has no query-API
+ *       property). Tenant A's query handler therefore answers every query with its distinctive
+ *       "query API is disabled" error — an answer that can only come from tenant A's engine on a
+ *       partition that exists only in tenant A's group. A misrouted query could never produce it:
+ *       routing to the default group fails to find partition 2 at all, and the default tenant's
+ *       enabled handler answers with resolution results, never with this error.
+ * </ul>
+ */
+@ZeebeIntegration
+final class PhysicalTenantQueryApiIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int TENANT_A_PARTITIONS_COUNT = 2;
+
+  private static final String DEFAULT_PROCESS_ID = "default.process";
+  private static final String TENANT_A_PROCESS_ID = "tenanta.process";
+  private static final String JOB_TYPE = "task";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none(), 1)
+          .withTenant(TENANT_A, Storage.none(), TENANT_A_PARTITIONS_COUNT)
+          .build();
+
+  @TestZeebe(initMethod = "initBroker", purgeAfterEach = false)
+  private static TestStandaloneBroker broker;
+
+  @AutoClose private CamundaClient defaultClient;
+  @AutoClose private CamundaClient tenantAClient;
+
+  @SuppressWarnings("unused")
+  static void initBroker() {
+    broker =
+        TENANTS.configure(
+            new TestStandaloneBroker()
+                .withUnauthenticatedAccess()
+                // legacy property: applies to the default tenant only, which is load-bearing here —
+                // see the class javadoc
+                .withProperty("zeebe.broker.experimental.queryApi.enabled", true)
+                .withUnifiedConfig(
+                    cfg -> {
+                      final var interceptor = new Interceptor();
+                      interceptor.setId("physical-tenant-query");
+                      interceptor.setClassName(
+                          PhysicalTenantQueryServerInterceptor.class.getName());
+                      interceptor.setJarPath(createInterceptorJar().getAbsolutePath());
+                      cfg.getApi().getGrpc().getInterceptors().add(interceptor);
+                    }));
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    // the interceptor under test only guards the gRPC transport
+    defaultClient =
+        TENANTS
+            .newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+            .preferRestOverGrpc(false)
+            .build();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).preferRestOverGrpc(false).build();
+  }
+
+  @Test
+  void shouldResolveDefaultTenantQueryViaExplicitFallback() {
+    // given — a job in the default tenant
+    deploy(defaultClient, DEFAULT_PROCESS_ID);
+    final ActivatedJob job = awaitActivatedJob(defaultClient, DEFAULT_PROCESS_ID, 1);
+
+    // when — completing it without a physical tenant header runs the interceptor's query-API
+    // lookup, which must explicitly fall back to the default tenant and resolve the process id
+    final Future<?> result = defaultClient.newCompleteCommand(job.getKey()).send();
+
+    // then — the completion goes through, proving the query resolved the correct process id (the
+    // interceptor rejects the call if the lookup fails or resolves a foreign process id)
+    assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+  }
+
+  @Test
+  void shouldRouteScopedQueryToTheScopedTenantsEngine() {
+    // given — a job on tenant A's partition 2, a partition the default group does not have
+    deploy(tenantAClient, TENANT_A_PROCESS_ID);
+    final ActivatedJob job = awaitActivatedJob(tenantAClient, TENANT_A_PROCESS_ID, 2);
+
+    // when — completing it with the tenant A header makes the interceptor query under tenant A's
+    // context; then — the query reached tenant A's own engine: only tenant A's query handler
+    // answers with its disabled-API error (see the class javadoc for why this observation is the
+    // strongest available and why it cannot come from a misrouted query)
+    assertThatThrownBy(() -> tenantAClient.newCompleteCommand(job.getKey()).send().join())
+        .hasMessageContaining("query API is disabled");
+  }
+
+  private static void deploy(final CamundaClient client, final String processId) {
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    // the tenant's partition group may need a moment to elect a leader after startup; retry the
+    // first command until it lands
+    await("deployment of '%s' succeeds".formatted(processId))
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+  }
+
+  /**
+   * Creates instances until a job of the process is activated whose key decodes to the given
+   * partition. Instance creation is round-robined across the tenant's partitions, so a few
+   * instances suffice; creations that land on a partition the deployment has not been distributed
+   * to yet are absorbed by the retry.
+   */
+  private static ActivatedJob awaitActivatedJob(
+      final CamundaClient client, final String processId, final int partitionId) {
+    final var match = new AtomicReference<ActivatedJob>();
+    await("a job of '%s' is activated on partition %d".formatted(processId, partitionId))
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              client
+                  .newCreateInstanceCommand()
+                  .bpmnProcessId(processId)
+                  .latestVersion()
+                  .send()
+                  .join();
+              client
+                  .newActivateJobsCommand()
+                  .jobType(JOB_TYPE)
+                  .maxJobsToActivate(10)
+                  .requestTimeout(Duration.ofSeconds(1))
+                  .send()
+                  .join()
+                  .getJobs()
+                  .stream()
+                  .filter(job -> Protocol.decodePartitionId(job.getKey()) == partitionId)
+                  .findFirst()
+                  .ifPresent(match::set);
+              assertThat(match.get()).isNotNull();
+            });
+    return match.get();
+  }
+
+  /**
+   * Creates a JAR on the fly containing the {@link PhysicalTenantQueryServerInterceptor}. Any type
+   * that is not part of the distribution but is required by the interceptor must be added as a
+   * required type, and all such types must be public, otherwise ByteBuddy cannot inject them.
+   */
+  private static File createInterceptorJar() {
+    final var byteBuddy = new ByteBuddy();
+    try {
+      final var baseDir = Files.createTempDirectory("interceptorJar").toFile();
+      return byteBuddy
+          .decorate(PhysicalTenantQueryServerInterceptor.class)
+          .require(byteBuddy.decorate(PhysicalTenantQueryListener.class).make())
+          .require(byteBuddy.decorate(CloseAwareListener.class).make())
+          .make()
+          .toJar(new File(baseDir, "interceptor.jar"));
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantQueryListener.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantQueryListener.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
+import io.camunda.zeebe.gateway.query.QueryApi;
+import io.camunda.zeebe.test.util.grpc.CloseAwareListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.Status;
+import java.time.Duration;
+
+/**
+ * Listener backing {@link PhysicalTenantQueryServerInterceptor}. On every {@code
+ * CompleteJobRequest} it resolves the job's BPMN process id through the interceptor-facing {@link
+ * QueryApi} — which routes the underlying broker query to the physical tenant stamped into the gRPC
+ * context — and only lets the call proceed if the resolved process id is prefixed with that
+ * tenant's id. A failed lookup aborts the call, propagating the query error's message so the test
+ * can assert on which engine answered.
+ */
+public final class PhysicalTenantQueryListener<ReqT> extends CloseAwareListener<ReqT> {
+
+  private final QueryApi api;
+  private final ServerCall<ReqT, ?> call;
+
+  public PhysicalTenantQueryListener(
+      final Listener<ReqT> delegate, final QueryApi api, final ServerCall<ReqT, ?> call) {
+    super(delegate);
+    this.api = api;
+    this.call = call;
+  }
+
+  @Override
+  public void onMessage(final ReqT message) {
+    if (!(message instanceof CompleteJobRequest)) {
+      super.onMessage(message);
+      return;
+    }
+
+    final var request = (CompleteJobRequest) message;
+    final var physicalTenantId = InterceptorUtil.getPhysicalTenantIdKey().get();
+
+    final String processId;
+    try {
+      processId =
+          api.getBpmnProcessIdFromJob(request.getJobKey(), Duration.ofSeconds(5))
+              .toCompletableFuture()
+              .join();
+    } catch (final Exception e) {
+      call.close(
+          Status.ABORTED.augmentDescription(
+              "Query for the job's process id failed: " + rootCauseMessage(e)),
+          new Metadata());
+      isClosed = true;
+      return;
+    }
+
+    if (physicalTenantId == null || !processId.startsWith(physicalTenantId)) {
+      call.close(
+          Status.PERMISSION_DENIED.augmentDescription(
+              "Query resolved process id '"
+                  + processId
+                  + "' which does not belong to physical tenant '"
+                  + physicalTenantId
+                  + "'"),
+          new Metadata());
+      isClosed = true;
+      return;
+    }
+
+    super.onMessage(message);
+  }
+
+  private static String rootCauseMessage(final Throwable throwable) {
+    var cause = throwable;
+    while (cause.getCause() != null) {
+      cause = cause.getCause();
+    }
+    return cause.getMessage();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantQueryServerInterceptor.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantQueryServerInterceptor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+/**
+ * Test interceptor for {@link PhysicalTenantQueryApiIT}: gates every {@code CompleteJob} call on a
+ * {@link io.camunda.zeebe.gateway.query.QueryApi} lookup of the job's BPMN process id (see {@link
+ * PhysicalTenantQueryListener}). All other calls pass through untouched.
+ *
+ * <p>Loaded into the gateway from an external JAR (built via ByteBuddy in the test), so this class
+ * and everything it references that is not part of the distribution must be public.
+ */
+public final class PhysicalTenantQueryServerInterceptor implements ServerInterceptor {
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
+    final var api = InterceptorUtil.getQueryApiKey().get();
+    return new PhysicalTenantQueryListener<>(next.startCall(call, headers), api, call);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantUserTaskIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantUserTaskIT.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.response.UserTask;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the full user task lifecycle (deploy, create, search, assign, complete) per physical
+ * tenant over REST, on an <em>asymmetric</em> cluster: the default tenant runs a single partition
+ * while tenant A runs two. The asymmetry is what makes the routing assertion strong — a user task
+ * command misrouted to the default tenant's partition group cannot find a partition 2 at all and
+ * fails loudly, whereas on a symmetric cluster it could silently land on an identical-looking
+ * partition of the wrong tenant and pass. Tenant A is driven with enough instances that at least
+ * one user task provably lives on its partition 2 (checked via {@link
+ * Protocol#decodePartitionId(long)}).
+ *
+ * <p>Both tenants complete user tasks, so the isolation assertion is also strong: each tenant's
+ * user task search must see exactly its own tasks — not merely "the other tenant sees nothing".
+ */
+@ZeebeIntegration
+final class PhysicalTenantUserTaskIT {
+
+  private static final String DEFAULT = PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+  private static final String TENANT_A = "tenanta";
+  private static final int TENANT_A_PARTITION_COUNT = 2;
+  private static final int MAX_INSTANCES_PER_TENANT = 20;
+
+  // both tenants use an isolated in-memory RDBMS so the REST user task search (which reads from
+  // secondary storage) can serve results per tenant
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(DEFAULT, Storage.rdbmsH2("pt-ut-default"))
+          .withTenant(TENANT_A, Storage.rdbmsH2("pt-ut-tenanta"), TENANT_A_PARTITION_COUNT)
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  @Test
+  void shouldCompleteUserTasksPerPhysicalTenantWithoutCrossTenantVisibility() {
+    try (final CamundaClient defaultClient = TENANTS.newClientBuilder(broker, DEFAULT).build();
+        final CamundaClient tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build()) {
+      // given - a user task process deployed on each tenant, with instances spanning tenant A's
+      // second partition so at least one user task key decodes to a partition the default tenant
+      // does not have
+      deployUserTaskProcess(defaultClient, DEFAULT);
+      deployUserTaskProcess(tenantAClient, TENANT_A);
+
+      final List<Long> defaultInstances =
+          createInstancesCoveringPartitions(defaultClient, DEFAULT, Set.of(1));
+      final List<Long> tenantAInstances =
+          createInstancesCoveringPartitions(tenantAClient, TENANT_A, Set.of(1, 2));
+
+      // when - each tenant assigns and completes all of its user tasks through its own
+      // tenant-scoped REST client
+      final Set<Long> defaultTaskKeys =
+          assignAndCompleteUserTasks(defaultClient, DEFAULT, defaultInstances.size());
+      final Set<Long> tenantATaskKeys =
+          assignAndCompleteUserTasks(tenantAClient, TENANT_A, tenantAInstances.size());
+
+      // then - a task completed on tenant A's partition 2 proves commands routed into the right
+      // partition group, not just any partition group with a matching partition id
+      assertThat(tenantATaskKeys.stream().map(Protocol::decodePartitionId).collect(toSet()))
+          .as("tenant A's completed user tasks span both of its partitions")
+          .containsExactlyInAnyOrder(Protocol.START_PARTITION_ID, Protocol.START_PARTITION_ID + 1);
+
+      // and - every completion is visible in the owning tenant's search
+      awaitCompletedUserTasks(defaultClient, DEFAULT, defaultTaskKeys);
+      awaitCompletedUserTasks(tenantAClient, TENANT_A, tenantATaskKeys);
+
+      // and - each tenant's search sees exactly its own tasks and none of the other tenant's
+      assertThat(searchUserTaskKeys(defaultClient))
+          .as("the default tenant's user task search sees only its own tasks")
+          .containsExactlyInAnyOrderElementsOf(defaultTaskKeys)
+          .doesNotContainAnyElementsOf(tenantATaskKeys);
+      assertThat(searchUserTaskKeys(tenantAClient))
+          .as("tenant A's user task search sees only its own tasks")
+          .containsExactlyInAnyOrderElementsOf(tenantATaskKeys)
+          .doesNotContainAnyElementsOf(defaultTaskKeys);
+    }
+  }
+
+  private void deployUserTaskProcess(final CamundaClient client, final String tenantId) {
+    final String processId = processId(tenantId);
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .userTask("user-task-" + tenantId, AbstractUserTaskBuilder::zeebeUserTask)
+            .endEvent()
+            .done();
+
+    // the tenant's partition group may need a moment to elect a leader after startup; retry the
+    // deployment until it goes through
+    await("deployment to tenant '%s' succeeds".formatted(tenantId))
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () ->
+                client
+                    .newDeployResourceCommand()
+                    .addProcessModel(process, processId + ".bpmn")
+                    .send()
+                    .join()
+                    .getProcesses()
+                    .get(0)
+                    .getProcessDefinitionKey(),
+            key -> key > 0);
+  }
+
+  /**
+   * Creates process instances one by one until their keys cover all of the tenant's expected
+   * partitions. Instance creation is round-robined across the tenant's healthy partitions, but a
+   * freshly started partition group may briefly route everything to partition 1 until the second
+   * partition elects a leader and receives the distributed deployment — hence the retry loop
+   * instead of a fixed instance count.
+   */
+  private List<Long> createInstancesCoveringPartitions(
+      final CamundaClient client, final String tenantId, final Set<Integer> expectedPartitions) {
+    final List<Long> instanceKeys = new ArrayList<>();
+    final Set<Integer> coveredPartitions = new HashSet<>();
+    await("instances on tenant '%s' cover partitions %s".formatted(tenantId, expectedPartitions))
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () -> {
+              // fail fast (not ignored, unlike the transient creation failures below) if coverage
+              // is not reached within a sane number of instances — round-robin should get there in
+              // a handful
+              assertThat(instanceKeys)
+                  .as(
+                      "partition coverage should be reached within %d instances",
+                      MAX_INSTANCES_PER_TENANT)
+                  .hasSizeLessThan(MAX_INSTANCES_PER_TENANT);
+              try {
+                final long key =
+                    client
+                        .newCreateInstanceCommand()
+                        .bpmnProcessId(processId(tenantId))
+                        .latestVersion()
+                        .send()
+                        .join()
+                        .getProcessInstanceKey();
+                instanceKeys.add(key);
+                coveredPartitions.add(Protocol.decodePartitionId(key));
+              } catch (final Exception e) {
+                // a partition may transiently reject creation until it elects a leader and
+                // receives the distributed deployment; retry on the next poll
+                return false;
+              }
+              return coveredPartitions.containsAll(expectedPartitions);
+            });
+    return instanceKeys;
+  }
+
+  /**
+   * Waits until the tenant's user task search shows all created tasks, then assigns and completes
+   * each of them via the tenant-scoped REST client, returning the completed task keys.
+   */
+  private Set<Long> assignAndCompleteUserTasks(
+      final CamundaClient client, final String tenantId, final int expectedTaskCount) {
+    final List<UserTask> tasks =
+        await(
+                "all %d user tasks of tenant '%s' appear in its search"
+                    .formatted(expectedTaskCount, tenantId))
+            .atMost(Duration.ofSeconds(60))
+            .pollInterval(Duration.ofMillis(500))
+            .until(
+                () ->
+                    client
+                        .newUserTaskSearchRequest()
+                        .filter(f -> f.state(UserTaskState.CREATED))
+                        .send()
+                        .join()
+                        .items(),
+                items -> items.size() == expectedTaskCount);
+
+    final Set<Long> taskKeys = new HashSet<>();
+    for (final UserTask task : tasks) {
+      final long taskKey = task.getUserTaskKey();
+      client.newAssignUserTaskCommand(taskKey).assignee(tenantId + "-user").send().join();
+      client.newCompleteUserTaskCommand(taskKey).send().join();
+      taskKeys.add(taskKey);
+    }
+    return taskKeys;
+  }
+
+  private void awaitCompletedUserTasks(
+      final CamundaClient client, final String tenantId, final Set<Long> taskKeys) {
+    await("all user tasks of tenant '%s' show as completed in its search".formatted(tenantId))
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newUserTaskSearchRequest()
+                            .filter(f -> f.state(UserTaskState.COMPLETED))
+                            .send()
+                            .join()
+                            .items())
+                    .extracting(UserTask::getUserTaskKey)
+                    .containsExactlyInAnyOrderElementsOf(taskKeys));
+  }
+
+  private Set<Long> searchUserTaskKeys(final CamundaClient client) {
+    final Set<Long> keys = new HashSet<>();
+    client
+        .newUserTaskSearchRequest()
+        .send()
+        .join()
+        .items()
+        .forEach(task -> keys.add(task.getUserTaskKey()));
+    return keys;
+  }
+
+  private String processId(final String tenantId) {
+    return "user-task-process-" + tenantId;
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -85,12 +85,11 @@ public final class PhysicalTenantsITHelper {
   }
 
   /**
-   * Applies each tenant's static configuration: the {@code admin} default role for each
-   * non-default physical tenant's {@code <tenant>-admin} user, the exporters-assigned manifest,
-   * and the per-tenant partition count when one was declared via {@link
-   * Builder#withTenant(String, Storage, int)}. Does not touch secondary storage, so it is safe to
-   * call once at static setup while storage is (re-)applied per run via {@link
-   * #refreshSecondaryStorage}.
+   * Applies each tenant's static configuration: the {@code admin} default role for each non-default
+   * physical tenant's {@code <tenant>-admin} user, the exporters-assigned manifest, and the
+   * per-tenant partition count when one was declared via {@link Builder#withTenant(String, Storage,
+   * int)}. Does not touch secondary storage, so it is safe to call once at static setup while
+   * storage is (re-)applied per run via {@link #refreshSecondaryStorage}.
    */
   public TestStandaloneBroker configureAdminRoles(final TestStandaloneBroker broker) {
     tenants.forEach(

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -62,9 +62,9 @@ public final class PhysicalTenantsITHelper {
 
   private static final Duration ADMIN_READY_TIMEOUT = Duration.ofSeconds(30);
 
-  private final Map<String, Storage> tenants;
+  private final Map<String, TenantSpec> tenants;
 
-  private PhysicalTenantsITHelper(final Map<String, Storage> tenants) {
+  private PhysicalTenantsITHelper(final Map<String, TenantSpec> tenants) {
     this.tenants = Collections.unmodifiableMap(new LinkedHashMap<>(tenants));
   }
 
@@ -85,11 +85,27 @@ public final class PhysicalTenantsITHelper {
   }
 
   /**
-   * Assigns the {@code admin} default role to each non-default physical tenant's {@code
-   * <tenant>-admin} user. Does not touch secondary storage, so it is safe to call once at static
-   * setup while storage is (re-)applied per run via {@link #refreshSecondaryStorage}.
+   * Applies each tenant's static configuration: the {@code admin} default role for each
+   * non-default physical tenant's {@code <tenant>-admin} user, the exporters-assigned manifest,
+   * and the per-tenant partition count when one was declared via {@link
+   * Builder#withTenant(String, Storage, int)}. Does not touch secondary storage, so it is safe to
+   * call once at static setup while storage is (re-)applied per run via {@link
+   * #refreshSecondaryStorage}.
    */
   public TestStandaloneBroker configureAdminRoles(final TestStandaloneBroker broker) {
+    tenants.forEach(
+        (tenant, spec) -> {
+          if (spec.partitionCount() == null) {
+            return;
+          }
+          if (DEFAULT_TENANT_ID.equals(tenant)) {
+            // the default tenant's partitions are the broker's root cluster configuration
+            broker.withClusterConfig(cluster -> cluster.setPartitionCount(spec.partitionCount()));
+          } else {
+            broker.withPtConfig(
+                tenant, camunda -> camunda.getCluster().setPartitionCount(spec.partitionCount()));
+          }
+        });
     tenants
         .keySet()
         .forEach(
@@ -182,7 +198,7 @@ public final class PhysicalTenantsITHelper {
    * left untouched.
    */
   public TestStandaloneBroker refreshSecondaryStorage(final TestStandaloneBroker broker) {
-    tenants.forEach((tenant, storage) -> storage.applyTo(broker, tenant));
+    tenants.forEach((tenant, spec) -> spec.storage().applyTo(broker, tenant));
     return broker;
   }
 
@@ -261,18 +277,40 @@ public final class PhysicalTenantsITHelper {
     return new LinkedHashSet<>(tenants.keySet());
   }
 
+  private record TenantSpec(Storage storage, Integer partitionCount) {}
+
   public static final class Builder {
 
-    private final Map<String, Storage> tenants = new LinkedHashMap<>();
+    private final Map<String, TenantSpec> tenants = new LinkedHashMap<>();
 
     private Builder() {}
 
     public Builder withTenant(final String tenantId, final Storage storage) {
+      return withTenant(tenantId, storage, null);
+    }
+
+    /**
+     * Declares a physical tenant with an explicit partition count. Giving tenants different
+     * partition counts is the configuration that exposes misrouted requests: on a symmetric
+     * cluster, a request that reaches the wrong tenant's engine often still finds an
+     * identical-looking partition and passes.
+     */
+    public Builder withTenant(
+        final String tenantId, final Storage storage, final int partitionCount) {
+      if (partitionCount < 1) {
+        throw new IllegalArgumentException(
+            "partitionCount of tenant '" + tenantId + "' must be at least 1");
+      }
+      return withTenant(tenantId, storage, Integer.valueOf(partitionCount));
+    }
+
+    private Builder withTenant(
+        final String tenantId, final Storage storage, final Integer partitionCount) {
       if (tenantId == null || tenantId.isBlank()) {
         throw new IllegalArgumentException("tenantId must not be null or blank");
       }
       Objects.requireNonNull(storage, "storage must not be null for tenant '" + tenantId + "'");
-      if (tenants.putIfAbsent(tenantId, storage) != null) {
+      if (tenants.putIfAbsent(tenantId, new TenantSpec(storage, partitionCount)) != null) {
         throw new IllegalArgumentException(
             "physical tenant '" + tenantId + "' is already declared");
       }


### PR DESCRIPTION
## Description

The #60103 audit found four senders silently routing to the default physical tenant, none caught by tests. The root cause on the test side: nearly all ~40 multi-physical-tenant ITs run **symmetric 1-partition-per-tenant clusters**, where a misrouted request finds an identical-looking partition and passes. This PR adds coverage in the shape that actually exposes misrouting — **asymmetric partition counts** combined with data-plane features.

- **Harness**: `PhysicalTenantsITHelper.Builder#withTenant(id, storage, partitionCount)` — declaring asymmetric tenants becomes a one-argument change instead of a hand-written root-config/`withPtConfig` split.
- **`PhysicalTenantJobReactivationIT`** — jobs deferred because an activation response exceeds `maxMessageSize` are re-failed on their own tenant (the audit's bug 1 path).
- **`PhysicalTenantQueryApiIT`** — the interceptor-facing query API resolves the tenant from the gRPC context (bug 4 path). Note: the query API cannot currently be *enabled* for non-default tenants (the legacy flag has no unified-config mapping), so the tenanta half asserts via that tenant's own distinctive disabled-response — see the class javadoc.
- **`PhysicalTenantMessageCorrelationIT`** — message correlation, previously untested on multi-tenant clusters; `HashMod(partitionCount)` makes the same correlation key land on different partitions per tenant.
- **`PhysicalTenantUserTaskIT`** — user tasks had zero physical-tenant coverage; full deploy→search→assign→complete round trip per tenant with cross-tenant isolation asserted.
- **`PhysicalTenantPartitionScalingIT#shouldServeTheScaledUpPartitionFromItsOwnPhysicalTenant`** — requires a scaled-up partition to serve its own tenant's deployments. Writing it immediately caught a real cross-tenant defect: `SnapshotApiRequestHandler` keys transfer services by bare partition number, so the new partition can bootstrap from the **default tenant's snapshot** (#60676). The test is committed `@Disabled` linking that issue, so the fix only needs to flip the annotation.

All new tests are green (the disabled reproducer skipped); each was run at least three times to check stability.

## Follow-ups surfaced, not addressed here

- #60676 — the cross-tenant snapshot bootstrap bug above.
- `ExportingEndpoint`/`BackupEndpoint` hardcode the default tenant; `ActorClockEndpoint`/`RebalancingEndpoint` take no tenant parameter (`RebalancingService` is tenant-aware but untested).
- `@MultiDbPhysicalTenants` (acceptance tests) cannot express per-tenant partition counts yet.

Relates to #60103.