### PR TITLE
fix: prefer the Identity backend URL for the OIDC back-channel endpoints

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -71,6 +71,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   private static final String IDENTITY_TYPE = "camunda.identity.type";
   private static final String IDENTITY_TYPE_ENV_VAR = "CAMUNDA_IDENTITY_TYPE";
   private static final String KEYCLOAK_IDENTITY_TYPE = "KEYCLOAK";
+  private static final String ISSUER_LABEL = "the configured OIDC issuer";
   private static final String LEGACY_KEY_REMOVAL_VERSION = "8.11";
   // Keycloak publishes its endpoints under <base>/realms/<realm>/protocol/openid-connect/*.
   private static final Pattern KEYCLOAK_REALM_URL = Pattern.compile("/realms/[^/]+$");
@@ -253,19 +254,50 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
       return;
     }
     final String browserIssuer = legacyIssuer(env);
-    final String backChannel =
-        browserIssuer == null ? legacyIssuerBackendUrl(env) : keycloakBackChannel(env);
-    if (backChannel == null && browserIssuer == null) {
+    final String backendUrl = legacyIssuerBackendUrl(env);
+    if (browserIssuer == null) {
+      // No issuer, so no login dials the front channel and one URL serves both.
+      if (backendUrl != null) {
+        putDerivedEndpoints(env, derived, backendUrl, backendUrl);
+        warnEndpointsDerived(backendUrlLabel(), backendUrlLabel());
+        LOG.info(
+            "Optimize has no browser-facing OIDC issuer, so its authorization endpoint points at an"
+                + " internal URL that browser login cannot reach: set '{}' if this deployment"
+                + " serves the Optimize UI.",
+            IDENTITY_ISSUER);
+      }
       return;
     }
-    // With one URL configured it serves both channels; CSL needs the complete trio either way.
-    final String front = browserIssuer != null ? browserIssuer : backChannel;
-    final String back = backChannel != null ? backChannel : browserIssuer;
-    // With an issuer configured, login dials these endpoints, so their paths have to be known to be
-    // right. Without one there is no login to dial them.
-    if (browserIssuer != null && !isKeycloak(env, back)) {
+    final String backChannel = keycloakBackChannel(env);
+    if (backChannel != null) {
+      putDerivedEndpoints(env, derived, browserIssuer, backChannel);
+      warnEndpointsDerived(ISSUER_LABEL, backendUrlLabel());
       return;
     }
+    if (backendUrl != null && !backendUrl.equals(browserIssuer)) {
+      // A distinct back channel whose endpoint paths are unknown. Substituting the issuer would
+      // point Optimize at a host it may not reach, so CSL keeps the issuer and discovers instead.
+      LOG.info(
+          "Optimize left '{}' unused: its OIDC endpoint paths are only known for Keycloak, so CSL"
+              + " resolves the endpoints from the issuer by discovery. Set the"
+              + " 'camunda.security.authentication.oidc.authorization-uri', 'token-uri',"
+              + " 'jwk-set-uri', 'user-info-uri' and 'end-session-endpoint-uri' explicitly to have"
+              + " Optimize reach the provider on that URL.",
+          IDENTITY_ISSUER_BACKEND_URL);
+      return;
+    }
+    if (!isKeycloak(env, browserIssuer)) {
+      return;
+    }
+    putDerivedEndpoints(env, derived, browserIssuer, browserIssuer);
+    warnEndpointsDerived(ISSUER_LABEL, ISSUER_LABEL);
+  }
+
+  private void putDerivedEndpoints(
+      final ConfigurableEnvironment env,
+      final Map<String, Object> derived,
+      final String front,
+      final String back) {
     // Front channel: the browser is redirected here, so it must be externally reachable.
     derived.putIfAbsent(OIDC_PREFIX + "authorization-uri", front + "/protocol/openid-connect/auth");
     // RP-initiated logout has no endpoint unless it is set explicitly.
@@ -283,22 +315,21 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     derived.putIfAbsent(
         OIDC_PREFIX + "jwk-set-uri",
         isBlank(publicApiJwks) ? back + "/protocol/openid-connect/certs" : publicApiJwks);
-    final String issuerLabel = "the configured OIDC issuer";
-    final String backendUrlLabel = "'" + IDENTITY_ISSUER_BACKEND_URL + "'";
-    LOG.info(
+  }
+
+  private void warnEndpointsDerived(final String frontSource, final String backSource) {
+    LOG.warn(
         "Optimize derived the CSL OIDC endpoints, assuming Keycloak's realm paths (configure them"
             + " explicitly for another provider): the browser-facing ones from {}, the back-channel"
             + " ones from {}. No 'camunda.security.authentication.oidc.issuer-uri' is set, so CSL"
-            + " runs no OIDC discovery at startup.",
-        browserIssuer != null ? issuerLabel : backendUrlLabel,
-        backChannel != null ? backendUrlLabel : issuerLabel);
-    if (browserIssuer == null) {
-      LOG.info(
-          "Optimize has no browser-facing OIDC issuer, so its authorization endpoint points at an"
-              + " internal URL that browser login cannot reach: set '{}' if this deployment serves"
-              + " the Optimize UI.",
-          IDENTITY_ISSUER);
-    }
+            + " runs no OIDC discovery at startup and registers no issuer validator: tokens are"
+            + " accepted on their signature, audience and expiry alone.",
+        frontSource,
+        backSource);
+  }
+
+  private static String backendUrlLabel() {
+    return "'" + IDENTITY_ISSUER_BACKEND_URL + "'";
   }
 
   // Null when unset, so callers can fall back to the other URL. Templated

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -62,7 +63,17 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   static final String CANONICAL_FLAG_PROPERTY_SOURCE_NAME = "optimizeCslFlagCanonical";
 
   private static final String OIDC_PREFIX = "camunda.security.authentication.oidc.";
+  private static final String IDENTITY_ISSUER = "camunda.identity.issuer";
+  private static final String IDENTITY_ISSUER_BACKEND_URL = "camunda.identity.issuerBackendUrl";
+  private static final String LEGACY_ISSUER_ENV_VAR = "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL";
+  private static final String LEGACY_ISSUER_BACKEND_URL_ENV_VAR =
+      "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL";
+  private static final String IDENTITY_TYPE = "camunda.identity.type";
+  private static final String IDENTITY_TYPE_ENV_VAR = "CAMUNDA_IDENTITY_TYPE";
+  private static final String KEYCLOAK_IDENTITY_TYPE = "KEYCLOAK";
   private static final String LEGACY_KEY_REMOVAL_VERSION = "8.11";
+  // Keycloak publishes its endpoints under <base>/realms/<realm>/protocol/openid-connect/*.
+  private static final Pattern KEYCLOAK_REALM_URL = Pattern.compile("/realms/[^/]+$");
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OptimizeSecurityConfigCompatibilityPostProcessor.class);
@@ -161,9 +172,8 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
   // for OIDC discovery AND for validating each token's iss claim against the discovery document's
   // issuer field. Keycloak reports the same externally-configured issuer regardless of which URL
   // was dialed to reach it, so pointing issuer-uri at the backend-reachable URL would make
