### PR TITLE
perf: fan in business-value overview report evaluation

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.businessvalue;
 
+import static io.camunda.optimize.BusinessValueInstanceFixtures.bvdInstanceWithDuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
@@ -27,11 +28,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies the scheduler compute path end to end: after persisting one process definition (with the
- * "not defined" tenant surfaced as {@code null} alongside a real tenant) and writing a target,
- * invoking the compute service produces one overview row per range preset for the real-tenant
- * definition — the null-tenant bucket is skipped rather than crashing the sweep, and the row's
- * target block matches the caller-scoped tenant instead of leaking across tenants.
+ * Verifies the scheduler compute path end to end, across two concerns.
+ *
+ * <p><strong>Row materialization.</strong> After persisting one process definition (with the "not
+ * defined" tenant surfaced as {@code null} alongside a real tenant) and writing a target, invoking
+ * the compute service produces one overview row per range preset for the real-tenant definition —
+ * the null-tenant bucket is skipped rather than crashing the sweep, and the row's target block
+ * matches the caller-scoped tenant instead of leaking across tenants.
+ *
+ * <p><strong>Values produced by the fanned-in evaluation.</strong> Per-tenant isolation on a shared
+ * process key, distinct values for definitions resolved by a single evaluation, and a
+ * deployed-but-never-run definition neither disturbing its neighbours nor losing its row.
  */
 class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
 
@@ -161,6 +168,111 @@ class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
               assertThat(r.getAutomationRate().getTarget()).isNull();
               assertThat(r.getTargetsSet()).isZero();
             });
+  }
+
+  /**
+   * Guards per-tenant scoping of the computed values, which nothing else does — {@link
+   * #shouldNotLeakTargetsAcrossTenantsOnSameProcessKey} asserts on targets, and those come from the
+   * target index rather than from report evaluation, so it stays green however evaluation behaves.
+   *
+   * <p>Note the failure mode if the {@code businessValueReport} flag stopped being cleared: the
+   * evaluation handler would resolve definitions for a user, this sweep has none, and the sweep
+   * would fail with {@code ForbiddenException("userId is null")} — so this test would go red on an
+   * exception rather than on a blended average. Either way the pinned tenant scope is gone.
+   */
+  @Test
+  void shouldComputeTenantScopedValuesForTheSameProcessKey() {
+    // given the same process key on two tenants with clearly separated cycle times. Unique per-test
+    // identifiers keep this independent of the other tests that use PROCESS_KEY.
+    final String processKey = PROCESS_KEY + "-tenant-scoped";
+    final String tenantA = DEFAULT_TENANT;
+    final String otherTenant = "tenant-scoped-b";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithDuration(processKey, 1_000L).build(),
+            bvdInstanceWithDuration(processKey, 1_000L).build()));
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithDuration(processKey, 9_000L).tenantId(otherTenant).build(),
+            bvdInstanceWithDuration(processKey, 9_000L).tenantId(otherTenant).build()));
+    // persistProcessInstances derives its definitions on the default tenant only, so the
+    // other tenant's definition has to be written explicitly for it to enter the sweep
+    persistProcessDefinitions(List.of(bvdDefinition(processKey, otherTenant)));
+
+    // when compute runs for the 7d preset
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then each tenant's row carries its own average, not the 5_000 blend of the two
+    assertThat(overviewRepository.getByKey(tenantA, processKey, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isEqualTo(1_000L));
+    assertThat(overviewRepository.getByKey(otherTenant, processKey, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isEqualTo(9_000L));
+  }
+
+  @Test
+  void shouldComputeDistinctValuesForDefinitionsSharingOneEvaluation() {
+    // given three definitions on one tenant, all resolved by a single fanned-in evaluation
+    final String slow = PROCESS_KEY + "-slow";
+    final String mid = PROCESS_KEY + "-mid";
+    final String fast = PROCESS_KEY + "-fast";
+    persistProcessInstances(
+        List.of(
+            bvdInstanceWithDuration(slow, 10_000L).build(),
+            bvdInstanceWithDuration(mid, 5_000L).build(),
+            bvdInstanceWithDuration(fast, 1_000L).build()));
+
+    // when compute runs for the 7d preset
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then every definition takes its own value out of the shared result map
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, slow, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isEqualTo(10_000L));
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, mid, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isEqualTo(5_000L));
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, fast, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isEqualTo(1_000L));
+  }
+
+  @Test
+  void shouldStillComputeNeighboursWhenADefinitionHasNeverRun() {
+    // given one definition with instances and one that was deployed but never ran, so it has no
+    // process instance index at all
+    final String neverRun = PROCESS_KEY + "-never-run";
+    persistProcessInstances(List.of(bvdInstanceWithDuration(PROCESS_KEY, 4_000L).build()));
+    persistProcessDefinitions(List.of(bvdDefinition(neverRun, DEFAULT_TENANT)));
+
+    // when compute runs for the 7d preset
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the definition with data is unaffected. Without the pre-filter the missing index would
+    // fail the search and the interpreter would retry against the instance multi alias — correct
+    // results, but every instance index in the cluster opened. The never-run definition still gets
+    // a
+    // row, with no value.
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, PROCESS_KEY, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isEqualTo(4_000L));
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, neverRun, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isNull());
+  }
+
+  private static ProcessDefinitionOptimizeDto bvdDefinition(
+      final String key, final String tenantId) {
+    return ProcessDefinitionOptimizeDto.builder()
+        .id(key + "-" + tenantId)
+        .key(key)
+        .version("1")
+        .name(key)
+        .dataSource(new ZeebeDataSourceDto("test", 1))
+        .tenantId(tenantId)
+        .bpmn20Xml("<definitions/>")
+        .build();
   }
 
   @Test

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
@@ -31,15 +31,23 @@ import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
 import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
+import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
 import io.camunda.optimize.service.report.ReportService;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -49,13 +57,40 @@ import org.springframework.stereotype.Component;
  * the two target-bearing seeded reports are evaluated ({@code bv-duration-by-process} and {@code
  * bv-automation-rate-by-process}) — volume has no target in v1 and is not part of the L0 rollup.
  *
