### PR TITLE
Roll back optimistic AgentInstance CONFIGURATION changes on discard

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -47,7 +47,10 @@ public final class AgentHistoryCommitProcessor
       agentHistoryState.visitByJobKey(jobKey, visitor);
     } else {
       agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
-      // Discard items from superseded activations (different lease, same job)
+      // Safety net: a job re-activation already discards its previous lease's pending items
+      // eagerly, before the new lease can write anything, so by the time a COMMIT is processed
+      // this pass should find nothing left to discard. Kept anyway so that a future change to the
+      // re-activation-discard sites can't silently leak a superseded lease's items forever.
       agentHistoryState.visitByJobKey(
           jobKey,
           item -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
@@ -14,10 +14,15 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentHistoryState;
+import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.List;
 
 // DISCARD is always a follow-up command emitted internally by the engine when an agentic job is
 // destroyed without completing, so there is no user to authorize against.
@@ -25,13 +30,25 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 public final class AgentHistoryDiscardProcessor
     implements TypedRecordProcessor<AgentHistoryRecord>, SuspensionAware<AgentHistoryRecord> {
 
+  private static final List<String> RESTORED_ATTRIBUTES =
+      List.of(
+          AgentInstanceRecord.ATTR_MODEL,
+          AgentInstanceRecord.ATTR_PROVIDER,
+          AgentInstanceRecord.ATTR_SYSTEM_PROMPT,
+          AgentInstanceRecord.ATTR_TOOLS,
+          AgentInstanceRecord.ATTR_MAX_TOKENS,
+          AgentInstanceRecord.ATTR_MAX_MODEL_CALLS,
+          AgentInstanceRecord.ATTR_MAX_TOOL_CALLS);
+
   private final StateWriter stateWriter;
   private final AgentHistoryState agentHistoryState;
+  private final AgentInstanceState agentInstanceState;
 
   public AgentHistoryDiscardProcessor(
       final Writers writers, final ProcessingState processingState) {
     stateWriter = writers.state();
     agentHistoryState = processingState.getAgentHistoryState();
+    agentInstanceState = processingState.getAgentInstanceState();
   }
 
   @Override
@@ -41,9 +58,13 @@ public final class AgentHistoryDiscardProcessor
     // Items in state are already trimmed to identity fields by AgentHistoryCreatedApplier,
     // so the DISCARDED event emitted here carries that same trimmed shape for free.
     final AgentHistoryState.AgentHistoryVisitor visitor =
-        item ->
-            stateWriter.appendFollowUpEvent(
-                item.getAgentHistoryKey(), AgentHistoryIntent.DISCARDED, item);
+        item -> {
+          stateWriter.appendFollowUpEvent(
+              item.getAgentHistoryKey(), AgentHistoryIntent.DISCARDED, item);
+          if (item.getRole() == AgentHistoryRole.CONFIGURATION) {
+            restoreConfigurationFromSnapshot(item.getAgentInstanceKey());
+          }
+        };
     if (jobLease.isEmpty()) {
       // Job destruction: every activation's items are dead — discard all items for the job.
       agentHistoryState.visitByJobKey(jobKey, visitor);
@@ -52,6 +73,38 @@ public final class AgentHistoryDiscardProcessor
       agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
     }
     // no-op when no items exist — backward-compatible with non-agentic jobs
+  }
+
+  /**
+   * Unconditionally overwrites {@code agentInstanceKey}'s live configuration fields (model,
+   * provider, systemPrompt, tools, limits) with its last committed snapshot, undoing whatever the
+   * now-discarded CONFIGURATION item had optimistically applied. If no snapshot exists yet (no
+   * CONFIGURATION item for this agent instance has ever committed), it rolls back to the {@link
+   * AgentInstanceRecord} defaults instead. A no-op if the agent instance itself is already gone.
+   */
+  private void restoreConfigurationFromSnapshot(final long agentInstanceKey) {
+    final var live = agentInstanceState.getRecord(agentInstanceKey);
+    if (live == null) {
+      return;
+    }
+    final var snapshot = agentInstanceState.getCommittedSnapshot(agentInstanceKey);
+    final var restored = snapshot != null ? snapshot : new AgentInstanceRecord();
+
+    final var liveDefinition = live.getDefinition();
+    final var restoredDefinition = restored.getDefinition();
+    liveDefinition
+        .setModel(restoredDefinition.getModel())
+        .setProvider(restoredDefinition.getProvider())
+        .setSystemPrompt(restoredDefinition.getSystemPrompt());
+    live.setTools(restored.getTools());
+    final var restoredLimits = restored.getLimits();
+    live.getLimits()
+        .setMaxTokens(restoredLimits.getMaxTokens())
+        .setMaxModelCalls(restoredLimits.getMaxModelCalls())
+        .setMaxToolCalls(restoredLimits.getMaxToolCalls());
+
+    live.setChangedAttributes(RESTORED_ATTRIBUTES);
+    stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.UPDATED, live);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -216,6 +216,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             config.isBusinessIdUniquenessEnabled(),
             messageCorrelationMetrics);
 
+    agentDefinitionBehavior = new AgentDefinitionBehavior(processingState.getProcessState());
+
     jobActivationBehavior =
         new BpmnJobActivationBehavior(
             jobStreamer,
@@ -227,7 +229,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             cslCheck,
             tenantCheck,
             secretStoreRegistry,
-            incidentBehavior);
+            incidentBehavior,
+            agentDefinitionBehavior);
 
     multiInstanceInputCollectionBehavior =
         new MultiInstanceInputCollectionBehavior(
@@ -264,8 +267,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getGroupState(),
             config.isCandidateGroupNameResolution(),
             clock);
-
-    agentDefinitionBehavior = new AgentDefinitionBehavior(processingState.getProcessState());
 
     jobBehavior =
         new BpmnJobBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -27,13 +27,16 @@ import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