-  // discovery fail (issuer mismatch) instead of fixing reachability. camunda.identity.issuer (the
-  // browser-facing one) is the correct, and only, source for issuer-uri. The backend URL does feed
-  // the OIDC endpoints, which carry no issuer check — see deriveOidcEndpointsFromIssuerBackendUrl.
+  // discovery fail (issuer mismatch) instead of fixing reachability. It feeds the back-channel
+  // endpoints, which carry no issuer check — see deriveOidcEndpoints.
   //
   // Also deliberately NOT bridged: camunda.identity.clientSecret, the config-file secret key that
   // application-ccsm.yaml also declares — the official Helm chart never renders it, only the
@@ -173,17 +183,17 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     if (isAuth0Configured(env)) {
       return;
     }
-    mapIssuerUri(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL");
+    mapIssuerUri(env, derived, LEGACY_ISSUER_ENV_VAR);
     mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", OIDC_PREFIX + "client-secret");
     // Only when that env var is absent: application-ccsm.yaml mirrors it into
     // camunda.identity.issuer for every docker-compose CCSM install, so feeding both would
     // double-warn for a value the operator only set once.
-    if (isBlank(env.getProperty("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL"))) {
-      mapIssuerUri(env, derived, "camunda.identity.issuer");
+    if (isBlank(env.getProperty(LEGACY_ISSUER_ENV_VAR))) {
+      mapIssuerUri(env, derived, IDENTITY_ISSUER);
     }
-    deriveOidcEndpointsFromIssuerBackendUrl(env, derived);
+    deriveOidcEndpoints(env, derived);
 
     // The Helm chart's Optimize ConfigMap can legitimately render clientId/CAMUNDA_IDENTITY_
     // CLIENT_SECRET while leaving camunda.identity.issuer blank. Bridging a client-id/secret with
@@ -225,45 +235,124 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     bridgeAuth0SaasOrgAndCluster(env, derived, clusterId);
   }
 
-  // Last resort when no issuer-uri could be derived, so CSL can still build a registration: the
-  // endpoints carry no issuer check, unlike issuer-uri, so the backend URL is usable for them.
+  // Spells out the endpoints so CSL builds the registration without OIDC discovery: CSL
+  // would run that from inside the pod at startup, against a browser-facing issuer. Each
+  // endpoint gets the URL its caller can reach.
   //
-  // The paths assume Keycloak's realm layout, which is what the chart's issuerBackendUrl points
-  // at. Elsewhere they are wrong, but only jwk-set-uri can be dialed from here: no issuer means
-  // no browser login for authorization-uri/token-uri, and the public API's own JWK set URI wins
-  // when it is set. Any other provider has to configure the endpoints explicitly.
-  private void deriveOidcEndpointsFromIssuerBackendUrl(
+  // The paths follow Keycloak's realm layout, so they are only derived for a Keycloak
+  // provider or for endpoints nothing can dial. Every other provider keeps issuer-uri
+  // and lets CSL discover its real endpoints.
+  private void deriveOidcEndpoints(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    if (hasExplicitOidcEndpoints(env)) {
+      // The operator owns the endpoints, including any this would otherwise add.
+      return;
+    }
     if (!isBlank(effectiveOidcProperty(env, derived, "issuer-uri"))) {
+      // CSL discovers the endpoints from the issuer.
       return;
     }
-    final String backendUrl = env.getProperty("camunda.identity.issuerBackendUrl");
-    if (isBlank(backendUrl)) {
+    final String browserIssuer = legacyIssuer(env);
+    final String backChannel =
+        browserIssuer == null ? legacyIssuerBackendUrl(env) : keycloakBackChannel(env);
+    if (backChannel == null && browserIssuer == null) {
       return;
     }
-    final String base = backendUrl.trim().replaceAll("/+$", "");
-    derived.putIfAbsent(OIDC_PREFIX + "authorization-uri", base + "/protocol/openid-connect/auth");
-    derived.putIfAbsent(OIDC_PREFIX + "token-uri", base + "/protocol/openid-connect/token");
-    // The public API's own JWK set URI wins: it is configured for the IdP that signs the API
-    // tokens, which need not be the Identity instance behind issuerBackendUrl. bridgePublicApiJwt
-    // runs later and would not overwrite a value put here.
+    // With one URL configured it serves both channels; CSL needs the complete trio either way.
+    final String front = browserIssuer != null ? browserIssuer : backChannel;
+    final String back = backChannel != null ? backChannel : browserIssuer;
+    // With an issuer configured, login dials these endpoints, so their paths have to be known to be
+    // right. Without one there is no login to dial them.
+    if (browserIssuer != null && !isKeycloak(env, back)) {
+      return;
+    }
+    // Front channel: the browser is redirected here, so it must be externally reachable.
+    derived.putIfAbsent(OIDC_PREFIX + "authorization-uri", front + "/protocol/openid-connect/auth");
+    // RP-initiated logout has no endpoint unless it is set explicitly.
+    derived.putIfAbsent(
+        OIDC_PREFIX + "end-session-endpoint-uri", front + "/protocol/openid-connect/logout");
+    // Back channel: Optimize calls these itself.
+    derived.putIfAbsent(OIDC_PREFIX + "token-uri", back + "/protocol/openid-connect/token");
+    // CSL requests UserInfo during login by default, and Spring skips the call when the endpoint is
+    // unknown, dropping the claims it contributes.
+    derived.putIfAbsent(OIDC_PREFIX + "user-info-uri", back + "/protocol/openid-connect/userinfo");
+    // The public API's own JWK set URI wins: it belongs to the IdP that signs the API tokens, which
+    // need not be the Identity instance behind issuerBackendUrl.
     final String publicApiJwks =
         env.getProperty("SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI");
     derived.putIfAbsent(
         OIDC_PREFIX + "jwk-set-uri",
-        isBlank(publicApiJwks) ? base + "/protocol/openid-connect/certs" : publicApiJwks);
+        isBlank(publicApiJwks) ? back + "/protocol/openid-connect/certs" : publicApiJwks);
+    final String issuerLabel = "the configured OIDC issuer";
+    final String backendUrlLabel = "'" + IDENTITY_ISSUER_BACKEND_URL + "'";
     LOG.info(
-        "Optimize derived the CSL OIDC endpoints from 'camunda.identity.issuerBackendUrl', assuming"
-            + " Keycloak's realm paths, because no OIDC issuer is configured. Browser login cannot"
-            + " work against an internal URL: set 'camunda.identity.issuer' if this deployment"
-            + " serves the Optimize UI, or set the OIDC endpoints explicitly for a non-Keycloak"
-            + " provider.");
+        "Optimize derived the CSL OIDC endpoints, assuming Keycloak's realm paths (configure them"
+            + " explicitly for another provider): the browser-facing ones from {}, the back-channel"
+            + " ones from {}. No 'camunda.security.authentication.oidc.issuer-uri' is set, so CSL"
+            + " runs no OIDC discovery at startup.",
+        browserIssuer != null ? issuerLabel : backendUrlLabel,
+        backChannel != null ? backendUrlLabel : issuerLabel);
+    if (browserIssuer == null) {
+      LOG.info(
+          "Optimize has no browser-facing OIDC issuer, so its authorization endpoint points at an"
+              + " internal URL that browser login cannot reach: set '{}' if this deployment serves"
+              + " the Optimize UI.",
+          IDENTITY_ISSUER);
+    }
   }
 
-  // Bridges a legacy issuer source into issuer-uri, but only when the host left the OIDC endpoints
-  // to CSL: an issuer-uri makes CSL discover them by dialing the browser-facing issuer from inside
-  // the pod, which is what explicit endpoints exist to avoid. The key is deprecated either way, so
-  // the warning is emitted whenever it is set.
+  // Null when unset, so callers can fall back to the other URL. Templated
+  // values carry padding and trailing slashes.
+  private static String realmBase(final String url) {
+    return isBlank(url) ? null : url.trim().replaceAll("/+$", "");
+  }
+
+  // Both spellings: application-ccsm.yaml mirrors the env var into camunda.identity.issuer, but
+  // only under the ccsm profile.
+  private static String legacyIssuer(final ConfigurableEnvironment env) {
+    return realmBase(firstNonBlankProperty(env, LEGACY_ISSUER_ENV_VAR, IDENTITY_ISSUER));
+  }
+
+  private static String legacyIssuerBackendUrl(final ConfigurableEnvironment env) {
+    return realmBase(
+        firstNonBlankProperty(env, LEGACY_ISSUER_BACKEND_URL_ENV_VAR, IDENTITY_ISSUER_BACKEND_URL));
+  }
+
+  // The back-channel URL only when it is a distinct, usable host: a value equal to the issuer
+  // splits nothing, so the registration keeps its issuer-uri and CSL resolves the endpoints by
+  // discovery as it always has. Only a differing URL says the pod reaches the provider elsewhere.
+  private static String keycloakBackChannel(final ConfigurableEnvironment env) {
+    final String backChannel = legacyIssuerBackendUrl(env);
+    if (backChannel == null || backChannel.equals(legacyIssuer(env))) {
+      return null;
+    }
+    return isKeycloak(env, backChannel) ? backChannel : null;
+  }
+
+  // camunda.identity.type names the provider, and the official Helm chart puts it in every app's
+  // environment (CAMUNDA_IDENTITY_TYPE, from the shared identity-env-vars ConfigMap). Where it is
+  // absent, as in the docker-compose distributions, a realm URL identifies Keycloak instead.
+  private static boolean isKeycloak(final ConfigurableEnvironment env, final String backChannel) {
+    final String type = firstNonBlankProperty(env, IDENTITY_TYPE_ENV_VAR, IDENTITY_TYPE);
+    return type != null
+        ? KEYCLOAK_IDENTITY_TYPE.equalsIgnoreCase(type.trim())
+        : KEYCLOAK_REALM_URL.matcher(backChannel).find();
+  }
+
+  private static String firstNonBlankProperty(
+      final ConfigurableEnvironment env, final String preferredKey, final String fallbackKey) {
+    final String preferred = env.getProperty(preferredKey);
+    if (!isBlank(preferred)) {
+      return preferred;
+    }
+    final String fallback = env.getProperty(fallbackKey);
+    return isBlank(fallback) ? null : fallback;
+  }
+
+  // Bridges a legacy issuer source into issuer-uri, which makes CSL discover the endpoints by
+  // dialing that issuer from inside the pod. Only when neither explicit endpoints nor a Keycloak
+  // back channel are configured, because deriveOidcEndpoints covers those. The key is deprecated
+  // either way, so each branch names the replacement that suits it.
   private void mapIssuerUri(
       final ConfigurableEnvironment env,
       final Map<String, Object> derived,
@@ -272,10 +361,20 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     if (isBlank(value)) {
       return;
     }
-    warnDeprecated(legacyKey, OIDC_PREFIX + "issuer-uri");
-    if (!hasExplicitOidcEndpoints(env)) {
-      derived.putIfAbsent(OIDC_PREFIX + "issuer-uri", value);
+    if (hasExplicitOidcEndpoints(env) || keycloakBackChannel(env) != null) {
+      LOG.warn(
+          "Optimize config '{}' is deprecated; migrate to the explicit"
+              + " 'camunda.security.authentication.oidc.authorization-uri', 'token-uri',"
+              + " 'jwk-set-uri', 'user-info-uri' and 'end-session-endpoint-uri' — the last two are"
+              + " needed for the UserInfo claims and for RP-initiated logout. Prefer those over"
+              + " 'camunda.security.authentication.oidc.issuer-uri', which makes CSL dial this URL"
+              + " for OIDC discovery at startup. Support for the legacy key will be removed in {}.",
+          legacyKey,
+          LEGACY_KEY_REMOVAL_VERSION);
+      return;
     }
+    warnDeprecated(legacyKey, OIDC_PREFIX + "issuer-uri");
+    derived.putIfAbsent(OIDC_PREFIX + "issuer-uri", value);
   }
 
   // All three are required: CSL accepts an issuer-uri or the complete trio, so withholding the

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -424,6 +424,63 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldLeaveANonKeycloakBackendUrlUnusedRatherThanSubstituteTheIssuer() {
+    // A Keycloak-shaped issuer with a distinct back channel whose paths are unknown. Deriving the
+    // back channel from the issuer would send Optimize at a host it may not reach and ignore the
+    // configured URL, so nothing is derived and the log names the setting it left unused.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "https://camunda.example.com/auth/realms/camunda");
+    legacy.put("camunda.identity.issuerBackendUrl", "https://idp.internal.svc/oauth2/default");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "secret");
+    legacy.put(OIDC + "issuer-uri", "");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "authorization-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "token-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "jwk-set-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "user-info-uri")).isNull();
+    logs.assertContains("left 'camunda.identity.issuerBackendUrl' unused");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"keycloak", "KeyCloak", " KEYCLOAK "})
+  void shouldTreatTheIdentityTypeCaseAndPaddingInsensitively(final String type) {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.type", type);
+    legacy.put("camunda.identity.issuer", "https://idp.example.com/tenant/v2.0");
+    legacy.put("camunda.identity.issuerBackendUrl", "http://idp.internal.svc/tenant/v2.0");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    // Neither URL has a realm path, so only the configured type can select the split.
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo("http://idp.internal.svc/tenant/v2.0/protocol/openid-connect/token");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "   "})
+  void shouldFallBackToTheUrlShapeWhenTheIdentityTypeIsBlank(final String type) {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.type", type);
+    legacy.put("camunda.identity.issuer", "https://camunda.example.com/auth/realms/camunda");
+    legacy.put(
+        "camunda.identity.issuerBackendUrl", "http://keycloak:8080/auth/realms/camunda-platform");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(
+            "http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token");
+  }
+
+  @Test
   void shouldKeepDiscoveryWhenTheBackendUrlEqualsTheIssuer() {
     // The shape of Optimize's own local and smoke-test setups: both settings name the same host, so
     // there is no reachability problem to solve and nothing to split. Keeping issuer-uri leaves the

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -293,7 +293,8 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     processor.postProcessEnvironment(environmentWith(legacy), OPTIMIZE_APPLICATION);
 
     logs.assertContains("camunda.identity.issuerBackendUrl");
-    logs.assertContains("Browser login cannot work against an internal URL");
+    logs.assertContains("browser login cannot reach");
+    logs.assertContains("camunda.identity.issuer'");
   }
 
   @Test
