### PR TITLE
fix: correct Delete resource endpoint history description

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -261,9 +261,12 @@ paths:
 
         The two supported types differ in how the history is removed. For a decision requirements
         definition the history is deleted asynchronously via a batch operation whose details are
-        returned in the `batchOperation` field of the response. For a process definition the
-        definition first drains its running instances and its history is deleted asynchronously once
-        the definition is fully removed cluster-wide; no batch operation is returned in the response.
+        returned in the `batchOperation` field of the response. For a process definition that still
+        exists in the runtime state, the definition first drains its running instances and its
+        history is deleted asynchronously once the definition is fully removed cluster-wide; no batch
+        operation is returned in the response. If the process definition has already been removed
+        from the runtime state and the deletion is later re-triggered with `deleteHistory` set to
+        `true`, a batch operation is created immediately and returned in the `batchOperation` field.
       parameters:
         - name: resourceKey
           in: path


### PR DESCRIPTION
## Description

The Delete resource endpoint description in the deployments OpenAPI spec stated flatly that a process definition's history deletion never returns a batch operation ("no batch operation is returned in the response"). This contradicted the `DeleteResourceResponse.batchOperation` schema-property description in the same file, which correctly documents a synchronous batch-operation case for process definitions.

The schema-property description is the accurate one. When `deleteHistory` is true, the resourceType is stamped from secondary storage in ResourceServices, not from runtime state. If the process definition has already been removed from ProcessState but still exists in history (a history-only deletion re-triggered after the definition itself was deleted), the synchronous deleteHistory branch in ResourceDeletionDeleteProcessor fires, creates a DELETE_PROCESS_INSTANCE batch operation, and returns it in the response. Only when the definition still exists in runtime state does deletion go through the drain lifecycle, where history is removed asynchronously at FULLY_DELETED and no batch operation reaches the caller.

Update the endpoint description to distinguish these two cases, so it agrees with the schema-property description: a process definition still present in runtime state drains and returns no batch operation, while a history-only deletion of an already-removed definition returns a batch operation.

## Related issues

closes #60527