### PR TITLE
test: await element export after suspend/resume lifecycle

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -13,6 +13,7 @@ import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -94,8 +95,22 @@ public class ProcessInstanceSuspendResumeIT {
     // then - both complete, with the same elements in the same end state
     waitForProcessInstancesToBeCompleted(
         camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, notSuspendedKey)), 2);
-    assertThat(elementIdsAndStates(suspendedKey))
-        .containsExactlyInAnyOrderElementsOf(elementIdsAndStates(notSuspendedKey));
+    // Process-instance COMPLETED can be searchable before every element-instance update is
+    // exported. Wait until both trees agree and are fully COMPLETED rather than comparing once.
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var suspendedElements = elementIdsAndStates(suspendedKey);
+              final var notSuspendedElements = elementIdsAndStates(notSuspendedKey);
+              assertThat(suspendedElements)
+                  .isNotEmpty()
+                  .extracting(t -> t.toList().get(1))
+                  .containsOnly(ElementInstanceState.COMPLETED);
+              assertThat(suspendedElements)
+                  .containsExactlyInAnyOrderElementsOf(notSuspendedElements);
+            });
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -96,7 +96,8 @@ public class ProcessInstanceSuspendResumeIT {
     waitForProcessInstancesToBeCompleted(
         camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, notSuspendedKey)), 2);
     // Process-instance COMPLETED can be searchable before every element-instance update is
-    // exported. Wait until both trees agree and are fully COMPLETED rather than comparing once.
+    // exported. Wait until both trees are fully exported and agree rather than comparing once.
+    // Require the known service-task ids so equal-but-incomplete lag cannot pass early.
     await()
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
@@ -104,8 +105,12 @@ public class ProcessInstanceSuspendResumeIT {
             () -> {
               final var suspendedElements = elementIdsAndStates(suspendedKey);
               final var notSuspendedElements = elementIdsAndStates(notSuspendedKey);
+              // start + taskA/B/C + end
+              assertThat(suspendedElements).hasSize(ELEMENT_IDS.length + 2);
               assertThat(suspendedElements)
-                  .isNotEmpty()
+                  .extracting(t -> t.toList().get(0))
+                  .contains((Object[]) ELEMENT_IDS);
+              assertThat(suspendedElements)
                   .extracting(t -> t.toList().get(1))
                   .containsOnly(ElementInstanceState.COMPLETED);
               assertThat(suspendedElements)


### PR DESCRIPTION
## Summary

- Fixes a flake in `ProcessInstanceSuspendResumeIT#shouldSuspendAndResumeAndCompleteAsIfNeverSuspended`.
- The test waited for both process instances to be `COMPLETED`, then compared element-instance trees in a single snapshot.
- Process-instance `COMPLETED` can be searchable before every element-instance update is exported, so one tree could still show `taskC` ACTIVE while the other was fully `COMPLETED`.
- Await until both element trees agree and all states are `COMPLETED` before asserting equality.

## Test plan

- [x] `./mvnw test-compile -pl qa/acceptance-tests -Dquickly`
- [x] `./mvnw verify -pl qa/acceptance-tests -Pmulti-db-test,e2e-elasticsearch-test -Dit.test=ProcessInstanceSuspendResumeIT` (full class, 4/4; repeated 3 times)