@@ -314,8 +315,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
 
   @Test
   void shouldDeriveEndpointsWhenTheCslIssuerUriIsExplicitlyBlank() {
-    // The legacy issuer would be bridged into issuer-uri, but the explicitly blank value outranks
-    // it, so CSL still sees no issuer and needs the endpoints.
+    // The explicitly blank value outranks the bridged issuer-uri, so CSL needs the endpoints.
     final String backend = "http://identity.svc:18080/auth/realms/camunda-platform";
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put("camunda.identity.issuer", "https://weblogin.example.com/realm");
@@ -328,7 +328,7 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "authorization-uri"))
-        .isEqualTo(backend + "/protocol/openid-connect/auth");
+        .isEqualTo("https://weblogin.example.com/realm/protocol/openid-connect/auth");
     assertThat(env.getProperty(OIDC + "token-uri"))
         .isEqualTo(backend + "/protocol/openid-connect/token");
     assertThat(env.getProperty(OIDC + "jwk-set-uri"))
@@ -338,11 +338,11 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
-  void shouldWithholdCredentialsWhenTheCslIssuerUriIsExplicitlyBlankAndNoEndpointsCanBeDerived() {
-    // Same shadowed legacy issuer, but nothing to derive endpoints from: CSL would get credentials
-    // and no way to build a registration.
+  void shouldDeriveEndpointsFromTheIssuerAloneWhenNoBackendUrlIsConfigured() {
+    // The only host configured, so it serves both channels.
+    final String issuer = "https://keycloak.example.com/auth/realms/camunda-platform";
     final Map<String, Object> legacy = cslEnabledConfig();
-    legacy.put("camunda.identity.issuer", "https://weblogin.example.com/realm");
+    legacy.put("camunda.identity.issuer", issuer);
     legacy.put("camunda.identity.clientId", "optimize");
     legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "secret");
     legacy.put(OIDC + "issuer-uri", "");
@@ -350,8 +350,14 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     final StandardEnvironment env = environmentWith(legacy);
     processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
-    assertThat(env.getProperty(OIDC + "client-id")).isNull();
-    assertThat(env.getProperty(OIDC + "client-secret")).isNull();
+    assertThat(env.getProperty(OIDC + "authorization-uri"))
+        .isEqualTo(issuer + "/protocol/openid-connect/auth");
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(issuer + "/protocol/openid-connect/token");
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
+    assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("secret");
+    // The log must not credit a key the operator never set.
+    logs.assertDoesNotContain("camunda.identity.issuerBackendUrl");
   }
 
   @Test