- * <p>Called from {@link BusinessValueOverviewSchedulerService} on each tick. The target-write and
- * stale-read backstop paths described in the technical design will call in from follow-up PRs once
- * the target REST endpoint and stale-read handler exist; this class currently exposes only the
- * scheduler entry point so unused surfaces don't linger.
+ * <p>Both seeded reports group by process definition key, so one evaluation returns a bucket per
+ * definition. Evaluation is therefore fanned in to once per {@code (report, metricRange, tenantId,
+ * chunk)} rather than once per definition, so the query count scales with the number of chunks
+ * rather than with the definition count itself — a catalog of 1000 definitions on one tenant costs
+ * 32 evaluations per sweep instead of 8000. Tenant is the finest scope a single evaluation can
+ * serve: the reports group by definition key only, with no tenant dimension in the result, so
+ * definitions have to be grouped by tenant for a per-tenant row to be correct.
+ *
+ * <p>Called from {@link BusinessValueOverviewSchedulerService} on each tick, and from {@code
+ * BusinessValueOverviewReadService}'s stale-read backstop on the common pool. Those two can
+ * overlap: the backstop's in-flight guard only excludes a second backstop, not a concurrent
+ * scheduler tick, so two full-scope sweeps may build chunk state and upsert the same document ids
+ * at once. That is tolerable because a row is a pure function of its inputs and the writes are
+ * idempotent, but it is worth knowing before adding per-sweep state that is not.
  */
 @Component
 public class BusinessValueOverviewComputeService {
+
+  /**
+   * Byte budget for the index names a single evaluation may target. Every pinned definition adds
+   * its {@code process-instance-<key>} alias to the search request, and those aliases travel in the
+   * request <em>line</em> (the URL path), not the body — so the binding ceiling is Elasticsearch's
+   * {@code http.max_initial_line_length}, 4 KB by default and not configured in this repository.
+   *
+   * <p>Exceeding it fails the request with a {@code 400}, which — unlike {@code index_not_found} —
+   * has no retry path in the interpreter, so the exception propagates and the whole sweep dies.
+   * Chunking by <em>count</em> cannot prevent that, because the length of a chunk depends on how
+   * long the BPMN process ids happen to be; hence a byte budget. 3 KB leaves room for the rest of
+   * the request line.
+   */
+  private static final int INDEX_NAME_BUDGET_BYTES = 3_000;
+
+  /** The comma joining one alias to the next in the request line. */
+  private static final int ALIAS_SEPARATOR_BYTES = 1;
 
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewComputeService.class);
@@ -65,18 +100,24 @@ public class BusinessValueOverviewComputeService {
   private final DefinitionService definitionService;
   private final ReportService reportService;
   private final PlainReportEvaluationHandler reportEvaluationHandler;
+  private final MappingMetadataRepository mappingMetadataRepository;
+  private final SearchLimitsRepository searchLimitsRepository;
 
   public BusinessValueOverviewComputeService(
       final BusinessValueTargetRepository targetRepository,
       final BusinessValueOverviewWriter overviewWriter,
       final DefinitionService definitionService,
       final ReportService reportService,
-      final PlainReportEvaluationHandler reportEvaluationHandler) {
+      final PlainReportEvaluationHandler reportEvaluationHandler,
+      final MappingMetadataRepository mappingMetadataRepository,
+      final SearchLimitsRepository searchLimitsRepository) {
     this.targetRepository = targetRepository;
     this.overviewWriter = overviewWriter;
     this.definitionService = definitionService;
     this.reportService = reportService;
     this.reportEvaluationHandler = reportEvaluationHandler;
+    this.mappingMetadataRepository = mappingMetadataRepository;
+    this.searchLimitsRepository = searchLimitsRepository;
   }
 
   public void computeOverviewRows(final List<MetricRange> ranges) {
@@ -91,36 +132,193 @@ public class BusinessValueOverviewComputeService {
     }
 
     final Map<String, BusinessValueTargetDto> targetsByDocId = readTargets();
+    final Set<String> keysWithInstanceIndex =
+        mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex();
     final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 
+    final Map<String, List<DefinitionEntry>> definitionsByTenant =
+        definitions.stream()
+            .collect(
+                Collectors.groupingBy(
+                    DefinitionEntry::tenantId, LinkedHashMap::new, Collectors.toList()));
+
     final List<BusinessValueOverviewDto> rowsToUpsert = new ArrayList<>();
-    for (final MetricRange range : ranges) {
-      for (final DefinitionEntry def : definitions) {
-        rowsToUpsert.add(buildRow(def, range, targetsByDocId, now));
-      }
+    for (final Map.Entry<String, List<DefinitionEntry>> perTenant :
+        definitionsByTenant.entrySet()) {
+      rowsToUpsert.addAll(
+          rowsForTenant(
+              perTenant.getKey(),
+              perTenant.getValue(),
+              ranges,
+              keysWithInstanceIndex,
+              targetsByDocId,
+              now));
     }
 
     overviewWriter.bulkUpsertFromScheduler(rowsToUpsert);
   }
 
+  /**
+   * Evaluates one tenant's definitions across every range and assembles their rows. Chunking is per
+   * tenant because the reports group by definition key alone, with no tenant dimension in the
+   * result — so the saving is proportional to how many definitions this one tenant owns.
+   */
+  private List<BusinessValueOverviewDto> rowsForTenant(
+      final String tenantId,
+      final List<DefinitionEntry> tenantDefinitions,
+      final List<MetricRange> ranges,
+      final Set<String> keysWithInstanceIndex,
+      final Map<String, BusinessValueTargetDto> targetsByDocId,
+      final OffsetDateTime now) {
+    final List<List<DefinitionEntry>> chunks =
+        chunk(evaluableDefinitions(tenantDefinitions, keysWithInstanceIndex));
+    final List<BusinessValueOverviewDto> rows = new ArrayList<>();
+
+    for (final MetricRange range : ranges) {
+      final Map<String, Double> cycleMillisByKey =
+          evaluateChunks(
+              BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID, range, tenantId, chunks);
+      final Map<String, Double> automationPctByKey =
+          evaluateChunks(
+              BusinessValueDashboardService.AUTOMATION_RATE_BY_PROCESS_REPORT_ID,
+              range,
+              tenantId,
+              chunks);
+
+      for (final DefinitionEntry def : tenantDefinitions) {
+        rows.add(
+            buildRow(
+                def,
+                range,
+                cycleMillisByKey.get(def.processDefinitionKey()),
+                automationPctByKey.get(def.processDefinitionKey()),
+                targetsByDocId,
+                now));
+      }
+    }
+    return rows;
+  }
+
+  /** Evaluates one report across every chunk of a tenant's definitions and merges the results. */
+  private Map<String, Double> evaluateChunks(
+      final String reportId,
+      final MetricRange range,
+      final String tenantId,
+      final List<List<DefinitionEntry>> chunks) {
+    final Map<String, Double> valuesByKey = new HashMap<>();
+    for (final List<DefinitionEntry> chunk : chunks) {
+      valuesByKey.putAll(evaluateByDefinitionKey(reportId, range, tenantId, chunk));
+    }
+    return valuesByKey;
+  }
+
+  /**
+   * Drops definitions with no process instance index. That index is created by {@code
+   * ProcessInstanceWriter} on the first instance import, so a definition that is deployed but never
+   * run has none. Naming a missing index makes the search fail with {@code index_not_found}; with
+   * several definitions pinned the interpreter recovers by retrying the whole query against the
+   * process instance multi alias, so results stay correct but every instance index in the cluster
+   * gets opened instead of the ones asked for. (A single-definition request has no such retry and
+   * falls through to an empty result instead.)
+   *
+   * <p>Nothing is lost by dropping them: no instance index means no instances, so no completed
+   * instances, so the value is null either way. They still get a row, with null values.
+   *
+   * <p>{@link MappingMetadataRepository#getProcessDefinitionKeysWithInstanceIndex()} promises
+   * lowercased keys, because index names are built by lowercasing the definition key. The
+   * definition keeps the casing of its BPMN process id, so the definition side is lowercased here
+   * to match — without it every mixed-case key ({@code Process_1} and friends) would be dropped
+   * from the query and left with a permanently null-valued row.
+   */
+  private static List<DefinitionEntry> evaluableDefinitions(
+      final List<DefinitionEntry> definitions, final Set<String> lowercasedKeysWithInstanceIndex) {
+    return definitions.stream()
+        .filter(
+            def ->
+                lowercasedKeysWithInstanceIndex.contains(
+                    def.processDefinitionKey().toLowerCase(Locale.ENGLISH)))
+        .toList();
+  }
+
+  /**
+   * Splits a tenant's definitions into chunks that are safe to pin onto one evaluation. Two
+   * ceilings apply independently: the index names must fit the request line ({@link
+   * #INDEX_NAME_BUDGET_BYTES}) and the group-by terms aggregation must be able to return a bucket
+   * per definition (the active engine's aggregation bucket limit, which silently drops buckets past
+   * it).
+   *
+   * <p>A single definition whose name alone exceeds the byte budget still gets its own chunk rather
+   * than being dropped — one oversized request is a better failure than a silently missing row.
+   */
+  private List<List<DefinitionEntry>> chunk(final List<DefinitionEntry> definitions) {
+    final int maxDefinitions = searchLimitsRepository.aggregationBucketLimit();
+    final String indexPrefix = searchLimitsRepository.indexNamePrefix();
+    final List<List<DefinitionEntry>> chunks = new ArrayList<>();
+    List<DefinitionEntry> current = new ArrayList<>();
+    int currentBytes = 0;
+
+    for (final DefinitionEntry def : definitions) {
+      final int cost = requestLineCostBytes(indexPrefix, def.processDefinitionKey());
+      final boolean full =
+          !current.isEmpty()
+              && (currentBytes + cost > INDEX_NAME_BUDGET_BYTES
+                  || current.size() >= maxDefinitions);
+      if (full) {
+        chunks.add(current);
+        current = new ArrayList<>();
+        currentBytes = 0;
+      }
+      current.add(def);
+      currentBytes += cost;
+    }
+    if (!current.isEmpty()) {
+      chunks.add(current);
+    }
+    return chunks;
+  }
+
+  /**
+   * Bytes this definition's alias occupies in the request line, counted as it is actually encoded
+   * rather than as characters.
+   *
+   * <p>{@code http.max_initial_line_length} limits bytes on the wire, and index names reach
+   * Elasticsearch percent-encoded in the URL path. A BPMN process id is an XML NCName, so non-ASCII
+   * letters are legal and the engines accept them in index names — and there they are anything but
+   * one byte each. {@code ü} arrives as {@code %C3%BC}, six bytes; a CJK character costs nine.
+   * Counting characters would let a chunk of such names pass this budget and still overrun the
+   * limit, which fails the request with a 400 that has no retry path and takes the sweep with it.
+   *
+   * <p>ASCII names are unaffected — an unreserved character still costs one — so the common case
+   * chunks exactly as before.
+   */
+  private static int requestLineCostBytes(final String indexPrefix, final String definitionKey) {
+    final String alias = indexPrefix + "-" + ProcessInstanceIndex.constructIndexName(definitionKey);
+    int bytes = ALIAS_SEPARATOR_BYTES;
+    for (final byte encoded : alias.getBytes(StandardCharsets.UTF_8)) {
+      bytes += isUnreservedInPath(encoded) ? 1 : 3;
+    }
+    return bytes;
+  }
+
+  /** Unreserved per RFC 3986; anything else is percent-encoded to three characters per byte. */
+  private static boolean isUnreservedInPath(final byte encoded) {
+    final int c = encoded & 0xFF;
+    return (c >= 'a' && c <= 'z')
+        || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9')
+        || c == '-'
+        || c == '.'
+        || c == '_'
+        || c == '~';
+  }
+
   private BusinessValueOverviewDto buildRow(
       final DefinitionEntry def,
       final MetricRange range,
+      final Double cycleMillis,
+      final Double automationPct,
       final Map<String, BusinessValueTargetDto> targetsByDocId,
       final OffsetDateTime now) {
-    final Double cycleMillis =
-        evaluatePerProcess(
-            BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID,
-            range,
-            def.tenantId(),
-            def.processDefinitionKey());
-    final Double automationPct =
-        evaluatePerProcess(
-            BusinessValueDashboardService.AUTOMATION_RATE_BY_PROCESS_REPORT_ID,
-            range,
-            def.tenantId(),
-            def.processDefinitionKey());
-
     final BusinessValueTargetDto target =
         targetsByDocId.get(targetDocId(def.tenantId(), def.processDefinitionKey()));
 
@@ -151,20 +349,38 @@ public class BusinessValueOverviewComputeService {
   }
 
   /**
-   * Evaluates a per-process seeded business-value report scoped to a single {@code (tenantId,
-   * processDefinitionKey)} pair. {@link
+   * Evaluates a seeded business-value report once for a whole chunk of definitions belonging to one
+   * tenant, returning each definition's value keyed by process definition key. Both seeded reports
+   * group by process definition key, so a single evaluation yields one bucket per definition — the
+   * per-definition value comes out of the result map instead of costing its own evaluation.
+   *
+   * <p>Clearing the {@code businessValueReport} flag on the in-memory copy is what makes the pinned
+   * definitions survive. {@link
    * io.camunda.optimize.service.db.report.ReportEvaluationHandler#setDataSourcesForSystemGeneratedReports}
-   * would otherwise expand any business-value report to every tenant the definition exists on,
-   * silently dropping the per-tenant scope and mixing metrics across tenants. Fetching the report
-   * fresh, clearing the {@code businessValueReport} flag on the in-memory copy, and pinning the
-   * definition to the exact {@code (key, tenantId)} pair here bypasses that path and preserves the
-   * caller's tenant scoping.
+   * overwrites the definitions of any report carrying that flag, and with no definitions supplied
+   * through the additional filters it takes the branch that substitutes every fully-imported
+   * definition. That branch resolves them for a user, and this sweep has no user — so with the flag
+   * left set the evaluation fails outright with {@code ForbiddenException("userId is null")} rather
+   * than returning blended data. Either way the pinned scope is gone.
+   *
+   * <p>Supplying the definitions through the additional filters instead is no better: that path
+   * resolves each key with its own search — reinstating the per-definition fan-out this method
+   * exists to remove — and replaces the tenant list with every tenant the definition exists on,
+   * which would blend tenants into a single bucket since the report carries no tenant dimension.
+   *
+   * <p>The report is fetched fresh per evaluation on purpose: evaluation appends the additional
+   * filters onto the report's own filter list, so a reused instance would accumulate one rolling
+   * date filter per range and silently narrow every subsequent range.
    */
-  private Double evaluatePerProcess(
+  private Map<String, Double> evaluateByDefinitionKey(
       final String reportId,
       final MetricRange range,
       final String tenantId,
-      final String processDefinitionKey) {
+      final List<DefinitionEntry> definitions) {
+    if (definitions.isEmpty()) {
+      return Map.of();
+    }
+
     final ReportDefinitionDto<?> report = reportService.getReportDefinition(reportId);
     if (!(report.getData() instanceof final ProcessReportDataDto reportData)) {
       throw new IllegalStateException(
@@ -172,7 +388,9 @@ public class BusinessValueOverviewComputeService {
     }
     reportData.setBusinessValueReport(false);
     reportData.setDefinitions(
-        List.of(new ReportDataDefinitionDto(processDefinitionKey, List.of(tenantId))));
+        definitions.stream()
+            .map(def -> new ReportDataDefinitionDto(def.processDefinitionKey(), List.of(tenantId)))
+            .toList());
 
     final AdditionalProcessReportEvaluationFilterDto additionalFilters =
         new AdditionalProcessReportEvaluationFilterDto();
@@ -192,14 +410,18 @@ public class BusinessValueOverviewComputeService {
         (MapCommandResult) evaluationResult.getFirstCommandResult();
     final List<MapResultEntryDto> entries = commandResult.getFirstMeasureData();
     if (entries == null) {
-      return null;
+      return Map.of();
     }
+
+    final Map<String, Double> valuesByKey = new HashMap<>(entries.size());
     for (final MapResultEntryDto entry : entries) {
-      if (processDefinitionKey.equals(entry.getKey())) {
-        return entry.getValue();
+      // A definition with no completed instances in the window produces no bucket at all, so it is
+      // simply absent here and its row keeps null values.
+      if (entry.getKey() != null && entry.getValue() != null) {
+        valuesByKey.put(entry.getKey(), entry.getValue());
       }
     }
-    return null;
+    return valuesByKey;
   }
 
   private List<DefinitionEntry> resolveDefinitions() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/MappingMetadataRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/MappingMetadataRepository.java
@@ -7,6 +7,27 @@
  */
 package io.camunda.optimize.service.db.repository;
 
+import java.util.Set;
+
 public interface MappingMetadataRepository {
   String[] getIndexAliasesWithImportIndexFlag(final boolean isImportIndex);
+
+  /**
+   * Returns the process definition keys that currently have an instance index, <strong>lowercased
+   * </strong>, resolved in a single request against the index pattern rather than one existence
+   * check per key.
+   *
+   * <p>The keys are lowercased because that is how they exist in the index names these values are
+   * derived from — {@code ProcessInstanceIndex#constructIndexName} lowercases the definition key,
+   * and the engines reject uppercase index names outright. A definition keeps the casing of its
+   * BPMN process id, so callers comparing against a definition key must lowercase that side;
+   * comparing directly silently drops every mixed-case key.
+   *
+   * <p>Instance indices are created by {@code ProcessInstanceWriter} when the first instance for a
+   * definition is imported, so a definition that is deployed but never run has none. Naming a
+   * missing index in a search fails the request with {@code index_not_found}; a caller pinning
+   * several definitions recovers via a retry against the instance multi alias, at the cost of
+   * opening every instance index in the cluster, so it is cheaper to leave those definitions out.
+   */
+  Set<String> getProcessDefinitionKeysWithInstanceIndex();
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/SearchLimitsRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/SearchLimitsRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository;
+
+/**
+ * Exposes search-shaping limits of the <em>active</em> database engine. Callers that size a request
+ * against these limits would otherwise have to read both engines' configuration and guess which one
+ * applies, which lets an irrelevant engine's setting shape a request it will never serve.
+ */
+public interface SearchLimitsRepository {
+
+  /**
+   * Maximum number of buckets a single aggregation may return, from the active engine's
+   * configuration. Aggregations are sized at this value and silently drop buckets beyond it, so a
+   * request must not ask for more groups than this.
+   *
+   * <p>Never returns less than 1: a configured 0 or negative value would otherwise make a caller
+   * sizing work against it either produce nothing or loop forever.
+   */
+  int aggregationBucketLimit();
+
+  /**
+   * The index-name prefix the active engine prepends to every alias in a request ({@code optimize}
+   * by default). Callers budgeting the length of a request line need the prefix itself rather than
+   * its length, because the cost on the wire depends on how the characters encode, not how many
+   * there are.
+   */
+  String indexNamePrefix();
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/MappingMetadataRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/MappingMetadataRepositoryES.java
@@ -11,6 +11,9 @@ import io.camunda.optimize.service.db.es.MappingMetadataUtilES;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -22,17 +25,29 @@ public class MappingMetadataRepositoryES implements MappingMetadataRepository {
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(MappingMetadataRepositoryES.class);
   private final OptimizeElasticsearchClient esClient;
+  private final MappingMetadataUtilES mappingUtil;
 
   public MappingMetadataRepositoryES(final OptimizeElasticsearchClient esClient) {
     this.esClient = esClient;
+    mappingUtil = new MappingMetadataUtilES(esClient);
   }
 
   @Override
   public String[] getIndexAliasesWithImportIndexFlag(final boolean isImportIndex) {
-    final MappingMetadataUtilES mappingUtil = new MappingMetadataUtilES(esClient);
     return mappingUtil.getAllMappings(esClient.getIndexNameService().getIndexPrefix()).stream()
         .filter(mapping -> isImportIndex == mapping.isImportIndex())
         .map(esClient.getIndexNameService()::getOptimizeIndexAliasForIndex)
         .toArray(String[]::new);
+  }
+
+  @Override
+  public Set<String> getProcessDefinitionKeysWithInstanceIndex() {
+    // Already lowercase, since these are index-name suffixes — normalized anyway so the interface's
+    // promise holds even if the naming rules change.
+    return mappingUtil
+        .retrieveProcessInstanceIndexIdentifiers(esClient.getIndexNameService().getIndexPrefix())
+        .stream()
+        .map(key -> key.toLowerCase(Locale.ENGLISH))
+        .collect(Collectors.toUnmodifiableSet());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SearchLimitsRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SearchLimitsRepositoryES.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.es;
+
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
+import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class SearchLimitsRepositoryES implements SearchLimitsRepository {
+
+  private final ConfigurationService configurationService;
+  private final OptimizeElasticsearchClient esClient;
+
+  public SearchLimitsRepositoryES(
+      final ConfigurationService configurationService, final OptimizeElasticsearchClient esClient) {
+    this.configurationService = configurationService;
+    this.esClient = esClient;
+  }
+
+  @Override
+  public int aggregationBucketLimit() {
+    // DatabaseSettings boxes this, so a value explicitly removed from the configuration arrives as
+    // null. Substituting a default here would duplicate the one shipped in service-config.yaml and
+    // silently diverge from it, while hiding a configuration that is broken for every aggregation
+    // rather than just this caller — the group-by is sized from the same value.
+    final Integer configured =
+        configurationService.getElasticSearchConfiguration().getAggregationBucketLimit();
+    if (configured == null) {
+      throw new OptimizeConfigurationException(
+          "es.settings.aggregationBucketLimit is not configured. It is required to size "
+              + "aggregations and to bound how many definitions a single search may group by.");
+    }
+    // Zero or negative is present but nonsensical rather than missing: clamp so a caller sizing
+    // work against it cannot produce nothing or fail to make progress.
+    return Math.max(1, configured);
+  }
+
+  @Override
+  public String indexNamePrefix() {
+    return esClient.getIndexNameService().getIndexPrefix();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/MappingMetadataRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/MappingMetadataRepositoryOS.java
@@ -11,6 +11,9 @@ import io.camunda.optimize.service.db.os.MappingMetadataUtilOS;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -22,17 +25,29 @@ public class MappingMetadataRepositoryOS implements MappingMetadataRepository {
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(MappingMetadataRepositoryOS.class);
   private final OptimizeOpenSearchClient osClient;
+  private final MappingMetadataUtilOS mappingUtil;
 
   public MappingMetadataRepositoryOS(final OptimizeOpenSearchClient osClient) {
     this.osClient = osClient;
+    mappingUtil = new MappingMetadataUtilOS(osClient);
   }
 
   @Override
   public String[] getIndexAliasesWithImportIndexFlag(final boolean isImportIndex) {
-    final MappingMetadataUtilOS mappingUtil = new MappingMetadataUtilOS(osClient);
     return mappingUtil.getAllMappings(osClient.getIndexNameService().getIndexPrefix()).stream()
         .filter(mapping -> isImportIndex == mapping.isImportIndex())
         .map(osClient.getIndexNameService()::getOptimizeIndexAliasForIndex)
         .toArray(String[]::new);
+  }
+
+  @Override
+  public Set<String> getProcessDefinitionKeysWithInstanceIndex() {
+    // Already lowercase, since these are index-name suffixes — normalized anyway so the interface's
+    // promise holds even if the naming rules change.
+    return mappingUtil
+        .retrieveProcessInstanceIndexIdentifiers(osClient.getIndexNameService().getIndexPrefix())
+        .stream()
+        .map(key -> key.toLowerCase(Locale.ENGLISH))
+        .collect(Collectors.toUnmodifiableSet());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/SearchLimitsRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/SearchLimitsRepositoryOS.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.os;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
+import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class SearchLimitsRepositoryOS implements SearchLimitsRepository {
+
+  private final ConfigurationService configurationService;
+  private final OptimizeOpenSearchClient osClient;
+
+  public SearchLimitsRepositoryOS(
+      final ConfigurationService configurationService, final OptimizeOpenSearchClient osClient) {
+    this.configurationService = configurationService;
+    this.osClient = osClient;
+  }
+
+  @Override
+  public int aggregationBucketLimit() {
+    // DatabaseSettings boxes this, so a value explicitly removed from the configuration arrives as
+    // null. Substituting a default here would duplicate the one shipped in service-config.yaml and
+    // silently diverge from it, while hiding a configuration that is broken for every aggregation
+    // rather than just this caller — the group-by is sized from the same value.
+    final Integer configured =
+        configurationService.getOpenSearchConfiguration().getAggregationBucketLimit();
+    if (configured == null) {
+      throw new OptimizeConfigurationException(
+          "opensearch.settings.aggregationBucketLimit is not configured. It is required to size "
+              + "aggregations and to bound how many definitions a single search may group by.");
+    }
+    // Zero or negative is present but nonsensical rather than missing: clamp so a caller sizing
+    // work against it cannot produce nothing or fail to make progress.
+    return Math.max(1, configured);
+  }
+
+  @Override
+  public String indexNamePrefix() {
+    return osClient.getIndexNameService().getIndexPrefix();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeServiceTest.java
@@ -1,0 +1,680 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.RoleType;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.dto.optimize.query.report.AuthorizedReportEvaluationResult;
+import io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult;
+import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
+import io.camunda.optimize.dto.optimize.query.report.single.result.MeasureDto;
+import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
+import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
+import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
+import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
+import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
+import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
+import io.camunda.optimize.service.report.ReportService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Guards the property the fan-in exists for: report evaluations per sweep scale with the number of
+ * definition <em>chunks per tenant</em> rather than with the definition count. The per-tenant
+ * qualifier matters — chunking happens inside the per-tenant loop, so the saving is proportional to
+ * how many definitions a single tenant owns, not to catalog size.
+ */
+class BusinessValueOverviewComputeServiceTest {
+
+  private static final String DEFAULT_TENANT = "<default>";
+
+  private BusinessValueTargetRepository targetRepository;
+  private BusinessValueOverviewWriter overviewWriter;
+  private DefinitionService definitionService;
+  private ReportService reportService;
+  private PlainReportEvaluationHandler reportEvaluationHandler;
+  private MappingMetadataRepository mappingMetadataRepository;
+  private BusinessValueOverviewComputeService computeService;
+
+  /** Values the stubbed evaluation should return, keyed by process definition key. */
+  private final Map<String, Double> stubbedValuesByKey = new HashMap<>();
+
+  /**
+   * Values keyed by tenant instead, for asserting that a tenant's answer lands only on that
+   * tenant's rows. Takes precedence over {@link #stubbedValuesByKey} when populated.
+   */
+  private final Map<String, Double> valuesByTenant = new HashMap<>();
+
+  /**
+   * Bucket key the stub should emit for a given definition key, when it must differ from the pinned
+   * key. Without this the stub echoes the pinned key back and the bucket-key to lookup-key mapping
+   * cannot fail, whatever the production code does.
+   */
+  private final Map<String, String> bucketKeyOverrides = new HashMap<>();
+
+  private final AtomicInteger evaluationCount = new AtomicInteger();
+
+  @BeforeEach
+  void setUp() {
+    targetRepository = mock(BusinessValueTargetRepository.class);
+    overviewWriter = mock(BusinessValueOverviewWriter.class);
+    definitionService = mock(DefinitionService.class);
+    reportService = mock(ReportService.class);
+    reportEvaluationHandler = mock(PlainReportEvaluationHandler.class);
+    mappingMetadataRepository = mock(MappingMetadataRepository.class);
+
+    when(targetRepository.scanAll()).thenReturn(List.of());
+    when(reportService.getReportDefinition(anyString())).thenAnswer(invocation -> seededReport());
+
+    stubEvaluation();
+
+    computeService =
+        new BusinessValueOverviewComputeService(
+            targetRepository,
+            overviewWriter,
+            definitionService,
+            reportService,
+            reportEvaluationHandler,
+            mappingMetadataRepository,
+            searchLimitsWithBucketLimit(1000));
+  }
+
+  private void stubEvaluation() {
+    when(reportEvaluationHandler.evaluateReport(any(ReportEvaluationInfo.class)))
+        .thenAnswer(
+            invocation -> {
+              evaluationCount.incrementAndGet();
+              final ReportEvaluationInfo info = invocation.getArgument(0);
+              final ProcessReportDataDto reportData =
+                  (ProcessReportDataDto) info.getReport().getData();
+              return evaluationResultFor(reportData);
+            });
+  }
+
+  @Test
+  void shouldEvaluateOncePerReportRangeAndChunkRatherThanPerDefinition() {
+    // given definitions that fit a single chunk
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(50));
+    givenDefinitions(DEFAULT_TENANT, 50);
+
+    // when computing across all four range presets
+    computeService.computeOverviewRows(allRanges());
+
+    // then two reports x four ranges x one chunk — 50 definitions cost 8 evaluations, not 400
+    assertThat(evaluationCount.get()).isEqualTo(2 * 4 * 1);
+  }
+
+  @Test
+  void shouldScaleEvaluationsWithChunkCountNotDefinitionCount() {
+    // given a chunk size of 50 and a catalog of 100 definitions on one tenant
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(50));
+    givenDefinitions(DEFAULT_TENANT, 100);
+    computeService.computeOverviewRows(allRanges());
+    final int evaluationsForOneHundred = evaluationCount.getAndSet(0);
+
+    // when the catalog doubles
+    reset(overviewWriter);
+    givenDefinitions(DEFAULT_TENANT, 200);
+    computeService.computeOverviewRows(allRanges());
+    final int evaluationsForTwoHundred = evaluationCount.get();
+
+    // then the unit of growth is the chunk, not the definition: doubling the catalog doubles the
+    // chunk count, where a per-definition sweep would have issued 800 and 1600 evaluations
+    assertThat(evaluationsForOneHundred).isEqualTo(2 * 4 * 2);
+    assertThat(evaluationsForTwoHundred).isEqualTo(2 * 4 * 4);
+  }
+
+  /**
+   * The chunk is bounded by request-line length as well as by bucket count. Index names travel in
+   * the URL, so long BPMN process ids split a chunk that the bucket limit alone would have allowed
+   * through — and an over-long request line fails with a 400 that has no retry path.
+   */
+  @Test
+  void shouldSplitOnRequestLineLengthEvenWhenTheBucketLimitAllowsMore() {
+    // given few enough definitions for the bucket limit, but very long keys
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(1000));
+    final String longKey = "a".repeat(200);
+    givenDefinitionKeys(DEFAULT_TENANT, IntStream.range(0, 40).mapToObj(i -> longKey + i).toList());
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the byte budget forces a split the bucket limit would not have
+    assertThat(capturedChunkKeys()).hasSizeGreaterThan(2);
+    assertThat(capturedChunkKeys().stream().flatMap(List::stream).distinct().toList()).hasSize(40);
+  }
+
+  /**
+   * Asserts chunk <em>membership</em>, not just the evaluation count. Counting alone is passable by
+   * a broken split: an off-by-one that overlapped or skipped a definition would still produce two
+   * chunks and the same number of calls.
+   */
+  @Test
+  void shouldSplitDefinitionsAcrossChunksWithoutLossOrOverlap() {
+    // given a bucket limit that forces a split at a known boundary
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(10));
+    givenDefinitions(DEFAULT_TENANT, 25);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then every definition is pinned exactly once, in chunks of the configured size
+    final List<List<String>> chunksPerEvaluation = capturedChunkKeys();
+    assertThat(chunksPerEvaluation).hasSize(3 * 2);
+    assertThat(chunksPerEvaluation.stream().map(List::size).distinct().toList())
+        .containsExactlyInAnyOrder(10, 5);
+
+    final List<String> firstReportChunks =
+        chunksPerEvaluation.stream().limit(3).flatMap(List::stream).toList();
+    assertThat(firstReportChunks)
+        .doesNotHaveDuplicates()
+        .containsExactlyInAnyOrderElementsOf(
+            IntStream.range(0, 25).mapToObj(i -> "process-" + i).toList());
+  }
+
+  /**
+   * Non-ASCII process ids cost far more on the wire than they do in characters, and the
+   * request-line limit counts bytes. {@code ü} is one character but arrives percent-encoded as
+   * {@code %C3%BC} — six bytes — and a CJK character costs nine. Budgeting by character length
+   * would let a chunk of such keys through and overrun the limit, which fails the request with a
+   * 400 that has no retry path.
+   */
+  @Test
+  void shouldChargeNonAsciiKeysTheirEncodedByteCost() {
+    // given two catalogs of identical character length, one ASCII and one CJK
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(1000));
+    final int keyLength = 30;
+    final int definitionCount = 60;
+
+    givenDefinitionKeys(
+        DEFAULT_TENANT,
+        IntStream.range(0, definitionCount).mapToObj(i -> "a".repeat(keyLength) + i).toList());
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+    final int asciiChunks = capturedChunkKeys().size();
+
+    reset(reportEvaluationHandler, overviewWriter);
+    stubEvaluation();
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(1000));
+    givenDefinitionKeys(
+        DEFAULT_TENANT,
+        IntStream.range(0, definitionCount).mapToObj(i -> "\u8acb".repeat(keyLength) + i).toList());
+
+    // when computing a single range over each
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+    final int cjkChunks = capturedChunkKeys().size();
+
+    // then the CJK catalog is split far more aggressively despite the same character count
+    assertThat(cjkChunks).isGreaterThan(asciiChunks);
+  }
+
+  /**
+   * A degenerate bucket limit must not be able to stall the sweep. The chunk loop only flushes a
+   * non-empty chunk, so it always makes progress — without that, a limit of 0 would append empty
+   * chunks forever and take the feature out until the process restarts, since the scheduler runs on
+   * a single-thread fixed-delay pool.
+   */
+  @Test
+  void shouldStillMakeProgressWhenTheBucketLimitIsDegenerate() {
+    // given a bucket limit of zero
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(0));
+    givenDefinitions(DEFAULT_TENANT, 3);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then it terminates, one definition per chunk, and every definition still gets a row
+    assertThat(capturedChunkKeys()).allSatisfy(chunk -> assertThat(chunk).hasSize(1));
+    assertThat(capturedRows()).hasSize(3);
+  }
+
+  /**
+   * Values are stubbed only for a definition in the <em>last</em> chunk, so a merge that kept just
+   * the first chunk's results — or overwrote instead of accumulating — would null this row.
+   */
+  @Test
+  void shouldKeepValuesFromEveryChunkNotJustTheFirst() {
+    // given three chunks' worth of definitions and a value only in the final chunk
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(10));
+    givenDefinitions(DEFAULT_TENANT, 25);
+    stubbedValuesByKey.put("process-0", 1_111.0);
+    stubbedValuesByKey.put("process-24", 4_242.0);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then values from the first and last chunk both survive — asserting both directions catches a
+    // merge that keeps only one chunk, whichever one it keeps
+    final List<BusinessValueOverviewDto> rows = capturedRows();
+    assertThat(rows)
+        .filteredOn(row -> "process-0".equals(row.getProcessDefinitionKey()))
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(1_111L));
+    assertThat(rows)
+        .filteredOn(row -> "process-24".equals(row.getProcessDefinitionKey()))
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(4_242L));
+  }
+
+  @Test
+  void shouldEvaluateSeparatelyForEachTenant() {
+    // given the same process key deployed on two tenants
+    givenDefinitionsAcrossTenants(Map.of("tenant-a", 1, "tenant-b", 1));
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then each tenant gets its own evaluation pair — the reports group by definition key only and
+    // carry no tenant dimension, so one evaluation cannot serve two tenants
+    assertThat(evaluationCount.get()).isEqualTo(2 * 2);
+  }
+
+  /**
+   * Counting evaluations proves the tenants are queried separately; this proves the answers are not
+   * crossed over on the way back into the rows.
+   */
+  @Test
+  void shouldAttributeEachTenantsValueToItsOwnRow() {
+    // given one process key on two tenants, each measuring a different cycle time
+    givenDefinitionsAcrossTenants(Map.of("tenant-a", 1, "tenant-b", 1));
+    valuesByTenant.put("tenant-a", 1_000.0);
+    valuesByTenant.put("tenant-b", 9_000.0);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then neither tenant sees the other's number, nor the blend of the two
+    final List<BusinessValueOverviewDto> rows = capturedRows();
+    assertThat(rows)
+        .filteredOn(row -> "tenant-a".equals(row.getTenantId()))
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(1_000L));
+    assertThat(rows)
+        .filteredOn(row -> "tenant-b".equals(row.getTenantId()))
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(9_000L));
+  }
+
+  @Test
+  void shouldSkipDefinitionsWhoseTenantIsNotDefined() {
+    // given a definition surfacing the "not defined" tenant bucket as a literal null alongside a
+    // real tenant, as DefinitionReader does for legacy or malformed rows
+    final DefinitionWithTenantIdsDto definition =
+        new DefinitionWithTenantIdsDto(
+            "process-0",
+            "process-0",
+            DefinitionType.PROCESS,
+            new ArrayList<>(Arrays.asList(null, DEFAULT_TENANT)),
+            Collections.emptySet());
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
+        .thenReturn(List.of(definition));
+    when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
+        .thenReturn(Set.of("process-0"));
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then only the real tenant gets a row — the writer rejects a null tenantId, and one
+    // un-tenanted definition must not abort the whole sweep
+    assertThat(capturedRows())
+        .singleElement()
+        .satisfies(row -> assertThat(row.getTenantId()).isEqualTo(DEFAULT_TENANT));
+  }
+
+  @Test
+  void shouldPinEveryDefinitionInTheChunkToTheEvaluatedTenant() {
+    // given two definitions on one tenant
+    givenDefinitions("tenant-a", 2);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the evaluated report carries both definitions, each pinned to that tenant, and the
+    // business-value flag is cleared so the handler does not replace them with the whole catalog
+    final ArgumentCaptor<ReportEvaluationInfo> captor =
+        ArgumentCaptor.forClass(ReportEvaluationInfo.class);
+    verify(reportEvaluationHandler, org.mockito.Mockito.atLeastOnce())
+        .evaluateReport(captor.capture());
+
+    final ProcessReportDataDto reportData =
+        (ProcessReportDataDto) captor.getValue().getReport().getData();
+    assertThat(reportData.isBusinessValueReport()).isFalse();
+    assertThat(reportData.getDefinitions())
+        .hasSize(2)
+        .allSatisfy(
+            definition -> assertThat(definition.getTenantIds()).containsExactly("tenant-a"));
+    assertThat(reportData.getDefinitions())
+        .extracting(ReportDataDefinitionDto::getKey)
+        .containsExactlyInAnyOrder("process-0", "process-1");
+  }
+
+  @Test
+  void shouldWriteEachDefinitionItsOwnValueFromTheSharedEvaluation() {
+    // given two definitions on one tenant with different measured values
+    givenDefinitions(DEFAULT_TENANT, 2);
+    stubbedValuesByKey.put("process-0", 1000.0);
+    stubbedValuesByKey.put("process-1", 5000.0);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then each row carries its own definition's value out of the shared result map
+    final List<BusinessValueOverviewDto> rows = capturedRows();
+    assertThat(rows)
+        .filteredOn(row -> "process-0".equals(row.getProcessDefinitionKey()))
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(1000L));
+    assertThat(rows)
+        .filteredOn(row -> "process-1".equals(row.getProcessDefinitionKey()))
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(5000L));
+  }
+
+  @Test
+  void shouldStillWriteARowForADefinitionWithNoInstanceIndex() {
+    // given two definitions of which only one has ever had an instance imported
+    givenDefinitions(DEFAULT_TENANT, 2);
+    when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
+        .thenReturn(Set.of("process-0"));
+    stubbedValuesByKey.put("process-0", 1000.0);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the definition without an index is kept out of the query — naming a missing index would
+    // fail the whole request — but still gets a row, with null values
+    final List<BusinessValueOverviewDto> rows = capturedRows();
+    assertThat(rows).hasSize(2);
+    assertThat(rows)
+        .filteredOn(row -> "process-1".equals(row.getProcessDefinitionKey()))
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isNull());
+
+    final ArgumentCaptor<ReportEvaluationInfo> captor =
+        ArgumentCaptor.forClass(ReportEvaluationInfo.class);
+    verify(reportEvaluationHandler, org.mockito.Mockito.atLeastOnce())
+        .evaluateReport(captor.capture());
+    final ProcessReportDataDto reportData =
+        (ProcessReportDataDto) captor.getValue().getReport().getData();
+    assertThat(reportData.getDefinitions())
+        .extracting(ReportDataDefinitionDto::getKey)
+        .containsExactly("process-0");
+  }
+
+  /**
+   * The instance index name is built by lowercasing the definition key, so the identifiers read
+   * back from the index pattern are lowercase while the definition keeps the casing of its BPMN
+   * process id. Comparing the two directly would drop every mixed-case key — {@code Process_1} is
+   * the Modeler default — out of the query and leave its row permanently null.
+   */
+  @Test
+  void shouldEvaluateDefinitionsWhoseKeyContainsUppercase() {
+    // given a definition whose BPMN process id is mixed case, whose instance index is therefore
+    // registered in lowercase
+    final DefinitionWithTenantIdsDto definition =
+        new DefinitionWithTenantIdsDto(
+            "Process_1",
+            "Process_1",
+            DefinitionType.PROCESS,
+            new ArrayList<>(List.of(DEFAULT_TENANT)),
+            Collections.emptySet());
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
+        .thenReturn(List.of(definition));
+    when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
+        .thenReturn(Set.of("process_1"));
+    stubbedValuesByKey.put("Process_1", 7_000.0);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then it is still evaluated and its row carries the measured value
+    assertThat(evaluationCount.get()).isEqualTo(2);
+    assertThat(capturedRows())
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(7_000L));
+  }
+
+  /**
+   * The index filter is case-insensitive; the value lookup is not, and must not become so. Bucket
+   * keys are raw {@code processDefinitionKey} term values, so they match the definition exactly —
+   * if the lookup ever normalized case it would silently pair a value with the wrong definition on
+   * a catalog holding both {@code Order} and {@code order}.
+   */
+  @Test
+  void shouldMatchValuesToDefinitionsOnTheExactBucketKey() {
+    // given a bucket returned under a differently-cased key than the definition carries
+    givenDefinitionKeys(DEFAULT_TENANT, List.of("Process_1"));
+    bucketKeyOverrides.put("Process_1", "process_1");
+    stubbedValuesByKey.put("Process_1", 5_000.0);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the value is not claimed by the mismatched definition
+    assertThat(capturedRows())
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isNull());
+  }
+
+  @Test
+  void shouldNotEvaluateWhenNoDefinitionHasAnInstanceIndex() {
+    // given definitions that have never run
+    givenDefinitions(DEFAULT_TENANT, 2);
+    when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
+        .thenReturn(Set.of());
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then no query is issued at all, and both definitions still get a row
+    verify(reportEvaluationHandler, never()).evaluateReport(any());
+    assertThat(capturedRows()).hasSize(2);
+  }
+
+  @Test
+  void shouldChunkBelowALoweredAggregationBucketLimit() {
+    // given a bucket limit smaller than the default chunk size
+    computeService =
+        new BusinessValueOverviewComputeService(
+            targetRepository,
+            overviewWriter,
+            definitionService,
+            reportService,
+            reportEvaluationHandler,
+            mappingMetadataRepository,
+            searchLimitsWithBucketLimit(10));
+    givenDefinitions(DEFAULT_TENANT, 20);
+
+    // when computing a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the chunk follows the lowered limit rather than the default — a chunk larger than the
+    // bucket limit would silently drop the definitions past it
+    assertThat(evaluationCount.get()).isEqualTo(2 * 2);
+  }
+
+  private BusinessValueOverviewComputeService computeServiceWith(
+      final SearchLimitsRepository searchLimits) {
+    return new BusinessValueOverviewComputeService(
+        targetRepository,
+        overviewWriter,
+        definitionService,
+        reportService,
+        reportEvaluationHandler,
+        mappingMetadataRepository,
+        searchLimits);
+  }
+
+  /** The definition keys pinned onto each evaluation, in invocation order. */
+  private List<List<String>> capturedChunkKeys() {
+    final ArgumentCaptor<ReportEvaluationInfo> captor =
+        ArgumentCaptor.forClass(ReportEvaluationInfo.class);
+    verify(reportEvaluationHandler, atLeastOnce()).evaluateReport(captor.capture());
+    return captor.getAllValues().stream()
+        .map(info -> (ProcessReportDataDto) info.getReport().getData())
+        .map(data -> data.getDefinitions().stream().map(ReportDataDefinitionDto::getKey).toList())
+        .toList();
+  }
+
+  private void givenDefinitions(final String tenantId, final int count) {
+    givenDefinitionsAcrossTenants(Map.of(tenantId, count));
+  }
+
+  private void givenDefinitionKeys(final String tenantId, final List<String> keys) {
+    final List<DefinitionWithTenantIdsDto> definitions =
+        keys.stream()
+            .map(
+                key ->
+                    new DefinitionWithTenantIdsDto(
+                        key,
+                        key,
+                        DefinitionType.PROCESS,
+                        new ArrayList<>(List.of(tenantId)),
+                        Collections.emptySet()))
+            .toList();
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
+        .thenReturn(definitions);
+    when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
+        .thenReturn(
+            keys.stream().map(k -> k.toLowerCase(Locale.ENGLISH)).collect(Collectors.toSet()));
+  }
+
+  private void givenDefinitionsAcrossTenants(final Map<String, Integer> countsByTenant) {
+    final List<DefinitionWithTenantIdsDto> definitions = new ArrayList<>();
+    final Set<String> keys = new HashSet<>();
+    countsByTenant.forEach(
+        (tenantId, count) ->
+            IntStream.range(0, count)
+                .forEach(
+                    index -> {
+                      final String key = "process-" + index;
+                      keys.add(key);
+                      definitions.add(
+                          new DefinitionWithTenantIdsDto(
+                              key,
+                              key,
+                              DefinitionType.PROCESS,
+                              // getTenantIds() sorts in place, so this list has to be mutable
+                              new ArrayList<>(List.of(tenantId)),
+                              Collections.emptySet()));
+                    }));
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
+        .thenReturn(definitions);
+    when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex()).thenReturn(keys);
+  }
+
+  private List<BusinessValueOverviewDto> capturedRows() {
+    final ArgumentCaptor<List<BusinessValueOverviewDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(overviewWriter).bulkUpsertFromScheduler(captor.capture());
+    return captor.getValue();
+  }
+
+  private static List<MetricRange> allRanges() {
+    return List.of(
+        MetricRange.SEVEN_DAYS,
+        MetricRange.THIRTY_DAYS,
+        MetricRange.THREE_MONTHS,
+        MetricRange.SIX_MONTHS);
+  }
+
+  private static SingleProcessReportDefinitionRequestDto seededReport() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
+            .groupBy(new ProcessDefinitionKeyGroupByDto())
+            .build();
+    reportData.setBusinessValueReport(true);
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto();
+    report.setId(BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID);
+    report.setData(reportData);
+    return report;
+  }
+
+  /**
+   * Mirrors the group-by-process-definition-key shape: one entry per definition that has data, with
+   * definitions lacking data simply absent from the result.
+   */
+  private AuthorizedReportEvaluationResult evaluationResultFor(
+      final ProcessReportDataDto reportData) {
+    final List<MapResultEntryDto> entries =
+        reportData.getDefinitions().stream()
+            .map(
+                definition ->
+                    new MapResultEntryDto(
+                        bucketKeyOverrides.getOrDefault(definition.getKey(), definition.getKey()),
+                        valueFor(definition)))
+            .filter(entry -> entry.getValue() != null)
+            .collect(Collectors.toList());
+
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto();
+    report.setData(reportData);
+
+    final MapCommandResult commandResult =
+        new MapCommandResult(List.of(MeasureDto.of(entries)), reportData);
+    return new AuthorizedReportEvaluationResult(
+        new SingleReportEvaluationResult<>(report, commandResult), RoleType.VIEWER);
+  }
+
+  /**
+   * Resolves the value a definition should report. Reading the tenant off the pinned definition is
+   * what lets a test prove a tenant's answer cannot land on another tenant's row — if the service
+   * ever stopped pinning the tenant, this would return null and the assertions would fail.
+   */
+  private Double valueFor(final ReportDataDefinitionDto definition) {
+    if (!valuesByTenant.isEmpty()) {
+      return definition.getTenantIds().stream().findFirst().map(valuesByTenant::get).orElse(null);
+    }
+    return stubbedValuesByKey.get(definition.getKey());
+  }
+
+  private static SearchLimitsRepository searchLimitsWithBucketLimit(final int bucketLimit) {
+    final SearchLimitsRepository searchLimits = mock(SearchLimitsRepository.class);
+    when(searchLimits.aggregationBucketLimit()).thenReturn(bucketLimit);
+    when(searchLimits.indexNamePrefix()).thenReturn("optimize");
+    return searchLimits;
+  }
+}


