### PR TITLE
Fix db-versions.yml accuracy and extend Renovate tracking

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -5,6 +5,21 @@
 # later versions so that the last entry in each list resolves to the newest supported minor.
 # A trailing `# LTS` comment flags longer upstream support — don't remove that entry early.
 #
+# ── Renovate coverage ────────────────────────────────────────────────────────────
+#   Entries with a `# renovate: datasource=... depName=...` comment are kept current
+#   automatically. Entries without one are deliberately un-annotated, not overlooked:
+#     - postgresql / mysql / mariadb: every tag here is a floating family tag
+#       (e.g. `postgres:18-alpine`) that the upstream registry repoints to the latest
+#       patch itself — there is nothing for Renovate to ever detect as outdated. The
+#       only real "update" possible is a new major, which is a deliberate, manual
+#       decision (new matrix row, needs its own test coverage), not something to
+#       automate.
+#     - mssql / azure-sql: floating `-latest`/version-wrapper tags — "latest is
+#       acceptable" here by design.
+#     - oracle `21-slim-faststart` (gvenzl/oracle-xe): also a floating tag, and
+#       appears abandoned upstream (last pushed 2024-10-01) — worth a separate
+#       follow-up to re-evaluate Oracle 21c/XE support, not tracked here.
+#
 # ── How to use this file in CI workflows ────────────────────────────────────────
 #   CI workflows read versions from this file via the reusable action:
 #     .github/actions/read-db-versions
@@ -20,7 +35,10 @@ elasticsearch:
     # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
     - &saas '8.19.16'
   es9:
-    - "9.5.0"
+    # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
+    - "9.4.5"
+    # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
+    - "9.5.2"
   saas: *saas
 
 opensearch:
@@ -28,8 +46,11 @@ opensearch:
     # renovate: datasource=docker depName=opensearchproject/opensearch
     - '2.19.6'
   os3:
+    # renovate: datasource=docker depName=opensearchproject/opensearch
     - "3.6.0"  # LTS - don't remove before EOL: https://opensearch.org/blog/bridging-the-gap-recapping-the-launch-of-opensearch-long-term-support-lts/
+    # renovate: datasource=docker depName=opensearchproject/opensearch
     - "3.7.0"
+    # renovate: datasource=docker depName=opensearchproject/opensearch
     - "3.8.0"
 
 # ── RDBMS databases ─────────────────────────────────────────────────────────────
@@ -63,4 +84,5 @@ azure-sql:
 
 oracle:
   - "21-slim-faststart"
-  - "23.26.1-slim-faststart"
+  # renovate: datasource=docker depName=gvenzl/oracle-free versioning=docker
+  - "23.26.2-slim-faststart"

--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -28,9 +28,9 @@ elasticsearch:
     - &saas '8.19.16'
   es9:
     # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
-    - "9.4.5"
+    - '9.4.5'
     # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
-    - "9.5.2"
+    - '9.5.2'
   saas: *saas
 
 opensearch:
@@ -39,11 +39,11 @@ opensearch:
     - '2.19.6'
   os3:
     # renovate: datasource=docker depName=opensearchproject/opensearch
-    - "3.6.0"  # LTS - don't remove before EOL: https://opensearch.org/blog/bridging-the-gap-recapping-the-launch-of-opensearch-long-term-support-lts/
+    - '3.6.0'  # LTS - don't remove before EOL: https://opensearch.org/blog/bridging-the-gap-recapping-the-launch-of-opensearch-long-term-support-lts/
     # renovate: datasource=docker depName=opensearchproject/opensearch
-    - "3.7.0"
+    - '3.7.0'
     # renovate: datasource=docker depName=opensearchproject/opensearch
-    - "3.8.0"
+    - '3.8.0'
 
 # ── RDBMS databases ─────────────────────────────────────────────────────────────
 # Each entry is a Docker image tag representing one supported major version.
@@ -77,4 +77,4 @@ azure-sql:
 oracle:
   - "21-slim-faststart"
   # renovate: datasource=docker depName=gvenzl/oracle-free versioning=docker
-  - "23.26.2-slim-faststart"
+  - '23.26.2-slim-faststart'

--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -6,19 +6,11 @@
 # A trailing `# LTS` comment flags longer upstream support — don't remove that entry early.
 #
 # ── Renovate coverage ────────────────────────────────────────────────────────────
