### PR TITLE
fix: keep /physical-tenants/default reachable when no physical tenant is configured

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -17,11 +17,13 @@ import io.camunda.authentication.config.spi.WebAppProviderAdapter;
 import io.camunda.authentication.pt.PhysicalTenantSecurityConfiguration;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.core.port.out.AdminUserPresencePort;
 import io.camunda.security.core.port.out.BasicAuthUserDetailsPort;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityAutoConfiguration;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.security.spring.security.CamundaSecurityFilterChainConstants;
 import io.camunda.security.spring.security.OidcResourceServerCustomizer;
 import io.camunda.security.spring.spi.WebAppProviderPort;
 import io.camunda.service.RoleServices;
@@ -33,6 +35,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.observation.SecurityObservationSettings;
 import org.springframework.security.core.Authentication;
@@ -70,9 +73,18 @@ import org.springframework.security.web.firewall.StrictHttpFirewall;
 })
 public class WebSecurityConfig {
 
+  /**
+   * The host's path declarations. {@code webapp-enabled} is read here with CSL's own property key
+   * and default, so this gate cannot drift from the cluster webapp chains' conditions, which read
+   * the same key from the same {@link Environment}.
+   */
   @Bean
-  public SecurityPathPort securityPathPort() {
-    return new SecurityPathAdapter();
+  public SecurityPathPort securityPathPort(final Environment environment) {
+    return new SecurityPathAdapter(
+        environment.getProperty(
+            CamundaSecurityFilterChainConstants.WEBAPP_ENABLED_PROPERTY,
+            Boolean.class,
+            AuthenticationConfiguration.DEFAULT_WEBAPP_ENABLED));
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.config.spi;
 
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import java.util.Optional;
 import java.util.Set;
@@ -18,6 +19,10 @@ import java.util.Set;
  */
 public class SecurityPathAdapter implements SecurityPathPort {
 
+  /**
+   * Shared instance for callers outside the Spring context. It reports the default {@code
+   * webapp-enabled} state, so read {@link #webappPaths()} from the configured bean instead.
+   */
   public static final SecurityPathAdapter INSTANCE = new SecurityPathAdapter();
 
   // Tenant-prefixed paths (/physical-tenants/<id>/...) are deliberately NOT listed here. They are
@@ -118,6 +123,16 @@ public class SecurityPathAdapter implements SecurityPathPort {
           // pre-CSL host AdminUserCheckFilter carried.
           "/admin/assets");
 
+  private final boolean webappEnabled;
+
+  public SecurityPathAdapter() {
+    this(AuthenticationConfiguration.DEFAULT_WEBAPP_ENABLED);
+  }
+
+  public SecurityPathAdapter(final boolean webappEnabled) {
+    this.webappEnabled = webappEnabled;
+  }
+
   @Override
   public Set<String> apiPaths() {
     return API_PATHS;
@@ -133,9 +148,14 @@ public class SecurityPathAdapter implements SecurityPathPort {
     return UNPROTECTED_PATHS;
   }
 
+  /**
+   * The webapp path patterns, or an empty set when the webapp is disabled — how a host tells CSL it
+   * serves no webapp, so it builds an inert chain instead. The scoped per-tenant chains need this
+   * because, unlike the cluster chains, they are not gated on {@code webapp-enabled} themselves.
+   */
   @Override
   public Set<String> webappPaths() {
-    return WEBAPP_PATHS;
+    return webappEnabled ? WEBAPP_PATHS : Set.of();
   }
 
   @Override

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
@@ -24,7 +24,7 @@ import org.springframework.core.env.Environment;
 /**
  * {@link CamundaSecurityScopeProvider} that emits one {@link ScopedSecurityDescriptor} per
  * explicitly configured physical tenant, plus an alias descriptor for the implicit {@code default}
- * tenant whenever any tenant is configured.
+ * tenant, which is always emitted.
  *
  * <p>Each descriptor carries:
  *
@@ -38,19 +38,10 @@ import org.springframework.core.env.Environment;
  *       one.
  * </ul>
  *
- * <p><b>Default alias:</b> when at least one physical tenant is configured, this provider also
- * emits a descriptor for the implicit {@code default} tenant at {@code /physical-tenants/default},
- * built from {@code forPhysicalTenant("default")} (root + any {@code physical-tenants.default}
- * overlay, narrowed by its {@code assigned}). The default (root) tenant is therefore addressable
- * both via the unprefixed cluster paths ({@code /v2/...}) and via {@code
- * /physical-tenants/default/v2/...} as an alias — and {@code PhysicalTenantSecurityConfiguration}
- * feeds that same resolved config to CSL's cluster chain, so the two surfaces are identical. This
- * mirrors {@code PhysicalTenantResolver}'s synthesis of a default entry.
- *
- * <p><b>Empty-list behaviour:</b> if no {@code camunda.physical-tenants.*} entries are present in
- * the {@link Environment}, this provider returns an empty list (the default alias is <em>not</em>
- * emitted). The cluster then behaves identically to a non-PT deployment — CSL's standard chains
- * serve all traffic.
+ * <p><b>Default alias:</b> a descriptor for the implicit {@code default} tenant is always emitted
+ * at {@code /physical-tenants/default}, built from {@code forPhysicalTenant("default")}, so the
+ * root tenant is addressable both unprefixed ({@code /v2/...}) and through the alias, and the
+ * descriptor list is never empty.
  */
 public final class PhysicalTenantScopeProvider implements CamundaSecurityScopeProvider {
 
@@ -71,34 +62,37 @@ public final class PhysicalTenantScopeProvider implements CamundaSecurityScopePr
 
   /**
    * Whether any physical tenant is configured (any key under {@code
-   * camunda.physical-tenants.<id>.*} with a valid id). When {@code true}, PT-scoped chains and the
-   * {@code /physical-tenants/default} alias are active — and the cluster {@code /v2} chain must be
-   * unified with the default tenant's resolved config (see {@code
-   * PhysicalTenantSecurityConfiguration}).
+   * camunda.physical-tenants.<id>.*} with a valid id). When {@code true}, the cluster {@code /v2}
+   * chain must be unified with the default tenant's resolved config (see {@code
+   * PhysicalTenantSecurityConfiguration}), which is the only thing this gates.
+   *
+   * <p>It does <em>not</em> gate the {@code /physical-tenants/default} alias, which is always
+   * emitted. With no {@code camunda.physical-tenants.*} keys the overlay bind is a no-op, so the
+   * alias and the cluster chain resolve to equivalent config without the unification step.
    */
   public static boolean hasConfiguredPhysicalTenants(final Environment environment) {
     return !discoverExplicitTenantIds(environment).isEmpty();
   }
 
   private List<ScopedSecurityDescriptor> buildDescriptors() {
-    final Set<String> tenantIds = discoverExplicitTenantIds(environment);
-    if (tenantIds.isEmpty()) {
-      LOG.debug("No camunda.physical-tenants.* entries found; PT-scoped security chains disabled.");
-      return List.of();
-    }
-
-    // Expose the implicit default tenant as an alias for the root/cluster surface (the unprefixed
-    // /v2/... paths), addressable at /physical-tenants/default — mirroring PhysicalTenantResolver's
-    // synthesis of a default entry. A valid OIDC cluster always configures its root provider (the
-    // unprefixed /v2 surface needs it), so the alias is always buildable; idempotent if default is
-    // already configured explicitly.
-    tenantIds.add(DEFAULT_PHYSICAL_TENANT_ID);
-
+    final Set<String> tenantIds = descriptorTenantIds();
     final List<ScopedSecurityDescriptor> result = new ArrayList<>();
     for (final String tenantId : tenantIds) {
       addDescriptor(result, tenantId);
     }
     return List.copyOf(result);
+  }
+
+  /**
+   * Every explicitly configured tenant, plus {@code default} — added unconditionally, so never
+   * empty. The add is idempotent when {@code default} is also configured explicitly, and always
+   * buildable, because a cluster serving the unprefixed {@code /v2} surface necessarily configures
+   * its root provider.
+   */
+  private Set<String> descriptorTenantIds() {
+    final Set<String> tenantIds = discoverExplicitTenantIds(environment);
+    tenantIds.add(DEFAULT_PHYSICAL_TENANT_ID);
+    return tenantIds;
   }
 
   private void addDescriptor(final List<ScopedSecurityDescriptor> result, final String tenantId) {

--- a/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
@@ -276,6 +276,14 @@ public class SessionAuthenticationRefreshTest {
       classes = {WebSecurityConfigTestContext.class, WebSecurityConfig.class},
       properties = {
         "camunda.security.authentication.method=oidc",
+        // The per-scope chains build their own issuer-aware decoder from the descriptor's config,
+        // so the mocked JwtDecoder and dummy ClientRegistrationRepository below — which satisfy the
+        // cluster chain — do not cover them. A provider must be declared, with a well-formed but
+        // unreachable URI; resolution is lazy, so nothing is fetched.
+        "camunda.security.authentication.oidc.client-id=example",
+        "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+        "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+        "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com",
         "camunda.security.authentication.authentication-refresh-interval=PT1S"
       })
   @AutoConfigureMockMvc

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
@@ -47,9 +47,9 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
       "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
-      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"
+      "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com"
     })
 public class ClusterAdminOidcChainIsolationTest extends AbstractWebSecurityConfigTest {
 

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcConverterWiringTest.java
@@ -45,9 +45,9 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
       "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
-      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"
+      "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com"
     })
 class ClusterAdminOidcConverterWiringTest extends AbstractWebSecurityConfigTest {
 

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerNoEndSessionWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerNoEndSessionWiringTest.java
@@ -37,9 +37,9 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
       "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
-      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"
+      "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com"
     })
 public class OidcLogoutSuccessHandlerNoEndSessionWiringTest extends AbstractWebSecurityConfigTest {
 

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
@@ -56,9 +56,9 @@ import org.springframework.web.util.UriComponentsBuilder;
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
       "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
-      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com",
       "camunda.security.authentication.oidc.end-session-endpoint-uri=https://idp.example.com/protocol/openid-connect/logout"
     })
 public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfigTest {

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcSaaSWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcSaaSWebSecurityConfigTest.java
@@ -33,9 +33,9 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
       "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
-      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com",
       "camunda.security.saas.cluster-id=foo",
       "camunda.security.saas.organization-id=bar"
     })

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
@@ -70,9 +70,9 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
       "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
-      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"
+      "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com"
     })
 public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
 

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
@@ -27,9 +27,15 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 public class WebSecurityOidcTestContext {
 
   /**
-   * No-op {@link JwtDecoder} mock. These tests configure a non-functional JWK URI (e.g. {@code
-   * jwks.example.com}) and do not exercise JWT validation — they test filter-chain behaviour only.
-   * CSL's {@code @ConditionalOnMissingBean} default backs off when this bean is present.
+   * No-op {@link JwtDecoder} mock. These tests configure an unreachable JWK URI (e.g. {@code
+   * https://jwks.example.com}) and do not exercise JWT validation — they test filter-chain
+   * behaviour only. CSL's {@code @ConditionalOnMissingBean} default backs off when this bean is
+   * present.
+   *
+   * <p>The URI must still be a well-formed absolute URL: the per-scope chains built from {@link
+   * io.camunda.authentication.pt.PhysicalTenantScopeProvider}'s descriptors construct their own
+   * issuer-aware decoder rather than consuming this bean, and that construction validates the URI
+   * format at startup. Resolution stays lazy, so no request is ever made to it.
    */
   @Bean
   public JwtDecoder testJwtDecoder() {

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterIntegrationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterIntegrationTest.java
@@ -59,8 +59,8 @@ import org.springframework.web.context.request.ServletRequestAttributes;
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
       "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=https://token.example.com",
       "camunda.security.authentication.oidc.prefer-id-token-claims=true",
     })
 public class OidcUserAuthenticationConverterIntegrationTest extends AbstractWebSecurityConfigTest {

--- a/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
@@ -62,8 +62,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
       "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=https://token.example.com",
       "camunda.security.authentication.oidc.groups-claim=groups",
       "camunda.security.authentication.oidc.user-info-augmentation.enabled=true",
     })