@@ -72,6 +75,7 @@ public class BpmnJobActivationBehavior {
   private final JobStreamer jobStreamer;
   private final JobVariablesCollector jobVariablesCollector;
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final SideEffectWriter sideEffectWriter;
   private final KeyGenerator keyGenerator;
   private final JobProcessingMetrics jobMetrics;
@@ -81,6 +85,7 @@ public class BpmnJobActivationBehavior {
   private final JobAuthorizationLogger jobAuthorizationLogger;
   private final JobSecretLookup secretLookup;
   private final BpmnIncidentBehavior incidentBehavior;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
 
   public BpmnJobActivationBehavior(
       final JobStreamer jobStreamer,
@@ -92,12 +97,14 @@ public class BpmnJobActivationBehavior {
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
       final SecretStoreRegistry secretStoreRegistry,
-      final BpmnIncidentBehavior incidentBehavior) {
+      final BpmnIncidentBehavior incidentBehavior,
+      final AgentDefinitionBehavior agentDefinitionBehavior) {
     this.jobStreamer = jobStreamer;
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
     jobVariablesCollector = new JobVariablesCollector(state);
     stateWriter = writers.state();
+    commandWriter = writers.command();
     sideEffectWriter = writers.sideEffect();
     this.clock = clock;
     this.cslCheck = cslCheck;
@@ -105,6 +112,7 @@ public class BpmnJobActivationBehavior {
     this.jobAuthorizationLogger = JobAuthorizationLogger.createDefault();
     secretLookup = new JobSecretLookup(secretStoreRegistry);
     this.incidentBehavior = incidentBehavior;
+    this.agentDefinitionBehavior = agentDefinitionBehavior;
   }
 
   /**
@@ -193,7 +201,7 @@ public class BpmnJobActivationBehavior {
     final JobStream jobStream = optionalJobStream.get();
     final JobActivationProperties properties = jobStream.properties();
 
-    setJobProperties(wrappedJobRecord, properties);
+    setJobProperties(jobKey, wrappedJobRecord, properties);
     jobVariablesCollector.setJobVariables(properties.fetchVariables(), wrappedJobRecord);
     final var pushableJobRecord = new JobRecord();
     cloneJob(wrappedJobRecord, pushableJobRecord);
@@ -360,12 +368,21 @@ public class BpmnJobActivationBehavior {
   }
 
   private void setJobProperties(
-      final JobRecord jobRecord, final JobActivationProperties properties) {
+      final long jobKey, final JobRecord jobRecord, final JobActivationProperties properties) {
     // we push the job immediately, so the deadline is always calculated from the current time
     final var deadline = clock.millis() + properties.timeout();
     jobRecord.setDeadline(deadline);
     jobRecord.setWorker(properties.worker());
     if (properties.withLease()) {
+      if (jobRecord.hasLeaseToken() && agentDefinitionBehavior.belongsToAgent(jobRecord)) {
+        // Re-activation: this push mints a new lease for a job that already held one, the same
+        // situation JobBatchCollector discards for on the poll path. This site never goes through
+        // the collector, so it must emit the same blanket, lease-agnostic discard itself.
+        commandWriter.appendFollowUpCommand(
+            jobKey,
+            AgentHistoryIntent.DISCARD,
+            new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
+      }
       jobRecord.setLeaseToken(LeaseTokens.generate());
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -23,14 +24,17 @@ import io.camunda.zeebe.engine.processing.job.JobSecretInjector.FailedInjectionJ
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.OversizedJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -70,6 +74,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final JobBatchRecord responseValue = new JobBatchRecord();
 
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final JobBatchCollector jobBatchCollector;
@@ -89,9 +94,11 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final CslTenantCheck tenantCheck,
       final InstantSource clock,
       final BpmnIncidentBehavior incidentBehavior,
+      final AgentDefinitionBehavior agentDefinitionBehavior,
       final SecretStoreRegistry secretStoreRegistry) {
 
     stateWriter = writers.state();
+    commandWriter = writers.command();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.cslCheck = cslCheck;
@@ -104,7 +111,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
             cslCheck,
             clock,
             jobMetrics,
-            jobSecretInjector);
+            jobSecretInjector,
+            agentDefinitionBehavior);
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
@@ -218,8 +226,27 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final var jobsWithNonCachedSecrets = jobSecretInjector.jobsWithNonCachedSecrets();
 
     activateJobBatch(record, value, jobBatchKey);
+    discardSupersededHistoryForReactivatedJobs();
 
     requestSecretResolution(jobsWithNonCachedSecrets);
+  }
+
+  /**
+   * A re-activated agentic job (already held a lease from a previous activation) gets a blanket,
+   * lease-agnostic {@code AGENT_HISTORY:DISCARD} for its previous lease's pending items — the new
+   * lease has not created any items yet, so discarding everything pending for the job is equivalent
+   * to discarding only the old lease's items, without needing to read or compare the old lease
+   * value itself.
+   */
+  private void discardSupersededHistoryForReactivatedJobs() {
+    jobBatchCollector
+        .reactivatedAgenticJobKeys()
+        .forEach(
+            jobKey ->
+                commandWriter.appendFollowUpCommand(
+                    jobKey,
+                    AgentHistoryIntent.DISCARD,
+                    new AgentHistoryRecord().setJobKey(jobKey).ignoreLease()));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -151,14 +151,11 @@ final class JobBatchCollector {
           // fill in the job record properties first in order to accurately estimate its size before
           // adding it to the batch
           jobRecord.setDeadline(deadline).setWorker(value.getWorkerBuffer());
+          final boolean isReactivation =
+              value.isWithLease()
+                  && !jobRecord.getLeaseToken().isEmpty()
+                  && agentDefinitionBehavior.belongsToAgent(jobRecord);
           if (value.isWithLease()) {
-            if (!jobRecord.getLeaseToken().isEmpty()
-                && agentDefinitionBehavior.belongsToAgent(jobRecord)) {
-              // Re-activation: the previous lease's pending history items must be discarded
-              // before the new lease starts accumulating its own, so at most one lease's
-              // optimistic edits are ever unresolved on the AgentInstance at a time.
-              reactivatedAgenticJobKeys.add(key);
-            }
             jobRecord.setLeaseToken(LeaseTokens.generate());
           }
           jobVariablesCollector.setJobVariables(requestedVariables, jobRecord);
@@ -176,6 +173,12 @@ final class JobBatchCollector {
             final var appendedJob = appendJobToBatch(jobIterator, jobKeyIterator, key, jobRecord);
             jobSecretInjector.registerForInjection(
                 secretCheckResult, activatedCount.value, appendedJob);
+            if (isReactivation) {
+              // Re-activation: the previous lease's pending history items must be discarded
+              // before the new lease starts accumulating its own, so at most one lease's
+              // optimistic edits are ever unresolved on the AgentInstance at a time.
+              reactivatedAgenticJobKeys.add(key);
+            }
             activatedCount.increment();
 
             // track the count of activated jobs by their JobKind

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -11,6 +11,7 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.LongHashSet;
 import org.agrona.collections.MutableInteger;
 import org.agrona.collections.MutableReference;
 import org.agrona.collections.ObjectHashSet;
@@ -43,6 +45,7 @@ import org.agrona.collections.ObjectHashSet;
  */
 final class JobBatchCollector {
   private final ObjectHashSet<DirectBuffer> variableNames = new ObjectHashSet<>();
+  private final LongHashSet reactivatedAgenticJobKeys = new LongHashSet();
 
   private final JobState jobState;
   private final JobVariablesCollector jobVariablesCollector;
@@ -51,6 +54,7 @@ final class JobBatchCollector {
   private final InstantSource clock;
   private final JobProcessingMetrics jobMetrics;
   private final JobSecretInjector jobSecretInjector;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
 
   /**
    * @param canWriteEventOfLength a predicate which should return whether the resulting {@link
@@ -66,7 +70,8 @@ final class JobBatchCollector {
       final CslAuthorizationCheck cslCheck,
       final InstantSource clock,
       final JobProcessingMetrics jobMetrics,
-      final JobSecretInjector jobSecretInjector) {
+      final JobSecretInjector jobSecretInjector,
+      final AgentDefinitionBehavior agentDefinitionBehavior) {
     jobState = state.getJobState();
     this.canWriteEventOfLength = canWriteEventOfLength;
     jobVariablesCollector = new JobVariablesCollector(state);
@@ -74,6 +79,7 @@ final class JobBatchCollector {
     this.clock = clock;
     this.jobMetrics = jobMetrics;
     this.jobSecretInjector = jobSecretInjector;
+    this.agentDefinitionBehavior = agentDefinitionBehavior;
   }
 
   /**
@@ -106,6 +112,7 @@ final class JobBatchCollector {
     final Predicate<JobRecord> isAuthorizedForJob = buildAuthzPredicate(record);
 
     jobSecretInjector.reset();
+    reactivatedAgenticJobKeys.clear();
     jobState.forEachActivatableJobs(
         value.getTypeBuffer(),
         tenantIds,
@@ -145,6 +152,13 @@ final class JobBatchCollector {
           // adding it to the batch
           jobRecord.setDeadline(deadline).setWorker(value.getWorkerBuffer());
           if (value.isWithLease()) {
+            if (!jobRecord.getLeaseToken().isEmpty()
+                && agentDefinitionBehavior.belongsToAgent(jobRecord)) {
+              // Re-activation: the previous lease's pending history items must be discarded
+              // before the new lease starts accumulating its own, so at most one lease's
+              // optimistic edits are ever unresolved on the AgentInstance at a time.
+              reactivatedAgenticJobKeys.add(key);
+            }
             jobRecord.setLeaseToken(LeaseTokens.generate());
           }
           jobVariablesCollector.setJobVariables(requestedVariables, jobRecord);
@@ -186,6 +200,14 @@ final class JobBatchCollector {
     }
 
     return Either.right(jobCountPerJobKind);
+  }
+
+  /**
+   * Returns the keys of agentic jobs collected by the last {@link #collectJobs} call that already
+   * held a lease from a previous activation — i.e. are being re-activated with a new one.
+   */
+  LongHashSet reactivatedAgenticJobKeys() {
+    return reactivatedAgenticJobKeys;
   }
 
   private Predicate<JobRecord> buildAuthzPredicate(final TypedRecord<JobBatchRecord> record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -139,6 +139,7 @@ public final class JobEventProcessors {
                 tenantCheck,
                 clock,
                 bpmnBehaviors.incidentBehavior(),
+                bpmnBehaviors.agentDefinitionBehavior(),
                 secretStoreRegistry))
         .withListener(
             new JobTimeoutCheckScheduler(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/LeaseTokens.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/LeaseTokens.java
@@ -27,6 +27,13 @@ public final class LeaseTokens {
    * Returns an opaque token; callers must not parse it. Call once per activated job — never reuse
    * one token across the jobs of a batch. Random with enough entropy that collisions between leased
    * jobs are negligible.
+   *
+   * <p>Every call site that applies a new lease to a job which may already hold one (a
+   * re-activation) must also discard that job's agent history for the old lease — see {@link
+   * io.camunda.zeebe.engine.processing.job.JobBatchCollector} and {@link
+   * io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior} for the two
+   * existing sites. A new lease-minting site that skips this leaves the previous lease's pending
+   * {@code AgentHistory} items stranded, never discarded or committed.
    */
   public static String generate() {
     return UUID.randomUUID().toString();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
@@ -113,4 +113,19 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
     agentInstancesColumnFamily.deleteIfExists(agentInstanceKey);
     byProcessInstanceKeyColumnFamily.deleteIfExists(processInstanceKeyAndAgentInstanceKey);
   }
+
+  @Override
+  public AgentInstanceRecord getCommittedSnapshot(final long key) {
+    throw new UnsupportedOperationException("not implemented yet");
+  }
+
+  @Override
+  public void putCommittedSnapshot(final long key, final AgentInstanceRecord record) {
+    throw new UnsupportedOperationException("not implemented yet");
+  }
+
+  @Override
+  public void deleteCommittedSnapshot(final long key) {
+    throw new UnsupportedOperationException("not implemented yet");
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
@@ -26,6 +26,9 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
   private final DbAgentInstance dbAgentInstance = new DbAgentInstance();
   private final ColumnFamily<DbLong, DbAgentInstance> agentInstancesColumnFamily;
 
+  private final DbAgentInstance committedSnapshotValue = new DbAgentInstance();
+  private final ColumnFamily<DbLong, DbAgentInstance> committedSnapshotColumnFamily;
+
   // Secondary index: (processInstanceKey, agentInstanceKey) -> nil
   private final DbLong processInstanceKey = new DbLong();
   private final DbCompositeKey<DbLong, DbLong> processInstanceKeyAndAgentInstanceKey =
@@ -47,6 +50,12 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
             transactionContext,
             processInstanceKeyAndAgentInstanceKey,
             DbNil.INSTANCE);
+    committedSnapshotColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.AGENT_INSTANCE_COMMITTED_SNAPSHOT,
+            transactionContext,
+            agentInstanceKey,
+            committedSnapshotValue);
   }
 
   @Override
@@ -116,16 +125,21 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
 
   @Override
   public AgentInstanceRecord getCommittedSnapshot(final long key) {
-    throw new UnsupportedOperationException("not implemented yet");
+    agentInstanceKey.wrapLong(key);
+    final var stored = committedSnapshotColumnFamily.get(agentInstanceKey, DbAgentInstance::new);
+    return stored == null ? null : stored.getRecord();
   }
 
   @Override
   public void putCommittedSnapshot(final long key, final AgentInstanceRecord record) {
-    throw new UnsupportedOperationException("not implemented yet");
+    agentInstanceKey.wrapLong(key);
+    committedSnapshotValue.setRecord(record);
+    committedSnapshotColumnFamily.upsert(agentInstanceKey, committedSnapshotValue);
   }
 
   @Override
   public void deleteCommittedSnapshot(final long key) {
-    throw new UnsupportedOperationException("not implemented yet");
+    agentInstanceKey.wrapLong(key);
+    committedSnapshotColumnFamily.deleteIfExists(agentInstanceKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
@@ -41,6 +41,9 @@ public final class AgentHistoryCommittedApplier
    */
   private void syncCommittedSnapshot(final long agentInstanceKey) {
     final var live = agentInstanceState.getRecord(agentInstanceKey);
+    if (live == null) {
+      return;
+    }
     final var snapshot = new AgentInstanceRecord();
     snapshot
         .getDefinition()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
@@ -9,21 +9,51 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 
 public final class AgentHistoryCommittedApplier
     implements TypedEventApplier<AgentHistoryIntent, AgentHistoryRecord> {
 
   private final MutableAgentHistoryState agentHistoryState;
+  private final MutableAgentInstanceState agentInstanceState;
 
   public AgentHistoryCommittedApplier(final MutableProcessingState processingState) {
     agentHistoryState = processingState.getAgentHistoryState();
+    agentInstanceState = processingState.getAgentInstanceState();
   }
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
+    if (value.getRole() == AgentHistoryRole.CONFIGURATION) {
+      syncCommittedSnapshot(value.getAgentInstanceKey());
+    }
     agentHistoryState.delete(key, value);
+  }
+
+  /**
+   * Copies the current (already optimistically-applied) configuration fields of the live agent
+   * instance into its committed snapshot, so a later discard can restore exactly this state.
+   */
+  private void syncCommittedSnapshot(final long agentInstanceKey) {
+    final var live = agentInstanceState.getRecord(agentInstanceKey);
+    final var snapshot = new AgentInstanceRecord();
+    snapshot
+        .getDefinition()
+        .setModel(live.getDefinition().getModel())
+        .setProvider(live.getDefinition().getProvider())
+        .setSystemPrompt(live.getDefinition().getSystemPrompt());
+    snapshot.setTools(live.getTools());
+    final var liveLimits = live.getLimits();
+    snapshot
+        .getLimits()
+        .setMaxTokens(liveLimits.getMaxTokens())
+        .setMaxModelCalls(liveLimits.getMaxModelCalls())
+        .setMaxToolCalls(liveLimits.getMaxToolCalls());
+    agentInstanceState.putCommittedSnapshot(agentInstanceKey, snapshot);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
@@ -24,5 +24,6 @@ public final class AgentInstanceCompletedApplier
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
+    agentInstanceState.deleteCommittedSnapshot(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
@@ -30,4 +30,10 @@ public interface AgentInstanceState {
    *     or {@code null} if none remain
    */
   Long getFirstAgentInstanceKeyByProcessInstanceKey(long processInstanceKey);
+
+  /**
+   * @return the last committed configuration snapshot for the given agent instance, or {@code null}
+   *     if none exists
+   */
+  AgentInstanceRecord getCommittedSnapshot(long agentInstanceKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentInstanceState.java
@@ -26,4 +26,13 @@ public interface MutableAgentInstanceState extends AgentInstanceState {
    * locate the secondary index entry, avoiding an extra state lookup.
    */
   void delete(long agentInstanceKey, AgentInstanceRecord record);
+
+  /** Inserts or overwrites the committed configuration snapshot for {@code agentInstanceKey}. */
+  void putCommittedSnapshot(long agentInstanceKey, AgentInstanceRecord record);
+
+  /**
+   * Deletes the committed configuration snapshot for {@code agentInstanceKey}, if any. No-op if
+   * none exists.
+   */
+  void deleteCommittedSnapshot(long agentInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -354,13 +354,14 @@ public class AgentHistoryCommitTest {
   }
 
   @Test
-  public void shouldCommitWinningAndDiscardSupersededOnLeasedJobCompletion() {
+  public void shouldDiscardSupersededItemOnReactivationThenCommitOnlyWinningItemOnCompletion() {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
     final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
 
-    // Activation 1 (superseded): create a history item, then fail to trigger re-activation.
+    // Activation 1 (superseded): create a history item, then fail to make the job activatable
+    // again.
     final var job1 = activateJobForProcessInstanceWithLease(processInstanceKey);
     final long supersededItemKey =
         createHistoryItem(agentInstanceKey, job1.key(), elementInstanceKey, job1.leaseToken());
@@ -373,12 +374,21 @@ public class AgentHistoryCommitTest {
         .withRetries(1)
         .fail();
 
-    // Activation 2 (winning): create a history item, then complete the job.
+    // Activation 2 (winning): re-activating with a new lease eagerly discards activation 1's item.
     final var job2 = activateJobForProcessInstanceWithLease(processInstanceKey);
     assertThat(job2.key()).as("re-activation must reuse the same job key").isEqualTo(job1.key());
     assertThat(job2.leaseToken())
         .as("re-activation must advance the lease token")
         .isNotEqualTo(job1.leaseToken());
+
+    final var discarded =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+            .withRecordKey(supersededItemKey)
+            .getFirst();
+    assertThat(discarded.getValue().getJobKey())
+        .as("the superseded activation's item is discarded as soon as the job is re-activated")
+        .isEqualTo(job1.key());
+
     final long winningItemKey =
         createHistoryItem(agentInstanceKey, job2.key(), elementInstanceKey, job2.leaseToken());
 
@@ -397,7 +407,9 @@ public class AgentHistoryCommitTest {
     final long commitPosition = firstCommitted.getSourceRecordPosition();
     final long clockResetKey = ENGINE.clock().reset().getKey();
 
-    // visitByJobLease(job2.leaseToken()) → winning item COMMITTED
+    // visitByJobLease(job2.leaseToken()) → only the winning item is committed; the superseded item
+    // was already discarded earlier and the commit-time safety-net discard pass finds nothing left
+    // to do for it.
     assertThat(
             RecordingExporter.records()
                 .limit(r -> r.getKey() == clockResetKey)
@@ -407,17 +419,6 @@ public class AgentHistoryCommitTest {
                 .map(Record::getKey))
         .as("only the winning activation's history item should be committed")
         .containsExactly(winningItemKey);
-
-    // discard pass → superseded item DISCARDED
-    assertThat(
-            RecordingExporter.records()
-                .limit(r -> r.getKey() == clockResetKey)
-                .withValueType(ValueType.AGENT_HISTORY)
-                .withIntent(AgentHistoryIntent.DISCARDED)
-                .filter(r -> r.getSourceRecordPosition() == commitPosition)
-                .map(Record::getKey))
-        .as("the superseded activation's history item should be discarded")
-        .containsExactly(supersededItemKey);
   }
 
   // --- helpers ---

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationPushTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer.RecordingJobStream;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * The job streaming/push path's equivalent of {@link AgentHistoryDiscardOnJobReactivationTest}: a
+ * job pushed with a lease can also be re-pushed with a new one (e.g. on {@code fail} with retries),
+ * a lease-minting site {@link io.camunda.zeebe.engine.processing.job.JobBatchCollector} never sees.
+ */
+public class AgentHistoryDiscardOnJobReactivationPushTest {
+
+  private static final String TIMEOUT_MS = "30000";
+  private static final RecordingJobStreamer JOB_STREAMER = new RecordingJobStreamer();
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withJobStreamer(JOB_STREAMER);
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDiscardPendingItemsWhenPushReactivatesAgenticJobWithNewLease() {
+    // given — a leasing stream, an agentic service task, and a CONFIGURATION item pending under
+    // the job's first (pushed) lease.
+    final var jobType = "reactivation-discard-push";
+    final var worker = BufferUtil.wrapString("test");
+    final var properties =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(Long.parseLong(TIMEOUT_MS))
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .setWithLease(true);
+    final RecordingJobStream jobStream =
+        JOB_STREAMER.addJobStream(BufferUtil.wrapString(jobType), properties);
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+    final long jobKey = jobStream.getActivatedJobs().getFirst().jobKey();
+    final String firstLease = jobStream.getActivatedJobs().getFirst().jobRecord().getLeaseToken();
+    assertThat(firstLease).describedAs("the job under test must actually be leased").isNotEmpty();
+
+    final long agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(firstLease)
+            .create()
+            .getKey();
+    final var configurationItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-1")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(firstLease)
+            .withHistory(List.of(configurationItem))
+            .update();
+    final long pendingItemKey = updated.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when — the job fails with retries; the still-open leasing stream re-pushes it with a new,
+    // distinct lease token
+    ENGINE.job().withKey(jobKey).withLeaseToken(firstLease).withRetries(1).fail();
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(2));
+    final String secondLease = jobStream.getActivatedJobs().get(1).jobRecord().getLeaseToken();
+    assertThat(secondLease)
+        .describedAs("the re-push must mint a new, distinct lease token")
+        .isNotEmpty()
+        .isNotEqualTo(firstLease);
+
+    // then — a blanket discard (no lease filter) is emitted for the job, and the first lease's
+    // pending item is discarded, exactly like the poll path
+    final var discardCommand =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARD)
+            .onlyCommands()
+            .withJobKey(jobKey)
+            .getFirst();
+    assertThat(discardCommand.getValue().getJobLease()).isEmpty();
+
+    final var discarded =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+            .withRecordKey(pendingItemKey)
+            .getFirst();
+    assertThat(discarded.getValue().getJobKey()).isEqualTo(jobKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies that re-activating an agentic job with a new lease (the job already held a lease from a
+ * previous activation) emits a blanket {@code AGENT_HISTORY:DISCARD} for the job, so the prior
+ * activation's pending items are discarded before the new lease's own history starts accumulating.
+ */
+public class AgentHistoryDiscardOnJobReactivationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDiscardPendingItemsOnlyAfterJobIsReactivatedWithNewLease() {
+    // given — an agentic service task; the job is activated with a lease for the first time, and a
+    // CONFIGURATION item lands under that lease via the agent instance's own creation batch.
+    final var jobType = "reactivation-discard-fold";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+
+    final var firstBatch = ENGINE.jobs().withType(jobType).withTimeout(10L).withLease().activate();
+    final long jobKey = firstBatch.getValue().getJobKeys().get(0);
+    final String firstLease = firstBatch.getValue().getJobs().get(0).getLeaseToken();
+
+    final var configurationItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-1")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(firstLease)
+            .withHistory(List.of(configurationItem))
+            .create();
+    final long pendingItemKey = created.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when — the lease times out; a time-out never reactivates a leased job by itself, so no
+    // reactivation discard should fire yet.
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+    RecordingExporter.jobRecords(JobIntent.TIMED_OUT).withRecordKey(jobKey).getFirst();
+    final long afterTimeoutKey = ENGINE.clock().reset().getKey();
+
+    // then — the pending item is still untouched
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == afterTimeoutKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARD)
+                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == jobKey)
+                .exists())
+        .isFalse();
+
+    // when — a leasing worker re-activates the timed-out job, minting a new lease token
+    final var secondBatch = ENGINE.jobs().withType(jobType).withLease().activate();
+    assertThat(secondBatch.getValue().getJobKeys()).containsExactly(jobKey);
+    final String secondLease = secondBatch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(secondLease).isNotEmpty().isNotEqualTo(firstLease);
+
+    // then — a blanket discard (no lease filter) is emitted for the job, and the first lease's
+    // pending item is discarded
+    final var discardCommand =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARD)
+            .onlyCommands()
+            .withJobKey(jobKey)
+            .getFirst();
+    assertThat(discardCommand.getRecordType()).isEqualTo(RecordType.COMMAND);
+    assertThat(discardCommand.getValue().getJobLease()).isEmpty();
+
+    final var discarded =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+            .withRecordKey(pendingItemKey)
+            .getFirst();
+    assertThat(discarded.getValue().getJobKey()).isEqualTo(jobKey);
+  }
+
+  @Test
+  public void shouldNotDiscardOnFirstActivationOfAgenticJob() {
+    // given/when — a fresh agentic job is activated with a lease for the very first time
+    final var jobType = "reactivation-discard-first-activation";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    final var batch = ENGINE.jobs().withType(jobType).withLease().activate();
+    final long jobKey = batch.getValue().getJobKeys().get(0);
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // then — no re-activation discard is emitted; there was no prior lease to supersede
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARD)
+                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == jobKey)
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldNotDiscardWhenNonAgenticJobIsReactivatedWithNewLease() {
+    // given — a plain (non-agentic) service task; the job is activated with a lease, then times out
+    final var jobType = "reactivation-discard-non-agentic";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("plain-task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .deploy();
+    ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    final var firstBatch = ENGINE.jobs().withType(jobType).withTimeout(10L).withLease().activate();
+    final long jobKey = firstBatch.getValue().getJobKeys().get(0);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+    RecordingExporter.jobRecords(JobIntent.TIMED_OUT).withRecordKey(jobKey).getFirst();
+
+    // when — it is re-activated with a new lease
+    final var secondBatch = ENGINE.jobs().withType(jobType).withLease().activate();
+    assertThat(secondBatch.getValue().getJobKeys()).containsExactly(jobKey);
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // then — no discard is emitted; the job is not agentic
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARD)
+                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == jobKey)
+                .exists())
+        .isFalse();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardRestoresConfigurationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardRestoresConfigurationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AgentHistoryDiscardRestoresConfigurationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRestoreLiveConfigurationToLastCommittedSnapshotOnDiscard() {
+    // given — an agent instance whose CONFIGURATION item is applied and committed, so the
+    // committed snapshot mirrors that change.
+    final var jobType = "discard-restore-committed-snapshot";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+    final long agentInstanceKey =
+        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
+    final long jobKey = ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys().get(0);
+
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-committed")
+                    .setRole(AgentHistoryRole.CONFIGURATION)
+                    .setLoopIteration(1)
+                    .setModel("gpt-4o-mini")
+                    .setChangedAttributes(List.of("model"))))
+        .update();
+    ENGINE.agentHistories().withJobKey(jobKey).commit();
+
+    // when — a second CONFIGURATION change is applied but never committed, then discarded
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-pending")
+                    .setRole(AgentHistoryRole.CONFIGURATION)
+                    .setLoopIteration(1)
+                    .setModel("gpt-5")
+                    .setChangedAttributes(List.of("model"))))
+        .update();
+    final var discardCommand = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    // then — the live definition is rolled back to the last committed value, not the pending one
+    final var restored =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.UPDATED)
+            .filter(r -> r.getSourceRecordPosition() == discardCommand.getSourceRecordPosition())
+            .getFirst();
+    assertThat(restored.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(restored.getValue().getChangedAttributes())
+        .containsExactlyInAnyOrder(
+            "model",
+            "provider",
+            "systemPrompt",
+            "tools",
+            "maxTokens",
+            "maxModelCalls",
+            "maxToolCalls");
+  }
+
+  @Test
+  public void shouldRestoreToEmptyDefaultsWhenDiscardingBeforeAnyCommitEverHappened() {
+    // given — a CONFIGURATION item is applied but discarded before any item for this agent
+    // instance was ever committed, so no snapshot exists yet.
+    final var jobType = "discard-restore-no-snapshot";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+    final long agentInstanceKey =
+        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
+    final long jobKey = ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys().get(0);
+
+    // when
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-pending")
+                    .setRole(AgentHistoryRole.CONFIGURATION)
+                    .setLoopIteration(1)
+                    .setModel("gpt-4o-mini")
+                    .setChangedAttributes(List.of("model"))))
+        .update();
+    final var discardCommand = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    // then — restored to the AgentInstanceRecord defaults (empty), not the pre-change value
+    final var restored =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.UPDATED)
+            .filter(r -> r.getSourceRecordPosition() == discardCommand.getSourceRecordPosition())
+            .getFirst();
+    assertThat(restored.getValue().getDefinition().getModel()).isEmpty();
+    assertThat(restored.getValue().getChangedAttributes())
+        .containsExactlyInAnyOrder(
+            "model",
+            "provider",
+            "systemPrompt",
+            "tools",
+            "maxTokens",
+            "maxModelCalls",
+            "maxToolCalls");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -29,6 +29,7 @@ import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -85,6 +86,8 @@ final class JobBatchCollectorTest {
           new SecretStoreRegistry(
               Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, new NoopSecretStore()),
               Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, secretCache)));
+  private final AgentDefinitionBehavior agentDefinitionBehavior =
+      mock(AgentDefinitionBehavior.class);
 
   @SuppressWarnings("unused") // injected by the extension
   private MutableProcessingState state;
@@ -98,7 +101,14 @@ final class JobBatchCollectorTest {
     // are never invoked by the collector — pass nulls to satisfy the CslAuthorizationCheck ctor.
     final var cslCheck = new CslAuthorizationCheck(null, null, securityConfig);
     collector =
-        new JobBatchCollector(state, lengthEvaluator, cslCheck, clock, jobMetrics, secretInjector);
+        new JobBatchCollector(
+            state,
+            lengthEvaluator,
+            cslCheck,
+            clock,
+            jobMetrics,
+            secretInjector,
+            agentDefinitionBehavior);
   }
 
   @Test
@@ -148,7 +158,13 @@ final class JobBatchCollectorTest {
     final var securityConfig = EngineSecurityConfigurations.defaultConfig();
     final var cslCheck = new CslAuthorizationCheck(authzService, claimsConverter, securityConfig);
     return new JobBatchCollector(
-        state, lengthEvaluator, cslCheck, clock, jobMetrics, secretInjector);
+        state,
+        lengthEvaluator,
+        cslCheck,
+        clock,
+        jobMetrics,
+        secretInjector,
+        agentDefinitionBehavior);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -313,6 +313,25 @@ final class JobBatchCollectorTest {
   }
 
   @Test
+  void shouldNotTrackReactivationWhenJobIsRejectedForBatchSize() {
+    // given — an agentic job that already holds a lease from a previous activation, so it looks
+    // like a re-activation, but the collector rejects it for being too large to write. Its
+    // existing lease is left untouched in state, so it must not be treated as reactivated.
+    final long variableScopeKey = state.getKeyGenerator().nextKey();
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    record.getValue().setWithLease(true);
+    createLeasedJob(variableScopeKey);
+    when(agentDefinitionBehavior.belongsToAgent(any())).thenReturn(true);
+    lengthEvaluator.canWriteEventOfLength = (length) -> false;
+
+    // when
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+
+    // then
+    assertThat(collector.reactivatedAgenticJobKeys()).isEmpty();
+  }
+
+  @Test
   void shouldCollectJobsWithVariables() {
     // given - multiple jobs to ensure variables are collected based on the scope
     final TypedRecord<JobBatchRecord> record = createRecord();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
@@ -233,4 +233,63 @@ public final class AgentInstanceStateTest {
     // given / when / then
     assertThatCode(() -> agentInstanceState.delete(9999L)).doesNotThrowAnyException();
   }
+
+  @Test
+  public void shouldStoreAndLoadCommittedSnapshot() {
+    // given
+    final long key = 4242L;
+    final var snapshot =
+        new AgentInstanceRecord().setAgentInstanceKey(key).setElementInstanceKey(1234L);
+
+    // when
+    agentInstanceState.putCommittedSnapshot(key, snapshot);
+
+    // then
+    final var loaded = agentInstanceState.getCommittedSnapshot(key);
+    assertThat(loaded).isNotNull();
+    assertThat(loaded.getAgentInstanceKey()).isEqualTo(key);
+    assertThat(loaded.getElementInstanceKey()).isEqualTo(1234L);
+  }
+
+  @Test
+  public void shouldReturnNullForMissingCommittedSnapshot() {
+    assertThat(agentInstanceState.getCommittedSnapshot(9999L)).isNull();
+  }
+
+  @Test
+  public void shouldOverwriteCommittedSnapshotOnPut() {
+    // given
+    final long key = 4242L;
+    agentInstanceState.putCommittedSnapshot(
+        key, new AgentInstanceRecord().setAgentInstanceKey(key).setElementInstanceKey(1234L));
+
+    // when
+    agentInstanceState.putCommittedSnapshot(
+        key, new AgentInstanceRecord().setAgentInstanceKey(key).setElementInstanceKey(5678L));
+
+    // then
+    final var loaded = agentInstanceState.getCommittedSnapshot(key);
+    assertThat(loaded.getElementInstanceKey()).isEqualTo(5678L);
+  }
+
+  @Test
+  public void shouldDeleteCommittedSnapshot() {
+    // given
+    final long key = 4242L;
+    agentInstanceState.putCommittedSnapshot(
+        key, new AgentInstanceRecord().setAgentInstanceKey(key).setElementInstanceKey(1234L));
+
+    // when
+    agentInstanceState.deleteCommittedSnapshot(key);
+
+    // then
+    assertThat(agentInstanceState.getCommittedSnapshot(key)).isNull();
+  }
+
+  @Test
+  public void shouldNoOpOnDeleteOfMissingCommittedSnapshot() {
+    // given / when / then
+    assertThatCode(() -> agentInstanceState.deleteCommittedSnapshot(9999L))
+        .doesNotThrowAnyException();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplierTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class AgentHistoryCommittedApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableAgentInstanceState agentInstanceState;
+  private MutableAgentHistoryState agentHistoryState;
+  private AgentHistoryCommittedApplier committedApplier;
+
+  @BeforeEach
+  public void setup() {
+    agentInstanceState = processingState.getAgentInstanceState();
+    agentHistoryState = processingState.getAgentHistoryState();
+    committedApplier = new AgentHistoryCommittedApplier(processingState);
+  }
+
+  @Test
+  void shouldSyncCommittedSnapshotWhenConfigurationItemCommits() {
+    // given — an agent instance whose live definition/tools/limits already reflect the
+    // optimistically-applied change (as done by AgentHistoryBatchBehavior at CREATE time).
+    final long agentInstanceKey = 1L;
+    final var live = new AgentInstanceRecord().setAgentInstanceKey(agentInstanceKey);
+    live.getLimits().setMaxTokens(111).setMaxModelCalls(2).setMaxToolCalls(3);
+    live.getDefinition()
+        .setModel("gpt-5")
+        .setProvider("openai")
+        .setSystemPrompt(
+            List.of(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("be helpful")));
+    agentInstanceState.insert(agentInstanceKey, live);
+
+    final long historyKey = 10L;
+    final var item =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(historyKey)
+            .setAgentInstanceKey(agentInstanceKey)
+            .setRole(AgentHistoryRole.CONFIGURATION);
+    agentHistoryState.insert(historyKey, item);
+
+    // when
+    committedApplier.applyState(historyKey, item);
+
+    // then
+    final var snapshot = agentInstanceState.getCommittedSnapshot(agentInstanceKey);
+    assertThat(snapshot).isNotNull();
+    assertThat(snapshot.getDefinition().getModel()).isEqualTo("gpt-5");
+    assertThat(snapshot.getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(snapshot.getDefinition().getSystemPrompt()).hasSize(1);
+    assertThat(snapshot.getDefinition().getSystemPrompt().get(0).getText()).isEqualTo("be helpful");
+    assertThat(snapshot.getLimits().getMaxTokens()).isEqualTo(111);
+    assertThat(snapshot.getLimits().getMaxModelCalls()).isEqualTo(2);
+    assertThat(snapshot.getLimits().getMaxToolCalls()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldNotSyncSnapshotForNonConfigurationItem() {
+    // given
+    final long agentInstanceKey = 1L;
+    agentInstanceState.insert(
+        agentInstanceKey, new AgentInstanceRecord().setAgentInstanceKey(agentInstanceKey));
+
+    final long historyKey = 10L;
+    final var item =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(historyKey)
+            .setAgentInstanceKey(agentInstanceKey)
+            .setRole(AgentHistoryRole.ASSISTANT);
+    agentHistoryState.insert(historyKey, item);
+
+    // when
+    committedApplier.applyState(historyKey, item);
+
+    // then
+    assertThat(agentInstanceState.getCommittedSnapshot(agentInstanceKey)).isNull();
+  }
+
+  @Test
+  void shouldStillDeleteHistoryItemOnCommit() {
+    // given
+    final long agentInstanceKey = 1L;
+    agentInstanceState.insert(
+        agentInstanceKey, new AgentInstanceRecord().setAgentInstanceKey(agentInstanceKey));
+
+    final long historyKey = 10L;
+    final var item =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(historyKey)
+            .setAgentInstanceKey(agentInstanceKey)
+            .setRole(AgentHistoryRole.CONFIGURATION);
+    agentHistoryState.insert(historyKey, item);
+
+    // when
+    committedApplier.applyState(historyKey, item);
+
+    // then — the existing delete-from-primary-storage behavior is unaffected by the new sync.
+    assertThat(agentHistoryState.get(historyKey)).isNull();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplierTest.java
@@ -103,6 +103,27 @@ public class AgentHistoryCommittedApplierTest {
   }
 
   @Test
+  void shouldNotFailWhenAgentInstanceIsAlreadyGone() {
+    // given — a CONFIGURATION item whose agent instance was already deleted (e.g. the process
+    // instance completed before this COMMIT was processed).
+    final long agentInstanceKey = 1L;
+    final long historyKey = 10L;
+    final var item =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(historyKey)
+            .setAgentInstanceKey(agentInstanceKey)
+            .setRole(AgentHistoryRole.CONFIGURATION);
+    agentHistoryState.insert(historyKey, item);
+
+    // when — applying should not throw despite there being no live agent instance to read from
+    committedApplier.applyState(historyKey, item);
+
+    // then — no snapshot is created, and the history item is still deleted as usual
+    assertThat(agentInstanceState.getCommittedSnapshot(agentInstanceKey)).isNull();
+    assertThat(agentHistoryState.get(historyKey)).isNull();
+  }
+
+  @Test
   void shouldStillDeleteHistoryItemOnCommit() {
     // given
     final long agentInstanceKey = 1L;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
@@ -97,4 +97,30 @@ public class AgentInstanceCompletedApplierTest {
     assertThat(agentInstanceState.getAgentInstanceKeysByProcessInstanceKey(processInstanceKey))
         .containsExactly(secondAgentInstanceKey);
   }
+
+  @Test
+  void shouldDeleteCommittedSnapshotOnCompletion() {
+    // given — a committed configuration snapshot exists for the agent instance.
+    final long agentInstanceKey = 9L;
+    final long processInstanceKey = 5L;
+    createdApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentInstanceState.putCommittedSnapshot(
+        agentInstanceKey, new AgentInstanceRecord().setAgentInstanceKey(agentInstanceKey));
+
+    // when
+    completedApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then
+    assertThat(agentInstanceState.getCommittedSnapshot(agentInstanceKey)).isNull();
+  }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
@@ -41,6 +41,9 @@ public final class AgentHistoryCommittedApplier
    */
   private void syncCommittedSnapshot(final long agentInstanceKey) {
     final var live = agentInstanceState.getRecord(agentInstanceKey);
+    if (live == null) {
+      return;
+    }
     final var snapshot = new AgentInstanceRecord();
     snapshot
         .getDefinition()

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
@@ -9,21 +9,51 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 
 public final class AgentHistoryCommittedApplier
     implements TypedEventApplier<AgentHistoryIntent, AgentHistoryRecord> {
 
   private final MutableAgentHistoryState agentHistoryState;
+  private final MutableAgentInstanceState agentInstanceState;
 
   public AgentHistoryCommittedApplier(final MutableProcessingState processingState) {
     agentHistoryState = processingState.getAgentHistoryState();
+    agentInstanceState = processingState.getAgentInstanceState();
   }
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
+    if (value.getRole() == AgentHistoryRole.CONFIGURATION) {
+      syncCommittedSnapshot(value.getAgentInstanceKey());
+    }
     agentHistoryState.delete(key, value);
+  }
+
+  /**
+   * Copies the current (already optimistically-applied) configuration fields of the live agent
+   * instance into its committed snapshot, so a later discard can restore exactly this state.
+   */
+  private void syncCommittedSnapshot(final long agentInstanceKey) {
+    final var live = agentInstanceState.getRecord(agentInstanceKey);
+    final var snapshot = new AgentInstanceRecord();
+    snapshot
+        .getDefinition()
+        .setModel(live.getDefinition().getModel())
+        .setProvider(live.getDefinition().getProvider())
+        .setSystemPrompt(live.getDefinition().getSystemPrompt());
+    snapshot.setTools(live.getTools());
+    final var liveLimits = live.getLimits();
+    snapshot
+        .getLimits()
+        .setMaxTokens(liveLimits.getMaxTokens())
+        .setMaxModelCalls(liveLimits.getMaxModelCalls())
+        .setMaxToolCalls(liveLimits.getMaxToolCalls());
+    agentInstanceState.putCommittedSnapshot(agentInstanceKey, snapshot);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
@@ -24,5 +24,6 @@ public final class AgentInstanceCompletedApplier
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
+    agentInstanceState.deleteCommittedSnapshot(key);
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -372,7 +372,13 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // AGENT_DEFINITION_KEY_BY_PROCESS_DEFINITION_KEY_AND_ELEMENT_ID at deploy time, so the record can
   // be fully retrieved, without re-deriving it from the parsed BPMN model. GLOBAL for the same
   // reason as the sibling CF above.
-  AGENT_DEFINITION_BY_KEY(162, GLOBAL);
+  AGENT_DEFINITION_BY_KEY(162, GLOBAL),
+
+  // agentInstanceKey -> DbAgentInstance holding the last CONFIGURATION fields (systemPrompt,
+  // model, provider, tools, limits) committed for that agent instance. Reuses DbAgentInstance
+  // as the value type even though only those fields are populated, so the optimistically-applied
+  // live AgentInstance can be rolled back to this snapshot on history-item discard.
+  AGENT_INSTANCE_COMMITTED_SNAPSHOT(163, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

Keeps an `AgentInstance`'s live `CONFIGURATION` fields (and pending history) correctly synchronized with what actually gets durably committed, so an optimistically-applied-but-later-discarded change (e.g. a job re-activation, a rolled-back lease) doesn't leave the live state out of sync with reality.

When a job carries a `CONFIGURATION`-role history item (system prompt, model, provider, tools, or limits), that change is applied immediately to the `AgentInstance`'s live state as soon as the item is processed — before it's known whether the job's lease will ultimately be committed or discarded. Until now, if that lease was later discarded instead of committed (the job got re-activated, destroyed, or otherwise superseded), the live state simply kept the uncommitted edit forever, silently drifting from what was actually durably persisted.

This PR closes that gap:

- Adds a new engine-internal-only column family (`AGENT_INSTANCE_COMMITTED_SNAPSHOT`) that stores the last durably-committed configuration for each `AgentInstance`, reusing the existing `DbAgentInstance` value shape rather than introducing a new one.
- On commit of a `CONFIGURATION` history item, copies the 7 concrete configuration fields (system prompt, model, provider, tools, maxTokens, maxModelCalls, maxToolCalls) into that snapshot.
- On discard of pending history — covering explicit discard, job-destruction discard, and the re-activation-triggered discard below — restores the live `AgentInstance` record from the snapshot (or to empty defaults if no snapshot exists yet, e.g. a discarded first `CREATE`), and emits a real `AgentInstanceIntent.UPDATED` event carrying the restored values.
- Deletes the snapshot row when the `AgentInstance` completes, so it doesn't outlive its owner.
- Adds a prerequisite correctness fix (part of the broader job-leasing work in #56706): re-activating a job now eagerly discards its previous lease's pending history items, on both the poll path (`JobBatchCollector`) and the push/stream path (`BpmnJobActivationBehavior`), instead of relying on that being discovered lazily at commit time. This establishes the invariant that at most one lease's optimistic edits can be outstanding on a given `AgentInstance` at any time, which is what lets the commit/discard logic above be simple whole-record operations rather than needing per-field diffing.
- Keeps the pre-existing commit-time superseded-lease discard rather than removing it: with the eager discard above in place it should never find anything left to discard in practice, but it's kept as a safety net in case a future change to the eager-discard call sites lets a superseded lease's items leak through undiscarded to a commit.

A `CREATE` command's own embedded history items go through the same PENDING/COMMIT lifecycle as items from any later job activation — there is no special immediate-commit path for `CREATE`. If the lease that created the agent instance is discarded before ever reaching a commit, the client (the connector) never durably persisted anything either, so restoring the live record to empty defaults in that case is correct, not a bug.

`AgentInstanceRecord`'s `systemPrompt` already uses the content-block-list type (from #60542, merged in #60602), so this mechanism's snapshot/restore logic operates on that shape directly with no separate migration needed.

## Out of scope

Job activation behavior — including job leasing — is currently duplicated across two independent code paths: `JobBatchCollector`/`JobBatchActivateProcessor` (the poll path) and `BpmnJobActivationBehavior` (the push/stream path). This PR had to add the same re-activation-discard logic to both sites independently, since there is no single shared place where job activation/leasing happens. It would make sense to unify job activation behavior into one place — ideally `JobBatchActivateProcessor` delegating to `BpmnJobActivationBehavior` rather than duplicating the logic — but that consolidation is a larger refactor left for a future PR.

## Test plan

Executed and passing:

- [x] New/updated coverage for the re-activation-triggered discard, on both the poll path and the push/stream path (`AgentHistoryDiscardOnJobReactivationTest`, `AgentHistoryDiscardOnJobReactivationPushTest`), including a job rejected for exceeding batch-size capacity not having its still-held lease's pending items wrongly discarded
- [x] Insert/get/delete-level coverage for the new `AGENT_INSTANCE_COMMITTED_SNAPSHOT` column family
- [x] Commit-side sync: a committed `CONFIGURATION` item copies all 7 concrete fields into the snapshot (golden files updated)
- [x] Discard-side restore: first-ever-`CREATE` discarded with no snapshot yet restores to defaults; a re-activation-triggered supersession mid-flight restores correctly and emits `AgentInstanceIntent.UPDATED`; multiple sequential commits followed by a later discard restore to the last-committed snapshot, not an earlier one; job-destruction discard restores correctly through the same shared path
- [x] Snapshot row deleted on `AgentInstanceCompletedApplier` when the instance completes (golden files updated)
- [x] Committed applier tolerates a missing live `AgentInstance` (matches the sibling discard-processor's existing guard; golden files updated)
- [x] Commit-time superseded-lease discard reclassified as a safety net: the one existing scenario that goes through a real re-activation now expects the item already discarded eagerly rather than at commit time; the synthetic-lease scenario is untouched since the safety net still fires for it
- [x] `AgentHistoryCommitTest`, `AgentHistoryDiscardTest`, `AgentHistoryDiscardOnJobDestructionTest`, `AgentHistoryDiscardOnJobReactivationTest`, `AgentHistoryDiscardOnJobReactivationPushTest`, `AgentInstanceCompletedApplierTest`
- [x] `JsonSerializableToJsonTest`, `RecordGoldenFilesTest`, `ZbColumnFamiliesTest`, `EventAppliersTest$NoChangesTest`
- [x] `StateModificationArchTest` (confirms the new/extended appliers only mutate state from within an applier, not a processor)
- [x] Full targeted regression sweep across `io.camunda.zeebe.engine.processing.job.**`, `io.camunda.zeebe.engine.processing.agenthistory.**`, `io.camunda.zeebe.engine.processing.agentinstance.**`, `io.camunda.zeebe.engine.processing.bpmn.behavior.**`, `io.camunda.zeebe.engine.state.**`
- [x] License, spotless, and checkstyle checks

## Checklist

No checklist items apply: this is a new feature (not a bug fix) and does not modify the C8 Orchestration Cluster E2E Test Suite.

## Related issues

closes #58797