@@ -376,9 +382,186 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
-  void shouldNotDeriveEndpointsFromIssuerBackendUrlWhenAnIssuerIsConfigured() {
-    // With an issuer, CSL resolves the endpoints through discovery against the browser-facing URL.
-    // Deriving internal endpoints on top would override that.
+  void shouldPointTheDeprecationGuidanceAtTheEndpointsWhenTheChannelsAreSplit() {
+    // Migrating to issuer-uri would restore the startup dial against the browser-facing URL, so the
+    // warning has to name the endpoints instead.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "https://camunda.example.com/auth/realms/camunda");
+    legacy.put(
+        "camunda.identity.issuerBackendUrl", "http://keycloak:8080/auth/realms/camunda-platform");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("camunda.identity.issuer")
+                && entry.getMessage().contains(OIDC + "authorization-uri"),
+        "expected migration guidance naming the explicit endpoints");
+  }
+
+  @Test
+  void shouldDeriveNothingForANonKeycloakProviderWhenTheCslIssuerUriIsBlanked() {
+    // A blank issuer-uri leaves CSL no issuer, but the issuer is still no basis for Keycloak paths
+    // on another provider. Withholding the credentials keeps a broken guess out of the
+    // registration.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.type", "MICROSOFT");
+    legacy.put("camunda.identity.issuer", "https://login.microsoftonline.com/tenant-id/v2.0");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "secret");
+    legacy.put(OIDC + "issuer-uri", "");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "authorization-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "token-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "jwk-set-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "user-info-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "client-id")).isNull();
+    assertThat(env.getProperty(OIDC + "client-secret")).isNull();
+  }
+
+  @Test
+  void shouldKeepDiscoveryWhenTheBackendUrlEqualsTheIssuer() {
+    // The shape of Optimize's own local and smoke-test setups: both settings name the same host, so
+    // there is no reachability problem to solve and nothing to split. Keeping issuer-uri leaves the
+    // registration with a discovered issuer, which CSL needs for issuer validation and for the
+    // UserInfo claims it merges.
+    final String url = "http://localhost:18080/auth/realms/camunda-platform";
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", url);
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL", url);
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", "optimize");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo(url);
+    assertThat(env.getProperty(OIDC + "authorization-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "token-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "user-info-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "end-session-endpoint-uri")).isNull();
+  }
+
+  @Test
+  void shouldKeepDiscoveryWhenTheConfiguredIdentityTypeIsNotKeycloak() {
+    // camunda.identity.type names the provider outright, so it decides even when the URL happens to
+    // look like a Keycloak realm.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.type", "MICROSOFT");
+    legacy.put("camunda.identity.issuer", "https://idp.example.com/auth/realms/lookalike");
+    // A distinct host, so only the configured type can rule Keycloak out: the realm path would
+    // otherwise satisfy the URL check and split the channels.
+    legacy.put(
+        "camunda.identity.issuerBackendUrl", "https://idp.internal.svc:8443/auth/realms/lookalike");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri"))
+        .isEqualTo("https://idp.example.com/auth/realms/lookalike");
+    assertThat(env.getProperty(OIDC + "authorization-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "end-session-endpoint-uri")).isNull();
+  }
+
+  @Test
+  void shouldSplitFrontAndBackChannelWhenTheIdentityTypeIsKeycloak() {
+    // The Helm chart's CAMUNDA_IDENTITY_TYPE, which the Optimize deployment imports from the shared
+    // identity-env-vars ConfigMap. It decides even for a realm path the URL check would not match.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_IDENTITY_TYPE", "KEYCLOAK");
+    legacy.put("camunda.identity.issuer", "https://camunda.example.com/auth/realms/camunda/extra");
+    legacy.put("camunda.identity.issuerBackendUrl", "http://keycloak:8080/auth/realms/kc/extra");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "authorization-uri"))
+        .isEqualTo(
+            "https://camunda.example.com/auth/realms/camunda/extra/protocol/openid-connect/auth");
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo("http://keycloak:8080/auth/realms/kc/extra/protocol/openid-connect/token");
+  }
+
+  @Test
+  void shouldKeepDiscoveryForANonKeycloakIssuerBackendUrl() {
+    // Only Keycloak publishes the paths this bridge would guess, so a provider with a different
+    // layout keeps issuer-uri and lets CSL discover its real endpoints.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "https://login.microsoftonline.com/tenant-id/v2.0");
+    // A distinct host, so the URL check is what has to reject it: an equal URL would short-circuit
+    // before the provider is ever inferred.
+    legacy.put(
+        "camunda.identity.issuerBackendUrl", "https://login.internal.example/tenant-id/v2.0");
+    legacy.put("camunda.identity.clientId", "optimize");
+    legacy.put("CAMUNDA_IDENTITY_CLIENT_SECRET", "secret");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri"))
+        .isEqualTo("https://login.microsoftonline.com/tenant-id/v2.0");
+    assertThat(env.getProperty(OIDC + "authorization-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "token-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "jwk-set-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "end-session-endpoint-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
+  }
+
+  @Test
+  void shouldDeriveNothingWhenTheHostConfiguredTheCompleteEndpointTrio() {
+    // CSL enables IdP logout by default, so a guessed end-session endpoint would send a provider
+    // that never published one to a URL it does not serve.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("camunda.identity.issuer", "https://idp.example.com/oauth2/default");
+    legacy.put("camunda.identity.issuerBackendUrl", "https://idp.example.com/oauth2/default");
+    legacy.put(OIDC + "authorization-uri", "https://idp.example.com/oauth2/v1/authorize");
+    legacy.put(OIDC + "token-uri", "https://idp.example.com/oauth2/v1/token");
+    legacy.put(OIDC + "jwk-set-uri", "https://idp.example.com/oauth2/v1/keys");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "end-session-endpoint-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "authorization-uri"))
+        .isEqualTo("https://idp.example.com/oauth2/v1/authorize");
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+  }
+
+  @Test
+  void shouldSplitFrontAndBackChannelForTheLegacyEnvVarSpelling() {
+    // The env vars alone, without the camunda.identity.* mirroring the ccsm profile adds. localhost
+    // is the host-published Keycloak port: it resolves to the Optimize container itself.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put(
+        "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL",
+        "http://localhost:18080/auth/realms/camunda-platform");
+    legacy.put(
+        "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL",
+        "http://keycloak:8080/auth/realms/camunda-platform");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "authorization-uri"))
+        .isEqualTo(
+            "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth");
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(
+            "http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token");
+    assertThat(env.getProperty(OIDC + "jwk-set-uri"))
+        .isEqualTo(
+            "http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/certs");
+  }
+
+  @Test
+  void shouldSplitFrontAndBackChannelWhenBothIssuerUrlsAreConfigured() {
+    // The docker-compose CCSM shape: the issuer is reachable from a browser only, so each endpoint
+    // takes the URL its caller can reach.
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put(
         "camunda.identity.issuer", "https://public.example.com/auth/realms/camunda-platform");
@@ -389,10 +572,22 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     final StandardEnvironment env = environmentWith(legacy);
     processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
-    assertThat(env.getProperty(OIDC + "issuer-uri"))
-        .isEqualTo("https://public.example.com/auth/realms/camunda-platform");
-    assertThat(env.getProperty(OIDC + "authorization-uri")).isNull();
-    assertThat(env.getProperty(OIDC + "token-uri")).isNull();
+    final String browser = "https://public.example.com/auth/realms/camunda-platform";
+    final String backend = "http://identity.svc:18080/auth/realms/camunda-platform";
+    // No issuer-uri, so CSL builds the registration without OIDC discovery.
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    assertThat(env.getProperty(OIDC + "authorization-uri"))
+        .isEqualTo(browser + "/protocol/openid-connect/auth");
+    assertThat(env.getProperty(OIDC + "end-session-endpoint-uri"))
+        .isEqualTo(browser + "/protocol/openid-connect/logout");
+    assertThat(env.getProperty(OIDC + "token-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/token");
+    assertThat(env.getProperty(OIDC + "jwk-set-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/certs");
+    // CSL requests UserInfo during login by default; without the endpoint the call is skipped
+    // and the claims it contributes are lost.
+    assertThat(env.getProperty(OIDC + "user-info-uri"))
+        .isEqualTo(backend + "/protocol/openid-connect/userinfo");
   }
 
   @Test
@@ -489,11 +684,15 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
     processor.postProcessEnvironment(env, OPTIMIZE_APPLICATION);
 
     assertThat(env.getProperty(OIDC + "issuer-uri")).isNull();
+    // The key stays deprecated, but pointing at issuer-uri would send CSL back to discovery, so the
+    // guidance names the endpoints it builds the registration from.
     logs.assertContains(
         entry ->
             entry.getMessage().contains("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL")
-                && entry.getMessage().contains(OIDC + "issuer-uri"),
-        "the key stays deprecated even when its value no longer feeds issuer-uri");
+                && entry.getMessage().contains(OIDC + "authorization-uri")
+                && entry.getMessage().contains("'token-uri'")
+                && entry.getMessage().contains("'jwk-set-uri'"),
+        "expected migration guidance naming the explicit endpoints");
   }
 
   @Test


### PR DESCRIPTION
## Description

CSL takes a **single** `issuer-uri` and dials it for OIDC discovery while the Spring context is still
building. So a browser-facing issuer that the pod cannot reach fails startup outright — the shape of
the docker-compose CCSM config, where the issuer is a host-published port
(`http://localhost:18080/...`) that resolves to the Optimize container itself. It was inert before
CSL became the default (#60190): nothing dialed it at startup. Currently breaking the
orchestration-cluster nightly E2E suite.

`camunda.identity.issuerBackendUrl` is the setting whose whole purpose is to name the host the pod
can reach, and the bridge did not use it at all. Bridge it: when it is set, the endpoints are spelled
out rather than discovered, and each one gets the URL its caller can reach.

|                endpoint                 |            source            |  dialed by  |
|------------------------------------------|------------------------------|-------------|
| `authorization-uri`                      | the issuer                   | the browser |
| `end-session-endpoint-uri`               | the issuer                   | the browser |
| `token-uri`                              | `issuerBackendUrl`           | Optimize    |
| `jwk-set-uri`                            | public-API JWKS, else backend| Optimize    |

Guessing endpoint paths is only safe where they are predictable, so the derivation is gated twice:

- **a complete explicit trio wins outright** — nothing is derived, including the end-session endpoint
- **only a Keycloak provider takes the split**; everything else keeps `issuer-uri` so CSL discovers
  that provider's real endpoints. The provider comes from `camunda.identity.type`, which the chart
  puts in Optimize's environment as `CAMUNDA_IDENTITY_TYPE` via the shared `identity-env-vars`
  ConfigMap the deployment already imports. Where it is absent, as in the docker-compose
  distributions, a `.../realms/<realm>` URL identifies Keycloak instead.

That leaves the backend-URL-only case (#60617, already merged) deriving unconditionally, which is
safe: with no issuer there is no login to dial an authorization or token endpoint, and the public
API's own `jwk-set-uri` wins over the derived one whenever it is set.

Follows #60618, which added the derivation for the no-issuer case.

Worth reviewing:

- **Discovery is skipped whenever a backend URL is set, so `iss` claim validation goes with it.** CSL
  registers a `JwtIssuerValidator` only when the registration carries a discovered issuer, and offers
  no way to declare an expected issuer without discovery. Signature (JWKS), audience and expiry
  validation are unaffected, and this is already the posture of every Helm install that renders the
  endpoint trio instead of an issuer — but it is worth a CSL follow-up.
- **`end-session-endpoint-uri` is derived from the issuer.** Without it, dropping discovery would
  silently break RP-initiated logout, since that endpoint would otherwise come from the discovery
  document. CSL lets an explicit value win over the discovered one.
- **Both env-var spellings are read** for each setting (`CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL`
  as well as `camunda.identity.issuerBackendUrl`), because the mirroring between them only happens
  under the `ccsm` profile. Without that, the compose config would keep deriving an `issuer-uri`.
- **The paths assume Keycloak's realm layout**, which is what both settings point at in the official
  chart and docker-compose distributions. Another provider has to configure the endpoints explicitly;
  the code and the startup log both say so.

`shouldNotDeriveEndpointsFromIssuerBackendUrlWhenAnIssuerIsConfigured` asserted exactly the behaviour
this fixes, so it is now `shouldSplitFrontAndBackChannelWhenBothIssuerUrlsAreConfigured`. The E2E
compose file needs no change — its config is legitimate and works as written once this lands.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), [for docs changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Closes #60706
