### PR TITLE
ci: load-test: fix usage of camunda/action-git-commit@v1

### DIFF
--- a/.github/workflows/load-test-golden-update.yml
+++ b/.github/workflows/load-test-golden-update.yml
@@ -78,10 +78,10 @@ jobs:
         run: make -C load-tests/setup/test update-golden
 
       - name: Commit and push golden files
-        uses: camunda/action-git-commit@v1
+        uses: camunda/action-git-commit@7aca5a200a50699bff14ac8e7950ce48be225aa0 # v1.9.0
         with:
           commit-message: "test: update load-test golden files"
-          token: ${{ steps.github-token.outputs.token }}
+          github-token: ${{ steps.github-token.outputs.token }}
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

Cf. https://github.com/camunda/action-git-commit/blob/7aca5a200a50699bff14ac8e7950ce48be225aa0/action.yml#L21-L24

Also pin the usage of the github action to fix security warnings.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