-#   Entries with a `# renovate: datasource=... depName=...` comment are kept current
-#   automatically. Entries without one are deliberately un-annotated, not overlooked:
-#     - postgresql / mysql / mariadb: every tag here is a floating family tag
-#       (e.g. `postgres:18-alpine`) that the upstream registry repoints to the latest
-#       patch itself — there is nothing for Renovate to ever detect as outdated. The
-#       only real "update" possible is a new major, which is a deliberate, manual
-#       decision (new matrix row, needs its own test coverage), not something to
-#       automate.
-#     - mssql / azure-sql: floating `-latest`/version-wrapper tags — "latest is
-#       acceptable" here by design.
-#     - oracle `21-slim-faststart` (gvenzl/oracle-xe): also a floating tag, and
-#       appears abandoned upstream (last pushed 2024-10-01) — worth a separate
-#       follow-up to re-evaluate Oracle 21c/XE support, not tracked here.
+#   A `# renovate:` comment keeps that entry current automatically. Entries without
+#   one (postgresql/mysql/mariadb/mssql/azure-sql, oracle's 21-slim-faststart) use
+#   floating tags the registry repoints itself — nothing for Renovate to bump, so
+#   they're deliberately left manual. gvenzl/oracle-xe also looks abandoned upstream
+#   (no push since 2024-10-01) — worth a follow-up for @camunda/data-layer.
 #
 # ── How to use this file in CI workflows ────────────────────────────────────────
 #   CI workflows read versions from this file via the reusable action:

--- a/.github/actions/compose/docker-compose.opensearch.yml
+++ b/.github/actions/compose/docker-compose.opensearch.yml
@@ -12,8 +12,6 @@ services:
     image: centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
     command: "sysctl -w vm.max_map_count=262144"
   opensearch:
-    # Fallback is inert (every caller sets OPENSEARCH_VERSION); dropped the stale 2.19.5
-    # digest pin rather than guess one for 2.19.6.
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.6}
     container_name: opensearch-${OPENSEARCH_HTTP_PORT:-9200}
     depends_on:

--- a/.github/actions/compose/docker-compose.opensearch.yml
+++ b/.github/actions/compose/docker-compose.opensearch.yml
@@ -12,10 +12,8 @@ services:
     image: centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
     command: "sysctl -w vm.max_map_count=262144"
   opensearch:
-    # OPENSEARCH_VERSION is always set by every current caller (ci-optimize.yml), so this
-    # fallback default is inert. It previously pinned a specific digest for 2.19.5; since
-    # nothing exercises this path, the digest was dropped rather than guessing a correct
-    # one for 2.19.6 -- re-add one if this file gains a caller that relies on the fallback.
+    # Fallback is inert (every caller sets OPENSEARCH_VERSION); dropped the stale 2.19.5
+    # digest pin rather than guess one for 2.19.6.
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.6}
     container_name: opensearch-${OPENSEARCH_HTTP_PORT:-9200}
     depends_on:

--- a/.github/actions/compose/docker-compose.opensearch.yml
+++ b/.github/actions/compose/docker-compose.opensearch.yml
@@ -12,7 +12,11 @@ services:
     image: centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
     command: "sysctl -w vm.max_map_count=262144"
   opensearch:
-    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.5@sha256:064e28dd66c1415b648d8e38a5de41bf3a91410c0f329fbb917c8e1e855ed4f2}
+    # OPENSEARCH_VERSION is always set by every current caller (ci-optimize.yml), so this
+    # fallback default is inert. It previously pinned a specific digest for 2.19.5; since
+    # nothing exercises this path, the digest was dropped rather than guessing a correct
+    # one for 2.19.6 -- re-add one if this file gains a caller that relies on the fallback.
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.6}
     container_name: opensearch-${OPENSEARCH_HTTP_PORT:-9200}
     depends_on:
       - fixsysctl

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -298,6 +298,7 @@
         "elasticsearch",
         "docker.elastic.co/elasticsearch/elasticsearch",
         "opensearchproject/opensearch",
+        "gvenzl/oracle-free",
         "eclipse-temurin",
         "reg.mini.dev/1212/openjre-base",
       ],