### PR DESCRIPTION
## Description

The business-value overview sweep evaluated the two seeded reports once per **(tenant, process definition, range)** — 8000 report evaluations per tick at 1000 definitions, each preceded by its own report read, growing linearly with the process catalog.

Both seeded reports already group by process definition key, so one evaluation returns a bucket per definition. Evaluation is now fanned in to once per **(report, range, tenant, chunk)**, so cost scales with chunk count rather than definition count. Chunks are bounded by how many bytes their index names occupy in the request line, so there is no fixed chunk size — for a single-tenant 1000-definition catalog with ordinary keys that is roughly **8000 evaluations per tick down to ~100**.

Behaviour is unchanged — a row is still written for every (tenant, definition, range) triple with the same values, so the stale-read backstop is unaffected.

**Why chunked, and why grouped by tenant.** The binding ceiling is `http.max_initial_line_length` (4 KB by default): index names travel in the URL path, and overrunning it fails the request with a 400 that has no retry path, taking the sweep with it. Chunks are budgeted by encoded request-line bytes — counting characters is not safe, since non-ASCII process ids are legal and cost up to nine bytes each once percent-encoded. The aggregation bucket limit caps a chunk too, so it cannot ask for more groups than the engine will return. Tenant is the finest scope one evaluation can serve — the reports group by definition key only, with no tenant dimension in the result, so evaluating two tenants together would collapse them into one bucket and give both rows the blend.

