### PR TITLE
fix: preserve RDBMS process definition updates order in flush

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -32,7 +32,9 @@ public enum ContextType {
   JOB_METRICS_BATCH(false),
   MAPPING_RULE(false),
   MESSAGE_SUBSCRIPTION(false),
-  PROCESS_DEFINITION(false),
+  // draining-deletion issues markDraining and markDeleted as two UPDATEs on the same row, their
+  // order must be preserved so the state is updated correctly
+  PROCESS_DEFINITION(true),
   PROCESS_INSTANCE(false),
   ROLE(false),
   SEQUENCE_FLOW(false),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
@@ -541,4 +541,28 @@ public class ProcessDefinitionIT {
                         .page(p -> p.from(0).size(10))));
     assertThat(resultAfterDeletion.total()).isZero();
   }
+
+  @TestTemplate
+  public void shouldMarkDeletedWhenDrainedAndDeletedInSameFlush(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given a process definition deleted with zero active instances emits DRAINING and
+    // FULLY_DELETED back-to-back, so markDraining and markDeleted are queued into the same flush
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final ProcessDefinitionDbReader processDefinitionReader =
+        rdbmsService.getProcessDefinitionReader();
+
+    final var processDefinition = createAndSaveRandomProcessDefinition(rdbmsWriters, b -> b);
+    final var key = processDefinition.processDefinitionKey();
+
+    // when both state transitions are flushed together
+    rdbmsWriters.getProcessDefinitionWriter().markDraining(key);
+    rdbmsWriters.getProcessDefinitionWriter().markDeleted(key);
+    rdbmsWriters.flush();
+
+    // then the terminal state wins and the row is DELETED, not stuck at DRAINING
+    final var deleted = processDefinitionReader.findOne(key).orElse(null);
+    assertThat(deleted).isNotNull();
+    assertThat(deleted.state()).isEqualTo(ProcessDefinitionEntity.ProcessDefinitionState.DELETED);
+  }
 }


### PR DESCRIPTION
## Description

Deleting a process definition with zero active instances against RDBMS
secondary storage left PROCESS_DEFINITION.STATE permanently at DRAINING,
even though the engine completed the full deletion lifecycle and emitted
FULLY_DELETED. Deletions that went through the instance-completion path
(a real time gap between DRAINING and FULLY_DELETED) ended at DELETED
correctly, so the read model, not the engine, was at fault.

Root cause is the execution-queue flush ordering, not the export handler.
The zero-instance path emits DRAINING and FULLY_DELETED back-to-back, so
ProcessExportHandler queues markDraining and markDeleted into the same
flush. Both are UPDATEs on the same row, and DefaultExecutionQueue's
optimizeQueueOrder re-sorts a non-preserve-order context by statement
type then statementId. The two share a type, so the alphabetical
statementId tiebreak orders markDeleted before markDraining, leaving the
row at DRAINING. The instance-completion path spread the two writes
across separate flushes, so enqueue order survived and DELETED won.

PROCESS_DEFINITION was preserveOrder=false because it never had two
different UPDATEs on the same row until draining-deletion introduced
markDraining alongside markDeleted; the flag was never revisited. Flip it
to true so the terminal state wins. Merging the two writes into one was
considered and rejected: a flush is a single transaction, so the
intermediate DRAINING is never observable and the merge buys nothing at
real complexity cost. Preserving order is negligible for this entity —
process-definition writes are low volume and a create burst stays
naturally consecutive, so batching is effectively unaffected, and there
is no INSERT-before-UPDATE hazard since create always precedes deletion
in an earlier flush.

The regression test exercises the real DB matrix: it drains and deletes
in one flush and asserts the row reads DELETED. It fails on all backends
before the flag flip and passes after.

## Related issues

closes #60472
