### PR TITLE
refactor: extract shared CurrentSchemaVersion for RDBMS/ES schema-version providers

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProvider.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProvider.java
@@ -8,13 +8,8 @@
 package io.camunda.db.rdbms;
 
 import io.camunda.cluster.migration.MigrationConditionStatus;
-import io.camunda.cluster.migration.MigrationState;
 import io.camunda.cluster.migration.MigrationStatusProvider;
 import io.camunda.zeebe.util.VisibleForTesting;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
@@ -67,71 +62,7 @@ public final class RdbmsSchemaMigrationStatusProvider implements MigrationStatus
     versionStoresByPhysicalTenant.forEach(
         (physicalTenantId, versionStore) ->
             statusesByPhysicalTenant.put(
-                physicalTenantId, toMigrationStatus(versionStore.getCurrentSchemaVersion())));
+                physicalTenantId, versionStore.getCurrentSchemaVersion().toMigrationStatus()));
     return statusesByPhysicalTenant;
-  }
-
-  /**
-   * Maps raw schema-version facts to the upgrade-readiness condition reported for one physical
-   * tenant.
-   *
-   * <ul>
-   *   <li>Schema version equals the application version ({@link Compatible.SameVersion}) → {@link
-   *       MigrationState#MIGRATED}.
-   *   <li>Schema version is one or more minors behind, on a supported upgrade path ({@link
-   *       Compatible.PatchUpgrade}/{@link Compatible.MinorUpgrade}), or no version has been
-   *       recorded yet (fresh database) → {@link MigrationState#MIGRATION_IN_PROGRESS}. This
-   *       includes externally-managed schemas ({@code auto-ddl=false}) that have not yet been
-   *       migrated by the operator's own tooling.
-   *   <li>An illegal upgrade path ({@link Incompatible}), an unparseable version ({@link
-   *       Indeterminate}, or an unparseable application version, or any read failure (e.g. a
-   *       connection error) → {@link MigrationState#UNKNOWN} — this is a "we don't know," not a "we
-   *       know it's not done."
-   * </ul>
-   */
-  @VisibleForTesting
-  MigrationConditionStatus toMigrationStatus(
-      final RdbmsSchemaVersionStore.CurrentSchemaVersion currentSchemaVersion) {
-    return switch (currentSchemaVersion.kind()) {
-      case AVAILABLE ->
-          toMigrationStatus(
-              VersionCompatibilityCheck.check(
-                  currentSchemaVersion.schemaVersion().orElseThrow(),
-                  currentSchemaVersion.stableApplicationVersion().orElseThrow()));
-      case FRESH_DATABASE ->
-          new MigrationConditionStatus(
-              MigrationState.MIGRATION_IN_PROGRESS,
-              "no schema version recorded yet for prefix '"
-                  + currentSchemaVersion.prefix()
-                  + "' (fresh database)");
-      case READ_FAILURE ->
-          new MigrationConditionStatus(
-              MigrationState.UNKNOWN, currentSchemaVersion.detail().orElseThrow());
-    };
-  }
-
-  private MigrationConditionStatus toMigrationStatus(
-      final VersionCompatibilityCheck.CheckResult result) {
-    return switch (result) {
-      case final Compatible.SameVersion same ->
-          new MigrationConditionStatus(
-              MigrationState.MIGRATED,
-              "schema version " + same.version() + " matches the application version");
-      case final Compatible.PatchUpgrade patch ->
-          new MigrationConditionStatus(
-              MigrationState.MIGRATION_IN_PROGRESS,
-              "schema version " + patch.from() + " has not yet migrated to " + patch.to());
-      case final Compatible.MinorUpgrade minor ->
-          new MigrationConditionStatus(
-              MigrationState.MIGRATION_IN_PROGRESS,
-              "schema version " + minor.from() + " has not yet migrated to " + minor.to());
-      case final Incompatible incompatible ->
-          new MigrationConditionStatus(
-              MigrationState.UNKNOWN, "incompatible schema upgrade path: " + incompatible);
-      case final Indeterminate indeterminate ->
-          new MigrationConditionStatus(
-              MigrationState.UNKNOWN,
-              "cannot determine schema version compatibility: " + indeterminate);
-    };
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.migration.CurrentSchemaVersion;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.LinkedHashSet;
@@ -393,44 +394,6 @@ public class RdbmsSchemaVersionStore {
         connection.prepareStatement("INSERT INTO " + tableName + " (ID, VERSION) VALUES (1, ?)")) {
       insertStmt.setString(1, stableVersion);
       insertStmt.executeUpdate();
-    }
-  }
-
-  public record CurrentSchemaVersion(
-      CurrentSchemaVersion.Kind kind,
-      String prefix,
-      Optional<String> schemaVersion,
-      Optional<String> stableApplicationVersion,
-      Optional<String> detail) {
-
-    static CurrentSchemaVersion available(
-        final String prefix, final String schemaVersion, final String stableApplicationVersion) {
-      return new CurrentSchemaVersion(
-          Kind.AVAILABLE,
-          prefix,
-          Optional.of(schemaVersion),
-          Optional.of(stableApplicationVersion),
-          Optional.empty());
-    }
-
-    static CurrentSchemaVersion freshDatabase(final String prefix) {
-      return new CurrentSchemaVersion(
-          Kind.FRESH_DATABASE, prefix, Optional.empty(), Optional.empty(), Optional.empty());
-    }
-
-    static CurrentSchemaVersion readFailure(final String prefix, final Exception e) {
-      return new CurrentSchemaVersion(
-          Kind.READ_FAILURE,
-          prefix,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.of("failed to read schema version: " + e.getMessage()));
-    }
-
-    public enum Kind {
-      AVAILABLE,
-      FRESH_DATABASE,
-      READ_FAILURE
     }
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProviderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaMigrationStatusProviderTest.java
@@ -20,7 +20,14 @@ import java.util.Map;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for the RDBMS upgrade-readiness condition, one entry per physical tenant. */
+/**
+ * Unit tests for the RDBMS upgrade-readiness condition, one entry per physical tenant. The
+ * schema-version-to-{@link MigrationState} mapping itself (patch/minor upgrade, fresh database,
+ * incompatible/indeterminate versions, read failures) is shared across every schema-version-backed
+ * provider and exhaustively covered once elsewhere -- these tests only cover what's genuinely
+ * specific to this provider: multi-tenant map-shaping and one smoke test confirming it's wired to
+ * that shared mapping correctly.
+ */
 class RdbmsSchemaMigrationStatusProviderTest {
 
   @Test
@@ -62,77 +69,6 @@ class RdbmsSchemaMigrationStatusProviderTest {
     // then
     assertThat(status.state()).isEqualTo(MigrationState.MIGRATED);
     assertThat(status.detail()).contains("8.10.0");
-  }
-
-  @Test
-  void shouldReportMigrationInProgressForPatchUpgrade() {
-    // given - schema=8.9.0, app=8.9.5 (not yet migrated to the running app's exact version)
-    final var status = singleStatus(versionStore("8.9.0", "8.9.5"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
-  }
-
-  @Test
-  void shouldReportMigrationInProgressForMinorUpgrade() {
-    // given - schema=8.9.1, app=8.10.0
-    final var status = singleStatus(versionStore("8.9.1", "8.10.0"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
-  }
-
-  @Test
-  void shouldReportMigrationInProgressForFreshDatabase() {
-    // given - resolveCurrentSchemaVersion returns null (fresh DB, not yet initialized)
-    final var status = singleStatus(versionStore(null, "8.11.0"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
-    assertThat(status.detail()).contains("fresh database");
-  }
-
-  @Test
-  void shouldReportUnknownForIncompatibleUpgradePath() {
-    // given - schema=8.9.0, app=8.11.0 (skipped 8.10) - a real problem, not "in progress"
-    final var status = singleStatus(versionStore("8.9.0", "8.11.0"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
-  }
-
-  @Test
-  void shouldReportUnknownForIndeterminateSchemaVersion() {
-    // given - stored schema version is not a valid semantic version
-    final var status = singleStatus(versionStore("not-a-semver", "8.10.0"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
-  }
-
-  @Test
-  void shouldReportUnknownForUnparseableApplicationVersion() {
-    // given - app=development (not a semantic version)
-    final var status = singleStatus(versionStore("8.9.0", "development"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
-    assertThat(status.detail()).contains("development");
-  }
-
-  @Test
-  void shouldReportUnknownWhenReadingCurrentVersionFails() throws Exception {
-    // given - getConnection() throws
-    final var dataSource = mock(DataSource.class);
-    when(dataSource.getConnection()).thenThrow(new RuntimeException("DB connection refused"));
-    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
-
-    // when
-    final var status = singleStatus(store);
-
-    // then - a read failure must never throw; it must be reported as UNKNOWN
-    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
-    assertThat(status.detail()).contains("DB connection refused");
   }
 
   private static RdbmsSchemaMigrationStatusProvider provider(

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
@@ -14,8 +14,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.db.rdbms.RdbmsSchemaVersionStore.CurrentSchemaVersion.Kind;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
+import io.camunda.zeebe.util.migration.CurrentSchemaVersion.Kind;
 import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;

--- a/schema-manager/src/main/java/io/camunda/search/schema/ElasticsearchSchemaMigrationStatusProvider.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/ElasticsearchSchemaMigrationStatusProvider.java
@@ -8,7 +8,6 @@
 package io.camunda.search.schema;
 
 import io.camunda.cluster.migration.MigrationConditionStatus;
-import io.camunda.cluster.migration.MigrationState;
 import io.camunda.cluster.migration.MigrationStatusProvider;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
@@ -16,10 +15,6 @@ import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.search.schema.opensearch.OpensearchEngineClient;
 import io.camunda.zeebe.util.VisibleForTesting;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
-import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -107,7 +102,7 @@ public final class ElasticsearchSchemaMigrationStatusProvider
     versionStoresByPhysicalTenant.forEach(
         (physicalTenantId, versionStore) ->
             statusesByPhysicalTenant.put(
-                physicalTenantId, toMigrationStatus(versionStore.getCurrentSchemaVersion())));
+                physicalTenantId, versionStore.getCurrentSchemaVersion().toMigrationStatus()));
     return statusesByPhysicalTenant;
   }
 
@@ -124,51 +119,5 @@ public final class ElasticsearchSchemaMigrationStatusProvider
                 e);
           }
         });
-  }
-
-  @VisibleForTesting
-  MigrationConditionStatus toMigrationStatus(
-      final ElasticsearchSchemaVersionStore.CurrentSchemaVersion currentSchemaVersion) {
-    return switch (currentSchemaVersion.kind()) {
-      case AVAILABLE ->
-          toMigrationStatus(
-              VersionCompatibilityCheck.check(
-                  currentSchemaVersion.schemaVersion().orElseThrow(),
-                  currentSchemaVersion.stableApplicationVersion().orElseThrow()));
-      case FRESH_DATABASE ->
-          new MigrationConditionStatus(
-              MigrationState.MIGRATION_IN_PROGRESS,
-              "no schema version recorded yet for prefix '"
-                  + currentSchemaVersion.prefix()
-                  + "' (fresh database)");
-      case READ_FAILURE ->
-          new MigrationConditionStatus(
-              MigrationState.UNKNOWN, currentSchemaVersion.detail().orElseThrow());
-    };
-  }
-
-  private MigrationConditionStatus toMigrationStatus(
-      final VersionCompatibilityCheck.CheckResult result) {
-    return switch (result) {
-      case final Compatible.SameVersion same ->
-          new MigrationConditionStatus(
-              MigrationState.MIGRATED,
-              "schema version " + same.version() + " matches the application version");
-      case final Compatible.PatchUpgrade patch ->
-          new MigrationConditionStatus(
-              MigrationState.MIGRATION_IN_PROGRESS,
-              "schema version " + patch.from() + " has not yet migrated to " + patch.to());
-      case final Compatible.MinorUpgrade minor ->
-          new MigrationConditionStatus(
-              MigrationState.MIGRATION_IN_PROGRESS,
-              "schema version " + minor.from() + " has not yet migrated to " + minor.to());
-      case final Incompatible incompatible ->
-          new MigrationConditionStatus(
-              MigrationState.UNKNOWN, "incompatible schema upgrade path: " + incompatible);
-      case final Indeterminate indeterminate ->
-          new MigrationConditionStatus(
-              MigrationState.UNKNOWN,
-              "cannot determine schema version compatibility: " + indeterminate);
-    };
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/ElasticsearchSchemaVersionStore.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/ElasticsearchSchemaVersionStore.java
@@ -10,6 +10,7 @@ package io.camunda.search.schema;
 import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.migration.CurrentSchemaVersion;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,43 +94,5 @@ public class ElasticsearchSchemaVersionStore {
   static Optional<String> toStableVersion(final String version) {
     return SemanticVersion.parse(version)
         .map(sv -> sv.major() + "." + sv.minor() + "." + sv.patch());
-  }
-
-  public record CurrentSchemaVersion(
-      CurrentSchemaVersion.Kind kind,
-      String prefix,
-      Optional<String> schemaVersion,
-      Optional<String> stableApplicationVersion,
-      Optional<String> detail) {
-
-    static CurrentSchemaVersion available(
-        final String prefix, final String schemaVersion, final String stableApplicationVersion) {
-      return new CurrentSchemaVersion(
-          Kind.AVAILABLE,
-          prefix,
-          Optional.of(schemaVersion),
-          Optional.of(stableApplicationVersion),
-          Optional.empty());
-    }
-
-    static CurrentSchemaVersion freshDatabase(final String prefix) {
-      return new CurrentSchemaVersion(
-          Kind.FRESH_DATABASE, prefix, Optional.empty(), Optional.empty(), Optional.empty());
-    }
-
-    static CurrentSchemaVersion readFailure(final String prefix, final Exception e) {
-      return new CurrentSchemaVersion(
-          Kind.READ_FAILURE,
-          prefix,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.of("failed to read schema version: " + e.getMessage()));
-    }
-
-    public enum Kind {
-      AVAILABLE,
-      FRESH_DATABASE,
-      READ_FAILURE
-    }
   }
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaMigrationStatusProviderTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaMigrationStatusProviderTest.java
@@ -19,7 +19,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for the Elasticsearch/OpenSearch upgrade-readiness condition. */
+/**
+ * Unit tests for the Elasticsearch/OpenSearch upgrade-readiness condition. The
+ * schema-version-to-{@link MigrationState} mapping itself (patch/minor upgrade, fresh database,
+ * incompatible/indeterminate versions, read failures) is shared across every schema-version-backed
+ * provider and exhaustively covered once elsewhere -- these tests only cover what's genuinely
+ * specific to this provider: multi-tenant map-shaping and one smoke test confirming it's wired to
+ * that shared mapping correctly.
+ */
 class ElasticsearchSchemaMigrationStatusProviderTest {
 
   @Test
@@ -61,78 +68,6 @@ class ElasticsearchSchemaMigrationStatusProviderTest {
     // then
     assertThat(status.state()).isEqualTo(MigrationState.MIGRATED);
     assertThat(status.detail()).contains("8.10.0");
-  }
-
-  @Test
-  void shouldReportMigrationInProgressForPatchUpgrade() {
-    // given - schema=8.9.0, app=8.9.5 (not yet migrated to the running app's exact version)
-    final var status = singleStatus(versionStore("8.9.0", "8.9.5"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
-  }
-
-  @Test
-  void shouldReportMigrationInProgressForMinorUpgrade() {
-    // given - schema=8.9.1, app=8.10.0
-    final var status = singleStatus(versionStore("8.9.1", "8.10.0"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
-  }
-
-  @Test
-  void shouldReportMigrationInProgressForFreshDatabase() {
-    // given - metadata index does not exist yet (fresh installation)
-    final var status = singleStatus(versionStore(null, "8.11.0"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
-    assertThat(status.detail()).contains("fresh database");
-  }
-
-  @Test
-  void shouldReportUnknownForIncompatibleUpgradePath() {
-    // given - schema=8.9.0, app=8.11.0 (skipped 8.10) - a real problem, not "in progress"
-    final var status = singleStatus(versionStore("8.9.0", "8.11.0"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
-  }
-
-  @Test
-  void shouldReportUnknownForIndeterminateSchemaVersion() {
-    // given - stored schema version is not a valid semantic version
-    final var status = singleStatus(versionStore("not-a-semver", "8.10.0"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
-  }
-
-  @Test
-  void shouldReportUnknownForUnparseableApplicationVersion() {
-    // given - app=development (not a semantic version)
-    final var status = singleStatus(versionStore("8.9.0", "development"));
-
-    // then
-    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
-    assertThat(status.detail()).contains("development");
-  }
-
-  @Test
-  void shouldReportUnknownWhenReadingCurrentVersionFails() {
-    // given - the search engine call itself fails (e.g. connection refused)
-    final var searchEngineClient = mock(SearchEngineClient.class);
-    when(searchEngineClient.indexExists(anyString()))
-        .thenThrow(new RuntimeException("connection refused"));
-    final var store = new ElasticsearchSchemaVersionStore(searchEngineClient, "", true, "8.10.0");
-
-    // when
-    final var status = singleStatus(store);
-
-    // then - a read failure must never throw; it must be reported as UNKNOWN
-    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
-    assertThat(status.detail()).contains("connection refused");
   }
 
   private static ElasticsearchSchemaMigrationStatusProvider provider(

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaVersionStoreIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaVersionStoreIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.search.schema;
 
-import static io.camunda.search.schema.ElasticsearchSchemaVersionStore.CurrentSchemaVersion.Kind;
 import static io.camunda.search.schema.utils.SchemaTestUtil.searchEngineClientFromConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,6 +15,7 @@ import io.camunda.search.schema.utils.SchemaManagerITInvocationProvider;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
+import io.camunda.zeebe.util.migration.CurrentSchemaVersion.Kind;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaVersionStoreTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaVersionStoreTest.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.search.schema;
 
-import static io.camunda.search.schema.ElasticsearchSchemaVersionStore.CurrentSchemaVersion.Kind;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
+import io.camunda.zeebe.util.migration.CurrentSchemaVersion.Kind;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/migration/CurrentSchemaVersion.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/migration/CurrentSchemaVersion.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.migration;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
+import java.util.Optional;
+
+/**
+ * The schema-version facts for one physical tenant's secondary-storage schema, read without side
+ * effects (never throws, never writes), for the upgrade-readiness endpoint. Different storage
+ * backends read the persisted version differently (e.g. a JDBC table vs. a search-engine metadata
+ * document), but converge on this same shape and the same mapping to an upgrade-readiness
+ * condition.
+ */
+public record CurrentSchemaVersion(
+    CurrentSchemaVersion.Kind kind,
+    String prefix,
+    Optional<String> schemaVersion,
+    Optional<String> stableApplicationVersion,
+    Optional<String> detail) {
+
+  public static CurrentSchemaVersion available(
+      final String prefix, final String schemaVersion, final String stableApplicationVersion) {
+    return new CurrentSchemaVersion(
+        Kind.AVAILABLE,
+        prefix,
+        Optional.of(schemaVersion),
+        Optional.of(stableApplicationVersion),
+        Optional.empty());
+  }
+
+  public static CurrentSchemaVersion freshDatabase(final String prefix) {
+    return new CurrentSchemaVersion(
+        Kind.FRESH_DATABASE, prefix, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  public static CurrentSchemaVersion readFailure(final String prefix, final Exception e) {
+    return new CurrentSchemaVersion(
+        Kind.READ_FAILURE,
+        prefix,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of("failed to read schema version: " + e.getMessage()));
+  }
+
+  /**
+   * Maps these raw schema-version facts to the upgrade-readiness condition reported for one
+   * physical tenant.
+   *
+   * <ul>
+   *   <li>Schema version equals the application version ({@link Compatible.SameVersion}) → {@link
+   *       MigrationState#MIGRATED}.
+   *   <li>Schema version is one or more minors behind, on a supported upgrade path ({@link
+   *       Compatible.PatchUpgrade}/{@link Compatible.MinorUpgrade}), or no version has been
+   *       recorded yet (fresh database) → {@link MigrationState#MIGRATION_IN_PROGRESS}. This
+   *       includes externally-managed or not-yet-initialized schemas that haven't been migrated by
+   *       the operator's own tooling yet.
+   *   <li>An illegal upgrade path ({@link Incompatible}), an unparseable version ({@link
+   *       Indeterminate}), an unparseable application version, or any read failure (e.g. a
+   *       connection error) → {@link MigrationState#UNKNOWN} — this is a "we don't know," not a "we
+   *       know it's not done."
+   * </ul>
+   */
+  public MigrationConditionStatus toMigrationStatus() {
+    return switch (kind) {
+      case AVAILABLE ->
+          toMigrationStatus(
+              VersionCompatibilityCheck.check(
+                  schemaVersion.orElseThrow(), stableApplicationVersion.orElseThrow()));
+      case FRESH_DATABASE ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "no schema version recorded yet for prefix '" + prefix + "' (fresh database)");
+      case READ_FAILURE ->
+          new MigrationConditionStatus(MigrationState.UNKNOWN, detail.orElseThrow());
+    };
+  }
+
+  private static MigrationConditionStatus toMigrationStatus(
+      final VersionCompatibilityCheck.CheckResult result) {
+    return switch (result) {
+      case final Compatible.SameVersion same ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATED,
+              "schema version " + same.version() + " matches the application version");
+      case final Compatible.PatchUpgrade patch ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "schema version " + patch.from() + " has not yet migrated to " + patch.to());
+      case final Compatible.MinorUpgrade minor ->
+          new MigrationConditionStatus(
+              MigrationState.MIGRATION_IN_PROGRESS,
+              "schema version " + minor.from() + " has not yet migrated to " + minor.to());
+      case final Incompatible incompatible ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN, "incompatible schema upgrade path: " + incompatible);
+      case final Indeterminate indeterminate ->
+          new MigrationConditionStatus(
+              MigrationState.UNKNOWN,
+              "cannot determine schema version compatibility: " + indeterminate);
+    };
+  }
+
+  public enum Kind {
+    AVAILABLE,
+    FRESH_DATABASE,
+    READ_FAILURE
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/migration/CurrentSchemaVersionTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/migration/CurrentSchemaVersionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.migration.MigrationState;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CurrentSchemaVersion#toMigrationStatus()} — the schema-version-to-{@link
+ * MigrationState} mapping shared across every schema-version-backed upgrade-readiness provider. No
+ * I/O or mocking needed: exercised directly against hand-built {@link CurrentSchemaVersion}
+ * instances.
+ */
+class CurrentSchemaVersionTest {
+
+  @Test
+  void shouldReportMigratedForSameVersion() {
+    // given - schema=8.10.0, app=8.10.0
+    final var status = CurrentSchemaVersion.available("", "8.10.0", "8.10.0").toMigrationStatus();
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(status.detail()).contains("8.10.0");
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForPatchUpgrade() {
+    // given - schema=8.9.0, app=8.9.5 (not yet migrated to the running app's exact version)
+    final var status = CurrentSchemaVersion.available("", "8.9.0", "8.9.5").toMigrationStatus();
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForMinorUpgrade() {
+    // given - schema=8.9.1, app=8.10.0
+    final var status = CurrentSchemaVersion.available("", "8.9.1", "8.10.0").toMigrationStatus();
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressForFreshDatabase() {
+    // given - no schema version recorded yet
+    final var status = CurrentSchemaVersion.freshDatabase("myPrefix_").toMigrationStatus();
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+    assertThat(status.detail()).contains("fresh database").contains("myPrefix_");
+  }
+
+  @Test
+  void shouldReportUnknownForIncompatibleUpgradePath() {
+    // given - schema=8.9.0, app=8.11.0 (skipped 8.10) - a real problem, not "in progress"
+    final var status = CurrentSchemaVersion.available("", "8.9.0", "8.11.0").toMigrationStatus();
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownForIndeterminateSchemaVersion() {
+    // given - stored schema version is not a valid semantic version
+    final var status =
+        CurrentSchemaVersion.available("", "not-a-semver", "8.10.0").toMigrationStatus();
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportUnknownForUnparseableApplicationVersion() {
+    // given - app=development (not a semantic version)
+    final var status =
+        CurrentSchemaVersion.available("", "8.9.0", "development").toMigrationStatus();
+
+    // then
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("development");
+  }
+
+  @Test
+  void shouldReportUnknownForReadFailure() {
+    // given - the underlying store could not read the schema version at all
+    final var status =
+        CurrentSchemaVersion.readFailure("", new RuntimeException("connection refused"))
+            .toMigrationStatus();
+
+    // then - a read failure must never throw; it must be reported as UNKNOWN
+    assertThat(status.state()).isEqualTo(MigrationState.UNKNOWN);
+    assertThat(status.detail()).contains("connection refused");
+  }
+}


### PR DESCRIPTION
- `RdbmsSchemaMigrationStatusProvider` (`db/rdbms`) and `ElasticsearchSchemaMigrationStatusProvider` (`schema-manager`) each carried their own private, nested `CurrentSchemaVersion` record plus an almost byte-for-byte identical `toMigrationStatus(CurrentSchemaVersion)` mapping method
- centralized this into `zeebe-util/io.camunda.zeebe.util.migration`

Closes #60710.