**Alternative considered:** passing definitions through `additionalFilters` instead of pinning them on the report. Rejected — that path resolves each key with its own search (recreating the fan-out) and overwrites the tenant list with every tenant the definition exists on.

**A bug found while reviewing this.** Filtering definitions by "has an instance index" compared definition keys against identifiers derived from index names, which are lowercased on creation. Any definition whose BPMN process id contains an uppercase character (`Process_1`, the Modeler default) would have been dropped from every query and left with permanently null values — silently, since the row is still written. Fixed in its own commit with coverage.

**Out of scope.** The issue also proposed writing rows only for definitions that are active and have a target. Not included: it does not reduce the evaluation count, and we decided the overview should keep listing every process definition. The issue's acceptance criteria need amending.

Follow-ups each needing their own issue: the read endpoint's 1000-row hard ceiling, target changes not being visible until the next tick, and cleanup of rows for deleted definitions.

**Testing.** Unit tests assert the scaling property (evaluations track chunk and tenant count, unchanged when the catalog doubles), chunk boundaries, a lowered bucket limit, mixed-case keys, and null tenants. Tenant isolation is covered twice over — unit tests assert each tenant's value lands only on its own rows, and a new IT asserts the same against real data. The pre-existing tenant test asserts on *targets*, which do not come from report evaluation, so it could not have caught a regression here.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes camunda/camunda-hub#27660



---

**Scaling, stated precisely.** The gain is `min(definitionsPerTenant, chunkSize)`, because chunking happens inside the per-tenant loop — proportional to how many definitions a single tenant owns, not to catalog size. It degrades gradually (10 tenants x 100 definitions still gives ~50x) and only vanishes at one definition per tenant, which is not a shape we expect. Discussed in full [in this thread](https://github.com/camunda/camunda/pull/60690#discussion_r3833934080), including the `distributedBy(process)` mechanism that would close it if it ever matters.