@@ -308,24 +309,37 @@
       enabled: false,
     },
     {
-      description: "Group ES container version bumps so db-versions.yml and parent/pom.xml are always updated together.",
+      description: "Group ES container version bumps so db-versions.yml and parent/pom.xml are always updated together. Also covers the docker-compose files where Renovate's native docker-compose manager auto-detects the same image without needing a comment.",
       matchPackageNames: [
         "docker.elastic.co/elasticsearch/elasticsearch",
       ],
       matchManagers: [
         "custom.regex",
+        "docker-compose",
       ],
       groupName: "elasticsearch container version",
     },
     {
-      description: "Group OS container version bumps so db-versions.yml and parent/pom.xml are always updated together.",
+      description: "Group OS container version bumps so db-versions.yml and parent/pom.xml are always updated together. Also covers the docker-compose files where Renovate's native docker-compose manager auto-detects the same image without needing a comment.",
       matchPackageNames: [
         "opensearchproject/opensearch",
       ],
       matchManagers: [
         "custom.regex",
+        "docker-compose",
       ],
       groupName: "opensearch container version",
+    },
+    {
+      description: "Group Oracle Free container version bumps across db-versions.yml and any docker-compose file where Renovate's native docker-compose manager auto-detects the same image.",
+      matchPackageNames: [
+        "gvenzl/oracle-free",
+      ],
+      matchManagers: [
+        "custom.regex",
+        "docker-compose",
+      ],
+      groupName: "oracle-free container version",
     },
     {
       description: "Skip lucene major updates to avoid breaking changes.",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -309,7 +309,7 @@
       enabled: false,
     },
     {
-      description: "Group ES container version bumps so db-versions.yml and parent/pom.xml are always updated together. Also covers the docker-compose files where Renovate's native docker-compose manager auto-detects the same image without needing a comment.",
+      description: "Group ES container version bumps (db-versions.yml, parent/pom.xml, and auto-detected docker-compose files) into one PR.",
       matchPackageNames: [
         "docker.elastic.co/elasticsearch/elasticsearch",
       ],
@@ -320,7 +320,7 @@
       groupName: "elasticsearch container version",
     },
     {
-      description: "Group OS container version bumps so db-versions.yml and parent/pom.xml are always updated together. Also covers the docker-compose files where Renovate's native docker-compose manager auto-detects the same image without needing a comment.",
+      description: "Group OS container version bumps (db-versions.yml, parent/pom.xml, and auto-detected docker-compose files) into one PR.",
       matchPackageNames: [
         "opensearchproject/opensearch",
       ],
@@ -331,7 +331,7 @@
       groupName: "opensearch container version",
     },
     {
-      description: "Group Oracle Free container version bumps across db-versions.yml and any docker-compose file where Renovate's native docker-compose manager auto-detects the same image.",
+      description: "Group Oracle Free container version bumps (db-versions.yml and auto-detected docker-compose files) into one PR.",
       matchPackageNames: [
         "gvenzl/oracle-free",
       ],

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -562,7 +562,7 @@ jobs:
             jdbc-username: "sa"
             jdbc-password: "Camunda#8_demo"
           # Oracle
-          - database-name: "Oracle 23ai"
+          - database-name: "Oracle 26ai"
             database-type: "oracle"
             database-image-version: "23.26.2-slim-faststart"
             jdbc-url: "jdbc:oracle:thin:@localhost:1521/FREEPDB1"

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -564,7 +564,7 @@ jobs:
           # Oracle
           - database-name: "Oracle 23ai"
             database-type: "oracle"
-            database-image-version: "23.26.1-slim-faststart"
+            database-image-version: "23.26.2-slim-faststart"
             jdbc-url: "jdbc:oracle:thin:@localhost:1521/FREEPDB1"
             jdbc-username: "camunda"
             jdbc-password: "camunda"

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -165,7 +165,7 @@ jobs:
           # Oracle
           - database-name: "Oracle 26ai"
             database-type: "oracle"
-            database-image-version: "23.26.1-slim-faststart"
+            database-image-version: "23.26.2-slim-faststart"
             jdbc-url: "jdbc:oracle:thin:@localhost:1521/FREEPDB1"
             jdbc-username: "camunda"
             jdbc-password: "camunda"

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "5432:5432"
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:${IMAGE_VERSION:-2022-latest}
+    image: mcr.microsoft.com/mssql/server:${IMAGE_VERSION:-2025-latest}
     restart: always
     environment:
       ACCEPT_EULA: y
@@ -70,7 +70,7 @@ services:
       # Name of the Docker Compose service
   oracle:
     # Override the pinned tag via the IMAGE_VERSION env var (see Docker Hub for available tags).
-    image: gvenzl/oracle-free:${IMAGE_VERSION:-23.26.1-slim-faststart}
+    image: gvenzl/oracle-free:${IMAGE_VERSION:-23.26.2-slim-faststart}
     # Forward Oracle port to localhost
     ports:
       - "1521:1521"
@@ -155,7 +155,7 @@ services:
     restart: always
 
   opensearch:
-    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.6}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster
@@ -182,7 +182,7 @@ services:
       - zeebe_network
 
   opensearch-tenant:
-    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.6}
     container_name: opensearch-tenant
     environment:
       - cluster.name=opensearch-tenant

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -3,7 +3,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     depends_on:
       - opensearch-init
     container_name: opensearch

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     container_name: opensearch
     environment:
       - cluster.name=opensearch

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     command: [ "sysctl", "-w", "vm.max_map_count=262144" ]
 
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     container_name: opensearch
     depends_on:
       - opensearch-init

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,6 +1,6 @@
 testcontainers:
   elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.19.16"