--- a/authentication/src/test/java/io/camunda/authentication/pt/JwksTestServer.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/JwksTestServer.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.pt;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Minimal JWKS + OIDC discovery HTTP server backed by a freshly generated RSA key pair. Serves:
+ *
+ * <ul>
+ *   <li>{@code /jwks} — the public JWK set (for token verification)
+ *   <li>{@code /.well-known/openid-configuration} — a discovery document pointing back to this
+ *       server
+ * </ul>
+ *
+ * <p>Mirrors the {@code JwksTestServer} pattern from CSL's {@code ScopedJwtDecoderFactoryTest}.
+ * Shared by {@link PhysicalTenantApiChainIsolationIT} and {@link PhysicalTenantDefaultAliasChainIT}
+ * — package-private rather than nested in either, since neither owns it.
+ */
+final class JwksTestServer {
+
+  private final HttpServer server;
+  private final String kid;
+  private final JWSSigner signer;
+
+  private JwksTestServer(final HttpServer server, final String kid, final JWSSigner signer) {
+    this.server = server;
+    this.kid = kid;
+    this.signer = signer;
+  }
+
+  static JwksTestServer start(final String kid) throws Exception {
+    final var generator = KeyPairGenerator.getInstance("RSA");
+    generator.initialize(2048);
+    final var pair = generator.generateKeyPair();
+    final var jwk =
+        new RSAKey.Builder((RSAPublicKey) pair.getPublic())
+            .privateKey((RSAPrivateKey) pair.getPrivate())
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .keyID(kid)
+            .build();
+    final var jwkSetJson = new JWKSet(jwk).toPublicJWKSet().toString();
+    final var httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    final var base = "http://127.0.0.1:" + httpServer.getAddress().getPort();
+    final var discoveryDoc =
+        """
+        {
+          "issuer": "%s",
+          "authorization_endpoint": "%s/auth",
+          "token_endpoint": "%s/token",
+          "jwks_uri": "%s/jwks",
+          "response_types_supported": ["code"],
+          "subject_types_supported": ["public"],
+          "id_token_signing_alg_values_supported": ["RS256"]
+        }
+        """
+            .formatted(base, base, base, base);
+
+    httpServer.createContext(
+        "/jwks",
+        exchange -> {
+          final var body = jwkSetJson.getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().set("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          try (exchange) {
+            exchange.getResponseBody().write(body);
+          }
+        });
+    httpServer.createContext(
+        "/.well-known/openid-configuration",
+        exchange -> {
+          final var body = discoveryDoc.getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().set("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          try (exchange) {
+            exchange.getResponseBody().write(body);
+          }
+        });
+    httpServer.start();
+    return new JwksTestServer(httpServer, kid, new RSASSASigner(jwk));
+  }
+
+  String kid() {
+    return kid;
+  }
+
+  JWSSigner signer() {
+    return signer;
+  }
+
+  String issuerUri() {
+    return "http://127.0.0.1:" + server.getAddress().getPort();
+  }
+
+  void stop() {
+    server.stop(0);
+  }
+
+  /** Signs a JWT for {@code issuer}, with {@code audiences} included only when non-empty. */
+  static String signForIssuer(
+      final JwksTestServer server, final String issuer, final List<String> audiences)
+      throws Exception {
+    final var header = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(server.kid()).build();
+    final var builder =
+        new JWTClaimsSet.Builder()
+            .subject("alice")
+            .issuer(issuer)
+            .issueTime(Date.from(Instant.now()))
+            .expirationTime(Date.from(Instant.now().plusSeconds(60)));
+    if (!audiences.isEmpty()) {
+      builder.audience(audiences);
+    }
+    final var jwt = new SignedJWT(header, builder.build());
+    jwt.sign(server.signer());
+    return jwt.serialize();
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
@@ -10,16 +10,6 @@ package io.camunda.authentication.pt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.KeyUse;
-import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
-import com.sun.net.httpserver.HttpServer;
 import io.camunda.authentication.config.spi.SecurityPathAdapter;
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import io.camunda.security.core.port.out.SecurityPathPort;
@@ -33,13 +23,6 @@ import io.camunda.security.spring.oidc.TokenValidatorFactory;
 import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilder;
 import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilderConfiguration;
 import io.camunda.security.spring.security.BaseSecurityConfiguration;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyPairGenerator;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
-import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -136,7 +119,8 @@ class PhysicalTenantApiChainIsolationIT {
               final var proxy = new FilterChainProxy(chains);
 
               final var request = new MockHttpServletRequest("GET", PATH_PT_A);
-              final var tokenForA = signForIssuer(serverA, serverA.issuerUri(), List.of());
+              final var tokenForA =
+                  JwksTestServer.signForIssuer(serverA, serverA.issuerUri(), List.of());
               request.addHeader("Authorization", "Bearer " + tokenForA);
               final var response = new MockHttpServletResponse();
               final var downstream = new MockFilterChain();
@@ -171,7 +155,8 @@ class PhysicalTenantApiChainIsolationIT {
 
               final var request = new MockHttpServletRequest("GET", PATH_PT_A);
               // Token from PT-B's issuer (different key and issuer) presented on PT-A's path
-              final var tokenFromB = signForIssuer(serverB, serverB.issuerUri(), List.of());
+              final var tokenFromB =
+                  JwksTestServer.signForIssuer(serverB, serverB.issuerUri(), List.of());
               request.addHeader("Authorization", "Bearer " + tokenFromB);
               final var response = new MockHttpServletResponse();
 
@@ -206,7 +191,8 @@ class PhysicalTenantApiChainIsolationIT {
               final var request = new MockHttpServletRequest("GET", PATH_PT_B);
               // Token carrying PT-A's audience (aud-pta) — only PT-A's chain should accept it
               final var tokenWithAudA =
-                  signForIssuer(serverShared, serverShared.issuerUri(), List.of("aud-pta"));
+                  JwksTestServer.signForIssuer(
+                      serverShared, serverShared.issuerUri(), List.of("aud-pta"));
               request.addHeader("Authorization", "Bearer " + tokenWithAudA);
               final var response = new MockHttpServletResponse();
 
@@ -303,7 +289,8 @@ class PhysicalTenantApiChainIsolationIT {
               final var chains = buildChainsFromProvider(ctx, assignedNarrowingEnv());
               final var proxy = new FilterChainProxy(chains);
 
-              final var ptbToken = signForIssuer(serverB, serverB.issuerUri(), List.of());
+              final var ptbToken =
+                  JwksTestServer.signForIssuer(serverB, serverB.issuerUri(), List.of());
 
               // ptb is a configured cluster provider, but PT-A is assigned [pta] only → 401 on
               // PT-A.
@@ -349,7 +336,8 @@ class PhysicalTenantApiChainIsolationIT {
               final var proxy = new FilterChainProxy(chains);
 
               // default-slot issuer (serverB) — dropped because `oidc` is not assigned → 401.
-              final var defaultSlotToken = signForIssuer(serverB, serverB.issuerUri(), List.of());
+              final var defaultSlotToken =
+                  JwksTestServer.signForIssuer(serverB, serverB.issuerUri(), List.of());
               final var reqDefault = new MockHttpServletRequest("GET", PATH_PT_A);
               reqDefault.addHeader("Authorization", "Bearer " + defaultSlotToken);
               final var respDefault = new MockHttpServletResponse();
@@ -360,7 +348,8 @@ class PhysicalTenantApiChainIsolationIT {
                   .isEqualTo(401);
 
               // Control: the assigned named provider `pta` (serverA) is still accepted → 200.
-              final var ptaToken = signForIssuer(serverA, serverA.issuerUri(), List.of());
+              final var ptaToken =
+                  JwksTestServer.signForIssuer(serverA, serverA.issuerUri(), List.of());
               final var reqPta = new MockHttpServletRequest("GET", PATH_PT_A);
               reqPta.addHeader("Authorization", "Bearer " + ptaToken);
               final var respPta = new MockHttpServletResponse();
@@ -384,7 +373,8 @@ class PhysicalTenantApiChainIsolationIT {
               final var chains = buildChainsFromProvider(ctx, reservedOidcEnv("oidc", "pta"));
               final var proxy = new FilterChainProxy(chains);
 
-              final var defaultSlotToken = signForIssuer(serverB, serverB.issuerUri(), List.of());
+              final var defaultSlotToken =
+                  JwksTestServer.signForIssuer(serverB, serverB.issuerUri(), List.of());
               final var req = new MockHttpServletRequest("GET", PATH_PT_A);
               req.addHeader("Authorization", "Bearer " + defaultSlotToken);
               final var resp = new MockHttpServletResponse();
@@ -663,124 +653,6 @@ class PhysicalTenantApiChainIsolationIT {
     return new String[] {
       "camunda.security.authentication.method=oidc",
     };
-  }
-
-  // =========================================================================
-  // JWT signing helper
-  // =========================================================================
-
-  private static String signForIssuer(
-      final JwksTestServer server, final String issuer, final List<String> audiences)
-      throws Exception {
-    final var header = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(server.kid()).build();
-    final var builder =
-        new JWTClaimsSet.Builder()
-            .subject("alice")
-            .issuer(issuer)
-            .issueTime(Date.from(Instant.now()))
-            .expirationTime(Date.from(Instant.now().plusSeconds(60)));
-    if (!audiences.isEmpty()) {
-      builder.audience(audiences);
-    }
-    final var jwt = new SignedJWT(header, builder.build());
-    jwt.sign(server.signer());
-    return jwt.serialize();
-  }
-
-  // =========================================================================
-  // In-JVM JWKS + OIDC discovery server
-  // =========================================================================
-
-  /**
-   * Minimal JWKS + OIDC discovery HTTP server backed by a freshly generated RSA key pair. Serves:
-   *
-   * <ul>
-   *   <li>{@code /jwks} — the public JWK set (for token verification)
-   *   <li>{@code /.well-known/openid-configuration} — a discovery document pointing back to this
-   *       server
-   * </ul>
-   *
-   * <p>Mirrors the {@code JwksTestServer} pattern from CSL's {@code ScopedJwtDecoderFactoryTest}.
-   */
-  private static final class JwksTestServer {
-
-    private final HttpServer server;
-    private final String kid;
-    private final JWSSigner signer;
-
-    private JwksTestServer(final HttpServer server, final String kid, final JWSSigner signer) {
-      this.server = server;
-      this.kid = kid;
-      this.signer = signer;
-    }
-
-    static JwksTestServer start(final String kid) throws Exception {
-      final var generator = KeyPairGenerator.getInstance("RSA");
-      generator.initialize(2048);
-      final var pair = generator.generateKeyPair();
-      final var jwk =
-          new RSAKey.Builder((RSAPublicKey) pair.getPublic())
-              .privateKey((RSAPrivateKey) pair.getPrivate())
-              .keyUse(KeyUse.SIGNATURE)
-              .algorithm(JWSAlgorithm.RS256)
-              .keyID(kid)
-              .build();
-      final var jwkSetJson = new JWKSet(jwk).toPublicJWKSet().toString();
-      final var httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-      final var base = "http://127.0.0.1:" + httpServer.getAddress().getPort();
-      final var discoveryDoc =
-          """
-          {
-            "issuer": "%s",
-            "authorization_endpoint": "%s/auth",
-            "token_endpoint": "%s/token",
-            "jwks_uri": "%s/jwks",
-            "response_types_supported": ["code"],
-            "subject_types_supported": ["public"],
-            "id_token_signing_alg_values_supported": ["RS256"]
-          }
-          """
-              .formatted(base, base, base, base);
-
-      httpServer.createContext(
-          "/jwks",
-          exchange -> {
-            final var body = jwkSetJson.getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, body.length);
-            try (exchange) {
-              exchange.getResponseBody().write(body);
-            }
-          });
-      httpServer.createContext(
-          "/.well-known/openid-configuration",
-          exchange -> {
-            final var body = discoveryDoc.getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, body.length);
-            try (exchange) {
-              exchange.getResponseBody().write(body);
-            }
-          });
-      httpServer.start();
-      return new JwksTestServer(httpServer, kid, new RSASSASigner(jwk));
-    }
-
-    String kid() {
-      return kid;
-    }
-
-    JWSSigner signer() {
-      return signer;
-    }
-
-    String issuerUri() {
-      return "http://127.0.0.1:" + server.getAddress().getPort();
-    }
-
-    void stop() {
-      server.stop(0);
-    }
   }
 
   // =========================================================================

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -15,7 +15,13 @@ import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.spring.utils.InvalidPhysicalTenantIdException;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
@@ -766,6 +772,43 @@ class PhysicalTenantAuthConfigurationsTest {
 
     // then — the public cross-module accessor returns an unmodifiable map
     assertThat(result).isUnmodifiable();
+  }
+
+  static Stream<Arguments> clusterShapesWithoutPhysicalTenants() {
+    return Stream.of(
+        Arguments.of(
+            "oidc with a flat slot and a named provider",
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root",
+                "camunda.security.authentication.oidc.audiences[0]", "root-aud",
+                "camunda.security.authentication.providers.oidc.extra.client-id", "extra-client",
+                "camunda.security.authentication.providers.oidc.extra.issuer-uri",
+                    "http://idp/extra")),
+        Arguments.of("basic", Map.of("camunda.security.authentication.method", "basic")),
+        Arguments.of(
+            "no method declared",
+            Map.of("camunda.security.authentication.unprotected-api", "true")));
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("clusterShapesWithoutPhysicalTenants")
+  void shouldResolveDefaultTenantIdenticallyToRawClusterBindWhenNoPhysicalTenantsConfigured(
+      final String shape, final Map<String, String> properties) {
+    // given
+    final var env = env(properties);
+
+    // when
+    final var clusterConfig =
+        Binder.get(env)
+            .bind("camunda.security.authentication", Bindable.of(AuthenticationConfiguration.class))
+            .orElseGet(AuthenticationConfiguration::new);
+    final var defaultTenantConfig =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("default", env);
+
+    // then
+    assertThat(defaultTenantConfig).usingRecursiveComparison().isEqualTo(clusterConfig);
   }
 
   // -------------------------------------------------------------------------

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.pt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.sun.net.httpserver.HttpServer;
+import io.camunda.authentication.config.spi.SecurityPathAdapter;
+import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
+import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.core.port.out.SecurityPathPort;
+import io.camunda.security.spring.CamundaSecurityConfiguration;
+import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
+import io.camunda.security.spring.oidc.JWSKeySelectorFactory;
+import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
+import io.camunda.security.spring.oidc.ScopedClientRegistrationFactory;
+import io.camunda.security.spring.oidc.ScopedJwtDecoderFactory;
+import io.camunda.security.spring.oidc.TokenValidatorFactory;
+import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilder;
+import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilderConfiguration;
+import io.camunda.security.spring.security.BaseSecurityConfiguration;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Integration test for the implicit {@code default} physical-tenant alias on a cluster with
+ * <b>no</b> {@code camunda.physical-tenants.*} entries configured.
+ *
+ * <p>Distinct from {@link PhysicalTenantApiChainIsolationIT}, which covers isolation
+ * <em>between</em> explicitly configured tenants and therefore runs with an empty root OIDC config.
+ * Here the root config is the only config there is, and the subject under test is whether {@code
+ * /physical-tenants/default} is reachable at all.
+ */
+class PhysicalTenantDefaultAliasChainIT {
+
+  /** basePath + the host's apiPaths() = /physical-tenants/default/v2/** */
+  private static final String DEFAULT_ALIAS_PATH = "/physical-tenants/default/v2/resource";
+
+  private static JwksTestServer rootServer;
+
+  @BeforeAll
+  static void startServers() throws Exception {
+    rootServer = JwksTestServer.start("key-root");
+  }
+
+  @AfterAll
+  static void stopServers() {
+    if (rootServer != null) {
+      rootServer.stop();
+    }
+  }
+
+  @Test
+  void defaultAliasShouldAcceptRootIssuerTokenWhenNoPhysicalTenantsConfigured() {
+    buildRunner()
+        .run(
+            ctx -> {
+              // given — a cluster with a root OIDC provider and no physical tenants
+              final var proxy = new FilterChainProxy(buildChains(ctx, rootOnlyEnv()));
+              final var request = new MockHttpServletRequest("GET", DEFAULT_ALIAS_PATH);
+              request.addHeader(
+                  "Authorization",
+                  "Bearer " + signForIssuer(rootServer, rootServer.issuerUri(), List.of()));
+              final var response = new MockHttpServletResponse();
+              final var downstream = new MockFilterChain();
+
+              // when
+              proxy.doFilter(request, response, downstream);
+
+              // then
+              assertThat(response.getStatus())
+                  .as(
+                      "a root-issuer token on the default alias must authenticate, not fall to the"
+                          + " catch-all")
+                  .isEqualTo(200);
+              // Load-bearing, not redundant: MockHttpServletResponse starts at 200, so the status
+              // assertion alone would also pass if no chain touched the request at all.
+              assertThat(downstream.getRequest())
+                  .as("the request must reach the downstream chain")
+                  .isNotNull();
+            });
+  }
+
+  // =========================================================================
+  // Chain assembly helpers
+  // =========================================================================
+
+  /**
+   * The method is set here <em>and</em> on the {@link MockEnvironment} in {@link #rootOnlyEnv()} on
+   * purpose: this one configures CSL's properties bean in the context, that one is what the scope
+   * provider reads. They are two separate consumers, not a duplicated setting.
+   */
+  private WebApplicationContextRunner buildRunner() {
+    return new WebApplicationContextRunner()
+        .withUserConfiguration(ObjectMapperConfig.class, OcPathsConfig.class)
+        .withConfiguration(
+            AutoConfigurations.of(
+                CamundaSecurityConfiguration.class,
+                BaseSecurityConfiguration.class,
+                ScopedApiSecurityChainBuilderConfiguration.class,
+                AuthFailureHandlerConfiguration.class))
+        .withPropertyValues("camunda.security.authentication.method=oidc");
+  }
+
+  /**
+   * Derives descriptors from OC's {@link PhysicalTenantScopeProvider} and builds one scoped API
+   * chain per descriptor, then appends CSL's catch-all last (lowest precedence).
+   */
+  private List<SecurityFilterChain> buildChains(
+      final ApplicationContext ctx, final MockEnvironment env) {
+    final var descriptors = new PhysicalTenantScopeProvider(env).get();
+
+    final var jwsKeySelectorFactory = new JWSKeySelectorFactory();
+    // Placeholder: the operative per-scope validator is built inside buildIssuerAwareDecoder from
+    // each descriptor's own provider map.
+    final var globalValidatorFactory =
+        new TokenValidatorFactory(Map.of(), OidcConfiguration.DEFAULT_CLOCK_SKEW, List.of());
+    final var scopedJwtDecoderFactory =
+        new ScopedJwtDecoderFactory(
+            new ScopedClientRegistrationFactory(),
+            new OidcAccessTokenDecoderFactory(jwsKeySelectorFactory, globalValidatorFactory));
+    final var chainBuilder = ctx.getBean(ScopedApiSecurityChainBuilder.class);
+
+    final var chains = new ArrayList<SecurityFilterChain>();
+    for (final ScopedSecurityDescriptor descriptor : descriptors) {
+      try {
+        chains.add(
+            chainBuilder.buildScopedApiChain(
+                ctx.getBean(HttpSecurity.class),
+                descriptor.basePath(),
+                descriptor.authentication(),
+                () ->
+                    scopedJwtDecoderFactory.buildIssuerAwareDecoder(descriptor.authentication())));
+      } catch (final Exception ex) {
+        throw new IllegalStateException("Failed to build chain for " + descriptor.basePath(), ex);
+      }
+    }
+    // A request matching no scoped chain lands here: `/**` denyAll, answered as 404.
+    chains.add(
+        ctx.getBean("protectedUnhandledPathsSecurityFilterChain", SecurityFilterChain.class));
+    return chains;
+  }
+
+  // =========================================================================
+  // Environment builders
+  // =========================================================================
+
+  /** Root/cluster OIDC provider only — deliberately no {@code camunda.physical-tenants.*} keys. */
+  private MockEnvironment rootOnlyEnv() {
+    final var env = new MockEnvironment();
+    env.setProperty("camunda.security.authentication.method", "oidc");
+    env.setProperty("camunda.security.authentication.oidc.client-id", "root-client");
+    env.setProperty("camunda.security.authentication.oidc.issuer-uri", rootServer.issuerUri());
+    env.setProperty(
+        "camunda.security.authentication.oidc.jwk-set-uri", rootServer.issuerUri() + "/jwks");
+    env.setProperty("camunda.security.authentication.oidc.redirect-uri", "{baseUrl}/sso-callback");
+    return env;
+  }
+
+  private static String signForIssuer(
+      final JwksTestServer server, final String issuer, final List<String> audiences)
+      throws Exception {
+    final var header = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(server.kid()).build();
+    final var builder =
+        new JWTClaimsSet.Builder()
+            .subject("alice")
+            .issuer(issuer)
+            .issueTime(Date.from(Instant.now()))
+            .expirationTime(Date.from(Instant.now().plusSeconds(60)));
+    if (!audiences.isEmpty()) {
+      builder.audience(audiences);
+    }
+    final var jwt = new SignedJWT(header, builder.build());
+    jwt.sign(server.signer());
+    return jwt.serialize();
+  }
+
+  // =========================================================================
+  // In-JVM JWKS + OIDC discovery server
+  // =========================================================================
+
+  @Configuration
+  static class ObjectMapperConfig {
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+  }
+
+  // =========================================================================
+  // Minimal host beans CSL's chain builder needs
+  // =========================================================================
+
+  /** The OC host's {@link SecurityPathPort}, so CSL knows {@code /v2/**} is an API path. */
+  @Configuration
+  static class OcPathsConfig {
+
+    @Bean
+    SecurityPathPort securityPathPort() {
+      return new SecurityPathAdapter();
+    }
+  }
+
+  /**
+   * Minimal JWKS + discovery server; mirrors the pattern in {@link
+   * PhysicalTenantApiChainIsolationIT}.
+   */
+  private static final class JwksTestServer {
+
+    private final HttpServer server;
+    private final String kid;
+    private final JWSSigner signer;
+
+    private JwksTestServer(final HttpServer server, final String kid, final JWSSigner signer) {
+      this.server = server;
+      this.kid = kid;
+      this.signer = signer;
+    }
+
+    static JwksTestServer start(final String kid) throws Exception {
+      final var generator = KeyPairGenerator.getInstance("RSA");
+      generator.initialize(2048);
+      final var pair = generator.generateKeyPair();
+      final var jwk =
+          new RSAKey.Builder((RSAPublicKey) pair.getPublic())
+              .privateKey((RSAPrivateKey) pair.getPrivate())
+              .keyUse(KeyUse.SIGNATURE)
+              .algorithm(JWSAlgorithm.RS256)
+              .keyID(kid)
+              .build();
+      final var jwkSetJson = new JWKSet(jwk).toPublicJWKSet().toString();
+      final var httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+      final var base = "http://127.0.0.1:" + httpServer.getAddress().getPort();
+      final var discoveryDoc =
+          """
+          {
+            "issuer": "%s",
+            "authorization_endpoint": "%s/auth",
+            "token_endpoint": "%s/token",
+            "jwks_uri": "%s/jwks",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"]
+          }
+          """
+              .formatted(base, base, base, base);
+
+      httpServer.createContext(
+          "/jwks",
+          exchange -> {
+            final var body = jwkSetJson.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (exchange) {
+              exchange.getResponseBody().write(body);
+            }
+          });
+      httpServer.createContext(
+          "/.well-known/openid-configuration",
+          exchange -> {
+            final var body = discoveryDoc.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (exchange) {
+              exchange.getResponseBody().write(body);
+            }
+          });
+      httpServer.start();
+      return new JwksTestServer(httpServer, kid, new RSASSASigner(jwk));
+    }
+
+    String kid() {
+      return kid;
+    }
+
+    JWSSigner signer() {
+      return signer;
+    }
+
+    String issuerUri() {
+      return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    void stop() {
+      server.stop(0);
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
@@ -10,16 +10,6 @@ package io.camunda.authentication.pt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.KeyUse;
-import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
-import com.sun.net.httpserver.HttpServer;
 import io.camunda.authentication.config.spi.SecurityPathAdapter;
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
@@ -34,14 +24,7 @@ import io.camunda.security.spring.oidc.TokenValidatorFactory;
 import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilder;
 import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilderConfiguration;
 import io.camunda.security.spring.security.BaseSecurityConfiguration;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyPairGenerator;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
@@ -98,7 +81,9 @@ class PhysicalTenantDefaultAliasChainIT {
               final var request = new MockHttpServletRequest("GET", DEFAULT_ALIAS_PATH);
               request.addHeader(
                   "Authorization",
-                  "Bearer " + signForIssuer(rootServer, rootServer.issuerUri(), List.of()));
+                  "Bearer "
+                      + JwksTestServer.signForIssuer(
+                          rootServer, rootServer.issuerUri(), List.of()));
               final var response = new MockHttpServletResponse();
               final var downstream = new MockFilterChain();
 
@@ -218,24 +203,6 @@ class PhysicalTenantDefaultAliasChainIT {
     return env;
   }
 
-  private static String signForIssuer(
-      final JwksTestServer server, final String issuer, final List<String> audiences)
-      throws Exception {
-    final var header = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(server.kid()).build();
-    final var builder =
-        new JWTClaimsSet.Builder()
-            .subject("alice")
-            .issuer(issuer)
-            .issueTime(Date.from(Instant.now()))
-            .expirationTime(Date.from(Instant.now().plusSeconds(60)));
-    if (!audiences.isEmpty()) {
-      builder.audience(audiences);
-    }
-    final var jwt = new SignedJWT(header, builder.build());
-    jwt.sign(server.signer());
-    return jwt.serialize();
-  }
-
   // =========================================================================
   // Minimal host beans CSL's chain builder needs
   // =========================================================================
@@ -256,95 +223,6 @@ class PhysicalTenantDefaultAliasChainIT {
     @Bean
     SecurityPathPort securityPathPort() {
       return new SecurityPathAdapter();
-    }
-  }
-
-  // =========================================================================
-  // In-JVM JWKS + OIDC discovery server
-  // =========================================================================
-
-  /**
-   * Minimal JWKS + discovery server; mirrors the pattern in {@link
-   * PhysicalTenantApiChainIsolationIT}.
-   */
-  private static final class JwksTestServer {
-
-    private final HttpServer server;
-    private final String kid;
-    private final JWSSigner signer;
-
-    private JwksTestServer(final HttpServer server, final String kid, final JWSSigner signer) {
-      this.server = server;
-      this.kid = kid;
-      this.signer = signer;
-    }
-
-    static JwksTestServer start(final String kid) throws Exception {
-      final var generator = KeyPairGenerator.getInstance("RSA");
-      generator.initialize(2048);
-      final var pair = generator.generateKeyPair();
-      final var jwk =
-          new RSAKey.Builder((RSAPublicKey) pair.getPublic())
-              .privateKey((RSAPrivateKey) pair.getPrivate())
-              .keyUse(KeyUse.SIGNATURE)
-              .algorithm(JWSAlgorithm.RS256)
-              .keyID(kid)
-              .build();
-      final var jwkSetJson = new JWKSet(jwk).toPublicJWKSet().toString();
-      final var httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-      final var base = "http://127.0.0.1:" + httpServer.getAddress().getPort();
-      final var discoveryDoc =
-          """
-          {
-            "issuer": "%s",
-            "authorization_endpoint": "%s/auth",
-            "token_endpoint": "%s/token",
-            "jwks_uri": "%s/jwks",
-            "response_types_supported": ["code"],
-            "subject_types_supported": ["public"],
-            "id_token_signing_alg_values_supported": ["RS256"]
-          }
-          """
-              .formatted(base, base, base, base);
-
-      httpServer.createContext(
-          "/jwks",
-          exchange -> {
-            final var body = jwkSetJson.getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, body.length);
-            try (exchange) {
-              exchange.getResponseBody().write(body);
-            }
-          });
-      httpServer.createContext(
-          "/.well-known/openid-configuration",
-          exchange -> {
-            final var body = discoveryDoc.getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, body.length);
-            try (exchange) {
-              exchange.getResponseBody().write(body);
-            }
-          });
-      httpServer.start();
-      return new JwksTestServer(httpServer, kid, new RSASSASigner(jwk));
-    }
-
-    String kid() {
-      return kid;
-    }
-
-    JWSSigner signer() {
-      return signer;
-    }
-
-    String issuerUri() {
-      return "http://127.0.0.1:" + server.getAddress().getPort();
-    }
-
-    void stop() {
-      server.stop(0);
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
@@ -214,7 +214,7 @@ class PhysicalTenantDefaultAliasChainIT {
   }
 
   // =========================================================================
-  // In-JVM JWKS + OIDC discovery server
+  // Minimal host beans CSL's chain builder needs
   // =========================================================================
 
   @Configuration
@@ -226,10 +226,6 @@ class PhysicalTenantDefaultAliasChainIT {
     }
   }
 
-  // =========================================================================
-  // Minimal host beans CSL's chain builder needs
-  // =========================================================================
-
   /** The OC host's {@link SecurityPathPort}, so CSL knows {@code /v2/**} is an API path. */
   @Configuration
   static class OcPathsConfig {
@@ -239,6 +235,10 @@ class PhysicalTenantDefaultAliasChainIT {
       return new SecurityPathAdapter();
     }
   }
+
+  // =========================================================================
+  // In-JVM JWKS + OIDC discovery server
+  // =========================================================================
 
   /**
    * Minimal JWKS + discovery server; mirrors the pattern in {@link

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
@@ -119,6 +119,29 @@ class PhysicalTenantDefaultAliasChainIT {
             });
   }
 
+  @Test
+  void unknownPhysicalTenantShouldReturn404WhenNoPhysicalTenantsConfigured() {
+    // The default alias is the only scoped chain on this cluster; an unrelated tenant id must still
+    // fall through to the catch-all rather than matching it.
+    buildRunner()
+        .run(
+            ctx -> {
+              // given
+              final var proxy = new FilterChainProxy(buildChains(ctx, rootOnlyEnv()));
+              final var request =
+                  new MockHttpServletRequest("GET", "/physical-tenants/nonexistent/v2/resource");
+              final var response = new MockHttpServletResponse();
+
+              // when
+              proxy.doFilter(request, response, new MockFilterChain());
+
+              // then
+              assertThat(response.getStatus())
+                  .as("an unconfigured physical tenant must be rejected by the catch-all")
+                  .isEqualTo(404);
+            });
+  }
+
   // =========================================================================
   // Chain assembly helpers
   // =========================================================================

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopeProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopeProviderTest.java
@@ -7,13 +7,18 @@
  */
 package io.camunda.authentication.pt;
 
+import static io.camunda.spring.utils.PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
@@ -27,7 +32,9 @@ import org.springframework.mock.env.MockEnvironment;
 class PhysicalTenantScopeProviderTest {
 
   @Test
-  void shouldReturnEmptyListWhenNoPhysicalTenantsConfigured() {
+  void shouldEmitOnlyDefaultAliasWhenNoPhysicalTenantsConfigured() {
+    // Without a descriptor the route is registered but matches no scoped chain, so the catch-all
+    // answers 404.
     // given - no camunda.physical-tenants.* properties
     final var env = env(Map.of("camunda.security.authentication.method", "oidc"));
 
@@ -35,7 +42,9 @@ class PhysicalTenantScopeProviderTest {
     final var provider = new PhysicalTenantScopeProvider(env);
 
     // then
-    assertThat(provider.get()).isEmpty();
+    assertThat(provider.get())
+        .extracting(ScopedSecurityDescriptor::basePath)
+        .containsExactly("/physical-tenants/default");
   }
 
   @Test
@@ -178,11 +187,29 @@ class PhysicalTenantScopeProviderTest {
   }
 
   @Test
-  void shouldNotEmitDefaultAliasWhenNoPhysicalTenantsConfigured() {
-    // Without PT scoping the default alias must not appear — a non-PT deployment stays vanilla.
-    final var env = env(Map.of("camunda.security.authentication.method", "oidc"));
+  void shouldEmitDefaultAliasCarryingRootConfigWhenNoPhysicalTenantsConfigured() {
+    // Zero-tenant counterpart to shouldEmitDefaultAliasDescriptorFromRootConfigWhenPtModeActive:
+    // the alias must carry the root/cluster providers, not an empty config. Field-wise equality
+    // with the cluster bind is pinned in PhysicalTenantAuthConfigurationsTest.
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root",
+                "camunda.security.authentication.oidc.audiences[0]", "root-aud"));
 
-    assertThat(new PhysicalTenantScopeProvider(env).get()).isEmpty();
+    // when
+    final var descriptors = new PhysicalTenantScopeProvider(env).get();
+
+    // then
+    assertThat(descriptors).hasSize(1);
+    final var defaultAlias = descriptors.getFirst();
+    assertThat(defaultAlias.basePath()).isEqualTo("/physical-tenants/default");
+    assertThat(defaultAlias.authentication().getOidc()).isNotNull();
+    assertThat(defaultAlias.authentication().getOidc().getClientId()).isEqualTo("root-client");
+    assertThat(defaultAlias.authentication().getOidc().getAudiences()).containsExactly("root-aud");
   }
 
   @Test
@@ -221,6 +248,65 @@ class PhysicalTenantScopeProviderTest {
     assertThatThrownBy(() -> new PhysicalTenantScopeProvider(env))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("default");
+  }
+
+  static Stream<Arguments> clusterShapes() {
+    return Stream.of(
+        Arguments.of(
+            "no physical tenants",
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root")),
+        Arguments.of(
+            "one explicit tenant",
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.tenanta.client-id",
+                    "tenanta-client",
+                "camunda.security.authentication.providers.oidc.tenanta.issuer-uri",
+                    "http://idp/tenanta",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.tenanta.client-id",
+                    "pt-tenanta-client")),
+        Arguments.of(
+            "explicit default alongside one tenant",
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.tenanta.client-id",
+                    "tenanta-client",
+                "camunda.security.authentication.providers.oidc.tenanta.issuer-uri",
+                    "http://idp/tenanta",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.tenanta.client-id",
+                    "pt-tenanta-client",
+                "camunda.physical-tenants.default.security.authentication.method", "oidc")),
+        Arguments.of(
+            "basic auth, no tenants", Map.of("camunda.security.authentication.method", "basic")));
+  }
+
+  /**
+   * Every tenant the config layer knows about gets a descriptor, and nothing else does. The config
+   * layer always knows about {@code default}; this provider once did not.
+   *
+   * <p>Not circular: both start from {@code discoverExplicitTenantIds}, but only the config layer
+   * added {@code default} unconditionally.
+   */
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("clusterShapes")
+  void shouldEmitOneDescriptorPerKnownPhysicalTenant(
+      final String shape, final Map<String, String> properties) {
+    // given
+    final var env = env(properties);
+
+    // when
+    final var descriptors = new PhysicalTenantScopeProvider(env).get();
+
+    // then
+    assertThat(descriptors)
+        .extracting(ScopedSecurityDescriptor::basePath)
+        .containsExactlyInAnyOrderElementsOf(
+            PhysicalTenantAuthConfigurations.forAllPhysicalTenants(env).keySet().stream()
+                .map(id -> PHYSICAL_TENANTS_PATH_SEGMENT + id)
+                .toList());
   }
 
   private static MockEnvironment env(final Map<String, String> properties) {

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
@@ -78,7 +78,7 @@ class PhysicalTenantScopedChainStartupIT {
             ctx -> {
               assertThat(ctx).hasNotFailed();
               assertThat(matchesAnyChain(ctx, SCOPED_LOGIN))
-                  .as("no chain may serve the scoped login path when the webapp is disabled")
+                  .as("no scoped chain may serve the scoped login path when the webapp is disabled")
                   .isFalse();
             });
   }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.pt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.security.core.port.out.SecurityPathPort;
+import io.camunda.security.spring.CamundaSecurityConfiguration;
+import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
+import io.camunda.security.spring.scope.ScopedSecurityChainConfiguration;
+import io.camunda.security.spring.security.BaseSecurityConfiguration;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Startup behaviour of the scoped chains on a cluster with no {@code camunda.physical-tenants.*}
+ * entries, through the real {@code ScopedSecurityChainRegistrar} — which builds a webapp chain as
+ * well as an API chain for every descriptor.
+ *
+ * <p>{@link PhysicalTenantDefaultAliasChainIT} builds API chains by hand to check request outcomes,
+ * so it never sees the webapp chain. This one does.
+ */
+class PhysicalTenantScopedChainStartupIT {
+
+  private static final String SCOPED_LOGIN = "/physical-tenants/default/login";
+  private static final String SCOPED_API = "/physical-tenants/default/v2/resource";
+
+  private static final String[] OIDC_PROVIDER = {
+    "camunda.security.authentication.method=oidc",
+    "camunda.security.authentication.oidc.client-id=example",
+    "camunda.security.authentication.oidc.authorization-uri=https://authorization.example.com",
+    "camunda.security.authentication.oidc.token-uri=https://token.example.com",
+    "camunda.security.authentication.oidc.jwk-set-uri=https://jwks.example.com",
+  };
+
+  static Stream<Arguments> authMethods() {
+    return Stream.of(
+        Arguments.of("oidc", OIDC_PROVIDER),
+        Arguments.of("basic", new String[] {"camunda.security.authentication.method=basic"}));
+  }
+
+  /**
+   * No case pairs this with {@code oidc} and no {@code client-id}: the scoped <em>API</em> chain
+   * needs a provider whatever the webapp setting is, so such a cluster cannot start either way and
+   * the gate makes no difference to it.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("authMethods")
+  void shouldNotServeScopedLoginWhenWebappDisabled(final String method, final String[] properties) {
+    runnerWith(properties)
+        .withPropertyValues("camunda.security.authentication.webapp-enabled=false")
+        .run(
+            ctx -> {
+              assertThat(ctx).hasNotFailed();
+              assertThat(matchesAnyChain(ctx, SCOPED_LOGIN))
+                  .as("no chain may serve the scoped login path when the webapp is disabled")
+                  .isFalse();
+            });
+  }
+
+  /** Over-gating guard: the gate must not suppress the webapp surface when it is enabled. */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("authMethods")
+  void shouldServeScopedLoginWhenWebappEnabled(final String method, final String[] properties) {
+    runnerWith(properties)
+        .run(
+            ctx -> {
+              assertThat(ctx).hasNotFailed();
+              assertThat(matchesAnyChain(ctx, SCOPED_LOGIN))
+                  .as("the scoped webapp chain must serve the login path when enabled")
+                  .isTrue();
+            });
+  }
+
+  @Test
+  void shouldStillServeScopedApiWhenWebappDisabled() {
+    // The gate must only affect the webapp chain — the API chain is the point of the fix.
+    runnerWith(OIDC_PROVIDER)
+        .withPropertyValues("camunda.security.authentication.webapp-enabled=false")
+        .run(
+            ctx -> {
+              assertThat(ctx).hasNotFailed();
+              assertThat(matchesAnyChain(ctx, SCOPED_API))
+                  .as("the scoped API chain must still serve the default alias")
+                  .isTrue();
+            });
+  }
+
+  private WebApplicationContextRunner runnerWith(final String... properties) {
+    return new WebApplicationContextRunner()
+        .withUserConfiguration(ObjectMapperConfig.class, OcPathsConfig.class)
+        .withConfiguration(
+            AutoConfigurations.of(
+                CamundaSecurityConfiguration.class,
+                BaseSecurityConfiguration.class,
+                ScopedSecurityChainConfiguration.class,
+                AuthFailureHandlerConfiguration.class,
+                PhysicalTenantSecurityConfiguration.class))
+        // Production supplies this via BasicAuthUserDetailsPort; it exists only so the basic-auth
+        // chains can be assembled, and no test authenticates as this user. Registered on the runner
+        // rather than in a @Configuration, which would be component-scanned into other tests'
+        // contexts and back CSL's own basic-auth beans off.
+        .withBean(
+            UserDetailsService.class,
+            () ->
+                new InMemoryUserDetailsManager(
+                    User.withUsername("test").password("{noop}test").authorities("USER").build()))
+        .withPropertyValues(properties);
+  }
+
+  /** Whether any registered scoped chain claims the given path. */
+  private boolean matchesAnyChain(final AssertableWebApplicationContext ctx, final String path) {
+    final var request = new MockHttpServletRequest("GET", path);
+    return Arrays.stream(ctx.getBeanNamesForType(SecurityFilterChain.class))
+        .filter(name -> name.startsWith("scoped"))
+        .map(name -> ctx.getBean(name, SecurityFilterChain.class))
+        .anyMatch(chain -> chain.matches(request));
+  }
+
+  @Configuration
+  static class ObjectMapperConfig {
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+  }
+
+  /**
+   * Builds the path port exactly as production does, so the {@code webapp-enabled} gate under test
+   * is the real wiring and not a copy of it.
+   */
+  @Configuration
+  static class OcPathsConfig {
+
+    @Bean
+    SecurityPathPort securityPathPort(final Environment environment) {
+      return new WebSecurityConfig().securityPathPort(environment);
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
@@ -62,14 +62,17 @@ class PhysicalTenantScopedChainStartupIT {
   }
 
   /**
-   * No case pairs this with {@code oidc} and no {@code client-id}: the scoped <em>API</em> chain
-   * needs a provider whatever the webapp setting is, so such a cluster cannot start either way and
-   * the gate makes no difference to it.
+   * Basic auth only. OC cannot start with {@code method=oidc} and the webapp disabled — {@code
+   * OidcOverrideBeansConfiguration}'s {@code authorizedClientManager} needs a {@code
+   * ClientRegistrationRepository}, which CSL publishes only while the webapp is enabled — so there
+   * is no OIDC configuration for this gate to act on.
+   *
+   * <p>Nor is it paired with {@code oidc} and no {@code client-id}: the scoped <em>API</em> chain
+   * needs a provider whatever the webapp setting is, so that cluster cannot start either way.
    */
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("authMethods")
-  void shouldNotServeScopedLoginWhenWebappDisabled(final String method, final String[] properties) {
-    runnerWith(properties)
+  @Test
+  void shouldNotServeScopedLoginWhenWebappDisabled() {
+    runnerWith("camunda.security.authentication.method=basic")
         .withPropertyValues("camunda.security.authentication.webapp-enabled=false")
         .run(
             ctx -> {

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfigurationTest.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.pt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.context.CamundaSecurityScopeProvider;
+import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -37,11 +38,13 @@ class PhysicalTenantSecurityConfigurationTest {
   }
 
   @Test
-  void shouldReturnEmptyDescriptorsWhenNoPhysicalTenantsConfigured() {
+  void shouldReturnOnlyDefaultAliasDescriptorWhenNoPhysicalTenantsConfigured() {
     runner.run(
         context -> {
           final var provider = context.getBean(CamundaSecurityScopeProvider.class);
-          assertThat(provider.get()).isEmpty();
+          assertThat(provider.get())
+              .extracting(ScopedSecurityDescriptor::basePath)
+              .containsExactly("/physical-tenants/default");
         });
   }
 


### PR DESCRIPTION
## Description

`/physical-tenants/default/**` returned 404 on a cluster with no `camunda.physical-tenants.*` entries, while the unprefixed `/v2/**` worked. The routes were always registered, but `PhysicalTenantScopeProvider` only emitted a security descriptor when a tenant was explicitly configured — so nothing matched the request and CSL's catch-all denied it.

**The fix** emits the `default` descriptor always, so the alias gets a security chain on every cluster. Seven lines removed from `PhysicalTenantScopeProvider`.

**A second, dependent change** in `SecurityPathAdapter` and `WebSecurityConfig`: emitting a descriptor also builds a webapp chain, and that chain ignores `webapp-enabled`. `webappPaths()` now returns an empty set when the property is false, which CSL treats as "no webapp here". The per-app `camunda.webapps.<name>.enabled` switches don't imply that property, and with `method=oidc` it can't be used at all — OC needs a `ClientRegistrationRepository` that CSL only publishes while the webapp is enabled.

**Two startup changes.** The scoped API chain validates OIDC config that nothing validated before, so a missing provider or a malformed `jwk-set-uri` now fails at startup instead of at the first request — which is also why nine OIDC test fixtures needed valid URLs. And each scoped chain builds its own client registration, so a cluster using `issuer-uri` makes three OIDC discovery calls at startup instead of one.

## Checklist

- [x] Enable backports when necessary — not applicable: physical tenants do not exist on `stable/8.9`, and 8.10 has not branched.

## Related issues

closes #60616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