-  opensearch: "opensearchproject/opensearch:2.19.5"
+  opensearch: "opensearchproject/opensearch:2.19.6"
 
 # Unified Configuration
 camunda:

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       timeout: 5s
       retries: 3
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     container_name: opensearch
     profiles: ['cloud:opensearch', 'self-managed:opensearch']
     environment:

--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -177,7 +177,7 @@ services:
     networks:
       - optimize
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     profiles: [ "opensearch" ]
     container_name: opensearch
     environment:

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -156,7 +156,7 @@ services:
     networks:
       - localhost
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     profiles: ["opensearch"]
     container_name: opensearch
     environment:

--- a/optimize/docker-compose.yml
+++ b/optimize/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     volumes:
       - /var/tmp:/var/tmp
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     profiles: ["opensearch", "setup-integration-test"]
     container_name: opensearch
     environment:

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/qa/orchestration-cluster-smoke-tests/config/docker-compose.yml
+++ b/qa/orchestration-cluster-smoke-tests/config/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
@@ -43,7 +43,7 @@ public final class SupportedVersions {
       LOG.warn("Failed to load {}", PROPERTIES_FILE, e);
     }
     TEST_ELASTICSEARCH_VERSION = resolve(props, "elasticsearch.version", "8.19.16");
-    TEST_OPENSEARCH_VERSION = resolve(props, "opensearch.version", "2.19.5");
+    TEST_OPENSEARCH_VERSION = resolve(props, "opensearch.version", "2.19.6");
   }
 
   private SupportedVersions() {}

--- a/zeebe/exporters/opensearch-exporter/docker-compose.yml
+++ b/zeebe/exporters/opensearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.6}
     container_name: opensearch
     environment:
       - "discovery.type=single-node"

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -29,16 +29,16 @@ public final class TestSearchContainers {
       DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch").withTag("8.19.16");
   // Keep in sync with version.opensearch.container in parent/pom.xml
   private static final DockerImageName OPENSEARCH_IMAGE =
-      DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.5");
+      DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.6");
   private static final DockerImageName POSTGRES_IMAGE =
-      DockerImageName.parse("postgres").withTag("15.3-alpine");
+      DockerImageName.parse("postgres").withTag("18-alpine");
   private static final DockerImageName MARIADB_IMAGE =
       DockerImageName.parse("mariadb").withTag("12.3");
   private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql").withTag("9.7");
   private static final DockerImageName MSSQLSERVER_IMAGE =
-      DockerImageName.parse("mcr.microsoft.com/mssql/server").withTag("2022-latest");
+      DockerImageName.parse("mcr.microsoft.com/mssql/server").withTag("2025-latest");
   private static final DockerImageName ORACLE_IMAGE =
-      DockerImageName.parse("gvenzl/oracle-free").withTag("slim");
+      DockerImageName.parse("gvenzl/oracle-free").withTag("23.26.2-slim-faststart");
 
   private TestSearchContainers() {}
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -31,12 +31,12 @@ public final class TestSearchContainers {
   private static final DockerImageName OPENSEARCH_IMAGE =
       DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.6");
   private static final DockerImageName POSTGRES_IMAGE =
-      DockerImageName.parse("postgres").withTag("18-alpine");
+      DockerImageName.parse("postgres").withTag("15-alpine");
   private static final DockerImageName MARIADB_IMAGE =
       DockerImageName.parse("mariadb").withTag("12.3");
   private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql").withTag("9.7");
   private static final DockerImageName MSSQLSERVER_IMAGE =
-      DockerImageName.parse("mcr.microsoft.com/mssql/server").withTag("2025-latest");
+      DockerImageName.parse("mcr.microsoft.com/mssql/server").withTag("2022-latest");
   private static final DockerImageName ORACLE_IMAGE =
       DockerImageName.parse("gvenzl/oracle-free").withTag("23.26.2-slim-faststart");
 


### PR DESCRIPTION
`.ci/db-versions.yml` is supposed to be the source of truth for tested database versions, but es9/os3/oracle weren't Renovate-tracked, and es9 was missing 9.4.

Several hardcoded copies elsewhere had also drifted behind `db-versions.yml`. This won't fix everything but gets us another step closer to complete unity and the DB versions being SSOT.

Two changes:
1. fixes `db-versions.yml` missing ES9.4 entry, and stale 9.5.0/oracle patch. Extends Renovate coverage to es9/os3/oracle-free, grouped with their docker-compose duplicates so bumps land in one PR.
2. aligns the drifted values everywhere else (TestSearchContainers.java, docker-compose fallbacks, two other teams' hardcoded RDBMS matrices). No new sync mechanism, just updates the current values